### PR TITLE
feat: admin notification control panel with 2-party approval

### DIFF
--- a/apps/convex/__tests__/admin-broadcasts.test.ts
+++ b/apps/convex/__tests__/admin-broadcasts.test.ts
@@ -378,6 +378,7 @@ describe("Admin Broadcasts", () => {
         // @ts-expect-error - test token auth
         "functions/adminBroadcasts:previewTargeting" as any,
         {
+          token: data.admin1Token,
           communityId: data.communityId,
           targetCriteria: { type: "no_profile_pic" },
         }
@@ -395,6 +396,7 @@ describe("Admin Broadcasts", () => {
         // @ts-expect-error - test token auth
         "functions/adminBroadcasts:previewTargeting" as any,
         {
+          token: data.admin1Token,
           communityId: data.communityId,
           targetCriteria: { type: "all_users" },
         }

--- a/apps/convex/__tests__/meeting-rsvps.test.ts
+++ b/apps/convex/__tests__/meeting-rsvps.test.ts
@@ -12,6 +12,7 @@ import { api } from "../_generated/api";
 import { generateTokens } from "../lib/auth";
 import type { Id } from "../_generated/dataModel";
 
+// Drain scheduled functions after submit calls to avoid convex-test open transaction errors
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
 // ============================================================================
@@ -526,3 +527,4 @@ describe("meetingRsvps.list", () => {
     expect(result.limitedAccess).toBe(true);
   });
 });
+

--- a/apps/convex/functions/adminBroadcasts.ts
+++ b/apps/convex/functions/adminBroadcasts.ts
@@ -1,17 +1,16 @@
 /**
- * Admin Broadcast functions
+ * Admin Broadcast functions — targeted notifications with 2-party approval
  *
- * Targeted notifications with 2-party approval for community admins.
  * Supports targeting by criteria (no profile pic, new users, etc.),
  * multiple channels (push/email/SMS), and deep linking.
  */
 
 import { v } from "convex/values";
-import { query, mutation, internalQuery, internalAction } from "../_generated/server";
+import { query, mutation, internalQuery, internalAction, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { requireAuth } from "../lib/auth";
-import { requireCommunityAdmin, COMMUNITY_ADMIN_THRESHOLD } from "../lib/permissions";
+import { requireCommunityAdmin } from "../lib/permissions";
 import { now } from "../lib/utils";
 
 // ============================================================================
@@ -40,11 +39,14 @@ export const DEEP_LINK_PRESETS = [
  */
 export const list = query({
   args: {
-    token: v.optional(v.string()),
+    token: v.string(),
     communityId: v.id("communities"),
     statusFilter: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireCommunityAdmin(ctx, args.communityId, userId);
+
     let q = ctx.db
       .query("adminBroadcasts")
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId));
@@ -85,11 +87,14 @@ export const list = query({
  */
 export const previewTargeting = query({
   args: {
-    token: v.optional(v.string()),
+    token: v.string(),
     communityId: v.id("communities"),
     targetCriteria: targetCriteriaValidator,
   },
   handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireCommunityAdmin(ctx, args.communityId, userId);
+
     const userIds = await resolveTargetUsers(ctx, args.communityId, args.targetCriteria);
     return { count: userIds.length };
   },
@@ -429,8 +434,8 @@ export const getUserPhones = internalQuery({
   handler: async (ctx, args) => {
     const users = await Promise.all(args.userIds.map((id) => ctx.db.get(id)));
     return users
-      .filter((u) => u !== null)
-      .map((u) => ({ userId: u._id, phone: u.phone || null }));
+      .filter((u): u is NonNullable<typeof u> => u !== null)
+      .map((u) => ({ userId: u._id as string, phone: u.phone || null }));
   },
 });
 
@@ -441,8 +446,6 @@ export const getUserEmails = internalQuery({
     return users.map((u) => ({ email: u?.email || null }));
   },
 });
-
-import { internalMutation } from "../_generated/server";
 
 export const updateResults = internalMutation({
   args: {
@@ -516,7 +519,7 @@ async function resolveTargetUsers(
       const targetType = groupTypes.find((gt: any) => gt.slug === criteria.groupTypeSlug);
       if (!targetType) return [];
 
-      const typeGroups = groups.filter((g: any) => g.groupType === targetType._id);
+      const typeGroups = groups.filter((g: any) => g.groupTypeId === targetType._id);
       const typeGroupIds = new Set(typeGroups.map((g: any) => g._id.toString()));
 
       // Find users who are NOT in any group of this type

--- a/apps/mobile/features/admin/components/BroadcastComposer.tsx
+++ b/apps/mobile/features/admin/components/BroadcastComposer.tsx
@@ -4,7 +4,7 @@
  * Flow: Select target → Preview count → Write content → Test on self → Submit for approval
  */
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   View,
   Text,
@@ -17,7 +17,7 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { useQuery, useAuthenticatedMutation, api } from "@services/api/convex";
+import { useAuthenticatedQuery, useAuthenticatedMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { useTheme } from "@hooks/useTheme";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
@@ -68,7 +68,7 @@ export function BroadcastComposer({
   };
 
   // Preview targeting count
-  const preview = useQuery(
+  const preview = useAuthenticatedQuery(
     api.functions.adminBroadcasts.previewTargeting,
     { communityId, targetCriteria }
   );

--- a/apps/mobile/features/admin/components/NotificationsContent.tsx
+++ b/apps/mobile/features/admin/components/NotificationsContent.tsx
@@ -37,6 +37,8 @@ export function NotificationsContent() {
     communityId ? { communityId } : "skip"
   );
 
+  const sendMutation = useAuthenticatedMutation(api.functions.adminBroadcasts.sendBroadcast);
+
   const pendingCount = broadcasts?.filter((b) => b.status === "pending_approval").length || 0;
 
   if (!communityId) {
@@ -128,6 +130,37 @@ export function NotificationsContent() {
                 </Text>
               )}
             </View>
+
+            {broadcast.status === "approved" && (
+              <TouchableOpacity
+                style={[styles.sendButton, { backgroundColor: DEFAULT_PRIMARY_COLOR }]}
+                onPress={() => {
+                  Alert.alert(
+                    "Send Broadcast",
+                    `Send "${broadcast.title}" to ${broadcast.targetUserCount} users?`,
+                    [
+                      { text: "Cancel", style: "cancel" },
+                      {
+                        text: "Send Now",
+                        onPress: async () => {
+                          try {
+                            await sendMutation({
+                              broadcastId: broadcast._id as Id<"adminBroadcasts">,
+                            });
+                            Alert.alert("Sent", "Broadcast is being delivered.");
+                          } catch (error: any) {
+                            Alert.alert("Error", error.message || "Failed to send.");
+                          }
+                        },
+                      },
+                    ]
+                  );
+                }}
+              >
+                <Ionicons name="send" size={16} color="#fff" />
+                <Text style={styles.sendButtonText}>Send Now</Text>
+              </TouchableOpacity>
+            )}
           </View>
         ))
       )}
@@ -251,5 +284,19 @@ const styles = StyleSheet.create({
   },
   metaText: {
     fontSize: 12,
+  },
+  sendButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    borderRadius: 10,
+    paddingVertical: 10,
+    marginTop: 10,
+  },
+  sendButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
   },
 });


### PR DESCRIPTION
## Summary
- Community admins can create targeted broadcasts to specific user segments
- Multiple channels: push notifications, email, and SMS
- 2-party approval workflow: creator cannot approve their own broadcast
- Test-to-self before submitting for approval
- Deep link support for notification tap actions

## Targeting Options
- All users
- New users (joined within N days)
- Users without profile picture
- Users not in a specific group type
- Group leaders without group image

## Changes
- **Schema**: New `adminBroadcasts` table with community/status indexes
- **Backend**: `adminBroadcasts.ts` — create, preview targeting, send test, request approval, approve/reject, send broadcast, targeting resolver
- **Frontend**: `NotificationsContent` tab in AdminScreen, `BroadcastComposer` with target/content/channel/deep-link selection, `BroadcastApprovalList` with approve/reject UI
- **Deep linking**: `admin_broadcast` case in NotificationProvider uses broadcast's deepLink or falls back to admin tab

## Test plan
- [ ] As admin, create broadcast with "no profile pic" targeting → verify user count preview
- [ ] Send test to self → verify notification received with correct deep link
- [ ] Submit for approval → verify second admin sees pending request
- [ ] Creator cannot approve their own broadcast (error shown)
- [ ] Second admin approves → verify "Send" capability
- [ ] Send broadcast → verify targeted users receive on selected channels
- [ ] Reject flow works and updates status

🤖 Generated with [Claude Code](https://claude.com/claude-code)