### PR TITLE
Add /issue and /contribute pages

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -823,6 +823,12 @@ function FAQSection() {
       answer:
         "Group leaders can schedule one-time or recurring meetings. Members get reminders and can RSVP directly in the app. You can even share events with non-members via a public link.",
     },
+    {
+      question: "Something is broken or I'd like something changed — what should I do?",
+      answer:
+        "We'd love to hear from you! Head over to our issue page to learn how to report a bug or request a feature. No technical skills needed — just a free GitHub account and a few minutes.",
+      link: "/issue",
+    },
   ];
 
   return (
@@ -841,7 +847,7 @@ function FAQSection() {
         {/* FAQ List */}
         <div className="space-y-4">
           {faqs.map((faq, index) => (
-            <FAQItem key={index} question={faq.question} answer={faq.answer} />
+            <FAQItem key={index} question={faq.question} answer={faq.answer} link={"link" in faq ? faq.link : undefined} />
           ))}
         </div>
       </div>
@@ -849,7 +855,7 @@ function FAQSection() {
   );
 }
 
-function FAQItem({ question, answer }: { question: string; answer: string }) {
+function FAQItem({ question, answer, link }: { question: string; answer: string; link?: string }) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -868,6 +874,11 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
       {isOpen && (
         <div className="px-6 pb-4">
           <p className="text-neutral-600">{answer}</p>
+          {link && (
+            <Link to={link} className="inline-block mt-3 text-sm font-medium text-neutral-900 underline underline-offset-2 hover:text-neutral-700">
+              Learn more &rarr;
+            </Link>
+          )}
         </div>
       )}
     </div>
@@ -984,9 +995,9 @@ function Footer() {
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/togathernyc/togather/issues" target="_blank" rel="noopener noreferrer" className="hover:text-white">
+                  <Link to="/contribute" className="hover:text-white">
                     Contribute
-                  </a>
+                  </Link>
                 </li>
               </ul>
             </div>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,8 @@ import App from './App.tsx'
 import { PrivacyPolicy } from './pages/PrivacyPolicy.tsx'
 import { TermsOfService } from './pages/TermsOfService.tsx'
 import { AndroidDownload } from './pages/AndroidDownload.tsx'
+import { Contribute } from './pages/Contribute.tsx'
+import { ReportIssue } from './pages/ReportIssue.tsx'
 import { ScrollToTop } from './components/ScrollToTop.tsx'
 
 createRoot(document.getElementById('root')!).render(
@@ -16,6 +18,8 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/" element={<App />} />
         <Route path="/android" element={<AndroidDownload />} />
         <Route path="/android-staging" element={<AndroidDownload variant="staging" />} />
+        <Route path="/contribute" element={<Contribute />} />
+        <Route path="/issue" element={<ReportIssue />} />
         <Route path="/legal/privacy" element={<PrivacyPolicy />} />
         <Route path="/legal/terms" element={<TermsOfService />} />
       </Routes>

--- a/apps/web/src/pages/Contribute.tsx
+++ b/apps/web/src/pages/Contribute.tsx
@@ -1,0 +1,233 @@
+import { Link } from "react-router-dom";
+
+const REPO_URL = "https://github.com/togathernyc/togather";
+
+export function Contribute() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto px-6 py-12">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-neutral-600 hover:text-neutral-900 mb-8"
+        >
+          <svg
+            className="w-5 h-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+          Back to Home
+        </Link>
+
+        <h1 className="text-4xl font-bold text-neutral-900 mb-3">
+          Contribute to Togather
+        </h1>
+        <p className="text-lg text-neutral-600 mb-12 leading-relaxed">
+          Togather is built by the communities that use it. Whether you write
+          code or not, there are ways you can help make it better.
+        </p>
+
+        {/* Non-technical */}
+        <section className="mb-14">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 rounded-xl bg-amber-50 border border-amber-200 flex items-center justify-center text-amber-700">
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-neutral-900">
+              Report a bug or request a feature
+            </h2>
+          </div>
+          <p className="text-neutral-600 leading-relaxed mb-6">
+            You don't need to be technical to help. If something isn't working
+            right or you have an idea for how Togather could be better, you can
+            file an issue on GitHub. We have templates that walk you through
+            exactly what to include.
+          </p>
+
+          <div className="bg-neutral-50 border border-neutral-200 rounded-2xl p-6 mb-6">
+            <h3 className="font-semibold text-neutral-900 mb-4">
+              How to file an issue
+            </h3>
+            <ol className="space-y-3 text-neutral-600">
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">1</span>
+                <span>
+                  <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer" className="text-neutral-900 font-medium underline underline-offset-2">Create a free GitHub account</a> if you don't have one.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">2</span>
+                <span>
+                  Go to our{" "}
+                  <a href={`${REPO_URL}/issues/new/choose`} target="_blank" rel="noopener noreferrer" className="text-neutral-900 font-medium underline underline-offset-2">issue page</a> and pick the right template:
+                </span>
+              </li>
+              <li className="pl-9 -mt-1">
+                <ul className="space-y-1.5 text-neutral-500">
+                  <li><strong className="text-neutral-700">Bug Report</strong> — something is broken or not working as expected</li>
+                  <li><strong className="text-neutral-700">Feature Request</strong> — you have an idea for something new</li>
+                </ul>
+              </li>
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">3</span>
+                <span>
+                  Fill in the template. The more detail the better — include screenshots if you can (you can paste them directly into the form).
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">4</span>
+                <span>Submit, and we'll take it from there.</span>
+              </li>
+            </ol>
+          </div>
+
+          <a
+            href={`${REPO_URL}/issues/new/choose`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-5 py-3 bg-neutral-900 hover:bg-neutral-800 text-white rounded-xl font-medium transition-colors"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+            </svg>
+            File an issue on GitHub
+          </a>
+        </section>
+
+        {/* Technical */}
+        <section className="mb-14">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 rounded-xl bg-violet-50 border border-violet-200 flex items-center justify-center text-violet-700">
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="16 18 22 12 16 6" />
+                <polyline points="8 6 2 12 8 18" />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-neutral-900">
+              Contribute code
+            </h2>
+          </div>
+          <p className="text-neutral-600 leading-relaxed mb-6">
+            Togather is source-available under the{" "}
+            <a href={`${REPO_URL}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer" className="text-neutral-900 font-medium underline underline-offset-2">AGPL-3.0 license</a>.
+            If you're a developer and want to contribute, here's how to get started.
+          </p>
+
+          <div className="bg-neutral-50 border border-neutral-200 rounded-2xl p-6 mb-6">
+            <h3 className="font-semibold text-neutral-900 mb-4">
+              Requirements
+            </h3>
+            <ul className="space-y-2 text-neutral-600">
+              <li className="flex gap-2">
+                <svg className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="20 6 9 17 4 12" /></svg>
+                <span>Node.js v20+</span>
+              </li>
+              <li className="flex gap-2">
+                <svg className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="20 6 9 17 4 12" /></svg>
+                <span>pnpm v8+</span>
+              </li>
+              <li className="flex gap-2">
+                <svg className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="20 6 9 17 4 12" /></svg>
+                <span>A free <a href="https://convex.dev" target="_blank" rel="noopener noreferrer" className="text-neutral-900 font-medium underline underline-offset-2">Convex</a> account (for the backend)</span>
+              </li>
+            </ul>
+          </div>
+
+          <div className="bg-neutral-50 border border-neutral-200 rounded-2xl p-6 mb-6">
+            <h3 className="font-semibold text-neutral-900 mb-4">
+              Getting started
+            </h3>
+            <div className="space-y-3 text-neutral-600 font-mono text-sm">
+              <div className="bg-neutral-900 text-neutral-100 rounded-xl p-4 overflow-x-auto">
+                <pre className="whitespace-pre">{`# Clone the repo
+git clone ${REPO_URL}.git
+cd togather
+
+# Install dependencies
+pnpm install
+
+# Set up environment
+cp .env.example .env.local
+
+# Start Convex (creates your dev database)
+npx convex dev
+
+# In a new terminal — seed test data
+npx convex run functions/seed:seedDemoData
+
+# Start the app
+pnpm dev`}</pre>
+              </div>
+            </div>
+            <p className="text-neutral-500 text-sm mt-4">
+              Full setup instructions are in the{" "}
+              <a href={`${REPO_URL}#readme`} target="_blank" rel="noopener noreferrer" className="text-neutral-700 font-medium underline underline-offset-2">README</a>.
+            </p>
+          </div>
+
+          <div className="bg-neutral-50 border border-neutral-200 rounded-2xl p-6 mb-6">
+            <h3 className="font-semibold text-neutral-900 mb-4">
+              Contribution workflow
+            </h3>
+            <ol className="space-y-2 text-neutral-600 list-decimal list-inside">
+              <li>Pick an issue from the <a href={`${REPO_URL}/issues`} target="_blank" rel="noopener noreferrer" className="text-neutral-900 font-medium underline underline-offset-2">issue tracker</a> (look for <code className="bg-neutral-200 px-1.5 py-0.5 rounded text-sm">good first issue</code>)</li>
+              <li>Fork the repo and create a branch</li>
+              <li>Make your changes and write tests</li>
+              <li>Open a pull request with a clear description</li>
+              <li>We'll review and work with you to get it merged</li>
+            </ol>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <a
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-5 py-3 bg-neutral-900 hover:bg-neutral-800 text-white rounded-xl font-medium transition-colors"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+              </svg>
+              View on GitHub
+            </a>
+            <a
+              href={`${REPO_URL}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-5 py-3 bg-white hover:bg-neutral-50 text-neutral-900 rounded-xl font-medium border border-neutral-200 transition-colors"
+            >
+              Browse good first issues
+            </a>
+          </div>
+        </section>
+
+        {/* Tech stack summary */}
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-neutral-900 mb-4">
+            Tech stack
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            {[
+              { label: "Backend", value: "Convex" },
+              { label: "Mobile", value: "React Native + Expo" },
+              { label: "Routing", value: "Expo Router" },
+              { label: "Language", value: "TypeScript" },
+              { label: "Styling", value: "Tailwind CSS / NativeWind" },
+              { label: "Auth", value: "Phone & Email OTP" },
+            ].map((item) => (
+              <div key={item.label} className="bg-neutral-50 border border-neutral-200 rounded-xl px-4 py-3">
+                <div className="text-xs text-neutral-400 font-medium uppercase tracking-wide">{item.label}</div>
+                <div className="text-neutral-900 font-medium">{item.value}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/ReportIssue.tsx
+++ b/apps/web/src/pages/ReportIssue.tsx
@@ -1,0 +1,203 @@
+import { Link } from "react-router-dom";
+
+const REPO_URL = "https://github.com/togathernyc/togather";
+
+export function ReportIssue() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto px-6 py-12">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-neutral-600 hover:text-neutral-900 mb-8"
+        >
+          <svg
+            className="w-5 h-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+          Back to Home
+        </Link>
+
+        <h1 className="text-4xl font-bold text-neutral-900 mb-3">
+          Report a problem or request a feature
+        </h1>
+        <p className="text-lg text-neutral-600 mb-6 leading-relaxed">
+          Togather is an open-source project built and maintained by a small
+          team and the community around it. Every bug report and feature request
+          helps make it better for everyone.
+        </p>
+
+        {/* Community effort callout */}
+        <div className="bg-amber-50 border border-amber-200 rounded-2xl p-6 mb-12">
+          <p className="text-amber-900 leading-relaxed">
+            <strong>This is a community effort.</strong> Issues are addressed on
+            a best-effort basis by contributors who volunteer their time. The
+            more detail you provide, the easier it is for someone to pick it up.
+            If a fix is important to you, consider{" "}
+            <Link to="/contribute" className="font-medium underline underline-offset-2">
+              contributing it yourself
+            </Link>
+            — we're happy to help you get started.
+          </p>
+        </div>
+
+        {/* Bug report section */}
+        <section className="mb-14">
+          <h2 className="text-2xl font-bold text-neutral-900 mb-2">
+            Reporting a bug
+          </h2>
+          <p className="text-neutral-600 leading-relaxed mb-6">
+            Something not working right? Here's how to write a bug report that
+            helps us fix it fast.
+          </p>
+
+          <div className="bg-neutral-50 border border-neutral-200 rounded-2xl p-6 mb-6">
+            <h3 className="font-semibold text-neutral-900 mb-4">
+              What to include
+            </h3>
+            <ul className="space-y-4 text-neutral-600">
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">1</span>
+                <div>
+                  <strong className="text-neutral-900">What happened</strong>
+                  <p className="text-sm mt-0.5">Describe exactly what you saw. "The app crashed" is okay, but "I tapped Send on a message with a photo and the app froze for 5 seconds then closed" is much better.</p>
+                </div>
+              </li>
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">2</span>
+                <div>
+                  <strong className="text-neutral-900">Steps to reproduce</strong>
+                  <p className="text-sm mt-0.5">Walk us through what you did, step by step. If we can recreate the problem, we can fix it.</p>
+                </div>
+              </li>
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">3</span>
+                <div>
+                  <strong className="text-neutral-900">Screenshots</strong>
+                  <p className="text-sm mt-0.5">A picture is worth a thousand words. Take 1-3 screenshots showing the problem. You can paste them directly into the GitHub form.</p>
+                </div>
+              </li>
+              <li className="flex gap-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">4</span>
+                <div>
+                  <strong className="text-neutral-900">What you expected</strong>
+                  <p className="text-sm mt-0.5">Tell us what you thought should happen. This helps us understand if something is a bug or a misunderstanding.</p>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <a
+            href={`${REPO_URL}/issues/new?template=bug_report.yml`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-5 py-3 bg-neutral-900 hover:bg-neutral-800 text-white rounded-xl font-medium transition-colors"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+            </svg>
+            Report a bug
+          </a>
+        </section>
+
+        {/* Feature request section */}
+        <section className="mb-14">
+          <h2 className="text-2xl font-bold text-neutral-900 mb-2">
+            Requesting a feature
+          </h2>
+          <p className="text-neutral-600 leading-relaxed mb-6">
+            Have an idea for how Togather could work better for your community?
+            We want to hear it.
+          </p>
+
+          <div className="bg-neutral-50 border border-neutral-200 rounded-2xl p-6 mb-6">
+            <h3 className="font-semibold text-neutral-900 mb-4">
+              Tips for a great request
+            </h3>
+            <ul className="space-y-4 text-neutral-600">
+              <li className="flex gap-3">
+                <svg className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="20 6 9 17 4 12" /></svg>
+                <div>
+                  <strong className="text-neutral-900">Start with the problem, not the solution</strong>
+                  <p className="text-sm mt-0.5">"I can't tell which members haven't shown up in weeks" is more helpful than "Add a red dot next to inactive members." Understanding the problem helps us design the best fix.</p>
+                </div>
+              </li>
+              <li className="flex gap-3">
+                <svg className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="20 6 9 17 4 12" /></svg>
+                <div>
+                  <strong className="text-neutral-900">Explain who it helps</strong>
+                  <p className="text-sm mt-0.5">Is this for group leaders? Members? Admins? Knowing the audience helps us prioritize.</p>
+                </div>
+              </li>
+              <li className="flex gap-3">
+                <svg className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="20 6 9 17 4 12" /></svg>
+                <div>
+                  <strong className="text-neutral-900">Include screenshots or examples</strong>
+                  <p className="text-sm mt-0.5">If you've seen something similar in another app, share a screenshot. A rough sketch or mockup works too.</p>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <a
+            href={`${REPO_URL}/issues/new?template=feature_request.yml`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-5 py-3 bg-neutral-900 hover:bg-neutral-800 text-white rounded-xl font-medium transition-colors"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+            </svg>
+            Request a feature
+          </a>
+        </section>
+
+        {/* Getting started with GitHub */}
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-neutral-900 mb-2">
+            New to GitHub?
+          </h2>
+          <p className="text-neutral-600 leading-relaxed mb-6">
+            GitHub is where we track all bugs and feature requests. You'll need
+            a free account to submit an issue — it only takes a minute.
+          </p>
+
+          <ol className="space-y-3 text-neutral-600 mb-6">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">1</span>
+              <span>
+                Go to{" "}
+                <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer" className="text-neutral-900 font-medium underline underline-offset-2">github.com/signup</a>{" "}
+                and create an account with your email.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">2</span>
+              <span>Click one of the buttons above ("Report a bug" or "Request a feature").</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">3</span>
+              <span>Fill in the template — the form will guide you through what to include.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-900 text-white text-sm font-semibold flex items-center justify-center">4</span>
+              <span>Hit submit, and we'll take it from there.</span>
+            </li>
+          </ol>
+
+          <p className="text-neutral-500 text-sm">
+            Want to go further?{" "}
+            <Link to="/contribute" className="text-neutral-700 font-medium underline underline-offset-2">
+              Learn how to contribute code
+            </Link>{" "}
+            to Togather.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/issue` page — guides users through reporting bugs and requesting features, with direct links to GitHub issue templates. Sets expectations about community effort and best-effort timelines.
- Add `/contribute` page — developer onboarding (requirements, setup, contribution workflow) and non-technical guide (filing issues via GitHub)
- New FAQ entry: "Something is broken or I'd like something changed — what should I do?" links to `/issue`
- Footer "Contribute" link now points to `/contribute`

## Test plan
- [x] TypeScript compiles with no errors
- [x] ESLint passes
- [x] Tests pass
- [x] Verified both pages render correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)