### PR TITLE
fix: skip navigation when tapping notification for active channel

### DIFF
--- a/apps/mobile/providers/NotificationProvider.tsx
+++ b/apps/mobile/providers/NotificationProvider.tsx
@@ -314,6 +314,13 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
         break;
       case 'new_message':
       case 'mention': {
+        // If user is already viewing this channel, skip navigation entirely
+        // to avoid re-mounting the screen and causing a blank flash.
+        if (channelId && activeChannelIdRef.current === channelId) {
+          console.log(`[${type}] Already viewing channel ${channelId}, skipping navigation`);
+          break;
+        }
+
         // Use the same prefetch-then-navigate flow as the inbox for a smooth experience.
         // Notification payload includes channelId, groupId, groupName, channelSlug.
         const resolvedSlug = channelSlug || (channelType === 'main' ? 'general' : channelType === 'leaders' ? 'leaders' : channelType);


### PR DESCRIPTION
## Summary
- When tapping a notification for a channel the user is already viewing, skip navigation entirely
- Prevents `router.push` from creating a duplicate screen instance that re-mounts from scratch, causing blank flash and toolbar flicker
- Uses existing `activeChannelIdRef` (already tracked by ConvexChatRoomScreen) to detect the active channel

## Test plan
- [ ] While viewing a chat, receive notification for same chat → tap it → should stay on current screen, no flicker
- [ ] While viewing chat A, tap notification for chat B → should navigate to chat B normally with prefetch
- [ ] While on inbox, tap notification → should navigate to chat with prefetch
- [ ] Cold start from notification → should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation guard that only short-circuits `router.push` when the tapped notification targets the channel already being viewed; other notification flows remain unchanged.
> 
> **Overview**
> Prevents redundant navigation when tapping `new_message`/`mention` notifications for the channel the user is already viewing by detecting the current channel via `activeChannelIdRef` and skipping the prefetch+navigate flow. This avoids re-mounting the chat screen (blank flash/toolbar flicker) while leaving normal navigation behavior intact for other channels and notification types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a31b764be4a02a83866f415d11c0ab02fd414fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->