### PR TITLE
Add configurable placeholder text and dim placeholder color

### DIFF
--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -607,6 +607,7 @@ export const saveConfig = mutation({
         slot: v.optional(v.string()),
         label: v.string(),
         type: v.string(),
+        placeholder: v.optional(v.string()),
         options: v.optional(v.array(v.string())),
         required: v.boolean(),
         order: v.number(),

--- a/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
+++ b/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
@@ -24,6 +24,7 @@ type FormField = {
   slot?: string;
   label: string;
   type: string;
+  placeholder?: string;
   options?: string[];
   required: boolean;
   order: number;
@@ -285,6 +286,7 @@ export default function CommunityLandingPageClient() {
                   value={firstName}
                   onChangeText={setFirstName}
                   placeholder="First name"
+                  placeholderTextColor="#aaa"
                   autoCapitalize="words"
                   autoComplete="given-name"
                 />
@@ -298,6 +300,7 @@ export default function CommunityLandingPageClient() {
                   value={lastName}
                   onChangeText={setLastName}
                   placeholder="Last name"
+                  placeholderTextColor="#aaa"
                   autoCapitalize="words"
                   autoComplete="family-name"
                 />
@@ -313,6 +316,7 @@ export default function CommunityLandingPageClient() {
                 value={phone}
                 onChangeText={setPhone}
                 placeholder="(555) 555-5555"
+                placeholderTextColor="#aaa"
                 keyboardType="phone-pad"
                 autoComplete="tel"
               />
@@ -325,6 +329,7 @@ export default function CommunityLandingPageClient() {
                 value={email}
                 onChangeText={setEmail}
                 placeholder="email@example.com"
+                placeholderTextColor="#aaa"
                 keyboardType="email-address"
                 autoCapitalize="none"
                 autoComplete="email"
@@ -445,7 +450,8 @@ function DynamicField({
               onChange(isNaN(num) ? undefined : num);
             }}
             keyboardType="numeric"
-            placeholder={field.label}
+            placeholder={field.placeholder}
+            placeholderTextColor="#aaa"
           />
         </View>
       );
@@ -493,7 +499,8 @@ function DynamicField({
             style={styles.textInput}
             value={value || ""}
             onChangeText={onChange}
-            placeholder={field.label}
+            placeholder={field.placeholder}
+            placeholderTextColor="#aaa"
           />
         </View>
       );

--- a/apps/mobile/features/admin/components/LandingPageContent.tsx
+++ b/apps/mobile/features/admin/components/LandingPageContent.tsx
@@ -66,6 +66,7 @@ type FormField = {
   slot?: string;
   label: string;
   type: string;
+  placeholder?: string;
   options?: string[];
   required: boolean;
   order: number;
@@ -606,6 +607,7 @@ function FieldEditorModal({
   const [slot, setSlot] = useState("");
   const [required, setRequired] = useState(false);
   const [options, setOptions] = useState("");
+  const [placeholder, setPlaceholder] = useState("");
 
   useEffect(() => {
     if (visible) {
@@ -614,6 +616,7 @@ function FieldEditorModal({
       setSlot(field?.slot || "");
       setRequired(field?.required || false);
       setOptions(field?.options?.join(", ") || "");
+      setPlaceholder(field?.placeholder || "");
     }
   }, [visible, field]);
 
@@ -642,6 +645,7 @@ function FieldEditorModal({
       slot: resolvedSlot,
       label: label.trim(),
       type,
+      placeholder: placeholder.trim() || undefined,
       required,
       order: field?.order ?? 0,
       options:
@@ -675,6 +679,21 @@ function FieldEditorModal({
                 placeholder="e.g., Neighborhood"
               />
             </View>
+
+            {!isDecorative && (
+              <View style={styles.field}>
+                <Text style={styles.fieldLabel}>Placeholder Text</Text>
+                <Text style={styles.fieldHint}>
+                  Hint text shown inside the field when empty
+                </Text>
+                <TextInput
+                  style={styles.textInput}
+                  value={placeholder}
+                  onChangeText={setPlaceholder}
+                  placeholder="e.g., Enter your neighborhood"
+                />
+              </View>
+            )}
 
             <View style={styles.field}>
               <Text style={styles.fieldLabel}>Type</Text>


### PR DESCRIPTION
## Summary
- Add optional `placeholder` field to landing page form field config
- Admin editor shows "Placeholder Text" input for non-decorative field types
- Custom fields use explicit placeholder only (empty if not set, no label fallback)
- All TextInputs on the public form now use `placeholderTextColor="#aaa"` for dimmer hint text

## Test plan
- [ ] Edit a field in the landing page admin and set custom placeholder text
- [ ] Verify placeholder appears dimmer than input text on the public form
- [ ] Verify fields without placeholder set show empty (no hint text)
- [ ] Verify built-in fields (name, phone, email) still show their default placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: expands persisted form-field schema and introduces new field types/reordering logic that affect both admin saves and public form rendering/validation, though changes are localized and not security-sensitive.
> 
> **Overview**
> Adds an optional `placeholder` attribute to landing-page custom form fields end-to-end (backend `saveConfig` validation + admin editor + public form rendering), and standardizes dimmer hint text via `placeholderTextColor="#aaa"`.
> 
> Extends landing-page forms with two *decorative* field types (`section_header`, `subtitle`) that render as non-input text, are excluded from required-field validation/submission payloads, and bypass slot validation. The admin UI also adds up/down controls to reorder fields by swapping their `order` values.
> 
> Separately, wraps the public `getBySlug` Convex query in a `try/catch` with error logging while preserving slug→subdomain fallback lookup behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76ebc9bfdd76dbb18ecca166929cb1d21589df69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->