### PR TITLE
Fix: Compare FINGERPRINT_HASH for native build detection

### DIFF
--- a/.github/workflows/build-mobile-native.yml
+++ b/.github/workflows/build-mobile-native.yml
@@ -78,11 +78,23 @@ jobs:
 
           echo "Comparing $BEFORE_SHA..$AFTER_SHA"
 
-          if git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -q "apps/mobile/.fingerprint"; then
-            echo "Fingerprint changed - native build required"
+          # Extract FINGERPRINT_HASH from before and after commits
+          # Only trigger a native build if the actual hash changed (not just RUNTIME_VERSION)
+          BEFORE_HASH=$(git show "$BEFORE_SHA:apps/mobile/.fingerprint" 2>/dev/null | grep "FINGERPRINT_HASH=" | cut -d= -f2)
+          AFTER_HASH=$(git show "$AFTER_SHA:apps/mobile/.fingerprint" 2>/dev/null | grep "FINGERPRINT_HASH=" | cut -d= -f2)
+
+          echo "Before FINGERPRINT_HASH: ${BEFORE_HASH:-<not found>}"
+          echo "After FINGERPRINT_HASH: ${AFTER_HASH:-<not found>}"
+
+          if [ -z "$BEFORE_HASH" ]; then
+            # No fingerprint in before commit - treat as native change
+            echo "No fingerprint in before commit - native build required"
+            echo "native_changed=true" >> $GITHUB_OUTPUT
+          elif [ "$BEFORE_HASH" != "$AFTER_HASH" ]; then
+            echo "FINGERPRINT_HASH changed - native build required"
             echo "native_changed=true" >> $GITHUB_OUTPUT
           else
-            echo "No fingerprint change - no native build required"
+            echo "FINGERPRINT_HASH unchanged ($AFTER_HASH) - only metadata changed, skipping native build"
             echo "native_changed=false" >> $GITHUB_OUTPUT
           fi
 

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -56,13 +56,11 @@
   "submit": {
     "staging": {
       "ios": {
-        "ascAppId": "ASC_STAGING_APP_ID",
         "bundleIdentifier": "life.togather.staging"
       }
     },
     "production": {
       "ios": {
-        "ascAppId": "ASC_PRODUCTION_APP_ID",
         "bundleIdentifier": "app.gatherful.mobile"
       }
     }

--- a/ee/deployment/workflows/build-mobile-native.yml
+++ b/ee/deployment/workflows/build-mobile-native.yml
@@ -78,11 +78,23 @@ jobs:
 
           echo "Comparing $BEFORE_SHA..$AFTER_SHA"
 
-          if git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -q "apps/mobile/.fingerprint"; then
-            echo "Fingerprint changed - native build required"
+          # Extract FINGERPRINT_HASH from before and after commits
+          # Only trigger a native build if the actual hash changed (not just RUNTIME_VERSION)
+          BEFORE_HASH=$(git show "$BEFORE_SHA:apps/mobile/.fingerprint" 2>/dev/null | grep "FINGERPRINT_HASH=" | cut -d= -f2)
+          AFTER_HASH=$(git show "$AFTER_SHA:apps/mobile/.fingerprint" 2>/dev/null | grep "FINGERPRINT_HASH=" | cut -d= -f2)
+
+          echo "Before FINGERPRINT_HASH: ${BEFORE_HASH:-<not found>}"
+          echo "After FINGERPRINT_HASH: ${AFTER_HASH:-<not found>}"
+
+          if [ -z "$BEFORE_HASH" ]; then
+            # No fingerprint in before commit - treat as native change
+            echo "No fingerprint in before commit - native build required"
+            echo "native_changed=true" >> $GITHUB_OUTPUT
+          elif [ "$BEFORE_HASH" != "$AFTER_HASH" ]; then
+            echo "FINGERPRINT_HASH changed - native build required"
             echo "native_changed=true" >> $GITHUB_OUTPUT
           else
-            echo "No fingerprint change - no native build required"
+            echo "FINGERPRINT_HASH unchanged ($AFTER_HASH) - only metadata changed, skipping native build"
             echo "native_changed=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Summary
- **Fixes false-positive native builds**: The staging build workflow previously triggered on any `.fingerprint` file change, including `RUNTIME_VERSION`-only bumps. Now compares the actual `FINGERPRINT_HASH` values between commits, so version-only changes don't waste ~30min of EAS build credits.
- **Removes placeholder `ascAppId` values from `eas.json`**: The submit profiles had fake `ASC_STAGING_APP_ID` / `ASC_PRODUCTION_APP_ID` strings that caused `eas submit` to fail. EAS will now auto-detect the App Store Connect app via `bundleIdentifier`.

## Test plan
- [ ] Verify: changing only `RUNTIME_VERSION` in `.fingerprint` results in `native_changed=false`
- [ ] Verify: changing `FINGERPRINT_HASH` in `.fingerprint` results in `native_changed=true`
- [ ] Verify: missing `.fingerprint` in before commit results in `native_changed=true` (safe default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)