### PR TITLE
fix: disable expo-av Video view on Fabric to prevent chat crash

### DIFF
--- a/apps/mobile/features/chat/components/VideoPlayer.tsx
+++ b/apps/mobile/features/chat/components/VideoPlayer.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { isAudioVideoSupported } from '../utils/fileTypes';
+import { isVideoViewSupported } from '../utils/fileTypes';
 import { getMediaUrl } from '@/utils/media';
 
 // ============================================================================
@@ -139,8 +139,8 @@ export function VideoPlayer({ url, name, isOwnMessage = false, onLongPress }: Vi
     return <WebVideoPlayer url={url} name={name} isOwnMessage={isOwnMessage} onLongPress={onLongPress} />;
   }
 
-  // Native: use expo-av if available, otherwise download fallback
-  if (!isAudioVideoSupported()) {
+  // Native: use expo-av if the Video view can render, otherwise download fallback
+  if (!isVideoViewSupported()) {
     return <VideoDownloadFallback url={url} name={name} isOwnMessage={isOwnMessage} />;
   }
 

--- a/apps/mobile/features/chat/utils/fileTypes.ts
+++ b/apps/mobile/features/chat/utils/fileTypes.ts
@@ -224,6 +224,7 @@ export function formatFileSize(bytes: number): string {
 // Cache for module detection results
 let _documentPickerSupported: boolean | null = null;
 let _audioVideoSupported: boolean | null = null;
+let _videoViewSupported: boolean | null = null;
 let _linearGradientSupported: boolean | null = null;
 
 /**
@@ -322,6 +323,37 @@ export function isAudioVideoSupported(): boolean {
 }
 
 /**
+ * Check if expo-av's Video *view* can render on this device.
+ *
+ * expo-av v16+ registers its Video view as 'ExpoVideoView' via
+ * requireNativeViewManager. On Fabric (New Architecture), the
+ * ViewManagerAdapter can't find the underlying view manager for
+ * ExpoView subclasses, causing a runtime crash:
+ *   "ViewManagerAdapter_ExpoVideoView_* must be a function (received undefined)"
+ *
+ * Audio-only playback (isAudioVideoSupported) still works because it
+ * doesn't instantiate the native view. This check gates only the
+ * Video rendering path.
+ */
+export function isVideoViewSupported(): boolean {
+  if (_videoViewSupported !== null) {
+    return _videoViewSupported;
+  }
+
+  // On web, we use HTML5 <video> — no native view needed
+  if (Platform.OS === 'web') {
+    _videoViewSupported = true;
+    return true;
+  }
+
+  // On native with Fabric, ExpoVideoView's view adapter crashes.
+  // Same issue as ExpoLinearGradient — disable until expo-av ships
+  // Fabric-compatible view support (or migration to expo-video).
+  _videoViewSupported = false;
+  return false;
+}
+
+/**
  * Check if expo-linear-gradient is available
  *
  * This module is only available after a native build that includes it.
@@ -382,5 +414,6 @@ export function isVoiceRecordingSupported(): boolean {
 export function resetModuleDetectionCache(): void {
   _documentPickerSupported = null;
   _audioVideoSupported = null;
+  _videoViewSupported = null;
   _linearGradientSupported = null;
 }


### PR DESCRIPTION
## Summary
- **EMERGENCY FIX**: Opening any chat with a video crashes the app on production and staging
- The `hasNativeModule()` helper (added via recent OTA) now detects `ExponentAV` via `expo-modules-core` on Fabric, so `isAudioVideoSupported()` returns `true`
- `expo-av` v16 then tries to render `ExpoVideoView` via `requireNativeViewManager`, which crashes: `"ViewManagerAdapter must be a function (received undefined)"` — same Fabric issue as LinearGradient
- Adds `isVideoViewSupported()` gate (returns `false` on native Fabric) so VideoPlayer falls back to download UI
- Audio playback is unaffected (no native view)

## Test plan
- [x] All 966 tests pass
- [ ] Verify chat with video messages opens without crash on staging after OTA
- [ ] Verify video download fallback works (tap to open in system player)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables native in-chat video rendering on Fabric by forcing a download fallback, which avoids a production crash but may regress expected playback behavior on some devices/builds.
> 
> **Overview**
> Prevents a Fabric runtime crash when opening chats containing videos by **separating “expo-av module present” from “Video view can safely render.”**
> 
> `VideoPlayer` now checks a new `isVideoViewSupported()` guard and falls back to the download UI when the native `ExpoVideoView` path is unsafe. `fileTypes.ts` adds this cached capability check and includes it in `resetModuleDetectionCache()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cd354b704071c0cd9f432cc32ff9659139affa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->