### PR TITLE
fix: position selector truncated during channel creation

### DIFF
--- a/apps/mobile/features/channels/components/PositionSelector.tsx
+++ b/apps/mobile/features/channels/components/PositionSelector.tsx
@@ -190,9 +190,7 @@ export function PositionSelector({
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: {},
   loadingContainer: {
     flexDirection: "row",
     alignItems: "center",
@@ -234,9 +232,7 @@ const styles = StyleSheet.create({
   searchBar: {
     marginBottom: 8,
   },
-  list: {
-    flex: 1,
-  },
+  list: {},
   positionItem: {
     flexDirection: "row",
     alignItems: "center",


### PR DESCRIPTION
## Summary
- Removed `flex: 1` from PositionSelector's `container` and `list` styles
- These flex constraints caused the position list to collapse inside the parent ScrollView, truncating the role list during channel creation

## Root Cause
`PositionSelector` had `flex: 1` on both its container and list View. Inside a ScrollView (the channel creation form), `flex: 1` causes children to collapse to 0 height since ScrollView provides infinite layout space. Removing these constraints lets the position list size naturally to fit all items.

## Test plan
- [ ] Open channel creation screen
- [ ] Enable "Filter by positions" toggle
- [ ] Verify all positions are visible (not truncated)
- [ ] Verify selected position chips wrap correctly

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>