### PR TITLE
Fix: Update Resend sender domain to verified studios.supa.media

### DIFF
--- a/apps/convex/functions/auth/emailOtp.ts
+++ b/apps/convex/functions/auth/emailOtp.ts
@@ -19,7 +19,7 @@ import { ActionCtx } from "../../_generated/server";
 import { MAGIC_CODE, isTestEmail } from "./helpers";
 
 // Email sender address
-const EMAIL_FROM = "Togather <togather@supa.media>";
+const EMAIL_FROM = "Togather <togather@studios.supa.media>";
 
 // Lazy-initialize Resend client to avoid throwing if API key is missing at module load
 let resendClient: Resend | null = null;


### PR DESCRIPTION
## Summary
- The `supa.media` domain is not verified in Resend, causing all email OTP verification to fail with a 403 error
- Users hitting "Server Error" when trying to verify their email during registration
- Updates sender from `togather@supa.media` to `togather@studios.supa.media`

## Test plan
- [ ] Deploy to production and have the affected user retry email verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change limited to a single sender-address constant, but it directly affects email OTP deliverability during signup/verification if the new domain is misconfigured.
> 
> **Overview**
> Fixes email OTP delivery by changing the Resend sender (`EMAIL_FROM`) from `togather@supa.media` to `togather@studios.supa.media` in `emailOtp.ts`, aligning the `from` domain with a verified sender.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4be68f9b049337603c4043a6c1fa867487afcfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->