### PR TITLE
Fix: Export EAS_PROJECT_ID env var in deploy workflows

### DIFF
--- a/.github/workflows/build-mobile-native.yml
+++ b/.github/workflows/build-mobile-native.yml
@@ -93,6 +93,8 @@ jobs:
     if: needs.detect-native-change.outputs.native_changed == 'true'
     runs-on: ubuntu-latest
     environment: staging
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -38,6 +38,8 @@ jobs:
     name: Build Mobile App
     runs-on: ubuntu-latest
     environment: production
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-mobile-update.yml
+++ b/.github/workflows/deploy-mobile-update.yml
@@ -28,6 +28,8 @@ jobs:
     name: Push OTA Update
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.channel || 'staging' }}
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -160,6 +160,8 @@ jobs:
     environment:
       name: production
       url: https://apps.apple.com/app/togather
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -362,6 +364,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -27,6 +27,8 @@ jobs:
     name: Deploy Web App
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'staging' }}
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile

--- a/ee/deployment/workflows/build-mobile-native.yml
+++ b/ee/deployment/workflows/build-mobile-native.yml
@@ -93,6 +93,8 @@ jobs:
     if: needs.detect-native-change.outputs.native_changed == 'true'
     runs-on: ubuntu-latest
     environment: staging
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code

--- a/ee/deployment/workflows/build-mobile.yml
+++ b/ee/deployment/workflows/build-mobile.yml
@@ -38,6 +38,8 @@ jobs:
     name: Build Mobile App
     runs-on: ubuntu-latest
     environment: production
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code

--- a/ee/deployment/workflows/deploy-mobile-update.yml
+++ b/ee/deployment/workflows/deploy-mobile-update.yml
@@ -28,6 +28,8 @@ jobs:
     name: Push OTA Update
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.channel || 'staging' }}
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile

--- a/ee/deployment/workflows/deploy-to-production.yml
+++ b/ee/deployment/workflows/deploy-to-production.yml
@@ -160,6 +160,8 @@ jobs:
     environment:
       name: production
       url: https://apps.apple.com/app/togather
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -362,6 +364,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code

--- a/ee/deployment/workflows/deploy-web.yml
+++ b/ee/deployment/workflows/deploy-web.yml
@@ -27,6 +27,8 @@ jobs:
     name: Deploy Web App
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'staging' }}
+    env:
+      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile


### PR DESCRIPTION
## Summary
- Add `EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}` as a job-level env var in all workflows that run EAS commands
- `app.config.js` reads `process.env.EAS_PROJECT_ID` to set the Expo project ID — without it, the hardcoded fallback ID (owned by the wrong account) causes "Owner does not match" errors
- Affected workflows: `deploy-mobile-update`, `deploy-web`, `build-mobile`, `build-mobile-native`, `deploy-to-production`

## Required action
After merging, add the `EAS_PROJECT_ID` repository variable in GitHub:
```
Settings → Secrets and variables → Actions → Variables → New repository variable
Name: EAS_PROJECT_ID
Value: <your togathernyc EAS project ID>
```

## Test plan
- [ ] Add `EAS_PROJECT_ID` GitHub variable
- [ ] Re-trigger Mobile OTA staging deploy
- [ ] Re-trigger Web staging deploy
- [ ] Verify both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)