### PR TITLE
fix: simplify Build Mobile to manual-only, always fresh builds

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,9 +1,7 @@
 name: Build Mobile
 
-# Trigger builds manually or on version tags
-# This avoids $2/build charges on every push
+# Manual trigger only — always builds fresh
 on:
-  # Manual trigger from GitHub Actions UI
   workflow_dispatch:
     inputs:
       platform:
@@ -27,15 +25,6 @@ on:
         description: "Submit iOS to App Store after build"
         type: boolean
         default: false
-      force:
-        description: "Force rebuild even if a build already exists"
-        type: boolean
-        default: false
-
-  # Automatic trigger on version tags (e.g., v1.0.0, v1.2.3)
-  push:
-    tags:
-      - "v*"
 
 jobs:
   build:
@@ -75,151 +64,48 @@ jobs:
       - name: Sync secrets to EAS
         working-directory: apps/mobile
         env:
-          # Determine target EAS environment based on profile (default to production for tag triggers)
-          # Note: staging profile uses "preview" environment in eas.json (see build-mobile-native.yml)
           EAS_ENV: ${{ inputs.profile == 'staging' && 'preview' || 'production' }}
         run: |
-          # Use eas env:create (eas secret:create is deprecated)
-          # Only sync to the environment matching the selected profile to avoid cross-contamination
           eas env:create --name EXPO_PUBLIC_MAPBOX_TOKEN --value "$EXPO_PUBLIC_MAPBOX_TOKEN" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
-          # Convex URL from loaded secrets
           eas env:create --name EXPO_PUBLIC_CONVEX_URL --value "$CONVEX_SITE_URL" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
-          # Project ID for push notifications (constant across all environments)
           eas env:create --name EXPO_PUBLIC_PROJECT_ID --value "$EAS_PROJECT_ID" --environment "$EAS_ENV" --visibility plaintext --force --non-interactive || true
-          # Sentry auth token for source map uploads during native builds
           eas env:create --name SENTRY_AUTH_TOKEN --value "$SENTRY_AUTH_TOKEN" --environment "$EAS_ENV" --visibility sensitive --force --non-interactive || true
-          # Sentry DSN for error tracking at runtime
           eas env:create --name EXPO_PUBLIC_SENTRY_DSN --value "$EXPO_PUBLIC_SENTRY_DSN" --environment "$EAS_ENV" --visibility sensitive --force --non-interactive || true
           echo "✓ Synced secrets to EAS ($EAS_ENV environment)"
 
-      # ── Check for existing EAS builds to avoid redundant builds ──
-      # Builds cost ~$2 each and take ~20 minutes, so we reuse recent successful builds
-      # Skip cache check entirely when force=true on manual runs
-      - name: Check for existing builds
-        id: check-builds
+      - name: Get version
+        id: version
         working-directory: apps/mobile
         run: |
           VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION"
 
-          # Force rebuild skips all cache checks
-          if [ "${{ inputs.force }}" = "true" ]; then
-            echo "⚡ Force rebuild requested — skipping cache checks"
-            echo "has_ios_build=false" >> $GITHUB_OUTPUT
-            echo "has_android_build=false" >> $GITHUB_OUTPUT
-            echo "has_android_apk_build=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Determine which profiles to check based on trigger
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PROFILE="${{ inputs.profile }}"
-          else
-            PROFILE="production"
-          fi
-
-          # Check for existing store build (production or staging profile)
-          check_existing_build() {
-            local platform=$1
-            local profile=$2
-            local output_key=$3
-
-            echo "Checking for existing $platform $profile build for version $VERSION..."
-
-            # Get the latest finished build for this platform/profile
-            BUILD_JSON=$(eas build:list --platform "$platform" --build-profile "$profile" --limit 1 --json --non-interactive 2>/dev/null || echo "[]")
-            BUILD_STATUS=$(echo "$BUILD_JSON" | jq -r '.[0].status // "none"')
-            BUILD_VERSION=$(echo "$BUILD_JSON" | jq -r '.[0].runtimeVersion // "none"')
-            BUILD_ARTIFACT=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.applicationArchiveUrl // "none"')
-
-            if [ "$BUILD_STATUS" = "FINISHED" ] && [ "$BUILD_VERSION" = "$VERSION" ] && [ "$BUILD_ARTIFACT" != "none" ] && [ "$BUILD_ARTIFACT" != "null" ]; then
-              echo "✓ Found existing $platform $profile build for version $VERSION"
-              echo "${output_key}=true" >> $GITHUB_OUTPUT
-            else
-              echo "✗ No existing $platform $profile build for version $VERSION (status=$BUILD_STATUS, version=$BUILD_VERSION)"
-              echo "${output_key}=false" >> $GITHUB_OUTPUT
-            fi
-          }
-
-          # Check iOS store build
-          check_existing_build "ios" "$PROFILE" "has_ios_build"
-
-          # Check Android store build
-          check_existing_build "android" "$PROFILE" "has_android_build"
-
-          # Check Android APK build (production-apk profile, used for R2 distribution)
-          if [ "$PROFILE" = "production" ]; then
-            check_existing_build "android" "production-apk" "has_android_apk_build"
-          else
-            echo "has_android_apk_build=false" >> $GITHUB_OUTPUT
-          fi
-
-      # ── Manual trigger: build only if no existing build found ──
-      - name: Build iOS (manual)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && (inputs.platform == 'ios' || inputs.platform == 'all')
-          && steps.check-builds.outputs.has_ios_build != 'true'
+      # ── Build ──
+      - name: Build iOS
+        if: inputs.platform == 'ios' || inputs.platform == 'all'
         working-directory: apps/mobile
         run: eas build --platform ios --profile ${{ inputs.profile }} --non-interactive
 
-      - name: Skip iOS build (cached)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && (inputs.platform == 'ios' || inputs.platform == 'all')
-          && steps.check-builds.outputs.has_ios_build == 'true'
-        run: echo "⏭️ Skipping iOS build — existing build found for version ${{ steps.check-builds.outputs.version }}"
-
-      - name: Build Android (manual)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && (inputs.platform == 'android' || inputs.platform == 'all')
-          && steps.check-builds.outputs.has_android_build != 'true'
+      - name: Build Android
+        if: inputs.platform == 'android' || inputs.platform == 'all'
         working-directory: apps/mobile
         run: eas build --platform android --profile ${{ inputs.profile }} --non-interactive
 
-      - name: Skip Android build (cached)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && (inputs.platform == 'android' || inputs.platform == 'all')
-          && steps.check-builds.outputs.has_android_build == 'true'
-        run: echo "⏭️ Skipping Android build — existing build found for version ${{ steps.check-builds.outputs.version }}"
-
-      # iOS App Store submission (only iOS — Android is distributed via R2)
-      - name: Submit iOS to App Store (manual)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && inputs.submit
-          && (inputs.platform == 'ios' || inputs.platform == 'all')
+      # ── Submit ──
+      - name: Submit iOS to App Store
+        if: inputs.submit && (inputs.platform == 'ios' || inputs.platform == 'all')
         working-directory: apps/mobile
         run: eas submit --platform ios --latest --non-interactive
 
-      # Build Android APK for direct distribution (manual, production only)
-      # Skips if a production-apk build already exists for this version
-      - name: Build Android APK for R2 (manual)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && inputs.profile == 'production'
-          && (inputs.platform == 'android' || inputs.platform == 'all')
-          && steps.check-builds.outputs.has_android_apk_build != 'true'
+      # ── Android APK for R2 distribution (production only) ──
+      - name: Build Android APK for R2
+        if: inputs.profile == 'production' && (inputs.platform == 'android' || inputs.platform == 'all')
         working-directory: apps/mobile
         run: eas build --platform android --profile production-apk --non-interactive
 
-      - name: Skip Android APK build (cached)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && inputs.profile == 'production'
-          && (inputs.platform == 'android' || inputs.platform == 'all')
-          && steps.check-builds.outputs.has_android_apk_build == 'true'
-        run: echo "⏭️ Skipping Android APK build — existing production-apk build found for version ${{ steps.check-builds.outputs.version }}"
-
-      # Upload Android APK to R2 for direct distribution (manual, production only)
-      # Always runs — pulls the latest production-apk build from EAS (cached or fresh)
-      - name: Upload Android APK to R2 (manual)
-        if: >-
-          github.event_name == 'workflow_dispatch'
-          && inputs.profile == 'production'
-          && (inputs.platform == 'android' || inputs.platform == 'all')
+      - name: Upload Android APK to R2
+        if: inputs.profile == 'production' && (inputs.platform == 'android' || inputs.platform == 'all')
         working-directory: apps/mobile
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
@@ -227,11 +113,9 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
         run: |
-          # Get version from code
-          VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
+          VERSION="${{ steps.version.outputs.version }}"
           echo "Uploading Android APK version $VERSION to R2..."
 
-          # Download the latest Android APK from EAS (cached or freshly built)
           mkdir -p ./build-output
           APK_URL=$(eas build:list --platform android --build-profile production-apk --limit 1 --json --non-interactive | jq -r '.[0].artifacts.applicationArchiveUrl')
 
@@ -243,15 +127,11 @@ jobs:
           echo "Downloading APK from: $APK_URL"
           curl -fL -o ./build-output/togather.apk "$APK_URL"
 
-          # Get file size for manifest
           FILE_SIZE=$(stat -f%z ./build-output/togather.apk 2>/dev/null || stat -c%s ./build-output/togather.apk)
           echo "APK size: $FILE_SIZE bytes"
 
-          # Install AWS CLI for R2 (S3-compatible)
           pip install awscli --quiet
 
-          # Override AWS credentials with R2 credentials
-          # (env vars take precedence over aws configure)
           export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
           export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
           export AWS_DEFAULT_REGION="auto"
@@ -271,7 +151,6 @@ jobs:
           echo "✓ Uploaded togather-latest.apk"
 
           # Create and upload manifest
-          # Uses R2 bucket served at IMAGE_CDN_URL (see docs/architecture/ADR-021-android-distribution.md)
           cat > ./build-output/manifest.json << EOF
           {
             "version": "${VERSION}",
@@ -293,158 +172,3 @@ jobs:
           echo "- Version: $VERSION" >> $GITHUB_STEP_SUMMARY
           echo "- Size: $(echo "scale=2; $FILE_SIZE/1048576" | bc) MB" >> $GITHUB_STEP_SUMMARY
           echo "- Download: https://togather.nyc/android" >> $GITHUB_STEP_SUMMARY
-
-      # ── Tag release flow ──
-      - name: Validate tag matches code version
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        working-directory: apps/mobile
-        run: |
-          # Extract version from tag (e.g., v1.0.17 -> 1.0.17)
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "Tag version: $TAG_VERSION"
-
-          # Get version from code
-          CODE_VERSION=$(node -p "require('./app.config.js').default.expo.runtimeVersion")
-          echo "Code version: $CODE_VERSION"
-
-          # Verify they match
-          if [ "$TAG_VERSION" != "$CODE_VERSION" ]; then
-            echo ""
-            echo "❌ ERROR: Tag version does not match code version!"
-            echo "   Tag:  v$TAG_VERSION"
-            echo "   Code: $CODE_VERSION"
-            echo ""
-            echo "   The version in app.config.js must match the git tag."
-            echo "   Either:"
-            echo "   1. Update the code version: pnpm version:bump $TAG_VERSION"
-            echo "   2. Or create a new tag: git tag v$CODE_VERSION"
-            exit 1
-          fi
-
-          # Also verify app.json matches
-          APP_JSON_VERSION=$(node -p "require('./app.json').expo.version")
-          if [ "$CODE_VERSION" != "$APP_JSON_VERSION" ]; then
-            echo ""
-            echo "❌ ERROR: app.json version does not match!"
-            echo "   app.config.js: $CODE_VERSION"
-            echo "   app.json:      $APP_JSON_VERSION"
-            exit 1
-          fi
-
-          echo ""
-          echo "✅ Version validated: $CODE_VERSION"
-
-      # Tag release: build iOS only if no existing build (Android goes through production-apk)
-      - name: Build iOS (tag release)
-        if: >-
-          github.event_name == 'push'
-          && startsWith(github.ref, 'refs/tags/v')
-          && steps.check-builds.outputs.has_ios_build != 'true'
-        working-directory: apps/mobile
-        run: eas build --platform ios --profile production --non-interactive
-
-      - name: Build Android (tag release)
-        if: >-
-          github.event_name == 'push'
-          && startsWith(github.ref, 'refs/tags/v')
-          && steps.check-builds.outputs.has_android_build != 'true'
-        working-directory: apps/mobile
-        run: eas build --platform android --profile production --non-interactive
-
-      # iOS App Store submission for tag releases
-      - name: Submit iOS to App Store (tag release)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        working-directory: apps/mobile
-        run: eas submit --platform ios --latest --non-interactive
-
-      # Build Android APK for direct distribution (tag release)
-      - name: Build Android APK for R2 (tag release)
-        if: >-
-          github.event_name == 'push'
-          && startsWith(github.ref, 'refs/tags/v')
-          && steps.check-builds.outputs.has_android_apk_build != 'true'
-        working-directory: apps/mobile
-        run: eas build --platform android --profile production-apk --non-interactive
-
-      # Upload Android APK to R2 for direct distribution (tag release)
-      - name: Upload Android APK to R2 (tag release)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        working-directory: apps/mobile
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_ACCESS_KEY }}
-          R2_BUCKET_NAME: ${{ env.R2_BUCKET_NAME }}
-        run: |
-          # Get version from tag
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "Uploading Android APK version $VERSION to R2..."
-
-          # Download the latest Android APK from EAS (cached or freshly built)
-          mkdir -p ./build-output
-          APK_URL=$(eas build:list --platform android --build-profile production-apk --limit 1 --json --non-interactive | jq -r '.[0].artifacts.applicationArchiveUrl')
-
-          if [ "$APK_URL" = "null" ] || [ -z "$APK_URL" ]; then
-            echo "❌ ERROR: No production-apk build artifact found on EAS"
-            exit 1
-          fi
-
-          echo "Downloading APK from: $APK_URL"
-          curl -fL -o ./build-output/togather.apk "$APK_URL"
-
-          # Get file size for manifest
-          FILE_SIZE=$(stat -f%z ./build-output/togather.apk 2>/dev/null || stat -c%s ./build-output/togather.apk)
-          echo "APK size: $FILE_SIZE bytes"
-
-          # Install AWS CLI for R2 (S3-compatible)
-          pip install awscli --quiet
-
-          # Override AWS credentials with R2 credentials
-          # (env vars take precedence over aws configure)
-          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-          export AWS_DEFAULT_REGION="auto"
-
-          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
-
-          # Upload versioned APK
-          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-${VERSION}.apk" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --content-type "application/vnd.android.package-archive"
-          echo "✓ Uploaded togather-${VERSION}.apk"
-
-          # Upload as latest
-          aws s3 cp ./build-output/togather.apk "s3://${R2_BUCKET_NAME}/releases/android/production/togather-latest.apk" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --content-type "application/vnd.android.package-archive"
-          echo "✓ Uploaded togather-latest.apk"
-
-          # Create and upload manifest
-          # Uses R2 bucket served at IMAGE_CDN_URL (see docs/architecture/ADR-021-android-distribution.md)
-          cat > ./build-output/manifest.json << EOF
-          {
-            "version": "${VERSION}",
-            "releaseDate": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "fileSize": ${FILE_SIZE},
-            "downloadUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-${VERSION}.apk",
-            "latestUrl": "${IMAGE_CDN_URL}/releases/android/production/togather-latest.apk",
-            "minSupportedVersion": "1.0.0"
-          }
-          EOF
-
-          aws s3 cp ./build-output/manifest.json "s3://${R2_BUCKET_NAME}/releases/android/production/manifest.json" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --content-type "application/json"
-          echo "✓ Uploaded manifest.json"
-
-      - name: Tag release summary
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "## Production Release: v$TAG_VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### iOS" >> $GITHUB_STEP_SUMMARY
-          echo "- Submitted to App Store Connect" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Android" >> $GITHUB_STEP_SUMMARY
-          echo "- APK uploaded to: https://togather.nyc/android" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Remove tag trigger (`v*` push) — builds only run via manual dispatch
- Remove build cache checking — always builds fresh
- Remove force checkbox (no longer needed)
- Delete duplicated tag release steps (~300 lines removed)

## Test plan
- [ ] Run workflow from GitHub Actions UI — should build without cache checks
- [ ] Verify no automatic triggers on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release/build automation: tag-based production builds and cache reuse are removed, which can break expected release flows and increase build time/cost if used frequently.
> 
> **Overview**
> **Simplifies the `Build Mobile` GitHub Actions workflow to run *only* via `workflow_dispatch` and always perform fresh EAS builds.**
> 
> Removes the `v*` tag push trigger, the `force` input, and all logic/steps for checking and reusing existing EAS builds (including the duplicated tag-release flow and tag/version validation). The remaining steps always run the requested iOS/Android builds, optional iOS submission, and (production-only) Android `production-apk` build + R2 upload, reusing a single `Get version` step for the upload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3af7c1e68da923d1212e820da575a8cd4fff413c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->