### PR TITLE
Independent channel membership

### DIFF
--- a/apps/convex/__tests__/messaging/shared-channels.test.ts
+++ b/apps/convex/__tests__/messaging/shared-channels.test.ts
@@ -804,3 +804,107 @@ describe("removeGroupFromChannel", () => {
     expect(channel!.isShared).toBe(false);
   });
 });
+
+// ============================================================================
+// addChannelMembers + shared channel membership rules
+// ============================================================================
+
+describe("addChannelMembers on shared channels", () => {
+  test("adds accepted secondary-group members without adding them to primary group", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSharedChannelTestData(t);
+
+    // Invite and accept secondary group so its members become eligible.
+    await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+      token: data.primaryLeaderToken,
+      channelId: data.channelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+      token: data.secondaryLeaderToken,
+      channelId: data.channelId,
+      groupId: data.secondaryGroupId,
+      response: "accepted",
+    });
+
+    const result = await t.mutation(api.functions.messaging.channels.addChannelMembers, {
+      token: data.primaryLeaderToken,
+      channelId: data.channelId,
+      userIds: [data.secondaryMemberUserId],
+    });
+
+    expect(result.addedCount).toBe(1);
+
+    // User should be added to channel membership.
+    const channelMembership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", data.channelId).eq("userId", data.secondaryMemberUserId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
+    });
+    expect(channelMembership).not.toBeNull();
+
+    // Critically, user should NOT be auto-added to the primary group.
+    const primaryGroupMembership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", data.primaryGroupId).eq("userId", data.secondaryMemberUserId)
+        )
+        .first();
+    });
+    expect(primaryGroupMembership).toBeNull();
+  });
+
+  test("rejects users not in primary or accepted shared groups", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSharedChannelTestData(t);
+
+    // Invite and accept one secondary group.
+    await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+      token: data.primaryLeaderToken,
+      channelId: data.channelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+      token: data.secondaryLeaderToken,
+      channelId: data.channelId,
+      groupId: data.secondaryGroupId,
+      response: "accepted",
+    });
+
+    // Create a user in the same community but in no eligible group.
+    const outsiderUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        firstName: "Outside",
+        lastName: "User",
+        phone: "+15555550999",
+        phoneVerified: true,
+        activeCommunityId: data.communityId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.mutation(api.functions.messaging.channels.addChannelMembers, {
+        token: data.primaryLeaderToken,
+        channelId: data.channelId,
+        userIds: [outsiderUserId],
+      })
+    ).rejects.toThrow(/must already belong to the primary group or an accepted shared group/i);
+
+    const outsiderMembership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", data.channelId).eq("userId", outsiderUserId)
+        )
+        .first();
+    });
+    expect(outsiderMembership).toBeNull();
+  });
+});

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -2135,10 +2135,21 @@ export const addChannelMembers = mutation({
       throw new Error("Only the channel owner or group leaders can add members.");
     }
 
-    // 4. Validate userIds exist and auto-add non-group members to the group
+    // 4. Validate userIds and enforce group eligibility
     const validUserIds: Id<"users">[] = [];
     const userDataMap = new Map<Id<"users">, { displayName: string; profilePhoto: string | undefined }>();
     const timestamp = Date.now();
+    const isSharedChannel = channel.isShared === true;
+    const eligibleGroupIds = new Set<Id<"groups">>([channel.groupId]);
+    const ineligibleUserDisplayNames: string[] = [];
+
+    if (isSharedChannel) {
+      for (const sharedGroup of channel.sharedGroups ?? []) {
+        if (sharedGroup.status === "accepted") {
+          eligibleGroupIds.add(sharedGroup.groupId);
+        }
+      }
+    }
 
     for (const userId of args.userIds) {
       // Check if user exists
@@ -2147,57 +2158,94 @@ export const addChannelMembers = mutation({
         continue; // Skip invalid user IDs
       }
 
-      // Check for any group membership (including inactive ones)
-      const existingGroupMembership = await ctx.db
-        .query("groupMembers")
-        .withIndex("by_group_user", (q) =>
-          q.eq("groupId", channel.groupId).eq("userId", userId)
-        )
-        .first();
+      if (isSharedChannel) {
+        // Shared channels must not mutate primary group membership.
+        // Users are only eligible if they already belong to the primary group
+        // or any accepted shared secondary group.
+        const userGroupMemberships = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_user", (q) => q.eq("userId", userId))
+          .filter((q) =>
+            q.and(
+              q.eq(q.field("leftAt"), undefined),
+              q.or(
+                q.eq(q.field("requestStatus"), undefined),
+                q.eq(q.field("requestStatus"), null),
+                q.eq(q.field("requestStatus"), "accepted")
+              )
+            )
+          )
+          .collect();
 
-      const isActiveGroupMember = existingGroupMembership && !existingGroupMembership.leftAt;
+        const hasEligibleGroupMembership = userGroupMemberships.some((membership) =>
+          eligibleGroupIds.has(membership.groupId)
+        );
 
-      if (!isActiveGroupMember) {
-        // Auto-add user to the group
-        if (existingGroupMembership && existingGroupMembership.leftAt) {
-          // Reactivate: clear leftAt, update joinedAt
-          await ctx.db.patch(existingGroupMembership._id, {
-            role: "member",
-            leftAt: undefined,
-            joinedAt: timestamp,
-            notificationsEnabled: true,
-          });
-        } else {
-          // Create new group membership
-          await ctx.db.insert("groupMembers", {
-            groupId: channel.groupId,
-            userId,
-            role: "member",
-            joinedAt: timestamp,
-            notificationsEnabled: true,
-          });
+        if (!hasEligibleGroupMembership) {
+          ineligibleUserDisplayNames.push(getDisplayName(user.firstName, user.lastName));
+          continue;
+        }
+      } else {
+        // Non-shared channels keep legacy behavior: add missing primary group memberships.
+        const existingGroupMembership = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", channel.groupId).eq("userId", userId)
+          )
+          .first();
 
-          // Trigger welcome message for NEW group members only
-          await ctx.scheduler.runAfter(
-            0,
-            internal.functions.scheduledJobs.sendWelcomeMessage,
-            {
+        const isActiveGroupMember = existingGroupMembership && !existingGroupMembership.leftAt;
+
+        if (!isActiveGroupMember) {
+          // Auto-add user to the group
+          if (existingGroupMembership && existingGroupMembership.leftAt) {
+            // Reactivate: clear leftAt, update joinedAt
+            await ctx.db.patch(existingGroupMembership._id, {
+              role: "member",
+              leftAt: undefined,
+              joinedAt: timestamp,
+              notificationsEnabled: true,
+            });
+          } else {
+            // Create new group membership
+            await ctx.db.insert("groupMembers", {
               groupId: channel.groupId,
               userId,
-            }
-          );
-        }
+              role: "member",
+              joinedAt: timestamp,
+              notificationsEnabled: true,
+            });
 
-        // Sync channel memberships for the newly added group member
-        await syncUserChannelMembershipsLogic(ctx, userId, channel.groupId);
+            // Trigger welcome message for NEW group members only
+            await ctx.scheduler.runAfter(
+              0,
+              internal.functions.scheduledJobs.sendWelcomeMessage,
+              {
+                groupId: channel.groupId,
+                userId,
+              }
+            );
+          }
+
+          // Sync channel memberships for the newly added group member
+          await syncUserChannelMembershipsLogic(ctx, userId, channel.groupId);
+        }
       }
 
-      // User is now a valid group member, add to channel
+      // User is eligible to be added to the channel
       validUserIds.push(userId);
       userDataMap.set(userId, {
         displayName: getDisplayName(user.firstName, user.lastName),
         profilePhoto: getMediaUrl(user.profilePhoto),
       });
+    }
+
+    if (isSharedChannel && ineligibleUserDisplayNames.length > 0) {
+      const previewNames = ineligibleUserDisplayNames.slice(0, 3).join(", ");
+      const suffix = ineligibleUserDisplayNames.length > 3 ? ", and others" : "";
+      throw new Error(
+        `Cannot add ${previewNames}${suffix}. Shared channel members must already belong to the primary group or an accepted shared group.`
+      );
     }
 
     // 5. For each valid user, add or reactivate channel membership


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Allow adding members to shared channels from secondary groups without forcing primary group membership.

<div><a href="https://cursor.com/agents/bc-dc49155c-9c80-48f8-8b24-ae301d07dd16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc49155c-9c80-48f8-8b24-ae301d07dd16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->