### PR TITLE
Fix: Remove template expression from action.yml description

### DIFF
--- a/.github/actions/load-secrets/action.yml
+++ b/.github/actions/load-secrets/action.yml
@@ -3,7 +3,7 @@ description: "Exports GitHub secrets as environment variables for downstream ste
 
 inputs:
   secrets-json:
-    description: "JSON object of all secrets (pass ${{ toJSON(secrets) }})"
+    description: "JSON object of all secrets - pass toJSON(secrets) from the calling workflow"
     required: true
 
 runs:


### PR DESCRIPTION
## Summary
Fixes the `Load secrets` step failing with: `A template expression is not allowed in this context`

The `${{ toJSON(secrets) }}` in the input description field was being parsed as a template expression by GitHub Actions. Replaced with plain text.

## Test plan
- [ ] Staging deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata change to a composite action input description; no runtime logic or secret handling behavior changes.
> 
> **Overview**
> Fixes the `Load Secrets` composite action metadata by removing the `${{ ... }}` template expression from the `secrets-json` input description and replacing it with plain text guidance (`toJSON(secrets)`).
> 
> This prevents GitHub Actions from attempting to evaluate the description as an expression, avoiding workflow/action load failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6f493ceae72a4c9aa8b01905b4fa1990a85b0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->