### PR TITLE
fix: hide leader/admin stats from non-admin followup views

### DIFF
--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -103,6 +103,43 @@ async function getLeaderGroupIdsInCommunity(
   return result;
 }
 
+/**
+ * Get the set of userIds that have a leader/admin role in the given group.
+ * Used to flag leader records so non-admin viewers don't see their engagement scores.
+ */
+async function getLeaderUserIdsForGroup(
+  ctx: { db: any },
+  groupId: Id<"groups">,
+): Promise<Set<string>> {
+  const members = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group", (q: any) => q.eq("groupId", groupId))
+    .collect();
+  const leaderIds = new Set<string>();
+  for (const m of members) {
+    if (isActiveMembership(m) && isLeaderRole(m.role)) {
+      leaderIds.add(m.userId.toString());
+    }
+  }
+  return leaderIds;
+}
+
+/**
+ * Redact engagement scores from leader/admin records for non-admin viewers.
+ * Returns the record with scores nulled out and an `isLeader` flag added.
+ */
+function redactLeaderScores<T extends Record<string, any>>(
+  doc: T,
+): T & { isLeader: boolean } {
+  return {
+    ...doc,
+    score1: undefined,
+    score2: undefined,
+    score3: undefined,
+    isLeader: true,
+  };
+}
+
 // ============================================================================
 // Index Mapping
 // ============================================================================
@@ -171,6 +208,12 @@ export const list = query({
       throw new ConvexError("Group not found");
     }
     await requireCommunityMember(ctx, group.communityId, userId);
+
+    // Non-admins get leader/admin scores redacted to prevent polluted followup data (GH #185)
+    const isAdmin = await isCommunityAdmin(ctx, group.communityId, userId);
+    const leaderUserIds = isAdmin
+      ? null
+      : await getLeaderUserIdsForGroup(ctx, args.groupId);
 
     // Server-enforced self-assignee: override any client-provided assigneeFilter
     const assigneeFilter = args.requireSelfAssignee
@@ -294,13 +337,29 @@ export const list = query({
       });
 
       return {
-        page: filtered,
+        page: leaderUserIds
+          ? filtered.map((doc: any) =>
+              leaderUserIds.has(doc.userId?.toString())
+                ? redactLeaderScores(doc)
+                : { ...doc, isLeader: false },
+            )
+          : filtered.map((doc: any) => ({ ...doc, isLeader: false })),
         isDone: true,
         continueCursor: "",
       };
     }
 
-    return await q.paginate(args.paginationOpts);
+    const result = await q.paginate(args.paginationOpts);
+    return {
+      ...result,
+      page: leaderUserIds
+        ? result.page.map((doc: any) =>
+            leaderUserIds.has(doc.userId?.toString())
+              ? redactLeaderScores(doc)
+              : { ...doc, isLeader: false },
+          )
+        : result.page.map((doc: any) => ({ ...doc, isLeader: false })),
+    };
   },
 });
 
@@ -334,6 +393,12 @@ export const search = query({
       throw new ConvexError("Group not found");
     }
     await requireCommunityMember(ctx, group.communityId, userId);
+
+    // Non-admins get leader/admin scores redacted (GH #185)
+    const isAdmin = await isCommunityAdmin(ctx, group.communityId, userId);
+    const leaderUserIds = isAdmin
+      ? null
+      : await getLeaderUserIdsForGroup(ctx, args.groupId);
 
     // Server-enforced self-assignee: override any client-provided assigneeFilter
     const assigneeFilter = args.requireSelfAssignee
@@ -427,7 +492,14 @@ export const search = query({
       );
     }
 
-    return filtered.slice(0, 200);
+    const sliced = filtered.slice(0, 200);
+    return leaderUserIds
+      ? sliced.map((doc: any) =>
+          leaderUserIds.has(doc.userId?.toString())
+            ? redactLeaderScores(doc)
+            : { ...doc, isLeader: false },
+        )
+      : sliced.map((doc: any) => ({ ...doc, isLeader: false }));
   },
 });
 

--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -84,6 +84,7 @@ type FollowupMember = {
   dateOfBirth?: number;
   latestNote?: string;
   latestNoteAt?: number;
+  isLeader: boolean;
   score1: number;
   score2: number;
   score3?: number;
@@ -1562,6 +1563,11 @@ export function FollowupDesktopTable({
               size={24}
             />
             <Text style={[s.cellText, { color: colors.text }]}>{item.firstName}</Text>
+            {item.isLeader && (
+              <View style={s.leaderBadge}>
+                <Text style={s.leaderBadgeText}>Leader</Text>
+              </View>
+            )}
           </View>
         );
 
@@ -1795,6 +1801,18 @@ export function FollowupDesktopTable({
         if (col.key.startsWith("score")) {
           const slot = col.key as "score1" | "score2" | "score3";
           const value = getSystemScoreValue(item, slot) ?? 0;
+
+          // Leader/admin scores are redacted for non-admin viewers
+          if (item.isLeader) {
+            return (
+              <View style={[s.scoreCell, { backgroundColor: colors.border + "40" }]}>
+                <Text style={[s.scoreCellText, { color: colors.textSecondary, fontSize: 10 }]}>
+                  Leader
+                </Text>
+              </View>
+            );
+          }
+
           return (
             <TouchableOpacity
               activeOpacity={0.7}
@@ -3362,6 +3380,17 @@ const s = StyleSheet.create({
     flexDirection: "row" as const,
     alignItems: "center" as const,
     gap: 6,
+  },
+  leaderBadge: {
+    backgroundColor: "#6366f120",
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+  },
+  leaderBadgeText: {
+    fontSize: 10,
+    color: "#6366f1",
+    fontWeight: "600" as const,
   },
   cellText: {
     fontSize: 13,

--- a/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
@@ -112,6 +112,7 @@ type FollowupMember = {
   customBool3?: boolean;
   customBool4?: boolean;
   customBool5?: boolean;
+  isLeader: boolean;
 };
 
 type LeaderRecord = {
@@ -1383,6 +1384,22 @@ export function FollowupMobileGrid({
   const renderDataCell = (member: FollowupMember, column: GridColumn) => {
     const value = column.getValue(member);
     if (column.kind === "score" && typeof value === "number") {
+      // Leader/admin scores are redacted for non-admin viewers
+      if (member.isLeader) {
+        return (
+          <View
+            style={[
+              styles.scorePill,
+              { borderColor: colors.border, backgroundColor: colors.border + "40" },
+            ]}
+          >
+            <Text style={[styles.scorePillText, { color: colors.textSecondary, fontSize: 10 }]}>
+              Leader
+            </Text>
+          </View>
+        );
+      }
+
       const scoreStyles = getScoreStyles(value, colors);
       return (
         <TouchableOpacity
@@ -1661,9 +1678,16 @@ export function FollowupMobileGrid({
           )}
 
           <View style={styles.memberTextWrap}>
-            <Text style={[styles.memberName, { color: colors.text }]} numberOfLines={1}>
-              {item.firstName} {item.lastName}
-            </Text>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+              <Text style={[styles.memberName, { color: colors.text }]} numberOfLines={1}>
+                {item.firstName} {item.lastName}
+              </Text>
+              {item.isLeader && (
+                <View style={styles.leaderBadge}>
+                  <Text style={styles.leaderBadgeText}>Leader</Text>
+                </View>
+              )}
+            </View>
             <Text style={[styles.memberSubtitle, { color: colors.textSecondary }]} numberOfLines={1}>
               {subtitleLine}
             </Text>
@@ -2649,6 +2673,17 @@ const styles = StyleSheet.create({
   memberSubtitle: {
     marginTop: 2,
     fontSize: 10,
+  },
+  leaderBadge: {
+    backgroundColor: "#6366f120",
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+  },
+  leaderBadgeText: {
+    fontSize: 10,
+    color: "#6366f1",
+    fontWeight: "600",
   },
   groupNameBadge: {
     fontSize: 11,

--- a/apps/mobile/features/leader-tools/components/followupShared.ts
+++ b/apps/mobile/features/leader-tools/components/followupShared.ts
@@ -201,5 +201,6 @@ export function adaptCommunityPerson(cp: any) {
     customBool5: cp.customBool5,
     latestNote: cp.latestNote,
     latestNoteAt: cp.latestNoteAt,
+    isLeader: cp.isLeader ?? false,
   };
 }


### PR DESCRIPTION
## Summary
- Non-admin users now see a "Leader" badge and greyed-out score cells instead of actual engagement scores for leader/admin members in followup views
- Backend `communityPeople.list` and `communityPeople.search` redact scores server-side when the viewer is not a community admin
- Both desktop table and mobile grid components handle the `isLeader` flag with visual indicators

Closes #185

## Test plan
- [ ] As a non-admin leader, open the followup dashboard — verify leader/admin members show "Leader" badge and greyed score cells
- [ ] As a community admin, verify all scores are visible as before
- [ ] Verify the mobile grid shows the same leader indicators
- [ ] Verify search results also redact leader scores for non-admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>