### PR TITLE
fix: use +native-intent to reliably pass subdomain from universal links

### DIFF
--- a/apps/mobile/app/+native-intent.ts
+++ b/apps/mobile/app/+native-intent.ts
@@ -1,0 +1,33 @@
+import { parseSubdomainFromLinkUrl } from "@/features/auth/utils/communitySubdomain";
+
+/**
+ * Intercepts incoming universal link URLs before Expo Router strips the hostname.
+ *
+ * When a user taps `https://fount.togather.nyc/nearme`, Expo Router extracts only
+ * the path (`/nearme`) for routing, discarding the hostname that contains the
+ * community subdomain. This hook appends `?subdomain=fount` to the URL so the
+ * subdomain arrives as a route parameter in the destination screen.
+ *
+ * Called by Expo Router for both cold starts (initial: true) and warm starts
+ * (initial: false), so it handles all deep link scenarios.
+ */
+export function redirectSystemPath({
+  path,
+  initial,
+}: {
+  path: string;
+  initial: boolean;
+}): string {
+  const subdomain = parseSubdomainFromLinkUrl(path);
+  if (!subdomain) return path;
+
+  try {
+    const url = new URL(path);
+    // Don't duplicate if already present
+    if (url.searchParams.has("subdomain")) return path;
+    url.searchParams.set("subdomain", subdomain);
+    return url.toString();
+  } catch {
+    return path;
+  }
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -42,10 +42,6 @@ import { ConvexProvider, useTokenSync } from "@services/api/convex";
 import { logCollector } from "@utils/logCollector";
 import { ChatPrefetchProvider } from "@features/chat/context/ChatPrefetchContext";
 import { usePrefetchExecutor } from "@features/chat/hooks/usePrefetchChannel";
-// Import to trigger module-level subdomain capture from universal link URL
-// before Expo Router consumes it. Must happen before child screens render.
-import "@features/auth/utils/communitySubdomain";
-
 // Initialize log collector to capture console output for debugging
 logCollector.initialize();
 

--- a/apps/mobile/features/auth/hooks/useSubdomainCommunity.ts
+++ b/apps/mobile/features/auth/hooks/useSubdomainCommunity.ts
@@ -1,13 +1,8 @@
 import { useState, useEffect, useMemo } from "react";
 import { Platform } from "react-native";
-import { useLinkingURL } from "expo-linking";
 import { useLocalSearchParams } from "expo-router";
 import { useQuery, api } from "@services/api/convex";
-import {
-  parseSubdomainFromHostname,
-  parseSubdomainFromLinkUrl,
-  getCapturedLinkSubdomain,
-} from "@/features/auth/utils/communitySubdomain";
+import { parseSubdomainFromHostname } from "@/features/auth/utils/communitySubdomain";
 
 /**
  * Hook to get community from subdomain
@@ -17,10 +12,9 @@ import {
  * - Falls back to ?subdomain= query param for local development
  *
  * On native:
- * - Uses the module-level captured subdomain (set in RootLayout via getLinkingURL()
- *   before Expo Router consumes the URL). This is reliable on real devices where
- *   useLinkingURL() never returns the URL in child screens.
- * - Falls back to useLinkingURL() for hot-reloading / development
+ * - The +native-intent.ts hook intercepts universal link URLs before Expo Router
+ *   strips the hostname. It extracts the subdomain from the hostname and appends
+ *   it as ?subdomain= to the URL, so it arrives as a route parameter.
  * - Falls back to ?subdomain= query param from deep links
  *
  * Returns:
@@ -31,7 +25,6 @@ import {
  */
 export function useSubdomainCommunity() {
   const params = useLocalSearchParams();
-  const linkingUrl = useLinkingURL();
   const [webHostnameSubdomain, setWebHostnameSubdomain] = useState<string | null>(
     null
   );
@@ -46,28 +39,10 @@ export function useSubdomainCommunity() {
     setIsHydrated(true);
   }, []);
 
-  const nativeSubdomainFromLink = useMemo(
-    () =>
-      Platform.OS !== "web" ? parseSubdomainFromLinkUrl(linkingUrl) : null,
-    [linkingUrl]
-  );
-
-  // Determine subdomain source: hostname (web), captured link (native), or query param
+  // Determine subdomain source: hostname (web) or query param (native via +native-intent)
   const subdomain = useMemo(() => {
-    if (Platform.OS === "web") {
-      if (webHostnameSubdomain) {
-        return webHostnameSubdomain;
-      }
-    } else {
-      // On native, prefer useLinkingURL() if available (works in dev/hot-reload),
-      // then fall back to the module-level captured subdomain from RootLayout
-      if (nativeSubdomainFromLink) {
-        return nativeSubdomainFromLink;
-      }
-      const captured = getCapturedLinkSubdomain();
-      if (captured) {
-        return captured;
-      }
+    if (Platform.OS === "web" && webHostnameSubdomain) {
+      return webHostnameSubdomain;
     }
 
     const paramSubdomain = params.subdomain;
@@ -76,7 +51,7 @@ export function useSubdomainCommunity() {
     }
 
     return null;
-  }, [webHostnameSubdomain, nativeSubdomainFromLink, params.subdomain]);
+  }, [webHostnameSubdomain, params.subdomain]);
 
   // Fetch community by subdomain using Convex
   // Pass "skip" when no subdomain to skip the query

--- a/apps/mobile/features/auth/utils/communitySubdomain.ts
+++ b/apps/mobile/features/auth/utils/communitySubdomain.ts
@@ -1,5 +1,3 @@
-import { Platform } from "react-native";
-import { getLinkingURL } from "expo-linking";
 import { DOMAIN_CONFIG } from "@togather/shared";
 
 /**
@@ -53,14 +51,4 @@ export function parseSubdomainFromLinkUrl(url: string | null): string | null {
   } catch {
     return null;
   }
-}
-
-// Capture subdomain from the initial universal link URL at module load time,
-// before Expo Router consumes the URL for routing. getLinkingURL() is synchronous
-// and available immediately. On web, subdomain comes from window.location instead.
-const _capturedLinkSubdomain: string | null =
-  Platform.OS !== "web" ? parseSubdomainFromLinkUrl(getLinkingURL()) : null;
-
-export function getCapturedLinkSubdomain(): string | null {
-  return _capturedLinkSubdomain;
 }


### PR DESCRIPTION
## Summary
- Uses Expo Router's `+native-intent.ts` hook to intercept universal link URLs **before** Expo Router strips the hostname for routing
- Extracts the community subdomain from the hostname (e.g., `fount` from `fount.togather.nyc`) and appends it as `?subdomain=fount` to the URL
- The subdomain arrives as a route parameter in destination screens, available via `useLocalSearchParams()`
- Removes the fragile module-level `getLinkingURL()` capture that didn't work on real devices

## Problem
The previous approach (PR #198) used `getLinkingURL()` at module load time to capture the subdomain before Expo Router consumed the URL. This failed because:
1. **Warm starts**: Module-level code only runs once on cold start. When the app is already running and receives a universal link, the module-level variable is stale
2. **Timing**: Even on cold start, `useLinkingURL()` in child screens returns `null` because Expo Router consumes the URL before children mount

## Solution
Expo Router's `+native-intent.ts` is called for **both cold starts and warm starts** with the full URL (including hostname). By appending `?subdomain=` before routing, the subdomain becomes a standard route parameter — no timing issues, no stale state.

## Tested in simulator
- Cold start with deep link → NearMe shows "FOUNT" community
- Normal app launch (no deep link) → App works normally, no interference
- Warm start with deep link → NearMe modal slides up with correct community
- Web with `?subdomain=` query param → Works correctly
- All 98 test suites pass (956 tests)

## Test plan
- [ ] Open `https://fount.togather.nyc/nearme?type=dinner_parties` from Messages on **real device** → should show NearMe with Fount community
- [ ] Normal app launch → should work normally
- [ ] Open universal link while app is already running (warm start) → should show correct community
- [ ] Web unaffected — `+native-intent.ts` only runs on native

🤖 Generated with [Claude Code](https://claude.com/claude-code)