### PR TITLE
fix: route new users to community picker + dark mode checkbox

### DIFF
--- a/apps/mobile/features/auth/components/PhoneSignInForm.tsx
+++ b/apps/mobile/features/auth/components/PhoneSignInForm.tsx
@@ -142,7 +142,7 @@ export function PhoneSignInForm({
               <Ionicons
                 name={termsAccepted ? "checkbox" : "square-outline"}
                 size={22}
-                color={termsAccepted ? colors.text : colors.border}
+                color={termsAccepted ? colors.text : colors.textTertiary}
               />
               <Text style={[styles.termsText, { color: colors.textSecondary }]}>
                 I agree to the{" "}
@@ -287,7 +287,7 @@ export function PhoneSignInForm({
             <Ionicons
               name={termsAccepted ? "checkbox" : "square-outline"}
               size={22}
-              color={termsAccepted ? colors.text : colors.border}
+              color={termsAccepted ? colors.text : colors.textTertiary}
             />
             <Text style={[styles.termsText, { color: colors.textSecondary }]}>
               I agree to the{" "}

--- a/apps/mobile/features/auth/hooks/__tests__/useInitialRouting.test.ts
+++ b/apps/mobile/features/auth/hooks/__tests__/useInitialRouting.test.ts
@@ -45,7 +45,7 @@ describe("getInitialRouteTarget", () => {
     expect(route).toBe("/(tabs)/profile");
   });
 
-  it("routes authenticated users without community but with profile to landing", () => {
+  it("routes authenticated users without community but with profile to community picker", () => {
     const route = getInitialRouteTarget({
       isAuthenticated: true,
       hasCommunity: false,
@@ -53,6 +53,6 @@ describe("getInitialRouteTarget", () => {
       hasUserProfile: true,
     });
 
-    expect(route).toBe("/(auth)/landing");
+    expect(route).toBe("/(auth)/select-community");
   });
 });

--- a/apps/mobile/features/auth/hooks/initialRouteTarget.ts
+++ b/apps/mobile/features/auth/hooks/initialRouteTarget.ts
@@ -28,5 +28,5 @@ export function getInitialRouteTarget({
     return "/(tabs)/profile";
   }
 
-  return "/(auth)/landing";
+  return "/(auth)/select-community";
 }


### PR DESCRIPTION
## Summary
- New users without a community were routed to `/(auth)/landing` (sign-in page) instead of `/(auth)/select-community` — now they land on the community picker
- Terms checkbox was nearly invisible in dark mode (`colors.border` #233138 against #0b141a). Changed to `colors.textTertiary` (#667781)

## Test plan
- [ ] Sign in with a new account that has no community → should see community picker
- [ ] Open sign-in screen in dark mode → checkbox should be visible
- [ ] Existing users with a community → should still go to chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes initial navigation for a specific authenticated state, which could misroute users if the conditions are wrong. UI change is low risk but impacts sign-in screens.
> 
> **Overview**
> Authenticated users who have a profile but no community (and no slug param) are now routed to `/(auth)/select-community` instead of `/(auth)/landing`, and the corresponding `getInitialRouteTarget` test is updated.
> 
> On the sign-in form, the unchecked terms icon color switches from `colors.border` to `colors.textTertiary` to improve contrast/visibility in dark mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 745066c5d44b8a389eb69717ab78262a660a595d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->