### PR TITLE
feat: thread bump via denormalized lastActivityAt

### DIFF
--- a/apps/convex/__tests__/messaging/messages.test.ts
+++ b/apps/convex/__tests__/messaging/messages.test.ts
@@ -1432,3 +1432,109 @@ describe("Thread Reply Count in Message List", () => {
     expect(message?.threadReplyCount ?? 0).toBe(0);
   });
 });
+
+// ============================================================================
+// Thread Bump Tests
+// ============================================================================
+
+describe("Thread Bump (lastActivityAt)", () => {
+  test("replying to a thread bumps it to most recent position", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { channelId, accessToken } = await seedTestData(t);
+
+    // Send message A
+    const msgA = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Message A",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    vi.advanceTimersByTime(100);
+
+    // Send message B (now B is more recent than A)
+    const msgB = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Message B",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    vi.advanceTimersByTime(100);
+
+    // Reply to A — should bump A's lastActivityAt
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Reply to A",
+      parentMessageId: msgA,
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    // Fetch messages — A should appear AFTER B (most recent) in chronological order
+    const result = await t.query(api.functions.messaging.messages.getMessages, {
+      token: accessToken,
+      channelId,
+    });
+
+    // Chronological order (oldest activity first): B first, then A (bumped)
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]._id).toBe(msgB);
+    expect(result.messages[1]._id).toBe(msgA);
+  });
+
+  test("lastActivityAt is set on parent message after a reply", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { channelId, accessToken } = await seedTestData(t);
+
+    const parentId = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Parent message",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const parentBefore = await t.run(async (ctx) => ctx.db.get(parentId));
+    const originalActivityAt = parentBefore?.lastActivityAt;
+    expect(originalActivityAt).toBeDefined();
+
+    vi.advanceTimersByTime(500);
+
+    // Send a reply
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "A reply",
+      parentMessageId: parentId,
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const parentAfter = await t.run(async (ctx) => ctx.db.get(parentId));
+    expect(parentAfter?.lastActivityAt).toBeDefined();
+    expect(parentAfter!.lastActivityAt!).toBeGreaterThan(originalActivityAt!);
+  });
+
+  test("top-level message without replies uses lastActivityAt equal to createdAt", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { channelId, accessToken } = await seedTestData(t);
+
+    const msgId = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Standalone message",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const msg = await t.run(async (ctx) => ctx.db.get(msgId));
+    expect(msg?.lastActivityAt).toBe(msg?.createdAt);
+  });
+});

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -188,40 +188,44 @@ export const getMessages = query({
 
     const blockedUserIds = new Set(blockedUsers.map((b) => b.blockedId));
 
-    // Get messages
+    // Get all messages for this channel
     let allMessages = await ctx.db
       .query("chatMessages")
       .withIndex("by_channel_createdAt", (q) => q.eq("channelId", args.channelId))
-      .order("desc")
       .collect();
-
-    // If cursor provided, filter messages older than cursor
-    if (args.cursor) {
-      const cursorIndex = allMessages.findIndex((m) => m._id === args.cursor);
-      if (cursorIndex >= 0) {
-        allMessages = allMessages.slice(cursorIndex + 1);
-      }
-    }
 
     // Filter out deleted, blocked users, and thread replies
     // Bot messages (no senderId) are never blocked
-    const filteredMessages = allMessages
-      .filter((m) => !m.isDeleted && (!m.senderId || !blockedUserIds.has(m.senderId)) && !m.parentMessageId)
-      .slice(0, limit);
-
-    // Determine if there are more messages
-    const remainingMessages = allMessages
+    let topLevelMessages = allMessages
       .filter((m) => !m.isDeleted && (!m.senderId || !blockedUserIds.has(m.senderId)) && !m.parentMessageId);
-    const hasMore = remainingMessages.length > limit;
 
-    // Get cursor for pagination (oldest message in this batch, for loading older messages)
-    const cursor = filteredMessages.length > 0
-      ? filteredMessages[filteredMessages.length - 1]._id
+    // Sort by lastActivityAt descending (thread bump ordering)
+    // Fall back to createdAt for messages without lastActivityAt (pre-migration)
+    topLevelMessages.sort((a, b) => {
+      const aTime = a.lastActivityAt ?? a.createdAt;
+      const bTime = b.lastActivityAt ?? b.createdAt;
+      return bTime - aTime;
+    });
+
+    // If cursor provided, find cursor position and slice after it
+    if (args.cursor) {
+      const cursorIndex = topLevelMessages.findIndex((m) => m._id === args.cursor);
+      if (cursorIndex >= 0) {
+        topLevelMessages = topLevelMessages.slice(cursorIndex + 1);
+      }
+    }
+
+    const hasMore = topLevelMessages.length > limit;
+    const pageMessages = topLevelMessages.slice(0, limit);
+
+    // Get cursor for pagination (oldest-activity message in this batch)
+    const cursor = pageMessages.length > 0
+      ? pageMessages[pageMessages.length - 1]._id
       : undefined;
 
     // Reverse to chronological order (oldest first, newest at bottom)
     // This is the expected order for chat UIs
-    const chronologicalMessages = [...filteredMessages].reverse();
+    const chronologicalMessages = [...pageMessages].reverse();
 
     return {
       messages: chronologicalMessages,
@@ -358,6 +362,8 @@ export const sendMessage = mutation({
       senderProfilePhoto,
       mentionedUserIds: args.mentionedUserIds,
       hideLinkPreview: args.hideLinkPreview,
+      // Set lastActivityAt for top-level messages (used for thread bump ordering)
+      ...(!args.parentMessageId ? { lastActivityAt: now } : {}),
     });
 
     // Update channel with last message info (for inbox preview)
@@ -381,6 +387,7 @@ export const sendMessage = mutation({
       if (parentMessage) {
         await ctx.db.patch(args.parentMessageId, {
           threadReplyCount: (parentMessage.threadReplyCount || 0) + 1,
+          lastActivityAt: now,
         });
       }
     }
@@ -567,6 +574,7 @@ export const sendSystemMessage = internalMutation({
       createdAt: now,
       updatedAt: now,
       isDeleted: false,
+      lastActivityAt: now,
     });
 
     // Update channel metadata

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1317,6 +1317,9 @@ export default defineSchema({
     senderProfilePhoto: v.optional(v.string()),
     // Mentions
     mentionedUserIds: v.optional(v.array(v.id("users"))),
+    // Thread bump: tracks when thread last had activity (reply or creation)
+    // Used for sorting top-level messages so threads with new replies float up
+    lastActivityAt: v.optional(v.number()),
     // Link preview control
     hideLinkPreview: v.optional(v.boolean()),
     // Reach Out request reference (for request cards in leaders channel)


### PR DESCRIPTION
## Summary
- Adds `lastActivityAt` field to `chatMessages` for thread bump ordering (Issue #93)
- When a reply is sent, the parent message's `lastActivityAt` updates to `now`, bumping it to the most recent position in the chat feed
- `getMessages` query sorts by `lastActivityAt` (with fallback to `createdAt` for pre-existing messages)

## Changes
- **Schema**: Added `lastActivityAt: v.optional(v.number())` to `chatMessages` (backward-compatible)
- **sendMessage**: Sets `lastActivityAt` on top-level messages at creation; updates parent's `lastActivityAt` on reply
- **sendSystemMessage**: Also sets `lastActivityAt` for consistency
- **getMessages**: Sorts by `lastActivityAt ?? createdAt` descending, then reverses to chronological for the chat UI

## Test plan
- [x] 3 new thread bump tests added (36 total messaging tests pass)
- [x] 951 total tests pass (pre-push hook verified)
- [x] Existing pagination, threading, and delete tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message listing order and pagination cursor semantics by sorting top-level messages on `lastActivityAt`, which could affect chat feed ordering and load-more behavior if edge cases aren’t covered (e.g., mixed migrated/unmigrated data). Schema change is backward-compatible but introduces a new field that must be consistently written.
> 
> **Overview**
> Implements *thread bumping* for chat by introducing a denormalized `lastActivityAt` timestamp on `chatMessages` and using it to order the channel message list.
> 
> Top-level messages now set `lastActivityAt` on creation, replies patch the parent message’s `lastActivityAt` (and still increment `threadReplyCount`), and system messages also populate the field. `getMessages` now filters to top-level messages and sorts by `lastActivityAt ?? createdAt` (descending) before returning results in chronological order with updated cursor/`hasMore` behavior.
> 
> Adds tests covering bump ordering, parent `lastActivityAt` updates on reply, and default `lastActivityAt == createdAt` for standalone messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02aaf1511f2679da10d463df578a58ca7ca6b600. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->