### PR TITLE
Fix download links on landing page success screen

### DIFF
--- a/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
+++ b/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
@@ -204,7 +204,7 @@ export default function CommunityLandingPageClient() {
               onPress={() => {
                 if (Platform.OS === "web") {
                   window.open(
-                    "https://apps.apple.com/app/togather-community/id6738880626",
+                    "https://apps.apple.com/us/app/togather-life-in-community/id6756286011",
                     "_blank"
                   );
                 }
@@ -218,14 +218,14 @@ export default function CommunityLandingPageClient() {
               onPress={() => {
                 if (Platform.OS === "web") {
                   window.open(
-                    "https://play.google.com/store/apps/details?id=com.togather.app",
+                    `${DOMAIN_CONFIG.appUrl}/android`,
                     "_blank"
                   );
                 }
               }}
             >
-              <Ionicons name="logo-google-playstore" size={20} color="#fff" />
-              <Text style={styles.appStoreButtonText}>Google Play</Text>
+              <Ionicons name="logo-android" size={20} color="#fff" />
+              <Text style={styles.appStoreButtonText}>Android APK</Text>
             </TouchableOpacity>
           </View>
         </View>


### PR DESCRIPTION
## Summary
- Fix iOS App Store link to correct URL (togather-life-in-community/id6756286011)
- Replace Google Play link with APK download page (/android)
- Change button label from "Google Play" to "Android APK"

## Test plan
- [ ] Submit the landing page form and verify both download buttons work
- [ ] iOS button opens correct App Store listing
- [ ] Android button opens the APK download page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change that updates outbound URLs, with no impact to data handling or core app logic.
> 
> **Overview**
> Updates the community landing page success screen download buttons: the iOS button now opens the correct App Store listing, and the Android button now links to the site-hosted APK download page (`${DOMAIN_CONFIG.appUrl}/android`) instead of Google Play.
> 
> Also updates the Android button icon and label from “Google Play” to “Android APK” to match the new destination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4cc9654691ce276fa6210a4d6650beaf965a824. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->