### PR TITLE
fix: iOS voice recording crash and inaudible playback

### DIFF
--- a/apps/mobile/features/chat/hooks/useVoiceRecorder.ts
+++ b/apps/mobile/features/chat/hooks/useVoiceRecorder.ts
@@ -291,6 +291,17 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
         // ignore
       }
       recordingRef.current = null;
+
+      // Reset to playback mode so audio plays through the speaker
+      try {
+        const { Audio } = require('expo-av');
+        await Audio.setAudioModeAsync({
+          allowsRecordingIOS: false,
+          playsInSilentModeIOS: true,
+        });
+      } catch {
+        // best-effort
+      }
     }
   }, []);
 
@@ -318,13 +329,30 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
         return;
       }
 
-      await Audio.setAudioModeAsync({
-        allowsRecordingIOS: true,
-        playsInSilentModeIOS: true,
-        staysActiveInBackground: false,
-        shouldDuckAndroid: true,
-        playThroughEarpieceAndroid: false,
-      });
+      // After the permission dialog dismisses, iOS briefly considers the app
+      // "in background" and setAudioModeAsync fails. Retry with backoff.
+      let audioModeSet = false;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          await Audio.setAudioModeAsync({
+            allowsRecordingIOS: true,
+            playsInSilentModeIOS: true,
+            staysActiveInBackground: false,
+            shouldDuckAndroid: true,
+            playThroughEarpieceAndroid: false,
+          });
+          audioModeSet = true;
+          break;
+        } catch (audioModeErr) {
+          if (attempt < 2) {
+            // Wait for the app to return to foreground
+            await new Promise(resolve => setTimeout(resolve, 300 * (attempt + 1)));
+          } else {
+            throw audioModeErr;
+          }
+        }
+      }
+      if (!audioModeSet) return;
 
       const { recording } = await Audio.Recording.createAsync(
         {
@@ -392,6 +420,11 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
               const uri = rec.getURI();
               setFileUri(uri);
               setState('preview');
+              // Reset to playback mode
+              try {
+                const { Audio: A } = require('expo-av');
+                await A.setAudioModeAsync({ allowsRecordingIOS: false, playsInSilentModeIOS: true });
+              } catch { /* best-effort */ }
               if (meteringIntervalRef.current) {
                 clearInterval(meteringIntervalRef.current);
                 meteringIntervalRef.current = null;
@@ -462,6 +495,11 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
               const uri = r.getURI();
               setFileUri(uri);
               setState('preview');
+              // Reset to playback mode
+              try {
+                const { Audio: A } = require('expo-av');
+                await A.setAudioModeAsync({ allowsRecordingIOS: false, playsInSilentModeIOS: true });
+              } catch { /* best-effort */ }
               if (meteringIntervalRef.current) {
                 clearInterval(meteringIntervalRef.current);
                 meteringIntervalRef.current = null;
@@ -488,6 +526,19 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
         const uri = rec.getURI();
         setFileUri(uri);
         setState('preview');
+
+        // Switch back to playback mode so audio plays through the speaker
+        // instead of the earpiece. Without this, all playback after recording
+        // is routed to the earpiece and sounds inaudible.
+        try {
+          const { Audio } = require('expo-av');
+          await Audio.setAudioModeAsync({
+            allowsRecordingIOS: false,
+            playsInSilentModeIOS: true,
+          });
+        } catch {
+          // Best-effort — don't block the flow
+        }
       } catch (err) {
         console.error('[useVoiceRecorder] Stop error:', err);
         setError(err instanceof Error ? err.message : 'Failed to stop');


### PR DESCRIPTION
## Summary
- **First-time recording crash**: After the iOS mic permission dialog dismisses, iOS briefly considers the app "in background" and `Audio.setAudioModeAsync()` fails. Added retry with backoff (3 attempts, 300ms/600ms delays) to let the app return to foreground.
- **Inaudible playback after recording**: `allowsRecordingIOS: true` was never reset to `false` after recording, leaving iOS audio routed through the **earpiece** instead of the speaker. Now reset in `stopRecording`, `cleanup`, and all auto-stop paths.

## Test plan
- [ ] Record a voice memo on iOS for the first time (fresh app install or cleared permissions) — should no longer crash
- [ ] After recording and sending a voice memo, tap play on that message — audio should play through the speaker, not the earpiece
- [ ] Record, cancel, then play any audio message — should still play through speaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native audio session configuration (`Audio.setAudioModeAsync`) and stop/cleanup paths, which can affect recording/playback behavior across iOS/Android. Changes are localized but impact a user-facing, timing-sensitive flow.
> 
> **Overview**
> Improves iOS voice recording reliability by retrying `Audio.setAudioModeAsync` with a short backoff after the mic permission dialog to avoid a first-run failure.
> 
> Ensures playback routes to the speaker again by resetting `allowsRecordingIOS` to `false` after recording ends, covering `stopRecording`, `cleanup`, and max-duration auto-stop paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dd03a60958253b422867156ab11975133cddcf9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->