### PR TITLE
fix: add multi-select support to FollowupSettingsPanel

### DIFF
--- a/apps/mobile/features/leader-tools/components/ColumnPickerModal.tsx
+++ b/apps/mobile/features/leader-tools/components/ColumnPickerModal.tsx
@@ -567,6 +567,7 @@ const styles = StyleSheet.create({
   },
   typePickerRow: {
     flexDirection: "row" as const,
+    flexWrap: "wrap" as const,
     gap: 6,
   },
   typeOption: {

--- a/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
@@ -89,12 +89,13 @@ const DEFAULT_SCORES: ScoreDefinition[] = [
 const SLOT_CANDIDATES: Record<string, string[]> = {
   text: ["customText1", "customText2", "customText3", "customText4", "customText5"],
   dropdown: ["customText1", "customText2", "customText3", "customText4", "customText5"],
+  multiselect: ["customText1", "customText2", "customText3", "customText4", "customText5"],
   number: ["customNum1", "customNum2", "customNum3", "customNum4", "customNum5"],
   boolean: ["customBool1", "customBool2", "customBool3", "customBool4", "customBool5"],
 };
 
 const SLOT_CAPACITIES: Record<string, { label: string; total: number; types: string[] }> = {
-  text: { label: "Text/Dropdown", total: 5, types: ["text", "dropdown"] },
+  text: { label: "Text/Dropdown/Multi", total: 5, types: ["text", "dropdown", "multiselect"] },
   number: { label: "Number", total: 5, types: ["number"] },
   boolean: { label: "Checkbox", total: 5, types: ["boolean"] },
 };
@@ -108,6 +109,7 @@ const FIELD_TYPES = [
   { value: "number", label: "Number" },
   { value: "boolean", label: "Checkbox" },
   { value: "dropdown", label: "Dropdown" },
+  { value: "multiselect", label: "Multi-Select" },
 ] as const;
 
 const SYSTEM_COLUMNS = new Set(["checkbox", "rowNum"]);
@@ -310,7 +312,7 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
       slot,
       name: newFieldName.trim(),
       type: newFieldType,
-      ...(newFieldType === "dropdown" && newFieldOptions.length > 0
+      ...((newFieldType === "dropdown" || newFieldType === "multiselect") && newFieldOptions.length > 0
         ? { options: newFieldOptions.filter((o) => o.trim()) }
         : {}),
     };
@@ -847,7 +849,7 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
                   <View style={styles.typeBadge}>
                     <Text style={styles.typeBadgeText}>{field.type}</Text>
                   </View>
-                  {field.type === "dropdown" && field.options && (
+                  {(field.type === "dropdown" || field.type === "multiselect") && field.options && (
                     <Text style={styles.fieldOptions} numberOfLines={1}>
                       ({field.options.join(", ")})
                     </Text>
@@ -902,8 +904,8 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
                   })}
                 </View>
 
-                {/* Dropdown options editor */}
-                {newFieldType === "dropdown" && (
+                {/* Dropdown / Multi-Select options editor */}
+                {(newFieldType === "dropdown" || newFieldType === "multiselect") && (
                   <View style={styles.optionsEditor}>
                     <Text style={styles.optionsLabel}>Options:</Text>
                     {newFieldOptions.map((opt, i) => (
@@ -916,7 +918,7 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
                           value={opt}
                           onChangeText={(text) => {
                             const next = [...newFieldOptions];
-                            next[i] = text;
+                            next[i] = text.replace(/;/g, "");
                             setNewFieldOptions(next);
                           }}
                           placeholder={`Option ${i + 1}`}


### PR DESCRIPTION
## Summary
- The desktop follow-up page uses `FollowupSettingsPanel` (not `ColumnPickerModal`) for column/custom field settings
- This panel had its own duplicate `SLOT_CANDIDATES`, `SLOT_CAPACITIES`, and `FIELD_TYPES` constants that were not updated when multi-select was added in #65
- Added multiselect entries to all three constants, enabled options editor for multiselect fields, and added semicolon stripping for option names
- Also added `flexWrap` to `ColumnPickerModal` typePickerRow style for the 5th type button

## Test plan
- [x] Open follow-up page > Settings gear > Columns > Add Custom Field
- [x] Verify "Multi-Select" button appears alongside Text, Number, Checkbox, Dropdown
- [x] Verify capacity label shows "Text/Dropdown/Multi: 2/5"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI/configuration wiring for an already-supported field type, plus minor input sanitization; low likelihood of impacting data integrity beyond how custom-field options are entered/displayed.
> 
> **Overview**
> Adds **multi-select** support to `FollowupSettingsPanel`’s custom field picker by updating slot/capacity/type constants, enabling the options editor + options display for `multiselect` fields, and sanitizing option input by stripping semicolons.
> 
> Also tweaks `ColumnPickerModal` styling to wrap the field-type buttons (`flexWrap`) so the extra type doesn’t overflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0239ea48beecc31e8e257f72ac3ed563710f716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->