### PR TITLE
fix: restore bubble padding and add web video playback

### DIFF
--- a/apps/mobile/features/chat/components/VideoPlayer.tsx
+++ b/apps/mobile/features/chat/components/VideoPlayer.tsx
@@ -100,6 +100,10 @@ function VideoDownloadFallback({ url, name, isOwnMessage }: VideoPlayerProps) {
 
 function WebVideoPlayer({ url, name, isOwnMessage = false, onLongPress }: VideoPlayerProps) {
   const resolvedUrl = getMediaUrl(url);
+  const fileName = name || url.split('/').pop()?.split('?')[0] || 'Video';
+  const displayName = fileName.length > 20
+    ? fileName.slice(0, 10) + '...' + fileName.slice(-8)
+    : fileName;
 
   return (
     <View style={styles.container}>
@@ -118,6 +122,9 @@ function WebVideoPlayer({ url, name, isOwnMessage = false, onLongPress }: VideoP
           }}
         />
       </Pressable>
+      <Text style={[styles.fileName, isOwnMessage && styles.ownMessageText]} numberOfLines={1}>
+        {displayName}
+      </Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- Restores `paddingHorizontal`/`paddingVertical` on `messageBubble` so voice messages and other content have proper spacing (was removed in #200)
- Adds HTML5 `<video>` player for web platform instead of showing the "Tap to download" fallback

## Test plan
- [ ] Voice messages display with proper horizontal padding on iOS
- [ ] Videos display with native HTML5 player on web (with controls)
- [ ] Videos still play in fullscreen modal on native (iOS)
- [ ] Text messages spacing unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change isolated to chat video rendering; main risk is web-specific playback/styling regressions due to introducing an HTML5 `<video>` element.
> 
> **Overview**
> Chat video attachments now render differently on web: `VideoPlayer` detects `Platform.OS === 'web'` and uses a new `WebVideoPlayer` that embeds an HTML5 `<video>` with native controls instead of falling back to “Tap to download”.
> 
> Native platforms keep the existing behavior (use `expo-av` when available, otherwise show the download fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db0137bf7301e00a9c34cb02cd2a0a89221d1014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->