### PR TITLE
Replace 1Password runtime fetching with GitHub secrets

### DIFF
--- a/.github/actions/load-secrets/action.yml
+++ b/.github/actions/load-secrets/action.yml
@@ -1,76 +1,31 @@
-name: "Load 1Password Secrets"
-description: "Fetches secrets from 1Password and exports them as environment variables"
+name: "Load Secrets"
+description: "Exports GitHub secrets as environment variables for downstream steps"
 
 inputs:
-  op-service-account-token:
-    description: "1Password Service Account Token"
-    required: true
-  environment:
-    description: "Environment to load secrets for (staging or production)"
+  secrets-json:
+    description: "JSON object of all secrets (pass ${{ toJSON(secrets) }})"
     required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Install 1Password CLI
-      uses: 1password/install-cli-action@v1
-
-    - name: Check 1Password rate limit (before)
+    - name: Export secrets to environment
       shell: bash
       env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
+        SECRETS_JSON: ${{ inputs.secrets-json }}
       run: |
-        echo "=== 1Password Rate Limit Status (BEFORE loading secrets) ==="
-        op service-account ratelimit || echo "Failed to get rate limit info"
+        # Parse the secrets JSON and export each key-value pair to GITHUB_ENV
+        # Uses multiline delimiter syntax for safety (handles values with special chars)
+        printf '%s' "$SECRETS_JSON" | jq -r '
+          to_entries[]
+          | select(.value != "" and .key != "github_token")
+          | @text "\(.key)<<__GH_ENV_DELIM__\n\(.value)\n__GH_ENV_DELIM__"
+        ' >> $GITHUB_ENV
 
-    - name: Load common secrets
-      uses: 1password/load-secrets-action@v2
-      env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
-        CONVEX_DEPLOY_KEY: op://Togather/CONVEX_DEPLOY_KEY/${{ inputs.environment }}
-        JWT_SECRET: op://Togather/JWT_SECRET/${{ inputs.environment }}
-        RESEND_API_KEY: op://Togather/RESEND_API_KEY/${{ inputs.environment }}
-        TWILIO_ACCOUNT_SID: op://Togather/TWILIO_ACCOUNT_SID/${{ inputs.environment }}
-        TWILIO_API_KEY_SID: op://Togather/TWILIO_API_KEY_SID/${{ inputs.environment }}
-        TWILIO_API_KEY_SECRET: op://Togather/TWILIO_API_KEY_SECRET/${{ inputs.environment }}
-        TWILIO_VERIFY_SERVICE_SID: op://Togather/TWILIO_VERIFY_SERVICE_SID/${{ inputs.environment }}
-        PLANNING_CENTER_CLIENT_ID: op://Togather/PLANNING_CENTER_CLIENT_ID/${{ inputs.environment }}
-        PLANNING_CENTER_CLIENT_SECRET: op://Togather/PLANNING_CENTER_CLIENT_SECRET/${{ inputs.environment }}
-        OTP_TEST_PHONE_NUMBERS: op://Togather/OTP_TEST_PHONE_NUMBERS/${{ inputs.environment }}
-        CLOUDFLARE_ACCOUNT_ID: op://Togather/CLOUDFLARE_ACCOUNT_ID/${{ inputs.environment }}
-        R2_ACCESS_KEY_ID: op://Togather/R2_ACCESS_KEY_ID/${{ inputs.environment }}
-        R2_SECRET_ACCESS_KEY: op://Togather/R2_SECRET_ACCESS_KEY/${{ inputs.environment }}
-        R2_BUCKET_NAME: op://Togather/R2_BUCKET_NAME/${{ inputs.environment }}
-        R2_PUBLIC_URL: op://Togather/R2_PUBLIC_URL/${{ inputs.environment }}
-        SLACK_BOT_TOKEN: op://Togather/SLACK_BOT_TOKEN/${{ inputs.environment }}
-        SLACK_SIGNING_SECRET: op://Togather/SLACK_SIGNING_SECRET/${{ inputs.environment }}
-        OPENAI_SECRET_KEY: op://Togather/OPENAI_SECRET_KEY/${{ inputs.environment }}
-        EXPO_TOKEN: op://Togather/EXPO_TOKEN/${{ inputs.environment }}
-        EAS_PROJECT_ID: op://Togather/EAS_PROJECT_ID/${{ inputs.environment }}
-        CONVEX_SITE_URL: op://Togather/CONVEX_SITE_URL/${{ inputs.environment }}
+    - name: Set IMAGE_CDN_URL alias
+      shell: bash
+      run: |
         # IMAGE_CDN_URL is the same as R2_PUBLIC_URL (CDN in front of R2 bucket)
-        IMAGE_CDN_URL: op://Togather/R2_PUBLIC_URL/${{ inputs.environment }}
-      with:
-        export-env: true
-
-    - name: Check 1Password rate limit (after common)
-      shell: bash
-      env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
-      run: |
-        echo "=== 1Password Rate Limit Status (AFTER loading common secrets) ==="
-        op service-account ratelimit || echo "Failed to get rate limit info"
-
-    - name: Load optional secrets
-      uses: 1password/load-secrets-action@v2
-      continue-on-error: true
-      env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
-        CLOUDFLARE_API_TOKEN: op://Togather/CLOUDFLARE_API_TOKEN/${{ inputs.environment }}
-        TF_API_TOKEN: op://Togather/TF_API_TOKEN/${{ inputs.environment }}
-        SENTRY_AUTH_TOKEN: op://Togather/SENTRY_AUTH_TOKEN/${{ inputs.environment }}
-        EXPO_PUBLIC_MAPBOX_TOKEN: op://Togather/EXPO_PUBLIC_MAPBOX_TOKEN/${{ inputs.environment }}
-        EXPO_PUBLIC_SENTRY_DSN: op://Togather/EXPO_PUBLIC_SENTRY_DSN/${{ inputs.environment }}
-        EXPO_PUBLIC_POSTHOG_API_KEY: op://Togather/EXPO_PUBLIC_POSTHOG_API_KEY/${{ inputs.environment }}
-      with:
-        export-env: true
+        if [ -n "$R2_PUBLIC_URL" ]; then
+          echo "IMAGE_CDN_URL=$R2_PUBLIC_URL" >> $GITHUB_ENV
+        fi

--- a/.github/workflows/build-mobile-native.yml
+++ b/.github/workflows/build-mobile-native.yml
@@ -124,11 +124,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: staging
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8
@@ -143,7 +142,7 @@ jobs:
           # Must match the "environment" field in eas.json staging profile (preview)
           # Note: EAS custom environments require Production/Enterprise plan, so we use "preview"
           eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment preview --visibility plaintext --force --non-interactive || true
-          # Convex URL from 1Password
+          # Convex URL from loaded secrets
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment preview --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
           eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment preview --visibility plaintext --force --non-interactive || true

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -37,7 +37,7 @@ jobs:
   build:
     name: Build Mobile App
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.profile == 'staging' && 'staging' || 'production' }}
 
     steps:
       - name: Checkout code
@@ -57,12 +57,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          # Use staging secrets for staging profile, production for production/tags
-          environment: ${{ inputs.profile == 'staging' && 'staging' || 'production' }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8
@@ -80,7 +78,7 @@ jobs:
           # Use eas env:create (eas secret:create is deprecated)
           # Only sync to the environment matching the selected profile to avoid cross-contamination
           eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
-          # Convex URL from 1Password (already loaded per environment)
+          # Convex URL from loaded secrets
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
           eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true

--- a/.github/workflows/deploy-convex.yml
+++ b/.github/workflows/deploy-convex.yml
@@ -3,8 +3,7 @@
 # Automatically deploys to staging on push to main branch
 # Production deployment is manual only (workflow_dispatch)
 #
-# All secrets (including CONVEX_DEPLOY_KEY) are loaded from 1Password
-# Only requires OP_SERVICE_ACCOUNT_TOKEN in GitHub Secrets
+# All secrets (including CONVEX_DEPLOY_KEY) are loaded from GitHub environment secrets
 
 name: Deploy Convex
 
@@ -74,11 +73,10 @@ jobs:
       - name: Type check Convex functions
         run: npx convex typecheck
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: ${{ steps.env.outputs.secrets_env }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Sync secrets to Convex
         run: |

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -65,11 +65,10 @@ jobs:
       - name: Build landing page
         run: pnpm --filter @togather/web build
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: ${{ steps.env.outputs.secrets_env }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Install Wrangler
         run: npm install -g wrangler

--- a/.github/workflows/deploy-link-preview.yml
+++ b/.github/workflows/deploy-link-preview.yml
@@ -50,11 +50,10 @@ jobs:
         with:
           node-version: 20
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: ${{ steps.env.outputs.secrets_env }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Install Wrangler
         run: npm install -g wrangler

--- a/.github/workflows/deploy-mobile-update.yml
+++ b/.github/workflows/deploy-mobile-update.yml
@@ -74,11 +74,10 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: .
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: ${{ steps.env.outputs.secrets_env }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8

--- a/.github/workflows/deploy-slack-bot.yml
+++ b/.github/workflows/deploy-slack-bot.yml
@@ -52,11 +52,10 @@ jobs:
       - name: Run Slack bot tests
         run: cd apps/convex && pnpm test __tests__/slackServiceBot.test.ts
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Sync secrets to Convex
         run: |

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -137,11 +137,10 @@ jobs:
       - name: Type check Convex functions
         run: npx convex typecheck
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Sync secrets to Convex
         run: |
@@ -191,11 +190,10 @@ jobs:
           fi
           echo "✅ Version validated: $VERSION"
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8
@@ -209,7 +207,7 @@ jobs:
           # Use eas env:create (eas secret:create is deprecated)
           # Production builds use the production EAS environment
           eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment production --visibility plaintext --force --non-interactive || true
-          # Convex URL from 1Password
+          # Convex URL from loaded secrets
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
           eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment production --visibility plaintext --force --non-interactive || true
@@ -381,11 +379,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8
@@ -399,7 +396,7 @@ jobs:
           # Sync secrets and config to EAS production environment
           # Required because eas update --environment reads from EAS env vars for app.config.js
           eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment production --visibility plaintext --force --non-interactive || true
-          # Convex URL from 1Password
+          # Convex URL from loaded secrets
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment production --visibility plaintext --force --non-interactive || true
           # Project ID for push notifications (constant across all environments)
           eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment production --visibility plaintext --force --non-interactive || true
@@ -460,11 +457,10 @@ jobs:
       - name: Build landing page
         run: pnpm --filter @togather/web build
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Install Wrangler
         run: npm install -g wrangler
@@ -493,11 +489,10 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Install Wrangler
         run: npm install -g wrangler
@@ -558,11 +553,10 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: .
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -68,11 +68,10 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: .
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: ${{ steps.env.outputs.secrets_env }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -1,0 +1,72 @@
+name: Sync Secrets from 1Password
+
+# Manual workflow to sync secrets from 1Password to GitHub environment secrets.
+# Run this whenever a secret is added, changed, or rotated in 1Password.
+#
+# Prerequisites:
+#   - OP_SERVICE_ACCOUNT_TOKEN: 1Password service account token (repo secret)
+#   - GH_ADMIN_TOKEN: GitHub PAT with repo admin scope (repo secret)
+#     (the default GITHUB_TOKEN cannot manage repository secrets)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to sync"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+          - both
+
+jobs:
+  sync:
+    name: Sync ${{ inputs.environment }} secrets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v1
+
+      - name: Sync secrets to GitHub
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+        run: |
+          if [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+            echo "Error: OP_SERVICE_ACCOUNT_TOKEN secret is not set"
+            exit 1
+          fi
+          if [ -z "$GH_TOKEN" ]; then
+            echo "Error: GH_ADMIN_TOKEN secret is not set"
+            echo "Create a GitHub PAT with repo admin scope and store it as GH_ADMIN_TOKEN"
+            exit 1
+          fi
+
+          chmod +x ee/scripts/sync-1password-to-github.sh
+
+          if [ "${{ inputs.environment }}" = "both" ]; then
+            ./ee/scripts/sync-1password-to-github.sh --all
+          else
+            ./ee/scripts/sync-1password-to-github.sh --environment "${{ inputs.environment }}"
+          fi
+
+      - name: Verify secrets
+        env:
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+        run: |
+          echo "=== Verifying synced secrets ==="
+          if [ "${{ inputs.environment }}" = "both" ] || [ "${{ inputs.environment }}" = "staging" ]; then
+            echo ""
+            echo "Staging secrets:"
+            gh secret list --env staging
+          fi
+          if [ "${{ inputs.environment }}" = "both" ] || [ "${{ inputs.environment }}" = "production" ]; then
+            echo ""
+            echo "Production secrets:"
+            gh secret list --env production
+          fi

--- a/.github/workflows/terraform-dns.yml
+++ b/.github/workflows/terraform-dns.yml
@@ -1,6 +1,6 @@
 name: Terraform DNS
 
-# Uses CLOUDFLARE_API_TOKEN from 1Password (production environment)
+# Uses CLOUDFLARE_API_TOKEN from GitHub environment secrets (production)
 # Token requires Zone:DNS:Edit and Zone:Zone:Read permissions
 
 on:
@@ -30,11 +30,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Load secrets from 1Password
+      - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
-          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          environment: production
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# Sync secrets from 1Password to GitHub environment-scoped secrets
+#
+# Prerequisites:
+#   - 1Password CLI (`op`) authenticated (or OP_SERVICE_ACCOUNT_TOKEN set)
+#   - GitHub CLI (`gh`) authenticated with repo admin access
+#
+# Usage:
+#   ./ee/scripts/sync-1password-to-github.sh --environment staging
+#   ./ee/scripts/sync-1password-to-github.sh --environment production
+#   ./ee/scripts/sync-1password-to-github.sh --all
+#   ./ee/scripts/sync-1password-to-github.sh --all --dry-run
+
+set -e
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+ENVIRONMENT=""
+DRY_RUN=false
+SYNC_ALL=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --environment|-e)
+      ENVIRONMENT="$2"
+      shift 2
+      ;;
+    --all)
+      SYNC_ALL=true
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: $0 --environment <staging|production> [--dry-run]"
+      echo "       $0 --all [--dry-run]"
+      echo ""
+      echo "Syncs secrets from 1Password vault 'Togather' to GitHub environment secrets."
+      echo ""
+      echo "Options:"
+      echo "  --environment, -e   Target environment (staging or production)"
+      echo "  --all               Sync both staging and production"
+      echo "  --dry-run           Show what would be synced without making changes"
+      echo "  -h, --help          Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$SYNC_ALL" = true ]; then
+  ENVIRONMENTS=("staging" "production")
+elif [ -n "$ENVIRONMENT" ]; then
+  if [ "$ENVIRONMENT" != "staging" ] && [ "$ENVIRONMENT" != "production" ]; then
+    echo "Error: environment must be 'staging' or 'production' (got '$ENVIRONMENT')"
+    exit 1
+  fi
+  ENVIRONMENTS=("$ENVIRONMENT")
+else
+  echo "Error: specify --environment <staging|production> or --all"
+  echo "Run with --help for usage"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Detect repo from git remote
+# ---------------------------------------------------------------------------
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null)
+if [ -z "$REPO" ]; then
+  echo "Error: could not detect GitHub repo. Make sure you're in the repo directory and gh is authenticated."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Verify prerequisites
+# ---------------------------------------------------------------------------
+if ! command -v op &> /dev/null; then
+  echo "Error: 1Password CLI (op) is not installed."
+  echo "Install: https://developer.1password.com/docs/cli/get-started/"
+  exit 1
+fi
+
+if ! command -v gh &> /dev/null; then
+  echo "Error: GitHub CLI (gh) is not installed."
+  echo "Install: https://cli.github.com/"
+  exit 1
+fi
+
+# Verify 1Password auth
+if ! op account list &> /dev/null; then
+  echo "Error: 1Password CLI is not authenticated."
+  echo "Run: op signin"
+  exit 1
+fi
+
+# Verify GitHub auth
+if ! gh auth status &> /dev/null; then
+  echo "Error: GitHub CLI is not authenticated."
+  echo "Run: gh auth login"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Secret definitions
+# ---------------------------------------------------------------------------
+# These match the secrets previously loaded by load-secrets/action.yml
+COMMON_SECRETS=(
+  "CONVEX_DEPLOY_KEY"
+  "JWT_SECRET"
+  "RESEND_API_KEY"
+  "TWILIO_ACCOUNT_SID"
+  "TWILIO_API_KEY_SID"
+  "TWILIO_API_KEY_SECRET"
+  "TWILIO_VERIFY_SERVICE_SID"
+  "PLANNING_CENTER_CLIENT_ID"
+  "PLANNING_CENTER_CLIENT_SECRET"
+  "OTP_TEST_PHONE_NUMBERS"
+  "CLOUDFLARE_ACCOUNT_ID"
+  "R2_ACCESS_KEY_ID"
+  "R2_SECRET_ACCESS_KEY"
+  "R2_BUCKET_NAME"
+  "R2_PUBLIC_URL"
+  "SLACK_BOT_TOKEN"
+  "SLACK_SIGNING_SECRET"
+  "OPENAI_SECRET_KEY"
+  "EXPO_TOKEN"
+  "EAS_PROJECT_ID"
+  "CONVEX_SITE_URL"
+)
+
+OPTIONAL_SECRETS=(
+  "CLOUDFLARE_API_TOKEN"
+  "TF_API_TOKEN"
+  "SENTRY_AUTH_TOKEN"
+  "EXPO_PUBLIC_MAPBOX_TOKEN"
+  "EXPO_PUBLIC_SENTRY_DSN"
+  "EXPO_PUBLIC_POSTHOG_API_KEY"
+)
+
+# ---------------------------------------------------------------------------
+# Sync function
+# ---------------------------------------------------------------------------
+sync_environment() {
+  local env="$1"
+  local synced=0
+  local skipped=0
+  local failed=0
+
+  echo ""
+  echo "========================================"
+  echo "  Syncing secrets to GitHub"
+  echo "  1Password: op://Togather/*/$env"
+  echo "  GitHub:    $REPO (environment: $env)"
+  if [ "$DRY_RUN" = true ]; then
+    echo "  Mode:      DRY RUN"
+  fi
+  echo "========================================"
+  echo ""
+
+  # Sync common secrets
+  echo "Common secrets:"
+  for KEY in "${COMMON_SECRETS[@]}"; do
+    VALUE=$(op read "op://Togather/$KEY/$env" 2>/dev/null || true)
+    if [ -n "$VALUE" ]; then
+      if [ "$DRY_RUN" = true ]; then
+        echo "  [dry-run] Would set $KEY"
+      else
+        echo -n "  Setting $KEY..."
+        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO" --body -; then
+          echo " done"
+        else
+          echo " FAILED"
+          failed=$((failed + 1))
+          continue
+        fi
+      fi
+      synced=$((synced + 1))
+    else
+      echo "  Skipping $KEY (not found in 1Password)"
+      skipped=$((skipped + 1))
+    fi
+  done
+
+  echo ""
+
+  # Sync optional secrets
+  echo "Optional secrets:"
+  for KEY in "${OPTIONAL_SECRETS[@]}"; do
+    VALUE=$(op read "op://Togather/$KEY/$env" 2>/dev/null || true)
+    if [ -n "$VALUE" ]; then
+      if [ "$DRY_RUN" = true ]; then
+        echo "  [dry-run] Would set $KEY"
+      else
+        echo -n "  Setting $KEY..."
+        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO" --body -; then
+          echo " done"
+        else
+          echo " FAILED"
+          failed=$((failed + 1))
+          continue
+        fi
+      fi
+      synced=$((synced + 1))
+    else
+      echo "  Skipping $KEY (not found in 1Password)"
+      skipped=$((skipped + 1))
+    fi
+  done
+
+  echo ""
+
+  # Handle IMAGE_CDN_URL alias (same value as R2_PUBLIC_URL)
+  R2_URL=$(op read "op://Togather/R2_PUBLIC_URL/$env" 2>/dev/null || true)
+  if [ -n "$R2_URL" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "  [dry-run] Would set IMAGE_CDN_URL (alias for R2_PUBLIC_URL)"
+    else
+      echo -n "  Setting IMAGE_CDN_URL (alias for R2_PUBLIC_URL)..."
+      if printf '%s' "$R2_URL" | gh secret set "IMAGE_CDN_URL" --env "$env" --repo "$REPO" --body -; then
+        echo " done"
+      else
+        echo " FAILED"
+        failed=$((failed + 1))
+      fi
+    fi
+    synced=$((synced + 1))
+  fi
+
+  echo ""
+
+  # Summary
+  local total=$((synced + skipped + failed))
+  echo "========================================"
+  echo "  $env sync complete!"
+  echo "  Synced:  $synced / $total"
+  echo "  Skipped: $skipped / $total"
+  if [ "$failed" -gt 0 ]; then
+    echo "  Failed:  $failed / $total"
+  fi
+  echo "========================================"
+
+  if [ "$failed" -gt 0 ]; then
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run sync for each environment
+# ---------------------------------------------------------------------------
+EXIT_CODE=0
+
+for ENV in "${ENVIRONMENTS[@]}"; do
+  if ! sync_environment "$ENV"; then
+    EXIT_CODE=1
+  fi
+done
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Eliminates 1Password API calls during deployments — fixes rate limit exhaustion (1,000 reads/day account limit was being hit)
- Secrets are now pre-synced from 1Password to GitHub environment-scoped secrets via a manual script/workflow
- The `load-secrets` composite action now reads from `${{ toJSON(secrets) }}` instead of calling the 1Password CLI
- GitHub environment secrets already populated for both staging and production

## Changes
- **`ee/scripts/sync-1password-to-github.sh`** — new script to sync secrets from 1Password to GitHub
- **`.github/workflows/sync-secrets.yml`** — manual workflow to trigger sync from Actions tab
- **`.github/actions/load-secrets/action.yml`** — rewritten to parse GitHub secrets JSON instead of fetching from 1Password
- **10 workflow files (15 call sites)** — updated to use new `secrets-json` input
- **`build-mobile.yml`** — fixed environment mismatch (was hardcoded `production`, now dynamic based on profile)

## Test plan
- [x] Secrets synced to GitHub staging environment (26 secrets)
- [x] Secrets synced to GitHub production environment (28 secrets)
- [ ] Push to main → staging deploy succeeds without 1Password
- [ ] Manual production deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the secret-loading path across multiple deploy/build workflows; misconfigured environment secrets or missing keys could break deployments or leak incorrect config between staging/production.
> 
> **Overview**
> **Replaces runtime 1Password secret fetching in CI with GitHub environment secrets.** The `load-secrets` composite action is rewritten to take `secrets-json` (from `${{ toJSON(secrets) }}`), export each secret into `GITHUB_ENV` via `jq`, and set `IMAGE_CDN_URL` as an alias of `R2_PUBLIC_URL`.
> 
> All affected GitHub workflows are updated to call the new action interface (dropping 1Password inputs), and `build-mobile.yml` now selects the GitHub Actions `environment` dynamically based on the chosen build profile. A new manual `sync-secrets.yml` workflow plus `ee/scripts/sync-1password-to-github.sh` are added to sync secrets from 1Password into GitHub environment-scoped secrets ahead of deploys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55b1d38d7757fe84e3e9f141b04cdbd98283aa1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->