### PR TITLE
fix(chat): prevent freeze after Share Group from chat menu

### DIFF
--- a/apps/mobile/features/chat/components/ChatMenuModal.tsx
+++ b/apps/mobile/features/chat/components/ChatMenuModal.tsx
@@ -52,7 +52,10 @@ export const ChatMenuModal = memo(function ChatMenuModal({
       onRequestClose={onClose}
     >
       <Pressable style={[styles.modalOverlay, { backgroundColor: themeColors.overlay }]} onPress={onClose}>
-        <View style={[styles.menuContainer, { backgroundColor: themeColors.modalBackground }]}>
+        <View
+          style={[styles.menuContainer, { backgroundColor: themeColors.modalBackground }]}
+          onStartShouldSetResponder={() => true}
+        >
           {/* Members - available to all */}
           {hasGroup && (
             <TouchableOpacity style={[styles.menuItem, { borderBottomColor: themeColors.borderLight }]} onPress={onMembersPress}>

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -19,6 +19,7 @@ import {
   Pressable,
   Share,
   ActionSheetIOS,
+  InteractionManager,
 } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -56,6 +57,16 @@ import { BlockedUsersProvider, useBlockedUsersContext } from "../context/Blocked
 import { useMutation, useAction } from "@services/api/convex";
 import { useGroupCache } from "@/stores/groupCache";
 import { useChannelsCache } from "@/stores/channelsCache";
+
+/**
+ * iOS freezes if ActionSheet / Share is presented in the same tick as closing an RN Modal.
+ * Defer until interactions + modal teardown complete (see SO #63062133, RN modal stack issues).
+ */
+function runAfterChatMenuDismiss(action: () => void) {
+  InteractionManager.runAfterInteractions(() => {
+    setTimeout(action, 320);
+  });
+}
 
 type ChatRoomParams = {
   chat_id?: string;
@@ -654,40 +665,42 @@ const ConvexChatRoomScreenInner: React.FC = () => {
     }
   }, [router, getGroupIdForNavigation]);
 
-  const handleShareGroup = useCallback(async () => {
+  const handleShareGroup = useCallback(() => {
     setMenuVisible(false);
-    const shortId = (groupDetails as { shortId?: string } | undefined)?.shortId
-      ?? (groupData as { shortId?: string } | undefined)?.shortId;
-    if (!shortId) {
-      Alert.alert("Cannot Share", "This group doesn't have a shareable link yet.");
-      return;
-    }
-    const groupUrl = DOMAIN_CONFIG.groupShareUrl(shortId);
-    const groupName = displayName || "Group";
+    runAfterChatMenuDismiss(() => {
+      const shortId = (groupDetails as { shortId?: string } | undefined)?.shortId
+        ?? (groupData as { shortId?: string } | undefined)?.shortId;
+      if (!shortId) {
+        Alert.alert("Cannot Share", "This group doesn't have a shareable link yet.");
+        return;
+      }
+      const groupUrl = DOMAIN_CONFIG.groupShareUrl(shortId);
+      const groupName = displayName || "Group";
 
-    if (Platform.OS === "ios") {
-      ActionSheetIOS.showActionSheetWithOptions(
-        {
-          options: ["Cancel", "Copy Link", "Share"],
-          cancelButtonIndex: 0,
-        },
-        async (buttonIndex) => {
-          if (buttonIndex === 1) {
-            await Clipboard.setStringAsync(groupUrl);
-            Alert.alert("Link Copied", "Group link has been copied to clipboard.");
-          } else if (buttonIndex === 2) {
-            await Share.share({
-              message: `${groupName}\n${groupUrl}`,
-              url: groupUrl,
-            });
+      if (Platform.OS === "ios") {
+        ActionSheetIOS.showActionSheetWithOptions(
+          {
+            options: ["Cancel", "Copy Link", "Share"],
+            cancelButtonIndex: 0,
+          },
+          async (buttonIndex) => {
+            if (buttonIndex === 1) {
+              await Clipboard.setStringAsync(groupUrl);
+              Alert.alert("Link Copied", "Group link has been copied to clipboard.");
+            } else if (buttonIndex === 2) {
+              await Share.share({
+                message: `${groupName}\n${groupUrl}`,
+                url: groupUrl,
+              });
+            }
           }
-        }
-      );
-    } else {
-      await Share.share({
-        message: `${groupName}\n${groupUrl}`,
-      });
-    }
+        );
+      } else {
+        void Share.share({
+          message: `${groupName}\n${groupUrl}`,
+        });
+      }
+    });
   }, [groupDetails, groupData, displayName]);
 
   // Message action handlers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
From a group channel, opening the header overflow menu and choosing **Share Group** briefly showed the iOS action sheet (Copy Link / Share), then the chat UI froze.

## Cause
`setMenuVisible(false)` dismisses a React Native `Modal` while `ActionSheetIOS` was presented in the same turn. Stacking/teardown of these native surfaces on iOS is unreliable and matches known reports of frozen UI after modal + action sheet interactions.

## Fix
- Defer presenting the action sheet / `Share.share` until after `InteractionManager.runAfterInteractions` plus a short delay (~320ms) so the menu modal can finish tearing down.
- On the chat menu panel, set `onStartShouldSetResponder={() => true}` so touches on menu rows are not treated as backdrop presses (same pattern as `ReachOutResolveModal`).

## Testing
- `pnpm test -- features/chat/components/__tests__/LeaderChatNavigation.test.tsx` (passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-674afbe0-4602-4595-bb8c-931d04a89f73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-674afbe0-4602-4595-bb8c-931d04a89f73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

