### PR TITLE
fix: include shared channels in run sheet queries for secondary groups

### DIFF
--- a/apps/convex/functions/pcoServices/actions.ts
+++ b/apps/convex/functions/pcoServices/actions.ts
@@ -980,18 +980,49 @@ export const triggerGroupSync = action({
 
 /**
  * Internal query to get all channels for a group.
- * Used by triggerGroupSync to find channels to sync.
+ * Used by triggerGroupSync and run sheet queries to find channels to sync.
+ *
+ * Returns channels owned by this group AND shared channels where this group
+ * is an accepted secondary participant — so secondary groups in a shared-group
+ * relationship can discover the primary group's PCO configuration.
  */
 export const getChannelsForGroup = internalQuery({
   args: {
     groupId: v.id("groups"),
   },
   handler: async (ctx, args) => {
-    return await ctx.db
+    // 1. Channels owned by this group
+    const ownedChannels = await ctx.db
       .query("chatChannels")
       .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
       .filter((q) => q.eq(q.field("isArchived"), false))
       .collect();
+
+    // 2. Shared channels where this group is an accepted secondary participant
+    const sharedChannels = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_isShared", (q) => q.eq("isShared", true))
+      .filter((q) => q.eq(q.field("isArchived"), false))
+      .collect();
+
+    const acceptedSharedChannels = sharedChannels.filter(
+      (ch) =>
+        ch.sharedGroups?.some(
+          (sg) => sg.groupId === args.groupId && sg.status === "accepted"
+        )
+    );
+
+    // 3. Deduplicate (a channel owned by the group won't also have it in sharedGroups,
+    // but guard against edge cases)
+    const seenIds = new Set(ownedChannels.map((ch) => ch._id));
+    for (const ch of acceptedSharedChannels) {
+      if (!seenIds.has(ch._id)) {
+        ownedChannels.push(ch);
+        seenIds.add(ch._id);
+      }
+    }
+
+    return ownedChannels;
   },
 });
 


### PR DESCRIPTION
## Summary

- **Bug:** Secondary groups in shared-group relationships couldn't see combined run sheets — they got "No PCO service type configured" because `getChannelsForGroup` only returned channels owned by the queried group
- **Fix:** `getChannelsForGroup` now also queries shared channels where the group is an accepted secondary participant via the `sharedGroups` array and `by_isShared` index
- **Impact:** All three run sheet entry points (`getAvailableServiceTypes`, `getRunSheet`, `getRunSheetPublic`) benefit from this single change since they all call `getChannelsForGroup`

Closes #15

## Test plan

- [ ] Verify a secondary group leader can see the combined run sheet (same service types as the primary group)
- [ ] Verify a primary group leader's run sheet is unchanged
- [ ] Verify `getAvailableServiceTypes` returns service types from shared channels for secondary groups
- [ ] Verify no duplicate channels are returned when a group both owns and shares a channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)