### PR TITLE
fix: retry entire audio setup after iOS permission dialog + prevent alert stacking

### DIFF
--- a/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
+++ b/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
@@ -168,8 +168,10 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
     };
   }, []);
 
+  const alertShownForRef = useRef<string | null>(null);
   useEffect(() => {
-    if (error) {
+    if (error && error !== alertShownForRef.current) {
+      alertShownForRef.current = error;
       Alert.alert(
         'Voice Recording',
         error,
@@ -178,6 +180,9 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
           ...(Platform.OS !== 'web' ? [{ text: 'Open Settings', onPress: () => Linking.openSettings?.() }] : []),
         ]
       );
+    }
+    if (!error) {
+      alertShownForRef.current = null;
     }
   }, [error, onCancel]);
 

--- a/apps/mobile/features/chat/hooks/useVoiceRecorder.ts
+++ b/apps/mobile/features/chat/hooks/useVoiceRecorder.ts
@@ -329,10 +329,12 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
         return;
       }
 
-      // After the permission dialog dismisses, iOS briefly considers the app
-      // "in background" and setAudioModeAsync fails. Retry with backoff.
-      let audioModeSet = false;
-      for (let attempt = 0; attempt < 3; attempt++) {
+      // After the iOS permission dialog dismisses, iOS briefly considers the
+      // app "in background". Both setAudioModeAsync and Recording.createAsync
+      // fail because the audio session can't activate while backgrounded.
+      // Retry the entire setup with backoff to let the app return to foreground.
+      let recording: any = null;
+      for (let attempt = 0; attempt < 5; attempt++) {
         try {
           await Audio.setAudioModeAsync({
             allowsRecordingIOS: true,
@@ -341,50 +343,51 @@ function useVoiceRecorderNative(): VoiceRecorderResult {
             shouldDuckAndroid: true,
             playThroughEarpieceAndroid: false,
           });
-          audioModeSet = true;
+
+          const result = await Audio.Recording.createAsync(
+            {
+              isMeteringEnabled: true,
+              android: {
+                extension: '.m4a',
+                outputFormat: Audio.AndroidOutputFormat.MPEG_4,
+                audioEncoder: Audio.AndroidAudioEncoder.AAC,
+                sampleRate: 22050,
+                numberOfChannels: 1,
+                bitRate: 32000,
+              },
+              ios: {
+                extension: '.m4a',
+                outputFormat: Audio.IOSOutputFormat.MPEG4AAC,
+                audioQuality: Audio.IOSAudioQuality.LOW,
+                sampleRate: 22050,
+                numberOfChannels: 1,
+                bitRate: 32000,
+              },
+              web: {
+                mimeType: 'audio/webm',
+                bitsPerSecond: 32000,
+              },
+            },
+            (status: any) => {
+              if (status.isRecording && status.durationMillis !== undefined) {
+                setDurationMs(status.durationMillis);
+              }
+            },
+            100
+          );
+          recording = result.recording;
           break;
-        } catch (audioModeErr) {
-          if (attempt < 2) {
-            // Wait for the app to return to foreground
-            await new Promise(resolve => setTimeout(resolve, 300 * (attempt + 1)));
+        } catch (setupErr: any) {
+          const isBgError = setupErr?.message?.includes('background') ||
+            setupErr?.message?.includes('audio session could not be activated');
+          if (isBgError && attempt < 4) {
+            await new Promise(resolve => setTimeout(resolve, 400 * (attempt + 1)));
           } else {
-            throw audioModeErr;
+            throw setupErr;
           }
         }
       }
-      if (!audioModeSet) return;
-
-      const { recording } = await Audio.Recording.createAsync(
-        {
-          isMeteringEnabled: true,
-          android: {
-            extension: '.m4a',
-            outputFormat: Audio.AndroidOutputFormat.MPEG_4,
-            audioEncoder: Audio.AndroidAudioEncoder.AAC,
-            sampleRate: 22050,
-            numberOfChannels: 1,
-            bitRate: 32000,
-          },
-          ios: {
-            extension: '.m4a',
-            outputFormat: Audio.IOSOutputFormat.MPEG4AAC,
-            audioQuality: Audio.IOSAudioQuality.LOW,
-            sampleRate: 22050,
-            numberOfChannels: 1,
-            bitRate: 32000,
-          },
-          web: {
-            mimeType: 'audio/webm',
-            bitsPerSecond: 32000,
-          },
-        },
-        (status) => {
-          if (status.isRecording && status.durationMillis !== undefined) {
-            setDurationMs(status.durationMillis);
-          }
-        },
-        100
-      );
+      if (!recording) return;
 
       recordingRef.current = recording;
       startTimeRef.current = Date.now();


### PR DESCRIPTION
## Summary
- Previous retry only covered `setAudioModeAsync`, but `Recording.createAsync` ("Prepare" step) also fails with the same "background" error after the iOS permission dialog. Now retries the **entire setup** (audio mode + create recording) up to 5 times with 400ms incremental backoff. Only retries on the specific background error; other errors throw immediately.
- `VoiceRecorderBar` showed `Alert.alert()` in a `useEffect` that fired on every `onCancel` reference change, stacking 20+ identical alerts. Added a ref to track which error has been shown, preventing duplicate alerts.

## Test plan
- [ ] Fresh install / reset mic permissions → tap Voice Memo → grant permission → should start recording without errors
- [ ] If recording does fail, only ONE alert should appear (not 20+)
- [ ] Normal recording flow still works on second+ attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core voice-recording startup on native by adding retry/backoff around audio session setup and recording creation, which could affect recording reliability across devices. UI change is low risk but touches user-visible error handling.
> 
> **Overview**
> Improves native voice recording startup by retrying the *entire* `expo-av` setup (audio mode + `Recording.createAsync`) with backoff when iOS temporarily reports the app as backgrounded after the mic permission dialog.
> 
> Prevents duplicate error dialogs in `VoiceRecorderBar` by tracking the last shown `error` in a ref and only showing an `Alert` when the error message changes (resetting when the error clears).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de1dbd66c7ff6cdea2a3a99ea88c138b8da5045f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->