### PR TITLE
Restore lost PRs 402-406: channel members + offline access

### DIFF
--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -130,6 +130,38 @@ async function createLeaderUser(
   return { userId, accessToken };
 }
 
+async function createCommunityAdminUser(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">
+): Promise<{ userId: Id<"users">; accessToken: string }> {
+  const userId = await t.run(async (ctx) => {
+    const createdAt = Date.now();
+    const adminId = await ctx.db.insert("users", {
+      firstName: "Community",
+      lastName: "Admin",
+      phone: "+15555550003",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    await ctx.db.insert("userCommunities", {
+      userId: adminId,
+      communityId,
+      roles: 3, // Community admin
+      status: 1, // Active
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    return adminId;
+  });
+
+  const { accessToken } = await generateTokens(userId);
+  return { userId, accessToken };
+}
+
 // ============================================================================
 // Channel Creation Tests
 // ============================================================================
@@ -2045,6 +2077,63 @@ describe("listGroupChannels", () => {
     expect(leadersChannel).toBeUndefined();
   });
 
+  test("allows community admins (non-group-members) to list group channels", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId } = await seedTestData(t);
+    const { userId: leaderId } = await createLeaderUser(t, communityId, groupId);
+    const { accessToken: adminToken } = await createCommunityAdminUser(t, communityId);
+
+    await t.run(async (ctx) => {
+      const now = Date.now();
+
+      const mainId = await ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "general",
+        channelType: "main",
+        name: "General",
+        createdById: leaderId,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: mainId,
+        userId: leaderId,
+        role: "admin",
+        joinedAt: now,
+        isMuted: false,
+      });
+
+      const leadersId = await ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "leaders",
+        channelType: "leaders",
+        name: "Leaders",
+        createdById: leaderId,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: leadersId,
+        userId: leaderId,
+        role: "admin",
+        joinedAt: now,
+        isMuted: false,
+      });
+    });
+
+    const channels = await t.query(api.functions.messaging.channels.listGroupChannels, {
+      token: adminToken,
+      groupId,
+    });
+
+    expect(channels.some((c) => c.channelType === "main")).toBe(true);
+    expect(channels.some((c) => c.channelType === "leaders")).toBe(true);
+  });
+
   test("excludes archived channels by default", async () => {
     const t = convexTest(schema, modules);
     const { communityId, groupId } = await seedTestData(t);
@@ -2074,6 +2163,51 @@ describe("listGroupChannels", () => {
 
     const archivedChannel = channels.find((c) => c.slug === "archived-channel");
     expect(archivedChannel).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// getChannelMembers Query Tests
+// ============================================================================
+
+describe("getChannelMembers", () => {
+  test("allows community admins (non-group-members) to view channel members", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, communityId, groupId } = await seedTestData(t);
+    const { userId: leaderId } = await createLeaderUser(t, communityId, groupId);
+    const { accessToken: adminToken } = await createCommunityAdminUser(t, communityId);
+
+    const channelId = await t.run(async (ctx) => {
+      const now = Date.now();
+      const chId = await ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "general",
+        channelType: "main",
+        name: "General",
+        createdById: leaderId,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: chId,
+        userId,
+        role: "member",
+        joinedAt: now,
+        isMuted: false,
+      });
+      return chId;
+    });
+
+    const result = await t.query(api.functions.messaging.channels.getChannelMembers, {
+      token: adminToken,
+      channelId,
+    });
+
+    expect(result.totalCount).toBe(1);
+    expect(result.members).toHaveLength(1);
+    expect(result.members[0].userId).toBe(userId);
   });
 });
 

--- a/apps/convex/__tests__/permissions.test.ts
+++ b/apps/convex/__tests__/permissions.test.ts
@@ -409,6 +409,72 @@ describe("Group Member Permissions - groupMembers.updateRole", () => {
     vi.useRealTimers();
   });
 
+  test("succeeds when leader has historical inactive membership row", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+
+    // Simulate leave/rejoin: old membership inactive, newer membership active.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(setup.leaderMembershipId, {
+        leftAt: Date.now() - 60_000,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: setup.groupId,
+        userId: setup.leaderId,
+        role: GROUP_ROLES.leader,
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+
+    const result = await t.mutation(api.functions.groupMembers.updateRole, {
+      token: setup.leaderToken,
+      groupId: setup.groupId,
+      userId: setup.memberId,
+      role: "leader",
+    });
+
+    expect(result).toBeDefined();
+    expect(result.role).toBe("leader");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    vi.useRealTimers();
+  });
+
+  test("succeeds when target member has historical inactive membership row", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+
+    // Simulate leave/rejoin for the target member.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(setup.memberMembershipId, {
+        leftAt: Date.now() - 60_000,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: setup.groupId,
+        userId: setup.memberId,
+        role: GROUP_ROLES.member,
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+
+    const result = await t.mutation(api.functions.groupMembers.updateRole, {
+      token: setup.leaderToken,
+      groupId: setup.groupId,
+      userId: setup.memberId,
+      role: "leader",
+    });
+
+    expect(result).toBeDefined();
+    expect(result.role).toBe("leader");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    vi.useRealTimers();
+  });
+
   test("throws when former leader tries to update roles", async () => {
     const t = convexTest(schema, modules);
     const setup = await seedTestData(t);

--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -572,6 +572,15 @@ export const updateRole = mutation({
       .withIndex("by_group_user", (q) =>
         q.eq("groupId", args.groupId).eq("userId", updatedBy)
       )
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("leftAt"), undefined),
+          q.or(
+            q.eq(q.field("requestStatus"), undefined),
+            q.eq(q.field("requestStatus"), "accepted")
+          )
+        )
+      )
       .first();
 
     const isGroupLeaderOrAdminRole = isActiveLeader(leaderMembership);
@@ -588,6 +597,15 @@ export const updateRole = mutation({
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
         q.eq("groupId", args.groupId).eq("userId", args.userId)
+      )
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("leftAt"), undefined),
+          q.or(
+            q.eq(q.field("requestStatus"), undefined),
+            q.eq(q.field("requestStatus"), "accepted")
+          )
+        )
       )
       .first();
 

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -11,6 +11,7 @@ import type { Id, Doc } from "../../_generated/dataModel";
 import { requireAuth, requireAuthFromToken } from "../../lib/auth";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { isAutoChannel, isCustomChannel, isLeaderRole } from "../../lib/helpers";
+import { isCommunityAdmin } from "../../lib/permissions";
 import { generateChannelSlug, getChannelSlug } from "../../lib/slugs";
 import { internal } from "../../_generated/api";
 import { syncUserChannelMembershipsLogic } from "../sync/memberships";
@@ -415,8 +416,9 @@ export const getChannelMembers = query({
       .first();
 
     if (!membership) {
-      // If not a channel member, check if user is a group leader/admin
-      // Group leaders can view members of any channel in their group
+      // If not a channel member, check elevated permissions:
+      // - group leaders/admins can view members of any channel in their group
+      // - community admins can manage/view members across all groups in community
       const groupMembership = await ctx.db
         .query("groupMembers")
         .withIndex("by_group_user", (q) =>
@@ -433,7 +435,12 @@ export const getChannelMembers = query({
         )
         .first();
 
-      if (!groupMembership) {
+      const group = await ctx.db.get(channel.groupId);
+      const isCommAdmin = group
+        ? await isCommunityAdmin(ctx, group.communityId, userId)
+        : false;
+
+      if (!groupMembership && !isCommAdmin) {
         return { members: [], nextCursor: null, totalCount: 0 };
       }
     }
@@ -450,18 +457,29 @@ export const getChannelMembers = query({
     const hasMore = result.page.length > limit;
     const members = hasMore ? result.page.slice(0, limit) : result.page;
 
+    // Enrich member data with fresh user info (denormalized displayName may be stale/missing)
+    const enrichedMembers = await Promise.all(
+      members.map(async (member) => {
+        const user = await ctx.db.get(member.userId);
+        const freshDisplayName = user
+          ? getDisplayName(user.firstName, user.lastName)
+          : member.displayName;
+
+        return {
+          id: member._id,
+          userId: member.userId,
+          displayName: freshDisplayName || member.displayName || "Unknown",
+          profilePhoto: member.profilePhoto || (user ? getMediaUrl(user.profilePhoto) : undefined),
+          role: member.role,
+          syncSource: member.syncSource,
+          syncMetadata: member.syncMetadata,
+        };
+      })
+    );
+
     // Return member data with pagination info
     return {
-      members: members.map((member) => ({
-        id: member._id,
-        userId: member.userId,
-        displayName: member.displayName || "Unknown",
-        profilePhoto: member.profilePhoto,
-        role: member.role,
-        // Include sync metadata for PCO-synced members
-        syncSource: member.syncSource,
-        syncMetadata: member.syncMetadata,
-      })),
+      members: enrichedMembers,
       nextCursor: result.isDone ? null : JSON.stringify(result.continueCursor),
       // Note: totalCount is expensive for large channels, use channel.memberCount instead
       totalCount: channel.memberCount || 0,
@@ -498,7 +516,15 @@ export const listGroupChannels = query({
     // 1. Authenticate user
     const userId = await requireAuth(ctx, args.token);
 
-    // 2. Verify user is group member
+    // 2. Verify user has group/community access
+    const group = await ctx.db.get(args.groupId);
+    if (!group) {
+      return [];
+    }
+
+    const isCommAdmin = await isCommunityAdmin(ctx, group.communityId, userId);
+
+    // Group membership still gates non-admin access.
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
@@ -507,14 +533,12 @@ export const listGroupChannels = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
-    if (!groupMembership) {
+    if (!groupMembership && !isCommAdmin) {
       return [];
     }
 
-    const userIsLeaderOrAdmin = isLeaderRole(groupMembership.role);
-
+    const userIsLeaderOrAdmin = isCommAdmin || isLeaderRole(groupMembership?.role);
     // 2b. Get group to fetch pinned channel slugs
-    const group = await ctx.db.get(args.groupId);
     const pinnedChannelSlugs: string[] = group?.pinnedChannelSlugs ?? [];
 
     // 3. Query all channels for group

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
@@ -27,7 +27,6 @@ import {
   FlatList,
   ActivityIndicator,
   Alert,
-  Image,
   Modal,
   KeyboardAvoidingView,
   Platform,
@@ -44,34 +43,11 @@ import { MemberSearch } from "@components/ui/MemberSearch";
 import type { CommunityMember } from "@/types/community";
 import { AutoChannelSettings } from "@features/channels";
 
-// Types for channel member
-interface ChannelMember {
-  id: string;
-  userId: Id<"users">;
-  displayName: string;
-  profilePhoto?: string;
-  role: string;
-  syncSource?: string;
-  syncMetadata?: {
-    serviceTypeName?: string;
-    teamName?: string;
-    position?: string;
-    serviceDate?: number;
-    serviceName?: string;
-  };
-}
-
-// Type for unsynced PCO people
-interface UnsyncedPerson {
-  pcoPersonId: string;
-  pcoName: string;
-  pcoPhone?: string;
-  pcoEmail?: string;
-  serviceTypeName?: string;
-  teamName?: string;
-  position?: string;
-  reason: string;
-}
+import { ChannelMember, UnsyncedPerson } from "@/utils/channel-members";
+import {
+  SyncedMemberRowContent,
+  UnsyncedPersonRowContent,
+} from "@/components/ui/ChannelMemberRows";
 
 // Unified list item type
 type ListItem =
@@ -385,24 +361,6 @@ export default function ChannelMembersScreen() {
     [token, channelData, groupId, removeGroupMutation, router]
   );
 
-  // Helper to format debug reason text
-  const getDebugReasonText = useCallback((reason: string, person: UnsyncedPerson) => {
-    switch (reason) {
-      case "not_in_group":
-        return "In community but not in this group";
-      case "not_in_community":
-        return "Not in this community";
-      case "no_contact_info":
-        return "No contact info in PCO";
-      case "phone_mismatch":
-        return `Phone ${person.pcoPhone || "unknown"} not found`;
-      case "email_mismatch":
-        return `Email ${person.pcoEmail || "unknown"} not found`;
-      default:
-        return "Unknown issue";
-    }
-  }, []);
-
   // Render unified list item (synced or unsynced)
   const renderListItem = useCallback(
     ({ item }: { item: ListItem }) => {
@@ -411,144 +369,47 @@ export default function ChannelMembersScreen() {
         const isOwner = member.role === "owner";
         const isCurrentUser = member.userId === user?.id;
         const isRemoving = removingMemberId === member.userId;
-        const isPcoSynced = member.syncSource === "pco_services";
-        const initials =
-          member.displayName
-            .split(" ")
-            .map((n) => n[0])
-            .join("")
-            .toUpperCase()
-            .slice(0, 2) || "?";
+        const showRemoveButton =
+          canManage && isCustomChannel && (!isSharedChannel || isPrimaryGroup) && !(isOwner && isCurrentUser);
 
         return (
           <View style={styles.memberItem}>
-            {/* Avatar */}
-            <View style={styles.memberAvatar}>
-              {member.profilePhoto ? (
-                <Image source={{ uri: member.profilePhoto }} style={styles.avatarImage} />
-              ) : (
-                <View style={[styles.avatarPlaceholder, { backgroundColor: primaryColor }]}>
-                  <Text style={styles.avatarInitials}>{initials}</Text>
-                </View>
-              )}
-            </View>
-
-            {/* Name and badges */}
-            <View style={styles.memberInfo}>
-              <View style={styles.memberNameRow}>
-                <Text style={styles.memberName} numberOfLines={1}>
-                  {member.displayName}
-                </Text>
-                {isCurrentUser && <Text style={styles.youBadge}>(you)</Text>}
-              </View>
-              {isOwner && (
-                <View style={[styles.ownerBadge, { backgroundColor: `${primaryColor}20` }]}>
-                  <Text style={[styles.ownerBadgeText, { color: primaryColor }]}>Owner</Text>
-                </View>
-              )}
-              {/* PCO sync metadata - team and position */}
-              {isPcoSynced && member.syncMetadata && (
-                <View style={styles.syncMetadataRow}>
-                  {member.syncMetadata.teamName && (
-                    <View style={styles.syncBadge}>
-                      <Ionicons name="people" size={10} color="#2196F3" />
-                      <Text style={styles.syncBadgeText}>
-                        {member.syncMetadata.serviceTypeName
-                          ? `${member.syncMetadata.serviceTypeName} > ${member.syncMetadata.teamName}`
-                          : member.syncMetadata.teamName}
-                      </Text>
-                    </View>
-                  )}
-                  {member.syncMetadata.position && (
-                    <View style={[styles.syncBadge, { backgroundColor: "#FF980020" }]}>
-                      <Ionicons name="musical-notes" size={10} color="#FF9800" />
-                      <Text style={[styles.syncBadgeText, { color: "#FF9800" }]}>{member.syncMetadata.position}</Text>
-                    </View>
-                  )}
-                </View>
-              )}
-            </View>
-
-            {/* Remove button (only show if can manage, is primary group for shared channels, and not removing self as owner) */}
-            {canManage && isCustomChannel && (!isSharedChannel || isPrimaryGroup) && !(isOwner && isCurrentUser) && (
-              <TouchableOpacity
-                style={styles.removeButton}
-                onPress={() => handleRemoveMember(member)}
-                disabled={isRemoving}
-              >
-                {isRemoving ? (
-                  <ActivityIndicator size="small" color="#FF3B30" />
-                ) : (
-                  <Ionicons name="remove-circle-outline" size={24} color="#FF3B30" />
-                )}
-              </TouchableOpacity>
-            )}
+            <SyncedMemberRowContent
+              member={member}
+              primaryColor={primaryColor}
+              isCurrentUser={isCurrentUser}
+              rightContent={
+                showRemoveButton ? (
+                  <TouchableOpacity
+                    style={styles.removeButton}
+                    onPress={() => handleRemoveMember(member)}
+                    disabled={isRemoving}
+                  >
+                    {isRemoving ? (
+                      <ActivityIndicator size="small" color="#FF3B30" />
+                    ) : (
+                      <Ionicons name="remove-circle-outline" size={24} color="#FF3B30" />
+                    )}
+                  </TouchableOpacity>
+                ) : undefined
+              }
+            />
           </View>
         );
       } else {
-        // Unsynced person
         const person = item.data;
-        const initials =
-          person.pcoName
-            .split(" ")
-            .map((n) => n[0])
-            .join("")
-            .toUpperCase()
-            .slice(0, 2) || "?";
 
         return (
           <View
             style={[styles.memberItem, styles.unsyncedMemberItem]}
             testID={`unsynced-member-${person.pcoPersonId}`}
           >
-            {/* Avatar with warning indicator */}
-            <View style={styles.memberAvatar}>
-              <View style={[styles.avatarPlaceholder, styles.unsyncedAvatarPlaceholder]}>
-                <Text style={[styles.avatarInitials, styles.unsyncedAvatarInitials]}>{initials}</Text>
-              </View>
-            </View>
-
-            {/* Name and badges */}
-            <View style={styles.memberInfo}>
-              <View style={styles.memberNameRow}>
-                <Text style={styles.memberName} numberOfLines={1}>
-                  {person.pcoName}
-                </Text>
-                <Ionicons name="warning" size={14} color="#B25000" style={{ marginLeft: 4 }} />
-              </View>
-
-              {/* Team and position chips */}
-              {(person.teamName || person.position) && (
-                <View style={styles.syncMetadataRow}>
-                  {person.teamName && (
-                    <View style={styles.syncBadge}>
-                      <Ionicons name="people" size={10} color="#2196F3" />
-                      <Text style={styles.syncBadgeText}>
-                        {person.serviceTypeName
-                          ? `${person.serviceTypeName} > ${person.teamName}`
-                          : person.teamName}
-                      </Text>
-                    </View>
-                  )}
-                  {person.position && (
-                    <View style={[styles.syncBadge, { backgroundColor: "#FF980020" }]}>
-                      <Ionicons name="musical-notes" size={10} color="#FF9800" />
-                      <Text style={[styles.syncBadgeText, { color: "#FF9800" }]}>{person.position}</Text>
-                    </View>
-                  )}
-                </View>
-              )}
-
-              {/* Debug reason text */}
-              <Text style={styles.unsyncedReasonText}>
-                {getDebugReasonText(person.reason, person)}
-              </Text>
-            </View>
+            <UnsyncedPersonRowContent person={person} />
           </View>
         );
       }
     },
-    [canManage, isCustomChannel, user, removingMemberId, primaryColor, handleRemoveMember, getDebugReasonText]
+    [canManage, isCustomChannel, isSharedChannel, isPrimaryGroup, user, removingMemberId, primaryColor, handleRemoveMember]
   );
 
   // Loading state

--- a/apps/mobile/components/ui/ChannelMemberRows.tsx
+++ b/apps/mobile/components/ui/ChannelMemberRows.tsx
@@ -1,0 +1,274 @@
+/**
+ * Shared components for rendering channel members and unsynced PCO people.
+ *
+ * These components extract the duplicated rendering logic from:
+ * - features/leader-tools/components/Members.tsx
+ * - app/inbox/[groupId]/[channelSlug]/members.tsx
+ * - features/channels/components/ChannelMembersModal.tsx
+ */
+import React, { ReactNode } from "react";
+import { View, Text, StyleSheet, Image } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { ChannelMember, UnsyncedPerson } from "@/utils/channel-members";
+import { getDebugReasonText } from "@/utils/channel-members";
+
+/**
+ * Calculate initials from a display name.
+ * Returns first letter of first and last names, uppercase, max 2 chars.
+ */
+export function getInitials(displayName: string): string {
+  return (
+    displayName
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2) || "?"
+  );
+}
+
+interface SyncedMemberRowContentProps {
+  member: ChannelMember;
+  primaryColor: string;
+  isCurrentUser?: boolean;
+  /** Optional content to render at the end of the row (e.g., remove button, chevron) */
+  rightContent?: ReactNode;
+}
+
+/**
+ * Renders the content of a synced member row: avatar, name, badges, and sync metadata.
+ * Does NOT include TouchableOpacity wrapper - parent components handle that.
+ */
+export function SyncedMemberRowContent({
+  member,
+  primaryColor,
+  isCurrentUser = false,
+  rightContent,
+}: SyncedMemberRowContentProps) {
+  const isOwner = member.role === "owner";
+  const isAdmin = member.role === "admin";
+  const isPcoSynced = member.syncSource === "pco_services";
+  const initials = getInitials(member.displayName);
+
+  return (
+    <>
+      {/* Avatar */}
+      <View style={styles.memberAvatar}>
+        {member.profilePhoto ? (
+          <Image source={{ uri: member.profilePhoto }} style={styles.avatarImage} />
+        ) : (
+          <View style={[styles.avatarPlaceholder, { backgroundColor: primaryColor }]}>
+            <Text style={styles.avatarInitials}>{initials}</Text>
+          </View>
+        )}
+      </View>
+
+      {/* Name and badges */}
+      <View style={styles.memberInfo}>
+        <View style={styles.memberNameRow}>
+          <Text style={styles.memberName} numberOfLines={1}>
+            {member.displayName}
+          </Text>
+          {isCurrentUser && <Text style={styles.youBadge}>(you)</Text>}
+        </View>
+
+        {/* Role badges */}
+        {isOwner && (
+          <View style={[styles.roleBadge, { backgroundColor: `${primaryColor}20` }]}>
+            <Text style={[styles.roleBadgeText, { color: primaryColor }]}>Owner</Text>
+          </View>
+        )}
+        {isAdmin && !isOwner && (
+          <View style={[styles.roleBadge, { backgroundColor: `${primaryColor}20` }]}>
+            <Text style={[styles.roleBadgeText, { color: primaryColor }]}>Admin</Text>
+          </View>
+        )}
+
+        {/* PCO sync metadata - team and position */}
+        {isPcoSynced && member.syncMetadata && (
+          <View style={styles.syncMetadataRow}>
+            {member.syncMetadata.teamName && (
+              <View style={styles.syncBadge}>
+                <Ionicons name="people" size={10} color="#2196F3" />
+                <Text style={styles.syncBadgeText}>
+                  {member.syncMetadata.serviceTypeName
+                    ? `${member.syncMetadata.serviceTypeName} > ${member.syncMetadata.teamName}`
+                    : member.syncMetadata.teamName}
+                </Text>
+              </View>
+            )}
+            {member.syncMetadata.position && (
+              <View style={[styles.syncBadge, styles.positionBadge]}>
+                <Ionicons name="musical-notes" size={10} color="#FF9800" />
+                <Text style={[styles.syncBadgeText, styles.positionBadgeText]}>
+                  {member.syncMetadata.position}
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
+      </View>
+
+      {rightContent}
+    </>
+  );
+}
+
+interface UnsyncedPersonRowContentProps {
+  person: UnsyncedPerson;
+}
+
+/**
+ * Renders the content of an unsynced PCO person row: avatar with warning, name, badges, and reason.
+ */
+export function UnsyncedPersonRowContent({
+  person,
+}: UnsyncedPersonRowContentProps) {
+  const initials = getInitials(person.pcoName);
+
+  return (
+    <>
+      {/* Avatar with warning indicator */}
+      <View style={styles.memberAvatar}>
+        <View style={[styles.avatarPlaceholder, styles.unsyncedAvatarPlaceholder]}>
+          <Text style={[styles.avatarInitials, styles.unsyncedAvatarInitials]}>
+            {initials}
+          </Text>
+        </View>
+      </View>
+
+      {/* Name and badges */}
+      <View style={styles.memberInfo}>
+        <View style={styles.memberNameRow}>
+          <Text style={styles.memberName} numberOfLines={1}>
+            {person.pcoName}
+          </Text>
+          <Ionicons name="warning" size={14} color="#B25000" style={{ marginLeft: 4 }} />
+        </View>
+
+        {/* Team and position chips */}
+        {(person.teamName || person.position) && (
+          <View style={styles.syncMetadataRow}>
+            {person.teamName && (
+              <View style={styles.syncBadge}>
+                <Ionicons name="people" size={10} color="#2196F3" />
+                <Text style={styles.syncBadgeText}>
+                  {person.serviceTypeName
+                    ? `${person.serviceTypeName} > ${person.teamName}`
+                    : person.teamName}
+                </Text>
+              </View>
+            )}
+            {person.position && (
+              <View style={[styles.syncBadge, styles.positionBadge]}>
+                <Ionicons name="musical-notes" size={10} color="#FF9800" />
+                <Text style={[styles.syncBadgeText, styles.positionBadgeText]}>
+                  {person.position}
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* Reason text */}
+        <Text style={styles.unsyncedReasonText}>
+          {getDebugReasonText(person.reason, person)}
+        </Text>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  memberAvatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    overflow: "hidden",
+    marginRight: 12,
+  },
+  avatarImage: {
+    width: "100%",
+    height: "100%",
+  },
+  avatarPlaceholder: {
+    width: "100%",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  avatarInitials: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#fff",
+  },
+  unsyncedAvatarPlaceholder: {
+    backgroundColor: "#FFB74D",
+  },
+  unsyncedAvatarInitials: {
+    color: "#fff",
+  },
+  memberInfo: {
+    flex: 1,
+  },
+  memberNameRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 2,
+  },
+  memberName: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#333",
+    flexShrink: 1,
+  },
+  youBadge: {
+    fontSize: 13,
+    color: "#888",
+    marginLeft: 4,
+  },
+  roleBadge: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+    marginTop: 2,
+  },
+  roleBadgeText: {
+    fontSize: 10,
+    fontWeight: "700",
+    textTransform: "uppercase",
+  },
+  syncMetadataRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 4,
+    marginTop: 4,
+  },
+  syncBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#E3F2FD",
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 8,
+    gap: 3,
+  },
+  syncBadgeText: {
+    fontSize: 11,
+    color: "#2196F3",
+    fontWeight: "500",
+  },
+  positionBadge: {
+    backgroundColor: "#FF980020",
+  },
+  positionBadgeText: {
+    color: "#FF9800",
+  },
+  unsyncedReasonText: {
+    fontSize: 12,
+    color: "#B25000",
+    marginTop: 4,
+    fontStyle: "italic",
+  },
+});

--- a/apps/mobile/components/ui/__tests__/ChannelMemberRows.test.tsx
+++ b/apps/mobile/components/ui/__tests__/ChannelMemberRows.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for ChannelMemberRows shared components
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { View } from "react-native";
+import {
+  SyncedMemberRowContent,
+  UnsyncedPersonRowContent,
+  getInitials,
+} from "../ChannelMemberRows";
+import type { ChannelMember, UnsyncedPerson } from "@/utils/channel-members";
+import type { Id } from "@services/api/convex";
+
+describe("getInitials", () => {
+  it("returns first letters of first and last name", () => {
+    expect(getInitials("John Doe")).toBe("JD");
+  });
+
+  it("handles single name", () => {
+    expect(getInitials("Madonna")).toBe("M");
+  });
+
+  it("handles multiple names", () => {
+    expect(getInitials("John Paul Jones")).toBe("JPJ".slice(0, 2));
+  });
+
+  it("returns ? for empty string", () => {
+    expect(getInitials("")).toBe("?");
+  });
+
+  it("uppercases initials", () => {
+    expect(getInitials("john doe")).toBe("JD");
+  });
+});
+
+describe("SyncedMemberRowContent", () => {
+  const mockMember: ChannelMember = {
+    id: "member-1",
+    userId: "user-1" as Id<"users">,
+    displayName: "John Doe",
+    role: "member",
+  };
+
+  const mockOwner: ChannelMember = {
+    id: "owner-1",
+    userId: "owner-user" as Id<"users">,
+    displayName: "Owner Person",
+    role: "owner",
+  };
+
+  const mockPcoMember: ChannelMember = {
+    id: "pco-1",
+    userId: "pco-user" as Id<"users">,
+    displayName: "PCO User",
+    role: "member",
+    syncSource: "pco_services",
+    syncMetadata: {
+      teamName: "Worship Team",
+      serviceTypeName: "Sunday Service",
+      position: "Vocals",
+    },
+  };
+
+  it("renders member name", () => {
+    const { getByText } = render(
+      <View>
+        <SyncedMemberRowContent
+          member={mockMember}
+          primaryColor="#007AFF"
+        />
+      </View>
+    );
+    expect(getByText("John Doe")).toBeTruthy();
+  });
+
+  it("shows (you) badge for current user", () => {
+    const { getByText } = render(
+      <View>
+        <SyncedMemberRowContent
+          member={mockMember}
+          primaryColor="#007AFF"
+          isCurrentUser
+        />
+      </View>
+    );
+    expect(getByText("(you)")).toBeTruthy();
+  });
+
+  it("shows Owner badge for owner role", () => {
+    const { getByText } = render(
+      <View>
+        <SyncedMemberRowContent
+          member={mockOwner}
+          primaryColor="#007AFF"
+        />
+      </View>
+    );
+    expect(getByText("Owner")).toBeTruthy();
+  });
+
+  it("shows PCO sync metadata badges", () => {
+    const { getByText } = render(
+      <View>
+        <SyncedMemberRowContent
+          member={mockPcoMember}
+          primaryColor="#007AFF"
+        />
+      </View>
+    );
+    expect(getByText("Sunday Service > Worship Team")).toBeTruthy();
+    expect(getByText("Vocals")).toBeTruthy();
+  });
+
+  it("renders rightContent when provided", () => {
+    const { getByTestId } = render(
+      <View>
+        <SyncedMemberRowContent
+          member={mockMember}
+          primaryColor="#007AFF"
+          rightContent={<View testID="right-content" />}
+        />
+      </View>
+    );
+    expect(getByTestId("right-content")).toBeTruthy();
+  });
+
+  it("renders initials when no profile photo", () => {
+    const { getByText } = render(
+      <View>
+        <SyncedMemberRowContent
+          member={mockMember}
+          primaryColor="#007AFF"
+        />
+      </View>
+    );
+    expect(getByText("JD")).toBeTruthy();
+  });
+});
+
+describe("UnsyncedPersonRowContent", () => {
+  const mockPerson: UnsyncedPerson = {
+    pcoPersonId: "pco-123",
+    pcoName: "Jane Smith",
+    teamName: "Band",
+    position: "Guitar",
+    reason: "not_in_group",
+  };
+
+  it("renders person name", () => {
+    const { getByText } = render(
+      <View>
+        <UnsyncedPersonRowContent person={mockPerson} />
+      </View>
+    );
+    expect(getByText("Jane Smith")).toBeTruthy();
+  });
+
+  it("shows team and position badges", () => {
+    const { getByText } = render(
+      <View>
+        <UnsyncedPersonRowContent person={mockPerson} />
+      </View>
+    );
+    expect(getByText("Band")).toBeTruthy();
+    expect(getByText("Guitar")).toBeTruthy();
+  });
+
+  it("shows reason text", () => {
+    const { getByText } = render(
+      <View>
+        <UnsyncedPersonRowContent person={mockPerson} />
+      </View>
+    );
+    expect(getByText("In community but not in this group")).toBeTruthy();
+  });
+
+  it("renders initials", () => {
+    const { getByText } = render(
+      <View>
+        <UnsyncedPersonRowContent person={mockPerson} />
+      </View>
+    );
+    expect(getByText("JS")).toBeTruthy();
+  });
+
+  it("handles different reason codes", () => {
+    const personNotInCommunity: UnsyncedPerson = {
+      ...mockPerson,
+      reason: "not_in_community",
+    };
+    const { getByText } = render(
+      <View>
+        <UnsyncedPersonRowContent person={personNotInCommunity} />
+      </View>
+    );
+    expect(getByText("Not in this community")).toBeTruthy();
+  });
+});

--- a/apps/mobile/features/auth/hooks/__tests__/useInitialRouting.test.ts
+++ b/apps/mobile/features/auth/hooks/__tests__/useInitialRouting.test.ts
@@ -1,0 +1,58 @@
+import { getInitialRouteTarget } from "../initialRouteTarget";
+
+describe("getInitialRouteTarget", () => {
+  it("routes unauthenticated users to signin", () => {
+    const route = getInitialRouteTarget({
+      isAuthenticated: false,
+      hasCommunity: false,
+      hasSlugParam: false,
+      hasUserProfile: false,
+    });
+
+    expect(route).toBe("/(auth)/signin");
+  });
+
+  it("routes authenticated users with community to chat", () => {
+    const route = getInitialRouteTarget({
+      isAuthenticated: true,
+      hasCommunity: true,
+      hasSlugParam: false,
+      hasUserProfile: true,
+    });
+
+    expect(route).toBe("/(tabs)/chat");
+  });
+
+  it("routes authenticated users with slug param to chat", () => {
+    const route = getInitialRouteTarget({
+      isAuthenticated: true,
+      hasCommunity: false,
+      hasSlugParam: true,
+      hasUserProfile: true,
+    });
+
+    expect(route).toBe("/(tabs)/chat");
+  });
+
+  it("routes token-only authenticated users to profile for offline access", () => {
+    const route = getInitialRouteTarget({
+      isAuthenticated: true,
+      hasCommunity: false,
+      hasSlugParam: false,
+      hasUserProfile: false,
+    });
+
+    expect(route).toBe("/(tabs)/profile");
+  });
+
+  it("routes authenticated users without community but with profile to signin", () => {
+    const route = getInitialRouteTarget({
+      isAuthenticated: true,
+      hasCommunity: false,
+      hasSlugParam: false,
+      hasUserProfile: true,
+    });
+
+    expect(route).toBe("/(auth)/signin");
+  });
+});

--- a/apps/mobile/features/auth/hooks/initialRouteTarget.ts
+++ b/apps/mobile/features/auth/hooks/initialRouteTarget.ts
@@ -1,0 +1,32 @@
+export interface InitialRouteTargetInput {
+  isAuthenticated: boolean;
+  hasCommunity: boolean;
+  hasSlugParam: boolean;
+  hasUserProfile: boolean;
+}
+
+/**
+ * Determine where the index route should send the user.
+ * Token-only sessions (no profile loaded yet) go to profile so the app
+ * remains usable while offline instead of forcing sign-in.
+ */
+export function getInitialRouteTarget({
+  isAuthenticated,
+  hasCommunity,
+  hasSlugParam,
+  hasUserProfile,
+}: InitialRouteTargetInput): string {
+  if (!isAuthenticated) {
+    return "/(auth)/signin";
+  }
+
+  if (hasCommunity || hasSlugParam) {
+    return "/(tabs)/chat";
+  }
+
+  if (!hasUserProfile) {
+    return "/(tabs)/profile";
+  }
+
+  return "/(auth)/signin";
+}

--- a/apps/mobile/features/auth/hooks/useInitialRouting.ts
+++ b/apps/mobile/features/auth/hooks/useInitialRouting.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { useRouter, usePathname, useLocalSearchParams } from "expo-router";
 import { Platform } from "react-native";
 import { useAuth } from "@providers/AuthProvider";
+import { getInitialRouteTarget } from "./initialRouteTarget";
 
 /**
  * Hook to handle initial routing based on authentication state
@@ -96,58 +97,50 @@ export function useInitialRouting() {
       return;
     }
 
-    // Determine target path based on auth state
-    let targetPath: string | null = null;
+    const targetPath = getInitialRouteTarget({
+      isAuthenticated,
+      hasCommunity: !!community,
+      hasSlugParam: !!params.slug,
+      hasUserProfile: !!user,
+    });
 
-    if (isAuthenticated) {
-      // Only redirect if community is selected
-      if (community || params.slug) {
-        targetPath = "/(tabs)/chat";
-        console.log(
-          "📄 Index: Authenticated with community, redirecting to",
-          targetPath
-        );
-      } else {
-        // If authenticated but no community, redirect to signin (will show community search)
-        targetPath = "/(auth)/signin";
-        console.log(
-          "📄 Index: Authenticated but no community, redirecting to signin"
-        );
-      }
-    } else {
-      // Not authenticated, redirect to signin
-      targetPath = "/(auth)/signin";
-      console.log("📄 Index: Not authenticated, redirecting to signin");
-    }
-
-    if (targetPath) {
+    if (targetPath === "/(tabs)/chat") {
       console.log(
-        "📄 Index: Setting redirect flags and scheduling redirect to",
+        "📄 Index: Authenticated with community, redirecting to",
         targetPath
       );
-      redirectingRef.current = true;
-      hasRedirectedRef.current = true; // Set BEFORE redirect to prevent loops
-
-      // Use setTimeout to defer redirect to next event loop tick
-      // This prevents the redirect from causing an immediate re-render loop
-      const timeoutId = setTimeout(() => {
-        try {
-          console.log("📄 Index: Executing redirect to", targetPath);
-          // Use router.replace for both web and native to ensure Expo Router paths work correctly
-          // window.location.href doesn't work with Expo Router route groups like (auth)
-          router.replace(targetPath!);
-        } catch (error) {
-          console.error("📄 Index: Redirect error:", error);
-          hasRedirectedRef.current = false; // Reset on error so we can retry
-        } finally {
-          redirectingRef.current = false;
-        }
-      }, 50); // Small delay to prevent immediate re-render loop
-
-      return () => clearTimeout(timeoutId);
+    } else if (isAuthenticated && targetPath === "/(tabs)/profile") {
+      console.log(
+        "📄 Index: Authenticated without profile/community (offline-safe), redirecting to profile"
+      );
     } else {
-      console.log("📄 Index: No target path determined");
+      console.log("📄 Index: Redirecting to signin");
     }
+
+    console.log(
+      "📄 Index: Setting redirect flags and scheduling redirect to",
+      targetPath
+    );
+    redirectingRef.current = true;
+    hasRedirectedRef.current = true; // Set BEFORE redirect to prevent loops
+
+    // Use setTimeout to defer redirect to next event loop tick
+    // This prevents the redirect from causing an immediate re-render loop
+    const timeoutId = setTimeout(() => {
+      try {
+        console.log("📄 Index: Executing redirect to", targetPath);
+        // Use router.replace for both web and native to ensure Expo Router paths work correctly
+        // window.location.href doesn't work with Expo Router route groups like (auth)
+        router.replace(targetPath);
+      } catch (error) {
+        console.error("📄 Index: Redirect error:", error);
+        hasRedirectedRef.current = false; // Reset on error so we can retry
+      } finally {
+        redirectingRef.current = false;
+      }
+    }, 50); // Small delay to prevent immediate re-render loop
+
+    return () => clearTimeout(timeoutId);
     // Use pathname inside effect, don't add to dependencies to prevent loops
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, isAuthenticated, community, params.slug, forceShow, router]);

--- a/apps/mobile/features/channels/components/ChannelMembersModal.tsx
+++ b/apps/mobile/features/channels/components/ChannelMembersModal.tsx
@@ -19,7 +19,6 @@ import {
   TouchableOpacity,
   FlatList,
   ActivityIndicator,
-  Image,
   Modal,
   Pressable,
   Alert,
@@ -32,34 +31,11 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useQuery, useAction, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 
-// Types for channel member
-interface ChannelMember {
-  id: string;
-  userId: Id<"users">;
-  displayName: string;
-  profilePhoto?: string;
-  role: string;
-  syncSource?: string;
-  syncMetadata?: {
-    serviceTypeName?: string;
-    teamName?: string;
-    position?: string;
-    serviceDate?: number;
-    serviceName?: string;
-  };
-}
-
-// Type for unsynced PCO people
-interface UnsyncedPerson {
-  pcoPersonId: string;
-  pcoName: string;
-  pcoPhone?: string;
-  pcoEmail?: string;
-  serviceTypeName?: string;
-  teamName?: string;
-  position?: string;
-  reason: string;
-}
+import { ChannelMember, UnsyncedPerson } from "@/utils/channel-members";
+import {
+  SyncedMemberRowContent,
+  UnsyncedPersonRowContent,
+} from "@/components/ui/ChannelMemberRows";
 
 // Unified list item type
 type ListItem =
@@ -180,24 +156,6 @@ export const ChannelMembersModal = memo(function ChannelMembersModal({
     return items;
   }, [membersData, unsyncedPeople]);
 
-  // Helper to format debug reason text (must be defined before renderItem uses it)
-  const getDebugReasonText = useCallback((reason: string, person: UnsyncedPerson) => {
-    switch (reason) {
-      case "not_in_group":
-        return "In community but not in this group";
-      case "not_in_community":
-        return "Not in this community";
-      case "no_contact_info":
-        return "No contact info in PCO";
-      case "phone_mismatch":
-        return `Phone ${person.pcoPhone || "unknown"} not found`;
-      case "email_mismatch":
-        return `Email ${person.pcoEmail || "unknown"} not found`;
-      default:
-        return "Unknown issue";
-    }
-  }, []);
-
   // Render member item - memoized to prevent FlatList re-renders
   const renderItem = useCallback(
     ({ item }: { item: ListItem }) => {
@@ -213,155 +171,29 @@ export const ChannelMembersModal = memo(function ChannelMembersModal({
 
       if (item.type === "unsynced") {
         const person = item.data;
-        const initials =
-          person.pcoName
-            .split(" ")
-            .map((n) => n[0])
-            .join("")
-            .toUpperCase()
-            .slice(0, 2) || "?";
 
         return (
           <View style={[styles.memberItem, styles.unsyncedItem]}>
-            {/* Avatar */}
-            <View style={styles.memberAvatar}>
-              <View style={[styles.avatarPlaceholder, styles.unsyncedAvatar]}>
-                <Text style={[styles.avatarInitials, styles.unsyncedInitials]}>
-                  {initials}
-                </Text>
-              </View>
-            </View>
-
-            {/* Name and badges */}
-            <View style={styles.memberInfo}>
-              <View style={styles.memberNameRow}>
-                <Text style={styles.memberName} numberOfLines={1}>
-                  {person.pcoName}
-                </Text>
-                <Ionicons
-                  name="warning"
-                  size={14}
-                  color="#B25000"
-                  style={{ marginLeft: 4 }}
-                />
-              </View>
-              <View style={styles.badgeRow}>
-                {person.teamName && (
-                  <View style={styles.syncBadge}>
-                    <Ionicons name="people" size={10} color="#2196F3" />
-                    <Text style={styles.syncBadgeText}>
-                      {person.serviceTypeName
-                        ? `${person.serviceTypeName} > ${person.teamName}`
-                        : person.teamName}
-                    </Text>
-                  </View>
-                )}
-                {person.position && (
-                  <View style={[styles.syncBadge, styles.positionBadge]}>
-                    <Ionicons name="musical-notes" size={10} color="#FF9800" />
-                    <Text style={[styles.syncBadgeText, styles.positionBadgeText]}>
-                      {person.position}
-                    </Text>
-                  </View>
-                )}
-              </View>
-              {/* Show reason */}
-              <Text style={styles.unsyncedReason}>
-                {getDebugReasonText(person.reason, person)}
-              </Text>
-            </View>
+            <UnsyncedPersonRowContent person={person} />
           </View>
         );
       }
 
       // Synced member
       const member = item.data;
-      const isOwner = member.role === "owner";
-      const isAdmin = member.role === "admin";
       const isCurrentUser = member.userId === user?.id;
-      const isPcoSynced = member.syncSource === "pco_services";
-      const initials =
-        member.displayName
-          .split(" ")
-          .map((n) => n[0])
-          .join("")
-          .toUpperCase()
-          .slice(0, 2) || "?";
 
       return (
         <View style={styles.memberItem}>
-          {/* Avatar */}
-          <View style={styles.memberAvatar}>
-            {member.profilePhoto ? (
-              <Image
-                source={{ uri: member.profilePhoto }}
-                style={styles.avatarImage}
-              />
-            ) : (
-              <View
-                style={[styles.avatarPlaceholder, { backgroundColor: primaryColor }]}
-              >
-                <Text style={styles.avatarInitials}>{initials}</Text>
-              </View>
-            )}
-          </View>
-
-          {/* Name and badges */}
-          <View style={styles.memberInfo}>
-            <View style={styles.memberNameRow}>
-              <Text style={styles.memberName} numberOfLines={1}>
-                {member.displayName}
-              </Text>
-              {isCurrentUser && <Text style={styles.youBadge}>(you)</Text>}
-            </View>
-            <View style={styles.badgeRow}>
-              {isOwner && (
-                <View
-                  style={[styles.roleBadge, { backgroundColor: `${primaryColor}20` }]}
-                >
-                  <Text style={[styles.roleBadgeText, { color: primaryColor }]}>
-                    Owner
-                  </Text>
-                </View>
-              )}
-              {isAdmin && !isOwner && (
-                <View
-                  style={[styles.roleBadge, { backgroundColor: `${primaryColor}20` }]}
-                >
-                  <Text style={[styles.roleBadgeText, { color: primaryColor }]}>
-                    Admin
-                  </Text>
-                </View>
-              )}
-              {/* PCO sync metadata - team and position */}
-              {isPcoSynced && member.syncMetadata && (
-                <>
-                  {member.syncMetadata.teamName && (
-                    <View style={styles.syncBadge}>
-                      <Ionicons name="people" size={10} color="#2196F3" />
-                      <Text style={styles.syncBadgeText}>
-                        {member.syncMetadata.serviceTypeName
-                          ? `${member.syncMetadata.serviceTypeName} > ${member.syncMetadata.teamName}`
-                          : member.syncMetadata.teamName}
-                      </Text>
-                    </View>
-                  )}
-                  {member.syncMetadata.position && (
-                    <View style={[styles.syncBadge, styles.positionBadge]}>
-                      <Ionicons name="musical-notes" size={10} color="#FF9800" />
-                      <Text style={[styles.syncBadgeText, styles.positionBadgeText]}>
-                        {member.syncMetadata.position}
-                      </Text>
-                    </View>
-                  )}
-                </>
-              )}
-            </View>
-          </View>
+          <SyncedMemberRowContent
+            member={member}
+            primaryColor={primaryColor}
+            isCurrentUser={isCurrentUser}
+          />
         </View>
       );
     },
-    [user?.id, primaryColor, getDebugReasonText]
+    [user?.id, primaryColor]
   );
 
   const keyExtractor = useCallback((item: ListItem, index: number) => {

--- a/apps/mobile/features/leader-tools/__tests__/Members.test.tsx
+++ b/apps/mobile/features/leader-tools/__tests__/Members.test.tsx
@@ -8,7 +8,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Members } from "@features/leader-tools/components/Members";
 import { useAuth } from "@providers/AuthProvider";
-import { useGroupMembers } from "@features/leader-tools/hooks";
+import { useAuthenticatedQuery } from "@services/api/convex";
 
 jest.mock("@providers/AuthProvider", () => ({
   useAuth: jest.fn(),
@@ -24,55 +24,101 @@ jest.mock("expo-router", () => ({
   useSegments: jest.fn(() => []),
 }));
 
-// Mock the useGroupMembers hook directly
-jest.mock("@features/leader-tools/hooks", () => ({
-  ...jest.requireActual("@features/leader-tools/hooks"),
-  useGroupMembers: jest.fn(),
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: jest.fn(() => ({
+    primaryColor: "#007AFF",
+    secondaryColor: "#5856D6",
+  })),
+}));
+
+jest.mock("@services/api/convex", () => ({
+  useAuthenticatedQuery: jest.fn(),
+  api: {
+    functions: {
+      messaging: {
+        channels: {
+          listGroupChannels: "listGroupChannels",
+          getChannelMembers: "getChannelMembers",
+        },
+      },
+      pcoServices: {
+        queries: {
+          getAutoChannelConfigByChannel: "getAutoChannelConfigByChannel",
+        },
+      },
+    },
+  },
 }));
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
-const mockUseGroupMembers = useGroupMembers as jest.MockedFunction<typeof useGroupMembers>;
+const mockUseAuthenticatedQuery = useAuthenticatedQuery as jest.MockedFunction<typeof useAuthenticatedQuery>;
+
+const mockChannels = [
+  {
+    _id: "channel-1",
+    slug: "general",
+    channelType: "main",
+    name: "General",
+    memberCount: 10,
+    isShared: false,
+  },
+  {
+    _id: "channel-2",
+    slug: "leaders",
+    channelType: "leaders",
+    name: "Leaders",
+    memberCount: 3,
+    isShared: false,
+  },
+  {
+    _id: "channel-3",
+    slug: "service",
+    channelType: "pco_services",
+    name: "Service",
+    memberCount: 12,
+    isShared: false,
+  },
+];
+
+const mockChannelMembers = {
+  members: [
+    {
+      id: "member-1",
+      userId: "user-1",
+      displayName: "John Doe",
+      profilePhoto: null,
+      role: "owner",
+      syncSource: null,
+      syncMetadata: null,
+    },
+    {
+      id: "member-2",
+      userId: "user-2",
+      displayName: "Jane Smith",
+      profilePhoto: null,
+      role: "member",
+      syncSource: null,
+      syncMetadata: null,
+    },
+  ],
+  totalCount: 2,
+  nextCursor: null,
+};
 
 describe("Members", () => {
   let queryClient: QueryClient;
+  let channelListResponse: any;
 
   const mockUser = {
-    id: "user-1", // Convex ID is a string
+    id: "user-1",
     legacyId: 1,
     email: "test@example.com",
     first_name: "Test",
     last_name: "User",
   };
 
-  const mockMembers = [
-    {
-      id: 1,
-      first_name: "John",
-      last_name: "Doe",
-      profile_photo: null,
-      role: "leader",
-      membership: {
-        id: 101,
-        role: 2, // LEADER
-      },
-      joined_at: "2024-01-01T00:00:00Z",
-    },
-    {
-      id: 2,
-      first_name: "Jane",
-      last_name: "Smith",
-      profile_photo: null,
-      role: "member",
-      membership: {
-        id: 102,
-        role: 1, // MEMBER
-      },
-      joined_at: "2024-01-15T00:00:00Z",
-    },
-  ];
-
   const defaultProps = {
-    groupId: "13",
+    groupId: "group-13",
     onMemberAction: jest.fn(),
   };
 
@@ -95,7 +141,7 @@ describe("Members", () => {
       isAuthenticated: true,
       isLoading: false,
       community: null,
-      token: null,
+      token: "test-token",
       logout: jest.fn(),
       refreshUser: jest.fn(),
       setCommunity: jest.fn(),
@@ -103,18 +149,14 @@ describe("Members", () => {
       signIn: jest.fn(),
     });
 
-    // Mock useGroupMembers to return member data
-    mockUseGroupMembers.mockReturnValue({
-      members: mockMembers,
-      isLoading: false,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn(),
-      refetch: jest.fn(),
-      isRefetching: false,
-      error: null,
-      data: { pages: [mockMembers] },
-    } as any);
+    channelListResponse = mockChannels;
+    mockUseAuthenticatedQuery.mockImplementation((queryFn: any, args: any) => {
+      if (args === "skip") return undefined;
+      if (queryFn === "listGroupChannels") return channelListResponse as any;
+      if (queryFn === "getChannelMembers") return mockChannelMembers as any;
+      if (queryFn === "getAutoChannelConfigByChannel") return undefined;
+      return undefined;
+    });
   });
 
   afterEach(() => {
@@ -130,78 +172,98 @@ describe("Members", () => {
     );
   };
 
-  it("renders loading state initially", async () => {
-    mockUseGroupMembers.mockReturnValue({
-      members: [],
-      isLoading: true,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn(),
-      refetch: jest.fn(),
-      isRefetching: false,
-      error: null,
-      data: undefined,
-    } as any);
+  it("renders loading state when channels are not loaded", async () => {
+    channelListResponse = undefined;
 
     renderComponent();
 
     expect(screen.getByText("Loading members...")).toBeTruthy();
   });
 
-  it("displays members list", async () => {
-    renderComponent();
-
-    // Wait for component to render with members data
-    await waitFor(
-      () => {
-        // Component should render successfully with members
-        // Since text rendering is unreliable in test environment,
-        // we verify the component rendered without errors
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-      },
-      { timeout: 3000 }
-    );
-
-    // Verify the component has rendered by checking for UI elements
-    // The component should have filter buttons and search input
-    expect(screen.getByText("All")).toBeTruthy();
-    expect(screen.getByText("Leaders")).toBeTruthy();
-    expect(screen.getByText("Members")).toBeTruthy();
-  });
-
-  it("shows leader badge for leaders", async () => {
+  it("displays channel chips", async () => {
     renderComponent();
 
     await waitFor(() => {
-      expect(screen.getByText("Leader")).toBeTruthy();
+      expect(screen.getByText("General")).toBeTruthy();
+      expect(screen.getByText("Leaders")).toBeTruthy();
+      expect(screen.getByText("Service")).toBeTruthy();
     });
   });
 
-  it("filters members by role", async () => {
+  it("shows search bar", async () => {
     renderComponent();
 
     await waitFor(() => {
-      // Wait for members to be rendered
       expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
     });
-
-    // Find and press the Leaders filter button
-    const leadersFilter = screen.getByText("Leaders");
-    fireEvent.press(leadersFilter);
-
-    // Verify the filter button interaction works
-    // The component should handle the filter change without crashing
-    await waitFor(
-      () => {
-        // Component should still be rendered after filtering
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-        expect(screen.getByText("Leaders")).toBeTruthy();
-      },
-      { timeout: 3000 }
-    );
   });
 
-  it("allows searching members", async () => {
+  it("loads channel members even when AuthProvider token is null", async () => {
+    mockUseAuth.mockReturnValue({
+      user: mockUser,
+      isAuthenticated: true,
+      isLoading: false,
+      community: null,
+      token: null,
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+      setCommunity: jest.fn(),
+      clearCommunity: jest.fn(),
+      signIn: jest.fn(),
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("Jane Smith")).toBeTruthy();
+    });
+  });
+
+  it("displays member count", async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 members/)).toBeTruthy();
+    });
+  });
+
+  it("shows empty state when no channels exist", async () => {
+    channelListResponse = [];
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("No channels found for this group")).toBeTruthy();
+    });
+  });
+
+  it("switches channel when chip is pressed", async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("Leaders")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText("Leaders"));
+
+    // Component should still render without crashing
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
+    });
+  });
+
+  it("shows PCO badge for PCO synced channels", async () => {
+    // Simulate selecting a PCO channel by returning only PCO channel
+    channelListResponse = [mockChannels[2]];
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("PCO Synced")).toBeTruthy();
+    });
+  });
+
+  it("handles search input", async () => {
     renderComponent();
 
     await waitFor(() => {
@@ -211,229 +273,53 @@ describe("Members", () => {
     const searchInput = screen.getByPlaceholderText("Search members...");
     fireEvent.changeText(searchInput, "John");
 
-    // Verify the search input accepts text and component handles it
-    await waitFor(
-      () => {
-        // Component should still be rendered after search
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-        // Verify the search input has the value we entered
-        expect(searchInput.props.value || searchInput.props.defaultValue).toBe(
-          "John"
-        );
-      },
-      { timeout: 3000 }
-    );
+    await waitFor(() => {
+      expect(searchInput.props.value || searchInput.props.defaultValue).toBe("John");
+    });
   });
 
-  it("opens member actions modal on member press", async () => {
-    const onMemberAction = jest.fn();
-    renderComponent({ onMemberAction });
-
-    await waitFor(
-      () => {
-        // Wait for component to render
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-      },
-      { timeout: 3000 }
-    );
-
-    // Note: In the test environment, we can't reliably find member cards by text
-    // since FlatList rendering is mocked. However, we verify that the component
-    // has the necessary structure to handle member presses. The actual interaction
-    // is tested in integration tests or browser tests.
-    // The component should render without errors, which validates the structure.
-    expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-  });
-
-  it("calls onMemberAction when remove is pressed", async () => {
-    const onMemberAction = jest.fn();
-    renderComponent({ onMemberAction });
-
-    await waitFor(
-      () => {
-        // Wait for component to render
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-      },
-      { timeout: 3000 }
-    );
-
-    // Note: In the test environment, we can't reliably simulate member card presses
-    // since FlatList rendering is mocked. However, we verify that:
-    // 1. The component renders without errors
-    // 2. The onMemberAction prop is passed correctly
-    // The actual modal interaction is tested in integration tests or browser tests.
-    expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-    expect(onMemberAction).toBeDefined();
-  });
-
-  it("shows empty state when no members", async () => {
-    mockUseGroupMembers.mockReturnValue({
-      members: [],
-      isLoading: false,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn(),
-      refetch: jest.fn(),
-      isRefetching: false,
-      error: null,
-      data: { pages: [[]] },
-    } as any);
+  it("filters DM and reach_out channels from chips", async () => {
+    channelListResponse = [
+      ...mockChannels,
+      { _id: "dm-1", slug: "dm-user", channelType: "dm", name: "DM", memberCount: 2 },
+      { _id: "ro-1", slug: "reach-out", channelType: "reach_out", name: "Reach Out", memberCount: 5 },
+    ];
 
     renderComponent();
 
     await waitFor(() => {
-      expect(screen.getByText("No members in this group")).toBeTruthy();
+      expect(screen.getByText("General")).toBeTruthy();
+      expect(screen.queryByText("DM")).toBeNull();
+      expect(screen.queryByText("Reach Out")).toBeNull();
     });
   });
 
-  it("handles pagination structure", async () => {
-    const mockFetchNextPage = jest.fn();
+  it("still allows promote action when leaders channel is unavailable", async () => {
+    const onMemberAction = jest.fn();
 
-    mockUseGroupMembers.mockReturnValue({
-      members: mockMembers,
-      isLoading: false,
-      isFetchingNextPage: false,
-      hasNextPage: true,
-      fetchNextPage: mockFetchNextPage,
-      refetch: jest.fn(),
-      isRefetching: false,
-      error: null,
-      data: { pages: [mockMembers] },
-    } as any);
+    // Simulate groups where leaders channel is not available in channel list
+    channelListResponse = [mockChannels[0]];
 
-    renderComponent();
-
-    // Wait for component to render with pagination data
-    await waitFor(
-      () => {
-        // Component should render successfully with paginated data
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-      },
-      { timeout: 3000 }
-    );
-
-    // Verify that the component rendered correctly with the pagination props
-    expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-  });
-
-  it("handles API errors correctly", async () => {
-    const error = new Error("Failed to fetch members");
-
-    mockUseGroupMembers.mockReturnValue({
-      members: [],
-      isLoading: false,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn(),
-      refetch: jest.fn(),
-      isRefetching: false,
-      error,
-      data: undefined,
-    } as any);
-
-    renderComponent();
+    renderComponent({ onMemberAction, canManageMembers: true });
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to load members")).toBeTruthy();
-      expect(screen.getByText("Failed to fetch members")).toBeTruthy();
+      expect(screen.getByText("Jane Smith")).toBeTruthy();
     });
-  });
 
-  it("uses correct sort_by parameter matching backend expectations", async () => {
-    renderComponent();
+    fireEvent.press(screen.getByText("Jane Smith"));
 
-    // Wait for the component to render
-    await waitFor(
-      () => {
-        // Component should render successfully
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-      },
-      { timeout: 3000 }
-    );
+    await waitFor(() => {
+      expect(screen.getByText("Promote to Leader")).toBeTruthy();
+    });
 
-    // Note: Since useInfiniteQuery is mocked, the actual API call isn't made in tests.
-    // However, we verify that the component uses the correct sortBy value in its state.
-    // The component's default sortBy is set to "-membership__role,last_name,first_name,id"
-    // which matches the backend's expected format. The previous value was "-role" which
-    // caused 400 errors, so this test ensures the correct default is used.
-    // In a real environment, useInfiniteQuery would call the queryFn which calls
-    // api.getGroupMembers with this sort_by parameter.
+    fireEvent.press(screen.getByText("Promote to Leader"));
 
-    // Verify the component rendered without errors (which would occur if sort_by was wrong)
-    expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-  });
-
-  it("handles null/undefined members gracefully", async () => {
-    // Test with null member in the response - the hook filters these out
-    const membersWithNull = [
-      {
-        id: 1,
-        first_name: "John",
-        last_name: "Doe",
-        role: "leader",
-        membership: { id: 101, role: 2 },
-        joined_at: "2024-01-01T00:00:00Z",
-      },
-      null, // Null member
-      {
-        id: 2,
-        first_name: "Jane",
-        last_name: "Smith",
+    expect(onMemberAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "user-2",
         role: "member",
-        membership: { id: 102, role: 1 },
-        joined_at: "2024-01-15T00:00:00Z",
-      },
-    ] as any;
-
-    mockUseGroupMembers.mockReturnValue({
-      members: membersWithNull,
-      isLoading: false,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn(),
-      refetch: jest.fn(),
-      isRefetching: false,
-      error: null,
-      data: { pages: [membersWithNull] },
-    } as any);
-
-    renderComponent();
-
-    // Wait for component to process the data - the key is that it doesn't crash
-    // on null members. We verify this by checking that the component renders
-    // without errors and processes the valid members.
-    await waitFor(
-      () => {
-        // Component should render without crashing - check for search input as evidence
-        expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-      },
-      { timeout: 3000 }
-    );
-
-    // Verify that the component handled the null member gracefully
-    expect(screen.getByPlaceholderText("Search members...")).toBeTruthy();
-  });
-
-  it("handles empty response gracefully", async () => {
-    mockUseGroupMembers.mockReturnValue({
-      members: [],
-      isLoading: false,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn(),
-      refetch: jest.fn(),
-      isRefetching: false,
-      error: null,
-      data: { pages: [[]] },
-    } as any);
-
-    renderComponent();
-
-    await waitFor(
-      () => {
-        expect(screen.getByText("No members in this group")).toBeTruthy();
-      },
-      { timeout: 3000 }
+      }),
+      "promote"
     );
   });
 });

--- a/apps/mobile/features/leader-tools/components/Members.tsx
+++ b/apps/mobile/features/leader-tools/components/Members.tsx
@@ -7,17 +7,15 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   FlatList,
-  RefreshControl,
   Modal,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { Avatar } from "@components/ui/Avatar";
 import { SearchBar } from "@components/ui/SearchBar";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
-import { format } from "date-fns";
 import { MembershipRole } from "@/constants/membership";
-import { useGroupMembers } from "../hooks";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
 
 interface MembersProps {
   groupId: string;
@@ -26,78 +24,155 @@ interface MembersProps {
   canManageMembers?: boolean;
 }
 
-interface MemberFilters {
-  role?: "leader" | "member" | "all";
-  noAttendanceDays?: number;
-  rsvpStatus?: "going" | "not_going" | "not_answered";
-  rsvpDate?: string;
+import { ChannelMember, UnsyncedPerson } from "@/utils/channel-members";
+import {
+  SyncedMemberRowContent,
+  UnsyncedPersonRowContent,
+} from "@/components/ui/ChannelMemberRows";
+
+type ListItem =
+  | { type: "synced"; data: ChannelMember }
+  | { type: "unsynced"; data: UnsyncedPerson };
+
+interface Channel {
+  _id: string;
+  slug: string;
+  channelType: string;
+  name: string;
+  memberCount: number;
+  isShared?: boolean;
 }
 
 export function Members({ groupId, onMemberAction, canManageMembers = false }: MembersProps) {
   const { user } = useAuth();
   const { primaryColor } = useCommunityTheme();
   const [searchQuery, setSearchQuery] = useState("");
-  const [sortBy, setSortBy] = useState<string>(
-    "-membership__role,last_name,first_name,id"
-  );
-  const [filters, setFilters] = useState<MemberFilters>({ role: "all" });
+  const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const [selectedMember, setSelectedMember] = useState<any>(null);
   const [showActionsModal, setShowActionsModal] = useState(false);
 
-  // Fetch members with pagination using infinite query
-  // Role filtering is now handled server-side
-  const {
-    members,
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    refetch,
-    isRefetching,
-    error,
-    data: membersData,
-    totalCount,
-  } = useGroupMembers(groupId, {
-    search: searchQuery,
-    sortBy,
-    noAttendanceDays: filters.noAttendanceDays,
-    rsvpStatus: filters.rsvpStatus,
-    rsvpDate: filters.rsvpDate,
-    role: filters.role === "all" ? undefined : filters.role,
-  });
+  // Fetch all channels for this group
+  const channels = useAuthenticatedQuery(
+    api.functions.messaging.channels.listGroupChannels,
+    { groupId: groupId as Id<"groups"> }
+  );
 
-  // Debug: Log the role being passed to the hook
-  if (__DEV__) {
-    console.log('📊 Members component render:', {
-      filterRole: filters.role,
-      hookRole: filters.role === "all" ? undefined : filters.role,
-      membersCount: members.length,
+  // Filter to relevant channels (exclude DMs, include shared)
+  const visibleChannels = useMemo((): Channel[] => {
+    if (!channels) return [];
+    return channels.filter(
+      (ch: Channel) => ch.channelType !== "dm" && ch.channelType !== "reach_out"
+    );
+  }, [channels]);
+
+  // Default to first channel when channels load
+  const activeChannelId = useMemo(() => {
+    if (selectedChannelId && visibleChannels.some((ch: Channel) => ch._id === selectedChannelId)) {
+      return selectedChannelId;
+    }
+    return visibleChannels[0]?._id ?? null;
+  }, [selectedChannelId, visibleChannels]);
+
+  const activeChannel = useMemo(
+    () => visibleChannels.find((ch: Channel) => ch._id === activeChannelId),
+    [visibleChannels, activeChannelId]
+  );
+
+  // Fetch channel members for selected channel
+  const membersData = useAuthenticatedQuery(
+    api.functions.messaging.channels.getChannelMembers,
+    activeChannelId
+      ? { channelId: activeChannelId as Id<"chatChannels"> }
+      : "skip"
+  );
+
+  // Fetch Leaders channel members to determine group role.
+  // Leaders channel membership is always in sync with group leadership,
+  // so presence in the Leaders channel = leader role.
+  const leadersChannel = useMemo(
+    () => visibleChannels.find((ch: Channel) => ch.channelType === "leaders"),
+    [visibleChannels]
+  );
+  const leadersData = useAuthenticatedQuery(
+    api.functions.messaging.channels.getChannelMembers,
+    leadersChannel?._id
+      ? { channelId: leadersChannel._id as Id<"chatChannels">, limit: 500 }
+      : "skip"
+  );
+  const leaderUserIds = useMemo(() => {
+    if (!leadersData?.members) return new Set<string>();
+    return new Set(leadersData.members.map((m: any) => m.userId));
+  }, [leadersData?.members]);
+
+  // For PCO channels, fetch auto channel config (for unsynced people)
+  const isPcoChannel = activeChannel?.channelType === "pco_services";
+  const autoChannelConfig = useAuthenticatedQuery(
+    api.functions.pcoServices.queries.getAutoChannelConfigByChannel,
+    activeChannelId && isPcoChannel
+      ? { channelId: activeChannelId as Id<"chatChannels"> }
+      : "skip"
+  );
+
+  // Get unsynced people from auto channel config
+  const unsyncedPeople = useMemo((): UnsyncedPerson[] => {
+    if (!autoChannelConfig?.lastSyncResults?.unmatchedPeople) return [];
+    return autoChannelConfig.lastSyncResults.unmatchedPeople;
+  }, [autoChannelConfig]);
+
+  // Build unified list: synced members + unsynced PCO people
+  const unifiedList = useMemo((): ListItem[] => {
+    const syncedItems: ListItem[] = (membersData?.members || []).map((m: any) => ({
+      type: "synced" as const,
+      data: m as ChannelMember,
+    }));
+    const unsyncedItems: ListItem[] = unsyncedPeople.map((p: UnsyncedPerson) => ({
+      type: "unsynced" as const,
+      data: p,
+    }));
+    return [...syncedItems, ...unsyncedItems];
+  }, [membersData?.members, unsyncedPeople]);
+
+  // Apply search filter
+  const filteredList = useMemo(() => {
+    if (!searchQuery.trim()) return unifiedList;
+    const q = searchQuery.toLowerCase().trim();
+    return unifiedList.filter((item: ListItem) => {
+      if (item.type === "synced") {
+        const displayName = item.data.displayName || "";
+        return displayName.toLowerCase().includes(q);
+      } else {
+        const pcoName = item.data.pcoName || "";
+        return pcoName.toLowerCase().includes(q);
+      }
     });
-  }
+  }, [unifiedList, searchQuery]);
 
-  // No need for client-side filtering - server handles role filtering
-  const filteredMembers = members;
+  const totalMemberCount = useMemo(() => {
+    const syncedCount = membersData?.totalCount ?? 0;
+    const unsyncedCount = unsyncedPeople.length;
+    return syncedCount + unsyncedCount;
+  }, [membersData?.totalCount, unsyncedPeople.length]);
 
-  const handleMemberPress = (member: any) => {
-    // Only open modal if member exists
-    if (!member) {
-      console.warn("Attempted to open modal with null/undefined member");
-      return;
-    }
-
-    // Debug: Log member structure to help diagnose issues
-    if (__DEV__) {
-      console.log("🔍 Opening member modal:", {
-        member,
-        hasRole: !!member.role,
-        hasMembership: !!member.membership,
-        membershipRole: member.membership?.role,
-      });
-    }
-
-    setSelectedMember(member);
+  const handleMemberPress = useCallback((member: ChannelMember) => {
+    if (!member) return;
+    // Map channel member to the format expected by onMemberAction
+    // Derive group role from Leaders channel membership (always in sync with group roles)
+    // Fallback to "member" when leaders data isn't available yet so promotion
+    // actions remain usable even if leader-role metadata is delayed/unavailable.
+    const groupRole = leadersChannel && leadersData
+      ? (leaderUserIds.has(member.userId) ? "leader" : "member")
+      : "member";
+    setSelectedMember({
+      id: member.userId,
+      _id: member.userId,
+      user: { id: member.userId },
+      first_name: member.displayName.split(" ")[0] || "",
+      last_name: member.displayName.split(" ").slice(1).join(" ") || "",
+      profile_photo: member.profilePhoto,
+      role: groupRole,
+    });
     setShowActionsModal(true);
-  };
+  }, [leadersChannel, leadersData, leaderUserIds]);
 
   const handleAction = (action: string) => {
     if (onMemberAction && selectedMember) {
@@ -107,157 +182,40 @@ export function Members({ groupId, onMemberAction, canManageMembers = false }: M
     setSelectedMember(null);
   };
 
-  const handleLoadMore = () => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  };
+  const renderListItem = useCallback(
+    ({ item }: { item: ListItem }) => {
+      if (item.type === "synced") {
+        const member = item.data;
+        const isCurrentUser = member.userId === user?.id;
 
-  const renderMemberItem = ({ item }: { item: any }) => {
-    if (!item) return null;
+        return (
+          <TouchableOpacity
+            style={styles.memberItem}
+            onPress={() => handleMemberPress(member)}
+          >
+            <SyncedMemberRowContent
+              member={member}
+              primaryColor={primaryColor}
+              isCurrentUser={isCurrentUser}
+              rightContent={<Ionicons name="chevron-forward" size={20} color="#999" />}
+            />
+          </TouchableOpacity>
+        );
+      } else {
+        const person = item.data;
 
-    const memberRole = item?.role || item?.membership?.role;
-    const isLeader =
-      memberRole === "leader" ||
-      memberRole === MembershipRole.LEADER ||
-      memberRole === 2;
-    const isCurrentUser = user?.id === item?.id;
-
-    return (
-      <TouchableOpacity
-        style={styles.memberItem}
-        onPress={() => handleMemberPress(item)}
-      >
-        <View style={styles.memberInfo}>
-          <Avatar
-            name={`${item?.first_name || ""} ${item?.last_name || ""}`}
-            imageUrl={item?.profile_photo}
-            size={48}
-          />
-          <View style={styles.memberDetails}>
-            <View style={styles.memberNameRow}>
-              <Text style={styles.memberName}>
-                {item?.first_name} {item?.last_name}
-                {isCurrentUser && " (You)"}
-              </Text>
-              {isLeader && (
-                <View style={[styles.leaderBadge, { backgroundColor: primaryColor }]}>
-                  <Text style={styles.leaderBadgeText}>Leader</Text>
-                </View>
-              )}
-            </View>
-            {item?.joined_at && (
-              <Text style={styles.memberMeta}>
-                Joined {format(new Date(item.joined_at), "MMM yyyy")}
-              </Text>
-            )}
+        return (
+          <View style={[styles.memberItem, styles.unsyncedMemberItem]}>
+            <UnsyncedPersonRowContent person={person} />
           </View>
-        </View>
-        <Ionicons name="chevron-forward" size={20} color="#999" />
-      </TouchableOpacity>
-    );
-  };
-
-  const handleFilterChange = useCallback(
-    (newRole: "all" | "leader" | "member") => {
-      if (__DEV__) {
-        console.log('🔄 Members filter changing to:', newRole);
+        );
       }
-      // Use functional update to avoid stale closures
-      setFilters((prev) => {
-        if (prev.role === newRole) {
-          if (__DEV__) {
-            console.log('⏭️  Filter unchanged, skipping');
-          }
-          return prev; // No change, avoid re-render
-        }
-        if (__DEV__) {
-          console.log('✅ Filter updated:', { prev: prev.role, new: newRole });
-        }
-        return { ...prev, role: newRole };
-      });
     },
-    []
+    [user, primaryColor, handleMemberPress]
   );
 
-  const renderFilterChips = () => {
-    const activeChipStyle = { backgroundColor: primaryColor, borderColor: primaryColor };
-    return (
-      <View style={styles.filterSection}>
-        <View style={styles.filterRow}>
-          <View style={styles.filterChips}>
-            <TouchableOpacity
-              style={[
-                styles.filterChip,
-                filters.role === "all" && activeChipStyle,
-              ]}
-              onPress={() => handleFilterChange("all")}
-              activeOpacity={0.7}
-            >
-              <Text
-                style={[
-                  styles.filterChipText,
-                  filters.role === "all" && styles.filterChipTextActive,
-                ]}
-              >
-                All
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.filterChip,
-                filters.role === "leader" && activeChipStyle,
-              ]}
-              onPress={() => handleFilterChange("leader")}
-              activeOpacity={0.7}
-            >
-              <Text
-                style={[
-                  styles.filterChipText,
-                  filters.role === "leader" && styles.filterChipTextActive,
-                ]}
-              >
-                Leaders
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.filterChip,
-                filters.role === "member" && activeChipStyle,
-              ]}
-              onPress={() => handleFilterChange("member")}
-              activeOpacity={0.7}
-            >
-              <Text
-                style={[
-                  styles.filterChipText,
-                  filters.role === "member" && styles.filterChipTextActive,
-                ]}
-              >
-                Members
-              </Text>
-            </TouchableOpacity>
-          </View>
-          {totalCount > 0 && (
-            <Text style={styles.totalCountText}>
-              {totalCount} total
-            </Text>
-          )}
-        </View>
-      </View>
-    );
-  };
-
-  // Debug: Log members data to help diagnose issues
-  if (__DEV__ && membersData) {
-    console.log("🔍 Members data:", {
-      totalMembers: members.length,
-      filteredCount: filteredMembers.length,
-      membersData: Array.isArray(membersData) ? membersData : membersData,
-    });
-  }
-
-  if (isLoading && !membersData) {
+  // Loading state - channels not loaded yet
+  if (!channels) {
     return (
       <View style={styles.loadingContainer}>
         <ActivityIndicator size="large" />
@@ -266,70 +224,16 @@ export function Members({ groupId, onMemberAction, canManageMembers = false }: M
     );
   }
 
-  // Debug: Log error details
-  if (error && __DEV__) {
-    const err = error as Error;
-    const errorObj = error as Error & { response?: { status?: number; statusText?: string; data?: unknown } };
-    console.error(
-      "❌ Members fetch error:",
-      JSON.stringify(
-        {
-          errorMessage: err.message || String(error),
-          errorStack: err.stack,
-          status: errorObj?.response?.status,
-          statusText: errorObj?.response?.statusText,
-          data: errorObj?.response?.data,
-          groupId,
-          isLoading,
-          hasData: !!membersData,
-        },
-        null,
-        2
-      )
-    );
-  }
-
-  // Show error state if there's an error and no data
-  if (error && !membersData) {
-    // Extract error message - cast to Error to satisfy TypeScript
-    const err = error as Error;
-    let errorMessage = "Please try again";
-    if (err.message) {
-      errorMessage = err.message;
-    } else {
-      // Handle axios errors
-      const axiosError = error as Error & { response?: { data?: { detail?: string; message?: string; error?: string } | string } };
-      if (axiosError?.response?.data) {
-        const data = axiosError.response.data;
-        if (typeof data === "string") {
-          errorMessage = data;
-        } else if (data.detail) {
-          errorMessage = data.detail;
-        } else if (data.message) {
-          errorMessage = data.message;
-        } else if (data.error) {
-          errorMessage = data.error;
-        }
-      }
-    }
-
+  // No channels available
+  if (visibleChannels.length === 0) {
     return (
-      <View style={styles.errorContainer}>
-        <Ionicons name="alert-circle-outline" size={48} color="#e74c3c" />
-        <Text style={styles.errorText}>Failed to load members</Text>
-        <Text style={styles.errorSubtext}>{errorMessage}</Text>
-        <TouchableOpacity
-          style={styles.retryButton}
-          onPress={() => {
-            console.log("🔄 Retrying members fetch...");
-            refetch();
-          }}
-        >
-          <Text style={styles.retryButtonText}>Retry</Text>
-        </TouchableOpacity>
+      <View style={styles.emptyState}>
+        <Text style={styles.emptyStateText}>No channels found for this group</Text>
       </View>
     );
   }
+
+  const isLoadingMembers = !membersData && !!activeChannelId;
 
   return (
     <View style={styles.container}>
@@ -342,37 +246,112 @@ export function Members({ groupId, onMemberAction, canManageMembers = false }: M
         />
       </View>
 
-      {/* Filter Chips */}
-      {renderFilterChips()}
+      {/* Channel Chips */}
+      <View style={styles.filterSection}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterChips}
+        >
+          {visibleChannels.map((channel: Channel) => {
+            const isActive = channel._id === activeChannelId;
+            const activeChipStyle = { backgroundColor: primaryColor, borderColor: primaryColor };
+            return (
+              <TouchableOpacity
+                key={channel._id}
+                style={[styles.filterChip, isActive && activeChipStyle]}
+                onPress={() => {
+                  setSelectedChannelId(channel._id);
+                  setSearchQuery("");
+                }}
+                activeOpacity={0.7}
+              >
+                <View style={styles.chipContent}>
+                  {channel.isShared && (
+                    <Ionicons
+                      name="link"
+                      size={12}
+                      color={isActive ? "#fff" : "#8B5CF6"}
+                      style={{ marginRight: 4 }}
+                    />
+                  )}
+                  {channel.channelType === "pco_services" && (
+                    <Ionicons
+                      name="sync"
+                      size={12}
+                      color={isActive ? "#fff" : "#2196F3"}
+                      style={{ marginRight: 4 }}
+                    />
+                  )}
+                  <Text
+                    style={[
+                      styles.filterChipText,
+                      isActive && styles.filterChipTextActive,
+                    ]}
+                  >
+                    {channel.name}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      </View>
+
+      {/* Member Count & Channel Info */}
+      {activeChannel && (
+        <View style={styles.memberCountSection}>
+          <Text style={styles.memberCountText}>
+            {totalMemberCount} member{totalMemberCount !== 1 ? "s" : ""}
+            {unsyncedPeople.length > 0 && (
+              <Text style={styles.unsyncedCountText}>
+                {" "}({unsyncedPeople.length} unsynced)
+              </Text>
+            )}
+          </Text>
+          {isPcoChannel && (
+            <View style={styles.pcoBadge}>
+              <Ionicons name="sync" size={12} color="#2196F3" />
+              <Text style={styles.pcoBadgeText}>PCO Synced</Text>
+            </View>
+          )}
+          {activeChannel.isShared && (
+            <View style={styles.sharedBadge}>
+              <Ionicons name="link" size={12} color="#8B5CF6" />
+              <Text style={styles.sharedBadgeText}>Shared</Text>
+            </View>
+          )}
+        </View>
+      )}
 
       {/* Members List */}
-      <FlatList
-        data={filteredMembers}
-        renderItem={renderMemberItem}
-        keyExtractor={(item, index) => item?.id?.toString() || index.toString()}
-        contentContainerStyle={styles.listContent}
-        refreshControl={
-          <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
-        }
-        onEndReached={handleLoadMore}
-        onEndReachedThreshold={0.5}
-        ListFooterComponent={
-          isFetchingNextPage ? (
-            <View style={styles.loadingMore}>
-              <ActivityIndicator size="small" />
+      {isLoadingMembers ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>Loading channel members...</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={filteredList}
+          renderItem={renderListItem}
+          keyExtractor={(item: ListItem) =>
+            item.type === "synced"
+              ? item.data.userId
+              : `unsynced-${item.data.pcoPersonId}`
+          }
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyStateText}>
+                {searchQuery
+                  ? "No members found matching your search"
+                  : "No members in this channel"}
+              </Text>
             </View>
-          ) : null
-        }
-        ListEmptyComponent={
-          <View style={styles.emptyState}>
-            <Text style={styles.emptyStateText}>
-              {searchQuery || filters.role !== "all"
-                ? "No members found matching your criteria"
-                : "No members in this group"}
-            </Text>
-          </View>
-        }
-      />
+          }
+        />
+      )}
 
       {/* Member Actions Modal */}
       <MemberActionsModal
@@ -394,7 +373,6 @@ interface MemberActionsModalProps {
   member: any;
   onClose: () => void;
   onAction: (action: string) => void;
-  /** Whether the current user can manage members (add/remove) */
   canManageMembers?: boolean;
 }
 
@@ -407,22 +385,18 @@ function MemberActionsModal({
 }: MemberActionsModalProps) {
   const { user } = useAuth();
 
-  // Early return if no member or not visible - do this FIRST before any property access
   if (!member || !visible) {
     return null;
   }
 
-  // Use optional chaining throughout to be extra defensive
-  // Even though we checked member is not null, member.role or member.membership could be null
-  const memberRole = member?.role || member?.membership?.role;
+  const memberRole = member?.role;
   const isLeader =
     memberRole === "leader" ||
     memberRole === MembershipRole.LEADER ||
     memberRole === 2;
   const isCurrentUser = user?.id === member?.id;
-
-  // Only community admins can promote/demote members
-  const canPromoteDemote = user?.is_admin ?? false;
+  // Show promote/demote if user can manage members AND we have group role data
+  const canPromoteDemote = canManageMembers && memberRole !== undefined;
 
   return (
     <Modal
@@ -448,7 +422,7 @@ function MemberActionsModal({
           </View>
 
           <View style={styles.modalActions}>
-            {canPromoteDemote && (
+            {canPromoteDemote && !isCurrentUser && (
               <>
                 {isLeader ? (
                   <TouchableOpacity
@@ -509,22 +483,16 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     borderBottomWidth: 1,
     borderBottomColor: "#e0e0e0",
-    paddingHorizontal: 16,
     paddingVertical: 12,
-  },
-  filterRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
   },
   filterChips: {
     flexDirection: "row",
     gap: 8,
+    paddingHorizontal: 16,
   },
-  totalCountText: {
-    fontSize: 14,
-    color: "#666",
-    fontWeight: "500",
+  chipContent: {
+    flexDirection: "row",
+    alignItems: "center",
   },
   filterChip: {
     paddingHorizontal: 16,
@@ -534,9 +502,6 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#e0e0e0",
   },
-  filterChipActive: {
-    // backgroundColor and borderColor set dynamically via style prop
-  },
   filterChipText: {
     fontSize: 14,
     color: "#666",
@@ -545,55 +510,66 @@ const styles = StyleSheet.create({
   filterChipTextActive: {
     color: "#fff",
   },
+  memberCountSection: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: "#f5f5f5",
+    gap: 8,
+  },
+  memberCountText: {
+    fontSize: 14,
+    color: "#666",
+    fontWeight: "500",
+  },
+  unsyncedCountText: {
+    color: "#B25000",
+  },
+  pcoBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#E3F2FD",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+    gap: 4,
+  },
+  pcoBadgeText: {
+    fontSize: 11,
+    color: "#2196F3",
+    fontWeight: "600",
+  },
+  sharedBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#F3E8FF",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+    gap: 4,
+  },
+  sharedBadgeText: {
+    fontSize: 11,
+    color: "#8B5CF6",
+    fontWeight: "600",
+  },
   listContent: {
     padding: 16,
   },
   memberItem: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
     backgroundColor: "#fff",
-    padding: 16,
+    padding: 12,
     borderRadius: 12,
-    marginBottom: 12,
+    marginBottom: 8,
     borderWidth: 1,
     borderColor: "#e0e0e0",
   },
-  memberInfo: {
-    flexDirection: "row",
-    alignItems: "center",
-    flex: 1,
-  },
-  memberDetails: {
-    marginLeft: 12,
-    flex: 1,
-  },
-  memberNameRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 4,
-  },
-  memberName: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: "#333",
-    marginRight: 8,
-  },
-  leaderBadge: {
-    // backgroundColor set dynamically via style prop
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 12,
-  },
-  leaderBadgeText: {
-    fontSize: 10,
-    fontWeight: "700",
-    color: "#fff",
-    textTransform: "uppercase",
-  },
-  memberMeta: {
-    fontSize: 13,
-    color: "#666",
+  unsyncedMemberItem: {
+    backgroundColor: "#FFF8F0",
+    borderColor: "#FFE0B2",
   },
   loadingContainer: {
     flex: 1,
@@ -605,10 +581,6 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: "#666",
   },
-  loadingMore: {
-    paddingVertical: 20,
-    alignItems: "center",
-  },
   emptyState: {
     padding: 40,
     alignItems: "center",
@@ -618,37 +590,7 @@ const styles = StyleSheet.create({
     color: "#999",
     textAlign: "center",
   },
-  errorContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 40,
-  },
-  errorText: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#e74c3c",
-    marginTop: 16,
-    textAlign: "center",
-  },
-  errorSubtext: {
-    fontSize: 14,
-    color: "#666",
-    marginTop: 8,
-    textAlign: "center",
-  },
-  retryButton: {
-    marginTop: 24,
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    backgroundColor: "#007bff",
-    borderRadius: 8,
-  },
-  retryButtonText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "600",
-  },
+  // Modal styles
   modalOverlay: {
     flex: 1,
     justifyContent: "flex-end",

--- a/apps/mobile/features/leader-tools/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/RunSheetScreen.tsx
@@ -440,9 +440,11 @@ export function RunSheetScreen({
   const [isStale, setIsStale] = useState(false);
   const {
     setRunSheet: cacheRunSheet,
-    getRunSheet: getCachedRunSheet,
+    getRunSheet: getFreshCachedRunSheet,
+    getRunSheetStale: getStaleCachedRunSheet,
     setServiceTypes: cacheServiceTypes,
-    getServiceTypes: getCachedServiceTypes,
+    getServiceTypes: getFreshCachedServiceTypes,
+    getServiceTypesStale: getStaleCachedServiceTypes,
   } = useRunSheetCache();
 
   // Type for group data with runSheetConfig
@@ -546,8 +548,10 @@ export function RunSheetScreen({
       }
     } catch (err) {
       console.error("Error fetching service types:", err);
-      // Try cache fallback on error
-      const cachedTypes = getCachedServiceTypes(group_id);
+      // Try cache fallback on error (fresh first, then stale/expired)
+      const cachedTypes =
+        getFreshCachedServiceTypes(group_id) ??
+        getStaleCachedServiceTypes(group_id);
       if (cachedTypes && cachedTypes.length > 0) {
         setServiceTypes(cachedTypes);
         setIsStale(true);
@@ -555,12 +559,26 @@ export function RunSheetScreen({
         setError(err instanceof Error ? err.message : "Failed to load service types");
       }
     }
-  }, [group_id, getAvailableServiceTypes, cacheServiceTypes, getCachedServiceTypes]);
+  }, [
+    group_id,
+    getAvailableServiceTypes,
+    cacheServiceTypes,
+    getFreshCachedServiceTypes,
+    getStaleCachedServiceTypes,
+  ]);
 
   // Apply default service type once both serviceTypes and groupData are available
   useEffect(() => {
     if (hasAppliedDefault || serviceTypes.length === 0) return;
-    if (groupData === undefined) return;
+
+    // Offline-friendly fallback: if group query hasn't resolved yet, still select
+    // the first service type so cached run sheet data can load.
+    if (groupData === undefined) {
+      if (!selectedServiceTypeId) {
+        setSelectedServiceTypeId(serviceTypes[0].id);
+      }
+      return;
+    }
 
     const groupConfig = groupData as { runSheetConfig?: { defaultServiceTypeIds?: string[] } } | null;
     const defaultIds = groupConfig?.runSheetConfig?.defaultServiceTypeIds;
@@ -574,9 +592,11 @@ export function RunSheetScreen({
       }
     }
 
-    setSelectedServiceTypeId(serviceTypes[0].id);
+    if (!selectedServiceTypeId || !serviceTypes.some((t: ServiceType) => t.id === selectedServiceTypeId)) {
+      setSelectedServiceTypeId(serviceTypes[0].id);
+    }
     setHasAppliedDefault(true);
-  }, [serviceTypes, groupData, hasAppliedDefault]);
+  }, [serviceTypes, groupData, hasAppliedDefault, selectedServiceTypeId]);
 
   // Fetch run sheet for selected service type (with offline cache fallback)
   const fetchRunSheet = useCallback(async (options?: { isRefresh?: boolean }) => {
@@ -589,7 +609,8 @@ export function RunSheetScreen({
     // Show cached data immediately on initial/service-type-switch loads.
     // Skip during pull-to-refresh to avoid stale banner flashing since
     // cache already matches the currently displayed data.
-    const cached = getCachedRunSheet(group_id, selectedServiceTypeId);
+    const freshCached = getFreshCachedRunSheet(group_id, selectedServiceTypeId);
+    const cached = freshCached ?? getStaleCachedRunSheet(group_id, selectedServiceTypeId);
     if (cached && !options?.isRefresh) {
       setRunSheet(cached);
       setIsStale(true);
@@ -616,7 +637,9 @@ export function RunSheetScreen({
         setIsStale(true);
       } else {
         // Check cache one more time as last resort
-        const fallback = getCachedRunSheet(group_id, selectedServiceTypeId);
+        const fallback =
+          getFreshCachedRunSheet(group_id, selectedServiceTypeId) ??
+          getStaleCachedRunSheet(group_id, selectedServiceTypeId);
         if (fallback) {
           setRunSheet(fallback);
           setIsStale(true);
@@ -628,7 +651,14 @@ export function RunSheetScreen({
       setLoading(false);
       setRefreshing(false);
     }
-  }, [group_id, selectedServiceTypeId, getRunSheet, getCachedRunSheet, cacheRunSheet]);
+  }, [
+    group_id,
+    selectedServiceTypeId,
+    getRunSheet,
+    getFreshCachedRunSheet,
+    getStaleCachedRunSheet,
+    cacheRunSheet,
+  ]);
 
   // Initial load (skip in external mode)
   useEffect(() => {

--- a/apps/mobile/features/leader-tools/components/__tests__/EventHistory.test.tsx
+++ b/apps/mobile/features/leader-tools/components/__tests__/EventHistory.test.tsx
@@ -54,13 +54,13 @@ function getDateInCurrentMonth(day: number): number {
 }
 
 function getPastDateInCurrentMonth(): number {
-  // Use the 1st of the month (always in the past unless it's the 1st)
-  return getDateInCurrentMonth(1);
+  // Use a relative timestamp to guarantee "past" regardless of day/time.
+  return Date.now() - 60 * 60 * 1000;
 }
 
 function getFutureDateInCurrentMonth(): number {
-  // Use the 28th (safe for all months)
-  return getDateInCurrentMonth(28);
+  // Use a relative timestamp to guarantee "future" regardless of day/time.
+  return Date.now() + 60 * 60 * 1000;
 }
 
 // Get current month (1-indexed) for date pattern matching

--- a/apps/mobile/providers/AuthProvider.tsx
+++ b/apps/mobile/providers/AuthProvider.tsx
@@ -40,6 +40,29 @@ const LEGACY_STORAGE_KEYS = [
   "newCommunityId",
 ];
 
+const NETWORK_ERROR_KEYWORDS = [
+  "network request failed",
+  "failed to fetch",
+  "network",
+  "timeout",
+  "econnrefused",
+  "etimedout",
+  "socket",
+  "websocket",
+  "offline",
+  "unreachable",
+];
+
+const INVALID_AUTH_ERROR_KEYWORDS = [
+  "not authenticated",
+  "invalid token",
+  "token expired",
+  "unauthorized",
+  "forbidden",
+  "permission denied",
+  "jwt",
+];
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -48,6 +71,11 @@ interface AuthTokens {
   accessToken: string;
   refreshToken?: string;
   userId: string;
+}
+
+interface NetConnectivitySnapshot {
+  isConnected: boolean | null;
+  isInternetReachable: boolean | null;
 }
 
 interface AuthContextType {
@@ -61,6 +89,44 @@ interface AuthContextType {
   setCommunity: (community: Community) => Promise<void>;
   clearCommunity: () => Promise<void>;
   signIn: (userId: string, tokens?: { accessToken?: string; refreshToken?: string }) => Promise<void>;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+/**
+ * Classify profile-fetch failures into "network" vs "not_found".
+ *
+ * This is intentionally conservative: unknown failures are treated as
+ * network errors so we preserve existing sessions instead of logging users
+ * out during transient/offline conditions.
+ */
+export function classifyProfileFetchError(
+  error: unknown,
+  netState: NetConnectivitySnapshot | null
+): "network_error" | "not_found" {
+  const isOffline =
+    !!netState &&
+    (netState.isConnected === false || netState.isInternetReachable === false);
+  if (isOffline) {
+    return "network_error";
+  }
+
+  const errorMsg = getErrorMessage(error).toLowerCase();
+  if (NETWORK_ERROR_KEYWORDS.some((keyword) => errorMsg.includes(keyword))) {
+    return "network_error";
+  }
+
+  if (INVALID_AUTH_ERROR_KEYWORDS.some((keyword) => errorMsg.includes(keyword))) {
+    return "not_found";
+  }
+
+  // Unknown errors should not force logout; preserve session and retry later.
+  return "network_error";
 }
 
 // ============================================================================
@@ -286,35 +352,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return { status: "success", user: profileData, community: communityData };
     } catch (error) {
       console.error("🔐 AuthProvider: Failed to fetch user profile:", error);
-
-      // Detect network errors vs server errors
-      const errorMsg = String(error);
-      const isNetworkError =
-        errorMsg.includes("Network request failed") ||
-        errorMsg.includes("Failed to fetch") ||
-        errorMsg.includes("network") ||
-        errorMsg.includes("timeout") ||
-        errorMsg.includes("ECONNREFUSED") ||
-        errorMsg.includes("ETIMEDOUT");
-
-      if (isNetworkError) {
-        // Check NetInfo imperatively to confirm network is actually down
-        // (AuthProvider is above ConnectionProvider, so no hook available)
-        try {
-          const netState = await NetInfo.fetch();
-          if (!netState.isConnected || netState.isInternetReachable === false) {
-            return { status: "network_error" };
-          }
-          // Device is connected but error contained network-like keywords
-          // This is likely a server error, not a network issue — treat as not_found
-          return { status: "not_found" };
-        } catch {
-          // If NetInfo itself fails, assume network error
-          return { status: "network_error" };
-        }
-      }
-
-      return { status: "not_found" };
+      const netState = await NetInfo.fetch().catch(() => null);
+      const classification = classifyProfileFetchError(
+        error,
+        netState
+          ? {
+              isConnected: netState.isConnected,
+              isInternetReachable: netState.isInternetReachable,
+            }
+          : null
+      );
+      return { status: classification };
     }
   }, []);
 
@@ -798,16 +846,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       } catch (error) {
         console.error("🔐 AuthProvider: Failed to initialize auth:", error);
-        // Check if this is a network error — don't clear tokens for network failures
-        const errMsg = String(error);
-        const isNetErr =
-          errMsg.includes("Network request failed") ||
-          errMsg.includes("Failed to fetch") ||
-          errMsg.includes("network") ||
-          errMsg.includes("timeout") ||
-          errMsg.includes("ECONNREFUSED") ||
-          errMsg.includes("ETIMEDOUT");
-        if (isNetErr) {
+        const netState = await NetInfo.fetch().catch(() => null);
+        const classification = classifyProfileFetchError(
+          error,
+          netState
+            ? {
+                isConnected: netState.isConnected,
+                isInternetReachable: netState.isInternetReachable,
+              }
+            : null
+        );
+        if (classification === "network_error") {
           console.log("🔐 AuthProvider: Network error during init catch, keeping tokens");
           // Try to restore from cache
           const cached = await loadCachedProfile();

--- a/apps/mobile/providers/__tests__/AuthProvider.errorClassification.test.ts
+++ b/apps/mobile/providers/__tests__/AuthProvider.errorClassification.test.ts
@@ -1,0 +1,39 @@
+import { classifyProfileFetchError } from "../AuthProvider";
+
+describe("classifyProfileFetchError", () => {
+  it("treats offline NetInfo state as network_error", () => {
+    const result = classifyProfileFetchError(
+      new Error("Some random error"),
+      { isConnected: false, isInternetReachable: false }
+    );
+
+    expect(result).toBe("network_error");
+  });
+
+  it("treats fetch/network failures as network_error", () => {
+    const result = classifyProfileFetchError(
+      new Error("TypeError: Failed to fetch"),
+      { isConnected: true, isInternetReachable: true }
+    );
+
+    expect(result).toBe("network_error");
+  });
+
+  it("treats invalid auth errors as not_found", () => {
+    const result = classifyProfileFetchError(
+      new Error("Not authenticated: invalid token"),
+      { isConnected: true, isInternetReachable: true }
+    );
+
+    expect(result).toBe("not_found");
+  });
+
+  it("defaults unknown connected failures to network_error to preserve session", () => {
+    const result = classifyProfileFetchError(
+      new Error("Unexpected server crash"),
+      { isConnected: true, isInternetReachable: true }
+    );
+
+    expect(result).toBe("network_error");
+  });
+});

--- a/apps/mobile/stores/__tests__/runSheetCache.test.ts
+++ b/apps/mobile/stores/__tests__/runSheetCache.test.ts
@@ -39,6 +39,24 @@ describe("runSheetCache", () => {
       expect(useRunSheetCache.getState().getRunSheet("g1", "st1")).toBeNull();
     });
 
+    it("returns expired data via stale getter", () => {
+      useRunSheetCache
+        .getState()
+        .setRunSheet("g1", "st1", { title: "Old but useful" });
+
+      const sheets = { ...useRunSheetCache.getState().sheets };
+      sheets["g1:st1"] = {
+        ...sheets["g1:st1"],
+        timestamp: Date.now() - 12 * 60 * 60 * 1000, // 12 hours ago
+      };
+      useRunSheetCache.setState({ sheets });
+
+      expect(useRunSheetCache.getState().getRunSheet("g1", "st1")).toBeNull();
+      expect(
+        useRunSheetCache.getState().getRunSheetStale("g1", "st1")
+      ).toEqual({ title: "Old but useful" });
+    });
+
     it("supports different service types for same group", () => {
       useRunSheetCache
         .getState()
@@ -119,6 +137,24 @@ describe("runSheetCache", () => {
       useRunSheetCache.setState({ serviceTypes });
 
       expect(useRunSheetCache.getState().getServiceTypes("g1")).toBeNull();
+    });
+
+    it("returns expired service types via stale getter", () => {
+      useRunSheetCache
+        .getState()
+        .setServiceTypes("g1", [{ id: "st1", name: "Old type" }]);
+
+      const serviceTypes = { ...useRunSheetCache.getState().serviceTypes };
+      serviceTypes["g1"] = {
+        ...serviceTypes["g1"],
+        timestamp: Date.now() - 12 * 60 * 60 * 1000,
+      };
+      useRunSheetCache.setState({ serviceTypes });
+
+      expect(useRunSheetCache.getState().getServiceTypes("g1")).toBeNull();
+      expect(useRunSheetCache.getState().getServiceTypesStale("g1")).toEqual([
+        { id: "st1", name: "Old type" },
+      ]);
     });
 
     it("supports multiple groups", () => {

--- a/apps/mobile/stores/runSheetCache.ts
+++ b/apps/mobile/stores/runSheetCache.ts
@@ -31,9 +31,15 @@ interface RunSheetCacheState {
   sheets: Record<string, CachedSheet>; // key: `${groupId}:${serviceTypeId}`
   serviceTypes: Record<string, CachedServiceTypes>; // key: groupId
   setRunSheet: (groupId: string, serviceTypeId: string, data: any) => void;
+  /** Returns only non-expired cache entries (preferred for online rendering). */
   getRunSheet: (groupId: string, serviceTypeId: string) => any | null;
+  /** Returns cached entry regardless of age (offline fallback). */
+  getRunSheetStale: (groupId: string, serviceTypeId: string) => any | null;
   setServiceTypes: (groupId: string, types: any[]) => void;
+  /** Returns only non-expired cache entries (preferred for online rendering). */
   getServiceTypes: (groupId: string) => any[] | null;
+  /** Returns cached entry regardless of age (offline fallback). */
+  getServiceTypesStale: (groupId: string) => any[] | null;
   clearAll: () => void;
 }
 
@@ -78,6 +84,11 @@ export const useRunSheetCache = create<RunSheetCacheState>()(
         return cached.data;
       },
 
+      getRunSheetStale: (groupId: string, serviceTypeId: string) => {
+        const key = `${groupId}:${serviceTypeId}`;
+        return get().sheets[key]?.data ?? null;
+      },
+
       setServiceTypes: (groupId: string, types: any[]) => {
         set((state) => ({
           serviceTypes: {
@@ -95,6 +106,10 @@ export const useRunSheetCache = create<RunSheetCacheState>()(
         if (!cached) return null;
         if (Date.now() - cached.timestamp > CACHE_EXPIRY_MS) return null;
         return cached.data;
+      },
+
+      getServiceTypesStale: (groupId: string) => {
+        return get().serviceTypes[groupId]?.data ?? null;
       },
 
       clearAll: () => {

--- a/apps/mobile/stores/runSheetCache.web.ts
+++ b/apps/mobile/stores/runSheetCache.web.ts
@@ -14,8 +14,10 @@ const state = {
   serviceTypes: {},
   setRunSheet: noop,
   getRunSheet: noopNull,
+  getRunSheetStale: noopNull,
   setServiceTypes: noop,
   getServiceTypes: noopNull,
+  getServiceTypesStale: noopNull,
   clearAll: noop,
 };
 

--- a/apps/mobile/utils/channel-members.ts
+++ b/apps/mobile/utils/channel-members.ts
@@ -1,0 +1,54 @@
+import type { Id } from "@services/api/convex";
+
+/**
+ * Channel member data structure returned by the backend
+ */
+export interface ChannelMember {
+  id: string;
+  userId: Id<"users">;
+  displayName: string;
+  profilePhoto?: string;
+  role: string;
+  syncSource?: string;
+  syncMetadata?: {
+    serviceTypeName?: string;
+    teamName?: string;
+    position?: string;
+    serviceDate?: number;
+    serviceName?: string;
+  };
+}
+
+/**
+ * Unsynced PCO person - someone scheduled in PCO but not matched to a user
+ */
+export interface UnsyncedPerson {
+  pcoPersonId: string;
+  pcoName: string;
+  pcoPhone?: string;
+  pcoEmail?: string;
+  serviceTypeName?: string;
+  teamName?: string;
+  position?: string;
+  reason: string;
+}
+
+/**
+ * Returns human-readable text explaining why a PCO person couldn't be synced
+ */
+export function getDebugReasonText(reason: string, person: UnsyncedPerson): string {
+  switch (reason) {
+    case "not_in_group":
+      return "In community but not in this group";
+    case "not_in_community":
+      return "Not in this community";
+    case "no_contact_info":
+      return "No contact info in PCO";
+    case "phone_mismatch":
+      return `Phone ${person.pcoPhone || "unknown"} not found`;
+    case "email_mismatch":
+      return `Email ${person.pcoEmail || "unknown"} not found`;
+    default:
+      return "Unknown issue";
+  }
+}


### PR DESCRIPTION
## Summary
- **PRs 402/404/405**: Replace role-based filter chips with channel-based chips on the members page, extract shared `ChannelMemberRows` components, enrich `getChannelMembers` with fresh user data, grant community admin access, and filter for active memberships in `updateRole`
- **PR 406**: Conservative error classification in AuthProvider to prevent logout on network errors, extract testable `getInitialRouteTarget` routing function, and add stale cache fallback getters for run sheet data
- Re-applied from GitHub PR diffs (`gh pr diff`) after merge commits were lost from private repo

## Test plan
- [x] Convex tests pass (121 tests — channels + permissions suites)
- [x] Mobile tests pass (57 tests across Members, ChannelMemberRows, useInitialRouting, AuthProvider error classification, runSheetCache)
- [x] Full test suite passes (826 tests, 73 suites)
- [x] TypeScript compilation clean
- [ ] Manual browser testing of channel-based members page
- [ ] Manual testing of offline access behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization paths for channel/member visibility and changes auth/offline routing behavior; mistakes could broaden access or alter session persistence, though changes are covered by new unit tests.
> 
> **Overview**
> **Messaging/permissions:** Expands access control so *community admins* (even if not group/channel members) can call `listGroupChannels` and `getChannelMembers`, and updates `getChannelMembers` to rehydrate display name/profile photo from the latest `users` data.
> 
> **Group member role updates:** Tightens `groupMembers.updateRole` lookups to only consider *active/accepted* membership rows (ignoring historical `leftAt` / non-accepted requests), with new regression tests for leave/rejoin scenarios.
> 
> **Mobile UI + offline resilience:** Reworks leader tools “Members” UI from role-based filters to channel-based chips driven by backend channel queries, including PCO unsynced people display, and extracts shared row rendering into `ChannelMemberRows` + `channel-members` utilities (with tests). Improves initial routing by extracting `getInitialRouteTarget` (token-only sessions can land on Profile for offline use), adds conservative auth/profile error classification to avoid logout on transient network failures, and extends run sheet caching with stale getters plus offline-first fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a3b37a40389cfabf10920af1a8e17404dcc039f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->