### PR TITLE
feat(settings): show native app version in App Info

### DIFF
--- a/apps/mobile/features/settings/components/AppInfoSection.tsx
+++ b/apps/mobile/features/settings/components/AppInfoSection.tsx
@@ -19,6 +19,7 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
+import * as Application from "expo-application";
 import * as Updates from "expo-updates";
 import { logCollector } from "@utils/logCollector";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
@@ -268,6 +269,18 @@ ${logs || "No logs captured yet. Try reproducing the issue first."}`;
           )}
         </View>
       </TouchableOpacity>
+
+      {/* Native app version (from Info.plist / build.gradle — doesn't change with OTA) */}
+      <View style={[styles.infoRow, { borderBottomColor: colors.surfaceSecondary }]}>
+        <View style={styles.infoLabel}>
+          <Ionicons name="hammer-outline" size={18} color={colors.textSecondary} />
+          <Text style={[styles.labelText, { color: colors.textSecondary }]}>Native Version</Text>
+        </View>
+        <Text style={[styles.infoValue, { color: colors.text }]}>
+          {Application.nativeApplicationVersion || "N/A"}
+          {Application.nativeBuildVersion ? ` (${Application.nativeBuildVersion})` : ""}
+        </Text>
+      </View>
 
       {/* Environment indicator */}
       <View style={[styles.infoRow, { borderBottomColor: colors.surfaceSecondary }]}>


### PR DESCRIPTION
## Summary
- Adds a "Native Version" row to the App Info settings section
- Shows `Application.nativeApplicationVersion` and `nativeBuildVersion` (from Info.plist / build.gradle)
- This value does NOT change with OTA updates, helping debug force-update issues

## Test plan
- [ ] Open Settings > App Info and verify "Native Version" row appears
- [ ] Confirm it shows the correct native binary version (e.g. `1.0.22 (1)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a read-only row sourced from `expo-application`; no auth, persistence, or networking logic is modified.
> 
> **Overview**
> Adds a new **Native Version** row in the Settings `AppInfoSection` to display the installed binary version/build number via `expo-application` (`nativeApplicationVersion` and optional `nativeBuildVersion`). This makes it easier to distinguish native release versions from OTA-updated versions when debugging update/force-upgrade issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f353b6a7252fd2571e2e63bd31345f4837052de. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->