### PR TITLE
Fix: Move EXPO_TOKEN to required secrets

### DIFF
--- a/.github/actions/load-secrets/action.yml
+++ b/.github/actions/load-secrets/action.yml
@@ -37,6 +37,7 @@ runs:
         SLACK_BOT_TOKEN: op://Togather/SLACK_BOT_TOKEN/${{ inputs.environment }}
         SLACK_SIGNING_SECRET: op://Togather/SLACK_SIGNING_SECRET/${{ inputs.environment }}
         OPENAI_SECRET_KEY: op://Togather/OPENAI_SECRET_KEY/${{ inputs.environment }}
+        EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
       with:
         export-env: true
 
@@ -45,7 +46,6 @@ runs:
       continue-on-error: true
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
-        EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
         CLOUDFLARE_API_TOKEN: op://Togather/CLOUDFLARE_API_TOKEN/${{ inputs.environment }}
         TF_API_TOKEN: op://Togather/TF_API_TOKEN/${{ inputs.environment }}
         SENTRY_AUTH_TOKEN: op://Togather/SENTRY_AUTH_TOKEN/${{ inputs.environment }}

--- a/ee/actions/load-secrets/action.yml
+++ b/ee/actions/load-secrets/action.yml
@@ -37,6 +37,7 @@ runs:
         SLACK_BOT_TOKEN: op://Togather/SLACK_BOT_TOKEN/${{ inputs.environment }}
         SLACK_SIGNING_SECRET: op://Togather/SLACK_SIGNING_SECRET/${{ inputs.environment }}
         OPENAI_SECRET_KEY: op://Togather/OPENAI_SECRET_KEY/${{ inputs.environment }}
+        EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
       with:
         export-env: true
 
@@ -45,7 +46,6 @@ runs:
       continue-on-error: true
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
-        EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
         CLOUDFLARE_API_TOKEN: op://Togather/CLOUDFLARE_API_TOKEN/${{ inputs.environment }}
         TF_API_TOKEN: op://Togather/TF_API_TOKEN/${{ inputs.environment }}
         SENTRY_AUTH_TOKEN: op://Togather/SENTRY_AUTH_TOKEN/${{ inputs.environment }}


### PR DESCRIPTION
## Summary
- Move `EXPO_TOKEN` from optional secrets batch to required common secrets in the 1Password load-secrets action
- The optional secrets section uses `continue-on-error: true`, which silently skips ALL secrets in the batch if any one fails (e.g., `IMAGE_CDN_URL` not yet configured)
- This caused Mobile OTA and Web deploys to fail with "An Expo user account is required"

## Test plan
- [ ] Verify Mobile OTA staging deploy succeeds
- [ ] Verify Web staging deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)