### PR TITLE
Load EAS_PROJECT_ID from 1Password instead of GitHub variables

### DIFF
--- a/.github/actions/load-secrets/action.yml
+++ b/.github/actions/load-secrets/action.yml
@@ -38,6 +38,7 @@ runs:
         SLACK_SIGNING_SECRET: op://Togather/SLACK_SIGNING_SECRET/${{ inputs.environment }}
         OPENAI_SECRET_KEY: op://Togather/OPENAI_SECRET_KEY/${{ inputs.environment }}
         EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
+        EAS_PROJECT_ID: op://Togather/EAS_PROJECT_ID/${{ inputs.environment }}
       with:
         export-env: true
 

--- a/.github/workflows/build-mobile-native.yml
+++ b/.github/workflows/build-mobile-native.yml
@@ -93,8 +93,6 @@ jobs:
     if: needs.detect-native-change.outputs.native_changed == 'true'
     runs-on: ubuntu-latest
     environment: staging
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -136,7 +134,7 @@ jobs:
           # Convex URL from 1Password
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment preview --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment preview --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment preview --visibility plaintext --force --non-interactive || true
           # Sentry auth token for source map uploads during native builds
           eas env:create --name SENTRY_AUTH_TOKEN --value "$SENTRY_AUTH_TOKEN" --environment preview --visibility sensitive --force --non-interactive || true
           # Sentry DSN for error tracking at runtime

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -38,8 +38,6 @@ jobs:
     name: Build Mobile App
     runs-on: ubuntu-latest
     environment: production
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -85,7 +83,7 @@ jobs:
           # Convex URL from 1Password (already loaded per environment)
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
           # Sentry auth token for source map uploads during native builds
           eas env:create --name SENTRY_AUTH_TOKEN --value "$SENTRY_AUTH_TOKEN" --environment "$EAS_ENV" --visibility sensitive --force --non-interactive || true
           # Sentry DSN for error tracking at runtime

--- a/.github/workflows/deploy-mobile-update.yml
+++ b/.github/workflows/deploy-mobile-update.yml
@@ -28,8 +28,6 @@ jobs:
     name: Push OTA Update
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.channel || 'staging' }}
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile
@@ -96,7 +94,7 @@ jobs:
           echo "Syncing secrets to EAS $EAS_ENV environment..."
           eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
 
           # APP_VARIANT for staging builds (determines bundle ID)
           if [ "$CHANNEL" = "staging" ]; then

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -160,8 +160,6 @@ jobs:
     environment:
       name: production
       url: https://apps.apple.com/app/togather
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -214,7 +212,7 @@ jobs:
           # Convex URL from 1Password
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment production --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment production --visibility plaintext --force --non-interactive || true
           echo "✓ Synced secrets to EAS production environment"
 
       - name: Build iOS
@@ -364,8 +362,6 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -406,7 +402,7 @@ jobs:
           # Convex URL from 1Password
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment production --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment production --visibility plaintext --force --non-interactive || true
           echo "✓ Synced secrets to EAS production environment"
 
       - name: Verify fingerprint matches

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -27,8 +27,6 @@ jobs:
     name: Deploy Web App
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'staging' }}
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile

--- a/ee/actions/load-secrets/action.yml
+++ b/ee/actions/load-secrets/action.yml
@@ -38,6 +38,7 @@ runs:
         SLACK_SIGNING_SECRET: op://Togather/SLACK_SIGNING_SECRET/${{ inputs.environment }}
         OPENAI_SECRET_KEY: op://Togather/OPENAI_SECRET_KEY/${{ inputs.environment }}
         EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
+        EAS_PROJECT_ID: op://Togather/EAS_PROJECT_ID/${{ inputs.environment }}
       with:
         export-env: true
 

--- a/ee/deployment/workflows/build-mobile-native.yml
+++ b/ee/deployment/workflows/build-mobile-native.yml
@@ -93,8 +93,6 @@ jobs:
     if: needs.detect-native-change.outputs.native_changed == 'true'
     runs-on: ubuntu-latest
     environment: staging
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -136,7 +134,7 @@ jobs:
           # Convex URL from 1Password
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment preview --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment preview --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment preview --visibility plaintext --force --non-interactive || true
           # Sentry auth token for source map uploads during native builds
           eas env:create --name SENTRY_AUTH_TOKEN --value "$SENTRY_AUTH_TOKEN" --environment preview --visibility sensitive --force --non-interactive || true
           # Sentry DSN for error tracking at runtime

--- a/ee/deployment/workflows/build-mobile.yml
+++ b/ee/deployment/workflows/build-mobile.yml
@@ -38,8 +38,6 @@ jobs:
     name: Build Mobile App
     runs-on: ubuntu-latest
     environment: production
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -85,7 +83,7 @@ jobs:
           # Convex URL from 1Password (already loaded per environment)
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
           # Sentry auth token for source map uploads during native builds
           eas env:create --name SENTRY_AUTH_TOKEN --value "$SENTRY_AUTH_TOKEN" --environment "$EAS_ENV" --visibility sensitive --force --non-interactive || true
           # Sentry DSN for error tracking at runtime

--- a/ee/deployment/workflows/deploy-mobile-update.yml
+++ b/ee/deployment/workflows/deploy-mobile-update.yml
@@ -28,8 +28,6 @@ jobs:
     name: Push OTA Update
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.channel || 'staging' }}
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile
@@ -96,7 +94,7 @@ jobs:
           echo "Syncing secrets to EAS $EAS_ENV environment..."
           eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment $EAS_ENV --visibility plaintext --force --non-interactive || true
 
           # APP_VARIANT for staging builds (determines bundle ID)
           if [ "$CHANNEL" = "staging" ]; then

--- a/ee/deployment/workflows/deploy-to-production.yml
+++ b/ee/deployment/workflows/deploy-to-production.yml
@@ -160,8 +160,6 @@ jobs:
     environment:
       name: production
       url: https://apps.apple.com/app/togather
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -214,7 +212,7 @@ jobs:
           # Convex URL from 1Password
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment production --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment production --visibility plaintext --force --non-interactive || true
           echo "✓ Synced secrets to EAS production environment"
 
       - name: Build iOS
@@ -364,8 +362,6 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
 
     steps:
       - name: Checkout code
@@ -406,7 +402,7 @@ jobs:
           # Convex URL from 1Password
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
-          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "${{ vars.EAS_PROJECT_ID }}" --environment production --visibility plaintext --force --non-interactive || true
+          eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment production --visibility plaintext --force --non-interactive || true
           echo "✓ Synced secrets to EAS production environment"
 
       - name: Verify fingerprint matches

--- a/ee/deployment/workflows/deploy-web.yml
+++ b/ee/deployment/workflows/deploy-web.yml
@@ -27,8 +27,6 @@ jobs:
     name: Deploy Web App
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'staging' }}
-    env:
-      EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
     defaults:
       run:
         working-directory: apps/mobile


### PR DESCRIPTION
## Summary
- Add `EAS_PROJECT_ID` to the 1Password load-secrets action (required secrets)
- Remove the job-level `env: EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}` from all workflows (load-secrets `export-env: true` handles this)
- Update `eas env:create` commands to use `$EAS_PROJECT_ID` shell env var instead of `${{ vars.EAS_PROJECT_ID }}`

## Required action
Add `EAS_PROJECT_ID` to the 1Password Togather vault with `staging` and `production` fields. The value is the EAS project UUID for the `togathernyc` org (find it at expo.dev project settings).

## Test plan
- [ ] Add `EAS_PROJECT_ID` to 1Password vault
- [ ] Re-trigger Mobile OTA staging deploy
- [ ] Re-trigger Web staging deploy
- [ ] Verify both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)