### PR TITLE
fix: web sign-in crash and native voice waveform

### DIFF
--- a/apps/mobile/features/chat/hooks/useVoiceRecorder.ts
+++ b/apps/mobile/features/chat/hooks/useVoiceRecorder.ts
@@ -328,6 +328,7 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
 
       const { recording } = await Audio.Recording.createAsync(
         {
+          isMeteringEnabled: true,
           android: {
             extension: '.m4a',
             outputFormat: Audio.AndroidOutputFormat.MPEG_4,

--- a/apps/mobile/features/chat/utils/fileTypes.ts
+++ b/apps/mobile/features/chat/utils/fileTypes.ts
@@ -243,7 +243,13 @@ function hasNativeModule(...moduleNames: string[]): boolean {
     if (NativeModules[name]) return true;
   }
 
-  // New architecture: try expo-modules-core's requireNativeModule
+  // On web, native modules don't exist — skip expo-modules-core
+  // (it ships TypeScript source which can't be required on web)
+  if (Platform.OS === 'web') {
+    return false;
+  }
+
+  // New architecture (native only): try expo-modules-core's requireNativeModule
   try {
     const expoModulesCore = require('expo-modules-core');
     for (const name of moduleNames) {


### PR DESCRIPTION
## Summary
- **Web crash fix**: `hasNativeModule()` tried to `require('expo-modules-core')` on web, which fails because the package ships TypeScript source. Added `Platform.OS === 'web'` guard to skip this path. This was breaking the sign-in page (and likely other pages).
- **Native waveform fix**: Voice recording on iOS didn't show live waveform bars because `isMeteringEnabled: true` was missing from the expo-av recording options. `status.metering` was always `undefined`.

## Test plan
- [ ] Web: sign-in page phone input is clickable/focusable
- [ ] Web: voice recording still works with waveform
- [ ] iOS native: voice recording shows live waveform bars during recording
- [ ] iOS native: voice messages play correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cross-platform native-module detection (can affect feature gating on web/native) and modifies voice recording configuration that could impact recording behavior on iOS/Android.
> 
> **Overview**
> Prevents a **web runtime crash** by updating `hasNativeModule()` to return `false` on `Platform.OS === 'web'` instead of attempting to `require('expo-modules-core')`.
> 
> Improves **native voice message waveform rendering** by enabling `expo-av` recording metering (`isMeteringEnabled: true`) so `status.metering` is populated during recording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fdce48333103ac4d06ea73c184c4bdc530d43f0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->