### PR TITLE
feat: URL-based feature flag overrides for web

### DIFF
--- a/apps/mobile/hooks/useFeatureFlag.ts
+++ b/apps/mobile/hooks/useFeatureFlag.ts
@@ -15,6 +15,19 @@ import { Environment } from "@/services/environment";
 
 const OVERRIDE_STORAGE_KEY = "togather_feature_flag_overrides";
 
+/**
+ * Check URL params for feature flag overrides (web only, all environments).
+ * Format: ?ff_<flagKey>=true|1|false|0
+ */
+function getUrlParamOverride(flagKey: string): boolean | undefined {
+  if (typeof window === "undefined") return undefined;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get(`ff_${flagKey}`);
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  return undefined;
+}
+
 // Cache for overrides to avoid async reads on every render
 let overrideCache: Record<string, boolean> | null = null;
 
@@ -125,6 +138,12 @@ export function useFeatureFlag(flagKey: string): boolean {
 
   if (canUseOverrides && loaded && override !== undefined) {
     return override;
+  }
+
+  // Check URL param overrides (web only, all environments)
+  const urlOverride = getUrlParamOverride(flagKey);
+  if (urlOverride !== undefined) {
+    return urlOverride;
   }
 
   // Fall back to PostHog


### PR DESCRIPTION
## Summary
- Add URL param support (`?ff_<key>=true`) for overriding feature flags on web in all environments
- Fixes the issue where AsyncStorage overrides are gated to dev/staging only, so flags like `system_scores` couldn't be tested in production web builds
- No-op on native (checks `typeof window`)

## Test plan
- [ ] Open web app at any URL, append `?ff_system_scores=true` — system scores UI should appear in followup settings
- [ ] Remove the param — should revert to PostHog/default behavior
- [ ] Verify native app is unaffected (no `window` available, helper returns `undefined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes feature-flag evaluation in `useFeatureFlag` by allowing URL query params to override PostHog in web production, which could unintentionally enable/disable gated UI when links include `ff_*` parameters.
> 
> **Overview**
> Adds **web-only URL query overrides** for boolean feature flags via `?ff_<flagKey>=true|1|false|0` in `useFeatureFlag`, with a `typeof window` guard to no-op on native.
> 
> This introduces a new precedence path where a URL parameter (in *all* environments) can override the PostHog result when no dev/staging AsyncStorage override is applied.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ce326936e0b72b7f9bfba89446c300024507a14. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->