### PR TITLE
feat: Cross-group People page for leaders

### DIFF
--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -31,6 +31,7 @@ import { now, getMediaUrl, normalizePhone, isValidPhone, buildSearchText, safeSl
 import { requireAuth } from "../lib/auth";
 import { parseDateOptional } from "../lib/validation";
 import { isCommunityAdmin } from "../lib/permissions";
+import { isActiveMembership, isLeaderRole } from "../lib/helpers";
 import { syncUserChannelMembershipsLogic } from "./sync/memberships";
 import {
   DEFAULT_SCORE_CONFIG,
@@ -836,6 +837,289 @@ export const count = query({
       count++;
     }
     return count;
+  },
+});
+
+// ============================================================================
+// Cross-Group Queries (People page in Profile)
+// ============================================================================
+
+/**
+ * Helper: Get IDs of groups where the current user is an active leader/admin.
+ */
+async function getActiveLeaderGroupIds(
+  ctx: { db: any },
+  userId: Id<"users">,
+): Promise<Id<"groups">[]> {
+  const memberships = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_user", (q: any) => q.eq("userId", userId))
+    .collect();
+  return memberships
+    .filter(
+      (membership: any) =>
+        isActiveMembership(membership) && isLeaderRole(membership.role),
+    )
+    .map((membership: any) => membership.groupId);
+}
+
+/**
+ * List all members assigned to the current user across all their leader groups.
+ * Paginated query using the by_assignee index.
+ */
+export const listAssignedToMe = query({
+  args: {
+    token: v.string(),
+    sortBy: v.optional(v.string()),
+    sortDirection: v.optional(v.string()),
+    statusFilter: v.optional(v.string()),
+    assigneeFilter: v.optional(v.id("users")),
+    excludedAssigneeFilters: v.optional(v.array(v.id("users"))),
+    scoreField: v.optional(v.string()),
+    scoreMin: v.optional(v.number()),
+    scoreMax: v.optional(v.number()),
+    addedAtMin: v.optional(v.number()),
+    addedAtMax: v.optional(v.number()),
+    groupFilter: v.optional(v.id("groups")),
+    paginationOpts: v.optional(paginationOptsValidator),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const leaderGroupIds = await getActiveLeaderGroupIds(ctx, userId);
+    if (leaderGroupIds.length === 0) {
+      return {
+        page: [],
+        isDone: true,
+        continueCursor: "",
+      };
+    }
+
+    const leaderGroupIdSet = new Set(leaderGroupIds.map((id) => id.toString()));
+
+    // Use the assignee filter if provided, otherwise default to current user
+    const assigneeId = args.assigneeFilter ?? userId;
+
+    let q = ctx.db
+      .query("memberFollowupScores")
+      .withIndex("by_assignee", (fq: any) => fq.eq("assigneeId", assigneeId));
+
+    // Apply filters
+    const scoreFilterField = (args.scoreField ?? "score1") as "score1" | "score2" | "score3" | "score4";
+    const hasFilters =
+      args.statusFilter ||
+      (args.excludedAssigneeFilters && args.excludedAssigneeFilters.length > 0) ||
+      args.scoreMax !== undefined ||
+      args.scoreMin !== undefined ||
+      args.addedAtMin !== undefined ||
+      args.addedAtMax !== undefined ||
+      args.groupFilter;
+
+    if (hasFilters) {
+      q = q.filter((fq) => {
+        const conds: any[] = [];
+        if (args.statusFilter) conds.push(fq.eq(fq.field("status"), args.statusFilter));
+        if (args.excludedAssigneeFilters?.length) {
+          for (const excludedId of args.excludedAssigneeFilters) {
+            conds.push(fq.neq(fq.field("assigneeId"), excludedId));
+          }
+        }
+        if (args.scoreMax !== undefined) conds.push(fq.lt(fq.field(scoreFilterField), args.scoreMax));
+        if (args.scoreMin !== undefined) conds.push(fq.gt(fq.field(scoreFilterField), args.scoreMin));
+        if (args.addedAtMax !== undefined) conds.push(fq.lte(fq.field("addedAt"), args.addedAtMax));
+        if (args.addedAtMin !== undefined) conds.push(fq.gte(fq.field("addedAt"), args.addedAtMin));
+        if (args.groupFilter) conds.push(fq.eq(fq.field("groupId"), args.groupFilter));
+        return conds.length === 0 ? true : conds.length === 1 ? conds[0] : fq.and(...(conds as [any, any, ...any[]]));
+      });
+    }
+
+    const paginatedResult = await q.paginate(
+      args.paginationOpts ?? { cursor: null, numItems: 50 }
+    );
+
+    // Filter to only leader groups (unless already group-filtered)
+    const filteredPage = args.groupFilter
+      ? paginatedResult.page
+      : paginatedResult.page.filter((doc: any) =>
+          leaderGroupIdSet.has(doc.groupId.toString())
+        );
+
+    // Enrich with group name
+    const groupNameCache = new Map<string, string>();
+    const enrichedPage = await Promise.all(
+      filteredPage.map(async (doc: any) => {
+        const gidStr = doc.groupId.toString();
+        if (!groupNameCache.has(gidStr)) {
+          const group = await ctx.db.get(doc.groupId as Id<"groups">);
+          groupNameCache.set(gidStr, (group as any)?.name ?? "Unknown Group");
+        }
+        return { ...doc, groupName: groupNameCache.get(gidStr) };
+      })
+    );
+
+    return {
+      ...paginatedResult,
+      page: enrichedPage,
+    };
+  },
+});
+
+/**
+ * Search members assigned to the current user across all leader groups.
+ * Uses full-text search index.
+ */
+export const searchAssignedToMe = query({
+  args: {
+    token: v.string(),
+    searchText: v.string(),
+    statusFilter: v.optional(v.string()),
+    assigneeFilter: v.optional(v.id("users")),
+    excludedAssigneeFilters: v.optional(v.array(v.id("users"))),
+    scoreField: v.optional(v.string()),
+    scoreMin: v.optional(v.number()),
+    scoreMax: v.optional(v.number()),
+    addedAtMin: v.optional(v.number()),
+    addedAtMax: v.optional(v.number()),
+    groupFilter: v.optional(v.id("groups")),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const leaderGroupIds = await getActiveLeaderGroupIds(ctx, userId);
+    if (leaderGroupIds.length === 0) return [];
+
+    const leaderGroupIdSet = new Set(leaderGroupIds.map((id) => id.toString()));
+    const assigneeId = args.assigneeFilter ?? userId;
+
+    let results = ctx.db
+      .query("memberFollowupScores")
+      .withSearchIndex("search_followup", (q) => {
+        let sq = q.search("searchText", args.searchText).eq("assigneeId", assigneeId);
+        if (args.statusFilter) sq = sq.eq("status", args.statusFilter);
+        if (args.groupFilter) sq = sq.eq("groupId", args.groupFilter);
+        return sq;
+      });
+
+    // Range filters via .filter()
+    const scoreFilterField = (args.scoreField ?? "score1") as "score1" | "score2" | "score3" | "score4";
+    if (args.scoreMax !== undefined || args.scoreMin !== undefined) {
+      results = results.filter((fq) => {
+        const conds: any[] = [];
+        if (args.scoreMax !== undefined) conds.push(fq.lt(fq.field(scoreFilterField), args.scoreMax));
+        if (args.scoreMin !== undefined) conds.push(fq.gt(fq.field(scoreFilterField), args.scoreMin));
+        return conds.length === 1 ? conds[0] : fq.and(...(conds as [any, any, ...any[]]));
+      });
+    }
+
+    if (
+      (args.excludedAssigneeFilters && args.excludedAssigneeFilters.length > 0) ||
+      args.addedAtMin !== undefined ||
+      args.addedAtMax !== undefined
+    ) {
+      results = results.filter((fq) => {
+        const conds: any[] = [];
+        if (args.excludedAssigneeFilters?.length) {
+          for (const excludedId of args.excludedAssigneeFilters) {
+            conds.push(fq.neq(fq.field("assigneeId"), excludedId));
+          }
+        }
+        if (args.addedAtMax !== undefined) conds.push(fq.lte(fq.field("addedAt"), args.addedAtMax));
+        if (args.addedAtMin !== undefined) conds.push(fq.gte(fq.field("addedAt"), args.addedAtMin));
+        return conds.length === 1 ? conds[0] : fq.and(...(conds as [any, any, ...any[]]));
+      });
+    }
+
+    const allResults = await results.take(200);
+
+    // Filter to leader groups
+    const filtered = args.groupFilter
+      ? allResults
+      : allResults.filter((doc: any) => leaderGroupIdSet.has(doc.groupId.toString()));
+
+    // Enrich with group name
+    const groupNameCache = new Map<string, string>();
+    return Promise.all(
+      filtered.map(async (doc: any) => {
+        const gidStr = doc.groupId.toString();
+        if (!groupNameCache.has(gidStr)) {
+          const group = await ctx.db.get(doc.groupId as Id<"groups">);
+          groupNameCache.set(gidStr, (group as any)?.name ?? "Unknown Group");
+        }
+        return { ...doc, groupName: groupNameCache.get(gidStr) };
+      })
+    );
+  },
+});
+
+/**
+ * Get cross-group config for the People page.
+ * Returns the union of score configs and leaders across all leader groups.
+ */
+export const getCrossGroupConfig = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const leaderGroupIds = await getActiveLeaderGroupIds(ctx, userId);
+    if (leaderGroupIds.length === 0) {
+      return {
+        scoreConfigScores: [],
+        leaderGroups: [],
+        leaders: [],
+      };
+    }
+
+    const groups = await Promise.all(leaderGroupIds.map((id) => ctx.db.get(id)));
+
+    // Use the score config from the first group that has one
+    // (cross-group view uses a single score config for sorting)
+    let scoreConfigScores: Array<{ id: string; name: string }> = [];
+    for (const group of groups) {
+      if (!group) continue;
+      const sc: ScoreConfig = group.followupScoreConfig ?? DEFAULT_SCORE_CONFIG;
+      if (sc.scores.length > 0) {
+        scoreConfigScores = sc.scores.map((s) => ({ id: s.id, name: s.name }));
+        break;
+      }
+    }
+
+    // Build leader groups list
+    const leaderGroupsList = groups
+      .filter((g): g is NonNullable<typeof g> => !!g)
+      .map((g) => ({ _id: g._id.toString(), name: g.name ?? "Unnamed Group" }));
+
+    // Collect all unique leaders across groups
+    const allLeaderMemberships = await Promise.all(
+      leaderGroupIds.map((gid) =>
+        ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q: any) => q.eq("groupId", gid))
+          .collect()
+      )
+    );
+
+    const leaderUserIds = new Set<string>();
+    const leaders: Array<{ userId: string; firstName: string; lastName: string; profilePhoto?: string }> = [];
+    for (const memberships of allLeaderMemberships) {
+      for (const m of memberships) {
+        if (!isActiveMembership(m) || !isLeaderRole(m.role)) continue;
+        const uid = m.userId.toString();
+        if (leaderUserIds.has(uid)) continue;
+        leaderUserIds.add(uid);
+        const user = await ctx.db.get(m.userId);
+        if (user) {
+          leaders.push({
+            userId: uid,
+            firstName: user.firstName ?? "",
+            lastName: user.lastName ?? "",
+            profilePhoto: user.profilePhoto,
+          });
+        }
+      }
+    }
+
+    return {
+      scoreConfigScores,
+      leaderGroups: leaderGroupsList,
+      leaders,
+    };
   },
 });
 

--- a/apps/convex/functions/seed.ts
+++ b/apps/convex/functions/seed.ts
@@ -17,7 +17,7 @@
  */
 
 import { v } from "convex/values";
-import { internalAction, internalMutation } from "../_generated/server";
+import { action, internalAction, internalMutation, mutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { now, generateShortId, normalizePhone, buildSearchText } from "../lib/utils";
@@ -876,6 +876,169 @@ export const seedDemoData = internalAction({
       success: true,
       message: `Seed completed! Use phone ${TEST_PHONE} with code 000000 to log in.`,
       summary,
+    };
+  },
+});
+
+// ============================================================================
+// Seed People Data (cross-group followup scores)
+// ============================================================================
+
+const FAKE_PEOPLE = [
+  { firstName: "Sarah", lastName: "Johnson", email: "sarah.j@example.com", phone: "+12025551001" },
+  { firstName: "Michael", lastName: "Chen", email: "michael.c@example.com", phone: "+12025551002" },
+  { firstName: "Emily", lastName: "Rodriguez", email: "emily.r@example.com", phone: "+12025551003" },
+  { firstName: "James", lastName: "Williams", email: "james.w@example.com", phone: "+12025551004" },
+  { firstName: "Olivia", lastName: "Martinez", email: "olivia.m@example.com", phone: "+12025551005" },
+  { firstName: "David", lastName: "Kim", email: "david.k@example.com", phone: "+12025551006" },
+  { firstName: "Rachel", lastName: "Brown", email: "rachel.b@example.com", phone: "+12025551007" },
+  { firstName: "Daniel", lastName: "Taylor", email: "daniel.t@example.com", phone: "+12025551008" },
+  { firstName: "Jessica", lastName: "Lee", email: "jessica.l@example.com", phone: "+12025551009" },
+  { firstName: "Andrew", lastName: "Garcia", email: "andrew.g@example.com", phone: "+12025551010" },
+  { firstName: "Amanda", lastName: "Wilson", email: "amanda.w@example.com", phone: "+12025551011" },
+  { firstName: "Brian", lastName: "Thomas", email: "brian.t@example.com", phone: "+12025551012" },
+];
+
+export const seedPeopleData = action({
+  args: {},
+  handler: async (ctx): Promise<{ success: boolean; message: string }> => {
+    return await ctx.runMutation(internal.functions.seed._seedPeopleDataMutation, {});
+  },
+});
+
+export const _seedPeopleDataMutation = internalMutation({
+  args: {},
+  returns: v.object({ success: v.boolean(), message: v.string() }),
+  handler: async (ctx) => {
+    // Find the test user
+    const testUser = await ctx.db
+      .query("users")
+      .withIndex("by_phone", (q: any) => q.eq("phone", TEST_PHONE))
+      .first();
+    if (!testUser) throw new Error("Test user not found — run seedDemoData first");
+
+    // Find Demo Community
+    const community = await ctx.db
+      .query("communities")
+      .withIndex("by_slug", (q: any) => q.eq("slug", DEMO_COMMUNITY_SLUG))
+      .first();
+    if (!community) throw new Error("Demo Community not found — run seedDemoData first");
+
+    // Find leader groups for the test user
+    const memberships = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_user", (q: any) => q.eq("userId", testUser._id))
+      .collect();
+    const leaderMemberships = memberships.filter(
+      (m) => m.leftAt === undefined && (m.role === "leader" || m.role === "admin")
+    );
+
+    console.log(`[seedPeople] Found ${leaderMemberships.length} leader groups`);
+
+    let created = 0;
+    const timestamp = now();
+
+    for (let gi = 0; gi < leaderMemberships.length; gi++) {
+      const gm = leaderMemberships[gi];
+      const group = await ctx.db.get(gm.groupId);
+      if (!group) continue;
+
+      // Skip large groups (Demo Community Announcements) to avoid doc read limits
+      if ((group as any).isAnnouncementGroup) {
+        console.log(`[seedPeople] Skipping announcement group "${group.name}"`);
+        continue;
+      }
+
+      // Assign 2-3 people per group from our fake list
+      const startIdx = (gi * 3) % FAKE_PEOPLE.length;
+      const count = gi % 2 === 0 ? 3 : 2;
+
+      for (let pi = 0; pi < count; pi++) {
+        const person = FAKE_PEOPLE[(startIdx + pi) % FAKE_PEOPLE.length];
+
+        // Create a user for this person (or find existing)
+        let personUser = await ctx.db
+          .query("users")
+          .withIndex("by_phone", (q: any) => q.eq("phone", normalizePhone(person.phone)))
+          .first();
+
+        if (!personUser) {
+          const personUserId = await ctx.db.insert("users", {
+            firstName: person.firstName,
+            lastName: person.lastName,
+            email: person.email,
+            phone: normalizePhone(person.phone),
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          });
+          personUser = await ctx.db.get(personUserId);
+        }
+
+        // Create group membership
+        let personGm = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q: any) =>
+            q.eq("groupId", gm.groupId).eq("userId", personUser!._id)
+          )
+          .first();
+
+        if (!personGm) {
+          const gmId = await ctx.db.insert("groupMembers", {
+            groupId: gm.groupId,
+            userId: personUser!._id,
+            role: "member",
+            joinedAt: timestamp,
+            notificationsEnabled: true,
+          });
+          personGm = await ctx.db.get(gmId);
+        }
+
+        // Create memberFollowupScores entry assigned to test user
+        const attendanceScore = Math.floor(Math.random() * 80) + 20;
+        const connectionScore = Math.floor(Math.random() * 70) + 15;
+        const searchText = buildSearchText({
+          firstName: person.firstName,
+          lastName: person.lastName,
+          email: person.email,
+          phone: person.phone,
+        });
+
+        await ctx.db.insert("memberFollowupScores", {
+          groupId: gm.groupId,
+          groupMemberId: personGm!._id,
+          userId: personUser!._id,
+          firstName: person.firstName,
+          lastName: person.lastName,
+          email: person.email,
+          phone: person.phone,
+          score1: attendanceScore / 100,
+          score2: connectionScore / 100,
+          scoreIds: ["attendance", "connection"],
+          alerts: attendanceScore < 30 ? ["Low Attendance"] : [],
+          isSnoozed: false,
+          attendanceScore,
+          connectionScore,
+          followupScore: 0,
+          missedMeetings: Math.floor(Math.random() * 5),
+          consecutiveMissed: Math.floor(Math.random() * 3),
+          assigneeId: testUser._id,
+          assigneeIds: [testUser._id],
+          status: ["new", "active", "needs-followup"][pi % 3],
+          searchText,
+          updatedAt: timestamp,
+          addedAt: timestamp - (pi * 7 * 24 * 60 * 60 * 1000), // staggered dates
+        });
+
+        created++;
+        console.log(
+          `[seedPeople] Created ${person.firstName} ${person.lastName} in "${group.name}"`
+        );
+      }
+    }
+
+    return {
+      success: true,
+      message: `Created ${created} people across ${leaderMemberships.length} leader groups`,
     };
   },
 });

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -918,6 +918,7 @@ export default defineSchema({
     // Lookup indexes
     .index("by_groupMember", ["groupMemberId"])
     .index("by_group", ["groupId"])
+    .index("by_assignee", ["assigneeId"])
     // Full-text search
     .searchIndex("search_followup", {
       searchField: "searchText",

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -90,6 +90,21 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="people"
+        options={{
+          title: 'People',
+          // Hidden tab — accessed via Profile menu
+          href: null,
+          tabBarIcon: ({ color, focused }) => (
+            <Ionicons
+              name={focused ? 'people' : 'people-outline'}
+              size={24}
+              color={color}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="chat"
         options={{
           title: 'Inbox',

--- a/apps/mobile/app/(tabs)/people.tsx
+++ b/apps/mobile/app/(tabs)/people.tsx
@@ -1,0 +1,3 @@
+import { PeopleTabScreen } from "@features/people/components/PeopleTabScreen";
+
+export default PeopleTabScreen;

--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -204,7 +204,15 @@ function useDebounce<T>(value: T, delay: number): T {
 // Component
 // ============================================================================
 
-export function FollowupDesktopTable({ groupId }: { groupId: string }) {
+export function FollowupDesktopTable({
+  groupId,
+  crossGroupMode,
+  returnTo,
+}: {
+  groupId: string;
+  crossGroupMode?: boolean;
+  returnTo?: string | null;
+}) {
   const router = useRouter();
   const { user } = useAuth();
   const currentUserId = user?.id as Id<"users"> | undefined;
@@ -253,26 +261,56 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
   // Custom field dropdown state
   const [customDropdownFor, setCustomDropdownFor] = useState<{ memberId: string; slot: string } | null>(null);
 
-  // Config query
-  const config = useAuthenticatedQuery(
-    api.functions.memberFollowups.getFollowupConfig,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+  // Cross-group config query
+  const crossGroupConfig = useAuthenticatedQuery(
+    api.functions.memberFollowups.getCrossGroupConfig,
+    crossGroupMode ? {} : "skip"
   );
-  const scoreConfig: ScoreConfigEntry[] = config?.scoreConfigScores ?? [];
-  const toolDisplayName = config?.toolDisplayName ?? "People";
-  const columnConfig = config?.followupColumnConfig ?? null;
-  const customFields: CustomFieldDef[] = (columnConfig?.customFields ?? []) as CustomFieldDef[];
 
-  // Leaders query (for assignee picker) — needs auth token
-  const leaders = useAuthenticatedQuery(
-    api.functions.groups.members.getLeaders,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+  // Cross-group local column config (localStorage)
+  const CROSS_GROUP_COL_CONFIG_KEY = "people-cross-group-col-config";
+  const [crossGroupColConfig, setCrossGroupColConfig] = useState<{
+    columnOrder: string[];
+    hiddenColumns: string[];
+  } | null>(null);
+
+  useEffect(() => {
+    if (!crossGroupMode || Platform.OS !== "web") return;
+    try {
+      const stored = localStorage.getItem(CROSS_GROUP_COL_CONFIG_KEY);
+      if (stored) setCrossGroupColConfig(JSON.parse(stored));
+    } catch { /* localStorage unavailable */ }
+  }, [crossGroupMode]);
+
+  // Group filter for cross-group mode
+  const [crossGroupFilter, setCrossGroupFilter] = useState<string>("all");
+
+  // Config query (per-group)
+  const perGroupConfig = useAuthenticatedQuery(
+    api.functions.memberFollowups.getFollowupConfig,
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   );
+  const config = crossGroupMode ? crossGroupConfig : perGroupConfig;
+  const scoreConfig: ScoreConfigEntry[] = crossGroupMode
+    ? (crossGroupConfig?.scoreConfigScores ?? [])
+    : (perGroupConfig?.scoreConfigScores ?? []);
+  const toolDisplayName = crossGroupMode ? "People" : (perGroupConfig?.toolDisplayName ?? "People");
+  const columnConfig = crossGroupMode
+    ? (crossGroupColConfig ? { columnOrder: crossGroupColConfig.columnOrder, hiddenColumns: crossGroupColConfig.hiddenColumns, customFields: [] } : null)
+    : (perGroupConfig?.followupColumnConfig ?? null);
+  const customFields: CustomFieldDef[] = crossGroupMode ? [] : ((perGroupConfig?.followupColumnConfig?.customFields ?? []) as CustomFieldDef[]);
+
+  // Leaders query (for assignee picker)
+  const perGroupLeaders = useAuthenticatedQuery(
+    api.functions.groups.members.getLeaders,
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+  );
+  const leaders = crossGroupMode ? crossGroupConfig?.leaders : perGroupLeaders;
 
   // Group tasks — used to build per-member task counts for the table
   const groupTasks = useAuthenticatedQuery(
     api.functions.tasks.index.listGroup,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   );
 
   const tasksByMember = useMemo(() => {
@@ -345,15 +383,22 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
     ];
 
     // All available non-system columns (built-in + score + custom)
-    const allAvailable: ColumnDef[] = [
-      { key: "addedAt", label: "Date Added", defaultWidth: 100, sortable: true, serverSortKey: "addedAt" },
-      { key: "firstName", label: "First Name", defaultWidth: 150, sortable: true, serverSortKey: "firstName" },
-      { key: "lastName", label: "Last Name", defaultWidth: 120, sortable: true, serverSortKey: "lastName" },
+    const allAvailable: ColumnDef[] = [];
+
+    // In cross-group mode, add a Group column at the start
+    if (crossGroupMode) {
+      allAvailable.push({ key: "groupName", label: "Group", defaultWidth: 160, sortable: false });
+    }
+
+    allAvailable.push(
+      { key: "addedAt", label: "Date Added", defaultWidth: 100, sortable: true, serverSortKey: crossGroupMode ? undefined : "addedAt" },
+      { key: "firstName", label: "First Name", defaultWidth: 150, sortable: true, serverSortKey: crossGroupMode ? undefined : "firstName" },
+      { key: "lastName", label: "Last Name", defaultWidth: 120, sortable: true, serverSortKey: crossGroupMode ? undefined : "lastName" },
       { key: "email", label: "Email", defaultWidth: 180, sortable: false },
       { key: "phone", label: "Phone", defaultWidth: 140, sortable: false },
       { key: "zipCode", label: "ZIP Code", defaultWidth: 100, sortable: false },
       { key: "dateOfBirth", label: "Birthday", defaultWidth: 110, sortable: false },
-    ];
+    );
 
     // Score columns — only score1 and score2 have server-side indexes;
     // score3+ are still sortable but use client-side sorting (no serverSortKey).
@@ -364,18 +409,18 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
         label: sc.name,
         defaultWidth: 100,
         sortable: true,
-        serverSortKey: key in SERVER_SORT_KEYS ? key : undefined,
+        serverSortKey: crossGroupMode ? undefined : (key in SERVER_SORT_KEYS ? key : undefined),
       });
     });
 
     allAvailable.push(
-      { key: "assignee", label: "Assignees", defaultWidth: 140, sortable: true, serverSortKey: "assignee" },
+      { key: "assignee", label: "Assignees", defaultWidth: 140, sortable: true, serverSortKey: crossGroupMode ? undefined : "assignee" },
       { key: "notes", label: "Notes", defaultWidth: 200, sortable: false },
       { key: "tasks", label: "Tasks", defaultWidth: 220, sortable: false },
-      { key: "status", label: "Status", defaultWidth: 100, sortable: true, serverSortKey: "status" },
-      { key: "lastAttendedAt", label: "Last Attended", defaultWidth: 120, sortable: true, serverSortKey: "lastAttendedAt" },
-      { key: "lastFollowupAt", label: "Last Contact", defaultWidth: 120, sortable: true, serverSortKey: "lastFollowupAt" },
-      { key: "lastActiveAt", label: "Date Active", defaultWidth: 120, sortable: true, serverSortKey: "lastActiveAt" },
+      { key: "status", label: "Status", defaultWidth: 100, sortable: true, serverSortKey: crossGroupMode ? undefined : "status" },
+      { key: "lastAttendedAt", label: "Last Attended", defaultWidth: 120, sortable: true, serverSortKey: crossGroupMode ? undefined : "lastAttendedAt" },
+      { key: "lastFollowupAt", label: "Last Contact", defaultWidth: 120, sortable: true, serverSortKey: crossGroupMode ? undefined : "lastFollowupAt" },
+      { key: "lastActiveAt", label: "Date Active", defaultWidth: 120, sortable: true, serverSortKey: crossGroupMode ? undefined : "lastActiveAt" },
       { key: "alerts", label: "Alerts", defaultWidth: 120, sortable: false },
     );
 
@@ -416,7 +461,7 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
     const visible = ordered.filter((c) => !hiddenSet.has(c.key));
 
     return [...systemCols, ...visible];
-  }, [scoreConfig, customFields, columnConfig]);
+  }, [scoreConfig, customFields, columnConfig, crossGroupMode]);
 
   // Editable columns (built-in + all custom field slots)
   const editableColumns = useMemo(() => {
@@ -431,23 +476,24 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
   const [colWidths, setColWidths] = useState<Record<string, number>>({});
 
   // Load from localStorage
+  const colWidthsKey = crossGroupMode ? STORAGE_PREFIX + "cross-group" : STORAGE_PREFIX + groupId;
   useEffect(() => {
     if (Platform.OS !== "web") return;
     try {
-      const stored = localStorage.getItem(STORAGE_PREFIX + groupId);
+      const stored = localStorage.getItem(colWidthsKey);
       if (stored) setColWidths(JSON.parse(stored));
     } catch { /* localStorage unavailable */ }
-  }, [groupId]);
+  }, [colWidthsKey]);
 
   // Save to localStorage
   const saveColWidths = useCallback(
     (widths: Record<string, number>) => {
       if (Platform.OS !== "web") return;
       try {
-        localStorage.setItem(STORAGE_PREFIX + groupId, JSON.stringify(widths));
+        localStorage.setItem(colWidthsKey, JSON.stringify(widths));
       } catch { /* localStorage unavailable */ }
     },
-    [groupId]
+    [colWidthsKey]
   );
 
   const getColWidth = (col: ColumnDef) => colWidths[col.key] ?? col.defaultWidth;
@@ -477,15 +523,20 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
     return args;
   }, [parsedQuery]);
 
+  // Cross-group group filter arg
+  const crossGroupFilterArg = crossGroupMode && crossGroupFilter !== "all"
+    ? { groupFilter: crossGroupFilter as Id<"groups"> }
+    : {};
+
   // Paginated query — used when there's NO text search
   const {
-    results: rawMembers,
-    status: paginationStatus,
-    loadMore,
-    isLoading,
+    results: perGroupRawMembers,
+    status: perGroupPaginationStatus,
+    loadMore: perGroupLoadMore,
+    isLoading: perGroupIsLoading,
   } = useAuthenticatedPaginatedQuery(
     api.functions.memberFollowups.list,
-    !hasTextSearch && groupId
+    !crossGroupMode && !hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           sortBy: serverSortBy,
@@ -496,10 +547,32 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
     { initialNumItems: 50 }
   );
 
+  // Cross-group paginated query
+  const {
+    results: crossGroupRawMembers,
+    status: crossGroupPaginationStatus,
+    loadMore: crossGroupLoadMore,
+    isLoading: crossGroupIsLoading,
+  } = useAuthenticatedPaginatedQuery(
+    api.functions.memberFollowups.listAssignedToMe,
+    crossGroupMode && !hasTextSearch
+      ? {
+          ...listFilterArgs,
+          ...crossGroupFilterArg,
+        }
+      : "skip",
+    { initialNumItems: 50 }
+  );
+
+  const rawMembers = crossGroupMode ? crossGroupRawMembers : perGroupRawMembers;
+  const paginationStatus = crossGroupMode ? crossGroupPaginationStatus : perGroupPaginationStatus;
+  const loadMore = crossGroupMode ? crossGroupLoadMore : perGroupLoadMore;
+  const isLoading = crossGroupMode ? crossGroupIsLoading : perGroupIsLoading;
+
   // Text search query — used when there IS text search
-  const searchResults = useAuthenticatedQuery(
+  const perGroupSearchResults = useAuthenticatedQuery(
     api.functions.memberFollowups.search,
-    hasTextSearch && groupId
+    !crossGroupMode && hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           searchText: parsedQuery.searchText,
@@ -516,10 +589,32 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
       : "skip"
   );
 
-  // Total member count
+  // Cross-group search query
+  const crossGroupSearchResults = useAuthenticatedQuery(
+    api.functions.memberFollowups.searchAssignedToMe,
+    crossGroupMode && hasTextSearch
+      ? {
+          searchText: parsedQuery.searchText,
+          ...(parsedQuery.statusFilter ? { statusFilter: parsedQuery.statusFilter } : {}),
+          ...(parsedQuery.assigneeFilter ? { assigneeFilter: parsedQuery.assigneeFilter as Id<"users"> } : {}),
+          ...(parsedQuery.excludedAssigneeFilters.length > 0
+            ? { excludedAssigneeFilters: parsedQuery.excludedAssigneeFilters as Id<"users">[] }
+            : {}),
+          ...(parsedQuery.scoreField ? { scoreField: parsedQuery.scoreField } : {}),
+          ...(parsedQuery.scoreMax !== undefined ? { scoreMax: parsedQuery.scoreMax } : {}),
+          ...(parsedQuery.scoreMin !== undefined ? { scoreMin: parsedQuery.scoreMin } : {}),
+          ...getDateAddedRangeArgs(parsedQuery.dateAddedFilter),
+          ...crossGroupFilterArg,
+        }
+      : "skip"
+  );
+
+  const searchResults = crossGroupMode ? crossGroupSearchResults : perGroupSearchResults;
+
+  // Total member count (only for per-group mode)
   const totalCount = useAuthenticatedQuery(
     api.functions.memberFollowups.count,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   );
 
   // Merge: use search results when text search active, otherwise paginated.
@@ -533,18 +628,31 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
 
     if (!isClientSideSort || filtered.length === 0) return filtered;
 
-    // Client-side sort by the score column (e.g. score3, score4)
-    // sortField is like "score3" — find the scoreConfig entry for it
-    const scoreIdx = parseInt(sortField.replace("score", ""), 10) - 1;
-    const scoreId = scoreConfig[scoreIdx]?.id;
-    if (!scoreId) return filtered;
-
     const sorted = [...filtered];
-    sorted.sort((a, b) => {
-      const aVal = getScoreValue(a, scoreId);
-      const bVal = getScoreValue(b, scoreId);
-      return sortDirection === "asc" ? aVal - bVal : bVal - aVal;
-    });
+
+    if (sortField.startsWith("score")) {
+      // Client-side sort by the score column (e.g. score3, score4)
+      const scoreIdx = parseInt(sortField.replace("score", ""), 10) - 1;
+      const scoreId = scoreConfig[scoreIdx]?.id;
+      if (!scoreId) return filtered;
+      sorted.sort((a, b) => {
+        const aVal = getScoreValue(a, scoreId);
+        const bVal = getScoreValue(b, scoreId);
+        return sortDirection === "asc" ? aVal - bVal : bVal - aVal;
+      });
+    } else {
+      // Client-side sort by other fields (cross-group mode)
+      const multiplier = sortDirection === "asc" ? 1 : -1;
+      sorted.sort((a, b) => {
+        const aVal = (a as any)[sortField] ?? "";
+        const bVal = (b as any)[sortField] ?? "";
+        if (typeof aVal === "number" && typeof bVal === "number") {
+          return (aVal - bVal) * multiplier;
+        }
+        return String(aVal).localeCompare(String(bVal)) * multiplier;
+      });
+    }
+
     return sorted;
   }, [
     hasTextSearch,
@@ -635,10 +743,10 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
   const removeGroupMember = useAuthenticatedMutation(api.functions.groupMembers.remove);
   const removeCommunityMember = useAuthenticatedMutation(api.functions.communities.removeMember);
 
-  // Group data for header
+  // Group data for header (per-group mode only)
   const groupData = useQuery(
     api.functions.groups.index.getById,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   );
 
   // ── Handlers ──
@@ -654,10 +762,14 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
   };
 
   const handleBack = () => {
+    if (returnTo) {
+      router.push(returnTo as any);
+      return;
+    }
     if (router.canGoBack()) {
       router.back();
     } else {
-      router.push("/(tabs)/chat");
+      router.push("/(tabs)/profile");
     }
   };
 
@@ -710,7 +822,7 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
             });
           } else {
             return removeGroupMember({
-              groupId: groupId as Id<"groups">,
+              groupId: getMemberGroupId(m.groupMemberId),
               userId: m.userId as Id<"users">,
             });
           }
@@ -742,18 +854,28 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
     setSelectedMemberId(null);
   };
 
+  // Helper to resolve groupId for a member (in cross-group mode, read from member data)
+  const getMemberGroupId = useCallback(
+    (memberId: string): Id<"groups"> => {
+      if (!crossGroupMode) return groupId as Id<"groups">;
+      const member = (rawMembers ?? []).find((m: any) => m.groupMemberId === memberId || m._id === memberId);
+      return ((member as any)?.groupId ?? groupId) as Id<"groups">;
+    },
+    [crossGroupMode, groupId, rawMembers]
+  );
+
   const enqueueAssigneeUpdate = useCallback(
     (memberId: string, assigneeIds: string[]) => {
       const previous = assigneeMutationQueueRef.current[memberId] ?? Promise.resolve();
       const next = previous
         .catch(() => undefined)
-        .then(() =>
+        .then(() => {
           setAssigneeMut({
-            groupId: groupId as Id<"groups">,
+            groupId: getMemberGroupId(memberId),
             groupMemberId: memberId as Id<"groupMembers">,
             assigneeIds: assigneeIds as Id<"users">[],
-          })
-        );
+          });
+        });
       assigneeMutationQueueRef.current[memberId] = next.finally(() => {
         if (assigneeMutationQueueRef.current[memberId] === next) {
           delete assigneeMutationQueueRef.current[memberId];
@@ -761,7 +883,7 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
       });
       return next;
     },
-    [groupId, setAssigneeMut]
+    [getMemberGroupId, setAssigneeMut]
   );
 
   const handleAssigneeSelect = async (memberId: string, assigneeIds: string[]) => {
@@ -792,7 +914,7 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
     setDropdownPos(null);
     try {
       await setStatusMut({
-        groupId: groupId as Id<"groups">,
+        groupId: getMemberGroupId(memberId),
         groupMemberId: memberId as Id<"groupMembers">,
         status: status || undefined,
       });
@@ -815,7 +937,7 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
     setDropdownPos(null);
     try {
       await setCustomFieldMut({
-        groupId: groupId as Id<"groups">,
+        groupId: getMemberGroupId(memberId),
         groupMemberId: memberId as Id<"groupMembers">,
         slot,
         value: value ?? undefined,
@@ -854,7 +976,7 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
 
     try {
       await setCustomFieldMut({
-        groupId: groupId as Id<"groups">,
+        groupId: getMemberGroupId(memberId),
         groupMemberId: memberId as Id<"groupMembers">,
         slot,
         value: newValue || undefined,
@@ -1006,6 +1128,9 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
 
       case "rowNum":
         return <Text style={s.rowNumText}>{rowIndex + 1}</Text>;
+
+      case "groupName":
+        return <Text style={s.cellText} numberOfLines={1}>{(item as any).groupName ?? ""}</Text>;
 
       case "addedAt":
         return <Text style={s.cellText}>{formatShortDate(item.addedAt)}</Text>;
@@ -1382,31 +1507,56 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
         </TouchableOpacity>
         <View style={s.headerContent}>
           <Text style={s.headerTitle}>{toolDisplayName}</Text>
-          <Text style={s.headerSubtitle}>{groupData?.name || "Group"}</Text>
+          <Text style={s.headerSubtitle}>
+            {crossGroupMode ? "All assigned people across groups" : (groupData?.name || "Group")}
+          </Text>
         </View>
-        <TouchableOpacity
-          style={s.addButton}
-          onPress={() => {
-            setSelectedMemberId(null);
-            setShowSettingsPanel(false);
-            setShowQuickAddPanel(true);
-          }}
-        >
-          <Ionicons name="person-add-outline" size={16} color="#16A34A" />
-          <Text style={s.addButtonText}>Add Person</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={s.importButton}
-          onPress={() => {
-            setSelectedMemberId(null);
-            setShowSettingsPanel(false);
-            setShowQuickAddPanel(false);
-            setShowCsvImportModal(true);
-          }}
-        >
-          <Ionicons name="cloud-upload-outline" size={16} color="#2563EB" />
-          <Text style={s.importButtonText}>Import CSV</Text>
-        </TouchableOpacity>
+        {crossGroupMode && crossGroupConfig?.leaderGroups && crossGroupConfig.leaderGroups.length > 1 ? (
+          <View style={s.crossGroupFilterRow}>
+            <TouchableOpacity
+              style={[s.crossGroupFilterChip, crossGroupFilter === "all" && s.crossGroupFilterChipActive]}
+              onPress={() => setCrossGroupFilter("all")}
+            >
+              <Text style={[s.crossGroupFilterChipText, crossGroupFilter === "all" && s.crossGroupFilterChipTextActive]}>All Groups</Text>
+            </TouchableOpacity>
+            {crossGroupConfig.leaderGroups.map((g: { _id: string; name: string }) => (
+              <TouchableOpacity
+                key={g._id}
+                style={[s.crossGroupFilterChip, crossGroupFilter === g._id && s.crossGroupFilterChipActive]}
+                onPress={() => setCrossGroupFilter(g._id)}
+              >
+                <Text style={[s.crossGroupFilterChipText, crossGroupFilter === g._id && s.crossGroupFilterChipTextActive]}>{g.name}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        ) : null}
+        {!crossGroupMode && (
+          <>
+            <TouchableOpacity
+              style={s.addButton}
+              onPress={() => {
+                setSelectedMemberId(null);
+                setShowSettingsPanel(false);
+                setShowQuickAddPanel(true);
+              }}
+            >
+              <Ionicons name="person-add-outline" size={16} color="#16A34A" />
+              <Text style={s.addButtonText}>Add Person</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={s.importButton}
+              onPress={() => {
+                setSelectedMemberId(null);
+                setShowSettingsPanel(false);
+                setShowQuickAddPanel(false);
+                setShowCsvImportModal(true);
+              }}
+            >
+              <Ionicons name="cloud-upload-outline" size={16} color="#2563EB" />
+              <Text style={s.importButtonText}>Import CSV</Text>
+            </TouchableOpacity>
+          </>
+        )}
         <TouchableOpacity style={s.settingsButton} onPress={handleSettingsPress}>
           <Ionicons name="settings-outline" size={22} color="#666" />
         </TouchableOpacity>
@@ -1454,7 +1604,9 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
         <Text style={s.memberCount}>
           {hasTextSearch
             ? `${members.length} result${members.length !== 1 ? "s" : ""}`
-            : `${totalCount ?? "\u2014"} members${hasAnyFilter ? " (filtered)" : ""}`}
+            : crossGroupMode
+              ? `${members.length} people${hasAnyFilter || crossGroupFilter !== "all" ? " (filtered)" : ""}`
+              : `${totalCount ?? "\u2014"} members${hasAnyFilter ? " (filtered)" : ""}`}
         </Text>
       </View>
 
@@ -1633,11 +1785,21 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
             <View style={s.sideSheet}>
               <FollowupSettingsPanel
                 groupId={groupId}
+                crossGroupMode={crossGroupMode}
+                crossGroupColConfig={crossGroupColConfig}
+                onCrossGroupColConfigChange={(newConfig) => {
+                  setCrossGroupColConfig(newConfig);
+                  if (Platform.OS === "web") {
+                    try {
+                      localStorage.setItem(CROSS_GROUP_COL_CONFIG_KEY, JSON.stringify(newConfig));
+                    } catch { /* localStorage unavailable */ }
+                  }
+                }}
                 onClose={() => setShowSettingsPanel(false)}
               />
             </View>
           </>
-        ) : showQuickAddPanel ? (
+        ) : !crossGroupMode && showQuickAddPanel ? (
           <>
             <View style={s.divider} />
             <View style={s.sideSheet}>
@@ -1656,20 +1818,27 @@ export function FollowupDesktopTable({ groupId }: { groupId: string }) {
               />
             </View>
           </>
-        ) : selectedMemberId ? (
-          <>
-            <View style={s.divider} />
-            <View style={s.sideSheet}>
-              <FollowupDetailContent
-                groupId={groupId}
-                memberId={selectedMemberId}
-                onClose={() => setSelectedMemberId(null)}
-                scrollToNotes={scrollToNotes}
-                scrollToTasks={scrollToTasks}
-              />
-            </View>
-          </>
-        ) : null}
+        ) : selectedMemberId ? (() => {
+          // In cross-group mode, find the groupId from the selected member's data
+          const selectedMember = displayMembers.find((m) => m.groupMemberId === selectedMemberId);
+          const detailGroupId = crossGroupMode
+            ? ((selectedMember as any)?.groupId?.toString() ?? "")
+            : groupId;
+          return (
+            <>
+              <View style={s.divider} />
+              <View style={s.sideSheet}>
+                <FollowupDetailContent
+                  groupId={detailGroupId}
+                  memberId={selectedMemberId}
+                  onClose={() => setSelectedMemberId(null)}
+                  scrollToNotes={scrollToNotes}
+                  scrollToTasks={scrollToTasks}
+                />
+              </View>
+            </>
+          );
+        })() : null}
       </View>
 
       {/* Dropdown portal — rendered outside the ScrollView at fixed position */}
@@ -1973,6 +2142,33 @@ const s = StyleSheet.create({
   },
   settingsButton: {
     padding: 6,
+  },
+  crossGroupFilterRow: {
+    flexDirection: "row" as const,
+    alignItems: "center" as const,
+    gap: 6,
+    flexWrap: "wrap" as const,
+    marginRight: 12,
+  },
+  crossGroupFilterChip: {
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: "#CBD5E1",
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    backgroundColor: "#fff",
+  },
+  crossGroupFilterChipActive: {
+    borderColor: "#2563EB",
+    backgroundColor: "#EFF6FF",
+  },
+  crossGroupFilterChipText: {
+    color: "#334155",
+    fontSize: 12,
+    fontWeight: "600" as const,
+  },
+  crossGroupFilterChipTextActive: {
+    color: "#1D4ED8",
   },
   importButton: {
     flexDirection: "row" as const,

--- a/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
@@ -210,7 +210,15 @@ function compareSortValues(
   );
 }
 
-export function FollowupMobileGrid({ groupId }: { groupId: string }) {
+export function FollowupMobileGrid({
+  groupId,
+  crossGroupMode,
+  returnTo,
+}: {
+  groupId: string;
+  crossGroupMode?: boolean;
+  returnTo?: string | null;
+}) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { primaryColor } = useCommunityTheme();
@@ -247,43 +255,50 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
     >
   >({});
 
+  // Cross-group config
+  const crossGroupConfig = useAuthenticatedQuery(
+    api.functions.memberFollowups.getCrossGroupConfig,
+    crossGroupMode ? {} : "skip"
+  );
+  const [crossGroupFilter, setCrossGroupFilter] = useState<string>("all");
+
   const debouncedSearch = useDebounce(searchQuery, 450);
 
-  const config = useAuthenticatedQuery(
+  const perGroupConfig = useAuthenticatedQuery(
     api.functions.memberFollowups.getFollowupConfig,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
-  const scoreConfigScores = config?.scoreConfigScores;
+  const config = crossGroupMode ? crossGroupConfig : perGroupConfig;
+  const scoreConfigScores = crossGroupMode ? (crossGroupConfig?.scoreConfigScores ?? []) : (perGroupConfig?.scoreConfigScores ?? []);
   const scoreConfig = useMemo<ScoreConfigEntry[]>(
     () => scoreConfigScores ?? [],
     [scoreConfigScores],
   );
   const isConfigLoaded = config !== undefined;
-  const toolDisplayName =
-    typeof config?.toolDisplayName === "string"
-      ? config.toolDisplayName
-      : "People";
+  const toolDisplayName = crossGroupMode ? "People" : (typeof perGroupConfig?.toolDisplayName === "string" ? perGroupConfig.toolDisplayName : "People");
+  const memberSubtitleRaw = crossGroupMode ? "" : ((config as any)?.memberSubtitle ?? "");
   const memberSubtitleIds = useMemo(
     () =>
       normalizeSubtitleVariableIds(
-        typeof config?.memberSubtitle === "string" ? config.memberSubtitle : "",
+        typeof memberSubtitleRaw === "string" ? memberSubtitleRaw : "",
       ),
-    [config?.memberSubtitle],
+    [memberSubtitleRaw],
   );
-  const columnConfig = config?.followupColumnConfig ?? null;
+  const columnConfig = crossGroupMode ? null : (perGroupConfig?.followupColumnConfig ?? null);
   const customFields = useMemo<CustomFieldDef[]>(
-    () => (columnConfig?.customFields ?? []) as CustomFieldDef[],
-    [columnConfig?.customFields],
+    () => crossGroupMode ? [] : ((columnConfig?.customFields ?? []) as CustomFieldDef[]),
+    [crossGroupMode, columnConfig?.customFields],
   );
 
-  const leaders = useAuthenticatedQuery(
+  const perGroupLeaders = useAuthenticatedQuery(
     api.functions.groups.members.getLeaders,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
+  const leaders = crossGroupMode ? crossGroupConfig?.leaders : perGroupLeaders;
 
   const groupTasks = useAuthenticatedQuery(
     api.functions.tasks.index.listGroup,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
 
   const tasksByMember = useMemo(() => {
@@ -399,14 +414,18 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
     : "score1";
   const serverSortDirection = isClientSideSort ? "desc" : sortDirection;
 
+  const crossGroupFilterArg = crossGroupMode && crossGroupFilter !== "all"
+    ? { groupFilter: crossGroupFilter as Id<"groups"> }
+    : {};
+
   const {
-    results: rawMembers,
-    status: paginationStatus,
-    loadMore,
-    isLoading,
+    results: perGroupRawMembers,
+    status: perGroupPaginationStatus,
+    loadMore: perGroupLoadMore,
+    isLoading: perGroupIsLoading,
   } = useAuthenticatedPaginatedQuery(
     api.functions.memberFollowups.list,
-    !hasTextSearch && groupId
+    !crossGroupMode && !hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           sortBy: serverSortBy,
@@ -417,9 +436,30 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
     { initialNumItems: 50 },
   );
 
-  const searchResults = useAuthenticatedQuery(
+  const {
+    results: crossGroupRawMembers,
+    status: crossGroupPaginationStatus,
+    loadMore: crossGroupLoadMore,
+    isLoading: crossGroupIsLoading,
+  } = useAuthenticatedPaginatedQuery(
+    api.functions.memberFollowups.listAssignedToMe,
+    crossGroupMode && !hasTextSearch
+      ? {
+          ...listFilterArgs,
+          ...crossGroupFilterArg,
+        }
+      : "skip",
+    { initialNumItems: 50 },
+  );
+
+  const rawMembers = crossGroupMode ? crossGroupRawMembers : perGroupRawMembers;
+  const paginationStatus = crossGroupMode ? crossGroupPaginationStatus : perGroupPaginationStatus;
+  const loadMore = crossGroupMode ? crossGroupLoadMore : perGroupLoadMore;
+  const isLoading = crossGroupMode ? crossGroupIsLoading : perGroupIsLoading;
+
+  const perGroupSearchResults = useAuthenticatedQuery(
     api.functions.memberFollowups.search,
-    hasTextSearch && groupId
+    !crossGroupMode && hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           searchText: parsedQuery.searchText,
@@ -449,9 +489,43 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
       : "skip",
   );
 
+  const crossGroupSearchResults = useAuthenticatedQuery(
+    api.functions.memberFollowups.searchAssignedToMe,
+    crossGroupMode && hasTextSearch
+      ? {
+          searchText: parsedQuery.searchText,
+          ...(parsedQuery.statusFilter
+            ? { statusFilter: parsedQuery.statusFilter }
+            : {}),
+          ...(parsedQuery.assigneeFilter
+            ? { assigneeFilter: parsedQuery.assigneeFilter as Id<"users"> }
+            : {}),
+          ...(parsedQuery.excludedAssigneeFilters.length > 0
+            ? {
+                excludedAssigneeFilters:
+                  parsedQuery.excludedAssigneeFilters as Id<"users">[],
+              }
+            : {}),
+          ...(parsedQuery.scoreField
+            ? { scoreField: parsedQuery.scoreField }
+            : {}),
+          ...(parsedQuery.scoreMax !== undefined
+            ? { scoreMax: parsedQuery.scoreMax }
+            : {}),
+          ...(parsedQuery.scoreMin !== undefined
+            ? { scoreMin: parsedQuery.scoreMin }
+            : {}),
+          ...getDateAddedRangeArgs(parsedQuery.dateAddedFilter),
+          ...crossGroupFilterArg,
+        }
+      : "skip",
+  );
+
+  const searchResults = crossGroupMode ? crossGroupSearchResults : perGroupSearchResults;
+
   const totalCount = useAuthenticatedQuery(
     api.functions.memberFollowups.count,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
   const setAssigneeMut = useAuthenticatedMutation(
     api.functions.memberFollowups.setAssignee,
@@ -471,7 +545,16 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
 
   const groupData = useQuery(
     api.functions.groups.index.getById,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+  );
+
+  const getMemberGroupId = useCallback(
+    (memberId: string): Id<"groups"> => {
+      if (!crossGroupMode) return groupId as Id<"groups">;
+      const member = (rawMembers ?? []).find((m: any) => m.groupMemberId === memberId || m._id === memberId);
+      return ((member as any)?.groupId ?? groupId) as Id<"groups">;
+    },
+    [crossGroupMode, groupId, rawMembers]
   );
 
   const getSortFieldValue = useCallback(
@@ -916,10 +999,12 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
   };
 
   const handleBack = () => {
-    if (router.canGoBack()) {
+    if (returnTo) {
+      router.push(returnTo as any);
+    } else if (router.canGoBack()) {
       router.back();
     } else {
-      router.push("/(tabs)/chat");
+      router.push("/(tabs)/profile" as any);
     }
   };
 
@@ -977,7 +1062,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
             });
           }
           return removeGroupMember({
-            groupId: groupId as Id<"groups">,
+            groupId: getMemberGroupId(member.groupMemberId),
             userId: member.userId as Id<"users">,
           });
         }),
@@ -1006,7 +1091,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
     groupData,
     removeCommunityMember,
     removeGroupMember,
-    groupId,
+    getMemberGroupId,
   ]);
 
   const getMemberSubtitleLines = (member: FollowupMember): string[] => {
@@ -1102,7 +1187,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
       setIsUpdatingField(true);
       try {
         await setCustomFieldMut({
-          groupId: groupId as Id<"groups">,
+          groupId: getMemberGroupId(memberId),
           groupMemberId: memberId as Id<"groupMembers">,
           slot,
           value: value ?? undefined,
@@ -1114,7 +1199,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
         setIsUpdatingField(false);
       }
     },
-    [setCustomFieldMut, groupId],
+    [setCustomFieldMut, getMemberGroupId],
   );
 
   const handleCustomTextSubmit = useCallback(async () => {
@@ -1175,7 +1260,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
       setIsUpdatingField(true);
       try {
         await setCustomFieldMut({
-          groupId: groupId as Id<"groups">,
+          groupId: getMemberGroupId(memberId),
           groupMemberId: memberId as Id<"groupMembers">,
           slot,
           value: newValue || undefined,
@@ -1202,7 +1287,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
       }
       // Don't close sheet — allow multiple toggles
     },
-    [editSheet, activeEditMember, setCustomFieldMut, groupId],
+    [editSheet, activeEditMember, setCustomFieldMut, getMemberGroupId],
   );
 
   const handleMultiselectClear = useCallback(async () => {
@@ -1229,7 +1314,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
     setEditSheet(null);
     try {
       await setCustomFieldMut({
-        groupId: groupId as Id<"groups">,
+        groupId: getMemberGroupId(memberId),
         groupMemberId: memberId as Id<"groupMembers">,
         slot,
         value: undefined,
@@ -1251,7 +1336,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
       });
       Alert.alert("Could not update field", "Please try again.");
     }
-  }, [editSheet, activeEditMember, setCustomFieldMut, groupId]);
+  }, [editSheet, activeEditMember, setCustomFieldMut, getMemberGroupId]);
 
   const handleAssignChange = async (assigneeIds: string[]) => {
     if (!editSheet || !activeEditMember) return;
@@ -1269,7 +1354,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
     }));
     try {
       await setAssigneeMut({
-        groupId: groupId as Id<"groups">,
+        groupId: getMemberGroupId(memberId),
         groupMemberId: memberId as Id<"groupMembers">,
         assigneeIds: normalizedAssigneeIds as Id<"users">[],
       });
@@ -1312,7 +1397,7 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
     }));
     try {
       await setStatusMut({
-        groupId: groupId as Id<"groups">,
+        groupId: getMemberGroupId(memberId),
         groupMemberId: memberId as Id<"groupMembers">,
         status: status ?? undefined,
       });
@@ -1637,6 +1722,9 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
           )}
 
           <View style={styles.memberTextWrap}>
+            {crossGroupMode && (item as any).groupName ? (
+              <Text style={styles.groupNameBadge}>{(item as any).groupName}</Text>
+            ) : null}
             <Text style={styles.memberName} numberOfLines={1}>
               {item.firstName} {item.lastName}
             </Text>
@@ -1734,21 +1822,25 @@ export function FollowupMobileGrid({ groupId }: { groupId: string }) {
           <View style={styles.headerContent}>
             <Text style={styles.headerTitle}>{toolDisplayName}</Text>
             <Text style={styles.headerSubtitle}>
-              {groupData?.name || "Group"}
+              {crossGroupMode ? "All assigned people across groups" : (groupData?.name || "Group")}
             </Text>
           </View>
-          <TouchableOpacity
-            style={styles.headerAddButton}
-            onPress={() => setShowQuickAddModal(true)}
-          >
-            <Ionicons name="person-add-outline" size={20} color="#16A34A" />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.settingsButton}
-            onPress={handleSettingsPress}
-          >
-            <Ionicons name="settings-outline" size={22} color="#666" />
-          </TouchableOpacity>
+          {!crossGroupMode && (
+            <TouchableOpacity
+              style={styles.headerAddButton}
+              onPress={() => setShowQuickAddModal(true)}
+            >
+              <Ionicons name="person-add-outline" size={20} color="#16A34A" />
+            </TouchableOpacity>
+          )}
+          {!crossGroupMode && (
+            <TouchableOpacity
+              style={styles.settingsButton}
+              onPress={handleSettingsPress}
+            >
+              <Ionicons name="settings-outline" size={22} color="#666" />
+            </TouchableOpacity>
+          )}
         </View>
 
         <View style={styles.searchRow}>
@@ -2576,6 +2668,12 @@ const styles = StyleSheet.create({
     marginTop: 2,
     fontSize: 10,
     color: "#6B7280",
+  },
+  groupNameBadge: {
+    fontSize: 11,
+    color: "#6366F1",
+    fontWeight: "600",
+    marginBottom: 4,
   },
   rowDataCells: {
     flexDirection: "row",

--- a/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
@@ -38,6 +38,9 @@ import type { CustomFieldDef } from "./ColumnPickerModal";
 
 interface FollowupSettingsPanelProps {
   groupId: string;
+  crossGroupMode?: boolean;
+  crossGroupColConfig?: { columnOrder: string[]; hiddenColumns: string[] } | null;
+  onCrossGroupColConfigChange?: (config: { columnOrder: string[]; hiddenColumns: string[] }) => void;
   onClose: () => void;
 }
 
@@ -125,7 +128,13 @@ function normalizeSelectFieldOptions(options: string[]): string[] {
 // Component
 // ============================================================================
 
-export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPanelProps) {
+export function FollowupSettingsPanel({
+  groupId,
+  crossGroupMode,
+  crossGroupColConfig,
+  onCrossGroupColConfigChange,
+  onClose,
+}: FollowupSettingsPanelProps) {
   const { primaryColor } = useCommunityTheme();
   const themeColor = primaryColor || DEFAULT_PRIMARY_COLOR;
 
@@ -141,12 +150,12 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
 
   const config = useAuthenticatedQuery(
     api.functions.memberFollowups.getFollowupConfig,
-    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   );
 
   const groupData = useAuthenticatedQuery(
     api.functions.groups.queries.getById,
-    { groupId: groupId as Id<"groups"> }
+    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   ) as any;
 
   const availableVariables = useQuery(
@@ -425,6 +434,15 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
   }, [customFields]);
 
   const handleSaveColumns = useCallback(async () => {
+    if (crossGroupMode) {
+      // In cross-group mode, save to localStorage via callback
+      onCrossGroupColConfigChange?.({
+        columnOrder,
+        hiddenColumns: [...hiddenColumns],
+      });
+      Alert.alert("Columns saved", "Column preferences were saved.");
+      return;
+    }
     if (showAddField) {
       Alert.alert("Finish adding field", "Click Add Field or Cancel before saving columns.");
       return;
@@ -450,6 +468,8 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
       setIsSavingColumns(false);
     }
   }, [
+    crossGroupMode,
+    onCrossGroupColConfigChange,
     groupId,
     columnOrder,
     hiddenColumns,
@@ -795,9 +815,9 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
       </View>
 
       <ScrollView style={styles.scrollArea} contentContainerStyle={styles.scrollContent}>
-        {/* ── Section 1: Display Name ── */}
-        {renderSectionHeader("Display Name", displayNameOpen, () => setDisplayNameOpen((p) => !p))}
-        {displayNameOpen && (
+        {/* ── Section 1: Display Name (hidden in cross-group mode) ── */}
+        {!crossGroupMode && renderSectionHeader("Display Name", displayNameOpen, () => setDisplayNameOpen((p) => !p))}
+        {!crossGroupMode && displayNameOpen && (
           <View style={styles.sectionBody}>
             <TextInput
               style={[
@@ -817,9 +837,9 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
           </View>
         )}
 
-        {/* ── Section 2: Columns ── */}
-        {renderSectionHeader("Data", dataOpen, () => setDataOpen((p) => !p))}
-        {dataOpen && (
+        {/* ── Section 2: Data (hidden in cross-group mode) ── */}
+        {!crossGroupMode && renderSectionHeader("Data", dataOpen, () => setDataOpen((p) => !p))}
+        {!crossGroupMode && dataOpen && (
           <View style={styles.sectionBody}>
             <TouchableOpacity
               onPress={handleRefreshFollowupScores}
@@ -913,152 +933,156 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
               })}
             </View>
 
-            {/* Custom Fields subsection */}
-            <View style={styles.subsectionDivider} />
-            <Text style={styles.subsectionTitle}>Custom Fields</Text>
+            {/* Custom Fields subsection (hidden in cross-group mode) */}
+            {!crossGroupMode && (
+              <>
+                <View style={styles.subsectionDivider} />
+                <Text style={styles.subsectionTitle}>Custom Fields</Text>
 
-            {/* Capacity indicators */}
-            <View style={styles.capacityRow}>
-              {Object.entries(SLOT_CAPACITIES).map(([key, info]) => (
-                <View key={key} style={styles.capacityBadge}>
-                  <Text style={styles.capacityText}>
-                    {info.label}: {capacityInfo[key] ?? 0}/{info.total}
-                  </Text>
-                </View>
-              ))}
-            </View>
-
-            {/* Existing custom fields */}
-            {customFields.map((field, idx) => (
-              <View key={field.slot} style={styles.fieldRow}>
-                <View style={styles.fieldInfo}>
-                  <Text style={styles.fieldName}>{field.name}</Text>
-                  <View style={styles.typeBadge}>
-                    <Text style={styles.typeBadgeText}>{field.type}</Text>
-                  </View>
-                  {(field.type === "dropdown" || field.type === "multiselect") && field.options && (
-                    <Text style={styles.fieldOptions} numberOfLines={1}>
-                      ({field.options.join(", ")})
-                    </Text>
-                  )}
-                </View>
-                <TouchableOpacity onPress={() => handleDeleteField(idx)} style={styles.deleteBtn}>
-                  <Ionicons name="trash-outline" size={14} color="#EF4444" />
-                </TouchableOpacity>
-              </View>
-            ))}
-
-            {/* Add custom field form */}
-            {showAddField ? (
-              <View style={styles.addFieldForm}>
-                <TextInput
-                  style={[
-                    styles.fieldInput,
-                    Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
-                  ]}
-                  value={newFieldName}
-                  onChangeText={setNewFieldName}
-                  placeholder="Field name..."
-                  placeholderTextColor="#9CA3AF"
-                  autoFocus
-                />
-                <View style={styles.typePickerRow}>
-                  {FIELD_TYPES.map((ft) => {
-                    const enabled = canAddType(ft.value);
-                    const isActive = newFieldType === ft.value;
-                    return (
-                      <TouchableOpacity
-                        key={ft.value}
-                        style={[
-                          styles.typeOption,
-                          isActive && { borderColor: themeColor, backgroundColor: `${themeColor}10` },
-                          !enabled && styles.typeOptionDisabled,
-                        ]}
-                        onPress={() => enabled && setNewFieldType(ft.value)}
-                        disabled={!enabled}
-                      >
-                        <Text
-                          style={[
-                            styles.typeOptionText,
-                            isActive && { color: themeColor, fontWeight: "600" as const },
-                            !enabled && styles.typeOptionTextDisabled,
-                          ]}
-                        >
-                          {ft.label}
-                        </Text>
-                      </TouchableOpacity>
-                    );
-                  })}
+                {/* Capacity indicators */}
+                <View style={styles.capacityRow}>
+                  {Object.entries(SLOT_CAPACITIES).map(([key, info]) => (
+                    <View key={key} style={styles.capacityBadge}>
+                      <Text style={styles.capacityText}>
+                        {info.label}: {capacityInfo[key] ?? 0}/{info.total}
+                      </Text>
+                    </View>
+                  ))}
                 </View>
 
-                {/* Dropdown / multiselect options editor */}
-                {(newFieldType === "dropdown" || newFieldType === "multiselect") && (
-                  <View style={styles.optionsEditor}>
-                    <Text style={styles.optionsLabel}>Options:</Text>
-                    {newFieldOptions.map((opt, i) => (
-                      <View key={i} style={styles.optionRow}>
-                        <TextInput
-                          style={[
-                            styles.optionInput,
-                            Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
-                          ]}
-                          value={opt}
-                          onChangeText={(text) => {
-                            const next = [...newFieldOptions];
-                            next[i] = text.replace(/;/g, "");
-                            setNewFieldOptions(next);
-                          }}
-                          placeholder={`Option ${i + 1}`}
-                          placeholderTextColor="#9CA3AF"
-                        />
-                        <TouchableOpacity
-                          onPress={() => setNewFieldOptions(newFieldOptions.filter((_, j) => j !== i))}
-                          style={styles.optionDeleteBtn}
-                        >
-                          <Ionicons name="close-circle" size={16} color="#9CA3AF" />
-                        </TouchableOpacity>
+                {/* Existing custom fields */}
+                {customFields.map((field, idx) => (
+                  <View key={field.slot} style={styles.fieldRow}>
+                    <View style={styles.fieldInfo}>
+                      <Text style={styles.fieldName}>{field.name}</Text>
+                      <View style={styles.typeBadge}>
+                        <Text style={styles.typeBadgeText}>{field.type}</Text>
                       </View>
-                    ))}
-                    <TouchableOpacity
-                      onPress={() => setNewFieldOptions([...newFieldOptions, ""])}
-                      style={styles.addOptionBtn}
-                    >
-                      <Ionicons name="add" size={12} color={themeColor} />
-                      <Text style={[styles.addOptionText, { color: themeColor }]}>Add option</Text>
+                      {(field.type === "dropdown" || field.type === "multiselect") && field.options && (
+                        <Text style={styles.fieldOptions} numberOfLines={1}>
+                          ({field.options.join(", ")})
+                        </Text>
+                      )}
+                    </View>
+                    <TouchableOpacity onPress={() => handleDeleteField(idx)} style={styles.deleteBtn}>
+                      <Ionicons name="trash-outline" size={14} color="#EF4444" />
                     </TouchableOpacity>
                   </View>
-                )}
+                ))}
 
-                <View style={styles.addFieldActions}>
-                  <TouchableOpacity
-                    onPress={() => {
-                      setShowAddField(false);
-                      setNewFieldName("");
-                      setNewFieldType("text");
-                      setNewFieldOptions([]);
-                    }}
-                    style={styles.cancelFieldBtn}
-                  >
-                    <Text style={styles.cancelFieldText}>Cancel</Text>
+                {/* Add custom field form */}
+                {showAddField ? (
+                  <View style={styles.addFieldForm}>
+                    <TextInput
+                      style={[
+                        styles.fieldInput,
+                        Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
+                      ]}
+                      value={newFieldName}
+                      onChangeText={setNewFieldName}
+                      placeholder="Field name..."
+                      placeholderTextColor="#9CA3AF"
+                      autoFocus
+                    />
+                    <View style={styles.typePickerRow}>
+                      {FIELD_TYPES.map((ft) => {
+                        const enabled = canAddType(ft.value);
+                        const isActive = newFieldType === ft.value;
+                        return (
+                          <TouchableOpacity
+                            key={ft.value}
+                            style={[
+                              styles.typeOption,
+                              isActive && { borderColor: themeColor, backgroundColor: `${themeColor}10` },
+                              !enabled && styles.typeOptionDisabled,
+                            ]}
+                            onPress={() => enabled && setNewFieldType(ft.value)}
+                            disabled={!enabled}
+                          >
+                            <Text
+                              style={[
+                                styles.typeOptionText,
+                                isActive && { color: themeColor, fontWeight: "600" as const },
+                                !enabled && styles.typeOptionTextDisabled,
+                              ]}
+                            >
+                              {ft.label}
+                            </Text>
+                          </TouchableOpacity>
+                        );
+                      })}
+                    </View>
+
+                    {/* Dropdown / multiselect options editor */}
+                    {(newFieldType === "dropdown" || newFieldType === "multiselect") && (
+                      <View style={styles.optionsEditor}>
+                        <Text style={styles.optionsLabel}>Options:</Text>
+                        {newFieldOptions.map((opt, i) => (
+                          <View key={i} style={styles.optionRow}>
+                            <TextInput
+                              style={[
+                                styles.optionInput,
+                                Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
+                              ]}
+                              value={opt}
+                              onChangeText={(text) => {
+                                const next = [...newFieldOptions];
+                                next[i] = text.replace(/;/g, "");
+                                setNewFieldOptions(next);
+                              }}
+                              placeholder={`Option ${i + 1}`}
+                              placeholderTextColor="#9CA3AF"
+                            />
+                            <TouchableOpacity
+                              onPress={() => setNewFieldOptions(newFieldOptions.filter((_, j) => j !== i))}
+                              style={styles.optionDeleteBtn}
+                            >
+                              <Ionicons name="close-circle" size={16} color="#9CA3AF" />
+                            </TouchableOpacity>
+                          </View>
+                        ))}
+                        <TouchableOpacity
+                          onPress={() => setNewFieldOptions([...newFieldOptions, ""])}
+                          style={styles.addOptionBtn}
+                        >
+                          <Ionicons name="add" size={12} color={themeColor} />
+                          <Text style={[styles.addOptionText, { color: themeColor }]}>Add option</Text>
+                        </TouchableOpacity>
+                      </View>
+                    )}
+
+                    <View style={styles.addFieldActions}>
+                      <TouchableOpacity
+                        onPress={() => {
+                          setShowAddField(false);
+                          setNewFieldName("");
+                          setNewFieldType("text");
+                          setNewFieldOptions([]);
+                        }}
+                        style={styles.cancelFieldBtn}
+                      >
+                        <Text style={styles.cancelFieldText}>Cancel</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        onPress={handleAddField}
+                        style={[
+                          styles.confirmFieldBtn,
+                          { backgroundColor: themeColor },
+                          !canSubmitNewField && styles.btnDisabled,
+                        ]}
+                        disabled={!canSubmitNewField}
+                      >
+                        <Text style={styles.confirmFieldText}>Add Field</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                ) : (
+                  <TouchableOpacity onPress={() => setShowAddField(true)} style={styles.addFieldButton}>
+                    <Ionicons name="add-circle-outline" size={16} color={themeColor} />
+                    <Text style={[styles.addFieldButtonText, { color: themeColor }]}>Add Custom Field</Text>
                   </TouchableOpacity>
-                  <TouchableOpacity
-                    onPress={handleAddField}
-                    style={[
-                      styles.confirmFieldBtn,
-                      { backgroundColor: themeColor },
-                      !canSubmitNewField && styles.btnDisabled,
-                    ]}
-                    disabled={!canSubmitNewField}
-                  >
-                    <Text style={styles.confirmFieldText}>Add Field</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            ) : (
-              <TouchableOpacity onPress={() => setShowAddField(true)} style={styles.addFieldButton}>
-                <Ionicons name="add-circle-outline" size={16} color={themeColor} />
-                <Text style={[styles.addFieldButtonText, { color: themeColor }]}>Add Custom Field</Text>
-              </TouchableOpacity>
+                )}
+              </>
             )}
 
             {/* Save columns button */}
@@ -1081,8 +1105,8 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
         )}
 
         {/* ── Section 4: Scores ── */}
-        {renderSectionHeader("Scores", scoresOpen, () => setScoresOpen((p) => !p))}
-        {scoresOpen && (
+        {!crossGroupMode && renderSectionHeader("Scores", scoresOpen, () => setScoresOpen((p) => !p))}
+        {!crossGroupMode && scoresOpen && (
           <View style={styles.sectionBody}>
             {scores.map((score, scoreIndex) => (
               <View key={score.id} style={styles.scoreCard}>
@@ -1219,8 +1243,8 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
         )}
 
         {/* ── Section 5: Alerts ── */}
-        {renderSectionHeader("Alerts", alertsOpen, () => setAlertsOpen((p) => !p))}
-        {alertsOpen && (
+        {!crossGroupMode && renderSectionHeader("Alerts", alertsOpen, () => setAlertsOpen((p) => !p))}
+        {!crossGroupMode && alertsOpen && (
           <View style={styles.sectionBody}>
             <Text style={styles.hintText}>
               Flag members when a variable exceeds a threshold.
@@ -1332,14 +1356,14 @@ export function FollowupSettingsPanel({ groupId, onClose }: FollowupSettingsPane
           </View>
         )}
 
-        {/* ── Section 6: Member Card Subtitle ── */}
-        {renderSectionHeader(
+        {/* ── Section 6: Member Card Subtitle (hidden in cross-group mode) ── */}
+        {!crossGroupMode && renderSectionHeader(
           "Member Card Subtitle",
           subtitleOpen,
           () => setSubtitleOpen((p) => !p),
           <Text style={styles.sectionHeaderExtra}>(Mobile only)</Text>,
         )}
-        {subtitleOpen && (
+        {!crossGroupMode && subtitleOpen && (
           <View style={styles.sectionBody}>
             <Text style={styles.hintText}>
               Choose up to 2 items to show below each member's name.

--- a/apps/mobile/features/people/components/PeopleTabScreen.tsx
+++ b/apps/mobile/features/people/components/PeopleTabScreen.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useLocalSearchParams, usePathname } from "expo-router";
+import { UserRoute } from "@components/guards/UserRoute";
+import { useIsDesktopWeb } from "@hooks/useIsDesktopWeb";
+import { FollowupDesktopTable } from "@features/leader-tools/components/FollowupDesktopTable";
+import { FollowupMobileGrid } from "@features/leader-tools/components/FollowupMobileGrid";
+
+export function PeopleTabScreen() {
+  const isDesktop = useIsDesktopWeb();
+  const params = useLocalSearchParams<{ returnTo?: string }>();
+  const pathname = usePathname();
+  const returnToParam =
+    typeof params.returnTo === "string" && params.returnTo.trim().length > 0
+      ? decodeURIComponent(params.returnTo)
+      : null;
+  const returnTo = returnToParam && returnToParam !== pathname ? returnToParam : null;
+
+  return (
+    <UserRoute>
+      {isDesktop ? (
+        <FollowupDesktopTable groupId="" crossGroupMode returnTo={returnTo} />
+      ) : (
+        <FollowupMobileGrid groupId="" crossGroupMode returnTo={returnTo} />
+      )}
+    </UserRoute>
+  );
+}

--- a/apps/mobile/features/profile/components/ProfileMenu.tsx
+++ b/apps/mobile/features/profile/components/ProfileMenu.tsx
@@ -95,22 +95,40 @@ export function ProfileMenu() {
       </TouchableOpacity>
 
       {hasLeaderAccess === true ? (
-        <TouchableOpacity
-          style={styles.menuItem}
-          onPress={() =>
-            router.push({
-              pathname: "/tasks",
-              params: { returnTo: "/(tabs)/profile" },
-            })
-          }
-          activeOpacity={0.7}
-        >
-          <View style={styles.menuIconContainer}>
-            <Ionicons name="checkmark-done-outline" size={24} color={primaryColor} />
-          </View>
-          <Text style={styles.menuText}>Tasks</Text>
-          <Ionicons name="chevron-forward" size={20} color="#999" />
-        </TouchableOpacity>
+        <>
+          <TouchableOpacity
+            style={styles.menuItem}
+            onPress={() =>
+              router.push({
+                pathname: "/tasks",
+                params: { returnTo: "/(tabs)/profile" },
+              })
+            }
+            activeOpacity={0.7}
+          >
+            <View style={styles.menuIconContainer}>
+              <Ionicons name="checkmark-done-outline" size={24} color={primaryColor} />
+            </View>
+            <Text style={styles.menuText}>Tasks</Text>
+            <Ionicons name="chevron-forward" size={20} color="#999" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.menuItem}
+            onPress={() =>
+              router.push({
+                pathname: "/people",
+                params: { returnTo: "/(tabs)/profile" },
+              })
+            }
+            activeOpacity={0.7}
+          >
+            <View style={styles.menuIconContainer}>
+              <Ionicons name="people-outline" size={24} color={primaryColor} />
+            </View>
+            <Text style={styles.menuText}>People</Text>
+            <Ionicons name="chevron-forward" size={20} color="#999" />
+          </TouchableOpacity>
+        </>
       ) : null}
 
       <TouchableOpacity


### PR DESCRIPTION
## Summary
- Adds a unified **People** page accessible from Profile > People that shows all people assigned to the current leader across all their groups
- Reuses existing `FollowupDesktopTable`, `FollowupMobileGrid`, and `FollowupSettingsPanel` via a new `crossGroupMode` prop, avoiding duplicating 1700+ lines of component code
- Adds a **Group** column and group filter chips so leaders can see and filter by which group each person belongs to

## Changes
- **Backend**: Added `by_assignee` index on `memberFollowupScores`, plus 3 new queries (`listAssignedToMe`, `searchAssignedToMe`, `getCrossGroupConfig`)
- **Frontend**: Added hidden `people` tab route, `PeopleTabScreen` wrapper, and "People" menu item in ProfileMenu (gated on `hasLeaderAccess`)
- **Components**: Added `crossGroupMode` support to FollowupDesktopTable, FollowupMobileGrid, and FollowupSettingsPanel
- **Seed**: Added `seedPeopleData` helper for dev environments

## Test plan
- [x] Verified TypeScript compiles with no new errors
- [x] Verified People menu item appears in Profile for leader users
- [x] Verified cross-group table loads with people from multiple groups
- [x] Verified Group column displays correct group names
- [x] Verified group filter chips filter the table correctly
- [x] Verified settings panel hides group-specific sections in cross-group mode
- [x] Verified pre-commit hooks (lint) pass
- [x] Verified pre-push hooks (tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands followup/people data access from single-group to multi-group queries and mutations, so permission scoping and per-row group resolution need careful review to avoid leaking or misrouting updates; also adds new indexed query paths that may impact performance under large datasets.
> 
> **Overview**
> Adds a new cross-group **People** view for leaders, accessible from Profile via a hidden `/(tabs)/people` route, showing everyone assigned to the leader across all of their active leader/admin groups.
> 
> Backend adds a new `memberFollowupScores.by_assignee` index plus cross-group queries (`listAssignedToMe`, `searchAssignedToMe`, `getCrossGroupConfig`) that scope results to leader groups and enrich rows with `groupName`; seed tooling gains `seedPeopleData` to generate sample cross-group followup score data.
> 
> Frontend reuses existing followup UI via a `crossGroupMode` flag across desktop/mobile tables and the settings panel (disabling group-specific features like quick-add/CSV import/custom fields, adding group column + filter chips, localStorage-based column prefs, and resolving per-row `groupId` for mutations/navigation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 653bc7495e0526beec5c09229628f53f4e63ac13. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->