### PR TITLE
fix(ios): ensure sent voice messages play through speaker

### DIFF
--- a/apps/mobile/features/chat/components/AudioPlayer.tsx
+++ b/apps/mobile/features/chat/components/AudioPlayer.tsx
@@ -294,6 +294,14 @@ function AudioPlayerInner({ url, name, isOwnMessage = false, waveform, storedDur
         setIsLoading(true);
         const { Audio } = require('expo-av');
 
+        // On iOS, the audio session can remain in recording mode (earpiece) after
+        // recording voice messages. Set playback mode before loading so audio
+        // plays through the speaker. Must be called immediately before createAsync.
+        await Audio.setAudioModeAsync({
+          allowsRecordingIOS: false,
+          playsInSilentModeIOS: true,
+        });
+
         const { sound, status } = await Audio.Sound.createAsync(
           { uri: resolvedUrl },
           { shouldPlay: false },
@@ -350,6 +358,13 @@ function AudioPlayerInner({ url, name, isOwnMessage = false, waveform, storedDur
       if (isPlaying) {
         await soundRef.current.pauseAsync();
       } else {
+        // Ensure iOS audio session is in playback mode (speaker) before playing.
+        // Critical for sent voice messages where session may still be in recording mode.
+        const { Audio } = require('expo-av');
+        await Audio.setAudioModeAsync({
+          allowsRecordingIOS: false,
+          playsInSilentModeIOS: true,
+        });
         await soundRef.current.playAsync();
       }
     } catch (err) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
On iOS, sent voice messages would play (UI showed progress) but no sound was audible. The issue did not occur on web.

## Root Cause
On iOS, when recording a voice message, the audio session is switched to recording mode (`allowsRecordingIOS: true`) which routes audio through the earpiece. After stopping recording, `useVoiceRecorder` resets the session. However, when the user immediately plays their sent message via `AudioPlayer`, the audio session could still be in a transitional state or the reset hadn't fully taken effect.

The `AudioPlayer` component never explicitly set the audio mode before playback. Per [expo/expo#19298](https://github.com/expo/expo/issues/19298) and related reports, `setAudioModeAsync` must be called with `allowsRecordingIOS: false` **immediately before** creating/playing sound for audio to route through the speaker.

## Solution
Call `Audio.setAudioModeAsync({ allowsRecordingIOS: false, playsInSilentModeIOS: true })` in the native `AudioPlayer` component:
1. **Before loading** - at the start of `loadAudio`, right before `Sound.createAsync`
2. **Before playing** - in `togglePlayPause`, right before `playAsync`

This ensures that whenever a voice message (sent or received) is played, the iOS audio session is explicitly configured for speaker playback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8dcad37-ba45-4fcd-aa1a-c2f857b8709d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8dcad37-ba45-4fcd-aa1a-c2f857b8709d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

