### PR TITLE
fix: filter run sheet service type tabs by configured defaults

### DIFF
--- a/apps/mobile/features/leader-tools/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/RunSheetScreen.tsx
@@ -568,36 +568,36 @@ export function RunSheetScreen({
     getStaleCachedServiceTypes,
   ]);
 
+  // Filter service types to only those configured in defaultServiceTypeIds (if set)
+  const visibleServiceTypes = useMemo(() => {
+    const groupConfig = groupData as { runSheetConfig?: { defaultServiceTypeIds?: string[] } } | null;
+    const defaultIds = groupConfig?.runSheetConfig?.defaultServiceTypeIds;
+    if (defaultIds && defaultIds.length > 0) {
+      const filtered = serviceTypes.filter((t: ServiceType) => defaultIds.includes(t.id));
+      // Fall back to all types if none of the configured IDs match
+      return filtered.length > 0 ? filtered : serviceTypes;
+    }
+    return serviceTypes;
+  }, [serviceTypes, groupData]);
+
   // Apply default service type once both serviceTypes and groupData are available
   useEffect(() => {
-    if (hasAppliedDefault || serviceTypes.length === 0) return;
+    if (hasAppliedDefault || visibleServiceTypes.length === 0) return;
 
     // Offline-friendly fallback: if group query hasn't resolved yet, still select
     // the first service type so cached run sheet data can load.
     if (groupData === undefined) {
       if (!selectedServiceTypeId) {
-        setSelectedServiceTypeId(serviceTypes[0].id);
+        setSelectedServiceTypeId(visibleServiceTypes[0].id);
       }
       return;
     }
 
-    const groupConfig = groupData as { runSheetConfig?: { defaultServiceTypeIds?: string[] } } | null;
-    const defaultIds = groupConfig?.runSheetConfig?.defaultServiceTypeIds;
-
-    if (defaultIds && defaultIds.length > 0) {
-      const defaultType = serviceTypes.find((t: ServiceType) => defaultIds.includes(t.id));
-      if (defaultType) {
-        setSelectedServiceTypeId(defaultType.id);
-        setHasAppliedDefault(true);
-        return;
-      }
-    }
-
-    if (!selectedServiceTypeId || !serviceTypes.some((t: ServiceType) => t.id === selectedServiceTypeId)) {
-      setSelectedServiceTypeId(serviceTypes[0].id);
+    if (!selectedServiceTypeId || !visibleServiceTypes.some((t: ServiceType) => t.id === selectedServiceTypeId)) {
+      setSelectedServiceTypeId(visibleServiceTypes[0].id);
     }
     setHasAppliedDefault(true);
-  }, [serviceTypes, groupData, hasAppliedDefault, selectedServiceTypeId]);
+  }, [visibleServiceTypes, groupData, hasAppliedDefault, selectedServiceTypeId]);
 
   // Fetch run sheet for selected service type (with offline cache fallback)
   const fetchRunSheet = useCallback(async (options?: { isRefresh?: boolean }) => {
@@ -903,11 +903,11 @@ export function RunSheetScreen({
       {!isExternalMode && <DragHandle />}
 
       {/* Service Type Tabs (hidden in external mode) */}
-      {!isExternalMode && serviceTypes.length > 1 && (
+      {!isExternalMode && visibleServiceTypes.length > 1 && (
         <View style={[styles.serviceTypeTabs, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             <View style={styles.tabsRow}>
-              {serviceTypes.map((type) => (
+              {visibleServiceTypes.map((type) => (
                 <TouchableOpacity
                   key={type.id}
                   style={[

--- a/apps/mobile/features/leader-tools/components/RunSheetToolSettings.tsx
+++ b/apps/mobile/features/leader-tools/components/RunSheetToolSettings.tsx
@@ -54,6 +54,7 @@ export function RunSheetToolSettings({ groupId }: Props) {
   const [defaultServiceTypeIds, setDefaultServiceTypeIds] = useState<string[]>([]);
   const [loadingServiceTypes, setLoadingServiceTypes] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
+  const [hasInitializedDefaults, setHasInitializedDefaults] = useState(false);
   const [chipConfig, setChipConfig] = useState<{
     hidden: string[];
     order: string[];
@@ -92,19 +93,29 @@ export function RunSheetToolSettings({ groupId }: Props) {
     return Array.from(normalized).sort();
   }, [allCategories]);
 
-  // Load existing config when group data is available
+  // Load existing config when group data is available (only once on initial load)
   useEffect(() => {
+    if (hasInitializedDefaults) return;
     if (groupData?.runSheetConfig?.defaultServiceTypeIds) {
       setDefaultServiceTypeIds(groupData.runSheetConfig.defaultServiceTypeIds);
+      setHasInitializedDefaults(true);
+    } else if (groupData !== undefined) {
+      // groupData loaded but no config exists yet
+      setHasInitializedDefaults(true);
     }
-  }, [groupData?.runSheetConfig?.defaultServiceTypeIds]);
+  }, [groupData, hasInitializedDefaults]);
 
-  // Load existing chipConfig from group data
+  // Load existing chipConfig from group data (only once on initial load)
+  const [hasInitializedChipConfig, setHasInitializedChipConfig] = useState(false);
   useEffect(() => {
+    if (hasInitializedChipConfig) return;
     if (groupData?.runSheetConfig?.chipConfig) {
       setChipConfig(groupData.runSheetConfig.chipConfig);
+      setHasInitializedChipConfig(true);
+    } else if (groupData !== undefined) {
+      setHasInitializedChipConfig(true);
     }
-  }, [groupData?.runSheetConfig?.chipConfig]);
+  }, [groupData, hasInitializedChipConfig]);
 
   // Fetch available service types
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **RunSheetScreen**: Service type tabs now filter to only show types configured in `defaultServiceTypeIds` settings (falls back to all types if none configured or no matches)
- **RunSheetToolSettings**: Fixed checkbox toggles reverting due to `useEffect` continuously re-syncing from `groupData` reactive query — config now loads once on mount

## Root cause
The run sheet viewer (`RunSheetScreen`) was rendering ALL available service types as tabs, completely ignoring the `defaultServiceTypeIds` configuration set in the settings page. Additionally, the settings component's `useEffect` could overwrite unsaved local state on any Convex reactive update, making checkboxes appear to "snap back."

## Test plan
- [ ] Open run sheet settings, configure 2 of 3 service types, save
- [ ] Open run sheet viewer — verify only 2 tabs appear
- [ ] Toggle checkboxes in settings without saving — verify they don't revert
- [ ] Verify run sheet still works with no config saved (all types shown)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)