### PR TITLE
fix: native module detection for new architecture

### DIFF
--- a/apps/mobile/features/chat/utils/fileTypes.ts
+++ b/apps/mobile/features/chat/utils/fileTypes.ts
@@ -296,7 +296,7 @@ export function isAudioVideoSupported(): boolean {
 
   try {
     const ExpoAV = require('expo-av');
-    _audioVideoSupported = !!ExpoAV?.Audio;
+    _audioVideoSupported = !!ExpoAV?.Audio && !!ExpoAV?.Video;
     return _audioVideoSupported;
   } catch {
     _audioVideoSupported = false;


### PR DESCRIPTION
## Summary
- Native module detection (`isAudioVideoSupported`, `isDocumentPickerSupported`, `isLinearGradientSupported`) used `NativeModules.ExpoAV` etc. which returns `undefined` with the new architecture (Fabric/TurboModules)
- This caused the Voice button to not appear in chat on native iOS (v1.0.22)
- Added `hasNativeModule()` helper that checks both the legacy `NativeModules` bridge and `expo-modules-core`'s `requireNativeModule()` for new arch compatibility

## Test plan
- [ ] On native iOS: open chat, tap +, verify Voice option appears
- [ ] Record and send a voice memo on native
- [ ] Verify document picker still works (file attachments)
- [ ] Verify on web: voice recording still works via MediaRecorder API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches runtime native-module availability checks that gate chat attachments and media playback; incorrect detection could hide features or trigger failed dynamic imports on device.
> 
> **Overview**
> Fixes native module availability checks used by chat attachments/media so they work on the new RN architecture (Fabric/TurboModules) instead of relying solely on `NativeModules`.
> 
> Adds a `hasNativeModule()` helper that falls back to `expo-modules-core.requireNativeModule()` and updates `isDocumentPickerSupported`, `isAudioVideoSupported`, and `isLinearGradientSupported` to use it; `isAudioVideoSupported` now keys support off `expo-av`’s `Audio` export (not `Video`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee12b8d2611690834d4625a93ac9f484c2a416d4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->