### PR TITLE
Unify People Tab & Follow-up Page

### DIFF
--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -170,6 +170,20 @@ export const list = query({
     }
     await requireCommunityMember(ctx, group.communityId, userId);
 
+    // Build set of matching communityPerson IDs when filtering by assignee
+    let assigneeIdSet: Set<string> | null = null;
+    if (args.assigneeFilter) {
+      const junctionRows = await ctx.db
+        .query("communityPeopleAssignees")
+        .withIndex("by_group_assignee", (q: any) =>
+          q.eq("groupId", args.groupId).eq("assigneeUserId", args.assigneeFilter),
+        )
+        .collect();
+      assigneeIdSet = new Set(
+        junctionRows.map((r: any) => r.communityPersonId.toString()),
+      );
+    }
+
     const direction = args.sortDirection === "desc" ? "desc" : "asc";
     const indexName =
       INDEX_MAP[args.sortBy ?? "lastName"] ?? "by_group_lastName";
@@ -196,13 +210,6 @@ export const list = query({
         if (args.statusFilter) {
           conds.push(fq.eq(fq.field("status"), args.statusFilter));
         }
-        if (args.assigneeFilter) {
-          // assigneeFilter is a userId string — check if it's in the assigneeIds array
-          // Since Convex filter doesn't support array contains, we use a workaround:
-          // For single-assignee filtering, we check assigneeIds field existence
-          // This is a limitation — full array-contains filtering should be done client-side
-          // For now, we pass through and let the client handle complex array filtering
-        }
         if (args.scoreMax !== undefined) {
           conds.push(fq.lt(fq.field(scoreFilterField), args.scoreMax));
         }
@@ -214,6 +221,34 @@ export const list = query({
           ? conds[0]
           : fq.and(...(conds as [any, any, ...any[]]));
       });
+    }
+
+    // When filtering by assignee, we can't use Convex's .filter() for array-contains,
+    // so we manually paginate and filter. This uses the junction table lookup above.
+    if (assigneeIdSet) {
+      // Manual pagination: collect from the sorted index, skip non-matching, fill page
+      const { cursor, numItems } = args.paginationOpts;
+      const page: any[] = [];
+      let skipped = 0;
+      const cursorValue = cursor ?? null;
+
+      // We need to iterate through the query and manually filter
+      // Use a larger batch to compensate for filtered-out rows
+      const batchSize = numItems * 4;
+      const result = await q.paginate({ numItems: batchSize, cursor: cursorValue });
+
+      for (const doc of result.page) {
+        if (assigneeIdSet.has(doc._id.toString())) {
+          page.push(doc);
+          if (page.length >= numItems) break;
+        }
+      }
+
+      return {
+        page,
+        isDone: result.isDone && page.length < numItems,
+        continueCursor: result.isDone ? "" : result.continueCursor,
+      };
     }
 
     return await q.paginate(args.paginationOpts);
@@ -249,6 +284,36 @@ export const search = query({
     }
     await requireCommunityMember(ctx, group.communityId, userId);
 
+    // Build assignee filter set from junction table
+    let assigneeIdSet: Set<string> | null = null;
+    if (args.assigneeFilter) {
+      const junctionRows = await ctx.db
+        .query("communityPeopleAssignees")
+        .withIndex("by_group_assignee", (q: any) =>
+          q.eq("groupId", args.groupId).eq("assigneeUserId", args.assigneeFilter),
+        )
+        .collect();
+      assigneeIdSet = new Set(
+        junctionRows.map((r: any) => r.communityPersonId.toString()),
+      );
+    }
+
+    // Build excluded assignee sets from junction table
+    let excludedIdSets: Set<string>[] = [];
+    if (args.excludedAssigneeFilters?.length) {
+      excludedIdSets = await Promise.all(
+        args.excludedAssigneeFilters.map(async (excludedId) => {
+          const rows = await ctx.db
+            .query("communityPeopleAssignees")
+            .withIndex("by_group_assignee", (q: any) =>
+              q.eq("groupId", args.groupId).eq("assigneeUserId", excludedId),
+            )
+            .collect();
+          return new Set(rows.map((r: any) => r.communityPersonId.toString()));
+        }),
+      );
+    }
+
     let results = ctx.db
       .query("communityPeople")
       .withSearchIndex("search_communityPeople", (q: any) => {
@@ -259,7 +324,7 @@ export const search = query({
         return sq;
       });
 
-    // Range filters via .filter() - score, assignee, and date filters
+    // Range filters via .filter() - score and date filters
     const scoreFilterField = (args.scoreField ?? "score1") as
       | "score1"
       | "score2"
@@ -277,40 +342,36 @@ export const search = query({
       });
     }
 
-    // Assignee and date range filters
-    const hasExcludedAssignees =
-      args.excludedAssigneeFilters && args.excludedAssigneeFilters.length > 0;
-    const hasAssigneeFilter = args.assigneeFilter !== undefined;
-    const hasDateFilters =
-      args.addedAtMin !== undefined || args.addedAtMax !== undefined;
-
-    if (hasExcludedAssignees || hasAssigneeFilter || hasDateFilters) {
+    if (args.addedAtMax !== undefined || args.addedAtMin !== undefined) {
       results = results.filter((fq: any) => {
         const conds: any[] = [];
-        // assigneeFilter checks if assignee is in assigneeIds array
-        // Since Convex filter doesn't support array contains directly,
-        // we'll skip assigneeFilter here and apply it client-side
-        if (args.excludedAssigneeFilters?.length) {
-          for (const excludedAssigneeId of args.excludedAssigneeFilters) {
-            // Check that excluded assignee is not in the array
-            // This is an approximation - client-side filtering handles it more precisely
-            conds.push(
-              fq.neq(fq.field("assigneeIds"), [excludedAssigneeId] as any),
-            );
-          }
-        }
         if (args.addedAtMax !== undefined)
           conds.push(fq.lte(fq.field("addedAt"), args.addedAtMax));
         if (args.addedAtMin !== undefined)
           conds.push(fq.gte(fq.field("addedAt"), args.addedAtMin));
-        if (conds.length === 0) return true;
         return conds.length === 1
           ? conds[0]
           : fq.and(...(conds as [any, any, ...any[]]));
       });
     }
 
-    return await results.take(200);
+    const allResults = await results.take(500);
+
+    // Post-filter by assignee/excluded assignees using junction table sets
+    let filtered = allResults;
+    if (assigneeIdSet) {
+      filtered = filtered.filter((doc: any) =>
+        assigneeIdSet!.has(doc._id.toString()),
+      );
+    }
+    if (excludedIdSets.length > 0) {
+      filtered = filtered.filter(
+        (doc: any) =>
+          !excludedIdSets.some((set) => set.has(doc._id.toString())),
+      );
+    }
+
+    return filtered.slice(0, 200);
   },
 });
 
@@ -701,6 +762,56 @@ async function buildAssigneeSortKey(
 }
 
 // ============================================================================
+// Assignee Junction Sync
+// ============================================================================
+
+/**
+ * Keep `communityPeopleAssignees` rows in sync with a communityPeople record's
+ * assigneeIds array. Deletes removed rows and inserts added rows.
+ */
+async function syncAssigneeJunction(
+  ctx: any,
+  communityPersonId: Id<"communityPeople">,
+  groupId: Id<"groups">,
+  communityId: Id<"communities">,
+  newAssigneeIds: Id<"users">[] | undefined,
+) {
+  // Get existing junction rows
+  const existing = await ctx.db
+    .query("communityPeopleAssignees")
+    .withIndex("by_communityPerson", (q: any) =>
+      q.eq("communityPersonId", communityPersonId),
+    )
+    .collect();
+
+  const existingSet = new Set(
+    existing.map((r: any) => r.assigneeUserId.toString()),
+  );
+  const newSet = new Set(
+    (newAssigneeIds ?? []).map((id: Id<"users">) => id.toString()),
+  );
+
+  // Delete rows for removed assignees
+  for (const row of existing) {
+    if (!newSet.has(row.assigneeUserId.toString())) {
+      await ctx.db.delete(row._id);
+    }
+  }
+
+  // Insert rows for added assignees
+  for (const assigneeId of newAssigneeIds ?? []) {
+    if (!existingSet.has(assigneeId.toString())) {
+      await ctx.db.insert("communityPeopleAssignees", {
+        communityPersonId,
+        assigneeUserId: assigneeId,
+        groupId,
+        communityId,
+      });
+    }
+  }
+}
+
+// ============================================================================
 // Sibling Sync Helper
 // ============================================================================
 
@@ -896,8 +1007,34 @@ export const setAssignees = mutation({
       updatedAt: Date.now(),
     });
 
-    // Sync to sibling records in the same community
-    await syncToSiblingRecords(ctx, cpRecord, patchFields);
+    // Sync junction table
+    await syncAssigneeJunction(
+      ctx,
+      args.communityPeopleId,
+      cpRecord.groupId,
+      cpRecord.communityId,
+      normalizedIds,
+    );
+
+    // Sync to sibling records in the same community (including their junction rows)
+    const siblings = await ctx.db
+      .query("communityPeople")
+      .withIndex("by_community_user", (q: any) =>
+        q.eq("communityId", cpRecord.communityId).eq("userId", cpRecord.userId),
+      )
+      .collect();
+
+    for (const sibling of siblings) {
+      if (sibling._id === args.communityPeopleId) continue;
+      await ctx.db.patch(sibling._id, { ...patchFields, updatedAt: Date.now() });
+      await syncAssigneeJunction(
+        ctx,
+        sibling._id,
+        sibling.groupId,
+        sibling.communityId,
+        normalizedIds,
+      );
+    }
 
     return { success: true };
   },
@@ -1602,7 +1739,7 @@ export const upsertFromSubmission = internalMutation({
       }
     }
 
-    // 7. Upsert communityPeople record for each group
+    // 7. Upsert communityPeople record for each group + sync junction
     for (const groupId of communityGroupIds) {
       const existing = await ctx.db
         .query("communityPeople")
@@ -1611,15 +1748,26 @@ export const upsertFromSubmission = internalMutation({
         )
         .first();
 
+      let cpId: Id<"communityPeople">;
       if (existing) {
         await ctx.db.patch(existing._id, { ...canonicalFields, groupId });
+        cpId = existing._id;
       } else {
-        await ctx.db.insert("communityPeople", {
+        cpId = await ctx.db.insert("communityPeople", {
           ...canonicalFields,
           groupId,
           createdAt: nowTs,
         });
       }
+
+      // Keep junction table in sync
+      await syncAssigneeJunction(
+        ctx,
+        cpId,
+        groupId,
+        args.communityId,
+        assigneeIds,
+      );
     }
   },
 });
@@ -1738,6 +1886,70 @@ export const backfillAssigneeSortKey = internalMutation({
 
     return {
       updated,
+      isDone: results.isDone,
+      continueCursor: results.isDone ? null : results.continueCursor,
+    };
+  },
+});
+
+// ============================================================================
+// Backfill: assignee junction table
+// ============================================================================
+
+/**
+ * Backfill communityPeopleAssignees junction rows from existing communityPeople
+ * records. Processes in batches and auto-schedules continuation. Run via:
+ *   npx convex run functions/communityPeople:backfillAssigneeJunction
+ */
+export const backfillAssigneeJunction = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = args.batchSize ?? 100;
+    const results = await ctx.db
+      .query("communityPeople")
+      .paginate({ numItems: batchSize, cursor: args.cursor ?? null });
+
+    let created = 0;
+    for (const row of results.page) {
+      if (!row.assigneeIds || row.assigneeIds.length === 0) continue;
+
+      // Check if junction rows already exist (idempotent)
+      const existing = await ctx.db
+        .query("communityPeopleAssignees")
+        .withIndex("by_communityPerson", (q: any) =>
+          q.eq("communityPersonId", row._id),
+        )
+        .collect();
+      const existingSet = new Set(
+        existing.map((r: any) => r.assigneeUserId.toString()),
+      );
+
+      for (const assigneeId of row.assigneeIds) {
+        if (!existingSet.has(assigneeId.toString())) {
+          await ctx.db.insert("communityPeopleAssignees", {
+            communityPersonId: row._id,
+            assigneeUserId: assigneeId,
+            groupId: row.groupId,
+            communityId: row.communityId,
+          });
+          created++;
+        }
+      }
+    }
+
+    if (!results.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.communityPeople.backfillAssigneeJunction,
+        { cursor: results.continueCursor, batchSize },
+      );
+    }
+
+    return {
+      created,
       isDone: results.isDone,
       continueCursor: results.isDone ? null : results.continueCursor,
     };

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -435,7 +435,7 @@ export const upsertCommunityPeopleBatch = internalMutation({
           .first();
 
         const siblingAssigneeId = (siblingRecord as any)?.assigneeIds?.[0];
-        await ctx.db.insert("communityPeople", {
+        const cpId = await ctx.db.insert("communityPeople", {
           ...scoreDoc,
           // Copy leader-set fields from sibling if exists
           status: siblingRecord?.status,
@@ -460,6 +460,18 @@ export const upsertCommunityPeopleBatch = internalMutation({
           customBool5: siblingRecord?.customBool5,
           createdAt: nowTs,
         });
+
+        // Sync junction table for assignee filtering
+        if (siblingRecord?.assigneeIds?.length) {
+          for (const assigneeUserId of siblingRecord.assigneeIds) {
+            await ctx.db.insert("communityPeopleAssignees", {
+              communityPersonId: cpId,
+              assigneeUserId,
+              groupId: args.groupId,
+              communityId: args.communityId,
+            });
+          }
+        }
       }
     }
   },
@@ -487,6 +499,16 @@ export const pruneStaleRows = internalMutation({
     for (const doc of docs) {
       // Each record has a groupId — check if user is still an active member of that group
       if (!doc.groupId) {
+        // Clean up junction rows before deleting the communityPeople record
+        const legacyJunctionRows = await ctx.db
+          .query("communityPeopleAssignees")
+          .withIndex("by_communityPerson", (q: any) =>
+            q.eq("communityPersonId", doc._id),
+          )
+          .collect();
+        for (const row of legacyJunctionRows) {
+          await ctx.db.delete(row._id);
+        }
         // Legacy record without groupId — prune it
         await ctx.db.delete(doc._id);
         deleted++;
@@ -505,6 +527,16 @@ export const pruneStaleRows = internalMutation({
         !membership || membership.leftAt !== undefined;
 
       if (isStale) {
+        // Clean up junction rows before deleting the communityPeople record
+        const junctionRows = await ctx.db
+          .query("communityPeopleAssignees")
+          .withIndex("by_communityPerson", (q: any) =>
+            q.eq("communityPersonId", doc._id),
+          )
+          .collect();
+        for (const row of junctionRows) {
+          await ctx.db.delete(row._id);
+        }
         await ctx.db.delete(doc._id);
         deleted++;
       }

--- a/apps/convex/functions/followupScoreComputation.ts
+++ b/apps/convex/functions/followupScoreComputation.ts
@@ -227,6 +227,16 @@ export const deleteScoreDoc = internalMutation({
         )
         .first();
       if (cpRecord) {
+        // Clean up junction rows before deleting the communityPeople record
+        const junctionRows = await ctx.db
+          .query("communityPeopleAssignees")
+          .withIndex("by_communityPerson", (q: any) =>
+            q.eq("communityPersonId", cpRecord._id),
+          )
+          .collect();
+        for (const row of junctionRows) {
+          await ctx.db.delete(row._id);
+        }
         await ctx.db.delete(cpRecord._id);
       }
     }

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1902,4 +1902,21 @@ export default defineSchema({
     .index("by_user_community", ["createdById", "communityId"]),
 
   // =============================================================================
+  // COMMUNITY PEOPLE ASSIGNEES (junction table for multi-assignee indexing)
+  // =============================================================================
+  // Mirrors the assigneeIds array on communityPeople as individual rows
+  // so we can do efficient indexed lookups by assignee (Convex doesn't
+  // support array-contains in indexes).
+
+  communityPeopleAssignees: defineTable({
+    communityPersonId: v.id("communityPeople"),
+    assigneeUserId: v.id("users"),
+    groupId: v.id("groups"),
+    communityId: v.id("communities"),
+  })
+    .index("by_group_assignee", ["groupId", "assigneeUserId"])
+    .index("by_community_assignee", ["communityId", "assigneeUserId"])
+    .index("by_communityPerson", ["communityPersonId"]),
+
+  // =============================================================================
 });

--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -232,11 +232,11 @@ function useDebounce<T>(value: T, delay: number): T {
 
 export function FollowupDesktopTable({
   groupId,
-  crossGroupMode,
+  defaultAssigneeFilter,
   returnTo,
 }: {
   groupId: string;
-  crossGroupMode?: boolean;
+  defaultAssigneeFilter?: "me";
   returnTo?: string | null;
 }) {
   const { colors } = useTheme();
@@ -254,6 +254,13 @@ export function FollowupDesktopTable({
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const debouncedSearch = useDebounce(searchQuery, 300);
+
+  // Initialize assignee filter from defaultAssigneeFilter prop
+  useEffect(() => {
+    if (defaultAssigneeFilter === "me" && !searchQuery && currentUserId) {
+      setSearchQuery("assignee:me");
+    }
+  }, [defaultAssigneeFilter, currentUserId]);
 
   // Side sheet
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
@@ -354,104 +361,61 @@ export function FollowupDesktopTable({
     {},
   );
 
-  // Cross-group local column config (localStorage)
-  const CROSS_GROUP_COL_CONFIG_KEY = "people-cross-group-col-config";
-  const [crossGroupColConfig, setCrossGroupColConfig] = useState<{
-    columnOrder: string[];
-    hiddenColumns: string[];
-  } | null>(null);
-
-  useEffect(() => {
-    if (!crossGroupMode || Platform.OS !== "web") return;
-    try {
-      const stored = localStorage.getItem(CROSS_GROUP_COL_CONFIG_KEY);
-      if (stored) setCrossGroupColConfig(JSON.parse(stored));
-    } catch {
-      /* localStorage unavailable */
-    }
-  }, [crossGroupMode]);
-
-  // Group filter for cross-group mode — default to announcement group
-  const [crossGroupFilter, setCrossGroupFilter] = useState<string>("");
-
-  useEffect(() => {
-    if (!crossGroupMode || crossGroupFilter) return;
-    const defaultId = crossGroupConfig?.announcementGroupId
-      ?? crossGroupConfig?.leaderGroups?.[0]?._id;
-    if (defaultId) setCrossGroupFilter(defaultId);
-  }, [crossGroupMode, crossGroupFilter, crossGroupConfig]);
 
   // Config query (per-group)
   const perGroupConfig = useAuthenticatedQuery(
     api.functions.memberFollowups.getFollowupConfig,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
-  const config = crossGroupMode ? crossGroupConfig : perGroupConfig;
+  const config = perGroupConfig;
 
-  // Group data for header (per-group mode only)
+  // Group data for header
   const groupData = useQuery(
     api.functions.groups.index.getById,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
 
   // Community-level data source config
   const communityPeopleConfig = useAuthenticatedQuery(
     api.functions.communityPeople.getConfig,
-    !crossGroupMode && groupData?.communityId
+    groupData?.communityId
       ? { communityId: groupData.communityId }
       : "skip",
   );
 
-  const scoreConfig: ScoreConfigEntry[] = crossGroupMode
-    ? (crossGroupConfig?.scoreConfigScores ?? [])
-    : (communityPeopleConfig?.scores?.map((s: any) => ({
-        id: s.id,
-        name: s.name,
-      })) ?? []);
-  const toolDisplayName = crossGroupMode
-    ? "People"
-    : (perGroupConfig?.toolDisplayName ?? "People");
+  const scoreConfig: ScoreConfigEntry[] =
+    communityPeopleConfig?.scores?.map((s: any) => ({
+      id: s.id,
+      name: s.name,
+    })) ?? [];
+  const toolDisplayName = perGroupConfig?.toolDisplayName ?? "People";
   // Views are now the only way to persist column preferences.
-  // Per-group followupColumnConfig is ignored — no view selected = all columns visible.
-  const baseColumnConfig = crossGroupMode
-    ? crossGroupColConfig
-      ? {
-          columnOrder: crossGroupColConfig.columnOrder,
-          hiddenColumns: crossGroupColConfig.hiddenColumns,
-          customFields: [],
-        }
-      : null
-    : null;
-  // Local overrides take priority (from view selection or drag-reorder)
+  // Views are the only way to persist column preferences.
+  // No view selected = all columns visible. Local overrides come from view selection or drag-reorder.
   const columnConfig = useMemo(() => {
-    if (!localColumnOrder && !localHiddenColumns) return baseColumnConfig;
+    if (!localColumnOrder && !localHiddenColumns) return null;
     return {
-      ...(baseColumnConfig ?? {}),
-      columnOrder: localColumnOrder ?? baseColumnConfig?.columnOrder ?? [],
-      hiddenColumns:
-        localHiddenColumns ?? baseColumnConfig?.hiddenColumns ?? [],
+      columnOrder: localColumnOrder ?? [],
+      hiddenColumns: localHiddenColumns ?? [],
     };
-  }, [baseColumnConfig, localColumnOrder, localHiddenColumns]);
-  const customFields: CustomFieldDef[] = crossGroupMode
-    ? []
-    : ((communityPeopleConfig?.customFields ?? []) as CustomFieldDef[]);
+  }, [localColumnOrder, localHiddenColumns]);
+  const customFields: CustomFieldDef[] =
+    (communityPeopleConfig?.customFields ?? []) as CustomFieldDef[];
 
   // Leaders query (for assignee picker — current group only)
   const perGroupLeaders = useAuthenticatedQuery(
     api.functions.groups.members.getLeaders,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
-  // Picker options: current-group leaders only (cross-group mode uses crossGroupConfig leaders)
-  const pickerLeaders = crossGroupMode
-    ? crossGroupConfig?.leaders
-    : perGroupLeaders;
+  // Picker options: all community leaders so any leader can be assigned across groups
+  const pickerLeaders = crossGroupConfig?.leaders ?? perGroupLeaders;
   // Display: cross-group leaders so assignees from other groups render correctly
   const allLeaders = crossGroupConfig?.leaders ?? perGroupLeaders;
 
   // Group tasks — used to build per-member task counts for the table
   const groupTasks = useAuthenticatedQuery(
     api.functions.tasks.index.listGroup,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
 
   const tasksByMember = useMemo(() => {
@@ -521,11 +485,11 @@ export function FollowupDesktopTable({
       scoreMin: parsedQuery.scoreMin,
       scoreMax: parsedQuery.scoreMax,
     };
-    if (crossGroupMode || !groupId) {
+    if (!groupId) {
       return base;
     }
     return { ...base, groupId: groupId as Id<"groups"> };
-  }, [crossGroupMode, groupId, parsedQuery]);
+  }, [groupId, parsedQuery]);
   const hasTextSearch = !!parsedQuery.searchText;
   const hasAnyFilter =
     !!parsedQuery.statusFilter ||
@@ -558,37 +522,27 @@ export function FollowupDesktopTable({
     // All available non-system columns (built-in + score + custom)
     const allAvailable: ColumnDef[] = [];
 
-    // In cross-group mode, add a Group column at the start
-    if (crossGroupMode) {
-      allAvailable.push({
-        key: "groupName",
-        label: "Group",
-        defaultWidth: 160,
-        sortable: false,
-      });
-    }
-
     allAvailable.push(
       {
         key: "addedAt",
         label: "Date Added",
         defaultWidth: 100,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "addedAt",
+        serverSortKey: "addedAt",
       },
       {
         key: "firstName",
         label: "First Name",
         defaultWidth: 150,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "firstName",
+        serverSortKey: "firstName",
       },
       {
         key: "lastName",
         label: "Last Name",
         defaultWidth: 120,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "lastName",
+        serverSortKey: "lastName",
       },
       { key: "email", label: "Email", defaultWidth: 180, sortable: false },
       { key: "phone", label: "Phone", defaultWidth: 140, sortable: false },
@@ -597,7 +551,7 @@ export function FollowupDesktopTable({
         label: "ZIP Code",
         defaultWidth: 100,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "zipCode",
+        serverSortKey: "zipCode",
       },
       {
         key: "dateOfBirth",
@@ -615,11 +569,9 @@ export function FollowupDesktopTable({
         label: sc.name,
         defaultWidth: 100,
         sortable: true,
-        serverSortKey: crossGroupMode
-          ? undefined
-          : sc.slot in SERVER_SORT_KEYS
-            ? sc.slot
-            : undefined,
+        serverSortKey: sc.slot in SERVER_SORT_KEYS
+          ? sc.slot
+          : undefined,
       });
     });
 
@@ -629,7 +581,7 @@ export function FollowupDesktopTable({
         label: "Assignees",
         defaultWidth: 140,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "assignee",
+        serverSortKey: "assignee",
       },
       { key: "notes", label: "Notes", defaultWidth: 200, sortable: false },
       { key: "tasks", label: "Tasks", defaultWidth: 220, sortable: false },
@@ -638,28 +590,28 @@ export function FollowupDesktopTable({
         label: "Status",
         defaultWidth: 100,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "status",
+        serverSortKey: "status",
       },
       {
         key: "lastAttendedAt",
         label: "Last Attended",
         defaultWidth: 120,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "lastAttendedAt",
+        serverSortKey: "lastAttendedAt",
       },
       {
         key: "lastFollowupAt",
         label: "Last Contact",
         defaultWidth: 120,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "lastFollowupAt",
+        serverSortKey: "lastFollowupAt",
       },
       {
         key: "lastActiveAt",
         label: "Date Active",
         defaultWidth: 120,
         sortable: true,
-        serverSortKey: crossGroupMode ? undefined : "lastActiveAt",
+        serverSortKey: "lastActiveAt",
       },
       { key: "alerts", label: "Alerts", defaultWidth: 120, sortable: false },
     );
@@ -702,13 +654,12 @@ export function FollowupDesktopTable({
     const visible = ordered.filter((c) => !hiddenSet.has(c.key));
 
     return [...systemCols, ...visible];
-  }, [scoreConfig, customFields, columnConfig, crossGroupMode]);
+  }, [scoreConfig, customFields, columnConfig]);
 
   // Column label map — maps column keys to display labels (same labels as table header)
   // Used by FollowupSettingsPanel for consistent naming
   const columnLabelMap = useMemo(() => {
     const map: Record<string, string> = {};
-    if (crossGroupMode) map["groupName"] = "Group";
     map["addedAt"] = "Date Added";
     map["firstName"] = "First Name";
     map["lastName"] = "Last Name";
@@ -731,12 +682,11 @@ export function FollowupDesktopTable({
       map[cf.slot] = cf.name;
     }
     return map;
-  }, [customFields, crossGroupMode]);
+  }, [customFields]);
 
   // All non-system column keys (for passing to settings when no saved config exists)
   const allColumnKeys = useMemo(() => {
     const keys: string[] = [];
-    if (crossGroupMode) keys.push("groupName");
     keys.push(
       "addedAt",
       "firstName",
@@ -759,7 +709,7 @@ export function FollowupDesktopTable({
     );
     for (const cf of customFields) keys.push(cf.slot);
     return keys;
-  }, [customFields, crossGroupMode]);
+  }, [customFields]);
 
   // Editable columns (built-in + all custom field slots)
   const editableColumns = useMemo(() => {
@@ -774,9 +724,7 @@ export function FollowupDesktopTable({
   const [colWidths, setColWidths] = useState<Record<string, number>>({});
 
   // Load from localStorage
-  const colWidthsKey = crossGroupMode
-    ? STORAGE_PREFIX + "cross-group"
-    : STORAGE_PREFIX + groupId;
+  const colWidthsKey = STORAGE_PREFIX + groupId;
   useEffect(() => {
     if (Platform.OS !== "web") return;
     try {
@@ -827,21 +775,15 @@ export function FollowupDesktopTable({
     return args;
   }, [parsedQuery]);
 
-  // Cross-group group filter arg
-  const crossGroupFilterArg =
-    crossGroupMode && crossGroupFilter
-      ? { groupFilter: crossGroupFilter as Id<"groups"> }
-      : {};
-
   // Paginated query — used when there's NO text search
   const {
-    results: perGroupRawMembers,
-    status: perGroupPaginationStatus,
-    loadMore: perGroupLoadMore,
-    isLoading: perGroupIsLoading,
+    results: rawMembers,
+    status: paginationStatus,
+    loadMore,
+    isLoading,
   } = useAuthenticatedPaginatedQuery(
     api.functions.communityPeople.list,
-    !crossGroupMode && !hasTextSearch && groupId
+    !hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           sortBy:
@@ -857,44 +799,11 @@ export function FollowupDesktopTable({
       : "skip",
     { initialNumItems: 50 },
   );
-
-  // Cross-group paginated query — uses communityPeople (same data source as follow-up view)
-  const {
-    results: crossGroupRawMembers,
-    status: crossGroupPaginationStatus,
-    loadMore: crossGroupLoadMore,
-    isLoading: crossGroupIsLoading,
-  } = useAuthenticatedPaginatedQuery(
-    api.functions.communityPeople.listAssignedToMe,
-    crossGroupMode && !hasTextSearch && communityId && crossGroupFilter
-      ? {
-          communityId,
-          sortBy:
-            activeViewId === FOLLOWUP_MAP_VIEW_ID ? "zipCode" : serverSortBy,
-          sortDirection:
-            activeViewId === FOLLOWUP_MAP_VIEW_ID
-              ? "desc"
-              : isClientSideSort
-                ? "desc"
-                : sortDirection,
-          ...listFilterArgs,
-          ...crossGroupFilterArg,
-        }
-      : "skip",
-    { initialNumItems: 50 },
-  );
-
-  const rawMembers = crossGroupMode ? crossGroupRawMembers : perGroupRawMembers;
-  const paginationStatus = crossGroupMode
-    ? crossGroupPaginationStatus
-    : perGroupPaginationStatus;
-  const loadMore = crossGroupMode ? crossGroupLoadMore : perGroupLoadMore;
-  const isLoading = crossGroupMode ? crossGroupIsLoading : perGroupIsLoading;
 
   // Text search query — used when there IS text search
-  const perGroupSearchResults = useAuthenticatedQuery(
+  const searchResults = useAuthenticatedQuery(
     api.functions.communityPeople.search,
-    !crossGroupMode && hasTextSearch && groupId
+    hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           searchTerm: parsedQuery.searchText,
@@ -923,60 +832,13 @@ export function FollowupDesktopTable({
         }
       : "skip",
   );
-
-  // Cross-group search query — uses communityPeople
-  const crossGroupSearchResults = useAuthenticatedQuery(
-    api.functions.communityPeople.searchAssignedToMe,
-    crossGroupMode && hasTextSearch && communityId && crossGroupFilter
-      ? {
-          communityId,
-          searchTerm: parsedQuery.searchText,
-          ...(parsedQuery.statusFilter
-            ? { statusFilter: parsedQuery.statusFilter }
-            : {}),
-          ...(parsedQuery.assigneeFilter
-            ? { assigneeFilter: parsedQuery.assigneeFilter as Id<"users"> }
-            : {}),
-          ...(parsedQuery.excludedAssigneeFilters.length > 0
-            ? {
-                excludedAssigneeFilters:
-                  parsedQuery.excludedAssigneeFilters as Id<"users">[],
-              }
-            : {}),
-          ...(parsedQuery.scoreField
-            ? { scoreField: parsedQuery.scoreField }
-            : {}),
-          ...(parsedQuery.scoreMax !== undefined
-            ? { scoreMax: parsedQuery.scoreMax }
-            : {}),
-          ...(parsedQuery.scoreMin !== undefined
-            ? { scoreMin: parsedQuery.scoreMin }
-            : {}),
-          ...getDateAddedRangeArgs(parsedQuery.dateAddedFilter),
-          ...crossGroupFilterArg,
-        }
-      : "skip",
-  );
-
-  const searchResults = crossGroupMode
-    ? crossGroupSearchResults
-    : perGroupSearchResults;
 
   // Total member count
   const totalCount = useAuthenticatedQuery(
-    crossGroupMode
-      ? api.functions.communityPeople.countAssignedToMe
-      : api.functions.communityPeople.count,
-    crossGroupMode
-      ? communityId && crossGroupFilter
-        ? {
-            communityId,
-            groupFilter: crossGroupFilter as Id<"groups">,
-          }
-        : "skip"
-      : groupId
-        ? { groupId: groupId as Id<"groups"> }
-        : "skip",
+    api.functions.communityPeople.count,
+    groupId
+      ? { groupId: groupId as Id<"groups"> }
+      : "skip",
   );
 
   // Merge: use search results when text search active, otherwise paginated.
@@ -1021,7 +883,6 @@ export function FollowupDesktopTable({
     hasTextSearch,
     searchResults,
     rawMembers,
-    crossGroupMode,
     isClientSideSort,
     sortField,
     sortDirection,
@@ -1253,16 +1114,10 @@ export function FollowupDesktopTable({
     setSelectedMemberId(null);
   };
 
-  // Helper to resolve groupId for a member (in cross-group mode, read from member data)
+  // Helper to resolve groupId for a member
   const getMemberGroupId = useCallback(
-    (memberId: string): Id<"groups"> => {
-      if (!crossGroupMode) return groupId as Id<"groups">;
-      const member = (rawMembers ?? []).find(
-        (m: any) => m.groupMemberId === memberId || m._id === memberId,
-      );
-      return ((member as any)?.groupId ?? groupId) as Id<"groups">;
-    },
-    [crossGroupMode, groupId, rawMembers],
+    (_memberId: string): Id<"groups"> => groupId as Id<"groups">,
+    [groupId],
   );
 
   const enqueueAssigneeUpdate = useCallback(
@@ -1604,7 +1459,7 @@ export function FollowupDesktopTable({
 
   // Cross-group assigned leaders — assigned to this member but not in the current group's picker
   const crossGroupAssignees = useMemo(() => {
-    if (!activeDropdownMember || crossGroupMode) return [];
+    if (!activeDropdownMember) return [];
     const assigneeIds = getAssigneeIds(activeDropdownMember);
     if (assigneeIds.length === 0) return [];
     const pickerIds = new Set(leaderOptions.map((l) => l.id));
@@ -1658,7 +1513,6 @@ export function FollowupDesktopTable({
     }));
   }, [
     activeDropdownMember,
-    crossGroupMode,
     leaderOptions,
     crossGroupConfig,
     groupId,
@@ -2264,76 +2118,32 @@ export function FollowupDesktopTable({
         <View style={s.headerContent}>
           <Text style={[s.headerTitle, { color: colors.text }]}>{toolDisplayName}</Text>
           <Text style={[s.headerSubtitle, { color: colors.textSecondary }]}>
-            {crossGroupMode
-              ? "All assigned people across groups"
-              : groupData?.name || "Group"}
+            {groupData?.name || "Group"}
           </Text>
         </View>
-        {crossGroupMode &&
-        crossGroupConfig?.leaderGroups &&
-        crossGroupConfig.leaderGroups.length > 1 ? (
-          <View style={s.crossGroupFilterDropdown}>
-            {React.createElement(
-              "select",
-              {
-                value: crossGroupFilter,
-                onChange: (e: any) => setCrossGroupFilter(e.target.value),
-                style: {
-                  fontSize: 13,
-                  fontWeight: "600",
-                  color: colors.textSecondary,
-                  backgroundColor: colors.textInverse,
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: 8,
-                  padding: "6px 28px 6px 10px",
-                  appearance: "none",
-                  WebkitAppearance: "none",
-                  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23334155' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E")`,
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "right 8px center",
-                  cursor: "pointer",
-                  outline: "none",
-                  minWidth: 140,
-                },
-              },
-              ...crossGroupConfig.leaderGroups.map(
-                (g: { _id: string; name: string }) =>
-                  React.createElement(
-                    "option",
-                    { key: g._id, value: g._id },
-                    g.name,
-                  ),
-              ),
-            )}
-          </View>
-        ) : null}
-        {!crossGroupMode && (
-          <>
-            <TouchableOpacity
-              style={[s.addButton, { borderColor: colors.success, backgroundColor: colors.surfaceSecondary }]}
-              onPress={() => {
-                setSelectedMemberId(null);
-                setShowSettingsPanel(false);
-                setShowQuickAddPanel(true);
-              }}
-            >
-              <Ionicons name="person-add-outline" size={16} color={colors.success} />
-              <Text style={[s.addButtonText, { color: colors.success }]}>Add Person</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[s.importButton, { borderColor: colors.link, backgroundColor: colors.surfaceSecondary }]}
-              onPress={() => {
-                setSelectedMemberId(null);
-                setShowSettingsPanel(false);
-                setShowQuickAddPanel(false);
-                setShowCsvImportModal(true);
-              }}
-            >
-              <Ionicons name="cloud-upload-outline" size={16} color={colors.link} />
-              <Text style={[s.importButtonText, { color: colors.link }]}>Import CSV</Text>
-            </TouchableOpacity>
-          </>
-        )}
+        <TouchableOpacity
+          style={[s.addButton, { borderColor: colors.success, backgroundColor: colors.surfaceSecondary }]}
+          onPress={() => {
+            setSelectedMemberId(null);
+            setShowSettingsPanel(false);
+            setShowQuickAddPanel(true);
+          }}
+        >
+          <Ionicons name="person-add-outline" size={16} color={colors.success} />
+          <Text style={[s.addButtonText, { color: colors.success }]}>Add Person</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[s.importButton, { borderColor: colors.link, backgroundColor: colors.surfaceSecondary }]}
+          onPress={() => {
+            setSelectedMemberId(null);
+            setShowSettingsPanel(false);
+            setShowQuickAddPanel(false);
+            setShowCsvImportModal(true);
+          }}
+        >
+          <Ionicons name="cloud-upload-outline" size={16} color={colors.link} />
+          <Text style={[s.importButtonText, { color: colors.link }]}>Import CSV</Text>
+        </TouchableOpacity>
         <TouchableOpacity
           style={s.settingsButton}
           onPress={handleSettingsPress}
@@ -2395,9 +2205,7 @@ export function FollowupDesktopTable({
         <Text style={[s.memberCount, { color: colors.textSecondary }]}>
           {hasTextSearch
             ? `${members.length} result${members.length !== 1 ? "s" : ""}`
-            : crossGroupMode
-              ? `${members.length} people${hasAnyFilter ? " (filtered)" : ""}`
-              : `${totalCount ?? "\u2014"} members${hasAnyFilter ? " (filtered)" : ""}`}
+            : `${totalCount ?? "\u2014"} members${hasAnyFilter ? " (filtered)" : ""}`}
         </Text>
       </View>
 
@@ -2421,7 +2229,7 @@ export function FollowupDesktopTable({
       )}
 
       {/* People view bar */}
-      {(groupData?.communityId || (crossGroupMode && communityId)) && (
+      {groupData?.communityId && (
         <PeopleViewBar
           communityId={(groupData?.communityId ?? communityId)!}
           activeViewId={activeViewId}
@@ -2783,7 +2591,6 @@ export function FollowupDesktopTable({
             <View style={[s.sideSheet, { backgroundColor: colors.background }]}>
               <FollowupSettingsPanel
                 groupId={groupId}
-                crossGroupMode={crossGroupMode}
                 communityId={groupData?.communityId ?? communityId}
                 isAdmin={user?.is_admin === true}
                 currentColumnOrder={
@@ -2805,7 +2612,7 @@ export function FollowupDesktopTable({
               />
             </View>
           </>
-        ) : !crossGroupMode && showQuickAddPanel ? (
+        ) : showQuickAddPanel ? (
           <>
             <View style={[s.divider, { backgroundColor: colors.border }]} />
             <View style={[s.sideSheet, { backgroundColor: colors.background }]}>
@@ -2825,30 +2632,18 @@ export function FollowupDesktopTable({
             </View>
           </>
         ) : selectedMemberId ? (
-          (() => {
-            // In cross-group mode, find the groupId from the selected member's data
-            const selectedMember = displayMembers.find(
-              (m) => m.groupMemberId === selectedMemberId,
-            );
-            const detailGroupId = crossGroupMode
-              ? ((selectedMember as any)?.groupId?.toString() ?? "")
-              : groupId;
-            return (
-              <>
-                <View style={[s.divider, { backgroundColor: colors.border }]} />
-                <View style={[s.sideSheet, { backgroundColor: colors.background }]}>
-                  <FollowupDetailContent
-                    groupId={detailGroupId}
-                    memberId={selectedMemberId}
-                    onClose={() => setSelectedMemberId(null)}
-                    scrollToNotes={scrollToNotes}
-                    scrollToTasks={scrollToTasks}
-                    crossGroupMode={crossGroupMode}
-                  />
-                </View>
-              </>
-            );
-          })()
+          <>
+            <View style={[s.divider, { backgroundColor: colors.border }]} />
+            <View style={[s.sideSheet, { backgroundColor: colors.background }]}>
+              <FollowupDetailContent
+                groupId={groupId}
+                memberId={selectedMemberId}
+                onClose={() => setSelectedMemberId(null)}
+                scrollToNotes={scrollToNotes}
+                scrollToTasks={scrollToTasks}
+              />
+            </View>
+          </>
         ) : null}
       </View>
 
@@ -3286,7 +3081,7 @@ export function FollowupDesktopTable({
       />
 
       {/* Save view modal */}
-      {(groupData?.communityId || (crossGroupMode && communityId)) && (
+      {groupData?.communityId && (
         <SaveViewModal
           visible={showSaveViewModal}
           onClose={() => {
@@ -3404,10 +3199,6 @@ const s = StyleSheet.create({
   },
   settingsButton: {
     padding: 6,
-  },
-  crossGroupFilterDropdown: {
-    marginRight: 12,
-    justifyContent: "center" as const,
   },
   importButton: {
     flexDirection: "row" as const,

--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -45,15 +45,12 @@ export function FollowupDetailContent({
   onClose,
   scrollToNotes,
   scrollToTasks,
-  crossGroupMode,
 }: {
   groupId: string;
   memberId: string;
   onClose?: () => void;
   scrollToNotes?: boolean;
   scrollToTasks?: boolean;
-  /** When true, memberId is groupMemberId (from cross-group view). When false, memberId is communityPeopleId. */
-  crossGroupMode?: boolean;
 }) {
   const { colors, isDark } = useTheme();
   const insets = useSafeAreaInsets();
@@ -1423,7 +1420,6 @@ export function FollowupDetailScreen() {
       <FollowupDetailContent
         groupId={group_id || ""}
         memberId={member_id || ""}
-        crossGroupMode={cross_group === "1"}
       />
     </UserRoute>
   );

--- a/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
@@ -220,11 +220,11 @@ function compareSortValues(
 
 export function FollowupMobileGrid({
   groupId,
-  crossGroupMode,
+  defaultAssigneeFilter,
   returnTo,
 }: {
   groupId: string;
-  crossGroupMode?: boolean;
+  defaultAssigneeFilter?: "me";
   returnTo?: string | null;
 }) {
   const { colors } = useTheme();
@@ -232,6 +232,7 @@ export function FollowupMobileGrid({
   const insets = useSafeAreaInsets();
   const { community, user } = useAuth();
   const communityId = community?.id as Id<"communities"> | undefined;
+  const currentUserId = user?.id as Id<"users"> | undefined;
   const { primaryColor } = useCommunityTheme();
 
   const [sortField, setSortField] = useState("score1");
@@ -277,51 +278,47 @@ export function FollowupMobileGrid({
     >
   >({});
 
-  // Cross-group config
+  // Cross-group config — fetched so we have community-wide leaders for assignee picker
   const crossGroupConfig = useAuthenticatedQuery(
     api.functions.memberFollowups.getCrossGroupConfig,
-    crossGroupMode ? {} : "skip"
+    {},
   );
-  const [crossGroupFilter, setCrossGroupFilter] = useState<string>("");
-
-  useEffect(() => {
-    if (!crossGroupMode || crossGroupFilter) return;
-    const defaultId = crossGroupConfig?.announcementGroupId
-      ?? crossGroupConfig?.leaderGroups?.[0]?._id;
-    if (defaultId) setCrossGroupFilter(defaultId);
-  }, [crossGroupMode, crossGroupFilter, crossGroupConfig]);
 
   const debouncedSearch = useDebounce(searchQuery, 450);
 
+  useEffect(() => {
+    if (defaultAssigneeFilter === "me" && !searchQuery && currentUserId) {
+      setSearchQuery("assignee:me");
+    }
+  }, [defaultAssigneeFilter, currentUserId]);
+
   const perGroupConfig = useAuthenticatedQuery(
     api.functions.memberFollowups.getFollowupConfig,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
-  const config = crossGroupMode ? crossGroupConfig : perGroupConfig;
+  const config = perGroupConfig;
 
   const groupData = useQuery(
     api.functions.groups.index.getById,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
 
   const communityPeopleConfig = useAuthenticatedQuery(
-    !crossGroupMode && groupData?.communityId
+    groupData?.communityId
       ? api.functions.communityPeople.getConfig
       : ("skip" as any),
-    !crossGroupMode && groupData?.communityId
+    groupData?.communityId
       ? { communityId: groupData.communityId }
       : "skip",
   );
 
   const scoreConfig = useMemo<ScoreConfigEntry[]>(
-    () => crossGroupMode
-      ? (crossGroupConfig?.scoreConfigScores ?? [])
-      : (communityPeopleConfig?.scores?.map((s: any) => ({ id: s.id, name: s.name })) ?? []),
-    [crossGroupMode, crossGroupConfig?.scoreConfigScores, communityPeopleConfig?.scores],
+    () => communityPeopleConfig?.scores?.map((s: any) => ({ id: s.id, name: s.name })) ?? [],
+    [communityPeopleConfig?.scores],
   );
   const isConfigLoaded = config !== undefined;
-  const toolDisplayName = crossGroupMode ? "People" : (typeof perGroupConfig?.toolDisplayName === "string" ? perGroupConfig.toolDisplayName : "People");
-  const memberSubtitleRaw = crossGroupMode ? "" : ((config as any)?.memberSubtitle ?? "");
+  const toolDisplayName = typeof perGroupConfig?.toolDisplayName === "string" ? perGroupConfig.toolDisplayName : "People";
+  const memberSubtitleRaw = (config as any)?.memberSubtitle ?? "";
   const memberSubtitleIds = useMemo(
     () =>
       normalizeSubtitleVariableIds(
@@ -329,21 +326,22 @@ export function FollowupMobileGrid({
       ),
     [memberSubtitleRaw],
   );
-  const columnConfig = crossGroupMode ? null : (perGroupConfig?.followupColumnConfig ?? null);
+  const columnConfig = perGroupConfig?.followupColumnConfig ?? null;
   const customFields = useMemo<CustomFieldDef[]>(
-    () => crossGroupMode ? [] : ((communityPeopleConfig?.customFields ?? []) as CustomFieldDef[]),
-    [crossGroupMode, communityPeopleConfig?.customFields],
+    () => (communityPeopleConfig?.customFields ?? []) as CustomFieldDef[],
+    [communityPeopleConfig?.customFields],
   );
 
   const perGroupLeaders = useAuthenticatedQuery(
     api.functions.groups.members.getLeaders,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
-  const leaders = crossGroupMode ? crossGroupConfig?.leaders : perGroupLeaders;
+  // Use all community leaders so any leader can be assigned across groups
+  const leaders = crossGroupConfig?.leaders ?? perGroupLeaders;
 
   const groupTasks = useAuthenticatedQuery(
     api.functions.tasks.index.listGroup,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
 
   const tasksByMember = useMemo(() => {
@@ -414,11 +412,11 @@ export function FollowupMobileGrid({
       scoreMin: parsedQuery.scoreMin,
       scoreMax: parsedQuery.scoreMax,
     };
-    if (crossGroupMode || !groupId) {
+    if (!groupId) {
       return base;
     }
     return { ...base, groupId: groupId as Id<"groups"> };
-  }, [crossGroupMode, groupId, parsedQuery]);
+  }, [groupId, parsedQuery]);
   const hasTextSearch = parsedQuery.searchText.length > 0;
   const hasStructuredFilters =
     !!parsedQuery.statusFilter ||
@@ -469,18 +467,14 @@ export function FollowupMobileGrid({
     : "score1";
   const serverSortDirection = isClientSideSort ? "desc" : sortDirection;
 
-  const crossGroupFilterArg = crossGroupMode && crossGroupFilter
-    ? { groupFilter: crossGroupFilter as Id<"groups"> }
-    : {};
-
   const {
     results: perGroupRawMembersRaw,
-    status: perGroupPaginationStatus,
-    loadMore: perGroupLoadMore,
-    isLoading: perGroupIsLoading,
+    status: paginationStatus,
+    loadMore,
+    isLoading,
   } = useAuthenticatedPaginatedQuery(
     api.functions.communityPeople.list,
-    !crossGroupMode && !hasTextSearch && groupId
+    !hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           sortBy: serverSortBy,
@@ -490,54 +484,21 @@ export function FollowupMobileGrid({
       : "skip",
     { initialNumItems: 50 },
   );
-  const perGroupRawMembers = useMemo(
+  const rawMembers = useMemo(
     () => applyDevZipCodeSample(perGroupRawMembersRaw.map(adaptCommunityPerson)),
     [perGroupRawMembersRaw],
   );
 
-  const {
-    results: crossGroupRawMembersRaw,
-    status: crossGroupPaginationStatus,
-    loadMore: crossGroupLoadMore,
-    isLoading: crossGroupIsLoading,
-  } = useAuthenticatedPaginatedQuery(
-    api.functions.communityPeople.listAssignedToMe,
-    crossGroupMode && !hasTextSearch && communityId && crossGroupFilter
-      ? {
-          communityId,
-          sortBy: serverSortBy,
-          sortDirection: serverSortDirection,
-          ...listFilterArgs,
-          ...crossGroupFilterArg,
-        }
-      : "skip",
-    { initialNumItems: 50 },
-  );
-  const crossGroupRawMembers = useMemo(
-    () =>
-      crossGroupRawMembersRaw
-        ? applyDevZipCodeSample(
-            crossGroupRawMembersRaw.map((r: any) => adaptCommunityPerson(r)),
-          )
-        : [],
-    [crossGroupRawMembersRaw],
-  );
-
-  const rawMembers = crossGroupMode ? crossGroupRawMembers : perGroupRawMembers;
-  const paginationStatus = crossGroupMode ? crossGroupPaginationStatus : perGroupPaginationStatus;
-  const loadMore = crossGroupMode ? crossGroupLoadMore : perGroupLoadMore;
-  const isLoading = crossGroupMode ? crossGroupIsLoading : perGroupIsLoading;
-
   const perGroupSearchResultsRaw = useAuthenticatedQuery(
     api.functions.communityPeople.search,
-    !crossGroupMode && hasTextSearch && groupId
+    hasTextSearch && groupId
       ? {
           groupId: groupId as Id<"groups">,
           searchTerm: parsedQuery.searchText,
         }
       : "skip",
   );
-  const perGroupSearchResults = useMemo(
+  const searchResults = useMemo(
     () =>
       perGroupSearchResultsRaw
         ? applyDevZipCodeSample(perGroupSearchResultsRaw.map(adaptCommunityPerson))
@@ -545,64 +506,11 @@ export function FollowupMobileGrid({
     [perGroupSearchResultsRaw],
   );
 
-  const crossGroupSearchResultsRaw = useAuthenticatedQuery(
-    api.functions.communityPeople.searchAssignedToMe,
-    crossGroupMode && hasTextSearch && communityId && crossGroupFilter
-      ? {
-          communityId,
-          searchTerm: parsedQuery.searchText,
-          ...(parsedQuery.statusFilter
-            ? { statusFilter: parsedQuery.statusFilter }
-            : {}),
-          ...(parsedQuery.assigneeFilter
-            ? { assigneeFilter: parsedQuery.assigneeFilter as Id<"users"> }
-            : {}),
-          ...(parsedQuery.excludedAssigneeFilters.length > 0
-            ? {
-                excludedAssigneeFilters:
-                  parsedQuery.excludedAssigneeFilters as Id<"users">[],
-              }
-            : {}),
-          ...(parsedQuery.scoreField
-            ? { scoreField: parsedQuery.scoreField }
-            : {}),
-          ...(parsedQuery.scoreMax !== undefined
-            ? { scoreMax: parsedQuery.scoreMax }
-            : {}),
-          ...(parsedQuery.scoreMin !== undefined
-            ? { scoreMin: parsedQuery.scoreMin }
-            : {}),
-          ...getDateAddedRangeArgs(parsedQuery.dateAddedFilter),
-          ...crossGroupFilterArg,
-        }
-      : "skip",
-  );
-  const crossGroupSearchResults = useMemo(
-    () =>
-      crossGroupSearchResultsRaw
-        ? applyDevZipCodeSample(
-            crossGroupSearchResultsRaw.map((r: any) => adaptCommunityPerson(r)),
-          )
-        : undefined,
-    [crossGroupSearchResultsRaw],
-  );
-
-  const searchResults = crossGroupMode ? crossGroupSearchResults : perGroupSearchResults;
-
   const totalCount = useAuthenticatedQuery(
-    crossGroupMode
-      ? api.functions.communityPeople.countAssignedToMe
-      : api.functions.communityPeople.count,
-    crossGroupMode
-      ? communityId && crossGroupFilter
-        ? {
-            communityId,
-            groupFilter: crossGroupFilter as Id<"groups">,
-          }
-        : "skip"
-      : groupId
-        ? { groupId: groupId as Id<"groups"> }
-        : "skip",
+    api.functions.communityPeople.count,
+    groupId
+      ? { groupId: groupId as Id<"groups"> }
+      : "skip",
   );
   const setAssigneeMut = useAuthenticatedMutation(
     api.functions.communityPeople.setAssignees,
@@ -624,12 +532,10 @@ export function FollowupMobileGrid({
   );
 
   const getMemberGroupId = useCallback(
-    (memberId: string): Id<"groups"> => {
-      if (!crossGroupMode) return groupId as Id<"groups">;
-      const member = (rawMembers ?? []).find((m: any) => m.groupMemberId === memberId || m._id === memberId);
-      return ((member as any)?.groupId ?? groupId) as Id<"groups">;
+    (_memberId: string): Id<"groups"> => {
+      return groupId as Id<"groups">;
     },
-    [crossGroupMode, groupId, rawMembers]
+    [groupId]
   );
 
   const getSortFieldValue = useCallback(
@@ -1085,10 +991,8 @@ export function FollowupMobileGrid({
     }
   };
 
-  const handleMemberPress = (memberId: string, memberGroupId?: string) => {
-    const effectiveGroupId = crossGroupMode && memberGroupId ? memberGroupId : groupId;
-    const crossGroupParam = crossGroupMode ? "?cross_group=1" : "";
-    router.push(`/(user)/leader-tools/${effectiveGroupId}/followup/${memberId}${crossGroupParam}`);
+  const handleMemberPress = (memberId: string, _memberGroupId?: string) => {
+    router.push(`/(user)/leader-tools/${groupId}/followup/${memberId}`);
   };
 
   const handleSettingsPress = () => {
@@ -1809,9 +1713,6 @@ export function FollowupMobileGrid({
           )}
 
           <View style={styles.memberTextWrap}>
-            {crossGroupMode && (item as any).groupName ? (
-              <Text style={[styles.groupNameBadge, { color: colors.link }]}>{(item as any).groupName}</Text>
-            ) : null}
             <Text style={[styles.memberName, { color: colors.text }]} numberOfLines={1}>
               {item.firstName} {item.lastName}
             </Text>
@@ -1910,25 +1811,21 @@ export function FollowupMobileGrid({
           <View style={styles.headerContent}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>{toolDisplayName}</Text>
             <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>
-              {crossGroupMode ? "All assigned people across groups" : (groupData?.name || "Group")}
+              {groupData?.name || "Group"}
             </Text>
           </View>
-          {!crossGroupMode && (
-            <TouchableOpacity
-              style={styles.headerAddButton}
-              onPress={() => setShowQuickAddModal(true)}
-            >
-              <Ionicons name="person-add-outline" size={20} color={colors.success} />
-            </TouchableOpacity>
-          )}
-          {!crossGroupMode && (
-            <TouchableOpacity
-              style={styles.settingsButton}
-              onPress={handleSettingsPress}
-            >
-              <Ionicons name="settings-outline" size={22} color={colors.textSecondary} />
-            </TouchableOpacity>
-          )}
+          <TouchableOpacity
+            style={styles.headerAddButton}
+            onPress={() => setShowQuickAddModal(true)}
+          >
+            <Ionicons name="person-add-outline" size={20} color={colors.success} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.settingsButton}
+            onPress={handleSettingsPress}
+          >
+            <Ionicons name="settings-outline" size={22} color={colors.textSecondary} />
+          </TouchableOpacity>
         </View>
 
         <View style={[styles.searchRow, { borderColor: colors.border, backgroundColor: colors.surfaceSecondary }]}>
@@ -2009,9 +1906,9 @@ export function FollowupMobileGrid({
         </Text>
       </View>
 
-      {(groupData?.communityId || (crossGroupMode && communityId)) && (
+      {groupData?.communityId && (
         <PeopleViewBar
-          communityId={(groupData?.communityId ?? communityId)!}
+          communityId={groupData.communityId}
           activeViewId={activeViewId}
           onViewSelect={(viewId, view) => {
             if (view?.isSpecial) {
@@ -2050,11 +1947,7 @@ export function FollowupMobileGrid({
             setViewToDelete({ id: viewId, name: viewName, isShared });
           }}
           onCreateView={() => setShowSaveViewModal(true)}
-          isAdmin={
-            crossGroupMode
-              ? user?.is_admin === true
-              : groupData?.userRole === "admin"
-          }
+          isAdmin={groupData?.userRole === "admin"}
           specialViews={[{ id: FOLLOWUP_MAP_VIEW_ID, name: "Map", icon: "map-outline" }]}
         />
       )}
@@ -2092,12 +1985,9 @@ export function FollowupMobileGrid({
               groupName: (member as any).groupName,
             }))}
             loading={isInitialLoading}
-            onOpenMember={(memberId, memberGroupId) => {
-              const effectiveGroupId =
-                crossGroupMode && memberGroupId ? memberGroupId : groupId;
-              const crossGroupParam = crossGroupMode ? "?cross_group=1" : "";
+            onOpenMember={(memberId) => {
               router.push(
-                `/(user)/leader-tools/${effectiveGroupId}/followup/${memberId}${crossGroupParam}`,
+                `/(user)/leader-tools/${groupId}/followup/${memberId}`,
               );
             }}
           />
@@ -2484,19 +2374,15 @@ export function FollowupMobileGrid({
       />
 
       {/* Save view modal */}
-      {(groupData?.communityId || (crossGroupMode && communityId)) && (
+      {groupData?.communityId && (
         <SaveViewModal
           visible={showSaveViewModal}
           onClose={() => setShowSaveViewModal(false)}
-          communityId={(groupData?.communityId ?? communityId)!}
+          communityId={groupData.communityId}
           currentSortBy={sortField}
           currentSortDirection={sortDirection}
           currentFilters={saveViewFilters}
-          isAdmin={
-            crossGroupMode
-              ? user?.is_admin === true
-              : groupData?.userRole === "admin"
-          }
+          isAdmin={groupData?.userRole === "admin"}
         />
       )}
 

--- a/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupSettingsPanel.tsx
@@ -33,7 +33,6 @@ import { useTheme } from "@hooks/useTheme";
 
 interface FollowupSettingsPanelProps {
   groupId: string;
-  crossGroupMode?: boolean;
   communityId?: string;
   isAdmin?: boolean;
   // Current effective column state from parent
@@ -116,7 +115,6 @@ const ALERT_VARIABLES: VariableOption[] = [
 
 export function FollowupSettingsPanel({
   groupId,
-  crossGroupMode,
   communityId,
   isAdmin,
   currentColumnOrder,
@@ -141,12 +139,12 @@ export function FollowupSettingsPanel({
 
   const config = useAuthenticatedQuery(
     api.functions.memberFollowups.getFollowupConfig,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   );
 
   const groupData = useAuthenticatedQuery(
     api.functions.groups.queries.getById,
-    !crossGroupMode && groupId ? { groupId: groupId as Id<"groups"> } : "skip"
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip"
   ) as any;
 
   // ── Mutations ──
@@ -349,7 +347,6 @@ export function FollowupSettingsPanel({
 
   // Save custom fields only (structural change, group-level)
   const handleSaveCustomFields = useCallback(async () => {
-    if (crossGroupMode) return;
     if (showAddField) {
       Alert.alert("Finish adding field", "Click Add Field or Cancel before saving.");
       return;
@@ -375,7 +372,6 @@ export function FollowupSettingsPanel({
       setIsSavingColumns(false);
     }
   }, [
-    crossGroupMode,
     groupId,
     currentColumnOrder,
     currentHiddenColumns,
@@ -495,7 +491,7 @@ export function FollowupSettingsPanel({
 
   // ── Loading ──
 
-  if (!crossGroupMode && (!config || !groupData)) {
+  if (!config || !groupData) {
     return (
       <View style={[styles.container, { backgroundColor: colors.surface }]}>
         <View style={[styles.header, { borderBottomColor: colors.border }]}>
@@ -541,9 +537,9 @@ export function FollowupSettingsPanel({
       </View>
 
       <ScrollView style={styles.scrollArea} contentContainerStyle={styles.scrollContent}>
-        {/* ── Section 1: Display Name (hidden in cross-group mode) ── */}
-        {!crossGroupMode && renderSectionHeader("Display Name", displayNameOpen, () => setDisplayNameOpen((p) => !p))}
-        {!crossGroupMode && displayNameOpen && (
+        {/* ── Section 1: Display Name ── */}
+        {renderSectionHeader("Display Name", displayNameOpen, () => setDisplayNameOpen((p) => !p))}
+        {displayNameOpen && (
           <View style={[styles.sectionBody, { borderBottomColor: colors.borderLight }]}>
             <TextInput
               style={[
@@ -564,9 +560,9 @@ export function FollowupSettingsPanel({
           </View>
         )}
 
-        {/* ── Section 2: Data (hidden in cross-group mode) ── */}
-        {!crossGroupMode && renderSectionHeader("Data", dataOpen, () => setDataOpen((p) => !p))}
-        {!crossGroupMode && dataOpen && (
+        {/* ── Section 2: Data ── */}
+        {renderSectionHeader("Data", dataOpen, () => setDataOpen((p) => !p))}
+        {dataOpen && (
           <View style={[styles.sectionBody, { borderBottomColor: colors.borderLight }]}>
             <TouchableOpacity
               onPress={handleRefreshFollowupScores}
@@ -643,167 +639,163 @@ export function FollowupSettingsPanel({
               })}
             </View>
 
-            {/* Custom Fields subsection (hidden in cross-group mode) */}
-            {!crossGroupMode && (
-              <>
-                <View style={[styles.subsectionDivider, { backgroundColor: colors.border }]} />
-                <Text style={[styles.subsectionTitle, { color: colors.textTertiary }]}>Custom Fields</Text>
-                <Text style={[styles.noteText, { color: colors.textTertiary }]}>
-                  Custom fields are shared across all groups in your community.
-                </Text>
+            {/* Custom Fields subsection */}
+            <View style={[styles.subsectionDivider, { backgroundColor: colors.border }]} />
+            <Text style={[styles.subsectionTitle, { color: colors.textTertiary }]}>Custom Fields</Text>
+            <Text style={[styles.noteText, { color: colors.textTertiary }]}>
+              Custom fields are shared across all groups in your community.
+            </Text>
 
-                {/* Capacity indicators */}
-                <View style={styles.capacityRow}>
-                  {Object.entries(SLOT_CAPACITIES).map(([key, info]) => (
-                    <View key={key} style={[styles.capacityBadge, { backgroundColor: colors.surfaceSecondary }]}>
-                      <Text style={[styles.capacityText, { color: colors.textTertiary }]}>
-                        {info.label}: {capacityInfo[key] ?? 0}/{info.total}
-                      </Text>
-                    </View>
-                  ))}
+            {/* Capacity indicators */}
+            <View style={styles.capacityRow}>
+              {Object.entries(SLOT_CAPACITIES).map(([key, info]) => (
+                <View key={key} style={[styles.capacityBadge, { backgroundColor: colors.surfaceSecondary }]}>
+                  <Text style={[styles.capacityText, { color: colors.textTertiary }]}>
+                    {info.label}: {capacityInfo[key] ?? 0}/{info.total}
+                  </Text>
+                </View>
+              ))}
+            </View>
+
+            {/* Existing custom fields */}
+            {customFields.map((field, idx) => (
+              <View key={field.slot} style={[styles.fieldRow, { backgroundColor: colors.surfaceSecondary }]}>
+                <View style={styles.fieldInfo}>
+                  <Text style={[styles.fieldName, { color: colors.textSecondary }]}>{field.name}</Text>
+                  <View style={[styles.typeBadge, { backgroundColor: colors.border }]}>
+                    <Text style={[styles.typeBadgeText, { color: colors.textTertiary }]}>{field.type}</Text>
+                  </View>
+                  {(field.type === "dropdown" || field.type === "multiselect") && field.options && (
+                    <Text style={[styles.fieldOptions, { color: colors.textTertiary }]} numberOfLines={1}>
+                      ({field.options.join(", ")})
+                    </Text>
+                  )}
+                </View>
+                <TouchableOpacity onPress={() => handleDeleteField(idx)} style={styles.deleteBtn}>
+                  <Ionicons name="trash-outline" size={14} color={colors.destructive} />
+                </TouchableOpacity>
+              </View>
+            ))}
+
+            {/* Add custom field form */}
+            {showAddField ? (
+              <View style={[styles.addFieldForm, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
+                <TextInput
+                  style={[
+                    styles.fieldInput,
+                    { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground },
+                    Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
+                  ]}
+                  value={newFieldName}
+                  onChangeText={setNewFieldName}
+                  placeholder="Field name..."
+                  placeholderTextColor={colors.inputPlaceholder}
+                  autoFocus
+                />
+                <View style={styles.typePickerRow}>
+                  {FIELD_TYPES.map((ft) => {
+                    const enabled = canAddType(ft.value);
+                    const isActive = newFieldType === ft.value;
+                    return (
+                      <TouchableOpacity
+                        key={ft.value}
+                        style={[
+                          styles.typeOption,
+                          { borderColor: colors.inputBorder, backgroundColor: colors.inputBackground },
+                          isActive && { borderColor: themeColor, backgroundColor: `${themeColor}10` },
+                          !enabled && styles.typeOptionDisabled,
+                        ]}
+                        onPress={() => enabled && setNewFieldType(ft.value)}
+                        disabled={!enabled}
+                      >
+                        <Text
+                          style={[
+                            styles.typeOptionText,
+                            { color: colors.textSecondary },
+                            isActive && { color: themeColor, fontWeight: "600" as const },
+                            !enabled && { color: colors.textTertiary },
+                          ]}
+                        >
+                          {ft.label}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
                 </View>
 
-                {/* Existing custom fields */}
-                {customFields.map((field, idx) => (
-                  <View key={field.slot} style={[styles.fieldRow, { backgroundColor: colors.surfaceSecondary }]}>
-                    <View style={styles.fieldInfo}>
-                      <Text style={[styles.fieldName, { color: colors.textSecondary }]}>{field.name}</Text>
-                      <View style={[styles.typeBadge, { backgroundColor: colors.border }]}>
-                        <Text style={[styles.typeBadgeText, { color: colors.textTertiary }]}>{field.type}</Text>
-                      </View>
-                      {(field.type === "dropdown" || field.type === "multiselect") && field.options && (
-                        <Text style={[styles.fieldOptions, { color: colors.textTertiary }]} numberOfLines={1}>
-                          ({field.options.join(", ")})
-                        </Text>
-                      )}
-                    </View>
-                    <TouchableOpacity onPress={() => handleDeleteField(idx)} style={styles.deleteBtn}>
-                      <Ionicons name="trash-outline" size={14} color={colors.destructive} />
-                    </TouchableOpacity>
-                  </View>
-                ))}
-
-                {/* Add custom field form */}
-                {showAddField ? (
-                  <View style={[styles.addFieldForm, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
-                    <TextInput
-                      style={[
-                        styles.fieldInput,
-                        { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground },
-                        Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
-                      ]}
-                      value={newFieldName}
-                      onChangeText={setNewFieldName}
-                      placeholder="Field name..."
-                      placeholderTextColor={colors.inputPlaceholder}
-                      autoFocus
-                    />
-                    <View style={styles.typePickerRow}>
-                      {FIELD_TYPES.map((ft) => {
-                        const enabled = canAddType(ft.value);
-                        const isActive = newFieldType === ft.value;
-                        return (
-                          <TouchableOpacity
-                            key={ft.value}
-                            style={[
-                              styles.typeOption,
-                              { borderColor: colors.inputBorder, backgroundColor: colors.inputBackground },
-                              isActive && { borderColor: themeColor, backgroundColor: `${themeColor}10` },
-                              !enabled && styles.typeOptionDisabled,
-                            ]}
-                            onPress={() => enabled && setNewFieldType(ft.value)}
-                            disabled={!enabled}
-                          >
-                            <Text
-                              style={[
-                                styles.typeOptionText,
-                                { color: colors.textSecondary },
-                                isActive && { color: themeColor, fontWeight: "600" as const },
-                                !enabled && { color: colors.textTertiary },
-                              ]}
-                            >
-                              {ft.label}
-                            </Text>
-                          </TouchableOpacity>
-                        );
-                      })}
-                    </View>
-
-                    {/* Dropdown / multiselect options editor */}
-                    {(newFieldType === "dropdown" || newFieldType === "multiselect") && (
-                      <View style={styles.optionsEditor}>
-                        <Text style={[styles.optionsLabel, { color: colors.textTertiary }]}>Options:</Text>
-                        {newFieldOptions.map((opt, i) => (
-                          <View key={i} style={styles.optionRow}>
-                            <TextInput
-                              style={[
-                                styles.optionInput,
-                                { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground },
-                                Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
-                              ]}
-                              value={opt}
-                              onChangeText={(text) => {
-                                const next = [...newFieldOptions];
-                                next[i] = text.replace(/;/g, "");
-                                setNewFieldOptions(next);
-                              }}
-                              placeholder={`Option ${i + 1}`}
-                              placeholderTextColor={colors.inputPlaceholder}
-                            />
-                            <TouchableOpacity
-                              onPress={() => setNewFieldOptions(newFieldOptions.filter((_, j) => j !== i))}
-                              style={styles.optionDeleteBtn}
-                            >
-                              <Ionicons name="close-circle" size={16} color={colors.iconSecondary} />
-                            </TouchableOpacity>
-                          </View>
-                        ))}
+                {/* Dropdown / multiselect options editor */}
+                {(newFieldType === "dropdown" || newFieldType === "multiselect") && (
+                  <View style={styles.optionsEditor}>
+                    <Text style={[styles.optionsLabel, { color: colors.textTertiary }]}>Options:</Text>
+                    {newFieldOptions.map((opt, i) => (
+                      <View key={i} style={styles.optionRow}>
+                        <TextInput
+                          style={[
+                            styles.optionInput,
+                            { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground },
+                            Platform.OS === "web" ? ({ outlineStyle: "none" } as any) : {},
+                          ]}
+                          value={opt}
+                          onChangeText={(text) => {
+                            const next = [...newFieldOptions];
+                            next[i] = text.replace(/;/g, "");
+                            setNewFieldOptions(next);
+                          }}
+                          placeholder={`Option ${i + 1}`}
+                          placeholderTextColor={colors.inputPlaceholder}
+                        />
                         <TouchableOpacity
-                          onPress={() => setNewFieldOptions([...newFieldOptions, ""])}
-                          style={styles.addOptionBtn}
+                          onPress={() => setNewFieldOptions(newFieldOptions.filter((_, j) => j !== i))}
+                          style={styles.optionDeleteBtn}
                         >
-                          <Ionicons name="add" size={12} color={themeColor} />
-                          <Text style={[styles.addOptionText, { color: themeColor }]}>Add option</Text>
+                          <Ionicons name="close-circle" size={16} color={colors.iconSecondary} />
                         </TouchableOpacity>
                       </View>
-                    )}
-
-                    <View style={styles.addFieldActions}>
-                      <TouchableOpacity
-                        onPress={() => {
-                          setShowAddField(false);
-                          setNewFieldName("");
-                          setNewFieldType("text");
-                          setNewFieldOptions([]);
-                        }}
-                        style={styles.cancelFieldBtn}
-                      >
-                        <Text style={[styles.cancelFieldText, { color: colors.textTertiary }]}>Cancel</Text>
-                      </TouchableOpacity>
-                      <TouchableOpacity
-                        onPress={handleAddField}
-                        style={[
-                          styles.confirmFieldBtn,
-                          { backgroundColor: themeColor },
-                          !canSubmitNewField && styles.btnDisabled,
-                        ]}
-                        disabled={!canSubmitNewField}
-                      >
-                        <Text style={[styles.confirmFieldText, { color: '#fff' }]}>Add Field</Text>
-                      </TouchableOpacity>
-                    </View>
+                    ))}
+                    <TouchableOpacity
+                      onPress={() => setNewFieldOptions([...newFieldOptions, ""])}
+                      style={styles.addOptionBtn}
+                    >
+                      <Ionicons name="add" size={12} color={themeColor} />
+                      <Text style={[styles.addOptionText, { color: themeColor }]}>Add option</Text>
+                    </TouchableOpacity>
                   </View>
-                ) : (
-                  <TouchableOpacity onPress={() => setShowAddField(true)} style={styles.addFieldButton}>
-                    <Ionicons name="add-circle-outline" size={16} color={themeColor} />
-                    <Text style={[styles.addFieldButtonText, { color: themeColor }]}>Add Custom Field</Text>
-                  </TouchableOpacity>
                 )}
-              </>
+
+                <View style={styles.addFieldActions}>
+                  <TouchableOpacity
+                    onPress={() => {
+                      setShowAddField(false);
+                      setNewFieldName("");
+                      setNewFieldType("text");
+                      setNewFieldOptions([]);
+                    }}
+                    style={styles.cancelFieldBtn}
+                  >
+                    <Text style={[styles.cancelFieldText, { color: colors.textTertiary }]}>Cancel</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={handleAddField}
+                    style={[
+                      styles.confirmFieldBtn,
+                      { backgroundColor: themeColor },
+                      !canSubmitNewField && styles.btnDisabled,
+                    ]}
+                    disabled={!canSubmitNewField}
+                  >
+                    <Text style={[styles.confirmFieldText, { color: '#fff' }]}>Add Field</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ) : (
+              <TouchableOpacity onPress={() => setShowAddField(true)} style={styles.addFieldButton}>
+                <Ionicons name="add-circle-outline" size={16} color={themeColor} />
+                <Text style={[styles.addFieldButtonText, { color: themeColor }]}>Add Custom Field</Text>
+              </TouchableOpacity>
             )}
 
             {/* Save custom fields button (only when custom fields exist or were modified) */}
-            {!crossGroupMode && customFields.length > 0 && (
+            {customFields.length > 0 && (
               <TouchableOpacity
                 onPress={handleSaveCustomFields}
                 style={[
@@ -828,14 +820,14 @@ export function FollowupSettingsPanel({
           </View>
         )}
 
-        {/* ── Section 4: Member Card Subtitle (hidden in cross-group mode) ── */}
-        {!crossGroupMode && renderSectionHeader(
+        {/* ── Section 4: Member Card Subtitle ── */}
+        {renderSectionHeader(
           "Member Card Subtitle",
           subtitleOpen,
           () => setSubtitleOpen((p) => !p),
           <Text style={[styles.sectionHeaderExtra, { color: colors.textTertiary }]}>(Mobile only)</Text>,
         )}
-        {!crossGroupMode && subtitleOpen && (
+        {subtitleOpen && (
           <View style={[styles.sectionBody, { borderBottomColor: colors.borderLight }]}>
             <Text style={[styles.hintText, { color: colors.textTertiary }]}>
               Choose up to 2 items to show below each member's name.

--- a/apps/mobile/features/people/components/PeopleTabScreen.tsx
+++ b/apps/mobile/features/people/components/PeopleTabScreen.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { View, ActivityIndicator } from "react-native";
 import { useLocalSearchParams, usePathname } from "expo-router";
 import { UserRoute } from "@components/guards/UserRoute";
 import { useIsDesktopWeb } from "@hooks/useIsDesktopWeb";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
 import { FollowupDesktopTable } from "@features/leader-tools/components/FollowupDesktopTable";
 import { FollowupMobileGrid } from "@features/leader-tools/components/FollowupMobileGrid";
 
@@ -15,12 +17,28 @@ export function PeopleTabScreen() {
       : null;
   const returnTo = returnToParam && returnToParam !== pathname ? returnToParam : null;
 
+  const crossGroupConfig = useAuthenticatedQuery(
+    api.functions.memberFollowups.getCrossGroupConfig,
+    {},
+  );
+  const announcementGroupId = crossGroupConfig?.announcementGroupId ?? "";
+
+  if (!announcementGroupId) {
+    return (
+      <UserRoute>
+        <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+          <ActivityIndicator size="large" />
+        </View>
+      </UserRoute>
+    );
+  }
+
   return (
     <UserRoute>
       {isDesktop ? (
-        <FollowupDesktopTable groupId="" crossGroupMode returnTo={returnTo} />
+        <FollowupDesktopTable groupId={announcementGroupId} defaultAssigneeFilter="me" returnTo={returnTo} />
       ) : (
-        <FollowupMobileGrid groupId="" crossGroupMode returnTo={returnTo} />
+        <FollowupMobileGrid groupId={announcementGroupId} defaultAssigneeFilter="me" returnTo={returnTo} />
       )}
     </UserRoute>
   );


### PR DESCRIPTION
## Summary
- Adds `communityPeopleAssignees` junction table for efficient server-side assignee filtering (Convex doesn't support array-contains in indexes)
- People tab now uses the announcement group's ID as a regular `groupId` with `defaultAssigneeFilter="me"`, eliminating the entire `crossGroupMode` code path
- Both People tab and Follow-up page now share identical features: custom fields, server sorting, settings, add button, column config, etc.

## Changes
- **Schema**: New `communityPeopleAssignees` table with 3 indexes
- **Backend**: `syncAssigneeJunction` helper, server-side `assigneeFilter` in `list()`/`search()`, `backfillAssigneeJunction` mutation, junction cleanup in score computation create/prune/delete paths
- **Frontend**: Removed `crossGroupMode` from `FollowupDesktopTable`, `FollowupMobileGrid`, `FollowupSettingsPanel`, `FollowupDetailScreen`, and `PeopleTabScreen`
- Assignee picker now shows all community leaders across groups

## Post-deploy
- Run backfill: `npx convex run functions/communityPeople:backfillAssigneeJunction`

## Test plan
- [ ] Open People tab → shows only people assigned to me (same UI/features as Follow-up)
- [ ] Open Follow-up page for a group → shows all people in group (no pre-filter)
- [ ] Both pages have identical layout, columns, custom fields, sorting, settings
- [ ] Assign someone as a secondary assignee → they appear on the People tab
- [ ] Change assignee filter → results update correctly
- [ ] Settings panel works (custom fields, display name, subtitle)
- [ ] Detail screen opens correctly from both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `communityPeopleAssignees` table and rewires assignee filtering/pagination to depend on it; correctness and performance depend on junction sync/backfill and could affect list/search results and pagination behavior.
> 
> **Overview**
> Unifies the mobile **People tab** with the per-group follow-up experience by removing the `crossGroupMode` path and instead loading the announcement group id as a normal `groupId`, defaulting the search to `assignee:me`.
> 
> Adds a new `communityPeopleAssignees` junction table to support efficient server-side assignee filtering (and excluded-assignee filtering) for `communityPeople` `list`/`search`, plus introduces junction sync/backfill logic and ensures junction rows are created/cleaned up across score computation, upsert, and deletion flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b561eb9b513d15ec0db6e098cc0ad0921402a26f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->