### PR TITLE
fix: polish cross-group People page UI

### DIFF
--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -1512,22 +1512,33 @@ export function FollowupDesktopTable({
           </Text>
         </View>
         {crossGroupMode && crossGroupConfig?.leaderGroups && crossGroupConfig.leaderGroups.length > 1 ? (
-          <View style={s.crossGroupFilterRow}>
-            <TouchableOpacity
-              style={[s.crossGroupFilterChip, crossGroupFilter === "all" && s.crossGroupFilterChipActive]}
-              onPress={() => setCrossGroupFilter("all")}
-            >
-              <Text style={[s.crossGroupFilterChipText, crossGroupFilter === "all" && s.crossGroupFilterChipTextActive]}>All Groups</Text>
-            </TouchableOpacity>
-            {crossGroupConfig.leaderGroups.map((g: { _id: string; name: string }) => (
-              <TouchableOpacity
-                key={g._id}
-                style={[s.crossGroupFilterChip, crossGroupFilter === g._id && s.crossGroupFilterChipActive]}
-                onPress={() => setCrossGroupFilter(g._id)}
-              >
-                <Text style={[s.crossGroupFilterChipText, crossGroupFilter === g._id && s.crossGroupFilterChipTextActive]}>{g.name}</Text>
-              </TouchableOpacity>
-            ))}
+          <View style={s.crossGroupFilterDropdown}>
+            {React.createElement("select", {
+              value: crossGroupFilter,
+              onChange: (e: any) => setCrossGroupFilter(e.target.value),
+              style: {
+                fontSize: 13,
+                fontWeight: "600",
+                color: "#334155",
+                backgroundColor: "#fff",
+                border: "1px solid #CBD5E1",
+                borderRadius: 8,
+                padding: "6px 28px 6px 10px",
+                appearance: "none",
+                WebkitAppearance: "none",
+                backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23334155' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E")`,
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "right 8px center",
+                cursor: "pointer",
+                outline: "none",
+                minWidth: 140,
+              },
+            },
+              React.createElement("option", { value: "all" }, "All Groups"),
+              ...(crossGroupConfig.leaderGroups.map((g: { _id: string; name: string }) =>
+                React.createElement("option", { key: g._id, value: g._id }, g.name)
+              ))
+            )}
           </View>
         ) : null}
         {!crossGroupMode && (
@@ -2143,32 +2154,9 @@ const s = StyleSheet.create({
   settingsButton: {
     padding: 6,
   },
-  crossGroupFilterRow: {
-    flexDirection: "row" as const,
-    alignItems: "center" as const,
-    gap: 6,
-    flexWrap: "wrap" as const,
+  crossGroupFilterDropdown: {
     marginRight: 12,
-  },
-  crossGroupFilterChip: {
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: "#CBD5E1",
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    backgroundColor: "#fff",
-  },
-  crossGroupFilterChipActive: {
-    borderColor: "#2563EB",
-    backgroundColor: "#EFF6FF",
-  },
-  crossGroupFilterChipText: {
-    color: "#334155",
-    fontSize: 12,
-    fontWeight: "600" as const,
-  },
-  crossGroupFilterChipTextActive: {
-    color: "#1D4ED8",
+    justifyContent: "center" as const,
   },
   importButton: {
     flexDirection: "row" as const,

--- a/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
@@ -268,7 +268,11 @@ export function FollowupSettingsPanel({
 
   // Build allColumnsForPicker from config data
   const allColumnsForPicker = useMemo(() => {
-    const cols: { key: string; label: string }[] = [
+    const cols: { key: string; label: string }[] = [];
+    if (crossGroupMode) {
+      cols.push({ key: "groupName", label: "Group" });
+    }
+    cols.push(
       { key: "addedAt", label: "Date Added" },
       { key: "firstName", label: "First Name" },
       { key: "lastName", label: "Last Name" },
@@ -276,7 +280,7 @@ export function FollowupSettingsPanel({
       { key: "phone", label: "Phone" },
       { key: "zipCode", label: "ZIP Code" },
       { key: "dateOfBirth", label: "Birthday" },
-    ];
+    );
     scoreConfigScores.forEach((sc: { id: string; name: string }, i: number) => {
       cols.push({ key: `score${i + 1}`, label: sc.name });
     });
@@ -294,7 +298,7 @@ export function FollowupSettingsPanel({
       cols.push({ key: cf.slot, label: cf.name });
     }
     return cols;
-  }, [scoreConfigScores, customFields]);
+  }, [crossGroupMode, scoreConfigScores, customFields]);
 
   const configSignature = useMemo(
     () => JSON.stringify(columnConfig ?? { columnOrder: [], hiddenColumns: [], customFields: [] }),
@@ -303,6 +307,7 @@ export function FollowupSettingsPanel({
 
   // Initialize column state from config. Only resync when server config actually changes.
   useEffect(() => {
+    if (crossGroupMode) return; // handled separately below
     if (!config) return;
     if (lastAppliedConfigSignatureRef.current === configSignature) return;
     const allKeys = serverColumnKeys.filter((k) => !SYSTEM_COLUMNS.has(k));
@@ -325,7 +330,32 @@ export function FollowupSettingsPanel({
       }))
     );
     lastAppliedConfigSignatureRef.current = configSignature;
-  }, [config, configSignature, serverColumnKeys, columnConfig, initialCustomFields]);
+  }, [crossGroupMode, config, configSignature, serverColumnKeys, columnConfig, initialCustomFields]);
+
+  // Initialize column state for cross-group mode from localStorage-backed prop
+  const crossGroupInitRef = useRef(false);
+  useEffect(() => {
+    if (!crossGroupMode) return;
+    if (crossGroupInitRef.current) return;
+    crossGroupInitRef.current = true;
+    const defaultKeys = [
+      "groupName", "addedAt", "firstName", "lastName", "email", "phone",
+      "zipCode", "dateOfBirth", "assignee", "notes", "tasks", "status",
+      "lastAttendedAt", "lastFollowupAt", "lastActiveAt", "alerts",
+    ];
+    const savedOrder = crossGroupColConfig?.columnOrder ?? [];
+    if (savedOrder.length > 0) {
+      const orderSet = new Set(savedOrder);
+      const merged = [...savedOrder.filter((k) => defaultKeys.includes(k))];
+      for (const k of defaultKeys) {
+        if (!orderSet.has(k)) merged.push(k);
+      }
+      setColumnOrder(merged);
+    } else {
+      setColumnOrder(defaultKeys);
+    }
+    setHiddenColumns(new Set(crossGroupColConfig?.hiddenColumns ?? []));
+  }, [crossGroupMode, crossGroupColConfig]);
 
   const usedSlots = useMemo(
     () => new Set(customFields.map((f) => f.slot)),
@@ -697,7 +727,7 @@ export function FollowupSettingsPanel({
 
   // ── Loading ──
 
-  if (!config || !groupData || !availableVariables) {
+  if (!crossGroupMode && (!config || !groupData || !availableVariables)) {
     return (
       <View style={styles.container}>
         <View style={styles.header}>

--- a/apps/mobile/features/profile/components/ProfileMenu.tsx
+++ b/apps/mobile/features/profile/components/ProfileMenu.tsx
@@ -53,49 +53,64 @@ export function ProfileMenu() {
   };
 
   return (
-    <Card style={styles.section}>
-      <TouchableOpacity
-        style={styles.menuItem}
-        onPress={() => router.push('/(user)/edit-profile')}
-        activeOpacity={0.7}
-      >
-        <View style={styles.menuIconContainer}>
-          <Ionicons name="create-outline" size={24} color={primaryColor} />
-        </View>
-        <Text style={styles.menuText}>Edit Profile</Text>
-        <Ionicons name="chevron-forward" size={20} color="#999" />
-      </TouchableOpacity>
-
-      <TouchableOpacity
-        style={styles.menuItem}
-        onPress={handleSwitchCommunity}
-        activeOpacity={0.7}
-        disabled={isLoadingCommunities || isRefetching}
-      >
-        <View style={styles.menuIconContainer}>
-          <Ionicons
-            name={community?.id ? "swap-horizontal-outline" : "people-outline"}
-            size={24}
-            color={primaryColor}
-          />
-        </View>
-        <View style={styles.menuTextContainer}>
-          <Text style={styles.menuText}>
-            {community?.id ? "Switch Community" : "Pick a community"}
-          </Text>
-          {community?.name && (
-            <Text style={styles.menuSubtext}>{community.name}</Text>
-          )}
-        </View>
-        {isLoadingCommunities || isRefetching ? (
-          <ActivityIndicator size="small" color={primaryColor} />
-        ) : (
+    <>
+      <Card style={styles.section}>
+        <TouchableOpacity
+          style={styles.menuItem}
+          onPress={() => router.push('/(user)/edit-profile')}
+          activeOpacity={0.7}
+        >
+          <View style={styles.menuIconContainer}>
+            <Ionicons name="create-outline" size={24} color={primaryColor} />
+          </View>
+          <Text style={styles.menuText}>Edit Profile</Text>
           <Ionicons name="chevron-forward" size={20} color="#999" />
-        )}
-      </TouchableOpacity>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.menuItem}
+          onPress={handleSwitchCommunity}
+          activeOpacity={0.7}
+          disabled={isLoadingCommunities || isRefetching}
+        >
+          <View style={styles.menuIconContainer}>
+            <Ionicons
+              name={community?.id ? "swap-horizontal-outline" : "people-outline"}
+              size={24}
+              color={primaryColor}
+            />
+          </View>
+          <View style={styles.menuTextContainer}>
+            <Text style={styles.menuText}>
+              {community?.id ? "Switch Community" : "Pick a community"}
+            </Text>
+            {community?.name && (
+              <Text style={styles.menuSubtext}>{community.name}</Text>
+            )}
+          </View>
+          {isLoadingCommunities || isRefetching ? (
+            <ActivityIndicator size="small" color={primaryColor} />
+          ) : (
+            <Ionicons name="chevron-forward" size={20} color="#999" />
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.menuItem, styles.menuItemLast]}
+          onPress={() => router.push('/(user)/settings')}
+          activeOpacity={0.7}
+        >
+          <View style={styles.menuIconContainer}>
+            <Ionicons name="settings-outline" size={24} color={primaryColor} />
+          </View>
+          <Text style={styles.menuText}>Settings</Text>
+          <Ionicons name="chevron-forward" size={20} color="#999" />
+        </TouchableOpacity>
+      </Card>
 
       {hasLeaderAccess === true ? (
-        <>
+        <Card style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: primaryColor }]}>Leader Tools</Text>
           <TouchableOpacity
             style={styles.menuItem}
             onPress={() =>
@@ -113,7 +128,7 @@ export function ProfileMenu() {
             <Ionicons name="chevron-forward" size={20} color="#999" />
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.menuItem}
+            style={[styles.menuItem, styles.menuItemLast]}
             onPress={() =>
               router.push({
                 pathname: "/people",
@@ -128,22 +143,9 @@ export function ProfileMenu() {
             <Text style={styles.menuText}>People</Text>
             <Ionicons name="chevron-forward" size={20} color="#999" />
           </TouchableOpacity>
-        </>
+        </Card>
       ) : null}
-
-      <TouchableOpacity
-        style={[styles.menuItem, hasLeaderAccess === true ? undefined : styles.menuItemLast]}
-        onPress={() => router.push('/(user)/settings')}
-        activeOpacity={0.7}
-      >
-        <View style={styles.menuIconContainer}>
-          <Ionicons name="settings-outline" size={24} color={primaryColor} />
-        </View>
-        <Text style={styles.menuText}>Settings</Text>
-        <Ionicons name="chevron-forward" size={20} color="#999" />
-      </TouchableOpacity>
-
-    </Card>
+    </>
   );
 }
 
@@ -185,5 +187,12 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: '#666',
     marginTop: 2,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    marginBottom: 4,
   },
 });


### PR DESCRIPTION
## Summary
- Replace group filter chips with a dropdown `<select>` to prevent horizontal overflow when a leader has many groups
- Fix settings panel infinite loading in cross-group mode — was blocked on per-group data that's skipped in cross-group mode
- Move Tasks and People into a dedicated "Leader Tools" section on the profile page, only visible to users with leader access

## Test plan
- [ ] Open People page with many groups — verify dropdown shows instead of overflowing chips
- [ ] Click settings gear on People page — verify column picker loads (no infinite spinner)
- [ ] Check profile page as a leader — verify "Leader Tools" section with Tasks & People
- [ ] Check profile page as a non-leader — verify "Leader Tools" section is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-group People table rendering and settings-panel initialization logic; main risk is regressions in column configuration/loading behavior specifically for cross-group vs per-group modes.
> 
> **Overview**
> Improves the cross-group *People* page UX by replacing the horizontal group filter chips with a compact dropdown `select` to avoid overflow when leaders have many groups.
> 
> Fixes the settings panel in cross-group mode by decoupling its loading/initialization from per-group queries and initializing column order/visibility from a localStorage-backed config (including adding `groupName` to the picker).
> 
> Reorganizes the Profile menu to add a leader-only **Leader Tools** section containing `Tasks` and `People`, while keeping `Settings` in the main account section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43780ba8dc356b6f97aede3e1dcebddb72855528. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->