### PR TITLE
Fix followup assignment deep link route

### DIFF
--- a/apps/mobile/app/followup/[group_id]/[member_id].tsx
+++ b/apps/mobile/app/followup/[group_id]/[member_id].tsx
@@ -1,0 +1,2 @@
+import { FollowupDetailScreen } from "@features/leader-tools/components/FollowupDetailScreen";
+export default FollowupDetailScreen;

--- a/apps/mobile/providers/NotificationProvider.tsx
+++ b/apps/mobile/providers/NotificationProvider.tsx
@@ -371,10 +371,10 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
         break;
       }
       case 'followup_assigned': {
-        // Navigate to the member's follow-up card
+        // Navigate to the member's follow-up card via top-level route
         const groupMemberId = (data.groupMemberId || nestedData?.groupMemberId) as string;
         if (groupId && groupMemberId) {
-          router.push(`/(user)/leader-tools/${groupId}/followup/${groupMemberId}` as any);
+          router.push(`/followup/${groupId}/${groupMemberId}` as any);
         }
         break;
       }


### PR DESCRIPTION
## Summary
- Created a top-level `/followup/[group_id]/[member_id]` route for the followup assignment notification deep link
- Changed the notification handler from navigating to `/(user)/leader-tools/...` to `/followup/...`
- The `(user)` route group requires its Stack navigator to be mounted first, which fails on native when navigating from a push notification tap

## Test plan
- [x] Verified on web that `/followup/{groupId}/{memberId}` renders the correct follow-up detail card
- [ ] Verify on native device that tapping a followup assignment notification opens the member's follow-up card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes notification-tap navigation and routing, which can break deep links on native if params or route patterns don’t match. Scope is small and isolated to the `followup_assigned` path.
> 
> **Overview**
> Fixes follow-up assignment deep links by adding a top-level Expo Router entrypoint at `/followup/[group_id]/[member_id]` that renders `FollowupDetailScreen`.
> 
> Updates `NotificationProvider` handling for `followup_assigned` to navigate to `/followup/{groupId}/{groupMemberId}` instead of the nested `/(user)/leader-tools/...` route, avoiding reliance on that stack being mounted when opened from a push notification tap.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f6bcad32608c12d2b776d47afd62f89a56d9655. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->