### PR TITLE
Fix: Move cross-group attendance out of score batch query

### DIFF
--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -115,6 +115,7 @@ import type * as http from "../http.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_email_templates_BaseLayout from "../lib/email/templates/BaseLayout.js";
 import type * as lib_email_templates_VerificationCode from "../lib/email/templates/VerificationCode.js";
+import type * as lib_followupConstants from "../lib/followupConstants.js";
 import type * as lib_helpers from "../lib/helpers.js";
 import type * as lib_meetingConfig from "../lib/meetingConfig.js";
 import type * as lib_memberSearch from "../lib/memberSearch.js";
@@ -252,6 +253,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/email/templates/BaseLayout": typeof lib_email_templates_BaseLayout;
   "lib/email/templates/VerificationCode": typeof lib_email_templates_VerificationCode;
+  "lib/followupConstants": typeof lib_followupConstants;
   "lib/helpers": typeof lib_helpers;
   "lib/meetingConfig": typeof lib_meetingConfig;
   "lib/memberSearch": typeof lib_memberSearch;

--- a/apps/convex/functions/followupScoreComputation.ts
+++ b/apps/convex/functions/followupScoreComputation.ts
@@ -279,23 +279,40 @@ export const computeGroupScores = internalAction({
         continue;
       }
 
-      // Step 3: Score the batch using existing internalScoreBatch
+      // Step 3: Pre-compute cross-group attendance (only for groups with custom scoring)
       const memberBatch = page.members.map((m) => ({
         _id: m._id,
         userId: m.userId,
         joinedAt: m.joinedAt,
       }));
 
+      let crossGroupAttendanceMap: Record<string, number> | undefined;
+      if (groupDoc) {
+        crossGroupAttendanceMap = {};
+        const CROSS_BATCH = 20;
+        const userIds = page.members.map((m) => m.userId);
+        for (let i = 0; i < userIds.length; i += CROSS_BATCH) {
+          const batch = userIds.slice(i, i + CROSS_BATCH);
+          const batchResults: Record<string, number> = await ctx.runQuery(
+            internal.functions.memberFollowups.internalCrossGroupAttendance,
+            { groupId: args.groupId, userIds: batch }
+          );
+          Object.assign(crossGroupAttendanceMap, batchResults);
+        }
+      }
+
+      // Step 4: Score the batch using existing internalScoreBatch
       const scoredResults: any[] = await ctx.runQuery(
         internal.functions.memberFollowups.internalScoreBatch,
         {
           groupId: args.groupId,
           members: memberBatch,
           meetings: config.meetings,
+          crossGroupAttendanceMap,
         }
       );
 
-      // Step 4: Transform and upsert
+      // Step 5: Transform and upsert
       // Build a lookup map from memberId to member data for denormalized fields
       const memberMap = new Map(page.members.map((m) => [m._id.toString(), m]));
 
@@ -349,6 +366,15 @@ export const computeSingleMemberScore = internalAction({
 
     if (!memberData) return;
 
+    // Pre-compute cross-group attendance for this member (if custom scoring)
+    let crossGroupAttendanceMap: Record<string, number> | undefined;
+    if (groupDoc) {
+      crossGroupAttendanceMap = await ctx.runQuery(
+        internal.functions.memberFollowups.internalCrossGroupAttendance,
+        { groupId: args.groupId, userIds: [memberData.userId] }
+      );
+    }
+
     // Score the single member
     const scoredResults = await ctx.runQuery(
       internal.functions.memberFollowups.internalScoreBatch,
@@ -360,6 +386,7 @@ export const computeSingleMemberScore = internalAction({
           joinedAt: memberData.joinedAt,
         }],
         meetings: config.meetings,
+        crossGroupAttendanceMap,
       }
     );
 

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -389,6 +389,7 @@ export const internalScoreBatch = internalQuery({
         scheduledAt: v.number(),
       })
     ),
+    crossGroupAttendanceMap: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
     const currentTime = now();
@@ -467,48 +468,10 @@ export const internalScoreBatch = internalQuery({
           otherGroupAttendance: 0,
         });
 
-        // Cross-group attendance: find all other groups this user is in
-        let crossGroupAttendancePct: number | undefined;
-        if (useCustomScoring) {
-          const sixtyDaysAgo = currentTime - 60 * 24 * 60 * 60 * 1000;
-          const allMemberships = await ctx.db
-            .query("groupMembers")
-            .withIndex("by_user", (q) => q.eq("userId", member.userId))
-            .filter((q) => q.eq(q.field("leftAt"), undefined))
-            .collect();
-
-          let allGroupsTotal = memberMeetings.length;
-          let allGroupsAttended = meetingData.filter((m) => m.wasPresent).length;
-
-          for (const otherMember of allMemberships) {
-            if (otherMember.groupId.toString() === args.groupId.toString()) continue;
-            const otherMeetings = await ctx.db
-              .query("meetings")
-              .withIndex("by_group_status", (q) =>
-                q.eq("groupId", otherMember.groupId).eq("status", "completed")
-              )
-              .filter((q) => q.gte(q.field("scheduledAt"), sixtyDaysAgo))
-              .order("desc")
-              .take(10);
-
-            const otherAttendances = await Promise.all(
-              otherMeetings.map((m) =>
-                ctx.db
-                  .query("meetingAttendances")
-                  .withIndex("by_meeting_user", (q) =>
-                    q.eq("meetingId", m._id).eq("userId", member.userId)
-                  )
-                  .first()
-              )
-            );
-
-            allGroupsTotal += otherMeetings.length;
-            allGroupsAttended += otherAttendances.filter((a) => a?.status === 1).length;
-          }
-
-          crossGroupAttendancePct =
-            allGroupsTotal > 0 ? Math.round((allGroupsAttended / allGroupsTotal) * 100) : 0;
-        }
+        // Cross-group attendance: use pre-computed map (computed in action layer)
+        const crossGroupAttendancePct = useCustomScoring
+          ? (args.crossGroupAttendanceMap?.[member.userId.toString()] as number | undefined)
+          : undefined;
 
         // Compute configurable scores
         let memberScores: Record<string, number>;
@@ -579,6 +542,64 @@ export const internalScoreBatch = internalQuery({
     return results.filter(
       (r): r is NonNullable<(typeof results)[number]> => r !== null
     );
+  },
+});
+
+/**
+ * Compute cross-group attendance percentages for a batch of users.
+ * Processes ~20 users at a time to stay within Convex read limits.
+ * Returns a map of userId (string) -> attendance percentage (0-100).
+ */
+export const internalCrossGroupAttendance = internalQuery({
+  args: {
+    groupId: v.id("groups"),
+    userIds: v.array(v.id("users")),
+  },
+  handler: async (ctx, args) => {
+    const currentTime = now();
+    const sixtyDaysAgo = currentTime - 60 * 24 * 60 * 60 * 1000;
+    const results: Record<string, number> = {};
+
+    for (const userId of args.userIds) {
+      const allMemberships = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .collect();
+
+      let allGroupsTotal = 0;
+      let allGroupsAttended = 0;
+
+      for (const membership of allMemberships) {
+        const meetings = await ctx.db
+          .query("meetings")
+          .withIndex("by_group_status", (q) =>
+            q.eq("groupId", membership.groupId).eq("status", "completed")
+          )
+          .filter((q) => q.gte(q.field("scheduledAt"), sixtyDaysAgo))
+          .order("desc")
+          .take(10);
+
+        const attendances = await Promise.all(
+          meetings.map((m) =>
+            ctx.db
+              .query("meetingAttendances")
+              .withIndex("by_meeting_user", (q) =>
+                q.eq("meetingId", m._id).eq("userId", userId)
+              )
+              .first()
+          )
+        );
+
+        allGroupsTotal += meetings.length;
+        allGroupsAttended += attendances.filter((a) => a?.status === 1).length;
+      }
+
+      results[userId.toString()] =
+        allGroupsTotal > 0 ? Math.round((allGroupsAttended / allGroupsTotal) * 100) : 0;
+    }
+
+    return results;
   },
 });
 


### PR DESCRIPTION
## Summary
- Moved cross-group attendance computation from `internalScoreBatch` (query with strict read limits) to a dedicated `internalCrossGroupAttendance` query called in small batches of 20 from the action layer
- Pre-computes cross-group attendance in `computeGroupScores` and `computeSingleMemberScore` actions, passing results as a map to `internalScoreBatch`
- Fixes "Too many documents read" errors that were causing all score computations to fail

## Test plan
- [x] Dev backfill triggered successfully (190 groups, no read limit errors)
- [x] All Convex logs show successful execution (10-115ms per function)
- [ ] Verify production backfill succeeds after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scoring data flow and introduces new batched reads, which could alter custom score inputs or impact performance if the map is missing/incorrect, but it’s scoped to internal scoring/backfill paths.
> 
> **Overview**
> Follow-up score backfills now **precompute cross-group attendance outside** `memberFollowups.internalScoreBatch`, then pass it in as `crossGroupAttendanceMap` when custom scoring is enabled.
> 
> This adds `memberFollowups.internalCrossGroupAttendance` (batched for ~20 users) and updates `computeGroupScores`/`computeSingleMemberScore` to call it, removing the per-member cross-group reads from the scoring batch query to prevent "Too many documents read" failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 635a9ba249ad36ce4a833271fd86a4cfef8b81c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->