### PR TITLE
fix: bounce onboarding/admin/billing URLs to browser from app

### DIFF
--- a/apps/mobile/app/+native-intent.ts
+++ b/apps/mobile/app/+native-intent.ts
@@ -1,4 +1,9 @@
+import { Linking } from "react-native";
 import { parseSubdomainFromLinkUrl } from "@/features/auth/utils/communitySubdomain";
+
+// Web-only paths that should never be handled by the app.
+// If iOS universal links intercept these, bounce them to the browser.
+const WEB_ONLY_PREFIXES = ["/onboarding/", "/admin/", "/billing/"];
 
 /**
  * Intercepts incoming universal link URLs before Expo Router strips the hostname.
@@ -18,6 +23,21 @@ export function redirectSystemPath({
   path: string;
   initial: boolean;
 }): string {
+  // Bounce web-only URLs back to the browser
+  try {
+    const url = new URL(path);
+    if (WEB_ONLY_PREFIXES.some((p) => url.pathname.startsWith(p))) {
+      Linking.openURL(path);
+      // Return root so the app doesn't navigate to a broken route
+      return "/";
+    }
+  } catch {
+    // Not a full URL — check raw path
+    if (WEB_ONLY_PREFIXES.some((p) => path.startsWith(p))) {
+      return "/";
+    }
+  }
+
   const subdomain = parseSubdomainFromLinkUrl(path);
   if (!subdomain) return path;
 


### PR DESCRIPTION
## Summary
- Adds defense-in-depth URL bouncing in `+native-intent.ts`
- If iOS universal links intercept `/onboarding/*`, `/admin/*`, or `/billing/*` URLs, the app opens them in the browser and returns to root
- Prevents "Page Not Found" errors when web-only URLs get opened in the app

## Test plan
- [ ] Tapping an onboarding link opens in browser, not in app
- [ ] Normal deep links (events, groups, nearme) still work in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches universal-link routing, so incorrect prefix matching or URL parsing could cause unexpected redirects or broken navigation for some deep links.
> 
> **Overview**
> Prevents the mobile app from attempting to handle *web-only* universal links by adding a `WEB_ONLY_PREFIXES` allowlist in `+native-intent.ts`.
> 
> When an incoming URL/path matches `/onboarding/`, `/admin/`, or `/billing/`, the app opens the link via `Linking.openURL()` (for full URLs) and returns `/` to avoid routing to a non-existent in-app screen; other deep links keep the existing subdomain-parameter behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c68cb801cad351f0e39dac5b00dd576eb36dea24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->