### PR TITLE
fix: chat TextInput auto-grow without shaking

### DIFF
--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -116,7 +116,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
   const [uploadedImageUrls, setUploadedImageUrls] = useState<string[]>([]);
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
   const [uploadedFile, setUploadedFile] = useState<{ storagePath: string; name: string; category: FileCategory } | null>(null);
-  const [inputHeight, setInputHeight] = useState(LINE_HEIGHT);
+  const [nativeScrollEnabled, setNativeScrollEnabled] = useState(false);
   const [debouncedText, setDebouncedText] = useState('');
   const isWeb = Platform.OS === 'web';
   const prevChannelIdRef = useRef(channelId);
@@ -131,7 +131,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
       // Load draft for the new channel
       const draft = getDraft(channelId);
       setText(draft);
-      setInputHeight(LINE_HEIGHT);
+      setNativeScrollEnabled(false);
       prevChannelIdRef.current = channelId;
     }
   }, [channelId]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -547,7 +547,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
       // Clear input and draft
       setText('');
       setDebouncedText('');
-      setInputHeight(LINE_HEIGHT);
+      setNativeScrollEnabled(false);
       if (channelId) clearDraft(channelId);
       setSelectedImages([]);
       setUploadedImageUrls([]);
@@ -771,9 +771,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
           ref={textInputRef}
           style={[
             styles.input,
-            isWeb
-              ? styles.inputWeb
-              : { height: Math.max(40, inputHeight) },
+            isWeb ? styles.inputWeb : styles.inputNative,
           ]}
           value={text}
           onChangeText={handleTextChange}
@@ -781,13 +779,12 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
           onContentSizeChange={isWeb ? undefined : (event) => {
             const contentHeight = event.nativeEvent.contentSize.height;
             const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
-            const clamped = Math.min(contentHeight, maxHeight);
-            setInputHeight(prev => Math.abs(clamped - prev) > 2 || clamped >= maxHeight ? clamped : prev);
+            setNativeScrollEnabled(contentHeight >= maxHeight);
           }}
           placeholder="Message..."
           placeholderTextColor="#999"
           multiline
-          scrollEnabled={isWeb ? true : inputHeight >= LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2}
+          scrollEnabled={isWeb ? true : nativeScrollEnabled}
           maxLength={2000}
           editable={!uploading && !isSending}
         />
@@ -958,6 +955,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     maxHeight: LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2,
     backgroundColor: '#f9f9f9',
+  },
+  inputNative: {
+    minHeight: 40,
   },
   inputWeb: {
     minHeight: 40,

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
@@ -100,7 +100,7 @@ describe('MessageInput', () => {
     expect(getByPlaceholderText('Message...')).toBeTruthy();
   });
 
-  it('starts with minimum height of 40', () => {
+  it('uses native auto-grow with minHeight on iOS (no explicit height)', () => {
     const { getByPlaceholderText } = render(
       <MessageInput channelId={'test-channel' as any} />
     );
@@ -109,123 +109,20 @@ describe('MessageInput', () => {
     const flatStyle = Array.isArray(style)
       ? Object.assign({}, ...style.filter(Boolean))
       : style;
-    expect(flatStyle.height).toBeGreaterThanOrEqual(40);
+
+    // Should have minHeight for minimum size, not an explicit height
+    expect(flatStyle.minHeight).toBe(40);
+    // maxHeight should cap expansion
+    expect(flatStyle.maxHeight).toBe(LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2);
   });
 
-  describe('height calculation (anti-oscillation)', () => {
-    it('does NOT add extra padding to the explicit height style', () => {
+  describe('scroll behavior', () => {
+    it('disables scrolling when content is below max height', () => {
       const { getByPlaceholderText } = render(
         <MessageInput channelId={'test-channel' as any} />
       );
       const input = getByPlaceholderText('Message...');
 
-      act(() => {
-        fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: 60 } },
-        });
-      });
-
-      const style = input.props.style;
-      const flatStyle = Array.isArray(style)
-        ? Object.assign({}, ...style.filter(Boolean))
-        : style;
-
-      // Height should be the contentSize value directly, NOT contentSize + padding
-      // The old buggy code added INPUT_PADDING_VERTICAL * 2 (20) which caused oscillation
-      expect(flatStyle.height).toBeLessThanOrEqual(60);
-      expect(flatStyle.height).not.toBe(60 + INPUT_PADDING_VERTICAL * 2);
-    });
-
-    it('ignores height changes smaller than threshold to prevent oscillation', () => {
-      const { getByPlaceholderText } = render(
-        <MessageInput channelId={'test-channel' as any} />
-      );
-      const input = getByPlaceholderText('Message...');
-
-      act(() => {
-        fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: 60 } },
-        });
-      });
-
-      const styleAfterFirst = input.props.style;
-      const flatFirst = Array.isArray(styleAfterFirst)
-        ? Object.assign({}, ...styleAfterFirst.filter(Boolean))
-        : styleAfterFirst;
-      const heightAfterFirst = flatFirst.height;
-
-      // Fire again with a tiny change (1px) — should be ignored
-      act(() => {
-        fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: 61 } },
-        });
-      });
-
-      const styleAfterSecond = input.props.style;
-      const flatSecond = Array.isArray(styleAfterSecond)
-        ? Object.assign({}, ...styleAfterSecond.filter(Boolean))
-        : styleAfterSecond;
-
-      expect(flatSecond.height).toBe(heightAfterFirst);
-    });
-
-    it('applies height changes larger than threshold', () => {
-      const { getByPlaceholderText } = render(
-        <MessageInput channelId={'test-channel' as any} />
-      );
-      const input = getByPlaceholderText('Message...');
-
-      act(() => {
-        fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: 60 } },
-        });
-      });
-
-      act(() => {
-        fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: 80 } },
-        });
-      });
-
-      const style = input.props.style;
-      const flat = Array.isArray(style)
-        ? Object.assign({}, ...style.filter(Boolean))
-        : style;
-
-      expect(flat.height).toBe(80);
-    });
-
-    it('clamps height at max input height', () => {
-      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
-
-      const { getByPlaceholderText } = render(
-        <MessageInput channelId={'test-channel' as any} />
-      );
-      const input = getByPlaceholderText('Message...');
-
-      act(() => {
-        fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: 500 } },
-        });
-      });
-
-      const style = input.props.style;
-      const flat = Array.isArray(style)
-        ? Object.assign({}, ...style.filter(Boolean))
-        : style;
-
-      expect(flat.height).toBeLessThanOrEqual(maxHeight);
-    });
-
-    it('enables scrolling only after reaching max height', () => {
-      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
-
-      const { getByPlaceholderText } = render(
-        <MessageInput channelId={'test-channel' as any} />
-      );
-      const input = getByPlaceholderText('Message...');
-
-      // Below max — scrolling should be disabled
       act(() => {
         fireEvent(input, 'contentSizeChange', {
           nativeEvent: { contentSize: { width: 300, height: 60 } },
@@ -233,8 +130,16 @@ describe('MessageInput', () => {
       });
 
       expect(input.props.scrollEnabled).toBe(false);
+    });
 
-      // At/above max — scrolling should be enabled
+    it('enables scrolling when content reaches max height', () => {
+      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
+
+      const { getByPlaceholderText } = render(
+        <MessageInput channelId={'test-channel' as any} />
+      );
+      const input = getByPlaceholderText('Message...');
+
       act(() => {
         fireEvent(input, 'contentSizeChange', {
           nativeEvent: { contentSize: { width: 300, height: maxHeight + 10 } },
@@ -244,47 +149,29 @@ describe('MessageInput', () => {
       expect(input.props.scrollEnabled).toBe(true);
     });
 
-    it('reaches max height even when current height is within threshold of max (dead zone fix)', () => {
-      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2; // 180
+    it('disables scrolling again when content shrinks below max', () => {
+      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
 
       const { getByPlaceholderText } = render(
         <MessageInput channelId={'test-channel' as any} />
       );
       const input = getByPlaceholderText('Message...');
 
-      // Set height to just below maxHeight (within the 2px threshold)
-      const nearMaxHeight = maxHeight - 1.5; // 178.5
-      act(() => {
-        fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: nearMaxHeight } },
-        });
-      });
-
-      const styleAfterFirst = input.props.style;
-      const flatFirst = Array.isArray(styleAfterFirst)
-        ? Object.assign({}, ...styleAfterFirst.filter(Boolean))
-        : styleAfterFirst;
-      expect(flatFirst.height).toBe(nearMaxHeight);
-      expect(input.props.scrollEnabled).toBe(false);
-
-      // Now content grows beyond max - should clamp to maxHeight and enable scrolling
-      // The difference (180 - 178.5 = 1.5) is within threshold, but since clamped >= maxHeight,
-      // the fix ensures inputHeight updates to maxHeight anyway
+      // First, grow beyond max
       act(() => {
         fireEvent(input, 'contentSizeChange', {
           nativeEvent: { contentSize: { width: 300, height: maxHeight + 50 } },
         });
       });
-
-      const styleAfterSecond = input.props.style;
-      const flatSecond = Array.isArray(styleAfterSecond)
-        ? Object.assign({}, ...styleAfterSecond.filter(Boolean))
-        : styleAfterSecond;
-
-      // Input height should reach exactly maxHeight (not stuck at 178.5)
-      expect(flatSecond.height).toBe(maxHeight);
-      // Scrolling should now be enabled
       expect(input.props.scrollEnabled).toBe(true);
+
+      // Then shrink below max
+      act(() => {
+        fireEvent(input, 'contentSizeChange', {
+          nativeEvent: { contentSize: { width: 300, height: 60 } },
+        });
+      });
+      expect(input.props.scrollEnabled).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaces manual height management with React Native's built-in multiline auto-grow
- Fixes the text input not expanding when typing long messages (text was hidden/clipped)
- Fixes the oscillation/shaking that occurred when adding padding back to the height calc
- `onContentSizeChange` now only toggles `scrollEnabled` at the max height threshold

## Root Cause
`contentSize.height` on iOS doesn't include padding. PR #99 removed padding from the height formula to fix shaking, but that broke expansion. Adding padding back re-introduced the height↔contentSize feedback loop. The fix is to not manage height explicitly at all — let the TextInput auto-grow natively with `minHeight`/`maxHeight` constraints.

## Test plan
- [x] Verified in iOS Simulator: input expands smoothly from 1→8 lines
- [x] No shaking/oscillation at any line count
- [x] Input caps at max height (8 lines) and enables scrolling
- [x] All text visible at every line count
- [x] Unit tests pass (7/7)
- [ ] Verify on Android emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the chat `MessageInput`, but may affect typing/scroll feel across iOS/Android due to platform TextInput differences.
> 
> **Overview**
> Fixes chat `MessageInput` auto-grow on native by **removing explicit height management** and letting `TextInput` expand via `minHeight`/`maxHeight`.
> 
> `onContentSizeChange` now only toggles `scrollEnabled` once content reaches the max height (and resets on send/channel switch), and unit tests are updated to validate *no explicit height* and the new scroll-threshold behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ff70d9fb936b33fb9bb98b0a527087ad8319353. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->