### PR TITLE
test: implement 9 PCO filter action test stubs

### DIFF
--- a/apps/convex/__tests__/pco/filterActions.test.ts
+++ b/apps/convex/__tests__/pco/filterActions.test.ts
@@ -183,7 +183,7 @@ describe("PCO Services Filter Actions", () => {
       });
 
       // Director should appear for each service type (different composite keys)
-      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result).toHaveLength(2);
       expect(result.every((p) => p.name === "Director")).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- Replaces 9 placeholder `expect(true).toBe(true)` test stubs with real action calls to `getAvailablePositions` and `previewFilterResults`
- Fixes test setup: community role elevated from 2 (moderator) to 3 (admin) to match `COMMUNITY_ADMIN_THRESHOLD` required by the actions
- All 173 PCO tests and 967 mobile tests pass

## Test plan

- [x] All 9 previously-stubbed tests now call real Convex actions with mocked PCO API responses
- [x] Full PCO test suite passes (173 tests)
- [x] Full mobile test suite passes (967 tests)
- [ ] Feature Engineer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that tighten coverage around PCO filter actions; low production risk aside from potential increased test brittleness due to auth/token setup and mocking.
> 
> **Overview**
> Adds real unit coverage for PCO filter-based Convex actions by replacing placeholder assertions with actual `t.action` calls to `getAvailablePositions` and `previewFilterResults`, asserting sorting, aggregation, and filtering behavior.
> 
> Updates test setup to be auth-realistic: sets a test `JWT_SECRET`, generates an access token via `generateTokens`, ensures the seeded user/community membership meets admin authorization (roles `3+`), and stabilizes PCO API mocks (including reapplying `fetchServiceTypes` after `clearAllMocks`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 277915d000e383b7657cfe571f8dfd3d50cd3f85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->