### PR TITLE
fix(tasks): group leaders can complete/cancel tasks assigned to others

### DIFF
--- a/apps/convex/__tests__/tasks.test.ts
+++ b/apps/convex/__tests__/tasks.test.ts
@@ -1115,6 +1115,48 @@ describe("tasks functions", () => {
     ).rejects.toThrow("Leader access required");
   });
 
+  test("co-leader can complete, cancel, snooze, and reopen person tasks assigned to another leader", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, leaderId, secondLeaderToken } = await seedData(t);
+
+    const taskId = await t.mutation(api.functions.tasks.index.create, {
+      token: secondLeaderToken,
+      groupId,
+      title: "Assigned to leader one",
+      responsibilityType: "person",
+      assignedToId: leaderId,
+    });
+
+    await expect(
+      t.mutation(api.functions.tasks.index.markDone, {
+        token: secondLeaderToken,
+        taskId,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    await expect(
+      t.mutation(api.functions.tasks.index.reopen, {
+        token: secondLeaderToken,
+        taskId,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    await expect(
+      t.mutation(api.functions.tasks.index.snooze, {
+        token: secondLeaderToken,
+        taskId,
+        preset: "1_day",
+      }),
+    ).resolves.toMatchObject({ success: true });
+
+    await expect(
+      t.mutation(api.functions.tasks.index.cancel, {
+        token: secondLeaderToken,
+        taskId,
+      }),
+    ).resolves.toEqual({ success: true });
+  });
+
   test("leader cannot mutate tasks for groups they do not lead", async () => {
     const t = convexTest(schema, modules);
     const {

--- a/apps/convex/functions/tasks/index.ts
+++ b/apps/convex/functions/tasks/index.ts
@@ -1369,7 +1369,7 @@ function canResolvePersonTask(
 ) {
   if (task.responsibilityType !== "person") return true;
   if (!task.assignedToId) return true;
-  return task.assignedToId === userId || role === "admin";
+  return task.assignedToId === userId || isLeaderRole(role);
 }
 
 export const markDone = mutation({
@@ -1387,7 +1387,7 @@ export const markDone = mutation({
     }
     if (!canResolvePersonTask(task, userId, membership.role)) {
       throw new ConvexError(
-        "Only the assignee or an admin can complete this task",
+        "Only the assignee or a group leader can complete this task",
       );
     }
 
@@ -1425,7 +1425,7 @@ export const reopen = mutation({
     }
     if (!canResolvePersonTask(task, userId, membership.role)) {
       throw new ConvexError(
-        "Only the assignee or an admin can reopen this task",
+        "Only the assignee or a group leader can reopen this task",
       );
     }
 
@@ -1575,7 +1575,7 @@ export const snooze = mutation({
     }
     if (!canResolvePersonTask(task, userId, membership.role)) {
       throw new ConvexError(
-        "Only the assignee or an admin can snooze this task",
+        "Only the assignee or a group leader can snooze this task",
       );
     }
 
@@ -1614,7 +1614,7 @@ export const cancel = mutation({
     }
     if (!canResolvePersonTask(task, userId, membership.role)) {
       throw new ConvexError(
-        "Only the assignee or an admin can cancel this task",
+        "Only the assignee or a group leader can cancel this task",
       );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [togathernyc/togather#191](https://github.com/togathernyc/togather/issues/191).

Person-responsibility tasks assigned to another user were only resolvable by the assignee or a member with **admin** group role. Co-leaders with **leader** role already pass `getLeaderMembership` but failed `canResolvePersonTask`, so **Mark done** and **Cancel** (and snooze/reopen) errored incorrectly.

## Changes

- `canResolvePersonTask` now treats any `isLeaderRole` (leader or admin) like an admin for assigned person tasks, matching “any group leader can manage group tasks.”
- User-facing error strings updated from “assignee or an admin” to “assignee or a group leader.”
- Regression test: second leader completes, reopens, snoozes, and cancels a task assigned to the first leader.

## Testing

- `pnpm exec vitest run __tests__/tasks.test.ts` (from `apps/convex`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5098015-9827-4543-9db4-1b313834cc68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5098015-9827-4543-9db4-1b313834cc68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

