### PR TITLE
Fix: Use shared DOMAIN_CONFIG for email OTP sender

### DIFF
--- a/apps/convex/functions/auth/emailOtp.ts
+++ b/apps/convex/functions/auth/emailOtp.ts
@@ -17,9 +17,10 @@ import {
 import { internal } from "../../_generated/api";
 import { ActionCtx } from "../../_generated/server";
 import { MAGIC_CODE, isTestEmail } from "./helpers";
+import { DOMAIN_CONFIG } from "@togather/shared/config";
 
-// Email sender address
-const EMAIL_FROM = "Togather <togather@studios.supa.media>";
+// Email sender address - use shared config (notifications@togather.nyc)
+const EMAIL_FROM = DOMAIN_CONFIG.emailFrom;
 
 // Lazy-initialize Resend client to avoid throwing if API key is missing at module load
 let resendClient: Resend | null = null;


### PR DESCRIPTION
## Summary
- Previous fix (#22) changed to `studios.supa.media` but that domain also isn't verified in Resend
- The rest of the app uses `DOMAIN_CONFIG.emailFrom` (`notifications@togather.nyc`) which is verified and working
- Aligns email OTP sender with the same shared config

## Test plan
- [ ] Deploy to production and have user retry email verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `from` address used for OTP verification emails, which can affect deliverability and user account verification if misconfigured. Scope is small but it touches the email verification/auth flow.
> 
> **Overview**
> Aligns email OTP delivery with the rest of the app by switching the Resend sender `from` address in `emailOtp.ts` from a hardcoded value to `DOMAIN_CONFIG.emailFrom` (shared config).
> 
> This should ensure OTP verification emails send from the verified domain/address used elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 614ac1aacf8f76049765de7481369e2b3a545ae7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->