### PR TITLE
fix: improve native deep link experience for share pages

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -141,6 +141,7 @@ export default {
         "com.apple.developer.usernotifications.communication": true
       },
       infoPlist: {
+        ITSAppUsesNonExemptEncryption: false,
         NSUserActivityTypes: ["INSendMessageIntent"],
         NSCameraUsageDescription:
           "Togather uses your camera to take a profile photo that will be visible to other community members (for example, when you RSVP to events or appear in group member lists), and to capture photos to share in group chat conversations.",

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -401,10 +401,10 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
 
   // Show Join Community card on shared links for authenticated users not in the community
   // Wait for user data to load before showing card to avoid flash of incorrect state
-  const shouldShowJoinCommunityCard = !isInAppNavigation && isAuthenticated && !isLoadingUser && !isUserInCommunity;
+  const shouldShowJoinCommunityCard = Platform.OS === "web" && !isInAppNavigation && isAuthenticated && !isLoadingUser && !isUserInCommunity;
 
-  // Show tab bar for authenticated users on shared links
-  const shouldShowTabBar = !isInAppNavigation && isAuthenticated;
+  // Show tab bar for authenticated users on shared links (web only — native has its own tab bar)
+  const shouldShowTabBar = Platform.OS === "web" && !isInAppNavigation && isAuthenticated;
   // Use community from auth context (JWT) not userData (database)
   // This ensures we only show tabs that work with the current token
   const hasActiveCommunity = !!community?.id;

--- a/apps/mobile/app/g/[shortId]/GroupPageClient.tsx
+++ b/apps/mobile/app/g/[shortId]/GroupPageClient.tsx
@@ -377,8 +377,8 @@ export default function GroupPageClient({ initialGroupData }: GroupPageClientPro
           )}
         </View>
 
-        {/* Join Community Card for non-members */}
-        {isAuthenticated && !isInCommunity && groupData.communityId && (
+        {/* Join Community Card for non-members (web only — native has its own navigation) */}
+        {Platform.OS === "web" && isAuthenticated && !isInCommunity && groupData.communityId && (
           <View style={styles.joinCommunityContainer}>
             <JoinCommunityCard
               communityLogo={groupData.communityLogo || null}
@@ -442,8 +442,8 @@ export default function GroupPageClient({ initialGroupData }: GroupPageClientPro
         )}
       </View>
 
-      {/* Tab bar for authenticated users */}
-      {isAuthenticated && (
+      {/* Tab bar for authenticated users (web only — native has its own tab bar) */}
+      {Platform.OS === "web" && isAuthenticated && (
         <SharedPageTabBar
           hasActiveCommunity={hasActiveCommunity}
           isAdmin={isAdmin}

--- a/apps/mobile/targets/notification-service/NotificationService.swift
+++ b/apps/mobile/targets/notification-service/NotificationService.swift
@@ -152,13 +152,13 @@ final class NotificationService: UNNotificationServiceExtension {
   }
 
   private func donate(interaction: INInteraction) async throws {
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
       interaction.donate { error in
         if let error {
           continuation.resume(throwing: error)
           return
         }
-        continuation.resume()
+        continuation.resume(returning: ())
       }
     }
   }


### PR DESCRIPTION
## Summary
- Hide redundant tab bar and join community card on native platforms for group/event share pages — these are only useful on web since native already has its own tab bar
- Fix Swift type inference error in NotificationServiceExtension for newer Xcode (iOS 26 SDK)
- Add `ITSAppUsesNonExemptEncryption: false` to suppress App Store encryption compliance prompt

## Test plan
- [ ] Open `togather.nyc/g/[shortId]` from iMessage (member group) → clean layout, no redundant tab bar
- [ ] Open `togather.nyc/e/[shortId]` from iMessage → clean event page, no redundant tab bar
- [ ] Open event from chat "View Details" → identical clean layout
- [ ] Open both links on web → share pages unchanged (tab bar and join card visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to platform-conditional UI rendering for shared group/event pages plus small iOS config/extension build fixes, with no core data/auth flow changes.
> 
> **Overview**
> Improves the native deep-link/share-page experience by **rendering the Join Community card and shared-page tab bar only on web**, avoiding redundant navigation UI on iOS/Android for `GroupPageClient` and `EventPageClient`.
> 
> Updates iOS build/config details by adding `ITSAppUsesNonExemptEncryption: false` to `app.config.js` and fixing a newer-Xcode Swift inference issue in `NotificationService.swift` by explicitly typing the continuation and resuming with `returning: ()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d2dc24d1f8b69a91ca268221dd868173a6dc84. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->