### PR TITLE
Followup data parsing error

### DIFF
--- a/apps/convex/__tests__/utils-safeSliceForJson.test.ts
+++ b/apps/convex/__tests__/utils-safeSliceForJson.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { safeSliceForJson } from "../lib/utils";
+
+describe("safeSliceForJson", () => {
+  test("returns string unchanged when under maxLen", () => {
+    expect(safeSliceForJson("hello", 10)).toBe("hello");
+    expect(safeSliceForJson("", 10)).toBe("");
+  });
+
+  test("slices ASCII string at maxLen", () => {
+    expect(safeSliceForJson("hello world", 5)).toBe("hello");
+  });
+
+  test("avoids cutting surrogate pair - emoji at boundary", () => {
+    // "Hello " + wave emoji (U+1F44B) = 7 code units (emoji is 2: high+low surrogate)
+    // slice(0,7) would give "Hello " + high surrogate only - invalid JSON
+    const withEmoji = "Hello 👋";
+    const sliced = safeSliceForJson(withEmoji, 7);
+    expect(sliced).toBe("Hello ");
+    expect(JSON.stringify({ s: sliced })).toBe('{"s":"Hello "}');
+  });
+
+  test("keeps full emoji when slice ends after it", () => {
+    const withEmoji = "Hello 👋 World";
+    const sliced = safeSliceForJson(withEmoji, 8); // 6 + emoji(2) = 8
+    expect(sliced).toBe("Hello 👋");
+    expect(JSON.stringify({ s: sliced })).toBe('{"s":"Hello 👋"}');
+  });
+
+  test("handles multiple emojis", () => {
+    const multi = "👍😀🎉";
+    const sliced = safeSliceForJson(multi, 4);
+    // 4 code units = 2 full emojis
+    expect(sliced).toBe("👍😀");
+    expect(JSON.stringify({ s: sliced })).toBe('{"s":"👍😀"}');
+  });
+
+  test("handles slice in middle of second emoji", () => {
+    const multi = "A👍😀";
+    const sliced = safeSliceForJson(multi, 4);
+    // A=1, 👍=2, first half of 😀=1 -> would cut surrogate
+    expect(sliced).toBe("A👍");
+    expect(JSON.stringify({ s: sliced })).toBe('{"s":"A👍"}');
+  });
+
+  test("result parses as valid JSON (regression for 'unexpected end of hex escape')", () => {
+    // User note with emoji - slice(0,200) would cut surrogate (199 A's + high surrogate)
+    const longNoteWithEmoji = "A".repeat(199) + "👋";
+    const sliced = safeSliceForJson(longNoteWithEmoji, 200);
+    const json = JSON.stringify({ latestNoteContent: sliced });
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(JSON.parse(json).latestNoteContent).toBe("A".repeat(199));
+  });
+});

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -27,7 +27,7 @@ import { query, mutation, internalQuery, internalMutation } from "../_generated/
 import { paginationOptsValidator } from "convex/server";
 import { Doc, Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
-import { now, getMediaUrl, normalizePhone, isValidPhone, buildSearchText } from "../lib/utils";
+import { now, getMediaUrl, normalizePhone, isValidPhone, buildSearchText, safeSliceForJson } from "../lib/utils";
 import { requireAuth } from "../lib/auth";
 import { parseDateOptional } from "../lib/validation";
 import { isCommunityAdmin } from "../lib/permissions";
@@ -527,7 +527,9 @@ export const internalScoreBatch = internalQuery({
 
         // Extract latest note for denormalization
         const latestNoteEntry = followups.find(f => f.type === "note" && f.content);
-        const latestNoteContent = latestNoteEntry?.content?.slice(0, 200) ?? null;
+        const latestNoteContent = latestNoteEntry?.content
+          ? safeSliceForJson(latestNoteEntry.content, 200)
+          : null;
         const latestNoteAt = latestNoteEntry?.createdAt ?? null;
 
         return {

--- a/apps/convex/lib/utils.ts
+++ b/apps/convex/lib/utils.ts
@@ -82,6 +82,26 @@ export function normalizePhone(phone: string): string {
 }
 
 // ============================================================================
+// JSON-Safe String Helpers
+// ============================================================================
+
+/**
+ * Slice a string for JSON-safe serialization without cutting UTF-16 surrogate pairs.
+ * JavaScript's slice() can split emoji/supplementary chars (stored as surrogate pairs),
+ * leaving a lone high surrogate. When JSON-serialized, that produces invalid JSON
+ * ("unexpected end of hex escape") because \uD800-\uDBFF must be followed by \uDC00-\uDFFF.
+ */
+export function safeSliceForJson(str: string, maxLen: number): string {
+  if (!str || str.length <= maxLen) return str;
+  let sliced = str.slice(0, maxLen);
+  const lastCode = sliced.charCodeAt(sliced.length - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    sliced = sliced.slice(0, -1);
+  }
+  return sliced;
+}
+
+// ============================================================================
 // User Search Helpers
 // ============================================================================
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes "unexpected end of hex escape" JSON parsing error by safely truncating `latestNoteContent`.

The previous `.slice(0, 200)` could split UTF-16 surrogate pairs (e.g., emojis), leaving a lone high surrogate which is invalid in JSON and caused the "unexpected end of hex escape" error when the Convex function's return value was parsed. The new `safeSliceForJson` utility ensures strings are truncated without breaking these pairs.

---
<p><a href="https://cursor.com/agents/bc-3671de80-31aa-46f3-ad8e-1ea799092297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3671de80-31aa-46f3-ad8e-1ea799092297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->