### PR TITLE
fix: enable scrolling in chat input at max height

### DIFF
--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -778,8 +778,8 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
           onSelectionChange={handleSelectionChange}
           onContentSizeChange={isWeb ? undefined : (event) => {
             const contentHeight = event.nativeEvent.contentSize.height;
-            const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
-            setNativeScrollEnabled(contentHeight >= maxHeight);
+            const maxContentHeight = LINE_HEIGHT * MAX_INPUT_LINES;
+            setNativeScrollEnabled(contentHeight >= maxContentHeight);
           }}
           placeholder="Message..."
           placeholderTextColor="#999"

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
@@ -133,7 +133,7 @@ describe('MessageInput', () => {
     });
 
     it('enables scrolling when content reaches max height', () => {
-      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
+      const maxContentHeight = LINE_HEIGHT * MAX_INPUT_LINES;
 
       const { getByPlaceholderText } = render(
         <MessageInput channelId={'test-channel' as any} />
@@ -142,7 +142,7 @@ describe('MessageInput', () => {
 
       act(() => {
         fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: maxHeight + 10 } },
+          nativeEvent: { contentSize: { width: 300, height: maxContentHeight + 10 } },
         });
       });
 
@@ -150,7 +150,7 @@ describe('MessageInput', () => {
     });
 
     it('disables scrolling again when content shrinks below max', () => {
-      const maxHeight = LINE_HEIGHT * MAX_INPUT_LINES + INPUT_PADDING_VERTICAL * 2;
+      const maxContentHeight = LINE_HEIGHT * MAX_INPUT_LINES;
 
       const { getByPlaceholderText } = render(
         <MessageInput channelId={'test-channel' as any} />
@@ -160,7 +160,7 @@ describe('MessageInput', () => {
       // First, grow beyond max
       act(() => {
         fireEvent(input, 'contentSizeChange', {
-          nativeEvent: { contentSize: { width: 300, height: maxHeight + 50 } },
+          nativeEvent: { contentSize: { width: 300, height: maxContentHeight + 50 } },
         });
       });
       expect(input.props.scrollEnabled).toBe(true);


### PR DESCRIPTION
## Summary
- Fixes chat text input not being scrollable when text overflows the max height (8 lines)
- The scroll threshold compared against `maxHeight` (content + padding = 180), but iOS `contentSize.height` reports content height without padding (~160 for 8 lines), so the condition was never met
- Fix: compare against content-only max (`LINE_HEIGHT * MAX_INPUT_LINES` = 160)

## Test plan
- [x] Verified in iOS Simulator: input scrolls when text exceeds 8 lines
- [x] Auto-expand still works (1→8 lines, no shaking)
- [x] Unit tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior change limited to the chat input’s scroll threshold, with corresponding unit test updates and no data/auth impacts.
> 
> **Overview**
> Fixes `MessageInput` on native platforms so scrolling enables once the text content exceeds the 8-line limit by comparing `onContentSizeChange` height against a *content-only* max (`LINE_HEIGHT * MAX_INPUT_LINES`) instead of including vertical padding.
> 
> Updates `MessageInput.test.tsx` to assert the new scroll threshold and verify scroll toggles on grow/shrink around the max content height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b77f667247e6c7f5430e1f4126a17411b1531614. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->