### PR TITLE
fix: add E2E tests to CI and fix flaky EventHistory test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       shared: ${{ steps.changes.outputs.shared }}
       mobile: ${{ steps.changes.outputs.mobile }}
       convex: ${{ steps.changes.outputs.convex }}
+      e2e: ${{ steps.changes.outputs.e2e }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,6 +48,14 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'tsconfig.json'
+              - 'pnpm-workspace.yaml'
+            e2e:
+              - 'apps/mobile/**'
+              - 'packages/shared/**'
+              - 'tests/e2e/**'
+              - 'playwright.config.ts'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
 
   test-shared:
@@ -159,10 +168,52 @@ jobs:
         working-directory: apps/convex
         run: pnpm test
 
+  test-e2e:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.e2e == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+        env:
+          CI: true
+          EXPO_PUBLIC_PROJECT_ID: "dummy-project-id"
+          EXPO_PUBLIC_MAPBOX_TOKEN: "pk.dummy-token"
+          EXPO_PUBLIC_CONVEX_URL: "https://dummy-convex-url.convex.cloud"
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: test-results/
+          retention-days: 7
+
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [detect-changes, test-shared, test-mobile, test-convex]
+    needs: [detect-changes, test-shared, test-mobile, test-convex, test-e2e]
     if: always()
     steps:
       - name: Check test results
@@ -180,9 +231,10 @@ jobs:
           shared="${{ needs.test-shared.result }}"
           mobile="${{ needs.test-mobile.result }}"
           convex="${{ needs.test-convex.result }}"
+          e2e="${{ needs.test-e2e.result }}"
 
           failed=false
-          for job in shared mobile convex; do
+          for job in shared mobile convex e2e; do
             result=$(eval echo \$$job)
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "❌ test-$job: $result"

--- a/apps/mobile/features/leader-tools/components/__tests__/EventHistory.test.tsx
+++ b/apps/mobile/features/leader-tools/components/__tests__/EventHistory.test.tsx
@@ -117,8 +117,7 @@ describe("EventHistory", () => {
   ];
 
 
-  // TODO: Fix flaky test - times out intermittently
-  it.skip("renders event history with events", async () => {
+  it("renders event history with events", async () => {
     // Mock Convex to return raw meeting data (the hook transforms it)
     mockUseMeetingsQuery.mockReturnValue(mockConvexMeetings);
 
@@ -141,11 +140,12 @@ describe("EventHistory", () => {
       expect(getByText("New Event")).toBeTruthy();
     });
 
+    const month = getCurrentMonth();
     await waitFor(() => {
-      // Component formats dates as "EEE, M/d" (e.g., "Fri, 12/26")
-      expect(getByText(/12\/26/)).toBeTruthy();
-      expect(getByText(/12\/19/)).toBeTruthy();
-      expect(getByText(/12\/5/)).toBeTruthy();
+      // Component formats dates as "EEE, M/d" (e.g., "Fri, 3/26")
+      expect(getByText(new RegExp(`${month}\\/26`))).toBeTruthy();
+      expect(getByText(new RegExp(`${month}\\/19`))).toBeTruthy();
+      expect(getByText(new RegExp(`${month}\\/5`))).toBeTruthy();
     });
   });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     timeout: 10_000,
   },
   fullyParallel: false,
-  retries: 0,
+  retries: process.env.CI ? 2 : 0,
   reporter: "list",
   use: {
     baseURL: "http://localhost:8081",


### PR DESCRIPTION
## Summary
- **Fixed flaky EventHistory test** — assertions used hardcoded December dates (`12/26`, `12/19`, `12/5`) despite dynamic date generation via `getDateInCurrentMonth()`. Now uses `getCurrentMonth()` so the test passes in any month. Re-enabled the previously-skipped test.
- **Added Playwright E2E job to CI** — new `test-e2e` job runs `pnpm test:e2e` with Chromium, triggered by changes to `apps/mobile/`, `tests/e2e/`, or `playwright.config.ts`. Includes 2 retries in CI and artifact upload on failure.

## Test plan
- [x] All 958 unit/integration tests pass locally (including previously-skipped EventHistory test)
- [ ] CI pipeline runs the new E2E job successfully
- [ ] Verify test-summary correctly includes E2E results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow/test configuration and a unit test assertion update; no runtime application logic is modified.
> 
> **Overview**
> Adds Playwright E2E coverage to CI via a new `test-e2e` job that is gated by path-based change detection, installs Chromium, runs `pnpm test:e2e` with dummy Expo env vars, and uploads the Playwright report on failures; `test-summary` now includes the E2E result.
> 
> Re-enables the previously skipped `EventHistory` test and removes month-specific hardcoded date assertions by matching against the current month, and updates `playwright.config.ts` to retry flaky E2E runs in CI (`retries: 2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba8347389d6cdf05fc5db43408fee4863eba028f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->