### PR TITLE
fix: use correct domain and browser for Create a Community button

### DIFF
--- a/apps/mobile/features/auth/components/CommunitySelectionScreen.tsx
+++ b/apps/mobile/features/auth/components/CommunitySelectionScreen.tsx
@@ -8,13 +8,14 @@ import {
   ActivityIndicator,
   TextInput,
   Alert,
-  Linking,
 } from "react-native";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as WebBrowser from "expo-web-browser";
 import { useAuth } from "@/providers/AuthProvider";
 import { useSelectCommunity } from "../hooks/useAuth";
+import { Environment } from "@/services/environment";
 import type { CommunitySearchResult } from "../types";
 import { SwipeableCommunityRow } from './SwipeableCommunityRow';
 import { LeaveCommunityModal } from './LeaveCommunityModal';
@@ -648,7 +649,10 @@ export function CommunitySelectionScreen() {
           <Text style={[styles.createCommunitySubtitle, { color: colors.textSecondary }]}>Start your own community on Togather</Text>
           <TouchableOpacity
             style={[styles.createCommunityButton, { borderColor: colors.link }]}
-            onPress={() => Linking.openURL(`${DOMAIN_CONFIG.landingUrl}/propose`)}
+            onPress={() => {
+              const baseUrl = Environment.isStaging() ? "https://staging.togather.nyc" : DOMAIN_CONFIG.landingUrl;
+              WebBrowser.openBrowserAsync(`${baseUrl}/propose`);
+            }}
           >
             <Text style={[styles.createCommunityButtonText, { color: colors.link }]}>Create a Community</Text>
           </TouchableOpacity>


### PR DESCRIPTION
## Summary
- Staging builds now open `staging.togather.nyc/propose` instead of `togather.nyc/propose`
- Uses `WebBrowser.openBrowserAsync` instead of `Linking.openURL` to avoid iOS universal link interception (was opening `/propose` inside the app instead of in a browser)

## Test plan
- [ ] On staging build, "Create a Community" opens `staging.togather.nyc/propose` in browser
- [ ] On production build, "Create a Community" opens `togather.nyc/propose` in browser
- [ ] Link opens in in-app browser, not intercepted as universal link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation tweak: changes only the external link opening behavior and base domain selection for staging vs production.
> 
> **Overview**
> Fixes the **Create a Community** CTA in `CommunitySelectionScreen` to open `/propose` via `expo-web-browser` instead of `Linking`, avoiding universal-link interception on iOS.
> 
> The target domain is now environment-aware: staging builds use `https://staging.togather.nyc`, while production continues to use `DOMAIN_CONFIG.landingUrl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b741633e475d0859bd10f52f36c0ddad00d00177. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->