### PR TITLE
Add section headers, subtitles, checkbox, and field reordering to landing page

### DIFF
--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -29,41 +29,46 @@ import { checkRateLimit } from "../lib/rateLimit";
 export const getBySlug = query({
   args: { slug: v.string() },
   handler: async (ctx, args) => {
-    // Look up by slug first, then fall back to subdomain
-    let community = await ctx.db
-      .query("communities")
-      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
-      .first();
-
-    if (!community) {
-      community = await ctx.db
+    try {
+      let community = await ctx.db
         .query("communities")
-        .withIndex("by_subdomain", (q) => q.eq("subdomain", args.slug))
+        .withIndex("by_slug", (q) => q.eq("slug", args.slug))
         .first();
+
+      // Fallback to subdomain lookup (legacy communities may only have subdomain set)
+      if (!community) {
+        community = await ctx.db
+          .query("communities")
+          .withIndex("by_subdomain", (q) => q.eq("subdomain", args.slug))
+          .first();
+      }
+
+      if (!community) return null;
+
+      const landingPage = await ctx.db
+        .query("communityLandingPages")
+        .withIndex("by_community", (q) => q.eq("communityId", community._id))
+        .first();
+
+      if (!landingPage || !landingPage.isEnabled) return null;
+
+      return {
+        community: {
+          name: community.name,
+          logo: community.logo,
+          primaryColor: community.primaryColor,
+          slug: community.slug,
+        },
+        title: landingPage.title,
+        description: landingPage.description,
+        submitButtonText: landingPage.submitButtonText,
+        successMessage: landingPage.successMessage,
+        formFields: landingPage.formFields,
+      };
+    } catch (e: any) {
+      console.error("getBySlug error:", e.message, e.stack);
+      throw e;
     }
-
-    if (!community) return null;
-
-    const landingPage = await ctx.db
-      .query("communityLandingPages")
-      .withIndex("by_community", (q) => q.eq("communityId", community._id))
-      .first();
-
-    if (!landingPage || !landingPage.isEnabled) return null;
-
-    return {
-      community: {
-        name: community.name,
-        logo: community.logo,
-        primaryColor: community.primaryColor,
-        slug: community.slug,
-      },
-      title: landingPage.title,
-      description: landingPage.description,
-      submitButtonText: landingPage.submitButtonText,
-      successMessage: landingPage.successMessage,
-      formFields: landingPage.formFields,
-    };
   },
 });
 
@@ -77,7 +82,6 @@ export const getBySlug = query({
 export const getConfigBySlugInternal = internalQuery({
   args: { slug: v.string() },
   handler: async (ctx, args) => {
-    // Look up by slug first, then fall back to subdomain
     let community = await ctx.db
       .query("communities")
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
@@ -641,6 +645,7 @@ export const saveConfig = mutation({
 
     // Validate form field slots
     for (const field of args.formFields) {
+      if (field.type === "section_header" || field.type === "subtitle") continue;
       if (field.slot) {
         if (!VALID_CUSTOM_SLOTS.has(field.slot)) {
           throw new Error(`Invalid custom field slot: ${field.slot}`);

--- a/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
+++ b/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
@@ -9,7 +9,6 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   TextInput,
-  Switch,
   Platform,
   KeyboardAvoidingView,
 } from "react-native";
@@ -85,6 +84,7 @@ export default function CommunityLandingPageClient() {
 
     // Validate required custom fields
     for (const field of data.formFields || []) {
+      if (field.type === "section_header" || field.type === "subtitle") continue;
       if (field.required) {
         const key = field.slot || field.label;
         const value = customFieldValues[key];
@@ -108,6 +108,7 @@ export default function CommunityLandingPageClient() {
       // Build custom fields array — only include fields the user actually filled in
       const customFields = (data.formFields || [])
         .filter((field) => {
+          if (field.type === "section_header" || field.type === "subtitle") return false;
           const key = field.slot || field.label;
           const rawValue = customFieldValues[key];
 
@@ -398,19 +399,35 @@ function DynamicField({
   onChange: (value: any) => void;
 }) {
   switch (field.type) {
+    case "section_header":
+      return (
+        <View style={styles.sectionHeaderField}>
+          <Text style={styles.sectionHeaderText}>{field.label}</Text>
+        </View>
+      );
+
+    case "subtitle":
+      return (
+        <View style={styles.subtitleField}>
+          <Text style={styles.subtitleText}>{field.label}</Text>
+        </View>
+      );
+
     case "boolean":
       return (
-        <View style={styles.booleanField}>
-          <Switch
-            value={!!value}
-            onValueChange={onChange}
-            trackColor={{ false: "#ddd", true: "#4CAF50" }}
-          />
+        <TouchableOpacity
+          style={styles.booleanField}
+          onPress={() => onChange(!value)}
+          activeOpacity={0.7}
+        >
+          <View style={[styles.checkbox, !!value && styles.checkboxChecked]}>
+            {!!value && <Ionicons name="checkmark" size={16} color="#fff" />}
+          </View>
           <Text style={styles.booleanLabel}>
             {field.label}
             {field.required && <Text style={styles.required}> *</Text>}
           </Text>
-        </View>
+        </TouchableOpacity>
       );
 
     case "number":
@@ -600,12 +617,26 @@ const styles = StyleSheet.create({
     backgroundColor: "#fafafa",
   },
 
-  // Boolean field
+  // Boolean field (checkbox)
   booleanField: {
     flexDirection: "row",
     alignItems: "center",
     marginBottom: 16,
     gap: 12,
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderRadius: 6,
+    borderWidth: 2,
+    borderColor: "#ccc",
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#fff",
+  },
+  checkboxChecked: {
+    backgroundColor: "#4CAF50",
+    borderColor: "#4CAF50",
   },
   booleanLabel: {
     fontSize: 16,
@@ -638,6 +669,28 @@ const styles = StyleSheet.create({
   dropdownOptionTextSelected: {
     color: "#2E7D32",
     fontWeight: "600",
+  },
+
+  // Section header & subtitle (decorative fields)
+  sectionHeaderField: {
+    marginTop: 24,
+    marginBottom: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: "#eee",
+    paddingBottom: 8,
+  },
+  sectionHeaderText: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#333",
+  },
+  subtitleField: {
+    marginBottom: 12,
+  },
+  subtitleText: {
+    fontSize: 14,
+    color: "#666",
+    lineHeight: 20,
   },
 
   // Error

--- a/apps/mobile/features/admin/components/LandingPageContent.tsx
+++ b/apps/mobile/features/admin/components/LandingPageContent.tsx
@@ -39,7 +39,11 @@ const FIELD_TYPES = [
   { value: "number", label: "Number" },
   { value: "boolean", label: "Checkbox" },
   { value: "dropdown", label: "Dropdown" },
+  { value: "section_header", label: "Section Header" },
+  { value: "subtitle", label: "Subtitle" },
 ];
+
+const DECORATIVE_TYPES = new Set(["section_header", "subtitle"]);
 
 const OPERATORS = [
   { value: "equals", label: "Equals" },
@@ -159,6 +163,19 @@ export function LandingPageContent() {
   }, [config, followupCustomFields]);
 
   const markDirty = useCallback(() => setIsDirty(true), []);
+
+  const moveField = useCallback((index: number, direction: -1 | 1) => {
+    setFormFields((prev) => {
+      const sorted = [...prev].sort((a, b) => a.order - b.order);
+      const targetIdx = index + direction;
+      if (targetIdx < 0 || targetIdx >= sorted.length) return prev;
+      const tempOrder = sorted[index].order;
+      sorted[index] = { ...sorted[index], order: sorted[targetIdx].order };
+      sorted[targetIdx] = { ...sorted[targetIdx], order: tempOrder };
+      return sorted;
+    });
+    markDirty();
+  }, [markDirty]);
 
   const handleSave = async () => {
     try {
@@ -350,18 +367,60 @@ export function LandingPageContent() {
         {formFields.length === 0 ? (
           <Text style={styles.emptyText}>No custom fields configured</Text>
         ) : (
-          [...formFields]
-            .sort((a, b) => a.order - b.order)
-            .map((field) => {
+          (() => {
+            const sorted = [...formFields].sort((a, b) => a.order - b.order);
+            return sorted.map((field, sortedIndex) => {
               const originalIndex = formFields.indexOf(field);
+              const isDecorative = DECORATIVE_TYPES.has(field.type);
               return (
                 <View key={field.slot || field.label || originalIndex} style={styles.listItem}>
+                  <View style={styles.reorderButtons}>
+                    <TouchableOpacity
+                      onPress={() => moveField(sortedIndex, -1)}
+                      disabled={sortedIndex === 0}
+                      style={styles.iconButton}
+                    >
+                      <Ionicons
+                        name="chevron-up"
+                        size={18}
+                        color={sortedIndex === 0 ? "#ccc" : "#666"}
+                      />
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      onPress={() => moveField(sortedIndex, 1)}
+                      disabled={sortedIndex === sorted.length - 1}
+                      style={styles.iconButton}
+                    >
+                      <Ionicons
+                        name="chevron-down"
+                        size={18}
+                        color={sortedIndex === sorted.length - 1 ? "#ccc" : "#666"}
+                      />
+                    </TouchableOpacity>
+                  </View>
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.listItemTitle}>{field.label}</Text>
+                    <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+                      {isDecorative && (
+                        <Ionicons
+                          name={field.type === "section_header" ? "remove-outline" : "information-circle-outline"}
+                          size={16}
+                          color="#999"
+                        />
+                      )}
+                      <Text style={[
+                        styles.listItemTitle,
+                        field.type === "section_header" && { fontWeight: "700" },
+                        field.type === "subtitle" && { fontStyle: "italic", color: "#666" },
+                      ]}>
+                        {field.label}
+                      </Text>
+                    </View>
                     <Text style={styles.listItemSubtitle}>
-                      {field.type}
-                      {field.slot ? ` · ${field.slot}` : " · notes only"}
-                      {field.required ? " · required" : ""}
+                      {field.type === "section_header" ? "section header" :
+                       field.type === "subtitle" ? "subtitle" :
+                       field.type}
+                      {!isDecorative && (field.slot ? ` · ${field.slot}` : " · notes only")}
+                      {!isDecorative && field.required ? " · required" : ""}
                     </Text>
                   </View>
                   <TouchableOpacity
@@ -384,7 +443,8 @@ export function LandingPageContent() {
                   </TouchableOpacity>
                 </View>
               );
-            })
+            });
+          })()
         )}
       </View>
 
@@ -557,9 +617,21 @@ function FieldEditorModal({
     }
   }, [visible, field]);
 
+  const isDecorative = DECORATIVE_TYPES.has(type);
+
   const handleSave = () => {
     if (!label.trim()) {
       Alert.alert("Error", "Label is required");
+      return;
+    }
+
+    if (isDecorative) {
+      onSave({
+        label: label.trim(),
+        type,
+        required: false,
+        order: field?.order ?? 0,
+      });
       return;
     }
 
@@ -642,50 +714,52 @@ function FieldEditorModal({
               </View>
             </View>
 
-            <View style={styles.field}>
-              <Text style={styles.fieldLabel}>Custom Field Slot</Text>
-              <Text style={styles.fieldHint}>
-                Maps to a follow-up column. Leave empty for notes-only.
-              </Text>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                style={{ marginTop: 8 }}
-              >
-                <View style={modalStyles.chipContainer}>
-                  {availableSlots
-                    .filter((s) => {
-                      if (!s.value) return true; // "No slot" always shows
-                      if (type === "text" || type === "dropdown")
-                        return s.value.startsWith("customText");
-                      if (type === "number") return s.value.startsWith("customNum");
-                      if (type === "boolean") return s.value.startsWith("customBool");
-                      return false;
-                    })
-                    .map((s) => (
-                      <TouchableOpacity
-                        key={s.value}
-                        style={[
-                          modalStyles.chip,
-                          slot === s.value && modalStyles.chipSelected,
-                        ]}
-                        onPress={() => setSlot(s.value)}
-                      >
-                        <Text
+            {!isDecorative && (
+              <View style={styles.field}>
+                <Text style={styles.fieldLabel}>Custom Field Slot</Text>
+                <Text style={styles.fieldHint}>
+                  Maps to a follow-up column. Leave empty for notes-only.
+                </Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  style={{ marginTop: 8 }}
+                >
+                  <View style={modalStyles.chipContainer}>
+                    {availableSlots
+                      .filter((s) => {
+                        if (!s.value) return true; // "No slot" always shows
+                        if (type === "text" || type === "dropdown")
+                          return s.value.startsWith("customText");
+                        if (type === "number") return s.value.startsWith("customNum");
+                        if (type === "boolean") return s.value.startsWith("customBool");
+                        return false;
+                      })
+                      .map((s) => (
+                        <TouchableOpacity
+                          key={s.value}
                           style={[
-                            modalStyles.chipText,
-                            slot === s.value && modalStyles.chipTextSelected,
+                            modalStyles.chip,
+                            slot === s.value && modalStyles.chipSelected,
                           ]}
+                          onPress={() => setSlot(s.value)}
                         >
-                          {s.label}
-                        </Text>
-                      </TouchableOpacity>
-                    ))}
-                </View>
-              </ScrollView>
-            </View>
+                          <Text
+                            style={[
+                              modalStyles.chipText,
+                              slot === s.value && modalStyles.chipTextSelected,
+                            ]}
+                          >
+                            {s.label}
+                          </Text>
+                        </TouchableOpacity>
+                      ))}
+                  </View>
+                </ScrollView>
+              </View>
+            )}
 
-            {type === "dropdown" && (
+            {!isDecorative && type === "dropdown" && (
               <View style={styles.field}>
                 <Text style={styles.fieldLabel}>Options (comma-separated)</Text>
                 <TextInput
@@ -697,10 +771,12 @@ function FieldEditorModal({
               </View>
             )}
 
-            <View style={styles.row}>
-              <Text style={styles.rowLabel}>Required</Text>
-              <Switch value={required} onValueChange={setRequired} />
-            </View>
+            {!isDecorative && (
+              <View style={styles.row}>
+                <Text style={styles.rowLabel}>Required</Text>
+                <Switch value={required} onValueChange={setRequired} />
+              </View>
+            )}
           </ScrollView>
 
           <TouchableOpacity style={modalStyles.saveButton} onPress={handleSave}>
@@ -1013,6 +1089,10 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderBottomWidth: 1,
     borderBottomColor: "#f5f5f5",
+  },
+  reorderButtons: {
+    flexDirection: "column",
+    marginRight: 4,
   },
   listItemTitle: {
     fontSize: 15,


### PR DESCRIPTION
## Summary
- Add `section_header` and `subtitle` decorative field types for organizing the landing page form
- Replace `Switch` with a checkbox UI for boolean fields
- Add up/down chevron buttons to reorder fields in the admin editor
- Skip decorative fields during form validation and submission

## Test plan
- [ ] Add a section header and subtitle in the landing page admin editor
- [ ] Verify they render correctly on the public form at `/c/[slug]`
- [ ] Verify boolean fields show as checkboxes instead of switches
- [ ] Test reordering fields with the up/down buttons
- [ ] Verify decorative fields don't show slot/required options in the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both admin configuration and public form validation/submission behavior, so mis-handling new field types could break form rendering or required-field enforcement. Changes are localized and don’t affect auth or sensitive data paths.
> 
> **Overview**
> Adds *decorative* landing page form field types (`section_header`, `subtitle`) that render on the public landing page but are excluded from required-field validation, submission payload construction, and backend slot/type validation.
> 
> Updates boolean fields on the public landing page to use a tap-to-toggle checkbox UI (instead of a `Switch`).
> 
> Enhances the admin landing page editor to support adding these decorative field types, hides slot/required/options controls when editing them, and adds up/down controls that reorder fields by swapping their `order` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20cb5865c0b3fac648e2068cd973007ed9cbac04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->