### PR TITLE
fix: add missing JWT_SECRET to 10 test files, unblocking 107 tests

### DIFF
--- a/apps/convex/__tests__/auth.test.ts
+++ b/apps/convex/__tests__/auth.test.ts
@@ -20,6 +20,8 @@ import {
   isTokenRevoked,
 } from "../lib/auth";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 // ============================================================================
 // Constants
 // ============================================================================

--- a/apps/convex/__tests__/billing.test.ts
+++ b/apps/convex/__tests__/billing.test.ts
@@ -17,6 +17,8 @@ import { generateTokens } from "../lib/auth";
 
 import type { Id } from "../_generated/dataModel";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 // ============================================================================
 // Constants
 // ============================================================================

--- a/apps/convex/__tests__/community-events-visibility.test.ts
+++ b/apps/convex/__tests__/community-events-visibility.test.ts
@@ -45,6 +45,8 @@ import { api } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { modules } from "../test.setup";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 beforeEach(() => {
   vi.useFakeTimers();
 });

--- a/apps/convex/__tests__/community-membership.test.ts
+++ b/apps/convex/__tests__/community-membership.test.ts
@@ -15,6 +15,8 @@ import { modules } from "../test.setup";
 import { generateTokens } from "../lib/auth";
 import type { Id } from "../_generated/dataModel";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 // Use fake timers to properly handle scheduled functions
 vi.useFakeTimers();
 

--- a/apps/convex/__tests__/error-handling-group-creation-requests.test.ts
+++ b/apps/convex/__tests__/error-handling-group-creation-requests.test.ts
@@ -49,6 +49,8 @@ import { api } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { modules } from "../test.setup";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 // Use fake timers for all tests to handle scheduled functions properly
 beforeEach(() => {
   vi.useFakeTimers();

--- a/apps/convex/__tests__/followup-refresh-state.test.ts
+++ b/apps/convex/__tests__/followup-refresh-state.test.ts
@@ -5,6 +5,8 @@ import { modules } from "../test.setup";
 import { api, internal } from "../_generated/api";
 import { generateTokens } from "../lib/auth";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 vi.useFakeTimers();
 
 async function seedFollowupRefreshFixture(t: ReturnType<typeof convexTest>) {

--- a/apps/convex/__tests__/member-followups-list-compat.test.ts
+++ b/apps/convex/__tests__/member-followups-list-compat.test.ts
@@ -5,6 +5,8 @@ import { modules } from "../test.setup";
 import { api } from "../_generated/api";
 import { generateTokens } from "../lib/auth";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 async function seedFollowupListFixture(t: ReturnType<typeof convexTest>) {
   const timestamp = Date.now();
 

--- a/apps/convex/__tests__/security-group-privacy.test.ts
+++ b/apps/convex/__tests__/security-group-privacy.test.ts
@@ -47,6 +47,8 @@ import { api } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { modules } from "../test.setup";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 // Use fake timers for all tests
 beforeEach(() => {
   vi.useFakeTimers();

--- a/apps/convex/__tests__/security-groups-meetings.test.ts
+++ b/apps/convex/__tests__/security-groups-meetings.test.ts
@@ -52,6 +52,8 @@ import type { Id } from "../_generated/dataModel";
 import { modules } from "../test.setup";
 import { afterEach, beforeEach } from "vitest";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 // Use fake timers for all tests to handle scheduled functions properly
 beforeEach(() => {
   vi.useFakeTimers();

--- a/apps/convex/__tests__/security-rsvp-attendance.test.ts
+++ b/apps/convex/__tests__/security-rsvp-attendance.test.ts
@@ -20,6 +20,8 @@ import { modules } from "../test.setup";
 import type { Id } from "../_generated/dataModel";
 import { generateTokens } from "../lib/auth";
 
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
 // ============================================================================
 // Test Helper Functions
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add missing `process.env.JWT_SECRET` setup to 10 Convex test files that were silently failing
- Fixes 107 tests that threw "JWT_SECRET environment variable is not configured"

## Problem
These test files call `generateTokens()` or `requireAuth()` which need `JWT_SECRET`, but unlike other test files in the project, they never set the env var. This caused all their tests to fail with an env config error.

## Files fixed
- `auth.test.ts` (4 tests)
- `billing.test.ts` (multiple tests)
- `community-events-visibility.test.ts`
- `community-membership.test.ts`
- `error-handling-group-creation-requests.test.ts`
- `followup-refresh-state.test.ts`
- `member-followups-list-compat.test.ts`
- `security-group-privacy.test.ts`
- `security-groups-meetings.test.ts`
- `security-rsvp-attendance.test.ts`

## Test plan
- [x] All 10 previously-failing test files now pass (181 tests total)
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>