### PR TITLE
Add follow-up assignment push notifications

### DIFF
--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -10,6 +10,7 @@
 
 import { v } from "convex/values";
 import { query, mutation, internalMutation, internalQuery } from "../_generated/server";
+import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { requireAuth } from "../lib/auth";
 import { requireCommunityAdmin } from "../lib/permissions";
@@ -495,6 +496,14 @@ export const setCustomFieldsAndNotes = internalMutation({
             assigneeId,
             updatedAt: timestamp,
           });
+
+          // Notify the assignee about the auto-assignment
+          await ctx.scheduler.runAfter(0, internal.functions.notifications.senders.notifyFollowupAssigned, {
+            assigneeId,
+            groupId: announcementGroup._id,
+            groupMemberId: groupMember._id,
+          });
+
           // Stop after first matching assignee rule to provide deterministic behavior
           break;
         }

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -1499,6 +1499,16 @@ export const setAssignee = mutation({
       assigneeId: args.assigneeId,
       updatedAt: Date.now(),
     });
+
+    // Notify the assignee (skip if clearing assignment)
+    if (args.assigneeId) {
+      await ctx.scheduler.runAfter(0, internal.functions.notifications.senders.notifyFollowupAssigned, {
+        assigneeId: args.assigneeId,
+        groupId: args.groupId,
+        groupMemberId: args.groupMemberId,
+      });
+    }
+
     return { success: true };
   },
 });

--- a/apps/convex/functions/notifications/internal.ts
+++ b/apps/convex/functions/notifications/internal.ts
@@ -151,6 +151,21 @@ export const getGroupMembersForNotification = internalQuery({
 });
 
 /**
+ * Get group member info (userId) from a groupMembers doc
+ * Used by followup assignment notifications
+ */
+export const getGroupMemberInfo = internalQuery({
+  args: {
+    groupMemberId: v.id("groupMembers"),
+  },
+  handler: async (ctx, args) => {
+    const member = await ctx.db.get(args.groupMemberId);
+    if (!member) return null;
+    return { userId: member.userId };
+  },
+});
+
+/**
  * Get a chat channel for test notifications
  * Used by the dev notification tester
  */

--- a/apps/convex/functions/notifications/senders.ts
+++ b/apps/convex/functions/notifications/senders.ts
@@ -411,6 +411,101 @@ export const notifyLeaderPromotion = internalAction({
 });
 
 // ============================================================================
+// Notification Action for Follow-up Assignment
+// ============================================================================
+
+/**
+ * Notify a leader when they are assigned to follow up with a member.
+ * Called from setAssignee mutation (manual) and setCustomFieldsAndNotes (auto-assignment).
+ */
+export const notifyFollowupAssigned = internalAction({
+  args: {
+    assigneeId: v.id("users"),
+    groupId: v.id("groups"),
+    groupMemberId: v.id("groupMembers"),
+  },
+  handler: async (ctx, args): Promise<{ success: boolean; error?: string; sent?: number }> => {
+    try {
+      // Get group info
+      const groupInfo = await ctx.runQuery(internal.functions.notifications.internal.getGroupInfo, {
+        groupId: args.groupId,
+      });
+      if (!groupInfo) {
+        console.log("[NotifyFollowupAssigned] Group not found, skipping notification");
+        return { success: false, error: "Group not found" };
+      }
+
+      // Get group member doc to find the member's userId
+      const groupMember: { userId: Id<"users"> } | null = await ctx.runQuery(internal.functions.notifications.internal.getGroupMemberInfo, {
+        groupMemberId: args.groupMemberId,
+      });
+      if (!groupMember) {
+        console.log("[NotifyFollowupAssigned] Group member not found, skipping notification");
+        return { success: false, error: "Group member not found" };
+      }
+
+      // Get member name
+      const memberName: string = await ctx.runQuery(internal.functions.notifications.internal.getUserDisplayName, {
+        userId: groupMember.userId,
+      });
+
+      // Get assignee's push tokens
+      const tokens: Array<{ token: string; platform: string }> = await ctx.runQuery(internal.functions.notifications.tokens.getActiveTokensForUser, {
+        userId: args.assigneeId,
+      });
+
+      if (tokens.length === 0) {
+        console.log("[NotifyFollowupAssigned] No push tokens for assignee");
+        return { success: true, sent: 0 };
+      }
+
+      const title = "New follow-up assignment";
+      const body = `You've been assigned to follow up with ${memberName} in ${groupInfo.name}`;
+
+      // Build notifications
+      const notifications: Array<{ token: string; title: string; body: string; data: Record<string, unknown> }> = tokens.map((t: { token: string; platform: string }) => ({
+        token: t.token,
+        title,
+        body,
+        data: {
+          type: "followup_assigned",
+          groupId: args.groupId,
+          groupMemberId: args.groupMemberId,
+          communityId: groupInfo.communityId,
+        },
+      }));
+
+      // Send push notifications
+      const result: { success: boolean; ticketIds: string[]; errors: string[] } = await ctx.runAction(internal.functions.notifications.internal.sendBatchPushNotifications, {
+        notifications,
+      });
+
+      // Create notification record
+      await ctx.runMutation(internal.functions.notifications.mutations.createNotification, {
+        userId: args.assigneeId,
+        communityId: groupInfo.communityId,
+        groupId: args.groupId,
+        notificationType: "followup_assigned",
+        title,
+        body,
+        data: {
+          groupId: args.groupId,
+          groupMemberId: args.groupMemberId,
+          communityId: groupInfo.communityId,
+        },
+        status: result.success ? "sent" : "failed",
+      });
+
+      console.log(`[NotifyFollowupAssigned] Sent notification to assignee for member ${memberName} in ${groupInfo.name}`);
+      return { success: result.success, sent: notifications.length };
+    } catch (error) {
+      console.error("[NotifyFollowupAssigned] Error:", error);
+      return { success: false, error: String(error) };
+    }
+  },
+});
+
+// ============================================================================
 // Notification Action for Shared Channel Invitations
 // ============================================================================
 

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -137,6 +137,15 @@ interface BotGenericMessageData {
   senderId?: string;
 }
 
+// Follow-up Assignment Types
+interface FollowupAssignedData {
+  memberName: string;
+  groupName: string;
+  groupId: string;
+  groupMemberId: string;
+  communityId?: string;
+}
+
 // Test Types
 interface TestNotificationData {
   title: string;
@@ -580,6 +589,28 @@ export const botGenericMessage: NotificationDefinition<BotGenericMessageData> =
     },
     defaultChannels: ['chat'],
   };
+
+// ============================================================================
+// Follow-up Assignment Definitions
+// ============================================================================
+
+export const followupAssigned: NotificationDefinition<FollowupAssignedData> = {
+  type: 'followup_assigned',
+  description: 'Sent when a leader is assigned to follow up with a member',
+  formatters: {
+    push: (ctx) => ({
+      title: 'New follow-up assignment',
+      body: `You've been assigned to follow up with ${ctx.data.memberName} in ${ctx.data.groupName}`,
+      data: {
+        type: 'followup_assigned',
+        groupId: ctx.data.groupId,
+        groupMemberId: ctx.data.groupMemberId,
+        communityId: ctx.data.communityId,
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
 
 // ============================================================================
 // Test Definitions

--- a/apps/mobile/providers/NotificationProvider.tsx
+++ b/apps/mobile/providers/NotificationProvider.tsx
@@ -370,6 +370,14 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
         }
         break;
       }
+      case 'followup_assigned': {
+        // Navigate to the member's follow-up card
+        const groupMemberId = (data.groupMemberId || nestedData?.groupMemberId) as string;
+        if (groupId && groupMemberId) {
+          router.push(`/(user)/leader-tools/${groupId}/followup/${groupMemberId}` as any);
+        }
+        break;
+      }
       default:
         // Default: do nothing or navigate to home
         console.log('Unknown notification type:', type);


### PR DESCRIPTION
## Summary
- Sends push notification when a leader is assigned to follow up with a member (manual or auto-assignment)
- Tapping the notification opens the member's follow-up detail card
- No notification sent when clearing an assignment

## Test plan
- [ ] Assign a leader to a member in the follow-up tool → push notification received
- [ ] Submit landing page form matching an automation rule → assigned leader gets notification
- [ ] Tap notification → opens the correct member's follow-up card
- [ ] Clear assignee → no notification sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new notification-sending code path triggered by both manual mutations and landing-page automation; main risk is incorrect IDs/routing or unexpected notification volume rather than data/security impact.
> 
> **Overview**
> Adds a new *follow-up assignment* push notification flow: when a leader is assigned to a member (manually via `memberFollowups.setAssignee` or automatically via landing page automation), the backend now schedules `notifyFollowupAssigned` to send a push and persist a notification record.
> 
> Extends the notifications system with a `followup_assigned` type (internal query helper to resolve the member user, sender action, and notification definition), and updates the mobile app’s `NotificationProvider` to deep-link notification taps to the assigned member’s follow-up detail screen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77a06966547bb131fb8481384b85bb8bd31a0c5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->