### PR TITLE
fix: dark mode visual issues on profile, inbox, and sidebar

### DIFF
--- a/apps/mobile/components/DesktopSideNav.tsx
+++ b/apps/mobile/components/DesktopSideNav.tsx
@@ -3,6 +3,7 @@ import { type Href, usePathname, router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useTheme } from "@hooks/useTheme";
 
 type NavItem = {
   key: string;
@@ -22,6 +23,7 @@ export function DesktopSideNav() {
   const pathname = usePathname();
   const { user, community } = useAuth();
   const { primaryColor } = useCommunityTheme();
+  const { colors } = useTheme();
 
   const isAdmin = user?.is_admin === true;
   const hasCommunity = !!community?.id;
@@ -71,10 +73,10 @@ export function DesktopSideNav() {
   ];
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: colors.surface, borderRightColor: colors.border }]}>
       {items.map((item) => {
         const active = item.match(pathname);
-        const color = active ? primaryColor : "#999";
+        const color = active ? primaryColor : colors.tabBarInactive;
         return (
           <Pressable
             key={item.key}
@@ -98,9 +100,7 @@ export function DesktopSideNav() {
 const styles = StyleSheet.create({
   container: {
     width: 64,
-    backgroundColor: "#fff",
     borderRightWidth: 1,
-    borderRightColor: "#E5E5E5",
     paddingTop: 16,
     alignItems: "center",
   },

--- a/apps/mobile/features/__tests__/__snapshots__/safe-area-insets.test.tsx.snap
+++ b/apps/mobile/features/__tests__/__snapshots__/safe-area-insets.test.tsx.snap
@@ -347,12 +347,16 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
         >
           <Text
             style={
-              {
-                "color": "#1a1a1a",
-                "fontSize": 20,
-                "fontWeight": "600",
-                "marginBottom": 4,
-              }
+              [
+                {
+                  "fontSize": 20,
+                  "fontWeight": "600",
+                  "marginBottom": 4,
+                },
+                {
+                  "color": "#1a1a1a",
+                },
+              ]
             }
           >
             Test
@@ -361,11 +365,15 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
           </Text>
           <Text
             style={
-              {
-                "color": "#8e8e93",
-                "fontSize": 14,
-                "marginBottom": 6,
-              }
+              [
+                {
+                  "fontSize": 14,
+                  "marginBottom": 6,
+                },
+                {
+                  "color": "#666666",
+                },
+              ]
             }
           >
             test@example.com
@@ -431,7 +439,7 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
         style={
           {
             "alignItems": "center",
-            "borderBottomColor": "#e5e5e5",
+            "borderBottomColor": "#e0e0e0",
             "borderBottomWidth": 0.5,
             "flexDirection": "row",
             "opacity": 1,
@@ -441,15 +449,19 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#f5f5f5",
-              "borderRadius": 8,
-              "height": 36,
-              "justifyContent": "center",
-              "marginRight": 14,
-              "width": 36,
-            }
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 8,
+                "height": 36,
+                "justifyContent": "center",
+                "marginRight": 14,
+                "width": 36,
+              },
+              {
+                "backgroundColor": "#f5f5f5",
+              },
+            ]
           }
         >
           <Text>
@@ -458,12 +470,16 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
         </View>
         <Text
           style={
-            {
-              "color": "#1a1a1a",
-              "flex": 1,
-              "fontSize": 16,
-              "fontWeight": "400",
-            }
+            [
+              {
+                "flex": 1,
+                "fontSize": 16,
+                "fontWeight": "400",
+              },
+              {
+                "color": "#1a1a1a",
+              },
+            ]
           }
         >
           Edit Profile
@@ -503,7 +519,7 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
         style={
           {
             "alignItems": "center",
-            "borderBottomColor": "#e5e5e5",
+            "borderBottomColor": "#e0e0e0",
             "borderBottomWidth": 0.5,
             "flexDirection": "row",
             "opacity": 1,
@@ -513,15 +529,19 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#f5f5f5",
-              "borderRadius": 8,
-              "height": 36,
-              "justifyContent": "center",
-              "marginRight": 14,
-              "width": 36,
-            }
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 8,
+                "height": 36,
+                "justifyContent": "center",
+                "marginRight": 14,
+                "width": 36,
+              },
+              {
+                "backgroundColor": "#f5f5f5",
+              },
+            ]
           }
         >
           <Text>
@@ -530,12 +550,16 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
         </View>
         <Text
           style={
-            {
-              "color": "#1a1a1a",
-              "flex": 1,
-              "fontSize": 16,
-              "fontWeight": "400",
-            }
+            [
+              {
+                "flex": 1,
+                "fontSize": 16,
+                "fontWeight": "400",
+              },
+              {
+                "color": "#1a1a1a",
+              },
+            ]
           }
         >
           Pick a community
@@ -575,7 +599,7 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
         style={
           {
             "alignItems": "center",
-            "borderBottomColor": "#e5e5e5",
+            "borderBottomColor": "#e0e0e0",
             "borderBottomWidth": 0,
             "flexDirection": "row",
             "opacity": 1,
@@ -585,15 +609,19 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#f5f5f5",
-              "borderRadius": 8,
-              "height": 36,
-              "justifyContent": "center",
-              "marginRight": 14,
-              "width": 36,
-            }
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 8,
+                "height": 36,
+                "justifyContent": "center",
+                "marginRight": 14,
+                "width": 36,
+              },
+              {
+                "backgroundColor": "#f5f5f5",
+              },
+            ]
           }
         >
           <Text>
@@ -602,12 +630,16 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
         </View>
         <Text
           style={
-            {
-              "color": "#1a1a1a",
-              "flex": 1,
-              "fontSize": 16,
-              "fontWeight": "400",
-            }
+            [
+              {
+                "flex": 1,
+                "fontSize": 16,
+                "fontWeight": "400",
+              },
+              {
+                "color": "#1a1a1a",
+              },
+            ]
           }
         >
           Settings
@@ -1316,12 +1348,16 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
         >
           <Text
             style={
-              {
-                "color": "#1a1a1a",
-                "fontSize": 20,
-                "fontWeight": "600",
-                "marginBottom": 4,
-              }
+              [
+                {
+                  "fontSize": 20,
+                  "fontWeight": "600",
+                  "marginBottom": 4,
+                },
+                {
+                  "color": "#1a1a1a",
+                },
+              ]
             }
           >
             Test
@@ -1330,11 +1366,15 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
           </Text>
           <Text
             style={
-              {
-                "color": "#8e8e93",
-                "fontSize": 14,
-                "marginBottom": 6,
-              }
+              [
+                {
+                  "fontSize": 14,
+                  "marginBottom": 6,
+                },
+                {
+                  "color": "#666666",
+                },
+              ]
             }
           >
             test@example.com
@@ -1400,7 +1440,7 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
         style={
           {
             "alignItems": "center",
-            "borderBottomColor": "#e5e5e5",
+            "borderBottomColor": "#e0e0e0",
             "borderBottomWidth": 0.5,
             "flexDirection": "row",
             "opacity": 1,
@@ -1410,15 +1450,19 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#f5f5f5",
-              "borderRadius": 8,
-              "height": 36,
-              "justifyContent": "center",
-              "marginRight": 14,
-              "width": 36,
-            }
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 8,
+                "height": 36,
+                "justifyContent": "center",
+                "marginRight": 14,
+                "width": 36,
+              },
+              {
+                "backgroundColor": "#f5f5f5",
+              },
+            ]
           }
         >
           <Text>
@@ -1427,12 +1471,16 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
         </View>
         <Text
           style={
-            {
-              "color": "#1a1a1a",
-              "flex": 1,
-              "fontSize": 16,
-              "fontWeight": "400",
-            }
+            [
+              {
+                "flex": 1,
+                "fontSize": 16,
+                "fontWeight": "400",
+              },
+              {
+                "color": "#1a1a1a",
+              },
+            ]
           }
         >
           Edit Profile
@@ -1472,7 +1520,7 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
         style={
           {
             "alignItems": "center",
-            "borderBottomColor": "#e5e5e5",
+            "borderBottomColor": "#e0e0e0",
             "borderBottomWidth": 0.5,
             "flexDirection": "row",
             "opacity": 1,
@@ -1482,15 +1530,19 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#f5f5f5",
-              "borderRadius": 8,
-              "height": 36,
-              "justifyContent": "center",
-              "marginRight": 14,
-              "width": 36,
-            }
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 8,
+                "height": 36,
+                "justifyContent": "center",
+                "marginRight": 14,
+                "width": 36,
+              },
+              {
+                "backgroundColor": "#f5f5f5",
+              },
+            ]
           }
         >
           <Text>
@@ -1499,12 +1551,16 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
         </View>
         <Text
           style={
-            {
-              "color": "#1a1a1a",
-              "flex": 1,
-              "fontSize": 16,
-              "fontWeight": "400",
-            }
+            [
+              {
+                "flex": 1,
+                "fontSize": 16,
+                "fontWeight": "400",
+              },
+              {
+                "color": "#1a1a1a",
+              },
+            ]
           }
         >
           Pick a community
@@ -1544,7 +1600,7 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
         style={
           {
             "alignItems": "center",
-            "borderBottomColor": "#e5e5e5",
+            "borderBottomColor": "#e0e0e0",
             "borderBottomWidth": 0,
             "flexDirection": "row",
             "opacity": 1,
@@ -1554,15 +1610,19 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#f5f5f5",
-              "borderRadius": 8,
-              "height": 36,
-              "justifyContent": "center",
-              "marginRight": 14,
-              "width": 36,
-            }
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 8,
+                "height": 36,
+                "justifyContent": "center",
+                "marginRight": 14,
+                "width": 36,
+              },
+              {
+                "backgroundColor": "#f5f5f5",
+              },
+            ]
           }
         >
           <Text>
@@ -1571,12 +1631,16 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
         </View>
         <Text
           style={
-            {
-              "color": "#1a1a1a",
-              "flex": 1,
-              "fontSize": 16,
-              "fontWeight": "400",
-            }
+            [
+              {
+                "flex": 1,
+                "fontSize": 16,
+                "fontWeight": "400",
+              },
+              {
+                "color": "#1a1a1a",
+              },
+            ]
           }
         >
           Settings

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -167,7 +167,7 @@ export function ChatInboxScreen({
   if (!hasCommunity) {
     return (
       <Wrapper>
-        <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={[styles.container, { backgroundColor: colors.surface }]}>
           <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
           </View>
@@ -207,7 +207,7 @@ export function ChatInboxScreen({
   if (showLoadingSpinner) {
     return (
       <Wrapper>
-        <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={[styles.container, { backgroundColor: colors.surface }]}>
           <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
           </View>
@@ -223,7 +223,7 @@ export function ChatInboxScreen({
   if (!displayChannels || displayChannels.length === 0) {
     return (
       <Wrapper>
-        <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={[styles.container, { backgroundColor: colors.surface }]}>
           <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
           </View>
@@ -246,7 +246,7 @@ export function ChatInboxScreen({
 
   return (
     <Wrapper>
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.container, { backgroundColor: colors.surface }]}>
         <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
           <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
         </View>

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -372,14 +372,14 @@ export function MessageList({
   // Loading happens in the inbox before navigation, so this should be brief
   if (isLoading && messages.length === 0) {
     return (
-      <View style={[styles.container, { backgroundColor: themeColors.background }]} />
+      <View style={[styles.container, { backgroundColor: themeColors.surface }]} />
     );
   }
 
   // Empty state
   if (!isLoading && messages.length === 0) {
     return (
-      <View style={[styles.centerContainer, { backgroundColor: themeColors.background }]}>
+      <View style={[styles.centerContainer, { backgroundColor: themeColors.surface }]}>
         <Ionicons name="chatbubbles-outline" size={64} color={themeColors.iconSecondary} style={{ marginBottom: 16 }} />
         <Text style={[styles.emptyTitle, { color: themeColors.text }]}>No messages yet</Text>
         <Text style={[styles.emptySubtext, { color: themeColors.textSecondary }]}>Start the conversation!</Text>
@@ -389,7 +389,7 @@ export function MessageList({
 
   return (
     <ReactionsProvider messageIds={messageIds} channelId={channelId}>
-      <View style={[styles.container, { backgroundColor: themeColors.background }]}>
+      <View style={[styles.container, { backgroundColor: themeColors.surface }]}>
         <FlatList
           ref={listRef}
           data={listItems}

--- a/apps/mobile/features/profile/components/ProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/ProfileHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Avatar, Card } from '@components/ui';
 import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
 import { Profile } from '../types';
 
 interface ProfileHeaderProps {
@@ -9,6 +10,7 @@ interface ProfileHeaderProps {
 }
 
 export function ProfileHeader({ user }: ProfileHeaderProps) {
+  const { colors } = useTheme();
   // Filter associated emails to remove the current email
   const linkedEmails = user?.associated_emails?.filter(
     (email) => email !== user?.email
@@ -23,16 +25,16 @@ export function ProfileHeader({ user }: ProfileHeaderProps) {
           size={80}
         />
         <View style={styles.profileInfo}>
-          <Text style={styles.name}>
+          <Text style={[styles.name, { color: colors.text }]}>
             {user?.first_name} {user?.last_name}
           </Text>
-          <Text style={styles.email}>{user?.email}</Text>
+          <Text style={[styles.email, { color: colors.textSecondary }]}>{user?.email}</Text>
           {user?.phone && (
             <View style={styles.phoneContainer}>
-              <Ionicons name="call-outline" size={16} color="#666" />
-              <Text style={styles.phone}>{user.phone}</Text>
+              <Ionicons name="call-outline" size={16} color={colors.textSecondary} />
+              <Text style={[styles.phone, { color: colors.textSecondary }]}>{user.phone}</Text>
               {user?.phone_verified && (
-                <Ionicons name="checkmark-circle" size={14} color="#34C759" />
+                <Ionicons name="checkmark-circle" size={14} color={colors.success} />
               )}
             </View>
           )}
@@ -41,13 +43,13 @@ export function ProfileHeader({ user }: ProfileHeaderProps) {
 
       {/* Previously Linked Emails Section */}
       {linkedEmails.length > 0 && (
-        <View style={styles.linkedEmailsSection}>
+        <View style={[styles.linkedEmailsSection, { borderTopColor: colors.border }]}>
           <View style={styles.linkedEmailsHeader}>
-            <Ionicons name="mail-outline" size={16} color="#666" />
-            <Text style={styles.linkedEmailsTitle}>Previously Linked Emails</Text>
+            <Ionicons name="mail-outline" size={16} color={colors.textSecondary} />
+            <Text style={[styles.linkedEmailsTitle, { color: colors.textSecondary }]}>Previously Linked Emails</Text>
           </View>
           {linkedEmails.map((email, index) => (
-            <Text key={index} style={styles.linkedEmail}>
+            <Text key={index} style={[styles.linkedEmail, { color: colors.text }]}>
               {email}
             </Text>
           ))}
@@ -74,12 +76,10 @@ const styles = StyleSheet.create({
   name: {
     fontSize: 20,
     fontWeight: '600',
-    color: '#1a1a1a',
     marginBottom: 4,
   },
   email: {
     fontSize: 14,
-    color: '#8e8e93',
     marginBottom: 6,
   },
   phoneContainer: {
@@ -89,13 +89,11 @@ const styles = StyleSheet.create({
   },
   phone: {
     fontSize: 14,
-    color: '#8e8e93',
   },
   linkedEmailsSection: {
     marginTop: 16,
     paddingTop: 16,
     borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: '#e5e5e5',
   },
   linkedEmailsHeader: {
     flexDirection: 'row',
@@ -106,11 +104,9 @@ const styles = StyleSheet.create({
   linkedEmailsTitle: {
     fontSize: 13,
     fontWeight: '500',
-    color: '#8e8e93',
   },
   linkedEmail: {
     fontSize: 14,
-    color: '#1a1a1a',
     marginLeft: 24,
     marginBottom: 4,
   },

--- a/apps/mobile/features/profile/components/ProfileMenu.tsx
+++ b/apps/mobile/features/profile/components/ProfileMenu.tsx
@@ -4,16 +4,14 @@ import { useRouter } from 'expo-router';
 import { Card } from '@components/ui';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@providers/AuthProvider';
+import { useTheme } from '@hooks/useTheme';
 import { useAuthenticatedQuery, api } from '@services/api/convex';
 import type { Id } from '@services/api/convex';
-
-// Design constants
-const ICON_COLOR = "#1a1a1a";
-const ICON_BG = "#f5f5f5";
 
 export function ProfileMenu() {
   const router = useRouter();
   const { user, community } = useAuth();
+  const { colors } = useTheme();
   const userId = user?.id as Id<"users"> | undefined;
   const [isRefetching, setIsRefetching] = useState(false);
 
@@ -58,59 +56,59 @@ export function ProfileMenu() {
     <>
       <Card style={styles.section}>
         <TouchableOpacity
-          style={styles.menuItem}
+          style={[styles.menuItem, { borderBottomColor: colors.border }]}
           onPress={() => router.push('/(user)/edit-profile')}
           activeOpacity={0.7}
         >
-          <View style={styles.menuIconContainer}>
-            <Ionicons name="person-outline" size={20} color={ICON_COLOR} />
+          <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
+            <Ionicons name="person-outline" size={20} color={colors.text} />
           </View>
-          <Text style={styles.menuText}>Edit Profile</Text>
-          <Ionicons name="chevron-forward" size={18} color="#c7c7cc" />
+          <Text style={[styles.menuText, { color: colors.text }]}>Edit Profile</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
         </TouchableOpacity>
 
         <TouchableOpacity
-          style={styles.menuItem}
+          style={[styles.menuItem, { borderBottomColor: colors.border }]}
           onPress={handleSwitchCommunity}
           activeOpacity={0.7}
           disabled={isLoadingCommunities || isRefetching}
         >
-          <View style={styles.menuIconContainer}>
-            <Ionicons name="people-outline" size={20} color={ICON_COLOR} />
+          <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
+            <Ionicons name="people-outline" size={20} color={colors.text} />
           </View>
           {community?.name ? (
             <View style={styles.menuTextContainer}>
-              <Text style={styles.menuText}>Switch Community</Text>
-              <Text style={styles.menuSubtext}>{community.name}</Text>
+              <Text style={[styles.menuText, { color: colors.text }]}>Switch Community</Text>
+              <Text style={[styles.menuSubtext, { color: colors.textTertiary }]}>{community.name}</Text>
             </View>
           ) : (
-            <Text style={styles.menuText}>Pick a community</Text>
+            <Text style={[styles.menuText, { color: colors.text }]}>Pick a community</Text>
           )}
           {isLoadingCommunities || isRefetching ? (
-            <ActivityIndicator size="small" color="#999" />
+            <ActivityIndicator size="small" color={colors.textTertiary} />
           ) : (
-            <Ionicons name="chevron-forward" size={18} color="#c7c7cc" />
+            <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
           )}
         </TouchableOpacity>
 
         <TouchableOpacity
-          style={[styles.menuItem, styles.menuItemLast]}
+          style={[styles.menuItem, styles.menuItemLast, { borderBottomColor: colors.border }]}
           onPress={() => router.push('/(user)/settings')}
           activeOpacity={0.7}
         >
-          <View style={styles.menuIconContainer}>
-            <Ionicons name="settings-outline" size={20} color={ICON_COLOR} />
+          <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
+            <Ionicons name="settings-outline" size={20} color={colors.text} />
           </View>
-          <Text style={styles.menuText}>Settings</Text>
-          <Ionicons name="chevron-forward" size={18} color="#c7c7cc" />
+          <Text style={[styles.menuText, { color: colors.text }]}>Settings</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
         </TouchableOpacity>
       </Card>
 
       {hasLeaderAccess === true ? (
         <Card style={styles.section}>
-          <Text style={styles.sectionTitle}>Leader Tools</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textTertiary }]}>Leader Tools</Text>
           <TouchableOpacity
-            style={styles.menuItem}
+            style={[styles.menuItem, { borderBottomColor: colors.border }]}
             onPress={() =>
               router.push({
                 pathname: "/tasks",
@@ -119,14 +117,14 @@ export function ProfileMenu() {
             }
             activeOpacity={0.7}
           >
-            <View style={styles.menuIconContainer}>
-              <Ionicons name="checkbox-outline" size={20} color={ICON_COLOR} />
+            <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
+              <Ionicons name="checkbox-outline" size={20} color={colors.text} />
             </View>
-            <Text style={styles.menuText}>Tasks</Text>
-            <Ionicons name="chevron-forward" size={18} color="#c7c7cc" />
+            <Text style={[styles.menuText, { color: colors.text }]}>Tasks</Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
           </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.menuItem, styles.menuItemLast]}
+            style={[styles.menuItem, styles.menuItemLast, { borderBottomColor: colors.border }]}
             onPress={() =>
               router.push({
                 pathname: "/people",
@@ -135,11 +133,11 @@ export function ProfileMenu() {
             }
             activeOpacity={0.7}
           >
-            <View style={styles.menuIconContainer}>
-              <Ionicons name="people-outline" size={20} color={ICON_COLOR} />
+            <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
+              <Ionicons name="people-outline" size={20} color={colors.text} />
             </View>
-            <Text style={styles.menuText}>People</Text>
-            <Ionicons name="chevron-forward" size={18} color="#c7c7cc" />
+            <Text style={[styles.menuText, { color: colors.text }]}>People</Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
           </TouchableOpacity>
         </Card>
       ) : null}
@@ -159,7 +157,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 14,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#e5e5e5',
   },
   menuItemLast: {
     borderBottomWidth: 0,
@@ -168,7 +165,6 @@ const styles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 8,
-    backgroundColor: ICON_BG,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 14,
@@ -177,14 +173,12 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
     fontWeight: '400',
-    color: '#1a1a1a',
   },
   menuTextContainer: {
     flex: 1,
   },
   menuSubtext: {
     fontSize: 13,
-    color: '#8e8e93',
     marginTop: 2,
   },
   sectionTitle: {
@@ -192,7 +186,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     letterSpacing: 0.5,
     textTransform: 'uppercase',
-    color: '#8e8e93',
     marginTop: 8,
     marginBottom: 4,
   },

--- a/apps/mobile/theme/colors.ts
+++ b/apps/mobile/theme/colors.ts
@@ -124,7 +124,7 @@ export const lightColors: ThemeColors = {
 export const darkColors: ThemeColors = {
   // Backgrounds
   background: '#0b141a',
-  backgroundSecondary: '#0b141a',
+  backgroundSecondary: '#111b21',
   surface: '#1f2c34',
   surfaceSecondary: '#1a2730',
 


### PR DESCRIPTION
## Summary
- **DesktopSideNav**: Replace hardcoded `#fff` background and `#E5E5E5` border with theme-aware `colors.surface` / `colors.border` — was staying white in dark mode
- **ProfileHeader & ProfileMenu**: Migrate all remaining hardcoded light-mode colors (`#1a1a1a` text, `#f5f5f5` icon bg, `#e5e5e5` borders, etc.) to theme tokens — these components were never migrated in the original dark mode PR
- **ChatInboxScreen & MessageList**: Unify background color to `colors.surface` (matching the chat panel) instead of `colors.background` — eliminates the jarring two-shade effect in the inbox
- **Dark palette**: Adjust `backgroundSecondary` from `#0b141a` to `#111b21` for better contrast between page backgrounds and surface cards

## Test plan
- [x] Verified dark mode: profile page shows proper text, icon, and card colors
- [x] Verified dark mode: inbox has unified background across list and chat panels
- [x] Verified dark mode: sidebar uses theme-appropriate dark background
- [x] Verified light mode: profile, inbox, and sidebar all render correctly (no regression)
- [x] All 951 tests pass, 2 snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes that swap hardcoded colors for theme tokens and tweak the dark palette; main risk is minor UI contrast/regression differences across themes.
> 
> **Overview**
> Fixes dark-mode visual inconsistencies by migrating `DesktopSideNav`, `ProfileHeader`, and `ProfileMenu` off hardcoded light colors to `useTheme()` tokens (text, borders, icon backgrounds, inactive colors).
> 
> Unifies chat inbox and message list container backgrounds to `colors.surface` for consistent shading across inbox states, updates the dark palette `backgroundSecondary` for better contrast, and refreshes the affected snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43a9d069d57f924a04c5c73607f59c60c844a7fd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->