### PR TITLE
fix: make DOMAIN_CONFIG environment-aware

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Export web app
         env:
           EXPO_PUBLIC_CONVEX_URL: ${{ env.CONVEX_SITE_URL }}
+          APP_VARIANT: ${{ steps.env.outputs.target == 'staging' && 'staging' || '' }}
         run: npx expo export --platform web
 
       - name: Deploy to EAS Hosting

--- a/apps/mobile/components/ui/NativeUpdateModal.tsx
+++ b/apps/mobile/components/ui/NativeUpdateModal.tsx
@@ -21,7 +21,7 @@ import { useTheme } from '@hooks/useTheme';
 const isStaging = Constants.expoConfig?.extra?.isStaging === true;
 
 // R2 images bucket for release manifests
-const R2_IMAGES_URL = `https://images.${DOMAIN_CONFIG.baseDomain}`;
+const R2_IMAGES_URL = DOMAIN_CONFIG.imageCdnUrl;
 
 const URLS = {
   production: {

--- a/apps/mobile/features/auth/components/CommunitySelectionScreen.tsx
+++ b/apps/mobile/features/auth/components/CommunitySelectionScreen.tsx
@@ -649,7 +649,7 @@ export function CommunitySelectionScreen() {
                 // On web, use current origin (works for localhost, staging, and prod)
                 window.open(`${window.location.origin}/onboarding/proposal`, "_blank");
               } else {
-                const baseUrl = Environment.isStaging() ? "https://staging.togather.nyc" : DOMAIN_CONFIG.landingUrl;
+                const baseUrl = DOMAIN_CONFIG.landingUrl;
                 WebBrowser.openBrowserAsync(`${baseUrl}/onboarding/proposal`);
               }
             }}

--- a/apps/mobile/features/chat/utils/eventLinkUtils.ts
+++ b/apps/mobile/features/chat/utils/eventLinkUtils.ts
@@ -124,8 +124,8 @@ export function isTogatherLink(url: string | undefined): boolean {
       'www.togather.nyc',
       'app.togather.nyc',
       'staging.togather.nyc',
-      'togather.dev',
-      'www.togather.dev',
+      DOMAIN_CONFIG.legacyDomain,
+      `www.${DOMAIN_CONFIG.legacyDomain}`,
     ];
 
     return togatherDomains.some(domain => hostname === domain || hostname.endsWith('.' + domain));

--- a/apps/mobile/features/onboarding/components/SuccessScreen.tsx
+++ b/apps/mobile/features/onboarding/components/SuccessScreen.tsx
@@ -12,7 +12,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 
-const APP_STORE_URL = "https://apps.apple.com/app/togather/id6738726638";
+const APP_STORE_URL = "https://apps.apple.com/us/app/togather-life-in-community/id6756286011";
 const PLAY_STORE_URL =
   "https://play.google.com/store/apps/details?id=app.gatherful.mobile";
 

--- a/packages/shared/src/config/domain.d.ts
+++ b/packages/shared/src/config/domain.d.ts
@@ -3,6 +3,7 @@
  */
 
 export const BASE_DOMAIN: string;
+export const ROOT_DOMAIN: string;
 export const BRAND_NAME: string;
 
 export const DOMAIN_CONFIG: {
@@ -12,6 +13,7 @@ export const DOMAIN_CONFIG: {
   readonly landingUrl: string;
   readonly emailDomain: string;
   readonly emailFrom: string;
+  readonly imageCdnUrl: string;
   readonly domainSuffix: string;
   readonly legacyDomain: string;
   eventShareUrl(shortId: string): string;

--- a/packages/shared/src/config/domain.js
+++ b/packages/shared/src/config/domain.js
@@ -15,11 +15,32 @@
  * - README files, .env.example files, docs/*
  */
 
-// ============================================================
-// CHANGE THIS VALUE TO UPDATE THE DOMAIN ACROSS THE ENTIRE APP
-// ============================================================
-const BASE_DOMAIN = "togather.nyc";
-// ============================================================
+// Detect domain from environment at module load time.
+// Priority: APP_URL (backend) > APP_ENV (backend) > APP_VARIANT (mobile) > default (production)
+function detectBaseDomain() {
+  if (typeof process !== "undefined" && process.env) {
+    // Backend: APP_URL is the canonical URL (e.g., "https://staging.togather.nyc")
+    if (process.env.APP_URL) {
+      try {
+        return new URL(process.env.APP_URL).hostname;
+      } catch {
+        // Fall through on invalid URL
+      }
+    }
+    // Backend/Mobile: APP_ENV or APP_VARIANT explicitly set to staging
+    if (process.env.APP_ENV === "staging" || process.env.APP_VARIANT === "staging") {
+      return "staging.togather.nyc";
+    }
+  }
+  // Default: production
+  return "togather.nyc";
+}
+
+const BASE_DOMAIN = detectBaseDomain();
+
+// The root domain, always togather.nyc regardless of environment.
+// Used for: email sending domain, image CDN, regex patterns matching all environments.
+const ROOT_DOMAIN = "togather.nyc";
 
 // ============================================================
 // CONVEX DEPLOYMENT CONFIGURATION
@@ -31,7 +52,7 @@ const CONVEX_DEPLOYMENT = process.env.CONVEX_DEPLOYMENT || "";
 const BRAND_NAME = "Togather";
 
 // Escape domain for use in regex patterns
-const ESCAPED_DOMAIN = BASE_DOMAIN.replace(/\./g, '\\.');
+const ESCAPED_DOMAIN = ROOT_DOMAIN.replace(/\./g, '\\.');
 
 // Legacy domain (gatherful.app) for backwards compatibility
 const LEGACY_DOMAIN = "gatherful.app";
@@ -45,8 +66,9 @@ const DOMAIN_CONFIG = {
   brandName: BRAND_NAME,
   landingUrl: `https://${BASE_DOMAIN}`,
   appUrl: `https://${BASE_DOMAIN}`,
-  emailDomain: BASE_DOMAIN,
-  emailFrom: `${BRAND_NAME} <notifications@${BASE_DOMAIN}>`,
+  emailDomain: ROOT_DOMAIN,
+  emailFrom: `${BRAND_NAME} <notifications@${ROOT_DOMAIN}>`,
+  imageCdnUrl: `https://images.${ROOT_DOMAIN}`,
   eventShareUrl: (shortId) => `https://${BASE_DOMAIN}/e/${shortId}`,
   groupShareUrl: (shortId) => `https://${BASE_DOMAIN}/g/${shortId}`,
   communityUrl: (subdomain) => `https://${subdomain}.${BASE_DOMAIN}`,
@@ -78,4 +100,4 @@ const DOMAIN_CONFIG = {
   convexHttpUrl: CONVEX_DEPLOYMENT ? `https://${CONVEX_DEPLOYMENT}.convex.site` : null,
 };
 
-module.exports = { BASE_DOMAIN, BRAND_NAME, DOMAIN_CONFIG };
+module.exports = { BASE_DOMAIN, ROOT_DOMAIN, BRAND_NAME, DOMAIN_CONFIG };

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -2,6 +2,7 @@
 // Using require + re-export pattern for CommonJS module
 const domain = require("./domain.js");
 export const BASE_DOMAIN: string = domain.BASE_DOMAIN;
+export const ROOT_DOMAIN: string = domain.ROOT_DOMAIN;
 export const BRAND_NAME: string = domain.BRAND_NAME;
 
 // Type definition for DOMAIN_CONFIG (must match domain.js)
@@ -12,6 +13,7 @@ export interface DomainConfig {
   readonly appUrl: string;
   readonly emailDomain: string;
   readonly emailFrom: string;
+  readonly imageCdnUrl: string;
   readonly domainSuffix: string;
   readonly legacyDomain: string;
   readonly convexDeployment: string;


### PR DESCRIPTION
## Summary

- Makes `DOMAIN_CONFIG.baseDomain` detect the environment at module load time instead of being hardcoded to `togather.nyc`
- Fixes hardcoded domain URLs across the codebase
- Adds `ROOT_DOMAIN` constant for values that should always use the root domain (email, image CDN, regex patterns)

## Changes

**Core (`packages/shared/src/config/domain.js`):**
- `detectBaseDomain()` checks `APP_URL` → `APP_ENV` → `APP_VARIANT` → defaults to production
- `ROOT_DOMAIN = "togather.nyc"` — always the root domain, used for email sending, image CDN, and URL regex matching
- `emailDomain`/`emailFrom` use `ROOT_DOMAIN` (emails always from `@togather.nyc`)
- New `imageCdnUrl` property using `ROOT_DOMAIN` (CDN is shared across environments)
- Share URLs (`eventShareUrl`, etc.) use `BASE_DOMAIN` (environment-aware)

**Mobile fixes:**
- `CommunitySelectionScreen`: removed redundant `Environment.isStaging()` check with hardcoded URL
- `eventLinkUtils`: replaced hardcoded `togather.dev` with `DOMAIN_CONFIG.legacyDomain`
- `SuccessScreen`: fixed App Store ID from `id6738726638` → `id6756286011`
- `NativeUpdateModal`: use `DOMAIN_CONFIG.imageCdnUrl` instead of string interpolation

**CI/CD:**
- `deploy-web.yml`: pass `APP_VARIANT` env var during Expo web export for staging detection

## Test plan

- [ ] `APP_VARIANT=staging` → verify `DOMAIN_CONFIG.baseDomain` is `staging.togather.nyc`
- [ ] Default (no env vars) → verify `DOMAIN_CONFIG.baseDomain` is `togather.nyc`
- [ ] Email domain is always `togather.nyc` regardless of environment
- [ ] Image CDN URL is always `https://images.togather.nyc`
- [ ] Share URLs use environment-aware domain
- [ ] CommunitySelectionScreen "Propose" link uses correct domain
- [ ] App Store link in SuccessScreen matches rest of codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how domains are derived at runtime (via env vars) and updates URL/regex/email/CDN configuration that is widely used across web/mobile, which could break links or deployments if misconfigured.
> 
> **Overview**
> `DOMAIN_CONFIG` is updated to derive `baseDomain` at module load time from `APP_URL`/`APP_ENV`/`APP_VARIANT` instead of being hardcoded, and introduces `ROOT_DOMAIN` for values that must remain on the root domain.
> 
> Email sender fields and link-matching regexes now use `ROOT_DOMAIN`, while share/landing/app URLs use the environment-derived `BASE_DOMAIN`; a new `imageCdnUrl` is added and consumers are updated to use it.
> 
> Mobile/web wiring is adjusted to remove hardcoded staging URLs, update Togather domain detection to rely on `DOMAIN_CONFIG.legacyDomain`, fix the App Store link, and pass `APP_VARIANT` during web export so staging builds resolve the correct domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82b5c201effc159bb9953aec8c6a2a185e0975c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->