### PR TITLE
fix: use native binary version for force-update check

### DIFF
--- a/apps/mobile/components/ui/NativeUpdateModal.tsx
+++ b/apps/mobile/components/ui/NativeUpdateModal.tsx
@@ -12,6 +12,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import * as Updates from 'expo-updates';
 import Constants from 'expo-constants';
+import * as Application from 'expo-application';
 import { DEFAULT_PRIMARY_COLOR } from '@utils/styles';
 import { DOMAIN_CONFIG } from '@togather/shared';
 import { useTheme } from '@hooks/useTheme';
@@ -88,7 +89,11 @@ export function NativeUpdateModal() {
   const [isChecking, setIsChecking] = useState(true);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
 
-  const currentVersion = Constants.expoConfig?.version || '1.0.0';
+  // Use nativeApplicationVersion (from Info.plist / build.gradle) instead of
+  // Constants.expoConfig.version — the latter changes with OTA updates, so all
+  // users on the same runtimeVersion would report the latest OTA version and
+  // never see the force-update modal.
+  const currentVersion = Application.nativeApplicationVersion || Constants.expoConfig?.version || '1.0.0';
   const isAndroid = Platform.OS === 'android';
   const { colors, isDark } = useTheme();
 


### PR DESCRIPTION
## Summary
- Force-update modal was never triggering because `Constants.expoConfig.version` reflects the OTA bundle config, not the native binary. Since all builds share `runtimeVersion` 1.0.21 and all receive OTA updates, every user's app reports version 1.0.22 — so `1.0.22 < 1.0.22` is always false.
- Switch to `Application.nativeApplicationVersion` (from `expo-application`, already installed) which reads from Info.plist / build.gradle and doesn't change with OTA updates.

## Test plan
- [ ] Deploy OTA to production — users on old native builds (e.g. 1.0.20) should now see the force-update modal
- [ ] Users on 1.0.22 native build should NOT see the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the version source used to trigger a non-dismissable force-update modal; incorrect values could block users or fail to prompt updates.
> 
> **Overview**
> Updates `NativeUpdateModal` to derive `currentVersion` from `expo-application`’s `nativeApplicationVersion` (with fallback to `Constants.expoConfig.version`) so native force-update checks aren’t masked by OTA-updated Expo config versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 526fd10d6bd7e39940bba5d2a3274b75b7e7c273. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->