### PR TITLE
debug: add version source logging to NativeUpdateModal

### DIFF
--- a/apps/mobile/components/ui/NativeUpdateModal.tsx
+++ b/apps/mobile/components/ui/NativeUpdateModal.tsx
@@ -93,8 +93,21 @@ export function NativeUpdateModal() {
   // Constants.expoConfig.version — the latter changes with OTA updates, so all
   // users on the same runtimeVersion would report the latest OTA version and
   // never see the force-update modal.
-  const currentVersion = Application.nativeApplicationVersion || Constants.expoConfig?.version || '1.0.0';
+  const nativeVersion = Application.nativeApplicationVersion;
+  const expoVersion = Constants.expoConfig?.version;
+  const currentVersion = nativeVersion || expoVersion || '1.0.0';
   const isAndroid = Platform.OS === 'android';
+
+  // Debug: log all version sources to diagnose force-update issues
+  useEffect(() => {
+    console.log('[NativeUpdateModal] Version sources:', {
+      nativeApplicationVersion: nativeVersion,
+      expoConfigVersion: expoVersion,
+      resolvedCurrentVersion: currentVersion,
+      runtimeVersion: Constants.expoConfig?.runtimeVersion,
+      __DEV__,
+    });
+  }, []);
   const { colors, isDark } = useTheme();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Temporary debug logging to diagnose why force-update modal isn't triggering on old native builds. Logs `nativeApplicationVersion`, `expoConfig.version`, and the resolved version.

## Test plan
- [ ] Deploy OTA to production, check logs on old native build to see what versions are reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, as this only adds client-side debug logging and minor refactoring of version resolution; main concern is increased production log volume or leaking version metadata into logs.
> 
> **Overview**
> Adds temporary debug instrumentation to `NativeUpdateModal` to log `nativeApplicationVersion`, `expoConfig.version`, `runtimeVersion`, and the resolved `currentVersion` on mount.
> 
> Refactors version selection to store native/expo versions separately before resolving `currentVersion`, without changing the update-check logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db502a89fe83c2e05d5d62025b390623fbe96f9c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->