### PR TITLE
fix: disable LinearGradient on native — Fabric view adapter crashes

### DIFF
--- a/apps/mobile/features/chat/utils/fileTypes.ts
+++ b/apps/mobile/features/chat/utils/fileTypes.ts
@@ -344,19 +344,13 @@ export function isLinearGradientSupported(): boolean {
     }
   }
 
-  if (!hasNativeModule('ExpoLinearGradient')) {
-    _linearGradientSupported = false;
-    return false;
-  }
-
-  try {
-    const LinearGradientModule = require('expo-linear-gradient');
-    _linearGradientSupported = !!LinearGradientModule?.LinearGradient;
-    return _linearGradientSupported;
-  } catch {
-    _linearGradientSupported = false;
-    return false;
-  }
+  // On native with New Architecture (Fabric), ExpoLinearGradient's view adapter
+  // crashes at render time even though the module registers successfully.
+  // The Fabric ViewManagerAdapter can't find the underlying view manager for
+  // ExpoView subclasses. Disable until expo-linear-gradient ships Fabric support.
+  // See: ADR-013, MEMORY.md "Expo Modules Native Views (Fabric / New Architecture)"
+  _linearGradientSupported = false;
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `ExpoLinearGradient` module registers successfully but the Fabric `ViewManagerAdapter` crashes at render time
- The detection function (`isLinearGradientSupported`) was returning `true` because the module exists, but the view can't render
- Disables LinearGradient on native until `expo-linear-gradient` ships Fabric support
- `SafeLinearGradient` falls back to a solid `View` with the last gradient color

## Test plan
- [ ] App no longer crashes on screens using SafeLinearGradient
- [ ] Auth landing page renders with solid background instead of gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, defensive change that only disables `LinearGradient` on native to prevent a known render-time crash; main impact is loss of gradient UI styling on iOS/Android.
> 
> **Overview**
> Prevents native crashes under the New Architecture (Fabric) by changing `isLinearGradientSupported()` to **always return `false` on native**, even if `ExpoLinearGradient` registers successfully.
> 
> Web behavior is unchanged (still attempts to `require('expo-linear-gradient')`), but native callers will now consistently take their non-gradient fallback path until Fabric support lands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1358309ac3a1f5f14baf9e02e8559f451112b45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->