### PR TITLE
fix: communication bot posts to archived channel instead of active one

### DIFF
--- a/apps/convex/functions/groupBots.ts
+++ b/apps/convex/functions/groupBots.ts
@@ -13,7 +13,7 @@ import { query, mutation, action } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { now } from "../lib/utils";
-import { calculateCommunicationBotNextSchedule, calculateNextScheduledTimeForDayOfWeek } from "../lib/scheduling";
+import { calculateCommunicationBotNextSchedule } from "../lib/scheduling";
 import { requireAuth, requireAuthFromToken } from "../lib/auth";
 import { isActiveMembership, isLeaderRole } from "../lib/helpers";
 
@@ -483,17 +483,16 @@ export const toggle = mutation({
       const timezone = community?.timezone || "America/New_York";
       nextScheduledAt = calculateNext9AMInTimezone(timezone);
     } else if (args.botId === "communication" && args.enabled) {
-      // Communication bot uses custom schedule
+      // Communication bot: recalculate from existing config (supports both
+      // new multi-message format and legacy single-schedule format)
       const group = await ctx.db.get(args.groupId);
       if (!group) {
         throw new Error("Group not found");
       }
       const community = await ctx.db.get(group.communityId);
       const timezone = community?.timezone || "America/New_York";
-      // Use existing schedule from config if available, otherwise use default
-      const existingConfig = existing?.config as { schedule?: { dayOfWeek: number; hour: number; minute: number } } | undefined;
-      const schedule = existingConfig?.schedule || { dayOfWeek: 6, hour: 9, minute: 0 };
-      nextScheduledAt = calculateNextScheduledTimeForDayOfWeek(schedule, timezone);
+      const existingConfig = (existing?.config as Record<string, unknown>) || {};
+      nextScheduledAt = calculateCommunicationBotNextSchedule(existingConfig, timezone);
     }
 
     if (existing) {
@@ -648,7 +647,7 @@ function calculateNext9AMInTimezone(timezone: string): number {
   return result.getTime();
 }
 
-// calculateNextScheduledTimeForDayOfWeek is now imported from ../lib/scheduling
+// calculateCommunicationBotNextSchedule is imported from ../lib/scheduling
 
 // ============================================================================
 // Developer Tools - Test Functions

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -1715,11 +1715,14 @@ export const getChannelBySlug = internalQuery({
   },
   handler: async (ctx, { groupId, slug }) => {
     // Try by slug first (for custom channels and migrated channels)
+    // Exclude archived channels — archiving frees up slugs for reuse,
+    // so multiple channels can share the same slug if earlier ones are archived.
     let channel = await ctx.db
       .query("chatChannels")
       .withIndex("by_group_slug", (q) =>
         q.eq("groupId", groupId).eq("slug", slug),
       )
+      .filter((q) => q.eq(q.field("isArchived"), false))
       .first();
 
     if (channel) {
@@ -1740,6 +1743,7 @@ export const getChannelBySlug = internalQuery({
         .withIndex("by_group_type", (q) =>
           q.eq("groupId", groupId).eq("channelType", channelType),
         )
+        .filter((q) => q.eq(q.field("isArchived"), false))
         .first();
     }
 


### PR DESCRIPTION
## Summary
- **Root cause**: The internal `getChannelBySlug` in `scheduledJobs.ts` did not filter out archived channels. When the "Directors" channel was archived and a new one created with the same slug, the bot found the old archived channel first and silently failed every Sunday.
- **Secondary fix**: The `toggle` function in `groupBots.ts` used the legacy single-schedule format instead of the new multi-message format, causing `nextScheduledAt` to default to Saturday 9am when toggling the communication bot on.

## Changes
- `scheduledJobs.ts`: Added `isArchived: false` filter to internal `getChannelBySlug` query (both slug and channelType lookups), matching the public query in `channels.ts`
- `groupBots.ts`: Replaced legacy `config.schedule` lookup in `toggle` with `calculateCommunicationBotNextSchedule()` which handles both multi-message and legacy formats

## Test plan
- [x] TypeScript type-check passes
- [x] All 924 existing tests pass
- [ ] Verify on production: Fount Production group's communication bot (configId `jh785y2vcpcs88e40n8wnv6jvn816k2r`) should post to the active Directors channel next Sunday
- [ ] Verify "Send Now" works for the Directors message

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bot channel resolution and communication-bot scheduling, which could affect where/when automated messages are sent if filtering or schedule parsing behaves unexpectedly. Scope is limited to internal bot utilities and only adds stricter filtering plus a shared schedule calculator.
> 
> **Overview**
> Fixes communication-bot delivery and scheduling edge cases.
> 
> `getChannelBySlug` now filters out archived channels for both slug and legacy `channelType` lookups, preventing bots from selecting an archived channel when slugs are reused.
> 
> Enabling the communication bot (`groupBots.toggle`) now recalculates `nextScheduledAt` via `calculateCommunicationBotNextSchedule`, correctly supporting the newer multi-message config format while remaining compatible with legacy single-schedule configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 882135dca9d4d54cacc6cfb2709169ebeaa7c3b2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->