### PR TITLE
Fix: Load missing secrets for Cloudflare deploys

### DIFF
--- a/.github/actions/load-secrets/action.yml
+++ b/.github/actions/load-secrets/action.yml
@@ -39,6 +39,9 @@ runs:
         OPENAI_SECRET_KEY: op://Togather/OPENAI_SECRET_KEY/${{ inputs.environment }}
         EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
         EAS_PROJECT_ID: op://Togather/EAS_PROJECT_ID/${{ inputs.environment }}
+        CONVEX_SITE_URL: op://Togather/CONVEX_SITE_URL/${{ inputs.environment }}
+        # IMAGE_CDN_URL is the same as R2_PUBLIC_URL (CDN in front of R2 bucket)
+        IMAGE_CDN_URL: op://Togather/R2_PUBLIC_URL/${{ inputs.environment }}
       with:
         export-env: true
 
@@ -52,8 +55,6 @@ runs:
         SENTRY_AUTH_TOKEN: op://Togather/SENTRY_AUTH_TOKEN/${{ inputs.environment }}
         EXPO_PUBLIC_MAPBOX_TOKEN: op://Togather/EXPO_PUBLIC_MAPBOX_TOKEN/${{ inputs.environment }}
         EXPO_PUBLIC_SENTRY_DSN: op://Togather/EXPO_PUBLIC_SENTRY_DSN/${{ inputs.environment }}
-        EXPO_PUBLIC_CONVEX_URL: op://Togather/EXPO_PUBLIC_CONVEX_URL/${{ inputs.environment }}
         EXPO_PUBLIC_POSTHOG_API_KEY: op://Togather/EXPO_PUBLIC_POSTHOG_API_KEY/${{ inputs.environment }}
-        IMAGE_CDN_URL: op://Togather/IMAGE_CDN_URL/${{ inputs.environment }}
       with:
         export-env: true


### PR DESCRIPTION
## Summary
- **Root cause**: The optional secrets batch in `load-secrets` failed because `EXPO_PUBLIC_CONVEX_URL` and `IMAGE_CDN_URL` don't exist as 1Password items (they were bulk-exported from Infisical in the private repo). When the batch fails, `CLOUDFLARE_API_TOKEN` also doesn't get exported, breaking landing page and link preview worker deploys.
- Adds `CONVEX_SITE_URL` to common secrets — workflows reference it but it was never loaded
- Points `IMAGE_CDN_URL` to existing `R2_PUBLIC_URL` item (same value)
- Removes `EXPO_PUBLIC_CONVEX_URL` from optional block (redundant — workflows use `$CONVEX_SITE_URL`)

## Test plan
- [ ] Re-run Deploy to Production — landing page and link preview worker should succeed
- [ ] Verify `CONVEX_SITE_URL` is available in deploy workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)