### PR TITLE
chore: bump OTA for update modal testing

### DIFF
--- a/apps/mobile/providers/OTAUpdateProvider.tsx
+++ b/apps/mobile/providers/OTAUpdateProvider.tsx
@@ -55,7 +55,7 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // --- Background update check ---
   const checkForUpdates = useCallback(async () => {
-    console.log('[OTAUpdate] Starting update check...');
+    console.log('[OTAUpdate] Starting update check (v2)...');
     setStatus('checking');
     setErrorMessage(null);
 


### PR DESCRIPTION
Trivial log change to trigger OTA update for testing the new blocking modal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a console log string to force a new build/OTA version for testing, with no behavioral or data-handling impact.
> 
> **Overview**
> Tweaks the initial `OTAUpdateProvider` update-check log line (`Starting update check` -> `Starting update check (v2)`) to intentionally change the bundle and trigger an OTA update during modal testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08a46c7aaef39b1076d257857549915b21d514c1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->