### PR TITLE
Fix: Replace workflow symlinks with real files

### DIFF
--- a/.github/actions/load-secrets
+++ b/.github/actions/load-secrets
@@ -1,1 +1,0 @@
-../../ee/actions/load-secrets

--- a/.github/actions/load-secrets/action.yml
+++ b/.github/actions/load-secrets/action.yml
@@ -1,0 +1,60 @@
+name: "Load 1Password Secrets"
+description: "Fetches secrets from 1Password and exports them as environment variables"
+
+inputs:
+  op-service-account-token:
+    description: "1Password Service Account Token"
+    required: true
+  environment:
+    description: "Environment to load secrets for (staging or production)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install 1Password CLI
+      uses: 1password/install-cli-action@v1
+
+    - name: Load common secrets
+      uses: 1password/load-secrets-action@v2
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
+        CONVEX_DEPLOY_KEY: op://Togather/CONVEX_DEPLOY_KEY/${{ inputs.environment }}
+        JWT_SECRET: op://Togather/JWT_SECRET/${{ inputs.environment }}
+        EXPO_ACCESS_TOKEN: op://Togather/EXPO_ACCESS_TOKEN/${{ inputs.environment }}
+        RESEND_API_KEY: op://Togather/RESEND_API_KEY/${{ inputs.environment }}
+        TWILIO_ACCOUNT_SID: op://Togather/TWILIO_ACCOUNT_SID/${{ inputs.environment }}
+        TWILIO_AUTH_TOKEN: op://Togather/TWILIO_AUTH_TOKEN/${{ inputs.environment }}
+        TWILIO_API_KEY_SID: op://Togather/TWILIO_API_KEY_SID/${{ inputs.environment }}
+        TWILIO_API_KEY_SECRET: op://Togather/TWILIO_API_KEY_SECRET/${{ inputs.environment }}
+        TWILIO_VERIFY_SERVICE_SID: op://Togather/TWILIO_VERIFY_SERVICE_SID/${{ inputs.environment }}
+        PLANNING_CENTER_CLIENT_ID: op://Togather/PLANNING_CENTER_CLIENT_ID/${{ inputs.environment }}
+        PLANNING_CENTER_CLIENT_SECRET: op://Togather/PLANNING_CENTER_CLIENT_SECRET/${{ inputs.environment }}
+        OTP_TEST_PHONE_NUMBERS: op://Togather/OTP_TEST_PHONE_NUMBERS/${{ inputs.environment }}
+        CLOUDFLARE_ACCOUNT_ID: op://Togather/CLOUDFLARE_ACCOUNT_ID/${{ inputs.environment }}
+        R2_ACCESS_KEY_ID: op://Togather/R2_ACCESS_KEY_ID/${{ inputs.environment }}
+        R2_SECRET_ACCESS_KEY: op://Togather/R2_SECRET_ACCESS_KEY/${{ inputs.environment }}
+        R2_BUCKET_NAME: op://Togather/R2_BUCKET_NAME/${{ inputs.environment }}
+        R2_PUBLIC_URL: op://Togather/R2_PUBLIC_URL/${{ inputs.environment }}
+        SLACK_BOT_TOKEN: op://Togather/SLACK_BOT_TOKEN/${{ inputs.environment }}
+        SLACK_SIGNING_SECRET: op://Togather/SLACK_SIGNING_SECRET/${{ inputs.environment }}
+        OPENAI_SECRET_KEY: op://Togather/OPENAI_SECRET_KEY/${{ inputs.environment }}
+      with:
+        export-env: true
+
+    - name: Load optional secrets
+      uses: 1password/load-secrets-action@v2
+      continue-on-error: true
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
+        EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
+        CLOUDFLARE_API_TOKEN: op://Togather/CLOUDFLARE_API_TOKEN/${{ inputs.environment }}
+        TF_API_TOKEN: op://Togather/TF_API_TOKEN/${{ inputs.environment }}
+        SENTRY_AUTH_TOKEN: op://Togather/SENTRY_AUTH_TOKEN/${{ inputs.environment }}
+        EXPO_PUBLIC_MAPBOX_TOKEN: op://Togather/EXPO_PUBLIC_MAPBOX_TOKEN/${{ inputs.environment }}
+        EXPO_PUBLIC_SENTRY_DSN: op://Togather/EXPO_PUBLIC_SENTRY_DSN/${{ inputs.environment }}
+        EXPO_PUBLIC_CONVEX_URL: op://Togather/EXPO_PUBLIC_CONVEX_URL/${{ inputs.environment }}
+        EXPO_PUBLIC_POSTHOG_API_KEY: op://Togather/EXPO_PUBLIC_POSTHOG_API_KEY/${{ inputs.environment }}
+        IMAGE_CDN_URL: op://Togather/IMAGE_CDN_URL/${{ inputs.environment }}
+      with:
+        export-env: true

--- a/.github/workflows/build-mobile-native.yml
+++ b/.github/workflows/build-mobile-native.yml
@@ -1,1 +1,287 @@
-../../ee/deployment/workflows/build-mobile-native.yml
+name: Build Mobile Native (Staging)
+
+# STAGING ONLY - Auto-builds when native code changes are detected on main
+# Production builds go through deploy-to-production.yml
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/ios/**'
+      - 'apps/mobile/android/**'
+      - 'apps/mobile/app.config.js'
+      - 'apps/mobile/app.json'
+      - 'apps/mobile/eas.json'
+      - 'apps/mobile/package.json'
+      - 'apps/mobile/.fingerprint'
+
+jobs:
+  # First, check if this is actually a native change that requires a build
+  detect-native-change:
+    name: Detect Native Changes
+    runs-on: ubuntu-latest
+    outputs:
+      native_changed: ${{ steps.check.outputs.native_changed }}
+      version: ${{ steps.check.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history to compare across multi-commit pushes
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for native changes
+        id: check
+        working-directory: apps/mobile
+        run: |
+          # Get current version
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Check if fingerprint file changed (indicates native change with version bump)
+          # Use github.event.before to compare all commits in a multi-commit push
+          BEFORE_SHA="${{ github.event.before }}"
+          AFTER_SHA="${{ github.sha }}"
+
+          # Handle case where before is all zeros (new branch)
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            # For new branches, check if there's a parent commit
+            if git rev-parse HEAD~1 >/dev/null 2>&1; then
+              BEFORE_SHA="HEAD~1"
+            else
+              # Single commit on new branch - check if fingerprint exists in current tree
+              echo "New branch with single commit - checking if fingerprint file exists"
+              if [ -f "apps/mobile/.fingerprint" ]; then
+                echo "Fingerprint file exists in first commit - native build required"
+                echo "native_changed=true" >> $GITHUB_OUTPUT
+              else
+                echo "No fingerprint file - no native build required"
+                echo "native_changed=false" >> $GITHUB_OUTPUT
+              fi
+              exit 0
+            fi
+          fi
+
+          echo "Comparing $BEFORE_SHA..$AFTER_SHA"
+
+          if git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -q "apps/mobile/.fingerprint"; then
+            echo "Fingerprint changed - native build required"
+            echo "native_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No fingerprint change - no native build required"
+            echo "native_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+  # Build staging automatically when native changes detected
+  build-staging:
+    name: Build Staging
+    needs: detect-native-change
+    if: needs.detect-native-change.outputs.native_changed == 'true'
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: staging
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+
+      - name: Sync secrets to EAS
+        working-directory: apps/mobile
+        run: |
+          # Use eas env:create (eas secret:create is deprecated)
+          # Must match the "environment" field in eas.json staging profile (preview)
+          # Note: EAS custom environments require Production/Enterprise plan, so we use "preview"
+          eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment preview --visibility plaintext --force --non-interactive || true
+          # Convex URL from 1Password
+          eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment preview --visibility plaintext --force --non-interactive || true
+          # Project ID for push notifications (constant across all environments)
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment preview --visibility plaintext --force --non-interactive || true
+          # Sentry auth token for source map uploads during native builds
+          eas env:create --name SENTRY_AUTH_TOKEN --value "$SENTRY_AUTH_TOKEN" --environment preview --visibility sensitive --force --non-interactive || true
+          # Sentry DSN for error tracking at runtime
+          eas env:create --name EXPO_PUBLIC_SENTRY_DSN --value "$EXPO_PUBLIC_SENTRY_DSN" --environment preview --visibility sensitive --force --non-interactive || true
+          echo "✓ Synced secrets to EAS preview environment (for staging builds)"
+
+      - name: Build iOS (staging)
+        working-directory: apps/mobile
+        run: eas build --platform ios --profile staging --non-interactive
+
+      - name: Build Android (staging)
+        working-directory: apps/mobile
+        run: eas build --platform android --profile staging --non-interactive
+
+      - name: Submit to TestFlight (staging)
+        working-directory: apps/mobile
+        run: eas submit --platform ios --latest --profile staging --non-interactive
+
+      # Upload iOS manifest to R2 for version checking
+      - name: Upload iOS manifest to R2 (staging)
+        working-directory: apps/mobile
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
+        run: |
+          # Get version from code
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "Creating iOS staging manifest for version $VERSION..."
+
+          # Install AWS CLI for R2 (S3-compatible)
+          pip install awscli --quiet
+
+          # Override AWS credentials with R2 credentials
+          # (env vars take precedence over aws configure)
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Create and upload iOS staging manifest
+          # availableAfter is set to 45 minutes from now to allow TestFlight processing
+          mkdir -p ./build-output
+          AVAILABLE_AFTER=$(date -u -d '+45 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+45M +%Y-%m-%dT%H:%M:%SZ)
+          cat > ./build-output/ios-manifest.json << EOF
+          {
+            "version": "${VERSION}",
+            "platform": "ios",
+            "environment": "staging",
+            "releaseDate": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "availableAfter": "${AVAILABLE_AFTER}",
+            "downloadUrl": "https://testflight.apple.com/join/JNdDOp2N",
+            "minSupportedVersion": "1.0.0"
+          }
+          EOF
+
+          aws s3 cp ./build-output/ios-manifest.json "s3://${R2_BUCKET_NAME}/releases/ios/staging/manifest.json" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/json"
+          echo "✓ Uploaded iOS staging manifest.json"
+
+      # Upload Android APK to R2 for staging distribution
+      - name: Upload Android APK to R2 (staging)
+        working-directory: apps/mobile
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
+        run: |
+          # Get version from code
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "Uploading staging Android APK version $VERSION to R2..."
+
+          # Download the latest Android APK from EAS
+          mkdir -p ./build-output
+          # Get the artifact URL from the latest build
+          APK_URL=$(eas build:list --platform android --build-profile staging --limit 1 --json --non-interactive | jq -r '.[0].artifacts.applicationArchiveUrl')
+          echo "Downloading APK from: $APK_URL"
+          curl -fL -o ./build-output/togather-staging.apk "$APK_URL"
+
+          # Get file size for manifest
+          FILE_SIZE=$(stat -c%s ./build-output/togather-staging.apk 2>/dev/null || stat -f%z ./build-output/togather-staging.apk)
+          echo "APK size: $FILE_SIZE bytes"
+
+          # Install AWS CLI for R2 (S3-compatible)
+          pip install awscli --quiet
+
+          # Override AWS credentials with R2 credentials
+          # (env vars take precedence over aws configure)
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Upload versioned APK to staging folder
+          aws s3 cp ./build-output/togather-staging.apk "s3://${R2_BUCKET_NAME}/releases/android/staging/togather-staging-${VERSION}.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-staging-${VERSION}.apk"
+
+          # Upload as latest
+          aws s3 cp ./build-output/togather-staging.apk "s3://${R2_BUCKET_NAME}/releases/android/staging/togather-staging-latest.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-staging-latest.apk"
+
+          # Create and upload staging manifest
+          # Android APKs are uploaded directly to R2, so available immediately (no review period)
+          RELEASE_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          cat > ./build-output/manifest.json << EOF
+          {
+            "version": "${VERSION}",
+            "platform": "android",
+            "environment": "staging",
+            "releaseDate": "${RELEASE_DATE}",
+            "availableAfter": "${RELEASE_DATE}",
+            "fileSize": ${FILE_SIZE},
+            "downloadUrl": "${IMAGE_CDN_URL}/releases/android/staging/togather-staging-${VERSION}.apk",
+            "latestUrl": "${IMAGE_CDN_URL}/releases/android/staging/togather-staging-latest.apk",
+            "minSupportedVersion": "1.0.0"
+          }
+          EOF
+
+          aws s3 cp ./build-output/manifest.json "s3://${R2_BUCKET_NAME}/releases/android/staging/manifest.json" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/json"
+          echo "✓ Uploaded staging manifest.json"
+
+      - name: Summary
+        run: |
+          echo "## Staging Build Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ needs.detect-native-change.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** staging" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### iOS" >> $GITHUB_STEP_SUMMARY
+          echo "- Built and submitted to TestFlight" >> $GITHUB_STEP_SUMMARY
+          echo "- Wait for processing (~15-30 min)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Android" >> $GITHUB_STEP_SUMMARY
+          echo "- APK uploaded to R2" >> $GITHUB_STEP_SUMMARY
+          echo "- Download: https://togather.nyc/android-staging" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Next steps:**" >> $GITHUB_STEP_SUMMARY
+          echo "1. Test the staging apps thoroughly" >> $GITHUB_STEP_SUMMARY
+          echo "2. When ready, use 'Promote to Production' workflow" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,1 +1,438 @@
-../../ee/deployment/workflows/build-mobile.yml
+name: Build Mobile
+
+# Trigger builds manually or on version tags
+# This avoids $2/build charges on every push
+on:
+  # Manual trigger from GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform to build"
+        type: choice
+        required: true
+        default: "all"
+        options:
+          - ios
+          - android
+          - all
+      profile:
+        description: "Build profile"
+        type: choice
+        required: true
+        default: "production"
+        options:
+          - production
+          - staging
+      submit:
+        description: "Submit iOS to App Store after build"
+        type: boolean
+        default: false
+
+  # Automatic trigger on version tags (e.g., v1.0.0, v1.2.3)
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build Mobile App
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Use staging secrets for staging profile, production for production/tags
+          environment: ${{ inputs.profile == 'staging' && 'staging' || 'production' }}
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+
+      - name: Sync secrets to EAS
+        working-directory: apps/mobile
+        env:
+          # Determine target EAS environment based on profile (default to production for tag triggers)
+          # Note: staging profile uses "preview" environment in eas.json (see build-mobile-native.yml)
+          EAS_ENV: ${{ inputs.profile == 'staging' && 'preview' || 'production' }}
+        run: |
+          # Use eas env:create (eas secret:create is deprecated)
+          # Only sync to the environment matching the selected profile to avoid cross-contamination
+          eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
+          # Convex URL from 1Password (already loaded per environment)
+          eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
+          # Project ID for push notifications (constant across all environments)
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
+          # Sentry auth token for source map uploads during native builds
+          eas env:create --name SENTRY_AUTH_TOKEN --value "$SENTRY_AUTH_TOKEN" --environment "$EAS_ENV" --visibility sensitive --force --non-interactive || true
+          # Sentry DSN for error tracking at runtime
+          eas env:create --name EXPO_PUBLIC_SENTRY_DSN --value "$EXPO_PUBLIC_SENTRY_DSN" --environment "$EAS_ENV" --visibility sensitive --force --non-interactive || true
+          echo "✓ Synced secrets to EAS ($EAS_ENV environment)"
+
+      # ── Check for existing EAS builds to avoid redundant builds ──
+      # Builds cost ~$2 each and take ~20 minutes, so we reuse recent successful builds
+      - name: Check for existing builds
+        id: check-builds
+        working-directory: apps/mobile
+        run: |
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Determine which profiles to check based on trigger
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PROFILE="${{ inputs.profile }}"
+          else
+            PROFILE="production"
+          fi
+
+          # Check for existing store build (production or staging profile)
+          check_existing_build() {
+            local platform=$1
+            local profile=$2
+            local output_key=$3
+
+            echo "Checking for existing $platform $profile build for version $VERSION..."
+
+            # Get the latest finished build for this platform/profile
+            BUILD_JSON=$(eas build:list --platform "$platform" --build-profile "$profile" --limit 1 --json --non-interactive 2>/dev/null || echo "[]")
+            BUILD_STATUS=$(echo "$BUILD_JSON" | jq -r '.[0].status // "none"')
+            BUILD_VERSION=$(echo "$BUILD_JSON" | jq -r '.[0].runtimeVersion // "none"')
+            BUILD_ARTIFACT=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.applicationArchiveUrl // "none"')
+
+            if [ "$BUILD_STATUS" = "FINISHED" ] && [ "$BUILD_VERSION" = "$VERSION" ] && [ "$BUILD_ARTIFACT" != "none" ] && [ "$BUILD_ARTIFACT" != "null" ]; then
+              echo "✓ Found existing $platform $profile build for version $VERSION"
+              echo "${output_key}=true" >> $GITHUB_OUTPUT
+            else
+              echo "✗ No existing $platform $profile build for version $VERSION (status=$BUILD_STATUS, version=$BUILD_VERSION)"
+              echo "${output_key}=false" >> $GITHUB_OUTPUT
+            fi
+          }
+
+          # Check iOS store build
+          check_existing_build "ios" "$PROFILE" "has_ios_build"
+
+          # Check Android store build
+          check_existing_build "android" "$PROFILE" "has_android_build"
+
+          # Check Android APK build (production-apk profile, used for R2 distribution)
+          if [ "$PROFILE" = "production" ]; then
+            check_existing_build "android" "production-apk" "has_android_apk_build"
+          else
+            echo "has_android_apk_build=false" >> $GITHUB_OUTPUT
+          fi
+
+      # ── Manual trigger: build only if no existing build found ──
+      - name: Build iOS (manual)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && (inputs.platform == 'ios' || inputs.platform == 'all')
+          && steps.check-builds.outputs.has_ios_build != 'true'
+        working-directory: apps/mobile
+        run: eas build --platform ios --profile ${{ inputs.profile }} --non-interactive
+
+      - name: Skip iOS build (cached)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && (inputs.platform == 'ios' || inputs.platform == 'all')
+          && steps.check-builds.outputs.has_ios_build == 'true'
+        run: echo "⏭️ Skipping iOS build — existing build found for version ${{ steps.check-builds.outputs.version }}"
+
+      - name: Build Android (manual)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && (inputs.platform == 'android' || inputs.platform == 'all')
+          && steps.check-builds.outputs.has_android_build != 'true'
+        working-directory: apps/mobile
+        run: eas build --platform android --profile ${{ inputs.profile }} --non-interactive
+
+      - name: Skip Android build (cached)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && (inputs.platform == 'android' || inputs.platform == 'all')
+          && steps.check-builds.outputs.has_android_build == 'true'
+        run: echo "⏭️ Skipping Android build — existing build found for version ${{ steps.check-builds.outputs.version }}"
+
+      # iOS App Store submission (only iOS — Android is distributed via R2)
+      - name: Submit iOS to App Store (manual)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && inputs.submit
+          && (inputs.platform == 'ios' || inputs.platform == 'all')
+        working-directory: apps/mobile
+        run: eas submit --platform ios --latest --non-interactive
+
+      # Build Android APK for direct distribution (manual, production only)
+      # Skips if a production-apk build already exists for this version
+      - name: Build Android APK for R2 (manual)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && inputs.profile == 'production'
+          && (inputs.platform == 'android' || inputs.platform == 'all')
+          && steps.check-builds.outputs.has_android_apk_build != 'true'
+        working-directory: apps/mobile
+        run: eas build --platform android --profile production-apk --non-interactive
+
+      - name: Skip Android APK build (cached)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && inputs.profile == 'production'
+          && (inputs.platform == 'android' || inputs.platform == 'all')
+          && steps.check-builds.outputs.has_android_apk_build == 'true'
+        run: echo "⏭️ Skipping Android APK build — existing production-apk build found for version ${{ steps.check-builds.outputs.version }}"
+
+      # Upload Android APK to R2 for direct distribution (manual, production only)
+      # Always runs — pulls the latest production-apk build from EAS (cached or fresh)
+      - name: Upload Android APK to R2 (manual)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && inputs.profile == 'production'
+          && (inputs.platform == 'android' || inputs.platform == 'all')
+        working-directory: apps/mobile
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
+        run: |
+          # Get version from code
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "Uploading Android APK version $VERSION to R2..."
+
+          # Download the latest Android APK from EAS (cached or freshly built)
+          mkdir -p ./build-output
+          APK_URL=$(eas build:list --platform android --build-profile production-apk --limit 1 --json --non-interactive | jq -r '.[0].artifacts.applicationArchiveUrl')
+
+          if [ "$APK_URL" = "null" ] || [ -z "$APK_URL" ]; then
+            echo "❌ ERROR: No production-apk build artifact found on EAS"
+            exit 1
+          fi
+
+          echo "Downloading APK from: $APK_URL"
+          curl -fL -o ./build-output/togather.apk "$APK_URL"
+
+          # Get file size for manifest
+          FILE_SIZE=$(stat -f%z ./build-output/togather.apk 2>/dev/null || stat -c%s ./build-output/togather.apk)
+          echo "APK size: $FILE_SIZE bytes"
+
+          # Install AWS CLI for R2 (S3-compatible)
+          pip install awscli --quiet
+
+          # Override AWS credentials with R2 credentials
+          # (env vars take precedence over aws configure)
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Upload versioned APK
+          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-${VERSION}.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-${VERSION}.apk"
+
+          # Upload as latest
+          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-latest.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-latest.apk"
+
+          # Create and upload manifest
+          # Uses R2 bucket served at IMAGE_CDN_URL (see docs/architecture/ADR-021-android-distribution.md)
+          cat > ./build-output/manifest.json << EOF
+          {
+            "version": "${VERSION}",
+            "releaseDate": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "fileSize": ${FILE_SIZE},
+            "downloadUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-${VERSION}.apk",
+            "latestUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-latest.apk",
+            "minSupportedVersion": "1.0.0"
+          }
+          EOF
+
+          aws s3 cp ./build-output/manifest.json "s3://${R2_BUCKET_NAME}/releases/android/production/manifest.json" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/json"
+          echo "✓ Uploaded manifest.json"
+
+          echo "## Android APK Published to R2" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: $VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "- Size: $(echo "scale=2; $FILE_SIZE/1048576" | bc) MB" >> $GITHUB_STEP_SUMMARY
+          echo "- Download: https://togather.nyc/android" >> $GITHUB_STEP_SUMMARY
+
+      # ── Tag release flow ──
+      - name: Validate tag matches code version
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        working-directory: apps/mobile
+        run: |
+          # Extract version from tag (e.g., v1.0.17 -> 1.0.17)
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Tag version: $TAG_VERSION"
+
+          # Get version from code
+          CODE_VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "Code version: $CODE_VERSION"
+
+          # Verify they match
+          if [ "$TAG_VERSION" != "$CODE_VERSION" ]; then
+            echo ""
+            echo "❌ ERROR: Tag version does not match code version!"
+            echo "   Tag:  v$TAG_VERSION"
+            echo "   Code: $CODE_VERSION"
+            echo ""
+            echo "   The version in app.config.js must match the git tag."
+            echo "   Either:"
+            echo "   1. Update the code version: pnpm version:bump $TAG_VERSION"
+            echo "   2. Or create a new tag: git tag v$CODE_VERSION"
+            exit 1
+          fi
+
+          # Also verify app.json matches
+          APP_JSON_VERSION=$(node -p "require('./app.json').expo.version")
+          if [ "$CODE_VERSION" != "$APP_JSON_VERSION" ]; then
+            echo ""
+            echo "❌ ERROR: app.json version does not match!"
+            echo "   app.config.js: $CODE_VERSION"
+            echo "   app.json:      $APP_JSON_VERSION"
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ Version validated: $CODE_VERSION"
+
+      # Tag release: build iOS only if no existing build (Android goes through production-apk)
+      - name: Build iOS (tag release)
+        if: >-
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags/v')
+          && steps.check-builds.outputs.has_ios_build != 'true'
+        working-directory: apps/mobile
+        run: eas build --platform ios --profile production --non-interactive
+
+      - name: Build Android (tag release)
+        if: >-
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags/v')
+          && steps.check-builds.outputs.has_android_build != 'true'
+        working-directory: apps/mobile
+        run: eas build --platform android --profile production --non-interactive
+
+      # iOS App Store submission for tag releases
+      - name: Submit iOS to App Store (tag release)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        working-directory: apps/mobile
+        run: eas submit --platform ios --latest --non-interactive
+
+      # Build Android APK for direct distribution (tag release)
+      - name: Build Android APK for R2 (tag release)
+        if: >-
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags/v')
+          && steps.check-builds.outputs.has_android_apk_build != 'true'
+        working-directory: apps/mobile
+        run: eas build --platform android --profile production-apk --non-interactive
+
+      # Upload Android APK to R2 for direct distribution (tag release)
+      - name: Upload Android APK to R2 (tag release)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        working-directory: apps/mobile
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
+        run: |
+          # Get version from tag
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Uploading Android APK version $VERSION to R2..."
+
+          # Download the latest Android APK from EAS (cached or freshly built)
+          mkdir -p ./build-output
+          APK_URL=$(eas build:list --platform android --build-profile production-apk --limit 1 --json --non-interactive | jq -r '.[0].artifacts.applicationArchiveUrl')
+
+          if [ "$APK_URL" = "null" ] || [ -z "$APK_URL" ]; then
+            echo "❌ ERROR: No production-apk build artifact found on EAS"
+            exit 1
+          fi
+
+          echo "Downloading APK from: $APK_URL"
+          curl -fL -o ./build-output/togather.apk "$APK_URL"
+
+          # Get file size for manifest
+          FILE_SIZE=$(stat -f%z ./build-output/togather.apk 2>/dev/null || stat -c%s ./build-output/togather.apk)
+          echo "APK size: $FILE_SIZE bytes"
+
+          # Install AWS CLI for R2 (S3-compatible)
+          pip install awscli --quiet
+
+          # Override AWS credentials with R2 credentials
+          # (env vars take precedence over aws configure)
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Upload versioned APK
+          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-${VERSION}.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-${VERSION}.apk"
+
+          # Upload as latest
+          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-latest.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-latest.apk"
+
+          # Create and upload manifest
+          # Uses R2 bucket served at IMAGE_CDN_URL (see docs/architecture/ADR-021-android-distribution.md)
+          cat > ./build-output/manifest.json << EOF
+          {
+            "version": "${VERSION}",
+            "releaseDate": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "fileSize": ${FILE_SIZE},
+            "downloadUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-${VERSION}.apk",
+            "latestUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-latest.apk",
+            "minSupportedVersion": "1.0.0"
+          }
+          EOF
+
+          aws s3 cp ./build-output/manifest.json "s3://${R2_BUCKET_NAME}/releases/android/production/manifest.json" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/json"
+          echo "✓ Uploaded manifest.json"
+
+      - name: Tag release summary
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "## Production Release: v$TAG_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### iOS" >> $GITHUB_STEP_SUMMARY
+          echo "- Submitted to App Store Connect" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Android" >> $GITHUB_STEP_SUMMARY
+          echo "- APK uploaded to: https://togather.nyc/android" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-convex.yml
+++ b/.github/workflows/deploy-convex.yml
@@ -1,1 +1,97 @@
-../../ee/deployment/workflows/deploy-convex.yml
+# Deploy Convex backend
+#
+# Automatically deploys to staging on push to main branch
+# Production deployment is manual only (workflow_dispatch)
+#
+# All secrets (including CONVEX_DEPLOY_KEY) are loaded from 1Password
+# Only requires OP_SERVICE_ACCOUNT_TOKEN in GitHub Secrets
+
+name: Deploy Convex
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/convex/**"
+      - "packages/shared/**"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to deploy to"
+        required: true
+        default: "staging"
+        type: choice
+        options:
+          - staging
+          - production
+
+concurrency:
+  group: deploy-convex-${{ github.event.inputs.environment || 'staging' }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Convex
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine environment
+        id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            GH_ENV="${{ github.event.inputs.environment }}"
+          else
+            # Push to main triggers staging deploy
+            GH_ENV="staging"
+          fi
+          echo "environment=$GH_ENV" >> $GITHUB_OUTPUT
+          echo "secrets_env=$GH_ENV" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared package
+        run: pnpm --filter @togather/shared build
+
+      - name: Build notifications email templates
+        run: pnpm --filter @togather/notifications build:email
+
+      - name: Type check Convex functions
+        run: npx convex typecheck
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: ${{ steps.env.outputs.secrets_env }}
+
+      - name: Sync secrets to Convex
+        run: |
+          chmod +x ee/scripts/sync-secrets-to-convex.sh
+          ./ee/scripts/sync-secrets-to-convex.sh ${{ steps.env.outputs.secrets_env }}
+
+      - name: Deploy to Convex
+        run: npx convex deploy
+
+      - name: Deployment summary
+        run: |
+          echo "## Convex Deployment Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment:** ${{ steps.env.outputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,1 +1,99 @@
-../../ee/deployment/workflows/deploy-landing.yml
+name: Deploy Landing Page
+
+# Auto-deploys to staging on push to main branch
+# Production deployment via manual workflow_dispatch
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/deploy-landing.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine environment
+        id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TARGET="${{ github.event.inputs.environment }}"
+          else
+            # Push to main triggers staging deploy
+            TARGET="staging"
+          fi
+
+          if [ "$TARGET" = "production" ]; then
+            echo "target=production" >> $GITHUB_OUTPUT
+            echo "secrets_env=production" >> $GITHUB_OUTPUT
+            echo "branch=main" >> $GITHUB_OUTPUT
+          else
+            echo "target=staging" >> $GITHUB_OUTPUT
+            echo "secrets_env=staging" >> $GITHUB_OUTPUT
+            echo "branch=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build landing page
+        run: pnpm --filter @togather/web build
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: ${{ steps.env.outputs.secrets_env }}
+
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
+      - name: Deploy to Cloudflare Pages
+        working-directory: apps/web
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET_BRANCH: ${{ steps.env.outputs.branch }}
+        run: wrangler pages deploy dist --project-name=togather-landing --branch=$TARGET_BRANCH
+
+      - name: Summary
+        env:
+          TARGET_ENV: ${{ steps.env.outputs.target }}
+        run: |
+          BASE_DOMAIN=$(node -e "const { DOMAIN_CONFIG } = require('./packages/shared/src/config/domain.js'); console.log(DOMAIN_CONFIG.baseDomain);")
+          echo "## 🚀 Landing Page Deployed ($TARGET_ENV)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Project:** togather-landing" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### URL" >> $GITHUB_STEP_SUMMARY
+          if [[ "$TARGET_ENV" == "staging" ]]; then
+            echo "- https://staging.$BASE_DOMAIN" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- https://$BASE_DOMAIN" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/deploy-link-preview.yml
+++ b/.github/workflows/deploy-link-preview.yml
@@ -1,1 +1,131 @@
-../../ee/deployment/workflows/deploy-link-preview.yml
+name: Deploy Link Preview Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/link-preview/**'
+      - '.github/workflows/deploy-link-preview.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+
+jobs:
+  deploy:
+    name: Deploy Cloudflare Worker
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine environment
+        id: env
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TARGET="${{ github.event.inputs.environment }}"
+          else
+            # Push to main -> staging (trunk-based development)
+            TARGET="staging"
+          fi
+          echo "target=$TARGET" >> $GITHUB_OUTPUT
+
+          # Set secrets environment
+          if [[ "$TARGET" == "production" ]]; then
+            echo "secrets_env=production" >> $GITHUB_OUTPUT
+          else
+            echo "secrets_env=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: ${{ steps.env.outputs.secrets_env }}
+
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
+      - name: Deploy Worker
+        working-directory: apps/link-preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET_ENV: ${{ steps.env.outputs.target }}
+        run: |
+          if [[ "$TARGET_ENV" == "production" ]]; then
+            echo "Deploying to production worker (togather-link-preview)..."
+            wrangler deploy
+          else
+            echo "Deploying to staging worker (togather-link-preview-staging)..."
+            wrangler deploy -c wrangler.staging.toml
+          fi
+
+      - name: Configure Convex backend for worker
+        working-directory: apps/link-preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          CONVEX_SITE_URL: ${{ env.CONVEX_SITE_URL }}
+          TARGET_ENV: ${{ steps.env.outputs.target }}
+        run: |
+          # Set the Convex site URL as a secret for the worker
+          # The worker uses this to fetch event/group data for OG tags
+          if [ -z "$CONVEX_SITE_URL" ]; then
+            echo "CONVEX_SITE_URL is not set; cannot configure link-preview Convex endpoint." >&2
+            exit 1
+          fi
+
+          # Convert .convex.cloud to .convex.site for HTTP endpoints
+          # The WebSocket API uses .cloud, but HTTP endpoints use .site
+          CONVEX_HTTP_URL="${CONVEX_SITE_URL/.convex.cloud/.convex.site}"
+          echo "Using Convex HTTP URL: $CONVEX_HTTP_URL"
+
+          if [[ "$TARGET_ENV" == "production" ]]; then
+            printf "%s" "$CONVEX_HTTP_URL" | wrangler secret put CONVEX_SITE_URL
+          else
+            printf "%s" "$CONVEX_HTTP_URL" | wrangler secret put CONVEX_SITE_URL -c wrangler.staging.toml
+          fi
+
+      - name: Summary
+        env:
+          TARGET_ENV: ${{ steps.env.outputs.target }}
+        run: |
+          echo "## Link Preview Worker Deployed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$TARGET_ENV" == "production" ]]; then
+            echo "**Environment:** Production" >> $GITHUB_STEP_SUMMARY
+            echo "**Worker:** togather-link-preview" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Routes" >> $GITHUB_STEP_SUMMARY
+            echo "- \`togather.nyc/*\` - Root domain traffic" >> $GITHUB_STEP_SUMMARY
+            echo "- \`www.togather.nyc/*\` - www subdomain" >> $GITHUB_STEP_SUMMARY
+            echo "- \`*.togather.nyc/*\` - Community subdomain traffic" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Environment:** Staging" >> $GITHUB_STEP_SUMMARY
+            echo "**Worker:** togather-link-preview-staging" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Routes" >> $GITHUB_STEP_SUMMARY
+            echo "- \`staging.togather.nyc/*\` - Staging traffic" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### OG Tag Routes" >> $GITHUB_STEP_SUMMARY
+          echo "- \`/e/:shortId\` - Event previews" >> $GITHUB_STEP_SUMMARY
+          echo "- \`/g/:shortId\` - Group previews" >> $GITHUB_STEP_SUMMARY
+          echo "- \`/nearme\` - Near me page previews" >> $GITHUB_STEP_SUMMARY
+          echo "- \`/\` - Homepage (bots only)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-mobile-update.yml
+++ b/.github/workflows/deploy-mobile-update.yml
@@ -1,1 +1,163 @@
-../../ee/deployment/workflows/deploy-mobile-update.yml
+name: Deploy Mobile Update
+
+# Auto-deploys OTA updates to staging on push to main branch
+# Production deployment is manual only (workflow_dispatch)
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Update channel'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/**'
+      - '!apps/mobile/ios/**'
+      - '!apps/mobile/android/**'
+      - '!**/*.md'
+
+jobs:
+  update:
+    name: Push OTA Update
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.channel || 'staging' }}
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine environment
+        id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CHANNEL="${{ github.event.inputs.channel }}"
+          else
+            # Push to main triggers staging deploy
+            CHANNEL="staging"
+          fi
+
+          # Map to secrets and EAS environments
+          if [ "$CHANNEL" = "production" ]; then
+            SECRETS_ENV="production"
+            EAS_ENV="production"
+          else
+            SECRETS_ENV="staging"
+            EAS_ENV="preview"
+          fi
+
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+          echo "secrets_env=$SECRETS_ENV" >> $GITHUB_OUTPUT
+          echo "eas_env=$EAS_ENV" >> $GITHUB_OUTPUT
+          echo "Deploying to: $CHANNEL (secrets: $SECRETS_ENV, EAS: $EAS_ENV)"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: ${{ steps.env.outputs.secrets_env }}
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+
+      - name: Sync secrets to EAS
+        env:
+          EAS_ENV: ${{ steps.env.outputs.eas_env }}
+          CHANNEL: ${{ steps.env.outputs.channel }}
+        run: |
+          echo "Syncing secrets to EAS $EAS_ENV environment..."
+          eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
+
+          # APP_VARIANT for staging builds (determines bundle ID)
+          if [ "$CHANNEL" = "staging" ]; then
+            eas env:create --name APP_VARIANT --value "staging" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
+          fi
+
+          echo "✓ Synced secrets to EAS $EAS_ENV environment"
+
+      - name: Check for native code changes
+        run: |
+          echo "Checking if native code has changed..."
+          node scripts/check-fingerprint.js
+
+          # If fingerprint check fails, it means native code changed
+          # and we need a new build, not an OTA update
+          if [ $? -ne 0 ]; then
+            echo "❌ Native code has changed! Cannot push OTA update."
+            echo "   A new native build is required: eas build --platform all"
+            exit 1
+          fi
+
+          echo "✅ Fingerprint matches - safe to push OTA update"
+
+      - name: Generate OTA version
+        id: ota_version
+        run: |
+          # Get runtime version from app.config.js
+          RUNTIME_VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+
+          # Generate date and time in UTC (MMDDYY.HHMM format)
+          DATE_PART=$(date -u +"%m%d%y")
+          TIME_PART=$(date -u +"%H%M")
+
+          # Construct full OTA version: X.Y.Z.MMDDYY.HHMM
+          OTA_VERSION="${RUNTIME_VERSION}.${DATE_PART}.${TIME_PART}"
+
+          echo "ota_version=$OTA_VERSION" >> $GITHUB_OUTPUT
+          echo "Generated OTA version: $OTA_VERSION"
+
+      - name: Publish OTA Update
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message || '' }}
+          UPDATE_CHANNEL: ${{ steps.env.outputs.channel }}
+          EAS_ENV: ${{ steps.env.outputs.eas_env }}
+          OTA_VERSION: ${{ steps.ota_version.outputs.ota_version }}
+        run: |
+          # Extract only the first line (subject) of the commit message
+          if [ -n "$COMMIT_MSG" ]; then
+            COMMIT_SUBJECT=$(echo "$COMMIT_MSG" | head -n 1)
+          else
+            COMMIT_SUBJECT="Manual OTA deployment v$OTA_VERSION"
+          fi
+          echo "Publishing to channel: $UPDATE_CHANNEL"
+          echo "OTA Version: $OTA_VERSION"
+          eas update --channel "$UPDATE_CHANNEL" --environment $EAS_ENV --message "$COMMIT_SUBJECT" --non-interactive
+
+      - name: Deployment summary
+        env:
+          CHANNEL: ${{ steps.env.outputs.channel }}
+          OTA_VERSION: ${{ steps.ota_version.outputs.ota_version }}
+        run: |
+          echo "## OTA Update Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Channel:** $CHANNEL" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** $OTA_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-slack-bot.yml
+++ b/.github/workflows/deploy-slack-bot.yml
@@ -1,1 +1,79 @@
-../../ee/deployment/workflows/deploy-slack-bot.yml
+# Deploy Slack Service Bot to Convex (Production)
+#
+# Manual workflow_dispatch only — deploys directly to production.
+# This workflow is specific to the FOUNT service planning bot.
+#
+# Prerequisites:
+# - SLACK_BOT_TOKEN must be set in 1Password production environment
+# - SLACK_SIGNING_SECRET must be set in 1Password production environment
+# - OPENAI_SECRET_KEY must be set in 1Password production environment
+
+name: Deploy Slack Bot
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-slack-bot
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Slack Bot to Production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared package
+        run: pnpm --filter @togather/shared build
+
+      - name: Build notifications email templates
+        run: pnpm --filter @togather/notifications build:email
+
+      - name: Type check Convex functions
+        run: npx convex typecheck
+
+      - name: Run Slack bot tests
+        run: cd apps/convex && pnpm test __tests__/slackServiceBot.test.ts
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: production
+
+      - name: Sync secrets to Convex
+        run: |
+          chmod +x ee/scripts/sync-secrets-to-convex.sh
+          ./ee/scripts/sync-secrets-to-convex.sh production
+
+      - name: Deploy to Convex
+        run: npx convex deploy
+
+      - name: Deployment summary
+        run: |
+          echo "## Slack Bot Deployment Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment:** production" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "1. Configure Slack Events API URL: \`https://<deployment>.convex.site/slack/events\`" >> $GITHUB_STEP_SUMMARY
+          echo "2. Manually trigger \`createWeeklyThreads\` in Convex dashboard to test" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,1 +1,613 @@
-../../ee/deployment/workflows/deploy-to-production.yml
+name: Deploy to Production
+
+# Manual workflow to deploy to production
+# This is the ONLY way to deploy to production - ensures thorough testing first
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "deploy" to confirm you have tested staging'
+        required: true
+        type: string
+
+jobs:
+  # Validate confirmation and detect what needs to be deployed
+  validate-and-detect:
+    name: Validate & Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      convex_changed: ${{ steps.detect.outputs.convex_changed }}
+      mobile_native_changed: ${{ steps.detect.outputs.mobile_native_changed }}
+      mobile_js_changed: ${{ steps.detect.outputs.mobile_js_changed }}
+      version: ${{ steps.detect.outputs.version }}
+      changes_summary: ${{ steps.detect.outputs.changes_summary }}
+
+    steps:
+      - name: Validate confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "deploy" ]; then
+            echo "❌ You must type 'deploy' to confirm deployment"
+            echo "   This ensures you have tested the staging environment first."
+            exit 1
+          fi
+          echo "✅ Confirmation received"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for change detection
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Detect changes since last production deploy
+        id: detect
+        run: |
+          echo "Detecting changes to deploy..."
+
+          # Get the last production deployment tag or commit
+          # For now, we'll deploy everything that's on main
+          # In the future, you could track the last deployed commit
+
+          # Check for Convex changes
+          echo "convex_changed=true" >> $GITHUB_OUTPUT
+          echo "✓ Will deploy Convex"
+
+          # Check for mobile changes - detect based on fingerprint comparison
+          # Run fingerprint check to see if native code changed since last build
+          cd apps/mobile
+          if node scripts/check-fingerprint.js 2>/dev/null; then
+            # Fingerprint matches - only JS changes, safe for OTA
+            echo "mobile_native_changed=false" >> $GITHUB_OUTPUT
+            echo "mobile_js_changed=true" >> $GITHUB_OUTPUT
+            echo "✓ Fingerprint unchanged - will deploy mobile OTA"
+          else
+            # Fingerprint changed or doesn't exist - need native build
+            echo "mobile_native_changed=true" >> $GITHUB_OUTPUT
+            echo "mobile_js_changed=false" >> $GITHUB_OUTPUT
+            echo "✓ Fingerprint changed - will build mobile native"
+          fi
+          cd ../..
+
+          # Get version - must run from apps/mobile for proper package resolution
+          VERSION=$(cd apps/mobile && node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Create summary
+          echo "changes_summary=Convex, Mobile" >> $GITHUB_OUTPUT
+
+      - name: Show deployment plan
+        run: |
+          echo "## Deployment Plan" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.detect.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Convex | ${{ steps.detect.outputs.convex_changed == 'true' && '🔄 Will deploy' || '⏭️ No changes' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Mobile Native | ${{ steps.detect.outputs.mobile_native_changed == 'true' && '🔄 Will build & submit' || '⏭️ No changes' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Mobile OTA | ${{ steps.detect.outputs.mobile_js_changed == 'true' && '🔄 Will deploy' || '⏭️ No changes' }} |" >> $GITHUB_STEP_SUMMARY
+
+  # Deploy Convex to production
+  deploy-convex:
+    name: Deploy Convex
+    needs: validate-and-detect
+    if: needs.validate-and-detect.outputs.convex_changed == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ vars.CONVEX_PRODUCTION_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared package
+        run: pnpm --filter @togather/shared build
+
+      - name: Build notifications email templates
+        run: pnpm --filter @togather/notifications build:email
+
+      - name: Type check Convex functions
+        run: npx convex typecheck
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: production
+
+      - name: Sync secrets to Convex
+        run: |
+          chmod +x ee/scripts/sync-secrets-to-convex.sh
+          ./ee/scripts/sync-secrets-to-convex.sh production
+
+      - name: Deploy to Convex
+        run: npx convex deploy
+
+  # Build and submit mobile native app
+  deploy-mobile-native:
+    name: Build Mobile Native
+    needs: validate-and-detect
+    if: needs.validate-and-detect.outputs.mobile_native_changed == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://apps.apple.com/app/togather
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate version
+        working-directory: apps/mobile
+        run: |
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          APP_JSON_VERSION=$(node -p "require('./app.json').expo.version")
+
+          if [ "$VERSION" != "$APP_JSON_VERSION" ]; then
+            echo "❌ Version mismatch!"
+            exit 1
+          fi
+          echo "✅ Version validated: $VERSION"
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: production
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+
+      - name: Sync secrets to EAS
+        working-directory: apps/mobile
+        run: |
+          # Use eas env:create (eas secret:create is deprecated)
+          # Production builds use the production EAS environment
+          eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment production --visibility plaintext --force --non-interactive || true
+          # Convex URL from 1Password
+          eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
+          # Project ID for push notifications (constant across all environments)
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment production --visibility plaintext --force --non-interactive || true
+          echo "✓ Synced secrets to EAS production environment"
+
+      - name: Build iOS
+        working-directory: apps/mobile
+        run: eas build --platform ios --profile production --non-interactive
+
+      - name: Build Android
+        working-directory: apps/mobile
+        run: eas build --platform android --profile production --non-interactive
+
+      - name: Submit to App Store
+        working-directory: apps/mobile
+        run: eas submit --platform ios --latest --non-interactive
+
+      # Upload iOS manifest to R2 for version checking
+      - name: Upload iOS manifest to R2
+        working-directory: apps/mobile
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
+        run: |
+          # Get version from code
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "Creating iOS production manifest for version $VERSION..."
+
+          # Install AWS CLI for R2 (S3-compatible)
+          pip install awscli --quiet
+
+          # Override AWS credentials with R2 credentials
+          # (env vars take precedence over aws configure)
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Create and upload iOS production manifest
+          # availableAfter is set to 48 hours from now to allow App Store review
+          # NOTE: After app is approved, you can manually update the manifest to make
+          # the update available sooner by re-uploading with an earlier availableAfter
+          mkdir -p ./build-output
+          AVAILABLE_AFTER=$(date -u -d '+48 hours' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+48H +%Y-%m-%dT%H:%M:%SZ)
+          cat > ./build-output/ios-manifest.json << EOF
+          {
+            "version": "${VERSION}",
+            "platform": "ios",
+            "environment": "production",
+            "releaseDate": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "availableAfter": "${AVAILABLE_AFTER}",
+            "downloadUrl": "https://apps.apple.com/us/app/togather-life-in-community/id6756286011",
+            "minSupportedVersion": "1.0.0"
+          }
+          EOF
+
+          aws s3 cp ./build-output/ios-manifest.json "s3://${R2_BUCKET_NAME}/releases/ios/production/manifest.json" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/json"
+          echo "✓ Uploaded iOS production manifest.json"
+
+      - name: Submit to Play Store
+        working-directory: apps/mobile
+        run: eas submit --platform android --latest --non-interactive
+
+      # Build APK for website distribution (separate from AAB for Play Store)
+      - name: Build Android APK for website
+        working-directory: apps/mobile
+        run: eas build --platform android --profile production-apk --non-interactive
+
+      # Upload Android APK to R2 for website distribution
+      - name: Upload Android APK to R2
+        working-directory: apps/mobile
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
+        run: |
+          # Get version from code
+          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          echo "Uploading production Android APK version $VERSION to R2..."
+
+          # Download the latest Android APK from EAS (the production-apk build we just created)
+          mkdir -p ./build-output
+          # Get the artifact URL from the latest build
+          APK_URL=$(eas build:list --platform android --build-profile production-apk --limit 1 --json --non-interactive | jq -r '.[0].artifacts.applicationArchiveUrl')
+          echo "Downloading APK from: $APK_URL"
+          curl -fL -o ./build-output/togather.apk "$APK_URL"
+
+          # Get file size for manifest
+          FILE_SIZE=$(stat -c%s ./build-output/togather.apk 2>/dev/null || stat -f%z ./build-output/togather.apk)
+          echo "APK size: $FILE_SIZE bytes"
+
+          # Install AWS CLI for R2 (S3-compatible)
+          pip install awscli --quiet
+
+          # Override AWS credentials with R2 credentials
+          # (env vars take precedence over aws configure)
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Upload versioned APK
+          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-${VERSION}.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-${VERSION}.apk"
+
+          # Upload as latest
+          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-latest.apk" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/vnd.android.package-archive"
+          echo "✓ Uploaded togather-latest.apk"
+
+          # Create and upload manifest
+          # Android APKs are uploaded directly to R2, so available immediately (no review period)
+          RELEASE_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          cat > ./build-output/manifest.json << EOF
+          {
+            "version": "${VERSION}",
+            "platform": "android",
+            "environment": "production",
+            "releaseDate": "${RELEASE_DATE}",
+            "availableAfter": "${RELEASE_DATE}",
+            "fileSize": ${FILE_SIZE},
+            "latestUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-latest.apk",
+            "downloadUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-${VERSION}.apk",
+            "minSupportedVersion": "1.0.0"
+          }
+          EOF
+          aws s3 cp ./build-output/manifest.json "s3://${R2_BUCKET_NAME}/releases/android/production/manifest.json" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type "application/json"
+          echo "✓ Uploaded manifest.json"
+
+          echo "Production Android APK available at: ${IMAGE_CDN_URL}/releases/android/production/togather-latest.apk"
+
+  # Deploy mobile OTA update
+  deploy-mobile-ota:
+    name: Deploy Mobile OTA
+    needs: validate-and-detect
+    # mobile_js_changed is only true when fingerprint didn't change (no native changes)
+    if: needs.validate-and-detect.outputs.mobile_js_changed == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: production
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+
+      - name: Sync secrets to EAS
+        working-directory: apps/mobile
+        run: |
+          # Sync secrets and config to EAS production environment
+          # Required because eas update --environment reads from EAS env vars for app.config.js
+          eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment production --visibility plaintext --force --non-interactive || true
+          # Convex URL from 1Password
+          eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
+          # Project ID for push notifications (constant across all environments)
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment production --visibility plaintext --force --non-interactive || true
+          echo "✓ Synced secrets to EAS production environment"
+
+      - name: Verify fingerprint matches
+        working-directory: apps/mobile
+        run: |
+          echo "Verifying native code hasn't changed..."
+          node scripts/check-fingerprint.js
+          echo "✅ Fingerprint verified - safe for OTA"
+
+      - name: Generate OTA version
+        id: ota_version
+        working-directory: apps/mobile
+        run: |
+          RUNTIME_VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          DATE_PART=$(date -u +"%m%d%y")
+          TIME_PART=$(date -u +"%H%M")
+          OTA_VERSION="${RUNTIME_VERSION}.${DATE_PART}.${TIME_PART}"
+          echo "ota_version=$OTA_VERSION" >> $GITHUB_OUTPUT
+          echo "OTA Version: $OTA_VERSION"
+
+      - name: Publish OTA Update
+        working-directory: apps/mobile
+        env:
+          OTA_VERSION: ${{ steps.ota_version.outputs.ota_version }}
+        run: |
+          echo "Publishing production OTA update..."
+          # --environment production ensures EAS env vars are available when evaluating app.config.js
+          eas update --channel production --environment production --message "Production release $OTA_VERSION" --non-interactive
+
+  # Deploy landing page to production
+  deploy-landing:
+    name: Deploy Landing Page
+    needs: validate-and-detect
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://togather.nyc
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build landing page
+        run: pnpm --filter @togather/web build
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: production
+
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
+      - name: Deploy to Cloudflare Pages
+        working-directory: apps/web
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy dist --project-name=togather-landing --branch=main
+
+  # Deploy link preview worker to production
+  deploy-link-preview:
+    name: Deploy Link Preview Worker
+    needs: validate-and-detect
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: production
+
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
+      - name: Deploy Worker
+        working-directory: apps/link-preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler deploy
+
+      - name: Configure Convex backend for worker
+        working-directory: apps/link-preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          CONVEX_SITE_URL: ${{ env.CONVEX_SITE_URL }}
+        run: |
+          # Set the Convex site URL as a secret for the worker
+          if [ -z "$CONVEX_SITE_URL" ]; then
+            echo "CONVEX_SITE_URL is not set; cannot configure link-preview Convex endpoint." >&2
+            exit 1
+          fi
+
+          # Convert .convex.cloud to .convex.site for HTTP endpoints
+          CONVEX_HTTP_URL="${CONVEX_SITE_URL/.convex.cloud/.convex.site}"
+          echo "Using Convex HTTP URL: $CONVEX_HTTP_URL"
+
+          printf "%s" "$CONVEX_HTTP_URL" | wrangler secret put CONVEX_SITE_URL
+
+  # Summary after deployments
+  summary:
+    name: Deployment Summary
+    needs: [validate-and-detect, deploy-convex, deploy-mobile-native, deploy-mobile-ota, deploy-landing, deploy-link-preview]
+    if: always() && needs.validate-and-detect.result == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check deployment results
+        run: |
+          # Check if any deployments that were supposed to run failed
+          CONVEX_RESULT="${{ needs.deploy-convex.result }}"
+          NATIVE_RESULT="${{ needs.deploy-mobile-native.result }}"
+          OTA_RESULT="${{ needs.deploy-mobile-ota.result }}"
+          LANDING_RESULT="${{ needs.deploy-landing.result }}"
+          LINK_PREVIEW_RESULT="${{ needs.deploy-link-preview.result }}"
+
+          FAILED=false
+
+          if [ "${{ needs.validate-and-detect.outputs.convex_changed }}" == "true" ] && [ "$CONVEX_RESULT" != "success" ]; then
+            echo "❌ Convex deployment failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.validate-and-detect.outputs.mobile_native_changed }}" == "true" ] && [ "$NATIVE_RESULT" != "success" ]; then
+            echo "❌ Mobile native deployment failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.validate-and-detect.outputs.mobile_js_changed }}" == "true" ] && [ "$OTA_RESULT" != "success" ]; then
+            echo "❌ Mobile OTA deployment failed"
+            FAILED=true
+          fi
+
+          if [ "$LANDING_RESULT" != "success" ]; then
+            echo "❌ Landing page deployment failed"
+            FAILED=true
+          fi
+
+          if [ "$LINK_PREVIEW_RESULT" != "success" ]; then
+            echo "❌ Link preview worker deployment failed"
+            FAILED=true
+          fi
+
+          if [ "$FAILED" == "true" ]; then
+            echo ""
+            echo "Some deployments failed. Please check the logs and retry."
+            exit 1
+          fi
+
+          echo "✅ All required deployments succeeded"
+
+      - name: Summary
+        run: |
+          echo "## Production Deployment Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ needs.validate-and-detect.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Deployed Components" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Convex | ${{ needs.deploy-convex.result == 'success' && '✅ Deployed' || (needs.validate-and-detect.outputs.convex_changed == 'true' && '❌ Failed' || '⏭️ Skipped') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Mobile Native | ${{ needs.deploy-mobile-native.result == 'success' && '✅ Submitted' || (needs.validate-and-detect.outputs.mobile_native_changed == 'true' && '❌ Failed' || '⏭️ Skipped') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Mobile OTA | ${{ needs.deploy-mobile-ota.result == 'success' && '✅ Published' || (needs.validate-and-detect.outputs.mobile_js_changed == 'true' && '❌ Failed' || '⏭️ Skipped') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Landing Page | ${{ needs.deploy-landing.result == 'success' && '✅ Deployed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Link Preview | ${{ needs.deploy-link-preview.result == 'success' && '✅ Deployed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### What's Next" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.deploy-mobile-native.result }}" == "success" ]; then
+            echo "- **iOS**: Wait for App Store review (~24-48 hours)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Android**: Wait for Play Store review (~hours to days)" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ needs.deploy-mobile-ota.result }}" == "success" ]; then
+            echo "- **OTA**: Users will receive the update within minutes" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ needs.deploy-convex.result }}" == "success" ]; then
+            echo "- **Convex**: Deployed to production" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ needs.deploy-landing.result }}" == "success" ]; then
+            echo "- **Landing Page**: Live at https://togather.nyc" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,1 +1,176 @@
-../../ee/deployment/workflows/deploy-web.yml
+name: Deploy Web
+
+# Auto-deploys to staging on push to main branch
+# Production deployment is manual only (workflow_dispatch)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/shared/**'
+      - '.github/workflows/deploy-web.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - preview
+          - staging
+          - production
+
+jobs:
+  deploy:
+    name: Deploy Web App
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+    defaults:
+      run:
+        working-directory: apps/mobile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine environment
+        id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TARGET="${{ github.event.inputs.environment }}"
+          else
+            # Push to main triggers staging deploy
+            TARGET="staging"
+          fi
+
+          if [ "$TARGET" = "production" ]; then
+            echo "target=production" >> $GITHUB_OUTPUT
+            echo "secrets_env=production" >> $GITHUB_OUTPUT
+          else
+            echo "target=staging" >> $GITHUB_OUTPUT
+            echo "secrets_env=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: ${{ steps.env.outputs.secrets_env }}
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+
+      - name: Export web app
+        env:
+          EXPO_PUBLIC_CONVEX_URL: ${{ env.CONVEX_SITE_URL }}
+        run: npx expo export --platform web
+
+      - name: Deploy to EAS Hosting
+        id: deploy
+        env:
+          TARGET_ENV: ${{ steps.env.outputs.target }}
+        run: |
+          # Determine environment and flags for deployment
+          # TARGET_ENV is set by the "Determine environment" step:
+          # - Push to main -> staging
+          # - workflow_dispatch -> selected environment
+          if [[ "$TARGET_ENV" == "production" ]]; then
+            PROD_FLAG="--prod"
+            ENV_FLAG="--environment=production"
+          else
+            # Staging or preview deployments
+            PROD_FLAG=""
+            ENV_FLAG="--environment=preview"
+          fi
+
+          echo "Deploying with flags: $PROD_FLAG $ENV_FLAG (target: $TARGET_ENV)"
+
+          # Deploy and save JSON output to file (stderr goes to console)
+          npx eas-cli deploy $PROD_FLAG $ENV_FLAG --json --non-interactive > deploy_output.json || true
+
+          echo "Deploy output:"
+          cat deploy_output.json
+
+          # Extract deployment identifier using jq (more reliable than grep)
+          DEPLOYMENT_ID=$(cat deploy_output.json | jq -r '.identifier // empty' 2>/dev/null)
+
+          # Fallback to grep if jq fails
+          if [ -z "$DEPLOYMENT_ID" ]; then
+            DEPLOYMENT_ID=$(grep -o '"identifier":"[^"]*"' deploy_output.json | head -1 | cut -d'"' -f4)
+          fi
+
+          echo "Extracted deployment ID: $DEPLOYMENT_ID"
+          echo "deployment_id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+
+          if [ -z "$DEPLOYMENT_ID" ]; then
+            echo "❌ Failed to get deployment ID"
+            echo "Full output:"
+            cat deploy_output.json
+            exit 1
+          fi
+
+          echo "✅ Deployed with ID: $DEPLOYMENT_ID"
+
+      - name: Update subdomain aliases
+        env:
+          TARGET_ENV: ${{ steps.env.outputs.target }}
+        run: |
+          DEPLOYMENT_ID="${{ steps.deploy.outputs.deployment_id }}"
+
+          if [[ "$TARGET_ENV" == "staging" ]]; then
+            # Staging gets its own subdomain
+            ALIASES=("staging")
+          else
+            # Production gets the main aliases
+            # Note: Root domain (@) is handled by DNS/Cloudflare routing, not EAS aliases
+            ALIASES=("www" "app" "fount" "demo-community")
+          fi
+
+          echo "🔗 Updating subdomain aliases to deployment: $DEPLOYMENT_ID"
+
+          for ALIAS in "${ALIASES[@]}"; do
+            echo "   Updating alias: $ALIAS"
+            npx eas-cli deploy:alias --alias "$ALIAS" --id "$DEPLOYMENT_ID" --non-interactive
+          done
+
+          echo "✅ All aliases updated"
+
+      - name: Summary
+        working-directory: .
+        env:
+          TARGET_ENV: ${{ steps.env.outputs.target }}
+        run: |
+          # Get domain from config
+          BASE_DOMAIN=$(node -e "const { DOMAIN_CONFIG } = require('./packages/shared/src/config/domain.js'); console.log(DOMAIN_CONFIG.baseDomain);")
+          echo "## 🎉 Deployment Complete ($TARGET_ENV)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Deployment ID:** \`${{ steps.deploy.outputs.deployment_id }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### URLs" >> $GITHUB_STEP_SUMMARY
+          if [[ "$TARGET_ENV" == "staging" ]]; then
+            echo "- Staging: https://staging.$BASE_DOMAIN" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- App: https://app.$BASE_DOMAIN" >> $GITHUB_STEP_SUMMARY
+            echo "- Fount: https://fount.$BASE_DOMAIN" >> $GITHUB_STEP_SUMMARY
+            echo "- Demo: https://demo-community.$BASE_DOMAIN" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/terraform-dns.yml
+++ b/.github/workflows/terraform-dns.yml
@@ -1,1 +1,104 @@
-../../ee/deployment/workflows/terraform-dns.yml
+name: Terraform DNS
+
+# Uses CLOUDFLARE_API_TOKEN from 1Password (production environment)
+# Token requires Zone:DNS:Edit and Zone:Zone:Read permissions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/cloudflare/**'
+  pull_request:
+    paths:
+      - 'infrastructure/cloudflare/**'
+
+# Ensure only one Terraform run at a time to prevent state conflicts
+concurrency:
+  group: terraform-dns
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: infrastructure/cloudflare
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Load secrets from 1Password
+        uses: ./.github/actions/load-secrets
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          environment: production
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: true
+          cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color
+        env:
+          TF_VAR_cloudflare_api_token: ${{ env.CLOUDFLARE_API_TOKEN }}
+        continue-on-error: true
+
+      # Post plan output as PR comment
+      - name: Comment Plan on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format 🖌 \`${{ steps.fmt.outcome }}\`
+            #### Terraform Init ⚙️ \`${{ steps.init.outcome }}\`
+            #### Terraform Validate 🤖 \`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📖 \`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`terraform
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      # Only apply on push to main
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve
+        env:
+          TF_VAR_cloudflare_api_token: ${{ env.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

- GitHub Actions doesn't follow symlinks for workflow files in `.github/workflows/`
- All 10 workflow symlinks (pointing to `ee/deployment/workflows/`) replaced with real file copies
- `.github/actions/load-secrets` symlink also replaced with real directory
- The `ee/` directory retains source-of-truth copies under ELv2 license

This fixes all deployment workflows that failed after the previous merge.

## Test plan

- [x] All workflow files are real files (not symlinks)
- [ ] CI passes
- [ ] Staging deployments trigger on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)