### PR TITLE
fix: add horizontal padding to chat bubble attachments

### DIFF
--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -1098,6 +1098,7 @@ const styles = StyleSheet.create({
   },
   attachmentsContainer: {
     marginTop: 4,
+    paddingHorizontal: 10,
   },
   bubbleTextContent: {
     paddingHorizontal: 10,


### PR DESCRIPTION
## Summary
- Adds `paddingHorizontal: 10` to `attachmentsContainer` so voice messages, documents, videos, and images have proper spacing inside the message bubble
- Fixes the missing side padding on voice messages introduced by the edge-to-edge media refactor in #200/#201

## Test plan
- [ ] Voice messages display with proper horizontal padding
- [ ] Documents display with proper horizontal padding
- [ ] Images and videos still display correctly (with bubble-color border)
- [ ] Text-only messages unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adjusts layout padding for attachment rendering inside chat bubbles.
> 
> **Overview**
> Fixes missing side spacing for chat message attachments by adding `paddingHorizontal: 10` to the `attachmentsContainer` in `MessageItem.tsx`, ensuring audio/doc/video/image attachments align with the bubble’s text/footer padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28784f6f8a472dc2d99e3a058d5a8fa33db29692. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->