### PR TITLE
fix: remove 4 dead hooks with no importers

### DIFF
--- a/apps/mobile/features/auth/hooks/useAuth.ts
+++ b/apps/mobile/features/auth/hooks/useAuth.ts
@@ -223,51 +223,6 @@ export function useLogout() {
 }
 
 /**
- * Legacy email/password login
- *
- * @example
- * const { login, isPending } = useLegacyLogin();
- * await login({
- *   email: 'user@example.com',
- *   password: 'password123'
- * });
- */
-export function useLegacyLogin() {
-  const legacyLogin = useAction(api.functions.auth.login.legacyLogin);
-  const [isPending, setIsPending] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-  const [data, setData] = useState<Awaited<ReturnType<typeof legacyLogin>> | null>(null);
-  const [isSuccess, setIsSuccess] = useState(false);
-
-  const mutateAsync = useCallback(async (args: { email: string; password: string }) => {
-    setIsPending(true);
-    setError(null);
-    setIsSuccess(false);
-    try {
-      const result = await legacyLogin(args);
-      setData(result);
-      setIsSuccess(true);
-      return result;
-    } catch (err) {
-      setError(err as Error);
-      throw err;
-    } finally {
-      setIsPending(false);
-    }
-  }, [legacyLogin]);
-
-  return {
-    mutateAsync,
-    mutate: mutateAsync,
-    isPending,
-    isLoading: isPending,
-    error,
-    data,
-    isSuccess,
-  };
-}
-
-/**
  * Select a community after login
  *
  * Used when a user has multiple communities and needs to select one.
@@ -307,25 +262,6 @@ export function useSelectCommunity() {
     isPending,
     isLoading: isPending,
     error,
-  };
-}
-
-/**
- * Get phone verification status for the current user
- *
- * Note: Requires userId to be passed as Convex uses explicit IDs.
- *
- * @example
- * const status = usePhoneStatus(userId);
- * console.log(status?.phone, status?.phoneVerified);
- */
-export function usePhoneStatus(userId?: string) {
-  // TODO: This needs the user ID, which in Convex would typically come from the auth context
-  // For now, this is a placeholder that returns undefined when no userId is provided
-  const data = undefined; // Would use useQuery(api.functions.authInternal.phoneStatus, userId ? { userId } : "skip")
-  return {
-    data,
-    isLoading: false,
   };
 }
 
@@ -377,45 +313,3 @@ export function useRegisterPhone() {
   };
 }
 
-/**
- * Change password for the current user
- *
- * @example
- * const { changePassword, isPending } = useChangePassword();
- * await changePassword({
- *   token: 'jwt_token',
- *   oldPassword: 'old123',
- *   newPassword: 'new456'
- * });
- */
-export function useChangePassword() {
-  const changePassword = useAction(api.functions.auth.registration.changePassword);
-  const [isPending, setIsPending] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-
-  const mutateAsync = useCallback(async (args: {
-    token: string;
-    oldPassword: string;
-    newPassword: string;
-  }) => {
-    setIsPending(true);
-    setError(null);
-    try {
-      const result = await changePassword(args as any);
-      return result;
-    } catch (err) {
-      setError(err as Error);
-      throw err;
-    } finally {
-      setIsPending(false);
-    }
-  }, [changePassword]);
-
-  return {
-    mutateAsync,
-    mutate: mutateAsync,
-    isPending,
-    isLoading: isPending,
-    error,
-  };
-}

--- a/apps/mobile/features/profile/hooks/useProfile.ts
+++ b/apps/mobile/features/profile/hooks/useProfile.ts
@@ -148,24 +148,6 @@ export function useUserById(input: { userId: string }) {
 }
 
 /**
- * Search for users
- *
- * Note: User search is not yet implemented in Convex.
- * This is a placeholder that returns empty results.
- *
- * @example
- * const { data: users } = useSearchUsers({ query: 'John', communityId: 1 });
- */
-export function useSearchUsers(input: { query: string; communityId?: number }) {
-  // TODO: Implement user search in Convex
-  // For now, return empty results
-  return {
-    data: [],
-    isLoading: false,
-  };
-}
-
-/**
  * Get user's communities
  *
  * Returns list of communities the user belongs to (not blocked).


### PR DESCRIPTION
## Summary
- Remove 4 exported hooks that have zero importers anywhere in the codebase
- 124 lines of dead code eliminated
- No behavior change — none of these functions were called

## Removed hooks

| Hook | File | Why dead |
|------|------|----------|
| `useLegacyLogin` | `auth/hooks/useAuth.ts` | Legacy email/password flow, superseded by phone OTP |
| `usePhoneStatus` | `auth/hooks/useAuth.ts` | Stub (returns undefined), never wired up |
| `useChangePassword` | `auth/hooks/useAuth.ts` | Fully implemented but never called |
| `useSearchUsers` | `profile/hooks/useProfile.ts` | Stub (returns empty array), backend not implemented |

## Test plan
- [x] All 970 mobile tests pass
- [x] ESLint passes (pre-commit hook)
- [x] Grep confirms zero remaining references to removed hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>