### PR TITLE
fix: allow shared channel members to use invite links

### DIFF
--- a/apps/convex/functions/messaging/channelInvites.ts
+++ b/apps/convex/functions/messaging/channelInvites.ts
@@ -13,6 +13,22 @@ import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
 import { generateShortId, getDisplayName, getMediaUrl } from "../../lib/utils";
 
+/**
+ * Build the set of group IDs whose members are eligible to use a channel's invite link.
+ * Includes the primary group and all accepted secondary groups for shared channels.
+ */
+function getEligibleGroupIds(channel: { groupId: Id<"groups">; isShared?: boolean; sharedGroups?: Array<{ groupId: Id<"groups">; status: string }> }): Set<Id<"groups">> {
+  const ids = new Set<Id<"groups">>([channel.groupId]);
+  if (channel.isShared) {
+    for (const sg of channel.sharedGroups ?? []) {
+      if (sg.status === "accepted") {
+        ids.add(sg.groupId);
+      }
+    }
+  }
+  return ids;
+}
+
 // ============================================================================
 // Queries
 // ============================================================================
@@ -60,16 +76,18 @@ export const getByShortId = query({
       try {
         userId = await requireAuth(ctx, args.token);
 
-        // Check if user is a group member
-        const groupMembership = await ctx.db
+        // Check if user is a member of any eligible group (primary + accepted shared groups)
+        const eligibleGroupIds = getEligibleGroupIds(channel);
+        const userGroupMemberships = await ctx.db
           .query("groupMembers")
-          .withIndex("by_group_user", (q) =>
-            q.eq("groupId", channel.groupId).eq("userId", userId!),
-          )
+          .withIndex("by_user", (q) => q.eq("userId", userId!))
           .filter((q) => q.eq(q.field("leftAt"), undefined))
-          .first();
+          .collect();
+        const isEligibleGroupMember = userGroupMemberships.some((m) =>
+          eligibleGroupIds.has(m.groupId)
+        );
 
-        if (!groupMembership) {
+        if (!isEligibleGroupMember) {
           userStatus = "not_group_member";
         } else {
           // Check if already a channel member
@@ -442,16 +460,18 @@ export const joinViaInviteLink = mutation({
       throw new ConvexError("This invite link is no longer valid.");
     }
 
-    // Verify user is a group member
-    const groupMembership = await ctx.db
+    // Verify user is a member of any eligible group (primary + accepted shared groups)
+    const eligibleGroupIds = getEligibleGroupIds(channel);
+    const userGroupMemberships = await ctx.db
       .query("groupMembers")
-      .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
-      )
+      .withIndex("by_user", (q) => q.eq("userId", userId))
       .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
+      .collect();
+    const isEligibleGroupMember = userGroupMemberships.some((m) =>
+      eligibleGroupIds.has(m.groupId)
+    );
 
-    if (!groupMembership) {
+    if (!isEligibleGroupMember) {
       throw new ConvexError(
         "You must be a member of the group to join this channel.",
       );


### PR DESCRIPTION
## Summary
- Channel invite links only checked membership in the primary group, blocking members of accepted secondary groups from joining shared channels via invite link
- Added `getEligibleGroupIds` helper that builds a set of primary + accepted shared group IDs
- Updated `getByShortId` (share page) and `joinViaInviteLink` (join action) to check membership in any eligible group
- Leader management functions (enable/disable link, approve/decline requests) remain restricted to primary group leaders only

## Test plan
- [ ] Convex typecheck passes
- [ ] All 945 mobile tests pass
- [ ] Member of secondary group on a shared channel can view invite link share page without "not_group_member" status
- [ ] Member of secondary group can join shared channel via invite link
- [ ] Leader of secondary group CANNOT enable/disable invite links or approve/decline requests (primary group leaders only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes invite-link eligibility checks that gate who can view/join channels, so mistakes could unintentionally broaden access for shared channels. Also switches group membership lookup to a broader `by_user` query, which could have performance implications for users in many groups.
> 
> **Overview**
> Invite-link eligibility for shared channels now considers **primary group + accepted shared groups** instead of only the primary group.
> 
> Adds `getEligibleGroupIds()` and updates `getByShortId` (share page status) and `joinViaInviteLink` (join mutation) to treat a user as eligible if they have an active membership in any of those groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98ccf68c59f36845f0adeb4c0cc44bddb4602308. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->