### PR TITLE
fix: load secrets before build in landing page deploy

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -62,13 +62,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build landing page
-        run: pnpm --filter @togather/web build
-
       - name: Load secrets
         uses: ./.github/actions/load-secrets
         with:
           secrets-json: ${{ toJSON(secrets) }}
+
+      - name: Build landing page
+        run: pnpm --filter @togather/web build
 
       - name: Install Wrangler
         run: npm install -g wrangler


### PR DESCRIPTION
## Summary
- Moves the "Load secrets" step before the "Build landing page" step in the deploy-landing workflow
- `VITE_CONVEX_URL` must be available at build time for Vite to inline it — previously it was loaded after the build, causing the staging site to crash

**Note:** Also requires adding `VITE_CONVEX_URL` as a GitHub repo secret.

## Test plan
- [ ] Add `VITE_CONVEX_URL` GitHub secret
- [ ] Merge and verify staging.togather.nyc loads without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that reorders steps so build-time environment variables are available; main risk is misconfigured/missing GitHub secrets causing deploy failures.
> 
> **Overview**
> Fixes the landing page deployment workflow by **loading GitHub secrets before the Vite build** in `.github/workflows/deploy-landing.yml`, ensuring build-time env vars (e.g. `VITE_CONVEX_URL`) are inlined correctly before deploying to Cloudflare Pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38e6363a200484b2b34f7e28097f325ed01c5201. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->