### PR TITLE
fix: add force rebuild option to Build Mobile workflow

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -27,6 +27,10 @@ on:
         description: "Submit iOS to App Store after build"
         type: boolean
         default: false
+      force:
+        description: "Force rebuild even if a build already exists"
+        type: boolean
+        default: false
 
   # Automatic trigger on version tags (e.g., v1.0.0, v1.2.3)
   push:
@@ -90,12 +94,22 @@ jobs:
 
       # ── Check for existing EAS builds to avoid redundant builds ──
       # Builds cost ~$2 each and take ~20 minutes, so we reuse recent successful builds
+      # Skip cache check entirely when force=true on manual runs
       - name: Check for existing builds
         id: check-builds
         working-directory: apps/mobile
         run: |
           VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Force rebuild skips all cache checks
+          if [ "${{ inputs.force }}" = "true" ]; then
+            echo "⚡ Force rebuild requested — skipping cache checks"
+            echo "has_ios_build=false" >> $GITHUB_OUTPUT
+            echo "has_android_build=false" >> $GITHUB_OUTPUT
+            echo "has_android_apk_build=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           # Determine which profiles to check based on trigger
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Summary
- Adds a "Force rebuild" checkbox to the manual Build Mobile workflow dispatch UI
- When enabled, skips the existing build cache check and always triggers a fresh EAS build
- Useful when you need to rebuild at the same version (e.g., after credential changes or config updates)

## Test plan
- [ ] Run workflow without force → should skip builds if existing build found
- [ ] Run workflow with force checked → should always build regardless of cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk GitHub Actions change limited to the manual workflow path, with the main impact being potentially higher EAS build usage/cost when enabled.
> 
> **Overview**
> Adds a `force` boolean input to the `Build Mobile` GitHub Actions workflow to **override the existing-build cache check**.
> 
> When `force=true`, the `Check for existing builds` step short-circuits and marks all platforms as needing a build, ensuring manual runs always trigger fresh EAS builds even if a matching build already exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8833ef4861682797d24f4f74fb1b63cbe3bafde7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->