### PR TITLE
chore: add Stripe secrets to Convex sync script

### DIFF
--- a/ee/scripts/sync-secrets-to-convex.sh
+++ b/ee/scripts/sync-secrets-to-convex.sh
@@ -95,6 +95,9 @@ SECRET_KEYS=(
   "SLACK_BOT_TOKEN"
   "SLACK_SIGNING_SECRET"
   "OPENAI_SECRET_KEY"
+  "STRIPE_SECRET_KEY"
+  "STRIPE_WEBHOOK_SECRET"
+  "STRIPE_PRODUCT_ID"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRODUCT_ID` to the secret sync whitelist
- Secrets auto-sync to Convex deployment on each deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds three Stripe-related keys to an existing secret-sync whitelist without changing sync behavior or data handling logic.
> 
> **Overview**
> Updates `ee/scripts/sync-secrets-to-convex.sh` to include `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and `STRIPE_PRODUCT_ID` in the whitelisted environment variables that get synced to Convex during deploy/runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16f379f19919ca71bcd8aac0309bb3ca1cb6bdbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->