### PR TITLE
feat: expand emoji reaction picker (#44)

### DIFF
--- a/apps/mobile/features/chat/components/MessageActionsOverlay.tsx
+++ b/apps/mobile/features/chat/components/MessageActionsOverlay.tsx
@@ -34,6 +34,12 @@ const REACTIONS = [
   { type: "wow", emoji: "😮" },
   { type: "sad", emoji: "😢" },
   { type: "pray", emoji: "🙏" },
+  { type: "fire", emoji: "🔥" },
+  { type: "clap", emoji: "👏" },
+  { type: "celebrate", emoji: "🎉" },
+  { type: "hundred", emoji: "💯" },
+  { type: "eyes", emoji: "👀" },
+  { type: "heart_eyes", emoji: "😍" },
 ];
 
 // Action configuration
@@ -427,6 +433,8 @@ const styles = StyleSheet.create({
   // Reactions
   reactionsContainer: {
     flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
     borderRadius: 24,
     paddingHorizontal: 8,
     paddingVertical: 8,


### PR DESCRIPTION
## Summary
- Add 6 new emoji reactions to the message actions overlay: 🔥 fire, 👏 clap, 🎉 celebrate, 💯 hundred, 👀 eyes, 😍 heart-eyes
- Update reactions container layout with `flexWrap` and `justifyContent: center` so emojis wrap into two rows cleanly
- Backend already accepts any emoji string — no backend changes needed

Closes #44

## Test plan
- [ ] Long-press a message → verify 12 reactions display in 2 rows of 6
- [ ] Tap each new reaction → verify it toggles on/off correctly
- [ ] Verify reaction badges render correctly below messages
- [ ] Test on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>