### PR TITLE
Group tasks visibility

### DIFF
--- a/apps/convex/__tests__/groups-toolbar-settings.test.ts
+++ b/apps/convex/__tests__/groups-toolbar-settings.test.ts
@@ -1,0 +1,91 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import schema from "../schema";
+import { modules } from "../test.setup";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+interface SeededGroupLeader {
+  groupId: Id<"groups">;
+  leaderToken: string;
+}
+
+async function seedGroupLeader(
+  t: ReturnType<typeof convexTest>
+): Promise<SeededGroupLeader> {
+  const { groupId, leaderId } = await t.run(async (ctx) => {
+    const timestamp = Date.now();
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Toolbar Test Community",
+      slug: "toolbar-test-community",
+      isPublic: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: "small-group",
+      isActive: true,
+      createdAt: timestamp,
+      displayOrder: 1,
+    });
+
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Toolbar Test Group",
+      isArchived: false,
+      isPublic: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Toolbar",
+      lastName: "Leader",
+      phone: "+12025550999",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: leaderId,
+      role: "leader",
+      joinedAt: timestamp,
+      notificationsEnabled: true,
+    });
+
+    return { groupId, leaderId };
+  });
+
+  const { accessToken: leaderToken } = await generateTokens(leaderId);
+  return { groupId, leaderToken };
+}
+
+describe("groups.updateLeaderToolbarTools", () => {
+  test("persists tasks when leader saves toolbar tools", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, leaderToken } = await seedGroupLeader(t);
+
+    const result = await t.mutation(
+      api.functions.groups.index.updateLeaderToolbarTools,
+      {
+        token: leaderToken,
+        groupId,
+        tools: ["attendance", "tasks", "events"],
+      }
+    );
+
+    expect(result).toEqual({ success: true });
+
+    const group = await t.run(async (ctx) => ctx.db.get(groupId));
+    expect(group?.leaderToolbarTools).toEqual(["attendance", "tasks", "events"]);
+  });
+});

--- a/apps/convex/functions/groups/mutations.ts
+++ b/apps/convex/functions/groups/mutations.ts
@@ -704,7 +704,7 @@ export const updateLeaderToolbarTools = mutation({
     // Validate tool IDs
     // NOTE: This list must match apps/mobile/features/chat/constants/toolbarTools.ts
     // Backend validates independently for security; frontend uses for UI rendering.
-    const allowedBuiltInTools = ["attendance", "followup", "events", "bots", "sync", "runsheet"];
+    const allowedBuiltInTools = ["attendance", "followup", "tasks", "events", "bots", "sync", "runsheet"];
     for (const tool of args.tools) {
       // Allow built-in tools
       if (allowedBuiltInTools.includes(tool)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enable 'tasks' to be saved in leader toolbar settings, fixing an issue where the UI would re-hide tasks after saving.

<div><a href="https://cursor.com/agents/bc-4a333e2d-779c-48c4-b27c-4ae367f3c50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a333e2d-779c-48c4-b27c-4ae367f3c50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->