### PR TITLE
chore: update review-cycle skill for Bugbot Autofix

### DIFF
--- a/.claude/commands/review-cycle.md
+++ b/.claude/commands/review-cycle.md
@@ -204,10 +204,22 @@ For each failing check:
    git commit -m "fix: resolve CI failures
 
    Co-Authored-By: Claude <noreply@anthropic.com>"
+   ```
+
+4. **Wait for Bugbot Autofix before pushing:**
+   
+   Before pushing, check if Autofix is running:
+   ```bash
+   gh pr view <PR_NUMBER> --json statusCheckRollup \
+     --jq '.statusCheckRollup[] | select(.name == "Cursor Bugbot Autofix") | {status: .status}'
+   ```
+   If `IN_PROGRESS`, poll every 30 seconds until complete, then pull and push:
+   ```bash
+   git pull --rebase origin $BRANCH
    git push
    ```
 
-4. **Wait for CI to re-run (poll every 30 seconds)**
+5. **Wait for CI to re-run (poll every 30 seconds)**
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Phase 3.5: wait for Bugbot Autofix to complete before processing review threads (prevents push rejections, conflicts, and duplicate work)
- Always `git pull --rebase` before pushing to pick up concurrent Autofix commits
- Check if threads are already fixed by Autofix before making changes
- Cap Bugbot review rounds at 3; resolve Low severity threads without fixing after the cap to prevent infinite loops
- Add `Cursor Bugbot Autofix` to bot check list and status meanings
- Update completion report to track Autofix commits separately

## Test plan
- [ ] Run `/review-cycle` on a future PR and verify it waits for Autofix before processing comments
- [ ] Verify no push rejections or rebase conflicts from concurrent Autofix commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/process-only updates with no runtime code changes; risk is limited to potential workflow confusion if the new steps are misfollowed.
> 
> **Overview**
> Updates the `/review-cycle` playbook to account for the concurrent `Cursor Bugbot Autofix` check: it now waits for Autofix to finish (and pulls any pushed commits) before processing review threads, and prefers `git pull --rebase` workflows to avoid push rejections/conflicts.
> 
> Adds a 3-round cap on Bugbot reviews where remaining *Low* severity items are resolved without fixes, and expands the completion report/safety rules to track Autofix commits separately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8da6cd008c8b1bd75c5b99161417cd97f6529d77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->