### PR TITLE
refactor: complete isLeaderRole() DRY cleanup across remaining 6 files

### DIFF
--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -1384,7 +1384,7 @@ export const history = query({
             q.eq("groupId", otherMember.groupId).eq("userId", args.currentUserId!)
           )
           .first();
-        if (callerMembership && (callerMembership.role === "leader" || callerMembership.role === "admin")) {
+        if (callerMembership && isLeaderRole(callerMembership.role)) {
           canEdit = true;
         } else if (
           otherGroup?.communityId &&
@@ -2119,7 +2119,7 @@ async function requireImportAccess(
     .first();
 
   const isLeaderOrAdmin =
-    !!membership && !membership.leftAt && (membership.role === "leader" || membership.role === "admin");
+    !!membership && !membership.leftAt && isLeaderRole(membership.role);
   const isCommAdmin = await isCommunityAdmin(ctx, group.communityId, userId);
   if (!isLeaderOrAdmin && !isCommAdmin) {
     throw new ConvexError("Only group leaders or community admins can import CSV members");

--- a/apps/convex/functions/pcoServices/actions.ts
+++ b/apps/convex/functions/pcoServices/actions.ts
@@ -113,8 +113,7 @@ export const verifyGroupAccess = internalMutation({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
-    const isGroupLeader = groupMembership &&
-      (groupMembership.role === "leader" || groupMembership.role === "admin");
+    const isGroupLeader = groupMembership && isLeaderRole(groupMembership.role);
 
     // Check if user is a community admin
     const isAdmin = await isCommunityAdmin(ctx, group.communityId, userId);
@@ -254,8 +253,7 @@ export const verifyChannelAccess = internalMutation({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
-    const isGroupLeader = groupMembership &&
-      (groupMembership.role === "leader" || groupMembership.role === "admin");
+    const isGroupLeader = groupMembership && isLeaderRole(groupMembership.role);
 
     // Allow sync if user is either a channel member OR a group leader
     if (!channelMembership && !isGroupLeader) {

--- a/apps/convex/functions/seed.ts
+++ b/apps/convex/functions/seed.ts
@@ -22,6 +22,7 @@ import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { now, generateShortId, normalizePhone, buildSearchText } from "../lib/utils";
 import { COMMUNITY_ROLES } from "../lib/permissions";
+import { isLeaderRole } from "../lib/helpers";
 
 // ============================================================================
 // Constants
@@ -930,7 +931,7 @@ export const _seedPeopleDataMutation = internalMutation({
       .withIndex("by_user", (q: any) => q.eq("userId", testUser._id))
       .collect();
     const leaderMemberships = memberships.filter(
-      (m) => m.leftAt === undefined && (m.role === "leader" || m.role === "admin")
+      (m) => m.leftAt === undefined && isLeaderRole(m.role)
     );
 
     console.log(`[seedPeople] Found ${leaderMemberships.length} leader groups`);


### PR DESCRIPTION
## Summary
- Complete the DRY cleanup started in PR #260 — replace all remaining inline `role === "leader" || role === "admin"` checks with the existing `isLeaderRole()` helper from `lib/helpers.ts`
- After this PR, **zero** inline role checks remain in `apps/convex/functions/`
- Files updated: `pcoServices/queries.ts`, `pcoServices/actions.ts`, `memberFollowups.ts`, `seed.ts`

## Test plan
- [x] `npx tsc --noEmit` passes (excluding pre-existing uploads.ts issue from PR #252)
- [x] No behavior change — `isLeaderRole()` performs the same `role === "leader" || role === "admin"` check
- [x] Verified zero remaining inline role checks via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>