### PR TITLE
feat: make resource links tappable in tasks

### DIFF
--- a/apps/mobile/features/chat/components/ReachOutTaskCard.tsx
+++ b/apps/mobile/features/chat/components/ReachOutTaskCard.tsx
@@ -11,6 +11,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { usePathname, useRouter } from "expo-router";
 import type { Id } from "@services/api/convex";
 import { api, useAuthenticatedMutation } from "@services/api/convex";
+import { TaskTextWithLinks } from "../../tasks/components/TaskTextWithLinks";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 
@@ -168,7 +169,11 @@ export function ReachOutTaskCard({ task, variant }: ReachOutTaskCardProps) {
         <Text style={[styles.time, { color: colors.textTertiary }]}>{formatTime(task.createdAt)}</Text>
       </View>
 
-      <Text style={[styles.content, { color: colors.text }]}>{content}</Text>
+      <TaskTextWithLinks
+        text={content}
+        baseStyle={StyleSheet.flatten([styles.content, { color: colors.text }])}
+        linkStyle={{ color: primaryColor, textDecorationLine: "underline" }}
+      />
       {assigneeName ? <Text style={[styles.meta, { color: colors.textSecondary }]}>Assigned to {assigneeName}</Text> : null}
 
       {variant === "member" ? (


### PR DESCRIPTION
## Summary
- Use existing `TaskTextWithLinks` component in `ReachOutTaskCard` so URLs in task descriptions open in the system browser when tapped
- Links are styled with the community's primary color and underline

## Test plan
- [x] All 979 existing tests pass (including `ReachOutTaskCard.test.tsx`)
- [ ] Open a reach-out task card with a URL in the description → verify it renders as a tappable link
- [ ] Tap the link → verify it opens in the system browser

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>