### PR TITLE
fix: eliminate infinite setState loops, false connection banners, and unnecessary re-renders

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import { View } from 'react-native';
 import { Tabs } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -16,19 +16,21 @@ export default function TabsLayout() {
   const isAdmin = user?.is_admin === true;
   const isInternalUser = user?.is_staff === true || user?.is_superuser === true;
 
-  // Use stable state for tab visibility to prevent infinite loops
-  // Only update when community actually changes (not on every render)
-  const [hasCommunity, setHasCommunity] = useState(!!community?.id);
+  // Derive tab visibility from community ID using a ref to avoid
+  // setState during render which can cause infinite loops when Expo Router
+  // rehydrates navigation state (getRehydratedState → setState → re-render).
+  // Using useMemo instead of useState+useEffect avoids the extra render frame
+  // where stale state could cause the navigation config to oscillate.
   const prevCommunityIdRef = useRef(community?.id);
+  const prevHasCommunityRef = useRef(!!community?.id);
 
-  // Update hasCommunity state only when community.id actually changes
-  // This prevents infinite loops from Expo Router tab reconfiguration
-  useEffect(() => {
+  const hasCommunity = useMemo(() => {
     const currentCommunityId = community?.id;
     if (prevCommunityIdRef.current !== currentCommunityId) {
       prevCommunityIdRef.current = currentCommunityId;
-      setHasCommunity(!!currentCommunityId);
+      prevHasCommunityRef.current = !!currentCommunityId;
     }
+    return prevHasCommunityRef.current;
   }, [community?.id]);
 
   const tabs = (

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,4 +1,3 @@
-import { useMemo, useRef } from 'react';
 import { View } from 'react-native';
 import { Tabs } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -16,22 +15,10 @@ export default function TabsLayout() {
   const isAdmin = user?.is_admin === true;
   const isInternalUser = user?.is_staff === true || user?.is_superuser === true;
 
-  // Derive tab visibility from community ID using a ref to avoid
-  // setState during render which can cause infinite loops when Expo Router
-  // rehydrates navigation state (getRehydratedState → setState → re-render).
-  // Using useMemo instead of useState+useEffect avoids the extra render frame
-  // where stale state could cause the navigation config to oscillate.
-  const prevCommunityIdRef = useRef(community?.id);
-  const prevHasCommunityRef = useRef(!!community?.id);
-
-  const hasCommunity = useMemo(() => {
-    const currentCommunityId = community?.id;
-    if (prevCommunityIdRef.current !== currentCommunityId) {
-      prevCommunityIdRef.current = currentCommunityId;
-      prevHasCommunityRef.current = !!currentCommunityId;
-    }
-    return prevHasCommunityRef.current;
-  }, [community?.id]);
+  // community?.id is a primitive string — direct derivation is stable and
+  // won't cause tab config oscillation. The old useState+useEffect pattern
+  // was over-engineered and introduced a stale render frame.
+  const hasCommunity = !!community?.id;
 
   const tabs = (
     <Tabs

--- a/apps/mobile/app/inbox/[chat_id]/index.tsx
+++ b/apps/mobile/app/inbox/[chat_id]/index.tsx
@@ -52,8 +52,14 @@ export default function LegacyChatIdRoute() {
     [isConvexChannelId, chat_id]
   );
 
-  // Guard to prevent multiple redirect attempts which can cause infinite loops
+  // Guard to prevent multiple redirect attempts which can cause infinite loops.
+  // Reset when chat_id changes in case Expo Router reuses the component instance.
   const hasRedirected = useRef(false);
+  const prevChatId = useRef(chat_id);
+  if (prevChatId.current !== chat_id) {
+    prevChatId.current = chat_id;
+    hasRedirected.current = false;
+  }
 
   // Query channel data if we have a Convex channel ID
   const channelData = useQuery(

--- a/apps/mobile/app/inbox/[chat_id]/index.tsx
+++ b/apps/mobile/app/inbox/[chat_id]/index.tsx
@@ -16,7 +16,7 @@
  * - If channel lookup fails and the ID can't be validated as a group, redirects to inbox
  * - Prevents perpetual loading states for deleted/inaccessible channels
  */
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { View, ActivityIndicator, Text, StyleSheet, Pressable } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useQuery, api } from "@services/api/convex";
@@ -45,10 +45,15 @@ export default function LegacyChatIdRoute() {
     !chat_id.includes("_") && // Stream IDs have underscores
     chat_id.length > 10; // Convex IDs are longer
 
-  // Try to parse as Stream channel ID
-  const parsedChannel = !isConvexChannelId && chat_id
-    ? parseStreamChannelId(chat_id)
-    : null;
+  // Memoize parsed Stream channel ID to prevent new object references on every render.
+  // Without this, the useEffect below would re-fire on every render due to referential inequality.
+  const parsedChannel = useMemo(
+    () => (!isConvexChannelId && chat_id ? parseStreamChannelId(chat_id) : null),
+    [isConvexChannelId, chat_id]
+  );
+
+  // Guard to prevent multiple redirect attempts which can cause infinite loops
+  const hasRedirected = useRef(false);
 
   // Query channel data if we have a Convex channel ID
   const channelData = useQuery(
@@ -70,10 +75,15 @@ export default function LegacyChatIdRoute() {
   );
 
   useEffect(() => {
+    // Prevent multiple redirects — once we've navigated, stop re-running.
+    // This prevents infinite loops when navigation state changes trigger re-renders.
+    if (hasRedirected.current) return;
+
     // If we have parsed Stream channel ID with groupId (can determine type locally)
     if (parsedChannel?.groupId) {
       // Map channel type to slug: "main" -> "general", "leaders" -> "leaders"
       const channelSlug = parsedChannel.type === "leaders" ? "leaders" : "general";
+      hasRedirected.current = true;
       router.replace(`/inbox/${parsedChannel.groupId}/${channelSlug}`);
       return;
     }
@@ -82,6 +92,7 @@ export default function LegacyChatIdRoute() {
     if (channelData?.groupId) {
       // Use slug from channel data, fallback to mapping channelType to slug
       const channelSlug = channelData.slug ?? (channelData.channelType === "leaders" ? "leaders" : "general");
+      hasRedirected.current = true;
       router.replace(`/inbox/${channelData.groupId}/${channelSlug}`);
       return;
     }
@@ -101,6 +112,7 @@ export default function LegacyChatIdRoute() {
       }
       // Stream channel IDs are already handled by parsedChannel above
       // Fall back to general for non-channel IDs or when channel lookup failed
+      hasRedirected.current = true;
       router.replace(`/inbox/${groupIdParam}/general`);
       return;
     }
@@ -116,6 +128,7 @@ export default function LegacyChatIdRoute() {
       }
       if (groupValidation !== null) {
         // Group exists - redirect to it
+        hasRedirected.current = true;
         router.replace(`/inbox/${chat_id}/general`);
         return;
       }
@@ -127,6 +140,7 @@ export default function LegacyChatIdRoute() {
     // If chat_id looks like a group ID (not a channel ID), redirect to general
     // This handles the case where navigation passes a group ID as chat_id
     if (chat_id && !isConvexChannelId && !parsedChannel) {
+      hasRedirected.current = true;
       router.replace(`/inbox/${chat_id}/general`);
       return;
     }

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -435,7 +435,13 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // 1. User is on leaders slug
   // 2. Leaders channel lookup has COMPLETED (null, not undefined/loading) and channel not found
   // 3. Main channel exists (we have somewhere to redirect to)
+  // Reset guard when the group or slug changes (component instance may be reused)
   const hasRedirectedFromLeaders = useRef(false);
+  const prevLeadersKey = useRef(`${resolvedGroupId}:${activeSlug}`);
+  if (prevLeadersKey.current !== `${resolvedGroupId}:${activeSlug}`) {
+    prevLeadersKey.current = `${resolvedGroupId}:${activeSlug}`;
+    hasRedirectedFromLeaders.current = false;
+  }
   useEffect(() => {
     if (hasRedirectedFromLeaders.current) return;
     if (

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -435,7 +435,9 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // 1. User is on leaders slug
   // 2. Leaders channel lookup has COMPLETED (null, not undefined/loading) and channel not found
   // 3. Main channel exists (we have somewhere to redirect to)
+  const hasRedirectedFromLeaders = useRef(false);
   useEffect(() => {
+    if (hasRedirectedFromLeaders.current) return;
     if (
       activeSlug === "leaders" &&
       leadersChannelId === null && // null = query completed, channel not found (not undefined = still loading)
@@ -443,6 +445,7 @@ const ConvexChatRoomScreenInner: React.FC = () => {
       resolvedGroupId
     ) {
       // Leaders channel doesn't exist - redirect to general with preserved params
+      hasRedirectedFromLeaders.current = true;
       router.replace({
         pathname: `/inbox/${resolvedGroupId}/general` as any,
         params: {

--- a/apps/mobile/providers/AuthProvider.tsx
+++ b/apps/mobile/providers/AuthProvider.tsx
@@ -144,8 +144,12 @@ function decodeJwtPayload(token: string): { exp?: number; [key: string]: unknown
   try {
     const parts = token.split(".");
     if (parts.length !== 3) return null;
-    // Base64url → Base64 → decode
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    // Base64url → Base64 → decode (pad to multiple of 4 — required for atob on some runtimes)
+    let base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const pad = base64.length % 4;
+    if (pad === 2) base64 += "==";
+    else if (pad === 3) base64 += "=";
+    else if (pad === 1) return null;
     const json = atob(base64);
     return JSON.parse(json);
   } catch {

--- a/apps/mobile/providers/AuthProvider.tsx
+++ b/apps/mobile/providers/AuthProvider.tsx
@@ -133,6 +133,51 @@ export function classifyProfileFetchError(
 // Helper Functions
 // ============================================================================
 
+/** Refresh threshold — only refresh if token expires within this window */
+const TOKEN_REFRESH_THRESHOLD_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+/**
+ * Decode a JWT payload without verification (we only need the `exp` claim).
+ * Returns null if the token is malformed.
+ */
+function decodeJwtPayload(token: string): { exp?: number; [key: string]: unknown } | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    // Base64url → Base64 → decode
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const json = atob(base64);
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether an access token needs refreshing.
+ * Returns true if the token is expired, near expiry, or unparseable.
+ */
+function shouldRefreshToken(accessToken: string): boolean {
+  const payload = decodeJwtPayload(accessToken);
+  if (!payload?.exp) return true; // Can't read expiry — refresh to be safe
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const remainingSeconds = payload.exp - nowSeconds;
+
+  if (remainingSeconds <= 0) {
+    console.log("🔐 Token expired, needs refresh");
+    return true;
+  }
+
+  if (remainingSeconds < TOKEN_REFRESH_THRESHOLD_SECONDS) {
+    console.log(`🔐 Token expires in ${Math.floor(remainingSeconds / 86400)}d, refreshing`);
+    return true;
+  }
+
+  console.log(`🔐 Token still valid for ${Math.floor(remainingSeconds / 86400)}d, skipping refresh`);
+  return false;
+}
+
 /**
  * Store auth tokens in AsyncStorage
  */
@@ -762,9 +807,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         let result = await fetchUserProfile(tokens.userId, tokens.accessToken);
         const communityId = result.status === "success" ? result.community?.id : undefined;
 
-        // If we have a refresh token, refresh the tokens with community ID
-        if (tokens.refreshToken) {
-          console.log("🔐 AuthProvider: Refreshing tokens with communityId:", communityId);
+        // If we have a refresh token, refresh only if the access token is near expiry.
+        // Tokens last 30 days — skip refresh if plenty of time remains.
+        if (tokens.refreshToken && shouldRefreshToken(tokens.accessToken)) {
+          console.log("🔐 AuthProvider: Token near expiry, refreshing with communityId:", communityId);
           const refreshed = await refreshAuthTokens(communityId);
 
           if (refreshed) {
@@ -910,23 +956,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           return;
         }
 
-        console.log("🔐 AuthProvider: App foregrounded, refreshing tokens...");
+        // Only refresh if the token is expired or near expiry (< 7 days).
+        // Tokens last 30 days so most foreground events skip the refresh entirely,
+        // avoiding unnecessary re-renders across 50+ query consumers.
+        const needsRefresh = shouldRefreshToken(tokens.accessToken);
+        if (needsRefresh) {
+          console.log("🔐 AuthProvider: App foregrounded, token needs refresh");
+          const refreshed = await refreshAuthTokens(community?.id);
 
-        // Refresh tokens first, passing community ID to preserve it in the new token
-        const refreshed = await refreshAuthTokens(community?.id);
-
-        if (!refreshed) {
-          // Refresh failed - this could be due to network issues or expired refresh token
-          // Don't immediately logout as this could be a transient network error
-          // The user can continue with their existing session; if their token is truly
-          // expired, they'll encounter auth errors on their next action
-          console.log("🔐 AuthProvider: Token refresh failed on foreground, continuing with existing session");
-          SentryUtils.captureMessage(
-            "Token refresh failed on foreground - may be network or token issue",
-            "info",
-            { operation: "foreground_refresh" }
-          );
-          // Continue to try updating activity - this will fail gracefully if token is invalid
+          if (!refreshed) {
+            // Refresh failed - this could be due to network issues or expired refresh token
+            // Don't immediately logout as this could be a transient network error
+            // The user can continue with their existing session; if their token is truly
+            // expired, they'll encounter auth errors on their next action
+            console.log("🔐 AuthProvider: Token refresh failed on foreground, continuing with existing session");
+            SentryUtils.captureMessage(
+              "Token refresh failed on foreground - may be network or token issue",
+              "info",
+              { operation: "foreground_refresh" }
+            );
+          }
         }
 
         // Update last activity with the (potentially new) token

--- a/apps/mobile/providers/ConnectionProvider.tsx
+++ b/apps/mobile/providers/ConnectionProvider.tsx
@@ -27,6 +27,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useMemo,
   useRef,
   useCallback,
 } from 'react';
@@ -242,19 +243,31 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, [simulateOffline]);
 
+  const contextValue = useMemo(
+    () => ({
+      status,
+      isNetworkAvailable,
+      isWebSocketConnected,
+      isInternetReachable,
+      connectionType,
+      cellularGeneration,
+      isEffectivelyOffline,
+      ...(__DEV__ ? { simulateOffline } : {}),
+    }),
+    [
+      status,
+      isNetworkAvailable,
+      isWebSocketConnected,
+      isInternetReachable,
+      connectionType,
+      cellularGeneration,
+      isEffectivelyOffline,
+      simulateOffline,
+    ]
+  );
+
   return (
-    <ConnectionContext.Provider
-      value={{
-        status,
-        isNetworkAvailable,
-        isWebSocketConnected,
-        isInternetReachable,
-        connectionType,
-        cellularGeneration,
-        isEffectivelyOffline,
-        ...(__DEV__ ? { simulateOffline } : {}),
-      }}
-    >
+    <ConnectionContext.Provider value={contextValue}>
       {children}
     </ConnectionContext.Provider>
   );

--- a/apps/mobile/providers/ConnectionProvider.tsx
+++ b/apps/mobile/providers/ConnectionProvider.tsx
@@ -31,6 +31,7 @@ import React, {
   useRef,
   useCallback,
 } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import { useConvexConnectionState } from '@services/api/convex';
 
@@ -209,6 +210,38 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
       if (reconnectedTimerRef.current)
         clearTimeout(reconnectedTimerRef.current);
     };
+  }, []);
+
+  // When the app returns from background, iOS will have killed the WebSocket.
+  // Reset to 'connecting' so we use the cold-start grace period (6s, no banner)
+  // instead of the mid-session debounce (2s → red banner). The WebSocket
+  // typically reconnects in 1-3s, well within the grace window.
+  useEffect(() => {
+    let previousState = AppState.currentState;
+
+    const subscription = AppState.addEventListener(
+      'change',
+      (nextState: AppStateStatus) => {
+        if (
+          previousState.match(/inactive|background/) &&
+          nextState === 'active'
+        ) {
+          // Clear any pending disconnect timer from the backgrounding
+          if (disconnectTimerRef.current) {
+            clearTimeout(disconnectTimerRef.current);
+            disconnectTimerRef.current = null;
+          }
+          // Reset to connecting — the main effect will re-evaluate and
+          // either connect silently or start the grace timer
+          setStatus('connecting');
+          wasDisconnectedRef.current = false;
+          coldStartDisconnectRef.current = false;
+        }
+        previousState = nextState;
+      }
+    );
+
+    return () => subscription.remove();
   }, []);
 
   // Subscribe to NetInfo

--- a/apps/mobile/providers/ConnectionProvider.tsx
+++ b/apps/mobile/providers/ConnectionProvider.tsx
@@ -105,7 +105,18 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
   const isSlowConnection = connectionType === 'cellular' &&
     (cellularGeneration === '2g' || cellularGeneration === '3g');
 
+  // Use a ref to read current status inside the effect without including it
+  // in the dependency array. Including `status` as a dep caused the effect to
+  // re-run on every status change, creating a self-triggering cycle
+  // (setStatus → re-render → effect re-runs → setStatus again). React's
+  // same-value bail-out prevents true infinite loops, but the extra effect
+  // re-runs are wasteful and fragile if inputs flicker.
+  const statusRef = useRef(status);
+  statusRef.current = status;
+
   useEffect(() => {
+    const currentStatus = statusRef.current;
+
     if (!isConnected) {
       // Clear reconnected timer if running
       if (reconnectedTimerRef.current) {
@@ -113,7 +124,7 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
         reconnectedTimerRef.current = null;
       }
 
-      if (status === 'connecting') {
+      if (currentStatus === 'connecting') {
         // Cold start: use longer grace period before showing red banner
         if (!startupGraceTimerRef.current) {
           startupGraceTimerRef.current = setTimeout(() => {
@@ -153,7 +164,7 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
         startupGraceTimerRef.current = null;
       }
 
-      if (status === 'connecting') {
+      if (currentStatus === 'connecting') {
         // Cold start succeeded within grace period - connect silently, no banner
         setStatus(isSlowConnection ? 'slow' : 'connected');
       } else if (wasDisconnectedRef.current) {
@@ -166,13 +177,9 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
           setStatus(isSlowConnection ? 'slow' : 'connected');
           reconnectedTimerRef.current = null;
         }, 3000);
-      } else if (status === 'reconnected') {
-        // Already showing reconnected - effect re-ran due to status in deps; don't overwrite
-        // The reconnected timer will transition to connected/slow
-      } else if (isSlowConnection) {
-        setStatus('slow');
-      } else {
-        setStatus('connected');
+      } else if (currentStatus !== 'reconnected') {
+        // Not in reconnected state (which has its own timer) — sync with connection quality
+        setStatus(isSlowConnection ? 'slow' : 'connected');
       }
     }
 
@@ -180,10 +187,8 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
       if (disconnectTimerRef.current) clearTimeout(disconnectTimerRef.current);
       if (startupGraceTimerRef.current)
         clearTimeout(startupGraceTimerRef.current);
-      // Don't clear reconnectedTimerRef here - effect re-runs when status changes to
-      // 'reconnected', and we need that timer to fire. It's cleared when going offline.
     };
-  }, [isConnected, isSlowConnection, status]);
+  }, [isConnected, isSlowConnection]);
 
   // Clear reconnected timer on unmount
   useEffect(() => {

--- a/apps/mobile/providers/ConnectionProvider.tsx
+++ b/apps/mobile/providers/ConnectionProvider.tsx
@@ -89,10 +89,11 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
     null
   );
   const wasDisconnectedRef = useRef(false);
+  /** True if the disconnect happened during cold start (grace timer), not mid-session */
+  const coldStartDisconnectRef = useRef(false);
   // Track latest network state so the grace timer callback can distinguish
   // "network down" from "WebSocket slow to connect"
   const isNetworkAvailableRef = useRef(true);
-  const isInternetReachableRef = useRef(true);
 
   const isWebSocketConnected = convexState.isWebSocketConnected;
 
@@ -130,12 +131,15 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
         if (!startupGraceTimerRef.current) {
           startupGraceTimerRef.current = setTimeout(() => {
             startupGraceTimerRef.current = null;
-            // Only show "No internet" if the network is actually down.
-            // If NetInfo says we have internet but the WebSocket is slow,
-            // stay in 'connecting' (no banner) — not a network issue.
-            if (!isNetworkAvailableRef.current || !isInternetReachableRef.current) {
+            // Only show "No internet" if the device has no network at all.
+            // Do NOT check isInternetReachable here — on Android it does an
+            // HTTP probe that can report false for several seconds during cold
+            // start, causing a false "No internet" banner that flips to
+            // "Connected" once the probe completes.
+            if (!isNetworkAvailableRef.current) {
               setStatus('disconnected');
               wasDisconnectedRef.current = true;
+              coldStartDisconnectRef.current = true;
             }
           }, COLD_START_GRACE_MS);
         }
@@ -168,10 +172,18 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
       if (currentStatus === 'connecting') {
         // Cold start succeeded within grace period - connect silently, no banner
         setStatus(isSlowConnection ? 'slow' : 'connected');
+      } else if (wasDisconnectedRef.current && coldStartDisconnectRef.current) {
+        // Disconnect happened during cold start (grace timer), not a real
+        // mid-session drop. Skip the "reconnected" banner — go straight to
+        // connected so the user doesn't see a misleading green banner.
+        wasDisconnectedRef.current = false;
+        coldStartDisconnectRef.current = false;
+        setStatus(isSlowConnection ? 'slow' : 'connected');
       } else if (wasDisconnectedRef.current) {
-        // Was disconnected - show reconnected
+        // Real mid-session disconnect recovered - show reconnected banner
         setStatus('reconnected');
         wasDisconnectedRef.current = false;
+        coldStartDisconnectRef.current = false;
 
         // Auto-dismiss after 3 seconds
         reconnectedTimerRef.current = setTimeout(() => {
@@ -207,7 +219,6 @@ export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({
       setIsNetworkAvailable(networkAvailable);
       setIsInternetReachable(internetReachable);
       isNetworkAvailableRef.current = networkAvailable;
-      isInternetReachableRef.current = internetReachable;
       setConnectionType(state.type ?? 'unknown');
 
       // Extract cellular generation

--- a/apps/mobile/providers/EnvironmentProvider.tsx
+++ b/apps/mobile/providers/EnvironmentProvider.tsx
@@ -5,7 +5,7 @@
  * Environment is determined at build time - no runtime switching.
  */
 
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useMemo } from "react";
 import { Environment, EnvironmentConfig } from "@services/environment";
 
 interface EnvironmentContextValue {
@@ -21,12 +21,16 @@ interface EnvironmentProviderProps {
 }
 
 export function EnvironmentProvider({ children }: EnvironmentProviderProps) {
-  // Environment is determined at build time - no async loading needed
-  const value: EnvironmentContextValue = {
-    config: Environment.current,
-    isStaging: Environment.isStaging(),
-    isProduction: Environment.isProduction(),
-  };
+  // Environment is determined at build time — memoize to prevent cascading
+  // re-renders to all useEnvironment() consumers when a parent re-renders.
+  const value = useMemo<EnvironmentContextValue>(
+    () => ({
+      config: Environment.current,
+      isStaging: Environment.isStaging(),
+      isProduction: Environment.isProduction(),
+    }),
+    []
+  );
 
   return (
     <EnvironmentContext.Provider value={value}>

--- a/apps/mobile/providers/NotificationProvider.tsx
+++ b/apps/mobile/providers/NotificationProvider.tsx
@@ -19,6 +19,7 @@ import React, {
   createContext,
   useContext,
   useEffect,
+  useMemo,
   useState,
   useCallback,
   useRef,
@@ -654,21 +655,35 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, [refreshUnreadCount]);
 
+  const contextValue = useMemo(
+    () => ({
+      expoPushToken,
+      isEnabled,
+      unreadCount,
+      isReady,
+      requestPermissions,
+      refreshUnreadCount,
+      lastNotification,
+      handleNotificationTap,
+      setActiveChannelId,
+      activeChannelId,
+    }),
+    [
+      expoPushToken,
+      isEnabled,
+      unreadCount,
+      isReady,
+      requestPermissions,
+      refreshUnreadCount,
+      lastNotification,
+      handleNotificationTap,
+      setActiveChannelId,
+      activeChannelId,
+    ]
+  );
+
   return (
-    <NotificationContext.Provider
-      value={{
-        expoPushToken,
-        isEnabled,
-        unreadCount,
-        isReady,
-        requestPermissions,
-        refreshUnreadCount,
-        lastNotification,
-        handleNotificationTap,
-        setActiveChannelId,
-        activeChannelId,
-      }}
-    >
+    <NotificationContext.Provider value={contextValue}>
       {children}
     </NotificationContext.Provider>
   );

--- a/apps/mobile/providers/OTAUpdateProvider.tsx
+++ b/apps/mobile/providers/OTAUpdateProvider.tsx
@@ -10,7 +10,7 @@
  * When an update is ready and the app is backgrounded for 30+ seconds,
  * it will auto-apply the update on next foreground via Updates.reloadAsync().
  */
-import React, { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { AppState } from 'react-native';
 import * as Updates from 'expo-updates';
 
@@ -148,8 +148,13 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     };
   }, []);
 
+  const contextValue = useMemo(
+    () => ({ status, errorMessage }),
+    [status, errorMessage]
+  );
+
   return (
-    <OTAUpdateContext.Provider value={{ status, errorMessage }}>
+    <OTAUpdateContext.Provider value={contextValue}>
       {children}
     </OTAUpdateContext.Provider>
   );

--- a/apps/mobile/providers/__tests__/ConnectionProvider.test.tsx
+++ b/apps/mobile/providers/__tests__/ConnectionProvider.test.tsx
@@ -3,6 +3,7 @@
  * Tests the state machine: connected -> disconnected -> reconnected -> connected
  */
 import React from 'react';
+import { AppState } from 'react-native';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { ConnectionProvider, useConnectionStatus } from '../ConnectionProvider';
 
@@ -313,5 +314,70 @@ describe('ConnectionProvider', () => {
     await waitFor(() => expect(result.current.status).toBe('connected'));
     // Should be connected, not reconnected (no green banner flash)
     expect(result.current.status).toBe('connected');
+  });
+
+  it('resets to connecting on foreground and avoids mid-session disconnect debounce while WebSocket reconnects', async () => {
+    let mockCurrentState = 'active';
+    const currentStateDescriptor = Object.getOwnPropertyDescriptor(
+      AppState,
+      'currentState'
+    );
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      enumerable: currentStateDescriptor?.enumerable ?? true,
+      get: () => mockCurrentState,
+    });
+
+    const listeners: Array<(state: string) => void> = [];
+    const addListenerSpy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((event, listener) => {
+        if (event === 'change') {
+          listeners.push(listener as (state: string) => void);
+        }
+        return { remove: jest.fn() };
+      });
+
+    try {
+      const { result, rerender } = renderHook(() => useConnectionStatus(), {
+        wrapper,
+      });
+      await waitFor(() => expect(result.current.status).toBe('connected'));
+
+      // Mid-session WebSocket drop: would normally show disconnected after 2s debounce
+      act(() => {
+        mockIsWebSocketConnected = false;
+        rerender({});
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(result.current.status).toBe('connected');
+
+      // iOS-style resume: foreground resets to cold-start path (6s grace, no red banner)
+      const emitAppState = listeners[listeners.length - 1];
+      act(() => {
+        mockCurrentState = 'active';
+        emitAppState('background');
+        mockCurrentState = 'background';
+        emitAppState('active');
+      });
+
+      await waitFor(() => expect(result.current.status).toBe('connecting'));
+
+      // 2s debounce would have fired without the foreground reset — should still be connecting
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      expect(result.current.status).toBe('connecting');
+    } finally {
+      addListenerSpy.mockRestore();
+      if (currentStateDescriptor) {
+        Object.defineProperty(AppState, 'currentState', currentStateDescriptor);
+      } else {
+        delete (AppState as { currentState?: string }).currentState;
+      }
+    }
   });
 });

--- a/apps/mobile/services/api/convex.ts
+++ b/apps/mobile/services/api/convex.ts
@@ -235,15 +235,22 @@ export function useStoredAuthToken(): string | null {
   // receive the new JWT — stale tokens can 401 until the user navigates enough
   // to remount hooks. AuthProvider avoids putting `token` in context deps to
   // limit broad re-renders; this hook is the narrow place that should update.
+  //
+  // Use a ref to compare against the current token so `token` doesn't need
+  // to be a dependency. Including it would recreate the interval on every
+  // token change, which is wasteful and can cascade re-renders.
+  const tokenRef = React.useRef(token);
+  tokenRef.current = token;
+
   React.useEffect(() => {
     const interval = setInterval(() => {
-      if (cachedToken !== token) {
+      if (cachedToken !== tokenRef.current) {
         setToken(cachedToken);
       }
     }, 500);
 
     return () => clearInterval(interval);
-  }, [token]);
+  }, []); // Stable interval — reads token via ref
 
   return token;
 }
@@ -280,10 +287,19 @@ export function useAuthenticatedQuery<
   // If args is 'skip' or no token, skip the query
   const shouldSkip = args === 'skip' || !token;
 
-  // Compute args once - always call the hook unconditionally to satisfy rules of hooks
-  const queryArgs = shouldSkip
-    ? 'skip' as const
-    : ({ ...(args as Omit<FunctionArgs<Query>, 'token'>), token } as FunctionArgs<Query>);
+  // Memoize query args to avoid creating a new object on every render.
+  // Convex does deep comparison internally, but spreading { ...args, token }
+  // inline creates a new reference each render which still causes unnecessary
+  // work in Convex's comparison logic across 50+ call sites.
+  const argsKey = shouldSkip ? 'skip' : JSON.stringify(args);
+  const queryArgs = React.useMemo(
+    () =>
+      shouldSkip
+        ? ('skip' as const)
+        : ({ ...(args as Omit<FunctionArgs<Query>, 'token'>), token } as FunctionArgs<Query>),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- argsKey is the serialized form of args
+    [shouldSkip, argsKey, token]
+  );
 
   return useConvexQuery(queryFn, queryArgs);
 }
@@ -394,10 +410,16 @@ export function useAuthenticatedPaginatedQuery<
   // If args is 'skip' or no token, skip the query
   const shouldSkip = args === 'skip' || !token;
 
-  // Compute args once - always call the hook unconditionally to satisfy rules of hooks
-  const queryArgs = shouldSkip
-    ? ('skip' as const)
-    : { ...(args as object), token };
+  // Memoize query args (same pattern as useAuthenticatedQuery)
+  const argsKey = shouldSkip ? 'skip' : JSON.stringify(args);
+  const queryArgs = React.useMemo(
+    () =>
+      shouldSkip
+        ? ('skip' as const)
+        : { ...(args as object), token },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- argsKey is the serialized form of args
+    [shouldSkip, argsKey, token]
+  );
 
   return useConvexPaginatedQuery(queryFn, queryArgs as any, options);
 }

--- a/apps/mobile/services/api/convex.ts
+++ b/apps/mobile/services/api/convex.ts
@@ -17,6 +17,17 @@ import React from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Environment } from '@services/environment';
 
+/**
+ * Stable JSON serialization with sorted keys for use as memoization keys.
+ * Guarantees identical output regardless of property insertion order.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']';
+  const sorted = Object.keys(value as Record<string, unknown>).sort();
+  return '{' + sorted.map(k => JSON.stringify(k) + ':' + stableStringify((value as Record<string, unknown>)[k])).join(',') + '}';
+}
+
 // Re-export the API type for use in components
 export { api } from '../../../convex/_generated/api';
 
@@ -291,7 +302,7 @@ export function useAuthenticatedQuery<
   // Convex does deep comparison internally, but spreading { ...args, token }
   // inline creates a new reference each render which still causes unnecessary
   // work in Convex's comparison logic across 50+ call sites.
-  const argsKey = shouldSkip ? 'skip' : JSON.stringify(args);
+  const argsKey = shouldSkip ? 'skip' : stableStringify(args);
   const queryArgs = React.useMemo(
     () =>
       shouldSkip
@@ -411,7 +422,7 @@ export function useAuthenticatedPaginatedQuery<
   const shouldSkip = args === 'skip' || !token;
 
   // Memoize query args (same pattern as useAuthenticatedQuery)
-  const argsKey = shouldSkip ? 'skip' : JSON.stringify(args);
+  const argsKey = shouldSkip ? 'skip' : stableStringify(args);
   const queryArgs = React.useMemo(
     () =>
       shouldSkip


### PR DESCRIPTION
## Summary

Fixes four user-reported issues across 9 files:

### 1. "No internet connection" banner flash on app open (iOS)
iOS kills WebSocket connections when the app goes to background. On foreground, the WebSocket needs 1-3s to reconnect, but the old code treated this as a mid-session disconnect (2s debounce) — showing a false red "No internet" banner followed by a green "Connected" banner for 3s.

**Fix:** Reset ConnectionProvider to `'connecting'` state on foreground, using the 6s cold-start grace period (no banner). WebSocket reconnects silently within this window.

### 2. Refresh flicker when opening the app
Every foreground event unconditionally refreshed the auth token (30-day JWT), even with 29+ days remaining. This wrote a new token to AsyncStorage → 500ms polling detected the change → all 50+ `useAuthenticatedQuery` consumers got new args → every query re-subscribed → visible refresh jank.

**Fix:** Decode JWT `exp` claim, only refresh when < 7 days remain. Most foreground events skip refresh entirely.

### 3. Maximum update depth exceeded (Sentry)
Multiple `router.replace()` calls inside `useEffect` hooks without guards, plus `parsedChannel` creating new object references on every render, caused infinite navigation loops.

**Fix:** Added `hasRedirected` ref guards (with param-change reset) on all navigation effects. Memoized `parsedChannel`. Simplified `hasCommunity` derivation in tabs layout.

### 4. Cascading re-renders / general jank
- 4 context providers creating new value objects on every render
- `useStoredAuthToken` polling interval recreated on every token change
- `useAuthenticatedQuery` spreading `{ ...args, token }` inline (50+ call sites)
- ConnectionProvider's `status` in its own useEffect dependency array

**Fix:** Memoized all provider context values. Stabilized polling interval with refs. Memoized query args with `stableStringify` (sorted-key serialization). Removed self-triggering `status` dependency.

## Files changed (9)
- `apps/mobile/app/(tabs)/_layout.tsx` — simplified `hasCommunity` derivation
- `apps/mobile/app/inbox/[chat_id]/index.tsx` — memoized `parsedChannel`, added redirect guards
- `apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx` — added redirect guard
- `apps/mobile/providers/AuthProvider.tsx` — token refresh gating (`shouldRefreshToken`)
- `apps/mobile/providers/ConnectionProvider.tsx` — foreground reset, grace period fixes, memoized context
- `apps/mobile/providers/EnvironmentProvider.tsx` — memoized context value
- `apps/mobile/providers/NotificationProvider.tsx` — memoized context value
- `apps/mobile/providers/OTAUpdateProvider.tsx` — memoized context value
- `apps/mobile/services/api/convex.ts` — stable token polling, memoized query args

## Test plan
- [ ] Open app from background on iOS — no red/green banner flash
- [ ] Open app from background — no visible query refresh flicker
- [ ] Navigate between inbox channels rapidly — no crash
- [ ] Check Sentry for "Maximum update depth exceeded" errors — should stop
- [ ] Verify auth still works after 23+ days (token refresh kicks in at 7 days remaining)
- [ ] Verify real network loss still shows the red banner correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)