### PR TITLE
fix: move web signin to /onboarding/signin to avoid app route conflict

### DIFF
--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -90,7 +90,6 @@ function generateAppleAppSiteAssociation(hostname) {
     "/contribute",
     "/issue",
     "/propose",
-    "/signin",
     "/onboarding/*",
     "/admin/*",
     "/billing/*",
@@ -170,7 +169,7 @@ const DEFAULT_OG_IMAGE = "https://togather.nyc/og-image.png";
 
 // Static paths that should go to the landing page (not the app)
 // Note: /android path handling is environment-aware (see isLandingPagePath)
-const LANDING_PAGE_PATHS = ["/", "/download", "/legal", "/legal/privacy", "/legal/terms", "/contribute", "/issue", "/propose", "/signin"];
+const LANDING_PAGE_PATHS = ["/", "/download", "/legal", "/legal/privacy", "/legal/terms", "/contribute", "/issue", "/propose"];
 
 // Path prefixes that should go to the landing page (multi-segment routes)
 const LANDING_PAGE_PREFIXES = ["/onboarding/", "/admin/", "/billing/"];

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -347,7 +347,7 @@ function HeroSection() {
             {/* Desktop CTA */}
             <div className="hidden md:flex items-center gap-3">
               <a
-                href="/signin"
+                href="/onboarding/signin"
                 className="px-5 py-2.5 text-sm font-medium text-neutral-700 hover:text-neutral-900"
               >
                 Sign in
@@ -397,7 +397,7 @@ function HeroSection() {
             </a>
             <div className="pt-2 space-y-2">
               <a
-                href="/signin"
+                href="/onboarding/signin"
                 className="block text-center px-4 py-2.5 text-sm font-medium text-neutral-700 rounded-xl border border-neutral-200"
               >
                 Sign in

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -32,7 +32,7 @@ createRoot(document.getElementById('root')!).render(
           <Route path="/issue" element={<ReportIssue />} />
           <Route path="/legal/privacy" element={<PrivacyPolicy />} />
           <Route path="/legal/terms" element={<TermsOfService />} />
-          <Route path="/signin" element={<SignIn />} />
+          <Route path="/onboarding/signin" element={<SignIn />} />
           <Route path="/propose" element={<ProposeCommunity />} />
           <Route path="/onboarding/setup" element={<CommunitySetup />} />
           <Route path="/onboarding/success" element={<OnboardingSuccess />} />

--- a/apps/web/src/pages/AdminProposals.tsx
+++ b/apps/web/src/pages/AdminProposals.tsx
@@ -153,7 +153,7 @@ export default function AdminProposals() {
   // Redirect unauthenticated users
   useEffect(() => {
     if (!isAuthenticated) {
-      navigate("/signin?redirect=/admin/proposals", { replace: true });
+      navigate("/onboarding/signin?redirect=/admin/proposals", { replace: true });
     }
   }, [isAuthenticated, navigate]);
 

--- a/apps/web/src/pages/BillingManagement.tsx
+++ b/apps/web/src/pages/BillingManagement.tsx
@@ -107,7 +107,7 @@ export default function BillingManagement() {
   // Redirect unauthenticated users
   if (!isAuthenticated) {
     navigate(
-      `/signin?redirect=/billing/${communityId ?? ""}`,
+      `/onboarding/signin?redirect=/billing/${communityId ?? ""}`,
       { replace: true }
     );
     return null;

--- a/apps/web/src/pages/ProposeCommunity.tsx
+++ b/apps/web/src/pages/ProposeCommunity.tsx
@@ -17,7 +17,7 @@ export default function ProposeCommunity() {
   // Redirect to sign-in only when there is no auth AND no verification token
   useEffect(() => {
     if (!isAuthenticated && !hasVerificationToken) {
-      navigate("/signin?redirect=/propose", { replace: true });
+      navigate("/onboarding/signin?redirect=/propose", { replace: true });
     }
   }, [isAuthenticated, hasVerificationToken, navigate]);
 


### PR DESCRIPTION
/signin is used by the mobile app's (auth)/signin route. Adding it to
LANDING_PAGE_PATHS caused the Cloudflare Worker to route app signin
traffic to the web landing page instead of the Expo app.

Moves the web signin to /onboarding/signin which is already covered by
the /onboarding/ prefix in LANDING_PAGE_PREFIXES.
