### PR TITLE
fix: default People view to announcement group instead of all groups

### DIFF
--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -1064,6 +1064,7 @@ export const getCrossGroupConfig = query({
         scoreConfigScores: [],
         leaderGroups: [],
         leaders: [],
+        announcementGroupId: null,
       };
     }
 

--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -853,7 +853,7 @@ export function FollowupDesktopTable({
     isLoading: crossGroupIsLoading,
   } = useAuthenticatedPaginatedQuery(
     api.functions.communityPeople.listAssignedToMe,
-    crossGroupMode && !hasTextSearch && communityId
+    crossGroupMode && !hasTextSearch && communityId && crossGroupFilter
       ? {
           communityId,
           sortBy:
@@ -914,7 +914,7 @@ export function FollowupDesktopTable({
   // Cross-group search query — uses communityPeople
   const crossGroupSearchResults = useAuthenticatedQuery(
     api.functions.communityPeople.searchAssignedToMe,
-    crossGroupMode && hasTextSearch && communityId
+    crossGroupMode && hasTextSearch && communityId && crossGroupFilter
       ? {
           communityId,
           searchTerm: parsedQuery.searchText,
@@ -955,12 +955,10 @@ export function FollowupDesktopTable({
       ? api.functions.communityPeople.countAssignedToMe
       : api.functions.communityPeople.count,
     crossGroupMode
-      ? communityId
+      ? communityId && crossGroupFilter
         ? {
             communityId,
-            ...(crossGroupFilter
-              ? { groupFilter: crossGroupFilter as Id<"groups"> }
-              : {}),
+            groupFilter: crossGroupFilter as Id<"groups">,
           }
         : "skip"
       : groupId

--- a/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
@@ -489,7 +489,7 @@ export function FollowupMobileGrid({
     isLoading: crossGroupIsLoading,
   } = useAuthenticatedPaginatedQuery(
     api.functions.communityPeople.listAssignedToMe,
-    crossGroupMode && !hasTextSearch && communityId
+    crossGroupMode && !hasTextSearch && communityId && crossGroupFilter
       ? {
           communityId,
           sortBy: serverSortBy,
@@ -534,7 +534,7 @@ export function FollowupMobileGrid({
 
   const crossGroupSearchResultsRaw = useAuthenticatedQuery(
     api.functions.communityPeople.searchAssignedToMe,
-    crossGroupMode && hasTextSearch && communityId
+    crossGroupMode && hasTextSearch && communityId && crossGroupFilter
       ? {
           communityId,
           searchTerm: parsedQuery.searchText,
@@ -581,12 +581,10 @@ export function FollowupMobileGrid({
       ? api.functions.communityPeople.countAssignedToMe
       : api.functions.communityPeople.count,
     crossGroupMode
-      ? communityId
+      ? communityId && crossGroupFilter
         ? {
             communityId,
-            ...(crossGroupFilter
-              ? { groupFilter: crossGroupFilter as Id<"groups"> }
-              : {}),
+            groupFilter: crossGroupFilter as Id<"groups">,
           }
         : "skip"
       : groupId


### PR DESCRIPTION
## Summary
- The "All Groups" default in cross-group People view showed duplicate rows since the same person appears in multiple groups' `communityPeople` records
- Now defaults to the announcement group (which contains all community members exactly once)
- Removed the "All Groups" option from the group dropdown entirely

## Changes
- **Backend** (`memberFollowups.getCrossGroupConfig`): Returns `announcementGroupId` from the leader's groups
- **Desktop** (`FollowupDesktopTable`): Defaults `crossGroupFilter` to announcement group ID, removed "All Groups" dropdown option
- **Mobile** (`FollowupMobileGrid`): Same default logic applied

## Test plan
- [ ] Navigate to Profile > Leader Tools > People
- [ ] Verify it defaults to the announcement group (not "All Groups")
- [ ] Verify no duplicate rows appear
- [ ] Verify the group dropdown no longer has "All Groups" option
- [ ] Switch between groups in dropdown — data updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/query-behavior change that alters the default cross-group People filter and adds a new config field; main risk is unexpected defaults if an announcement group isn’t present or clients rely on the prior "all" behavior.
> 
> **Overview**
> Defaults the cross-group *People* view to a single group (prefer the announcement group) instead of an implicit "all groups" view to avoid duplicate rows.
> 
> `memberFollowups.getCrossGroupConfig` now returns `announcementGroupId`, and both desktop (`FollowupDesktopTable`) and mobile (`FollowupMobileGrid`) initialize `crossGroupFilter` to that ID (fallback to the first leader group) and remove the "All Groups" dropdown option, updating query/count logic to treat an empty filter as unfiltered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d60a0e5cfe619b83cf01ca117f014d218e1a12d8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->