### PR TITLE
Revert kill switch — outage was Convex platform incident

### DIFF
--- a/apps/convex/functions/followupScoreComputation.ts
+++ b/apps/convex/functions/followupScoreComputation.ts
@@ -320,13 +320,6 @@ export const computeGroupScores = internalAction({
     trigger: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    // EMERGENCY KILL SWITCH — skip scheduled cron runs to free up workers.
-    // Manual triggers (from UI refresh button) still run.
-    if (!args.trigger || args.trigger === "scheduled") {
-      console.log(`[computeGroupScores] SKIPPED (kill switch) group=${args.groupId}`);
-      return;
-    }
-
     const runId = args.runId ?? `auto_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
     await ctx.runMutation(


### PR DESCRIPTION
## Summary
- Reverts #86 (the followup score cron kill switch)
- The "no available workers" outage was caused by a Convex platform incident affecting pro instances, not our cron
- See: https://status.convex.dev/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables potentially heavy scheduled background work; if worker capacity is constrained, this could reintroduce load/queue pressure during cron runs.
> 
> **Overview**
> Removes the emergency “kill switch” early-return in `computeGroupScores`, so scheduled/cron-triggered follow-up score recomputation runs again instead of being skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f2a66de12dce3204caf69c2f2c89dd7b4bbe8ff. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->