### PR TITLE
fix: add error toast notifications for attendance save failures

### DIFF
--- a/apps/mobile/features/leader-tools/hooks/__tests__/useAttendanceEdit.test.ts
+++ b/apps/mobile/features/leader-tools/hooks/__tests__/useAttendanceEdit.test.ts
@@ -59,6 +59,13 @@ jest.mock("../useGroupMembers", () => ({
   useGroupMembers: (...args: any[]) => mockUseGroupMembers(...args),
 }));
 
+const mockToastError = jest.fn();
+jest.mock("@components/ui/Toast", () => ({
+  ToastManager: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
 // Import after mocks
 import { useAttendanceEdit } from "../useAttendanceEdit";
 
@@ -244,6 +251,73 @@ describe("useAttendanceEdit", () => {
       await waitFor(() => {
         expect(result.current.eventDate).toBe("2024-01-15T10:00:00Z");
       });
+    });
+  });
+
+  describe("handleSubmitAttendance date validation", () => {
+    beforeEach(() => {
+      mockUseGroupMembers.mockReturnValue({
+        members: [{ user: { _id: "member-1" } }],
+        isLoading: false,
+      });
+      mockMarkAttendance.mockResolvedValue(undefined);
+    });
+
+    it("shows invalid-date toast when eventDate is unparseable", async () => {
+      mockUseQuery.mockReturnValue({
+        _id: "group-123",
+        name: "Test Group",
+        defaultStartTime: "10:00",
+      });
+
+      const { result } = renderHook(() =>
+        useAttendanceEdit("group-123", "not-a-valid-date", "meeting-1")
+      );
+
+      await waitFor(() => {
+        expect(result.current.eventDate).toBe("not-a-valid-date");
+      });
+
+      await act(() => {
+        result.current.setAttendanceList(["member-1"]);
+      });
+      await act(async () => {
+        await result.current.handleSubmitAttendance();
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Invalid event date. Please select a valid date."
+      );
+      expect(mockMarkAttendance).not.toHaveBeenCalled();
+    });
+
+    it("shows future-event toast when eventDate is in the future", async () => {
+      const futureIso = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      mockUseQuery.mockReturnValue({
+        _id: "group-123",
+        name: "Test Group",
+        defaultStartTime: "10:00",
+      });
+
+      const { result } = renderHook(() =>
+        useAttendanceEdit("group-123", futureIso, "meeting-1")
+      );
+
+      await waitFor(() => {
+        expect(result.current.eventDate).toBe(futureIso);
+      });
+
+      await act(() => {
+        result.current.setAttendanceList(["member-1"]);
+      });
+      await act(async () => {
+        await result.current.handleSubmitAttendance();
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Cannot submit attendance for future events."
+      );
+      expect(mockMarkAttendance).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/mobile/features/leader-tools/hooks/useAttendanceEdit.ts
+++ b/apps/mobile/features/leader-tools/hooks/useAttendanceEdit.ts
@@ -137,9 +137,14 @@ export function useAttendanceEdit(
       return;
     }
 
-    // Prevent submitting attendance for future events
+    // Prevent submitting attendance for invalid or future event dates
     const eventDateObj = new Date(eventDate);
-    if (isNaN(eventDateObj.getTime()) || eventDateObj > new Date()) {
+    if (isNaN(eventDateObj.getTime())) {
+      console.error("Invalid event date for attendance submission");
+      ToastManager.error("Invalid event date. Please select a valid date.");
+      return;
+    }
+    if (eventDateObj > new Date()) {
       console.error("Cannot submit attendance for future events");
       ToastManager.error("Cannot submit attendance for future events.");
       return;


### PR DESCRIPTION
## Summary
- Replace 3 silent `console.error` paths in `useAttendanceEdit.ts` with user-visible `ToastManager.error()` notifications
- Missing meeting ID → "No meeting found for this date"
- Future event validation → "Cannot submit attendance for future events"
- Failed submission → "Failed to save attendance. Please try again."

Closes TOG-13

## Test plan
- [ ] Open attendance edit for a group meeting
- [ ] Verify error toast appears when meeting ID is missing
- [ ] Verify error toast appears when selecting a future date
- [ ] Verify error toast appears when network/server error occurs during submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding user-facing toast notifications and slightly refining date validation in `useAttendanceEdit`, with unit tests covering the new failure paths.
> 
> **Overview**
> Adds user-visible `ToastManager.error()` notifications when attendance submission cannot proceed (missing `meetingId`, invalid/unparseable `eventDate`, future-dated events) and when the save mutation fails.
> 
> Extends `useAttendanceEdit` hook tests to mock `ToastManager` and assert the new validation toasts fire and `markAttendance` is not called for invalid/future dates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aacac988a6fdd4e5e26ec7969862a8f90d29f1f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->