### PR TITLE
Fix: Set Expo owner to lilseyi to match EAS project

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -201,6 +201,6 @@ export default {
       },
       router: {}
     },
-    owner: process.env.EXPO_OWNER || "togathernyc"
+    owner: process.env.EXPO_OWNER || "lilseyi"
   }
 };

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -66,6 +66,6 @@
       "_comment_eas_projectId": "IMPORTANT: This is a static fallback. Set EAS_PROJECT_ID env var to override in app.config.js.",
       "router": {}
     },
-    "owner": "togathernyc"
+    "owner": "lilseyi"
   }
 }


### PR DESCRIPTION
## Summary
- Change `owner` from `togathernyc` to `lilseyi` in `app.config.js` and `app.json`
- The EAS project is owned by `lilseyi`, so the owner field must match to avoid "Owner does not match" errors during `eas update` and `eas deploy`

## Test plan
- [ ] Merge and re-trigger staging deploys
- [ ] Verify Mobile OTA and Web deploys succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)