### PR TITLE
Notifications group sender

### DIFF
--- a/apps/convex/__tests__/messaging/events.test.ts
+++ b/apps/convex/__tests__/messaging/events.test.ts
@@ -766,11 +766,12 @@ describe("sendMessageNotifications Notification Data", () => {
     expect(true).toBe(true);
   });
 
-  test("includes group avatar in Expo rich-content payload for push notifications", async () => {
+  test("prefers sender avatar while preserving group avatar metadata for push notifications", async () => {
     vi.useFakeTimers();
     const t = convexTest(schema, modules);
     const { userId, user2Id, groupId, channelId } = await seedTestData(t);
     const groupAvatarUrl = "https://example.com/group-avatar.jpg";
+    const senderAvatarUrl = "https://example.com/sender-avatar.jpg";
     const now = Date.now();
 
     const fetchMock = vi.fn().mockResolvedValue({
@@ -808,6 +809,7 @@ describe("sendMessageNotifications Notification Data", () => {
         createdAt: now,
         isDeleted: false,
         senderName: "Test User",
+        senderProfilePhoto: senderAvatarUrl,
       });
     });
 
@@ -824,8 +826,9 @@ describe("sendMessageNotifications Notification Data", () => {
     const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
     expect(requestBody[0].title).toBe("Test User");
     expect(requestBody[0].body).toBe("Test Group: General\nAvatar payload test message");
-    expect(requestBody[0].richContent.image).toBe(groupAvatarUrl);
+    expect(requestBody[0].richContent.image).toBe(senderAvatarUrl);
     expect(requestBody[0].mutableContent).toBe(true);
+    expect(requestBody[0].data.senderAvatarUrl).toBe(senderAvatarUrl);
     expect(requestBody[0].data.groupAvatarUrl).toBe(groupAvatarUrl);
 
     const recipientNotifications = await t.run(async (ctx) => {
@@ -834,7 +837,66 @@ describe("sendMessageNotifications Notification Data", () => {
         .withIndex("by_user", (q) => q.eq("userId", user2Id))
         .collect();
     });
+    expect(recipientNotifications[0]?.data?.senderAvatarUrl).toBe(senderAvatarUrl);
     expect(recipientNotifications[0]?.data?.groupAvatarUrl).toBe(groupAvatarUrl);
+  });
+
+  test("strips duplicated group prefix from channel names in push body", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, channelId } = await seedTestData(t);
+    const now = Date.now();
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "ticket-3", status: "ok" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(channelId, { name: "Test Group - General" });
+      await ctx.db.insert("chatReadState", {
+        channelId,
+        userId: user2Id,
+        lastReadAt: now,
+        unreadCount: 0,
+      });
+      await ctx.db.insert("pushTokens", {
+        userId: user2Id,
+        token: "ExponentPushToken[channel-name-dedupe-test]",
+        platform: "ios",
+        environment: "staging",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+        lastUsedAt: now,
+      });
+    });
+
+    const messageId = await t.run(async (ctx) => {
+      return await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: userId,
+        content: "Deduped body test message",
+        contentType: "text",
+        createdAt: now,
+        isDeleted: false,
+        senderName: "Test User",
+      });
+    });
+
+    await t.mutation(internal.functions.messaging.events.onMessageSent, {
+      messageId,
+      channelId,
+      senderId: userId,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(fetchMock).toHaveBeenCalled();
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(requestBody[0].body).toBe("Test Group: General\nDeduped body test message");
   });
 
   test("falls back to generated initials avatar when group has no photo", async () => {

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -114,6 +114,7 @@ export const onMessageSent = internalMutation({
         : sender
           ? `${sender.firstName || ""} ${sender.lastName || ""}`.trim() || "Someone"
           : "Togather Bot";
+      const senderAvatarUrl = message.senderProfilePhoto;
 
       // Schedule the notification action
       console.log(`[onMessageSent] Scheduling notifications for ${mentionRecipients.length} mentions and ${regularRecipients.length} regular recipients`);
@@ -123,6 +124,7 @@ export const onMessageSent = internalMutation({
         messageId: args.messageId,
         senderName,
         messagePreview: preview,
+        senderAvatarUrl,
         groupId: group?._id,
         groupName: group?.name || 'Group Chat',
         communityId: community?._id,
@@ -145,6 +147,7 @@ export const sendMessageNotifications = internalAction({
     messageId: v.id("chatMessages"),
     senderName: v.string(),
     messagePreview: v.string(),
+    senderAvatarUrl: v.optional(v.string()),
     groupId: v.optional(v.id("groups")),
     groupName: v.string(),
     communityId: v.optional(v.id("communities")),
@@ -162,6 +165,7 @@ export const sendMessageNotifications = internalAction({
         userIds: args.mentionRecipients,
         data: {
           senderName: args.senderName,
+          senderAvatarUrl: args.senderAvatarUrl,
           messagePreview: args.messagePreview,
           groupId: args.groupId,
           groupName: args.groupName,
@@ -183,6 +187,7 @@ export const sendMessageNotifications = internalAction({
         userIds: args.regularRecipients,
         data: {
           senderName: args.senderName,
+          senderAvatarUrl: args.senderAvatarUrl,
           messagePreview: args.messagePreview,
           groupId: args.groupId,
           groupName: args.groupName,

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -39,6 +39,7 @@ interface GroupCreationApprovedData {
 // Messaging Types
 interface MessageData {
   senderName: string;
+  senderAvatarUrl?: string;
   groupName: string;
   messagePreview: string;
   groupId: string;
@@ -298,8 +299,24 @@ export const groupCreationApproved: NotificationDefinition<GroupCreationApproved
 // ============================================================================
 
 function getChannelLabel(data: MessageData): string {
-  if (data.channelName?.trim()) {
-    return data.channelName.trim();
+  const groupName = data.groupName.trim();
+  const rawChannelName = data.channelName?.trim();
+
+  if (rawChannelName) {
+    // Some channels are stored as "Group Name - General", which causes
+    // duplicated group names in push bodies. Strip that prefix.
+    const groupPrefixRegex = new RegExp(
+      `^${groupName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*[-:|]\\s*`,
+      "i"
+    );
+    const normalizedChannelName = rawChannelName.replace(groupPrefixRegex, "").trim();
+    if (normalizedChannelName) {
+      return normalizedChannelName;
+    }
+
+    if (rawChannelName.toLowerCase() !== groupName.toLowerCase()) {
+      return rawChannelName;
+    }
   }
 
   if (data.channelType === "leaders") {
@@ -331,6 +348,7 @@ export const newMessage: NotificationDefinition<MessageData> = {
         channelName: ctx.data.channelName,
         channelType: ctx.data.channelType, // "general" or "leaders" - enables direct routing (Issue #302)
         communityId: ctx.data.communityId,
+        senderAvatarUrl: ctx.data.senderAvatarUrl,
       },
     }),
   },
@@ -351,6 +369,7 @@ export const mention: NotificationDefinition<MessageData> = {
         channelName: ctx.data.channelName,
         channelType: ctx.data.channelType, // "general" or "leaders" - enables direct routing
         communityId: ctx.data.communityId,
+        senderAvatarUrl: ctx.data.senderAvatarUrl,
       },
     }),
     email: (ctx) => {

--- a/apps/convex/lib/notifications/send.ts
+++ b/apps/convex/lib/notifications/send.ts
@@ -271,22 +271,33 @@ async function sendPushChannel<TData extends Record<string, unknown>>(
   groupId?: Id<"groups">
 ): Promise<ChannelSendResult> {
   const output = formatter(formatterCtx);
-  let notificationImageUrl: string | undefined;
+  let groupNotificationImageUrl: string | undefined;
 
   if (groupId) {
     const groupInfo = await ctx.runQuery(
       internal.functions.notifications.internal.getGroupInfo,
       { groupId }
     );
-    notificationImageUrl = groupInfo?.groupAvatarUrl;
+    groupNotificationImageUrl = groupInfo?.groupAvatarUrl;
   } else if (communityId) {
     // Community-level notifications (no group context) should use community branding.
     const communityInfo = await ctx.runQuery(
       internal.functions.notifications.internal.getCommunityInfo,
       { communityId }
     );
-    notificationImageUrl = communityInfo?.communityLogoUrl;
+    groupNotificationImageUrl = communityInfo?.communityLogoUrl;
   }
+
+  const senderAvatarFromPayload =
+    output.data &&
+    typeof output.data === "object" &&
+    "senderAvatarUrl" in output.data &&
+    typeof (output.data as { senderAvatarUrl?: unknown }).senderAvatarUrl === "string"
+      ? (output.data as { senderAvatarUrl: string }).senderAvatarUrl
+      : undefined;
+
+  // Prefer sender avatar for chat-like notifications; keep group/community image as fallback.
+  const notificationImageUrl = senderAvatarFromPayload || groupNotificationImageUrl;
 
   // Get push tokens for user (filters by environment and active status)
   // No tokens = user has disabled push or hasn't registered a token
@@ -305,7 +316,8 @@ async function sendPushChannel<TData extends Record<string, unknown>>(
   const notificationData = {
     type: notificationType,
     ...output.data,
-    ...(notificationImageUrl ? { groupAvatarUrl: notificationImageUrl } : {}),
+    ...(senderAvatarFromPayload ? { senderAvatarUrl: senderAvatarFromPayload } : {}),
+    ...(groupNotificationImageUrl ? { groupAvatarUrl: groupNotificationImageUrl } : {}),
   };
   console.log(`[sendPushChannel] Building push notification with data:`, JSON.stringify(notificationData));
 
@@ -331,7 +343,8 @@ async function sendPushChannel<TData extends Record<string, unknown>>(
     body: output.body,
     data: {
       ...(output.data || {}),
-      ...(notificationImageUrl ? { groupAvatarUrl: notificationImageUrl } : {}),
+      ...(senderAvatarFromPayload ? { senderAvatarUrl: senderAvatarFromPayload } : {}),
+      ...(groupNotificationImageUrl ? { groupAvatarUrl: groupNotificationImageUrl } : {}),
     },
     status: result.success ? "sent" : "failed",
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates notification formatting to remove duplicate group names and include sender profile pictures.

The previous notification cards duplicated the group name and did not display the sender's profile image, leading to a less intuitive user experience compared to platforms like Slack or WhatsApp. This change improves clarity and personalization in push notifications.

<div><a href="https://cursor.com/agents/bc-a4061132-c465-4497-af2c-3e123df042aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4061132-c465-4497-af2c-3e123df042aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->