### PR TITLE
fix: group photo upload broken on web (#92)

### DIFF
--- a/apps/mobile/components/ui/ImagePicker.tsx
+++ b/apps/mobile/components/ui/ImagePicker.tsx
@@ -155,6 +155,11 @@ export function ImagePickerComponent({
   };
 
   const showImageOptions = () => {
+    if (Platform.OS === 'web') {
+      // Web: Camera not available, go straight to file picker
+      pickImage();
+      return;
+    }
     Alert.alert(
       'Select Image',
       'Choose an option',

--- a/apps/mobile/features/groups/components/CreateGroupScreen.tsx
+++ b/apps/mobile/features/groups/components/CreateGroupScreen.tsx
@@ -158,18 +158,37 @@ export function CreateGroupScreen() {
         folder: "groups",
       });
 
-      // Upload file to R2 using expo-file-system/legacy
-      const uploadResult = await uploadAsync(uploadUrl, imageUri, {
-        httpMethod: 'PUT',
-        uploadType: FileSystemUploadType.BINARY_CONTENT,
-        headers: {
-          'Content-Type': contentType,
-        },
-      });
+      // Upload file to R2
+      if (Platform.OS === 'web') {
+        // Web: Use fetch/blob
+        const response = await fetch(imageUri);
+        const blob = await response.blob();
 
-      if (uploadResult.status < 200 || uploadResult.status >= 300) {
-        console.error('R2 upload failed:', uploadResult.status, uploadResult.body);
-        throw new Error('Failed to upload image to R2');
+        const uploadResponse = await fetch(uploadUrl, {
+          method: 'PUT',
+          body: blob,
+          headers: {
+            'Content-Type': contentType,
+          },
+        });
+
+        if (!uploadResponse.ok) {
+          throw new Error(`R2 upload failed: ${uploadResponse.status}`);
+        }
+      } else {
+        // Native (iOS/Android): Use expo-file-system for proper file handling
+        const uploadResult = await uploadAsync(uploadUrl, imageUri, {
+          httpMethod: 'PUT',
+          uploadType: FileSystemUploadType.BINARY_CONTENT,
+          headers: {
+            'Content-Type': contentType,
+          },
+        });
+
+        if (uploadResult.status < 200 || uploadResult.status >= 300) {
+          console.error('R2 upload failed:', uploadResult.status, uploadResult.body);
+          throw new Error('Failed to upload image to R2');
+        }
       }
 
       // Save the R2 storage path to the group's preview field


### PR DESCRIPTION
## Summary

- **CreateGroupScreen**: Added `Platform.OS === 'web'` check to use `fetch/blob` for R2 upload instead of `expo-file-system/uploadAsync` (which is not available on web). Matches the pattern already used in `EditGroupScreen` and `useUpdateProfilePhoto`.
- **ImagePickerComponent**: On web, skip the Camera/Photo Library dialog and go straight to the file picker since camera is not available in browser.

## Test plan

- [ ] On web: create a new group with a photo → verify upload succeeds and image displays
- [ ] On web: edit an existing group's photo → verify upload still works (no regression)
- [ ] On iOS: create/edit group photo → verify native upload path still works
- [ ] Verify image picker opens file dialog directly on web (no Camera option shown)

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)