### PR TITLE
perf: aggregate component for communityPeople.count

### DIFF
--- a/apps/convex/__tests__/delete-account.test.ts
+++ b/apps/convex/__tests__/delete-account.test.ts
@@ -8,8 +8,9 @@
 import { convexTest } from "convex-test";
 import { expect, test, describe } from "vitest";
 import schema from "../schema";
-import { modules } from "../test.setup";
+import { modules, convexTestWithAggregates } from "../test.setup";
 import { internal } from "../_generated/api";
+import { communityPeopleAggregate } from "../lib/aggregates";
 import type { Id } from "../_generated/dataModel";
 
 // ============================================================================
@@ -300,13 +301,13 @@ describe("deleteAccountInternal", () => {
   });
 
   test("removes communityPeople records and associated assignees", async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTestWithAggregates();
 
     const { userId, communityId, groupId } = await seedFullUser(t);
 
-    // Create a communityPeople record
+    // Create a communityPeople record and register it in the aggregate
     const cpId = await t.run(async (ctx) => {
-      return await ctx.db.insert("communityPeople", {
+      const id = await ctx.db.insert("communityPeople", {
         communityId,
         groupId,
         userId,
@@ -315,6 +316,9 @@ describe("deleteAccountInternal", () => {
         createdAt: Date.now(),
         updatedAt: Date.now(),
       });
+      const doc = await ctx.db.get(id);
+      await communityPeopleAggregate.insert(ctx, doc!);
+      return id;
     });
 
     // Create an assignee junction record

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -132,6 +132,7 @@ import type * as functions_toolShortLinks_index from "../functions/toolShortLink
 import type * as functions_uploads from "../functions/uploads.js";
 import type * as functions_users from "../functions/users.js";
 import type * as http from "../http.js";
+import type * as lib_aggregates from "../lib/aggregates.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_ee_emailTemplates from "../lib/ee/emailTemplates.js";
 import type * as lib_email_templates_BaseLayout from "../lib/email/templates/BaseLayout.js";
@@ -160,6 +161,7 @@ import type * as lib_utils from "../lib/utils.js";
 import type * as lib_validation from "../lib/validation.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as migrations_addChannelSlugs from "../migrations/addChannelSlugs.js";
+import type * as migrations_backfillCommunityPeopleAggregate from "../migrations/backfillCommunityPeopleAggregate.js";
 import type * as migrations_backfillLastActivityAt from "../migrations/backfillLastActivityAt.js";
 
 import type {
@@ -293,6 +295,7 @@ declare const fullApi: ApiFromModules<{
   "functions/uploads": typeof functions_uploads;
   "functions/users": typeof functions_users;
   http: typeof http;
+  "lib/aggregates": typeof lib_aggregates;
   "lib/auth": typeof lib_auth;
   "lib/ee/emailTemplates": typeof lib_ee_emailTemplates;
   "lib/email/templates/BaseLayout": typeof lib_email_templates_BaseLayout;
@@ -321,6 +324,7 @@ declare const fullApi: ApiFromModules<{
   "lib/validation": typeof lib_validation;
   "lib/validators": typeof lib_validators;
   "migrations/addChannelSlugs": typeof migrations_addChannelSlugs;
+  "migrations/backfillCommunityPeopleAggregate": typeof migrations_backfillCommunityPeopleAggregate;
   "migrations/backfillLastActivityAt": typeof migrations_backfillLastActivityAt;
 }>;
 
@@ -350,4 +354,191 @@ export declare const internal: FilterApi<
   FunctionReference<any, "internal">
 >;
 
-export declare const components: {};
+export declare const components: {
+  communityPeopleAggregate: {
+    btree: {
+      aggregateBetween: FunctionReference<
+        "query",
+        "internal",
+        { k1?: any; k2?: any; namespace?: any },
+        { count: number; sum: number }
+      >;
+      aggregateBetweenBatch: FunctionReference<
+        "query",
+        "internal",
+        { queries: Array<{ k1?: any; k2?: any; namespace?: any }> },
+        Array<{ count: number; sum: number }>
+      >;
+      atNegativeOffset: FunctionReference<
+        "query",
+        "internal",
+        { k1?: any; k2?: any; namespace?: any; offset: number },
+        { k: any; s: number; v: any }
+      >;
+      atOffset: FunctionReference<
+        "query",
+        "internal",
+        { k1?: any; k2?: any; namespace?: any; offset: number },
+        { k: any; s: number; v: any }
+      >;
+      atOffsetBatch: FunctionReference<
+        "query",
+        "internal",
+        {
+          queries: Array<{
+            k1?: any;
+            k2?: any;
+            namespace?: any;
+            offset: number;
+          }>;
+        },
+        Array<{ k: any; s: number; v: any }>
+      >;
+      get: FunctionReference<
+        "query",
+        "internal",
+        { key: any; namespace?: any },
+        null | { k: any; s: number; v: any }
+      >;
+      offset: FunctionReference<
+        "query",
+        "internal",
+        { k1?: any; key: any; namespace?: any },
+        number
+      >;
+      offsetUntil: FunctionReference<
+        "query",
+        "internal",
+        { k2?: any; key: any; namespace?: any },
+        number
+      >;
+      paginate: FunctionReference<
+        "query",
+        "internal",
+        {
+          cursor?: string;
+          k1?: any;
+          k2?: any;
+          limit: number;
+          namespace?: any;
+          order: "asc" | "desc";
+        },
+        {
+          cursor: string;
+          isDone: boolean;
+          page: Array<{ k: any; s: number; v: any }>;
+        }
+      >;
+      paginateNamespaces: FunctionReference<
+        "query",
+        "internal",
+        { cursor?: string; limit: number },
+        { cursor: string; isDone: boolean; page: Array<any> }
+      >;
+      validate: FunctionReference<
+        "query",
+        "internal",
+        { namespace?: any },
+        any
+      >;
+    };
+    inspect: {
+      display: FunctionReference<"query", "internal", { namespace?: any }, any>;
+      dump: FunctionReference<"query", "internal", { namespace?: any }, string>;
+      inspectNode: FunctionReference<
+        "query",
+        "internal",
+        { namespace?: any; node?: string },
+        null
+      >;
+      listTreeNodes: FunctionReference<
+        "query",
+        "internal",
+        { take?: number },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          aggregate?: { count: number; sum: number };
+          items: Array<{ k: any; s: number; v: any }>;
+          subtrees: Array<string>;
+        }>
+      >;
+      listTrees: FunctionReference<
+        "query",
+        "internal",
+        { take?: number },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          maxNodeSize: number;
+          namespace?: any;
+          root: string;
+        }>
+      >;
+    };
+    public: {
+      clear: FunctionReference<
+        "mutation",
+        "internal",
+        { maxNodeSize?: number; namespace?: any; rootLazy?: boolean },
+        null
+      >;
+      delete_: FunctionReference<
+        "mutation",
+        "internal",
+        { key: any; namespace?: any },
+        null
+      >;
+      deleteIfExists: FunctionReference<
+        "mutation",
+        "internal",
+        { key: any; namespace?: any },
+        any
+      >;
+      init: FunctionReference<
+        "mutation",
+        "internal",
+        { maxNodeSize?: number; namespace?: any; rootLazy?: boolean },
+        null
+      >;
+      insert: FunctionReference<
+        "mutation",
+        "internal",
+        { key: any; namespace?: any; summand?: number; value: any },
+        null
+      >;
+      makeRootLazy: FunctionReference<
+        "mutation",
+        "internal",
+        { namespace?: any },
+        null
+      >;
+      replace: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          currentKey: any;
+          namespace?: any;
+          newKey: any;
+          newNamespace?: any;
+          summand?: number;
+          value: any;
+        },
+        null
+      >;
+      replaceOrInsert: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          currentKey: any;
+          namespace?: any;
+          newKey: any;
+          newNamespace?: any;
+          summand?: number;
+          value: any;
+        },
+        any
+      >;
+    };
+  };
+};

--- a/apps/convex/convex.config.ts
+++ b/apps/convex/convex.config.ts
@@ -1,0 +1,7 @@
+import { defineApp } from "convex/server";
+import aggregate from "@convex-dev/aggregate/convex.config";
+
+const app = defineApp();
+app.use(aggregate, { name: "communityPeopleAggregate" });
+
+export default app;

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -22,6 +22,7 @@ import { isActiveMembership, isLeaderRole } from "../lib/helpers";
 import { VALID_CUSTOM_SLOTS } from "../lib/followupConstants";
 import { SYSTEM_SCORES, SYSTEM_VARIABLE_IDS } from "./systemScoring";
 import { getMediaUrl, safeSliceForJson } from "../lib/utils";
+import { communityPeopleAggregate } from "../lib/aggregates";
 
 // ============================================================================
 // Auth Helpers
@@ -1593,7 +1594,7 @@ export const setAssignees = mutation({
 
 /**
  * Count community people for a given group.
- * Uses the by_group index for a direct count — no joins needed.
+ * Uses the aggregate component for O(log n) counting instead of scanning rows.
  */
 export const count = query({
   args: {
@@ -1608,13 +1609,9 @@ export const count = query({
 
     await requireCommunityMember(ctx, group.communityId, userId);
 
-    let count = 0;
-    for await (const _cp of ctx.db
-      .query("communityPeople")
-      .withIndex("by_group", (q: any) => q.eq("groupId", args.groupId))) {
-      count++;
-    }
-    return count;
+    return await communityPeopleAggregate.count(ctx, {
+      namespace: args.groupId,
+    });
   },
 });
 
@@ -2437,6 +2434,8 @@ export const upsertFromSubmission = internalMutation({
           groupId,
           createdAt: nowTs,
         });
+        const newDoc = await ctx.db.get(cpId);
+        await communityPeopleAggregate.insert(ctx, newDoc!);
       }
 
       // Keep junction table in sync

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -26,6 +26,7 @@ import {
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { now, getMediaUrl, safeSliceForJson, getWeekStart } from "../lib/utils";
+import { communityPeopleAggregate } from "../lib/aggregates";
 import {
   extractSystemRawValues,
   calculateAllSystemScores,
@@ -482,6 +483,8 @@ export const upsertCommunityPeopleBatch = internalMutation({
           customBool5: siblingRecord?.customBool5,
           createdAt: nowTs,
         });
+        const newDoc = await ctx.db.get(cpId);
+        await communityPeopleAggregate.insert(ctx, newDoc!);
 
         // Sync junction table for assignee filtering
         if (siblingRecord?.assigneeIds?.length) {
@@ -531,7 +534,7 @@ export const pruneStaleRows = internalMutation({
         for (const row of legacyJunctionRows) {
           await ctx.db.delete(row._id);
         }
-        // Legacy record without groupId — prune it
+        // Legacy record without groupId — prune it (skip aggregate since these were never indexed)
         await ctx.db.delete(doc._id);
         deleted++;
         continue;
@@ -559,6 +562,7 @@ export const pruneStaleRows = internalMutation({
         for (const row of junctionRows) {
           await ctx.db.delete(row._id);
         }
+        await communityPeopleAggregate.delete(ctx, doc);
         await ctx.db.delete(doc._id);
         deleted++;
       }

--- a/apps/convex/functions/migrations/migrateToCommunityPeople.ts
+++ b/apps/convex/functions/migrations/migrateToCommunityPeople.ts
@@ -22,6 +22,7 @@ import {
 import { internal } from "../../_generated/api";
 import { Doc, Id } from "../../_generated/dataModel";
 import { getMediaUrl } from "../../lib/utils";
+import { communityPeopleAggregate } from "../../lib/aggregates";
 
 // ============================================================================
 // Constants
@@ -356,10 +357,12 @@ export const upsertMigratedBatch = internalMutation({
         if (existing) {
           await ctx.db.patch(existing._id, doc);
         } else {
-          await ctx.db.insert("communityPeople", {
+          const cpId = await ctx.db.insert("communityPeople", {
             ...doc,
             createdAt: nowTs,
           });
+          const newDoc = await ctx.db.get(cpId);
+          await communityPeopleAggregate.insert(ctx, newDoc!);
         }
       } catch (e) {
         console.error(

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -18,6 +18,7 @@ import { now, normalizePhone, getMediaUrl, buildSearchText } from "../lib/utils"
 import { requireAuth, getOptionalAuth } from "../lib/auth";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ROLES, COMMUNITY_ADMIN_THRESHOLD } from "../lib/permissions";
+import { communityPeopleAggregate } from "../lib/aggregates";
 
 /**
  * Get current user profile
@@ -721,6 +722,7 @@ export const deleteAccountInternal = internalMutation({
       for (const assignee of assigneeRecords) {
         await ctx.db.delete(assignee._id);
       }
+      await communityPeopleAggregate.delete(ctx, record);
       await ctx.db.delete(record._id);
     }
 

--- a/apps/convex/lib/aggregates.ts
+++ b/apps/convex/lib/aggregates.ts
@@ -1,0 +1,27 @@
+/**
+ * Aggregate definitions for efficient counting and summing.
+ *
+ * The communityPeople aggregate enables O(log n) count queries per group,
+ * replacing the O(n) full-scan loop in communityPeople.count.
+ */
+
+import { TableAggregate } from "@convex-dev/aggregate";
+import { components } from "../_generated/api";
+import { DataModel } from "../_generated/dataModel";
+
+/**
+ * Aggregate for the communityPeople table, namespaced by groupId.
+ *
+ * Usage:
+ *   - Count per group: `communityPeopleAggregate.count(ctx, { namespace: groupId })`
+ *   - Must call .insert / .delete in every mutation that adds/removes rows.
+ */
+export const communityPeopleAggregate = new TableAggregate<{
+  Namespace: string;
+  Key: null;
+  DataModel: DataModel;
+  TableName: "communityPeople";
+}>(components.communityPeopleAggregate, {
+  namespace: (doc) => doc.groupId as string,
+  sortKey: () => null,
+});

--- a/apps/convex/migrations/backfillCommunityPeopleAggregate.ts
+++ b/apps/convex/migrations/backfillCommunityPeopleAggregate.ts
@@ -1,0 +1,96 @@
+import { internalMutation } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { v } from "convex/values";
+import { communityPeopleAggregate } from "../lib/aggregates";
+
+/**
+ * Backfill the communityPeople aggregate B-Tree from existing table data.
+ *
+ * Processes in batches to avoid Convex function timeout/memory limits.
+ * Each invocation processes up to `batchSize` records, then self-schedules
+ * the next batch if more remain.
+ *
+ * Run with:
+ *   npx convex run migrations/backfillCommunityPeopleAggregate:backfill
+ *
+ * To clear and re-run (if aggregate drifted):
+ *   npx convex run migrations/backfillCommunityPeopleAggregate:clear
+ *   npx convex run migrations/backfillCommunityPeopleAggregate:backfill
+ */
+export const backfill = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    totalInserted: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = args.batchSize ?? 500;
+    const totalInserted = args.totalInserted ?? 0;
+
+    // Paginate using _creationTime + _id cursor
+    let query = ctx.db
+      .query("communityPeople")
+      .withIndex("by_creation_time")
+      .order("asc");
+
+    const batch = await query.take(batchSize + 1);
+
+    // Skip to cursor position
+    let startIdx = 0;
+    if (args.cursor) {
+      const cursorIdx = batch.findIndex((doc) => doc._id === args.cursor);
+      if (cursorIdx >= 0) {
+        startIdx = cursorIdx + 1;
+      }
+    }
+
+    const toProcess = batch.slice(startIdx, startIdx + batchSize);
+
+    if (toProcess.length === 0) {
+      console.log(
+        `Backfill complete — ${totalInserted} communityPeople records inserted into aggregate.`
+      );
+      return { totalInserted, isDone: true };
+    }
+
+    let inserted = 0;
+    for (const doc of toProcess) {
+      try {
+        await communityPeopleAggregate.insert(ctx, doc);
+        inserted++;
+      } catch (e) {
+        // Record may already exist in aggregate (idempotency on re-run)
+        console.warn(
+          `Skipped ${doc._id} (may already exist in aggregate): ${e}`
+        );
+      }
+    }
+
+    const lastDoc = toProcess[toProcess.length - 1];
+    const newTotal = totalInserted + inserted;
+
+    console.log(
+      `Batch done: inserted ${inserted} records (total: ${newTotal}), cursor: ${lastDoc._id}`
+    );
+
+    // Self-schedule next batch
+    await ctx.scheduler.runAfter(0, internal.migrations.backfillCommunityPeopleAggregate.backfill, {
+      cursor: lastDoc._id,
+      batchSize,
+      totalInserted: newTotal,
+    });
+
+    return { totalInserted: newTotal, isDone: false };
+  },
+});
+
+/**
+ * Clear the aggregate (useful before re-running backfill if data drifted).
+ */
+export const clear = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    await communityPeopleAggregate.clearAll(ctx);
+    console.log("Aggregate cleared.");
+  },
+});

--- a/apps/convex/package.json
+++ b/apps/convex/package.json
@@ -9,6 +9,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@convex-dev/aggregate": "^0.2.1",
     "@react-email/components": "^1.0.3",
     "@react-email/render": "^1.0.0",
     "@togather/shared": "workspace:*",

--- a/apps/convex/test.setup.ts
+++ b/apps/convex/test.setup.ts
@@ -18,3 +18,18 @@ export const modules = import.meta.glob([
   "!./*.config.ts",
   "!./*.setup.ts",
 ]);
+
+import { convexTest } from "convex-test";
+import { register as registerAggregate } from "@convex-dev/aggregate/test";
+import schema from "./schema";
+
+/**
+ * Create a convex-test instance with aggregate components registered.
+ * Use this instead of `convexTest(schema, modules)` in tests that touch
+ * mutations which use the communityPeople aggregate.
+ */
+export function convexTestWithAggregates() {
+  const t = convexTest(schema, modules);
+  registerAggregate(t, "communityPeopleAggregate");
+  return t;
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@auth/core": "^0.37.4",
+    "@convex-dev/aggregate": "^0.2.1",
     "@convex-dev/auth": "^0.0.90",
     "bcryptjs": "^3.0.3",
     "convex": "^1.31.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@auth/core':
         specifier: ^0.37.4
         version: 0.37.4
+      '@convex-dev/aggregate':
+        specifier: ^0.2.1
+        version: 0.2.1(convex@1.31.7)
       '@convex-dev/auth':
         specifier: ^0.0.90
         version: 0.0.90(@auth/core@0.37.4)(convex@1.31.7)(react@19.1.0)
@@ -124,6 +127,9 @@ importers:
 
   apps/convex:
     dependencies:
+      '@convex-dev/aggregate':
+        specifier: ^0.2.1
+        version: 0.2.1(convex@1.31.7)
       '@react-email/components':
         specifier: ^1.0.3
         version: 1.0.6(react-dom@19.2.4)(react@19.2.4)
@@ -2658,6 +2664,14 @@ packages:
     dev: true
     optional: true
 
+  /@convex-dev/aggregate@0.2.1(convex@1.31.7):
+    resolution: {integrity: sha512-z8GeUC+cIZEgtMXecX6WTBQHNW4E2ioRsc5IkO8BWnCjgDOru/Mw8zXe9JPe35JkqDjlSVKuwxiQHKs/jaYAyA==}
+    peerDependencies:
+      convex: ^1.24.8
+    dependencies:
+      convex: 1.31.7(react@19.2.4)
+    dev: false
+
   /@convex-dev/auth@0.0.90(@auth/core@0.37.4)(convex@1.31.7)(react@19.1.0):
     resolution: {integrity: sha512-aqw88EB042HvnaF4wcf/f/wTocmT2Bus2VDQRuV79cM0+8kORM0ICK/ByZ6XsHgQ9qr6TmidNbXm6QAgndrdpQ==}
     hasBin: true
@@ -3857,7 +3871,6 @@ packages:
       - graphql
       - supports-color
       - utf-8-validate
-    dev: false
 
   /@expo/code-signing-certificates@0.0.6:
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
@@ -3927,7 +3940,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(react@19.1.0)
 
   /@expo/env@2.0.8:
     resolution: {integrity: sha512-5VQD6GT8HIMRaSaB5JFtOXuvfDVU80YtZIuUT/GDhUF782usIXY13Tn3IdDz1Tm/lqA9qnRZQ1BF4t7LlvdJPA==}
@@ -3999,7 +4012,7 @@ packages:
       debug: 4.4.3
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
       getenv: 2.0.0
       glob: 13.0.0
       hermes-parser: 0.29.1
@@ -4099,7 +4112,7 @@ packages:
       '@expo/json-file': 10.0.8
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
       resolve-from: 5.0.0
       semver: 7.7.3
       xml2js: 0.6.0
@@ -5769,7 +5782,6 @@ packages:
       nullthrows: 1.1.1
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(react@19.1.0)
-    dev: false
 
   /@react-navigation/bottom-tabs@7.10.1(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native-screens@4.16.0)(react-native@0.81.5)(react@19.1.0):
     resolution: {integrity: sha512-MirOzKEe/rRwPSE9HMrS4niIo0LyUhewlvd01TpzQ1ipuXjH2wJbzAM9gS/r62zriB6HMHz2OY6oIRduwQJtTw==}
@@ -8003,7 +8015,7 @@ packages:
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
       react-refresh: 0.14.2
       resolve-from: 5.0.0
     transitivePeerDependencies:
@@ -8579,7 +8591,6 @@ packages:
       esbuild: 0.27.0
       prettier: 3.8.1
       react: 19.2.4
-    dev: true
 
   /cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -9472,10 +9483,10 @@ packages:
       react-native: '*'
     dependencies:
       '@expo/image-utils': 0.8.8
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
       expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9571,8 +9582,8 @@ packages:
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.8
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9624,8 +9635,8 @@ packages:
       expo: '*'
       react-native: '*'
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(react@19.1.0)
 
   /expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5)(react@19.1.0):
     resolution: {integrity: sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==}
@@ -9634,10 +9645,10 @@ packages:
       react: '*'
       react-native: '*'
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
       fontfaceobserver: 2.3.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(react@19.1.0)
 
   /expo-haptics@15.0.8(expo@54.0.33):
     resolution: {integrity: sha512-lftutojy8Qs8zaDzzjwM3gKHFZ8bOOEZDCkmh2Ddpe95Ra6kt2izeOfOfKuP/QEh0MZ1j9TfqippyHdRd1ZM9g==}
@@ -9682,7 +9693,7 @@ packages:
       expo: '*'
       react: '*'
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1)(react-native@0.81.5)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5)(react@19.1.0)
       react: 19.1.0
 
   /expo-linear-gradient@15.0.8(expo@54.0.33)(react-native@0.81.5)(react@19.1.0):
@@ -9778,7 +9789,7 @@ packages:
     dependencies:
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(react@19.1.0)
 
   /expo-notifications@0.32.16(expo@54.0.33)(react-native@0.81.5)(react@19.1.0):
     resolution: {integrity: sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==}
@@ -10086,7 +10097,6 @@ packages:
       - graphql
       - supports-color
       - utf-8-validate
-    dev: false
 
   /exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -13837,7 +13847,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /react-promise-suspense@0.3.4:
     resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}


### PR DESCRIPTION
## Summary

- Replace O(n) full-table scan with O(log n) aggregate lookup for counting community people per group
- `communityPeople.count` was the **#1 database bandwidth consumer at 313.5 MB** — this reduces it to near-zero
- Installs `@convex-dev/aggregate` component, instruments all INSERT/DELETE mutations, and includes a backfill migration

## Post-deploy step

```bash
npx convex run migrations/backfillCommunityPeopleAggregate:backfill
```

## Test plan

- [x] All 1268 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Deploy to staging and run backfill migration
- [ ] Verify `communityPeople.count` returns correct counts on People page
- [ ] Monitor database bandwidth reduction in Convex dashboard

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)