### PR TITLE
fix: suppress false 'No internet' banner on cold start

### DIFF
--- a/apps/mobile/providers/ConnectionProvider.tsx
+++ b/apps/mobile/providers/ConnectionProvider.tsx
@@ -88,6 +88,10 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
     null
   );
   const wasDisconnectedRef = useRef(false);
+  // Track latest network state so the grace timer callback can distinguish
+  // "network down" from "WebSocket slow to connect"
+  const isNetworkAvailableRef = useRef(true);
+  const isInternetReachableRef = useRef(true);
 
   const isWebSocketConnected = convexState.isWebSocketConnected;
 
@@ -113,9 +117,14 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
         // Cold start: use longer grace period before showing red banner
         if (!startupGraceTimerRef.current) {
           startupGraceTimerRef.current = setTimeout(() => {
-            setStatus('disconnected');
-            wasDisconnectedRef.current = true;
             startupGraceTimerRef.current = null;
+            // Only show "No internet" if the network is actually down.
+            // If NetInfo says we have internet but the WebSocket is slow,
+            // stay in 'connecting' (no banner) — not a network issue.
+            if (!isNetworkAvailableRef.current || !isInternetReachableRef.current) {
+              setStatus('disconnected');
+              wasDisconnectedRef.current = true;
+            }
           }, COLD_START_GRACE_MS);
         }
       } else {
@@ -187,8 +196,12 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
   // Subscribe to NetInfo
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {
-      setIsNetworkAvailable(state.isConnected ?? false);
-      setIsInternetReachable(state.isInternetReachable ?? true);
+      const networkAvailable = state.isConnected ?? false;
+      const internetReachable = state.isInternetReachable ?? true;
+      setIsNetworkAvailable(networkAvailable);
+      setIsInternetReachable(internetReachable);
+      isNetworkAvailableRef.current = networkAvailable;
+      isInternetReachableRef.current = internetReachable;
       setConnectionType(state.type ?? 'unknown');
 
       // Extract cellular generation

--- a/apps/mobile/providers/__tests__/ConnectionProvider.test.tsx
+++ b/apps/mobile/providers/__tests__/ConnectionProvider.test.tsx
@@ -254,11 +254,16 @@ describe('ConnectionProvider', () => {
     expect(result.current.isEffectivelyOffline).toBe(true);
   });
 
-  it('starts in connecting and shows disconnected after 6s grace if no connection on cold start', async () => {
+  it('starts in connecting and shows disconnected after 6s grace if network is down on cold start', async () => {
     mockIsWebSocketConnected = false;
     const { result } = renderHook(() => useConnectionStatus(), { wrapper });
 
     expect(result.current.status).toBe('connecting');
+
+    // Simulate network being down (not just WebSocket)
+    act(() => {
+      simulateNetInfoChange({ isConnected: false, isInternetReachable: false });
+    });
 
     // 2s debounce does NOT apply during cold start
     act(() => {
@@ -266,11 +271,29 @@ describe('ConnectionProvider', () => {
     });
     expect(result.current.status).toBe('connecting');
 
-    // After 6s grace period, show disconnected
+    // After 6s grace period, show disconnected (network is actually down)
     act(() => {
       jest.advanceTimersByTime(4000); // total 6s
     });
     expect(result.current.status).toBe('disconnected');
+  });
+
+  it('stays in connecting (no banner) after 6s grace if network is up but WebSocket is slow', async () => {
+    mockIsWebSocketConnected = false;
+    const { result } = renderHook(() => useConnectionStatus(), { wrapper });
+
+    expect(result.current.status).toBe('connecting');
+
+    // NetInfo reports network is available (default state)
+    act(() => {
+      simulateNetInfoChange({ isConnected: true, isInternetReachable: true });
+    });
+
+    // After 6s grace period, should NOT show disconnected — network is fine
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+    expect(result.current.status).toBe('connecting');
   });
 
   it('transitions from connecting to connected silently when connection established within grace period', async () => {


### PR DESCRIPTION
## Summary

- Fixes the false "No internet connection" red banner that appears on app launch even when the device has connectivity (GH #145)
- **Root cause:** The cold-start grace timer (6s) checked `isConnected` which includes WebSocket state. If the Convex WebSocket was slow to connect (>6s) but the device had internet, the banner incorrectly showed "No internet connection"
- **Fix:** The grace timer callback now checks actual NetInfo network state (via refs) before transitioning to `disconnected`. If the network is up but the WebSocket is just slow, the app stays in the invisible `connecting` state — no misleading banner

## Test plan

- [ ] Cold start on iOS with good connection — no red banner flashes
- [ ] Cold start on Android with good connection — no red banner flashes
- [ ] Cold start with airplane mode — red banner shows after 6s grace period
- [ ] Mid-session disconnect — 2s debounce still works as before
- [ ] Reconnection flow — green "Connected" banner still appears after reconnecting

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)