### PR TITLE
fix: ViewToggle does not switch back to Groups view

### DIFF
--- a/apps/mobile/features/explore/hooks/__tests__/useExploreFilters.test.ts
+++ b/apps/mobile/features/explore/hooks/__tests__/useExploreFilters.test.ts
@@ -1,0 +1,146 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+const mockReplace = jest.fn();
+const mockSetParams = jest.fn();
+let mockParams: Record<string, string> = {};
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: jest.fn(() => mockParams),
+  useRouter: jest.fn(() => ({
+    replace: mockReplace,
+    setParams: mockSetParams,
+    push: jest.fn(),
+    back: jest.fn(),
+  })),
+}));
+
+import { useExploreFilters } from '../useExploreFilters';
+
+describe('useExploreFilters', () => {
+  beforeEach(() => {
+    mockParams = {};
+    mockReplace.mockClear();
+    mockSetParams.mockClear();
+  });
+
+  it('defaults to groups view when no params', () => {
+    const { result } = renderHook(() => useExploreFilters());
+    expect(result.current.filters.view).toBe('groups');
+  });
+
+  it('reads view from URL params', () => {
+    mockParams = { view: 'events' };
+    const { result } = renderHook(() => useExploreFilters());
+    expect(result.current.filters.view).toBe('events');
+  });
+
+  describe('ViewToggle fix - switching back to groups', () => {
+    it('explicitly includes view=groups in URL when switching to groups', () => {
+      // Start with events view
+      mockParams = { view: 'events' };
+      const { result } = renderHook(() => useExploreFilters());
+
+      act(() => {
+        result.current.setFilters({ view: 'groups' });
+      });
+
+      // The critical assertion: view=groups must be in the URL
+      // Previously, view was omitted for 'groups' (default), causing
+      // Expo Router param merge to keep stale view=events
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      const calledUrl = mockReplace.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('view=groups');
+    });
+
+    it('explicitly includes view=events in URL when switching to events', () => {
+      mockParams = {};
+      const { result } = renderHook(() => useExploreFilters());
+
+      act(() => {
+        result.current.setFilters({ view: 'events' });
+      });
+
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      const calledUrl = mockReplace.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('view=events');
+    });
+
+    it('uses router.replace (not setParams) to avoid param merging', () => {
+      mockParams = { view: 'events' };
+      const { result } = renderHook(() => useExploreFilters());
+
+      act(() => {
+        result.current.setFilters({ view: 'groups' });
+      });
+
+      // Must use replace, not setParams
+      expect(mockReplace).toHaveBeenCalled();
+      expect(mockSetParams).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetFilters', () => {
+    it('always includes view param when resetting', () => {
+      mockParams = { view: 'events', dateFilter: 'this_week' };
+      const { result } = renderHook(() => useExploreFilters());
+
+      act(() => {
+        result.current.resetFilters();
+      });
+
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      const calledUrl = mockReplace.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('view=events');
+      expect(calledUrl).not.toContain('dateFilter');
+    });
+
+    it('includes view=groups when resetting from groups view', () => {
+      mockParams = { groupType: '5' };
+      const { result } = renderHook(() => useExploreFilters());
+
+      act(() => {
+        result.current.resetFilters();
+      });
+
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      const calledUrl = mockReplace.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('view=groups');
+    });
+  });
+
+  describe('skips update when nothing changed', () => {
+    it('does not call replace when setting same view', () => {
+      mockParams = { view: 'events' };
+      const { result } = renderHook(() => useExploreFilters());
+
+      act(() => {
+        result.current.setFilters({ view: 'events' });
+      });
+
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mode locking', () => {
+    it('uses mode as view when mode is set', () => {
+      mockParams = { mode: 'events' };
+      const { result } = renderHook(() => useExploreFilters());
+      expect(result.current.filters.view).toBe('events');
+      expect(result.current.isModeLocked).toBe(true);
+    });
+
+    it('does not include view param when mode is set', () => {
+      mockParams = { mode: 'events' };
+      const { result } = renderHook(() => useExploreFilters());
+
+      act(() => {
+        result.current.setFilters({ dateFilter: 'this_week' });
+      });
+
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      const calledUrl = mockReplace.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('mode=events');
+      expect(calledUrl).not.toMatch(/[?&]view=/);
+    });
+  });
+});

--- a/apps/mobile/features/explore/hooks/useExploreFilters.ts
+++ b/apps/mobile/features/explore/hooks/useExploreFilters.ts
@@ -144,8 +144,8 @@ export function useExploreFilters() {
       urlParams.mode = merged.mode;
     }
 
-    // View - only include if not default and mode isn't set
-    if (!merged.mode && merged.view !== 'groups') {
+    // View - always include so router.replace explicitly sets it
+    if (!merged.mode) {
       urlParams.view = merged.view;
     }
 
@@ -180,7 +180,7 @@ export function useExploreFilters() {
     const urlParams: Record<string, string> = {};
     if (filters.mode) {
       urlParams.mode = filters.mode;
-    } else if (filters.view !== 'groups') {
+    } else {
       urlParams.view = filters.view;
     }
     router.replace(buildUrl(urlParams));


### PR DESCRIPTION
## Summary
- Always explicitly include `view` param in explore URL when calling `router.replace`, even for the default `groups` value
- Previously, `view` was omitted when switching to groups (the default), but Expo Router's tab param handling could keep stale `view=events` params
- Added 10 tests covering the ViewToggle switching, resetFilters, mode locking, and no-op detection

Fixes TOG-3.

## Test plan
- [x] `useExploreFilters` unit tests pass (10/10)
- [x] Full test suite passes (977 tests)
- [ ] Manual: tap Groups → Events → Groups → Events repeatedly, each tap switches view
- [ ] Manual: URL params update correctly (`?view=groups` vs `?view=events`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Explore URL params are written via `router.replace`, which can affect in-app navigation and deep links if any callers relied on omitting the default view; added unit coverage reduces regression risk.
> 
> **Overview**
> Fixes Explore ViewToggle/navigation by **always writing the `view` query param** when updating or resetting filters (unless `mode` is set), ensuring `router.replace` explicitly overwrites prior params instead of leaving a stale `view` value.
> 
> Adds a dedicated `useExploreFilters` test suite covering view switching back to `groups`, reset behavior, mode locking (no `view` when `mode` is present), and no-op updates when filters don’t change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4364163d6a758bc341b706c29733c66fcd95e53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->