### PR TITLE
Backend selection enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,11 @@ They need:
 - Depending on what the user is asking, use the relevant keys from the relevant environment (dev, staging, prod)
 - Typically you will only make dev or staging related changes, double check if any action you take will affect production
 
+### Agent Backend Selection
+- Before any backend-affecting command, ask: "Which backend should I use: togather-agent-1 or togather-agent-2?"
+- Do not proceed until the user answers.
+- Use `pnpm dev:backend --backend=<choice>` only.
+
 ### Test-Driven Development
 
 - **Write tests first** - Create failing tests before implementing features

--- a/config/allowed-backends.json
+++ b/config/allowed-backends.json
@@ -1,0 +1,10 @@
+{
+  "togather-agent-1": {
+    "CONVEX_DEPLOYMENT": "dev:togather-agent-1",
+    "EXPO_PUBLIC_CONVEX_URL": "https://togather-agent-1.convex.cloud"
+  },
+  "togather-agent-2": {
+    "CONVEX_DEPLOYMENT": "dev:togather-agent-2",
+    "EXPO_PUBLIC_CONVEX_URL": "https://togather-agent-2.convex.cloud"
+  }
+}

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -16,6 +16,14 @@ pnpm dev
 
 ---
 
+## Agent Backend Selection Policy
+
+- Allowed backend names: `togather-agent-1`, `togather-agent-2`.
+- Required launcher command: `pnpm dev:backend --backend=<choice>`.
+- Startup fails fast if `CONVEX_DEPLOYMENT` or `EXPO_PUBLIC_CONVEX_URL` conflicts with the selected backend mapping.
+
+---
+
 ## Environment Overview
 
 | Environment | Use Case |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "description": "Togather monorepo - Backend API and cross-platform mobile app. Note: Uses React 18.3.1 (web) and React 19.1.0 (mobile) - see docs/architecture/decisions/ADR-004-dual-react-versions.md",
   "scripts": {
     "dev": "node scripts/dev.js",
+    "dev:backend": "node scripts/dev-backend.js",
+    "dev:agent1": "node scripts/dev-backend.js --backend=togather-agent-1",
+    "dev:agent2": "node scripts/dev-backend.js --backend=togather-agent-2",
     "dev:mobile": "node scripts/dev.js --mobile",
     "dev:convex": "node scripts/dev.js --convex",
     "dev:agent": "node scripts/agent-dev.js",

--- a/scripts/dev-backend.js
+++ b/scripts/dev-backend.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ALLOWED_BACKENDS_PATH = path.join(__dirname, '..', 'config', 'allowed-backends.json');
+
+function loadAllowedBackends() {
+  if (!fs.existsSync(ALLOWED_BACKENDS_PATH)) {
+    console.error('❌ Missing backend config: config/allowed-backends.json');
+    process.exit(1);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(ALLOWED_BACKENDS_PATH, 'utf-8'));
+  } catch (error) {
+    console.error(`❌ Failed to parse backend config: ${error.message}`);
+    process.exit(1);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    console.error('❌ Backend config must be an object keyed by backend name.');
+    process.exit(1);
+  }
+
+  return parsed;
+}
+
+function parseBackendFromArgs(argv) {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith('--backend=')) {
+      return arg.split('=')[1].trim();
+    }
+    if (arg === '--backend') {
+      const value = argv[i + 1];
+      return value ? value.trim() : '';
+    }
+  }
+  return null;
+}
+
+function stripBackendArgs(argv) {
+  const filtered = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith('--backend=')) {
+      continue;
+    }
+    if (arg === '--backend') {
+      i += 1;
+      continue;
+    }
+    filtered.push(arg);
+  }
+  return filtered;
+}
+
+function allowedBackendLines(names) {
+  return names.map(name => `   - ${name}`).join('\n');
+}
+
+function failMissingSelection(allowedNames) {
+  console.error('');
+  console.error('❌ Missing required backend selection.');
+  console.error('');
+  console.error('Allowed backends:');
+  console.error(allowedBackendLines(allowedNames));
+  console.error('');
+  console.error('Ask the user: "Which backend should I use: togather-agent-1 or togather-agent-2?"');
+  console.error('Then rerun: pnpm dev:backend --backend=<choice>');
+  console.error('');
+  process.exit(1);
+}
+
+function failUnknownBackend(selectedBackend, allowedNames) {
+  console.error('');
+  console.error(`❌ Unknown backend "${selectedBackend}".`);
+  console.error('');
+  console.error('Allowed backends:');
+  console.error(allowedBackendLines(allowedNames));
+  console.error('');
+  console.error('Ask the user which backend to use, then rerun with pnpm dev:backend --backend=<choice>.');
+  console.error('');
+  process.exit(1);
+}
+
+function failMismatch(variableName, actualValue, expectedValue, backendName) {
+  console.error('');
+  console.error(`❌ ${variableName} does not match backend "${backendName}".`);
+  console.error(`   Expected: ${expectedValue}`);
+  console.error(`   Actual:   ${actualValue}`);
+  console.error('');
+  console.error('Clear conflicting environment values and rerun:');
+  console.error(`pnpm dev:backend --backend=${backendName}`);
+  console.error('');
+  process.exit(1);
+}
+
+function main() {
+  const allowedBackends = loadAllowedBackends();
+  const allowedNames = Object.keys(allowedBackends);
+  const args = process.argv.slice(2);
+  const selectedBackend = parseBackendFromArgs(args) || process.env.BACKEND_AGENT;
+
+  if (!selectedBackend) {
+    failMissingSelection(allowedNames);
+  }
+
+  const selectedConfig = allowedBackends[selectedBackend];
+  if (!selectedConfig) {
+    failUnknownBackend(selectedBackend, allowedNames);
+  }
+
+  const expectedDeployment = selectedConfig.CONVEX_DEPLOYMENT;
+  const expectedUrl = selectedConfig.EXPO_PUBLIC_CONVEX_URL;
+
+  if (process.env.EXPO_PUBLIC_CONVEX_URL && process.env.EXPO_PUBLIC_CONVEX_URL !== expectedUrl) {
+    failMismatch('EXPO_PUBLIC_CONVEX_URL', process.env.EXPO_PUBLIC_CONVEX_URL, expectedUrl, selectedBackend);
+  }
+
+  const forwardedArgs = stripBackendArgs(args);
+  const child = spawn(
+    process.execPath,
+    [path.join(__dirname, 'dev.js'), `--backend=${selectedBackend}`, ...forwardedArgs],
+    {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        BACKEND_AGENT: selectedBackend,
+        CONVEX_DEPLOYMENT: expectedDeployment,
+        EXPO_PUBLIC_CONVEX_URL: expectedUrl,
+      },
+    }
+  );
+
+  child.on('error', (error) => {
+    console.error(`❌ Failed to start dev flow: ${error.message}`);
+    process.exit(1);
+  });
+
+  child.on('exit', (code) => {
+    process.exit(code || 0);
+  });
+}
+
+main();

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -8,11 +8,130 @@
  *   pnpm dev --mobile     # Run only Expo (if Convex is already running)
  *   pnpm dev --convex     # Run only Convex dev
  *   pnpm dev --agent=N    # Use worker N's Metro port (19000+N) for parallel development
+ *   pnpm dev --backend=<name> # Explicit backend selection (required in Cursor agent mode)
  */
 
 const { spawn, execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+
+const ALLOWED_BACKENDS_PATH = path.join(__dirname, '..', 'config', 'allowed-backends.json');
+let allowedBackendsCache = null;
+
+function loadAllowedBackends() {
+  if (allowedBackendsCache) {
+    return allowedBackendsCache;
+  }
+
+  if (!fs.existsSync(ALLOWED_BACKENDS_PATH)) {
+    console.error('❌ Missing backend config: config/allowed-backends.json');
+    process.exit(1);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(ALLOWED_BACKENDS_PATH, 'utf-8'));
+  } catch (error) {
+    console.error(`❌ Failed to parse backend config: ${error.message}`);
+    process.exit(1);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    console.error('❌ Backend config must be an object keyed by backend name.');
+    process.exit(1);
+  }
+
+  allowedBackendsCache = parsed;
+  return allowedBackendsCache;
+}
+
+function getAllowedBackendNames() {
+  return Object.keys(loadAllowedBackends());
+}
+
+function parseBackendFromArgs() {
+  for (let i = 0; i < process.argv.length; i += 1) {
+    const arg = process.argv[i];
+    if (arg.startsWith('--backend=')) {
+      return arg.split('=')[1].trim();
+    }
+    if (arg === '--backend') {
+      const next = process.argv[i + 1];
+      return next ? next.trim() : '';
+    }
+  }
+  return null;
+}
+
+function getSelectedBackend() {
+  return parseBackendFromArgs() || process.env.BACKEND_AGENT || null;
+}
+
+function isAgentCloudContext() {
+  return (
+    process.env.CURSOR_AGENT === '1' ||
+    process.env.CURSOR_AGENT === 'true' ||
+    Boolean(process.env.CLOUD_AGENT_INJECTED_SECRET_NAMES) ||
+    Boolean(process.env.CLOUD_AGENT_ALL_SECRET_NAMES)
+  );
+}
+
+function formatAllowedBackends() {
+  return getAllowedBackendNames().map(name => `   - ${name}`).join('\n');
+}
+
+function enforceAgentBackendSelection(env) {
+  if (!isAgentCloudContext()) {
+    return null;
+  }
+
+  const selectedBackend = getSelectedBackend();
+  const allowedBackends = loadAllowedBackends();
+  const selectedConfig = selectedBackend ? allowedBackends[selectedBackend] : null;
+
+  if (!selectedBackend) {
+    console.error('');
+    console.error('❌ Explicit backend selection is required in Cursor agent mode.');
+    console.error('');
+    console.error('Allowed backends:');
+    console.error(formatAllowedBackends());
+    console.error('');
+    console.error('Ask the user: "Which backend should I use: togather-agent-1 or togather-agent-2?"');
+    console.error('Then rerun: pnpm dev:backend --backend=<choice>');
+    console.error('');
+    process.exit(1);
+  }
+
+  if (!selectedConfig) {
+    console.error('');
+    console.error(`❌ Unknown backend "${selectedBackend}" in agent mode.`);
+    console.error('');
+    console.error('Allowed backends:');
+    console.error(formatAllowedBackends());
+    console.error('');
+    process.exit(1);
+  }
+
+  if (
+    env.EXPO_PUBLIC_CONVEX_URL &&
+    env.EXPO_PUBLIC_CONVEX_URL !== selectedConfig.EXPO_PUBLIC_CONVEX_URL
+  ) {
+    console.error('');
+    console.error(`❌ EXPO_PUBLIC_CONVEX_URL mismatch for backend "${selectedBackend}".`);
+    console.error(`   Expected: ${selectedConfig.EXPO_PUBLIC_CONVEX_URL}`);
+    console.error(`   Actual:   ${env.EXPO_PUBLIC_CONVEX_URL}`);
+    console.error('');
+    console.error(`Run: pnpm dev:backend --backend=${selectedBackend}`);
+    console.error('');
+    process.exit(1);
+  }
+
+  env.BACKEND_AGENT = selectedBackend;
+  env.CONVEX_DEPLOYMENT = selectedConfig.CONVEX_DEPLOYMENT;
+  env.EXPO_PUBLIC_CONVEX_URL = selectedConfig.EXPO_PUBLIC_CONVEX_URL;
+  console.log(`🔒 Backend locked: ${selectedBackend}`);
+  return selectedBackend;
+}
 
 /**
  * Check if dependencies need to be installed by comparing lockfile hash
@@ -311,6 +430,11 @@ function startConcurrently(names, colors, commands, env) {
 }
 
 function main() {
+  const env = { ...process.env };
+
+  // Enforce explicit backend selection in Cursor agent/cloud environments.
+  enforceAgentBackendSelection(env);
+
   // Ensure dependencies are up to date
   ensureDependencies();
 
@@ -321,8 +445,7 @@ function main() {
   // Get agent number and port
   const agentNum = getAgentNumber();
   const metroPort = getMetroPort(agentNum);
-
-  const env = { ...process.env };
+  const inAgentCloud = isAgentCloudContext();
 
   // Show agent info if using parallel development
   if (agentNum > 0) {
@@ -361,8 +484,17 @@ function main() {
   }
 
   // For mobile-only or full dev mode, we need the Convex URL
-  // Automatically derive it from .env.local if not already set
+  // Only non-agent local dev may derive it from .env.local
   if (!env.EXPO_PUBLIC_CONVEX_URL) {
+    if (inAgentCloud) {
+      console.error('');
+      console.error('❌ Missing EXPO_PUBLIC_CONVEX_URL for selected backend in agent mode.');
+      console.error('   Run with explicit backend selection:');
+      console.error('   pnpm dev:backend --backend=<togather-agent-1|togather-agent-2>');
+      console.error('');
+      process.exit(1);
+    }
+
     const convexUrl = getConvexUrlFromEnvLocal();
     if (convexUrl) {
       env.EXPO_PUBLIC_CONVEX_URL = convexUrl;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enforce strict backend selection for Cursor agents to prevent accidental use of incorrect backends and ensure explicit choice.

This change introduces a dedicated launcher (`dev:backend`) and runtime guards in `scripts/dev.js` to ensure that in agent/cloud contexts, a backend is explicitly chosen from a predefined allowlist (`config/allowed-backends.json`). It hard-fails on missing selection, unknown backends, or URL mismatches, preventing silent fallback to potentially incorrect environments.

---
<p><a href="https://cursor.com/agents/bc-025a5a38-37c0-44dc-b01c-1bcd43fc54e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-025a5a38-37c0-44dc-b01c-1bcd43fc54e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->