### PR TITLE
refactor: move proposal page to /onboarding/proposal

### DIFF
--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -89,7 +89,6 @@ function generateAppleAppSiteAssociation(hostname) {
     "/terms",
     "/contribute",
     "/issue",
-    "/propose",
     "/onboarding/*",
     "/admin/*",
     "/billing/*",
@@ -169,7 +168,7 @@ const DEFAULT_OG_IMAGE = "https://togather.nyc/og-image.png";
 
 // Static paths that should go to the landing page (not the app)
 // Note: /android path handling is environment-aware (see isLandingPagePath)
-const LANDING_PAGE_PATHS = ["/", "/download", "/legal", "/legal/privacy", "/legal/terms", "/contribute", "/issue", "/propose"];
+const LANDING_PAGE_PATHS = ["/", "/download", "/legal", "/legal/privacy", "/legal/terms", "/contribute", "/issue"];
 
 // Path prefixes that should go to the landing page (multi-segment routes)
 const LANDING_PAGE_PREFIXES = ["/onboarding/", "/admin/", "/billing/"];

--- a/apps/mobile/features/auth/components/CommunitySelectionScreen.tsx
+++ b/apps/mobile/features/auth/components/CommunitySelectionScreen.tsx
@@ -651,7 +651,7 @@ export function CommunitySelectionScreen() {
             style={[styles.createCommunityButton, { borderColor: colors.link }]}
             onPress={() => {
               const baseUrl = Environment.isStaging() ? "https://staging.togather.nyc" : DOMAIN_CONFIG.landingUrl;
-              WebBrowser.openBrowserAsync(`${baseUrl}/propose`);
+              WebBrowser.openBrowserAsync(`${baseUrl}/onboarding/proposal`);
             }}
           >
             <Text style={[styles.createCommunityButtonText, { color: colors.link }]}>Create a Community</Text>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -34,7 +34,7 @@ createRoot(document.getElementById('root')!).render(
           <Route path="/legal/terms" element={<TermsOfService />} />
           <Route path="/signin" element={<SignIn />} />
           <Route path="/onboarding/signin" element={<SignIn />} />
-          <Route path="/propose" element={<ProposeCommunity />} />
+          <Route path="/onboarding/proposal" element={<ProposeCommunity />} />
           <Route path="/onboarding/setup" element={<CommunitySetup />} />
           <Route path="/onboarding/success" element={<OnboardingSuccess />} />
           <Route path="/admin/proposals" element={<AdminProposals />} />

--- a/apps/web/src/pages/ProposeCommunity.tsx
+++ b/apps/web/src/pages/ProposeCommunity.tsx
@@ -17,7 +17,7 @@ export default function ProposeCommunity() {
   // Redirect to sign-in only when there is no auth AND no verification token
   useEffect(() => {
     if (!isAuthenticated && !hasVerificationToken) {
-      navigate("/onboarding/signin?redirect=/propose", { replace: true });
+      navigate("/onboarding/signin?redirect=/onboarding/proposal", { replace: true });
     }
   }, [isAuthenticated, hasVerificationToken, navigate]);
 

--- a/apps/web/src/pages/SignIn.tsx
+++ b/apps/web/src/pages/SignIn.tsx
@@ -18,7 +18,7 @@ function formatPhoneDisplay(digits: string): string {
 export default function SignIn() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const redirect = searchParams.get("redirect") || "/propose";
+  const redirect = searchParams.get("redirect") || "/onboarding/proposal";
 
   const { signIn } = useWebAuth();
 
@@ -147,10 +147,10 @@ export default function SignIn() {
         signIn(result.access_token, result.refresh_token);
         navigate(redirect, { replace: true });
       } else if (result.phoneVerificationToken) {
-        // New user -- no account yet. Redirect to registration/propose page
+        // New user -- no account yet. Redirect to proposal page
         // with the verification token so they can complete signup.
         navigate(
-          `/propose?phoneVerificationToken=${encodeURIComponent(result.phoneVerificationToken)}&phone=${encodeURIComponent(`+1${phoneDigits}`)}`,
+          `/onboarding/proposal?phoneVerificationToken=${encodeURIComponent(result.phoneVerificationToken)}&phone=${encodeURIComponent(`+1${phoneDigits}`)}`,
           { replace: true }
         );
       } else {


### PR DESCRIPTION
## Summary
- Moves proposal page from `/propose` to `/onboarding/proposal`
- All onboarding routes now under `/onboarding/` prefix: `signin`, `proposal`, `setup`, `success`
- Removes `/propose` from `LANDING_PAGE_PATHS` and AASA excluded paths (covered by `/onboarding/*`)

## Test plan
- [ ] "Create a Community" button in app opens `/onboarding/proposal` in browser
- [ ] Unauthenticated users redirect to `/onboarding/signin`
- [ ] After signin, redirects back to `/onboarding/proposal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public URL routing and redirect targets across web, mobile, and the Cloudflare worker; missed references could break onboarding navigation or deep linking.
> 
> **Overview**
> Moves the community proposal page from `/_propose_` to `/_onboarding/proposal_` and updates the web router plus sign-in/proposal redirects to consistently return users to the new path.
> 
> Updates the mobile "Create a Community" CTA to open the new onboarding proposal URL, and adjusts the Cloudflare worker’s landing/static routing and Universal Links exclusions by removing `/_propose_` (now covered under `/_onboarding/*_`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a0f9daecc58f8f1b4b8a9af05c89a90c2975119. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->