### PR TITLE
fix: sign-in phone input focus and typing on web

### DIFF
--- a/apps/mobile/components/guards/AuthGuard.tsx
+++ b/apps/mobile/components/guards/AuthGuard.tsx
@@ -150,19 +150,30 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, isAuthenticated, userId]);
 
-  // Don't show loading spinner if forceShow is true
-  if (isLoading && !forceShow) {
-    const timestamp = new Date().toISOString();
-    console.log(`🔄 [AuthGuard] [${timestamp}] Showing loading spinner`, {
-      isLoading,
-      forceShow,
-    });
-    return (
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <ActivityIndicator size="large" />
-      </View>
-    );
-  }
+  // Always render children to preserve focus/mount state (prevents TextInput
+  // focus loss on web when isLoading toggles). Overlay a spinner when loading.
+  const showSpinner = isLoading && !forceShow;
 
-  return <>{children}</>;
+  return (
+    <View style={{ flex: 1 }}>
+      {children}
+      {showSpinner && (
+        <View
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            justifyContent: "center",
+            alignItems: "center",
+            backgroundColor: "rgba(255,255,255,0.85)",
+            zIndex: 999,
+          }}
+        >
+          <ActivityIndicator size="large" />
+        </View>
+      )}
+    </View>
+  );
 }

--- a/apps/mobile/features/auth/components/PhoneSignInForm.tsx
+++ b/apps/mobile/features/auth/components/PhoneSignInForm.tsx
@@ -7,6 +7,7 @@ import {
   ActivityIndicator,
   Keyboard,
   TouchableWithoutFeedback,
+  Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
@@ -14,6 +15,22 @@ import { PhoneInput } from "@/components/ui/PhoneInput";
 import { OTPInput } from "@/components/ui/OTPInput";
 import { ProgrammaticTextInput } from "@/components/ui/ProgrammaticTextInput";
 import { useTheme } from "@hooks/useTheme";
+
+/**
+ * On native, wraps children in TouchableWithoutFeedback to dismiss the keyboard
+ * when tapping outside inputs. On web, this is unnecessary and
+ * TouchableWithoutFeedback interferes with TextInput focus/typing.
+ */
+function DismissKeyboardWrapper({ children }: { children: React.ReactNode }) {
+  if (Platform.OS === 'web') {
+    return <>{children}</>;
+  }
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      {children}
+    </TouchableWithoutFeedback>
+  );
+}
 
 interface PhoneSignInFormProps {
   // Phone step
@@ -92,7 +109,7 @@ export function PhoneSignInForm({
   if (step === "phone") {
     const isSubmitDisabled = isLoading || !termsAccepted;
     return (
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <DismissKeyboardWrapper>
         <View style={styles.container}>
           {/* Content area */}
           <View style={styles.content}>
@@ -155,13 +172,13 @@ export function PhoneSignInForm({
             </TouchableOpacity>
           </View>
         </View>
-      </TouchableWithoutFeedback>
+      </DismissKeyboardWrapper>
     );
   }
 
   if (step === "otp") {
     return (
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <DismissKeyboardWrapper>
         <View style={styles.container}>
           <View style={styles.content}>
             {/* Back button */}
@@ -210,13 +227,13 @@ export function PhoneSignInForm({
             </TouchableOpacity>
           </View>
         </View>
-      </TouchableWithoutFeedback>
+      </DismissKeyboardWrapper>
     );
   }
 
   // Legacy login step
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+    <DismissKeyboardWrapper>
       <View style={styles.container}>
         <View style={styles.content}>
           <TouchableOpacity style={styles.backButton} onPress={onSwitchToPhone}>
@@ -310,7 +327,7 @@ export function PhoneSignInForm({
           </View>
         </View>
       </View>
-    </TouchableWithoutFeedback>
+    </DismissKeyboardWrapper>
   );
 }
 


### PR DESCRIPTION
## Summary
- `TouchableWithoutFeedback` wrapping the sign-in form called `Keyboard.dismiss()` on every click. On web, click events bubble from TextInput to the wrapper, calling `document.activeElement.blur()` which immediately kills input focus. On native this doesn't happen because the touch system doesn't bubble from TextInput.
- `DismissKeyboardWrapper` renders `TouchableWithoutFeedback` only on native; on web it renders a plain fragment since the browser handles keyboard dismissal natively.
- AuthGuard now always renders children with a loading overlay instead of conditionally swapping, preventing unmount/remount cycles that could steal focus.

## Test plan
- [x] Open sign-in page on web (`/signin`)
- [x] Click into phone number input — focus is retained
- [x] Type phone number — characters appear correctly
- [x] Verified via Playwright with `pressSequentially` (real keystroke simulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guard rendering behavior and input wrappers in the sign-in flow; while localized to UI, it affects auth-page loading presentation and could impact interaction/layout across platforms.
> 
> **Overview**
> Fixes web sign-in focus/typing issues by replacing `TouchableWithoutFeedback` keyboard-dismiss wrappers with a platform-aware `DismissKeyboardWrapper` that only dismisses on native.
> 
> Updates `AuthGuard` to **always render its children** and show a full-screen loading *overlay* instead of conditionally swapping in a spinner, preventing unmount/remount cycles that can steal `TextInput` focus when `isLoading` toggles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b506c849265cb7ca15494793ee94f8bd41453f8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->