### PR TITLE
feat: enable AsyncStorage flag overrides in all environments

### DIFF
--- a/apps/mobile/hooks/useFeatureFlag.ts
+++ b/apps/mobile/hooks/useFeatureFlag.ts
@@ -5,13 +5,12 @@
  * Returns safe defaults when PostHog is not initialized.
  *
  * Developer overrides (stored in AsyncStorage) take precedence over PostHog
- * when in dev/staging mode or when the dev tools escape hatch is enabled.
+ * in all environments.
  */
 
 import { useCallback, useEffect, useState } from "react";
 import { usePostHog } from "posthog-react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { Environment } from "@/services/environment";
 
 const OVERRIDE_STORAGE_KEY = "togather_feature_flag_overrides";
 
@@ -133,10 +132,8 @@ export function useFeatureFlag(flagKey: string): boolean {
     return unsubscribe;
   }, [flagKey]);
 
-  // In dev/staging, check for local override first
-  const canUseOverrides = __DEV__ || Environment.isStaging();
-
-  if (canUseOverrides && loaded && override !== undefined) {
+  // Check for local override first (AsyncStorage, all environments)
+  if (loaded && override !== undefined) {
     return override;
   }
 


### PR DESCRIPTION
## Summary
- Remove the `__DEV__ || Environment.isStaging()` gate on AsyncStorage feature flag overrides
- Overrides now work in production, not just dev/staging
- Removes unused `Environment` import

## Test plan
- [ ] Set a flag override via dev tools in production — should take effect
- [ ] Clear overrides — should fall back to PostHog value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables persisted feature-flag overrides to take effect in production, which can unintentionally force features on/off if override values are present on user devices.
> 
> **Overview**
> Removes the dev/staging guard so `useFeatureFlag` always prefers AsyncStorage-stored overrides (and no longer depends on `Environment`) before falling back to URL params and PostHog.
> 
> This makes developer-tool feature flag overrides persist and apply in **all** environments, including production.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a058230a1a2ea80baf64a5b258aa0fda7f06e46. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->