### PR TITLE
fix: billing back button crashes on web after Stripe redirect

### DIFF
--- a/apps/mobile/features/onboarding/components/BillingScreen.tsx
+++ b/apps/mobile/features/onboarding/components/BillingScreen.tsx
@@ -297,7 +297,13 @@ export function BillingScreen() {
         <View style={styles.container}>
           {/* Back link */}
           <Pressable
-            onPress={() => router.back()}
+            onPress={() => {
+              if (Platform.OS === "web") {
+                router.push("/");
+              } else {
+                router.back();
+              }
+            }}
             style={styles.backButton}
           >
             <Ionicons


### PR DESCRIPTION
## Summary
- On web, after returning from Stripe checkout, `router.back()` has no valid back target in browser history, causing an infinite re-render loop (React error #185)
- Replace with `router.push("/")` on web, keeping `router.back()` on native where it works correctly
- Matches the existing pattern used in `SuccessScreen.tsx`

Closes #230

## Test plan
- [ ] On web: navigate to billing page via Stripe redirect → tap Back → should navigate to home without crash
- [ ] On web: navigate to billing page normally → tap Back → should navigate to home
- [ ] On native (iOS/Android): navigate to billing page → tap Back → should go back normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>