### PR TITLE
Follow up data consistency

### DIFF
--- a/apps/convex/__tests__/community-membership.test.ts
+++ b/apps/convex/__tests__/community-membership.test.ts
@@ -128,8 +128,8 @@ async function seedCommunityWithUsers(t: ReturnType<typeof convexTest>) {
   });
 
   // Add test user to announcement group
-  await t.run(async (ctx) => {
-    await ctx.db.insert("groupMembers", {
+  const testAnnouncementGroupMemberId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groupMembers", {
       groupId: announcementGroupId,
       userId: testUserId,
       role: "member",
@@ -144,6 +144,7 @@ async function seedCommunityWithUsers(t: ReturnType<typeof convexTest>) {
     announcementGroupId,
     adminUserId,
     testUserId,
+    testAnnouncementGroupMemberId,
   };
 }
 
@@ -152,6 +153,75 @@ async function seedCommunityWithUsers(t: ReturnType<typeof convexTest>) {
 // ============================================================================
 
 describe("Community Member Removal", () => {
+  test("removing a user deletes followup entries and denormalized score rows", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, testUserId, adminUserId, announcementGroupId, testAnnouncementGroupMemberId } =
+      await seedCommunityWithUsers(t);
+
+    const timestamp = Date.now();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberFollowups", {
+        groupMemberId: testAnnouncementGroupMemberId,
+        createdById: adminUserId,
+        type: "note",
+        content: "Should be removed with membership cleanup",
+        createdAt: timestamp,
+      });
+
+      await ctx.db.insert("memberFollowupScores", {
+        groupId: announcementGroupId,
+        groupMemberId: testAnnouncementGroupMemberId,
+        userId: testUserId,
+        firstName: "Zombie",
+        lastName: "Member",
+        score1: 10,
+        score2: 20,
+        alerts: [],
+        isSnoozed: false,
+        attendanceScore: 10,
+        connectionScore: 20,
+        followupScore: 15,
+        missedMeetings: 1,
+        consecutiveMissed: 1,
+        scoreIds: ["default_attendance", "default_connection"],
+        updatedAt: timestamp,
+        addedAt: timestamp,
+        searchText: "zombie member",
+      });
+    });
+
+    const { accessToken: adminToken } = await generateTokens(adminUserId);
+    await t.mutation(api.functions.communities.removeMember, {
+      token: adminToken,
+      communityId,
+      targetUserId: testUserId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const [membershipAfter, followupsAfter, scoreAfter] = await t.run(async (ctx) => {
+      const membership = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", announcementGroupId).eq("userId", testUserId)
+        )
+        .first();
+      const followups = await ctx.db
+        .query("memberFollowups")
+        .withIndex("by_groupMember", (q) => q.eq("groupMemberId", testAnnouncementGroupMemberId))
+        .collect();
+      const score = await ctx.db
+        .query("memberFollowupScores")
+        .withIndex("by_groupMember", (q) => q.eq("groupMemberId", testAnnouncementGroupMemberId))
+        .first();
+      return [membership, followups, score];
+    });
+
+    expect(membershipAfter).toBeNull();
+    expect(followupsAfter).toHaveLength(0);
+    expect(scoreAfter).toBeNull();
+  });
+
   test("removing a user should clear their activeCommunityId if it points to the removed community", async () => {
     /**
      * BUG REPRODUCTION:

--- a/apps/convex/__tests__/followup-refresh-state.test.ts
+++ b/apps/convex/__tests__/followup-refresh-state.test.ts
@@ -171,4 +171,68 @@ describe("followup refresh state + lastActiveAt", () => {
     expect(scoreDoc).toBeTruthy();
     expect(scoreDoc?.lastActiveAt).toBe(fixture.communityLastLogin);
   });
+
+  test("manual refresh prunes stale score rows for removed members", async () => {
+    const t = convexTest(schema, modules);
+    const fixture = await seedFollowupRefreshFixture(t);
+    const timestamp = Date.now();
+
+    const staleGroupMemberId = await t.run(async (ctx) => {
+      const staleUserId = await ctx.db.insert("users", {
+        firstName: "Stale",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      const staleMembershipId = await ctx.db.insert("groupMembers", {
+        groupId: fixture.groupId,
+        userId: staleUserId,
+        role: "member",
+        joinedAt: timestamp,
+        notificationsEnabled: true,
+      });
+      await ctx.db.insert("memberFollowupScores", {
+        groupId: fixture.groupId,
+        groupMemberId: staleMembershipId,
+        userId: staleUserId,
+        firstName: "Stale",
+        lastName: "Member",
+        score1: 1,
+        score2: 1,
+        alerts: [],
+        isSnoozed: false,
+        attendanceScore: 1,
+        connectionScore: 1,
+        followupScore: 1,
+        missedMeetings: 0,
+        consecutiveMissed: 0,
+        scoreIds: ["default_attendance", "default_connection"],
+        updatedAt: timestamp,
+        addedAt: timestamp,
+        searchText: "stale member",
+      });
+      await ctx.db.delete(staleMembershipId);
+      return staleMembershipId;
+    });
+
+    await t.mutation(api.functions.groups.mutations.refreshFollowupScores, {
+      token: fixture.token,
+      groupId: fixture.groupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const [staleScoreDoc, activeScoreDoc] = await t.run(async (ctx) => {
+      const staleDoc = await ctx.db
+        .query("memberFollowupScores")
+        .withIndex("by_groupMember", (q) => q.eq("groupMemberId", staleGroupMemberId))
+        .first();
+      const activeDoc = await ctx.db
+        .query("memberFollowupScores")
+        .withIndex("by_groupMember", (q) => q.eq("groupMemberId", fixture.memberGroupMemberId))
+        .first();
+      return [staleDoc, activeDoc];
+    });
+
+    expect(staleScoreDoc).toBeNull();
+    expect(activeScoreDoc).toBeTruthy();
+  });
 });

--- a/apps/convex/functions/communities.ts
+++ b/apps/convex/functions/communities.ts
@@ -557,9 +557,36 @@ async function removeUserFromCommunity(
     count: groupMembershipsToRemove.length,
   });
 
+  let followupsDeleted = 0;
+  let followupScoresDeleted = 0;
   for (const gm of groupMembershipsToRemove) {
+    // Clean up follow-up artifacts tied to this membership to prevent zombie rows
+    // in the denormalized follow-up table after community removal.
+    const followups = await ctx.db
+      .query("memberFollowups")
+      .withIndex("by_groupMember", (q: any) => q.eq("groupMemberId", gm._id))
+      .collect();
+    for (const followup of followups) {
+      await ctx.db.delete(followup._id);
+      followupsDeleted++;
+    }
+
+    const scoreDoc = await ctx.db
+      .query("memberFollowupScores")
+      .withIndex("by_groupMember", (q: any) => q.eq("groupMemberId", gm._id))
+      .first();
+    if (scoreDoc) {
+      await ctx.db.delete(scoreDoc._id);
+      followupScoresDeleted++;
+    }
+
     await ctx.db.delete(gm._id);
   }
+
+  console.log(`${logPrefix} Removed follow-up artifacts`, {
+    followupsDeleted,
+    followupScoresDeleted,
+  });
 
   // 4. Find all meetings in these groups and delete RSVPs
   let rsvpsCancelled = 0;

--- a/apps/convex/functions/followupScoreComputation.ts
+++ b/apps/convex/functions/followupScoreComputation.ts
@@ -213,6 +213,36 @@ export const deleteScoreDoc = internalMutation({
   },
 });
 
+/**
+ * Delete denormalized score docs that no longer map to an active group member.
+ * This prevents stale rows from surviving after community/group membership cleanup.
+ */
+export const pruneStaleScoreDocsForGroup = internalMutation({
+  args: { groupId: v.id("groups") },
+  handler: async (ctx, args) => {
+    const docs = await ctx.db
+      .query("memberFollowupScores")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .collect();
+
+    let deleted = 0;
+    for (const doc of docs) {
+      const groupMember = await ctx.db.get(doc.groupMemberId);
+      const isStale =
+        !groupMember ||
+        groupMember.groupId !== args.groupId ||
+        groupMember.leftAt !== undefined;
+
+      if (isStale) {
+        await ctx.db.delete(doc._id);
+        deleted++;
+      }
+    }
+
+    return { deleted };
+  },
+});
+
 // ============================================================================
 // Score Computation Actions
 // ============================================================================
@@ -417,6 +447,12 @@ export const computeGroupScores = internalAction({
         isDone = page.isDone;
         cursor = page.continueCursor;
       }
+
+      // Step 6: prune stale denormalized rows for deleted/left members.
+      await ctx.runMutation(
+        internal.functions.followupScoreComputation.pruneStaleScoreDocsForGroup,
+        { groupId: args.groupId }
+      );
 
       await ctx.runMutation(
         internal.functions.followupScoreComputation.setFollowupRefreshCompleted,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes orphaned follow-up entries upon community member deletion and prunes stale follow-up scores during refresh to ensure data consistency.

Previously, deleting a community member removed `groupMembers` but left `memberFollowups` and `memberFollowupScores` orphaned. Additionally, the follow-up refresh only upserted active members without pruning stale score documents, leading to "zombie" members persisting in the follow-up table.

<div><a href="https://cursor.com/agents/bc-417d40ae-49a9-4907-82be-a4bae21d13d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-417d40ae-49a9-4907-82be-a4bae21d13d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->