### PR TITLE
fix: modernize AASA to components format and remove cross-listing

### DIFF
--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -74,39 +74,42 @@ const ANDROID_SHA256_FINGERPRINTS = {
 function generateAppleAppSiteAssociation(hostname) {
   const env = getEnvironment(hostname);
 
-  // For staging domain, only include staging app
-  // For production domain, include both apps (production first, staging as fallback for testing)
-  const appIDs = env === "staging"
-    ? [`${APPLE_TEAM_ID}.${IOS_BUNDLE_IDS.staging}`]
-    : [
-        `${APPLE_TEAM_ID}.${IOS_BUNDLE_IDS.production}`,
-        `${APPLE_TEAM_ID}.${IOS_BUNDLE_IDS.staging}`,
-      ];
+  // Each domain only includes its own app — no cross-listing
+  const appID = env === "staging"
+    ? `${APPLE_TEAM_ID}.${IOS_BUNDLE_IDS.staging}`
+    : `${APPLE_TEAM_ID}.${IOS_BUNDLE_IDS.production}`;
+
+  // Paths to exclude from universal links (landing/static pages)
+  const excludedPaths = [
+    "/",
+    "/android",
+    "/android-staging",
+    "/download",
+    "/privacy",
+    "/terms",
+    "/contribute",
+    "/issue",
+  ];
 
   return {
     applinks: {
-      apps: [], // Required to be empty array
-      details: appIDs.map(appID => ({
-        appID,
-        paths: [
-          // Use exclusion pattern: open ALL paths EXCEPT landing pages
-          // This allows new app routes to work via OTA without updating AASA
-          "NOT /",           // Exclude root (landing page)
-          "NOT /android",    // Exclude Android download page
-          "NOT /android-staging", // Exclude staging Android page
-          "NOT /download",   // Exclude download page
-          "NOT /privacy",    // Exclude privacy policy
-          "NOT /terms",      // Exclude terms of service
-          "NOT /contribute", // Exclude contribute page
-          "NOT /issue",      // Exclude issue reporting page
-          "NOT /_expo/*",    // Exclude Expo internal routes
-          "*",               // Match everything else (app routes)
-        ],
-      })),
+      // Modern "components" format (iOS 13+, recommended by Apple)
+      details: [
+        {
+          appIDs: [appID],
+          components: [
+            // Exclude landing/static pages
+            ...excludedPaths.map(path => ({ "/": path, exclude: true })),
+            // Exclude Expo internal routes
+            { "/": "/_expo/*", exclude: true },
+            // Match everything else (app routes like /g/*, /e/*, /nearme)
+            { "/": "*" },
+          ],
+        },
+      ],
     },
-    // Web Credentials for password autofill (optional but good practice)
     webcredentials: {
-      apps: appIDs,
+      apps: [appID],
     },
   };
 }
@@ -118,37 +121,19 @@ function generateAppleAppSiteAssociation(hostname) {
 function generateAssetLinks(hostname) {
   const env = getEnvironment(hostname);
 
-  // For staging domain, only include staging app
-  // For production domain, include both apps
-  if (env === "staging") {
-    return [
-      {
-        relation: ["delegate_permission/common.handle_all_urls"],
-        target: {
-          namespace: "android_app",
-          package_name: ANDROID_PACKAGES.staging,
-          sha256_cert_fingerprints: ANDROID_SHA256_FINGERPRINTS.staging,
-        },
-      },
-    ];
-  }
+  // Each domain only includes its own app — no cross-listing
+  const pkg = env === "staging" ? ANDROID_PACKAGES.staging : ANDROID_PACKAGES.production;
+  const fingerprints = env === "staging"
+    ? ANDROID_SHA256_FINGERPRINTS.staging
+    : ANDROID_SHA256_FINGERPRINTS.production;
 
   return [
     {
       relation: ["delegate_permission/common.handle_all_urls"],
       target: {
         namespace: "android_app",
-        package_name: ANDROID_PACKAGES.production,
-        sha256_cert_fingerprints: ANDROID_SHA256_FINGERPRINTS.production,
-      },
-    },
-    // Include staging app for testing on production domain
-    {
-      relation: ["delegate_permission/common.handle_all_urls"],
-      target: {
-        namespace: "android_app",
-        package_name: ANDROID_PACKAGES.staging,
-        sha256_cert_fingerprints: ANDROID_SHA256_FINGERPRINTS.staging,
+        package_name: pkg,
+        sha256_cert_fingerprints: fingerprints,
       },
     },
   ];


### PR DESCRIPTION
## Summary
- Switch Apple App Site Association from legacy `paths` format to modern `components` format (iOS 13+, recommended by Apple)
- Each domain now only lists its own app — no cross-listing between production and staging for both iOS and Android asset links
- Simplify Android asset links generation (same logic, less duplication)

## Test plan
- [ ] Verify `togather.nyc/.well-known/apple-app-site-association` returns valid components format
- [ ] Verify `staging.togather.nyc/.well-known/apple-app-site-association` only lists staging app
- [ ] Verify deep links still open the app from iMessage/Safari
- [ ] Verify `/.well-known/assetlinks.json` returns correct Android config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the iOS/Android deep-link association files served from `/.well-known`, so mistakes could break Universal Links/App Links behavior per domain despite limited code scope.
> 
> **Overview**
> Updates the Cloudflare worker’s Universal Links/App Links responses so **each domain only lists its own iOS/Android app** (removing production↔staging cross-listing).
> 
> Modernizes the Apple App Site Association payload to the iOS 13+ `components` format, generating exclusions for landing/static routes (plus `/_expo/*`) and allowing all other paths to open in-app; `webcredentials` is likewise restricted to the single app ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c79c0b4eb301e3ab29ce44f433d3a12f0b2af448. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->