### PR TITLE
fix(chat): polish voice message UI and attachment panel

### DIFF
--- a/apps/mobile/features/chat/components/AttachmentPanel.tsx
+++ b/apps/mobile/features/chat/components/AttachmentPanel.tsx
@@ -48,7 +48,7 @@ export function AttachmentPanel({ visible, options, onOptionPress }: AttachmentP
 
   return (
     <Animated.View style={[styles.container, { height: heightAnim }]}>
-      <View style={[styles.inner, { backgroundColor: colors.surfaceSecondary, borderTopColor: colors.border }]}>
+      <View style={[styles.inner, { backgroundColor: colors.surface }]}>
         <View style={styles.grid}>
           {options.map((option) => (
             <Pressable
@@ -96,7 +96,6 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 16,
     paddingHorizontal: 24,
-    borderTopWidth: 1,
   },
   grid: {
     flexDirection: 'row',

--- a/apps/mobile/features/chat/components/AudioPlayer.tsx
+++ b/apps/mobile/features/chat/components/AudioPlayer.tsx
@@ -223,7 +223,9 @@ function AudioPlayerWeb({ url, name, isOwnMessage = false, waveform, storedDurat
 
   const playedFraction = duration > 0 ? position / duration : 0;
   const displayDuration = duration || storedDuration || 0;
-  const accentColor = isOwnMessage ? '#fff' : (isDark ? '#aaa' : '#555');
+  const accentColor = isOwnMessage
+    ? (isDark ? '#fff' : 'rgba(0,0,0,0.55)')
+    : (isDark ? '#aaa' : '#333');
 
   if (error) {
     return <AudioDownloadFallback url={url} name={name} isOwnMessage={isOwnMessage} />;
@@ -232,7 +234,7 @@ function AudioPlayerWeb({ url, name, isOwnMessage = false, waveform, storedDurat
   return (
     <View style={styles.container}>
       <Pressable
-        style={[styles.playButton, { backgroundColor: isOwnMessage ? 'rgba(255,255,255,0.25)' : (isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)') }]}
+        style={[styles.playButton, { backgroundColor: isOwnMessage ? (isDark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.12)') : (isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)') }]}
         onPress={togglePlayPause}
         disabled={isLoading}
       >
@@ -242,7 +244,7 @@ function AudioPlayerWeb({ url, name, isOwnMessage = false, waveform, storedDurat
           <Ionicons
             name={isPlaying ? 'pause' : 'play'}
             size={18}
-            color={isOwnMessage ? '#fff' : colors.text}
+            color={isOwnMessage ? (isDark ? '#fff' : 'rgba(0,0,0,0.6)') : colors.text}
           />
         )}
       </Pressable>
@@ -257,7 +259,7 @@ function AudioPlayerWeb({ url, name, isOwnMessage = false, waveform, storedDurat
         />
       </Pressable>
 
-      <Text style={[styles.time, { color: isOwnMessage ? 'rgba(255,255,255,0.7)' : colors.textSecondary }]}>
+      <Text style={[styles.time, { color: isOwnMessage ? (isDark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.45)') : colors.textSecondary }]}>
         {formatTime(isPlaying ? position : displayDuration)}
       </Text>
     </View>
@@ -382,7 +384,9 @@ function AudioPlayerInner({ url, name, isOwnMessage = false, waveform, storedDur
 
   const playedFraction = duration > 0 ? position / duration : 0;
   const displayDuration = duration || storedDuration || 0;
-  const accentColor = isOwnMessage ? '#fff' : (isDark ? '#aaa' : '#555');
+  const accentColor = isOwnMessage
+    ? (isDark ? '#fff' : 'rgba(0,0,0,0.55)')
+    : (isDark ? '#aaa' : '#333');
 
   if (error) {
     return <AudioDownloadFallback url={url} name={name} isOwnMessage={isOwnMessage} />;
@@ -391,7 +395,7 @@ function AudioPlayerInner({ url, name, isOwnMessage = false, waveform, storedDur
   return (
     <View style={styles.container}>
       <Pressable
-        style={[styles.playButton, { backgroundColor: isOwnMessage ? 'rgba(255,255,255,0.25)' : (isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)') }]}
+        style={[styles.playButton, { backgroundColor: isOwnMessage ? (isDark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.12)') : (isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)') }]}
         onPress={togglePlayPause}
         disabled={isLoading}
       >
@@ -401,7 +405,7 @@ function AudioPlayerInner({ url, name, isOwnMessage = false, waveform, storedDur
           <Ionicons
             name={isPlaying ? 'pause' : 'play'}
             size={18}
-            color={isOwnMessage ? '#fff' : colors.text}
+            color={isOwnMessage ? (isDark ? '#fff' : 'rgba(0,0,0,0.6)') : colors.text}
           />
         )}
       </Pressable>
@@ -422,7 +426,7 @@ function AudioPlayerInner({ url, name, isOwnMessage = false, waveform, storedDur
         />
       </Pressable>
 
-      <Text style={[styles.time, { color: isOwnMessage ? 'rgba(255,255,255,0.7)' : colors.textSecondary }]}>
+      <Text style={[styles.time, { color: isOwnMessage ? (isDark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.45)') : colors.textSecondary }]}>
         {formatTime(isPlaying ? position : displayDuration)}
       </Text>
     </View>

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -807,7 +807,11 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
       {isVoiceRecording ? (
         <VoiceRecorderBar
           onSend={handleVoiceMemoSend}
-          onCancel={() => setIsVoiceRecording(false)}
+          onCancel={() => {
+            setIsVoiceRecording(false);
+            setShowAttachmentMenu(false);
+            rotateAnim.setValue(0);
+          }}
         />
       ) : (
       <>

--- a/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
+++ b/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
@@ -7,7 +7,7 @@
  * - 7-day auto-delete disclaimer
  */
 
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef, useEffect, useContext } from 'react';
 import {
   View,
   Text,
@@ -22,6 +22,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { WaveformBars } from './WaveformBars';
 import { useVoiceRecorder } from '../hooks/useVoiceRecorder';
 import { isAudioVideoSupported } from '../utils/fileTypes';
+import { ThemeContext } from '@/providers/ThemeProvider';
 
 const DISCLAIMER_TEXT = 'Voice messages delete after 7 days';
 
@@ -38,6 +39,7 @@ interface VoiceRecorderBarProps {
 }
 
 export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
+  const { colors } = useContext(ThemeContext);
   const {
     state,
     durationMs,
@@ -181,10 +183,10 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
 
   if (state === 'sending') {
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor: colors.surface, borderTopColor: colors.border }]}>
         <View style={styles.row}>
-          <ActivityIndicator size="small" color="#007AFF" />
-          <Text style={styles.sendingText}>Sending...</Text>
+          <ActivityIndicator size="small" color={colors.link} />
+          <Text style={[styles.sendingText, { color: colors.textSecondary }]}>Sending...</Text>
         </View>
       </View>
     );
@@ -194,13 +196,13 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
   const isPreview = state === 'preview';
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.disclaimer}>{DISCLAIMER_TEXT}</Text>
+    <View style={[styles.container, { backgroundColor: colors.surface, borderTopColor: colors.border }]}>
+      <Text style={[styles.disclaimer, { color: colors.textTertiary }]}>{DISCLAIMER_TEXT}</Text>
 
       <View style={styles.row}>
         {/* Delete */}
         <Pressable style={styles.iconButton} onPress={handleDelete}>
-          <Ionicons name="trash-outline" size={22} color="#e74c3c" />
+          <Ionicons name="trash-outline" size={22} color={colors.destructive} />
         </Pressable>
 
         {/* Waveform */}
@@ -208,11 +210,12 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
           <WaveformBars
             meteringData={meteringData}
             playedFraction={isPreview ? previewPlayedFraction : 1}
+            accentColor={colors.textSecondary}
           />
         </View>
 
         {/* Timer */}
-        <Text style={styles.timer}>{formatDuration(durationMs)}</Text>
+        <Text style={[styles.timer, { color: colors.text }]}>{formatDuration(durationMs)}</Text>
 
         {isRecording && (
           <>
@@ -224,12 +227,12 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
               <Ionicons
                 name={state === 'recording' ? 'pause' : 'play'}
                 size={24}
-                color="#007AFF"
+                color={colors.link}
               />
             </Pressable>
             {/* Stop */}
             <Pressable style={styles.iconButton} onPress={stopRecording}>
-              <Ionicons name="stop" size={24} color="#007AFF" />
+              <Ionicons name="stop" size={24} color={colors.link} />
             </Pressable>
           </>
         )}
@@ -241,11 +244,11 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
               <Ionicons
                 name={previewPlaying ? 'pause' : 'play'}
                 size={24}
-                color="#007AFF"
+                color={colors.link}
               />
             </Pressable>
             {/* Send */}
-            <Pressable style={[styles.iconButton, styles.sendButton]} onPress={handleSend}>
+            <Pressable style={[styles.iconButton, styles.sendButton, { backgroundColor: colors.link }]} onPress={handleSend}>
               <Ionicons name="send" size={20} color="#fff" />
             </Pressable>
           </>
@@ -257,15 +260,12 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#fff',
     borderTopWidth: 1,
-    borderTopColor: '#e0e0e0',
     paddingVertical: 12,
     paddingHorizontal: 8,
   },
   disclaimer: {
     fontSize: 11,
-    color: '#999',
     textAlign: 'center',
     marginBottom: 8,
   },
@@ -282,9 +282,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  sendButton: {
-    backgroundColor: '#007AFF',
-  },
+  sendButton: {},
   waveformContainer: {
     flex: 1,
     maxWidth: 200,
@@ -292,13 +290,11 @@ const styles = StyleSheet.create({
   timer: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#333',
     minWidth: 36,
     textAlign: 'center',
   },
   sendingText: {
     fontSize: 14,
-    color: '#666',
     marginLeft: 8,
   },
 });


### PR DESCRIPTION
## Summary
- **AudioPlayer light mode visibility**: Waveform bars and play button were nearly invisible on light message bubbles (white-on-light-blue). Now uses darker accent colors in light mode.
- **Attachment panel background**: Removed gray `surfaceSecondary` background and border that created a visual double-background effect. Panel now uses the same `surface` color as the rest of the UI.
- **VoiceRecorderBar theme colors**: Replaced hardcoded color values with theme-aware colors for proper light/dark mode support.
- **MessageInput cleanup**: Reset attachment menu state when canceling voice recording.

## Test plan
- [ ] Light mode: verify waveform bars visible on own message bubbles (blue)
- [ ] Light mode: verify waveform bars visible on received messages
- [ ] Dark mode: verify attachment panel has no double background
- [ ] Light mode: verify attachment panel background matches main UI
- [ ] Verify voice recorder bar uses correct theme colors in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that adjust theming/styling and reset local component state; no auth, backend, or data-flow changes.
> 
> **Overview**
> Improves chat UI theming/contrast for attachments and voice messages.
> 
> The inline `AttachmentPanel` now uses `colors.surface` and drops the top border to avoid a double-background look. `AudioPlayer` updates waveform accent colors to improve light-mode visibility (especially for own-message bubbles). `VoiceRecorderBar` replaces hardcoded colors with theme-aware values (including waveform accent and send button styling), and `MessageInput` now fully resets attachment menu/rotation state when cancelling a voice recording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86c23b39ea18aa757c10b4c26534295f5509b71c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->