### PR TITLE
Mobile textbox resizing

### DIFF
--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -782,7 +782,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
             const contentHeight = event.nativeEvent.contentSize.height;
             const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
             const clamped = Math.min(contentHeight, maxHeight);
-            setInputHeight(prev => Math.abs(clamped - prev) > 2 ? clamped : prev);
+            setInputHeight(prev => Math.abs(clamped - prev) > 2 || clamped >= maxHeight ? clamped : prev);
           }}
           placeholder="Message..."
           placeholderTextColor="#999"

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
@@ -243,6 +243,49 @@ describe('MessageInput', () => {
 
       expect(input.props.scrollEnabled).toBe(true);
     });
+
+    it('reaches max height even when current height is within threshold of max (dead zone fix)', () => {
+      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2; // 180
+
+      const { getByPlaceholderText } = render(
+        <MessageInput channelId={'test-channel' as any} />
+      );
+      const input = getByPlaceholderText('Message...');
+
+      // Set height to just below maxHeight (within the 2px threshold)
+      const nearMaxHeight = maxHeight - 1.5; // 178.5
+      act(() => {
+        fireEvent(input, 'contentSizeChange', {
+          nativeEvent: { contentSize: { width: 300, height: nearMaxHeight } },
+        });
+      });
+
+      const styleAfterFirst = input.props.style;
+      const flatFirst = Array.isArray(styleAfterFirst)
+        ? Object.assign({}, ...styleAfterFirst.filter(Boolean))
+        : styleAfterFirst;
+      expect(flatFirst.height).toBe(nearMaxHeight);
+      expect(input.props.scrollEnabled).toBe(false);
+
+      // Now content grows beyond max - should clamp to maxHeight and enable scrolling
+      // The difference (180 - 178.5 = 1.5) is within threshold, but since clamped >= maxHeight,
+      // the fix ensures inputHeight updates to maxHeight anyway
+      act(() => {
+        fireEvent(input, 'contentSizeChange', {
+          nativeEvent: { contentSize: { width: 300, height: maxHeight + 50 } },
+        });
+      });
+
+      const styleAfterSecond = input.props.style;
+      const flatSecond = Array.isArray(styleAfterSecond)
+        ? Object.assign({}, ...styleAfterSecond.filter(Boolean))
+        : styleAfterSecond;
+
+      // Input height should reach exactly maxHeight (not stuck at 178.5)
+      expect(flatSecond.height).toBe(maxHeight);
+      // Scrolling should now be enabled
+      expect(input.props.scrollEnabled).toBe(true);
+    });
   });
 
   describe('web platform', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix aggressive textbox resizing/oscillation in `MessageInput.tsx` to prevent shaking on mobile.

A previous commit introduced a feedback loop in the height calculation by double-padding the explicit height style, causing `onContentSizeChange` and height updates to continuously trigger each other. This PR removes the redundant padding, adds an anti-oscillation threshold, and aligns height caps.

<div><a href="https://cursor.com/agents/bc-7afcc17e-ba75-4d46-8815-4f7e3ef836ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7afcc17e-ba75-4d46-8815-4f7e3ef836ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->