### PR TITLE
chore: bump OTA for testing (v3)

### DIFF
--- a/apps/mobile/providers/OTAUpdateProvider.tsx
+++ b/apps/mobile/providers/OTAUpdateProvider.tsx
@@ -55,7 +55,7 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // --- Background update check ---
   const checkForUpdates = useCallback(async () => {
-    console.log('[OTAUpdate] Starting update check (v2)...');
+    console.log('[OTAUpdate] Starting update check (v3)...');
     setStatus('checking');
     setErrorMessage(null);
 


### PR DESCRIPTION
Trivial change to trigger OTA update for testing the blocking modal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a debug log string to force a new OTA build/version for testing; no functional logic changes.
> 
> **Overview**
> Updates `OTAUpdateProvider` to log update checks as **v3** instead of **v2**, effectively creating a trivial change to trigger an OTA update for testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daa509d83a00f6a1366d7fcbecf27361b5ea4ab0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->