### PR TITLE
feat(broadcasts): per-channel reachability + drop SMS + write notification rows

### DIFF
--- a/apps/convex/functions/adminBroadcasts.ts
+++ b/apps/convex/functions/adminBroadcasts.ts
@@ -13,6 +13,7 @@ import type { Id } from "../_generated/dataModel";
 import { requireAuth } from "../lib/auth";
 import { requireCommunityAdmin } from "../lib/permissions";
 import { now } from "../lib/utils";
+import { getCurrentEnvironment } from "../lib/notifications/send";
 
 // ============================================================================
 // Target criteria type
@@ -109,7 +110,7 @@ export const previewTargeting = action({
     communityId: v.id("communities"),
     targetCriteria: targetCriteriaValidator,
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ count: number; reachable: { push: number; email: number } }> => {
     // Auth check via internal query
     const authResult = await ctx.runQuery(
       internal.functions.adminBroadcasts.checkAdminAuth,
@@ -118,7 +119,13 @@ export const previewTargeting = action({
     if (!authResult.authorized) throw new Error("Not authorized");
 
     const { userIds } = await resolveTargetUsersAction(ctx, args.communityId, args.targetCriteria);
-    return { count: userIds.length };
+
+    const reachable: { push: number; email: number } = await ctx.runQuery(
+      internal.functions.adminBroadcasts.getChannelReachability,
+      { userIds }
+    );
+
+    return { count: userIds.length, reachable };
   },
 });
 
@@ -142,6 +149,15 @@ export const create = mutation({
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
     await requireCommunityAdmin(ctx, args.communityId, userId);
+
+    if (args.channels.length === 0) {
+      throw new Error("At least one channel must be selected");
+    }
+    for (const channel of args.channels) {
+      if (channel !== "push" && channel !== "email") {
+        throw new Error(`Unsupported channel: ${channel}. Admin broadcasts support push and email only.`);
+      }
+    }
 
     const timestamp = now();
     const id = await ctx.db.insert("adminBroadcasts", {
@@ -406,7 +422,9 @@ export const sendToUsers = internalAction({
     if (!broadcast) return;
 
     const perUserLinks = (args.perUserDeepLinks || {}) as Record<string, string>;
-    const results = { pushSucceeded: 0, pushFailed: 0, emailSucceeded: 0, emailFailed: 0, smsSucceeded: 0, smsFailed: 0 };
+    const results = { pushSucceeded: 0, pushFailed: 0, emailSucceeded: 0, emailFailed: 0 };
+
+    const reachedUserIds = new Set<Id<"users">>();
 
     if (broadcast.channels.includes("push")) {
       const tokenResults: Array<{ userId: string; tokens: string[] }> =
@@ -424,6 +442,7 @@ export const sendToUsers = internalAction({
             data: {
               type: "admin_broadcast",
               communityId: broadcast.communityId,
+              broadcastId: args.broadcastId,
               // Per-user deep link if available, otherwise broadcast default (skip non-URL markers)
               url: perUserLinks[result.userId] || (broadcast.deepLink?.startsWith("/") ? broadcast.deepLink : undefined),
             },
@@ -438,48 +457,19 @@ export const sendToUsers = internalAction({
         results.pushSucceeded = pushResult.success ? notifications.length : 0;
         results.pushFailed = pushResult.success ? 0 : notifications.length;
       }
-    }
 
-    if (broadcast.channels.includes("sms")) {
-      const userPhones = await ctx.runQuery(
-        internal.functions.adminBroadcasts.getUserPhones,
-        { userIds: args.userIds }
-      );
-
-      // Build SMS with context prefix and character limit
-      const community = await ctx.runQuery(internal.functions.adminBroadcasts.getCommunity, {
-        communityId: broadcast.communityId as Id<"communities">,
-      });
-      const communityName = community?.name || "Your community";
-      const smsPrefix = `${communityName} sent a new message:\n\n`;
-      const rawBody = `${broadcast.title}\n\n${broadcast.body}`;
-      const maxBodyLen = 1600 - smsPrefix.length;
-      const truncatedBody = rawBody.length > maxBodyLen
-        ? rawBody.slice(0, maxBodyLen - 1) + "…"
-        : rawBody;
-      const smsMessage = smsPrefix + truncatedBody;
-
-      for (const { phone } of userPhones as Array<{ phone: string | null }>) {
-        if (!phone) continue;
-        try {
-          await ctx.runAction(internal.functions.auth.phoneOtp.sendSMS, {
-            phone,
-            message: smsMessage,
-          });
-          results.smsSucceeded++;
-        } catch {
-          results.smsFailed++;
-        }
+      for (const { userId } of tokenResults) {
+        reachedUserIds.add(userId as Id<"users">);
       }
     }
 
     if (broadcast.channels.includes("email")) {
-      const userEmails = await ctx.runQuery(
+      const userEmails: Array<{ userId: Id<"users">; email: string | null }> = await ctx.runQuery(
         internal.functions.adminBroadcasts.getUserEmails,
         { userIds: args.userIds }
       );
-      const emails = (userEmails as Array<{ email: string | null }>)
-        .filter((u): u is { email: string } => !!u.email)
+      const emails = userEmails
+        .filter((u): u is { userId: Id<"users">; email: string } => !!u.email)
         .map((u) => ({
           to: u.email,
           subject: broadcast.title,
@@ -493,6 +483,35 @@ export const sendToUsers = internalAction({
         );
         results.emailSucceeded = emailResults.filter((r: { success: boolean }) => r.success).length;
         results.emailFailed = emailResults.filter((r: { success: boolean }) => !r.success).length;
+      }
+
+      for (const u of userEmails) {
+        if (u.email) reachedUserIds.add(u.userId);
+      }
+    }
+
+    if (!args.isTest && reachedUserIds.size > 0) {
+      const notificationRecords = Array.from(reachedUserIds).map((userId) => ({
+        userId,
+        communityId: broadcast.communityId as Id<"communities">,
+        notificationType: "admin_broadcast",
+        title: broadcast.title,
+        body: broadcast.body,
+        data: {
+          broadcastId: args.broadcastId,
+          channels: broadcast.channels,
+          url: perUserLinks[userId] || (broadcast.deepLink?.startsWith("/") ? broadcast.deepLink : undefined),
+        },
+        status: "sent",
+      }));
+
+      // Chunk to keep each mutation well under Convex write limits
+      const CHUNK = 200;
+      for (let i = 0; i < notificationRecords.length; i += CHUNK) {
+        await ctx.runMutation(
+          internal.functions.notifications.mutations.createNotificationsBatch,
+          { notifications: notificationRecords.slice(i, i + CHUNK) }
+        );
       }
     }
 
@@ -532,21 +551,44 @@ export const getCommunity = internalQuery({
   handler: async (ctx, args) => ctx.db.get(args.communityId),
 });
 
-export const getUserPhones = internalQuery({
+export const getUserEmails = internalQuery({
   args: { userIds: v.array(v.id("users")) },
   handler: async (ctx, args) => {
     const users = await Promise.all(args.userIds.map((id) => ctx.db.get(id)));
     return users
       .filter((u): u is NonNullable<typeof u> => u !== null)
-      .map((u) => ({ userId: u._id as string, phone: u.phone || null }));
+      .map((u) => ({ userId: u._id, email: u.email || null }));
   },
 });
 
-export const getUserEmails = internalQuery({
+/**
+ * Count how many of the given users are reachable via each channel.
+ * Push: user has an active push token in the current environment.
+ * Email: user has a non-empty email and hasn't opted out (emailNotificationsEnabled !== false).
+ */
+export const getChannelReachability = internalQuery({
   args: { userIds: v.array(v.id("users")) },
   handler: async (ctx, args) => {
-    const users = await Promise.all(args.userIds.map((id) => ctx.db.get(id)));
-    return users.map((u) => ({ email: u?.email || null }));
+    const environment = getCurrentEnvironment();
+
+    let push = 0;
+    let email = 0;
+
+    for (const userId of args.userIds) {
+      const [user, tokens] = await Promise.all([
+        ctx.db.get(userId),
+        ctx.db
+          .query("pushTokens")
+          .withIndex("by_user", (q) => q.eq("userId", userId))
+          .filter((q) => q.eq(q.field("environment"), environment))
+          .collect(),
+      ]);
+
+      if (tokens.length > 0) push++;
+      if (user?.email && user.emailNotificationsEnabled !== false) email++;
+    }
+
+    return { push, email };
   },
 });
 

--- a/apps/convex/functions/adminBroadcasts.ts
+++ b/apps/convex/functions/adminBroadcasts.ts
@@ -460,20 +460,30 @@ export const sendToUsers = internalAction({
           }))
       );
 
-      let pushBatchOk = false;
-      if (notifications.length > 0) {
-        const pushResult = await ctx.runAction(
-          internal.functions.notifications.internal.sendBatchPushNotifications,
-          { notifications }
-        );
-        pushBatchOk = pushResult.success;
-        results.pushSucceeded = pushBatchOk ? notifications.length : 0;
-        results.pushFailed = pushBatchOk ? 0 : notifications.length;
+      const tickets: Array<{ ok: boolean; id?: string; error?: string }> =
+        notifications.length === 0
+          ? []
+          : (
+              await ctx.runAction(
+                internal.functions.notifications.internal.sendBatchPushNotifications,
+                { notifications }
+              )
+            ).tickets ?? [];
+
+      // Map per-ticket outcomes back to users. Each user may own multiple
+      // tokens; mark the user "sent" if at least one token delivered ok.
+      let ticketIdx = 0;
+      for (const { userId, tokens } of tokenResults) {
+        let anyOk = false;
+        for (let i = 0; i < tokens.length; i++) {
+          if (tickets[ticketIdx]?.ok) anyOk = true;
+          ticketIdx++;
+        }
+        pushOutcome.set(userId as Id<"users">, anyOk ? "sent" : "failed");
       }
 
-      for (const { userId } of tokenResults) {
-        pushOutcome.set(userId as Id<"users">, pushBatchOk ? "sent" : "failed");
-      }
+      results.pushSucceeded = tickets.filter((t) => t.ok).length;
+      results.pushFailed = tickets.length - results.pushSucceeded;
     }
 
     if (broadcast.channels.includes("email")) {
@@ -582,7 +592,12 @@ export const getUserEmails = internalQuery({
     const users = await Promise.all(args.userIds.map((id) => ctx.db.get(id)));
     return users
       .filter((u): u is NonNullable<typeof u> => u !== null)
-      .map((u) => ({ userId: u._id, email: u.email || null }));
+      .map((u) => ({
+        userId: u._id,
+        // Opted-out users (emailNotificationsEnabled === false) are excluded
+        // here so the send path and previewTargeting agree on reachability.
+        email: u.email && u.emailNotificationsEnabled !== false ? u.email : null,
+      }));
   },
 });
 

--- a/apps/convex/functions/adminBroadcasts.ts
+++ b/apps/convex/functions/adminBroadcasts.ts
@@ -202,6 +202,14 @@ export const sendTestToSelf = mutation({
     if (!broadcast) throw new Error("Broadcast not found");
     await requireCommunityAdmin(ctx, broadcast.communityId, userId);
 
+    for (const channel of broadcast.channels) {
+      if (channel !== "push" && channel !== "email") {
+        throw new Error(
+          `Broadcast has unsupported channel "${channel}". Admin broadcasts support push and email only.`,
+        );
+      }
+    }
+
     // Resolve per-user deep link for the test user so special links (e.g. per_user_group) work
     await ctx.scheduler.runAfter(0, internal.functions.adminBroadcasts.resolveAndTestSelf, {
       broadcastId: args.broadcastId,
@@ -295,6 +303,17 @@ export const sendBroadcast = mutation({
     if (!broadcast) throw new Error("Broadcast not found");
     if (broadcast.status !== "approved") throw new Error("Broadcast must be approved before sending");
     await requireCommunityAdmin(ctx, broadcast.communityId, userId);
+
+    // Reject legacy broadcasts that still carry unsupported channels (e.g. "sms"
+    // from before SMS was removed). Without this, sendToUsers would silently
+    // no-op for SMS-only broadcasts and flip the status to "sent".
+    for (const channel of broadcast.channels) {
+      if (channel !== "push" && channel !== "email") {
+        throw new Error(
+          `Broadcast has unsupported channel "${channel}". Admin broadcasts support push and email only.`,
+        );
+      }
+    }
 
     await ctx.db.patch(args.broadcastId, {
       status: "sent",

--- a/apps/convex/functions/adminBroadcasts.ts
+++ b/apps/convex/functions/adminBroadcasts.ts
@@ -120,10 +120,18 @@ export const previewTargeting = action({
 
     const { userIds } = await resolveTargetUsersAction(ctx, args.communityId, args.targetCriteria);
 
-    const reachable: { push: number; email: number } = await ctx.runQuery(
-      internal.functions.adminBroadcasts.getChannelReachability,
-      { userIds }
-    );
+    // Page the reachability query to stay under the per-query read budget
+    // (2 reads per user — user doc + pushTokens).
+    const reachable = { push: 0, email: 0 };
+    for (let i = 0; i < userIds.length; i += 500) {
+      const batch = userIds.slice(i, i + 500);
+      const batchReach: { push: number; email: number } = await ctx.runQuery(
+        internal.functions.adminBroadcasts.getChannelReachability,
+        { userIds: batch }
+      );
+      reachable.push += batchReach.push;
+      reachable.email += batchReach.email;
+    }
 
     return { count: userIds.length, reachable };
   },
@@ -424,7 +432,10 @@ export const sendToUsers = internalAction({
     const perUserLinks = (args.perUserDeepLinks || {}) as Record<string, string>;
     const results = { pushSucceeded: 0, pushFailed: 0, emailSucceeded: 0, emailFailed: 0 };
 
-    const reachedUserIds = new Set<Id<"users">>();
+    // Track per-user delivery outcome for each channel so notification rows
+    // reflect actual success rather than blanket "sent".
+    const pushOutcome = new Map<Id<"users">, "sent" | "failed">();
+    const emailOutcome = new Map<Id<"users">, "sent" | "failed">();
 
     if (broadcast.channels.includes("push")) {
       const tokenResults: Array<{ userId: string; tokens: string[] }> =
@@ -449,17 +460,19 @@ export const sendToUsers = internalAction({
           }))
       );
 
+      let pushBatchOk = false;
       if (notifications.length > 0) {
         const pushResult = await ctx.runAction(
           internal.functions.notifications.internal.sendBatchPushNotifications,
           { notifications }
         );
-        results.pushSucceeded = pushResult.success ? notifications.length : 0;
-        results.pushFailed = pushResult.success ? 0 : notifications.length;
+        pushBatchOk = pushResult.success;
+        results.pushSucceeded = pushBatchOk ? notifications.length : 0;
+        results.pushFailed = pushBatchOk ? 0 : notifications.length;
       }
 
       for (const { userId } of tokenResults) {
-        reachedUserIds.add(userId as Id<"users">);
+        pushOutcome.set(userId as Id<"users">, pushBatchOk ? "sent" : "failed");
       }
     }
 
@@ -468,42 +481,54 @@ export const sendToUsers = internalAction({
         internal.functions.adminBroadcasts.getUserEmails,
         { userIds: args.userIds }
       );
-      const emails = userEmails
-        .filter((u): u is { userId: Id<"users">; email: string } => !!u.email)
-        .map((u) => ({
-          to: u.email,
-          subject: broadcast.title,
-          htmlBody: `<h1>${broadcast.title}</h1><p>${broadcast.body}</p>`,
-        }));
+      const eligible = userEmails.filter(
+        (u): u is { userId: Id<"users">; email: string } => !!u.email,
+      );
+      const emails = eligible.map((u) => ({
+        to: u.email,
+        subject: broadcast.title,
+        htmlBody: `<h1>${broadcast.title}</h1><p>${broadcast.body}</p>`,
+      }));
 
       if (emails.length > 0) {
-        const emailResults = await ctx.runAction(
+        const emailResults: Array<{ success: boolean }> = await ctx.runAction(
           internal.functions.notifications.internal.sendEmails,
           { emails }
         );
-        results.emailSucceeded = emailResults.filter((r: { success: boolean }) => r.success).length;
-        results.emailFailed = emailResults.filter((r: { success: boolean }) => !r.success).length;
-      }
+        results.emailSucceeded = emailResults.filter((r) => r.success).length;
+        results.emailFailed = emailResults.filter((r) => !r.success).length;
 
-      for (const u of userEmails) {
-        if (u.email) reachedUserIds.add(u.userId);
+        eligible.forEach((u, i) => {
+          emailOutcome.set(u.userId, emailResults[i]?.success ? "sent" : "failed");
+        });
       }
     }
 
-    if (!args.isTest && reachedUserIds.size > 0) {
-      const notificationRecords = Array.from(reachedUserIds).map((userId) => ({
-        userId,
-        communityId: broadcast.communityId as Id<"communities">,
-        notificationType: "admin_broadcast",
-        title: broadcast.title,
-        body: broadcast.body,
-        data: {
-          broadcastId: args.broadcastId,
-          channels: broadcast.channels,
-          url: perUserLinks[userId] || (broadcast.deepLink?.startsWith("/") ? broadcast.deepLink : undefined),
-        },
-        status: "sent",
-      }));
+    const allReachedUserIds = new Set<Id<"users">>([
+      ...pushOutcome.keys(),
+      ...emailOutcome.keys(),
+    ]);
+
+    if (!args.isTest && allReachedUserIds.size > 0) {
+      const notificationRecords = Array.from(allReachedUserIds).map((userId) => {
+        const pushOk = pushOutcome.get(userId) === "sent";
+        const emailOk = emailOutcome.get(userId) === "sent";
+        // Row is "sent" if at least one selected channel succeeded for this user.
+        const status = pushOk || emailOk ? "sent" : "failed";
+        return {
+          userId,
+          communityId: broadcast.communityId as Id<"communities">,
+          notificationType: "admin_broadcast",
+          title: broadcast.title,
+          body: broadcast.body,
+          data: {
+            broadcastId: args.broadcastId,
+            channels: broadcast.channels,
+            url: perUserLinks[userId] || (broadcast.deepLink?.startsWith("/") ? broadcast.deepLink : undefined),
+          },
+          status,
+        };
+      });
 
       // Chunk to keep each mutation well under Convex write limits
       const CHUNK = 200;

--- a/apps/convex/functions/notifications/internal.ts
+++ b/apps/convex/functions/notifications/internal.ts
@@ -379,7 +379,7 @@ export const sendBatchPushNotifications = internalAction({
   },
   handler: async (_ctx, args) => {
     if (args.notifications.length === 0) {
-      return { success: true, ticketIds: [], errors: [] };
+      return { success: true, ticketIds: [], errors: [], tickets: [] };
     }
 
     try {
@@ -424,17 +424,27 @@ export const sendBatchPushNotifications = internalAction({
       }
 
       const result: { data?: PushTicket[] } = await response.json();
-      const ticketIds = result.data
-        ?.filter((t: PushTicket) => t.id)
-        .map((t: PushTicket) => t.id as string) || [];
-      const errors = result.data
-        ?.filter((t: PushTicket) => t.status === "error")
-        .map((t: PushTicket) => t.message || "Unknown error") || [];
+      const data = result.data || [];
+      const ticketIds = data
+        .filter((t: PushTicket) => t.id)
+        .map((t: PushTicket) => t.id as string);
+      const errors = data
+        .filter((t: PushTicket) => t.status === "error")
+        .map((t: PushTicket) => t.message || "Unknown error");
+      // Per-notification outcome, aligned 1:1 with args.notifications so callers
+      // can map ticket results back to the originating user/token.
+      const tickets = args.notifications.map((_, i) => {
+        const t = data[i];
+        if (!t) return { ok: false, error: "No ticket returned" };
+        if (t.status === "ok") return { ok: true, id: t.id };
+        return { ok: false, error: t.message || "Unknown error" };
+      });
 
       return {
         success: response.ok,
         ticketIds,
         errors,
+        tickets,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -442,6 +452,7 @@ export const sendBatchPushNotifications = internalAction({
         success: false,
         ticketIds: [],
         errors: [errorMessage],
+        tickets: args.notifications.map(() => ({ ok: false, error: errorMessage })),
       };
     }
   },

--- a/apps/mobile/features/admin/components/BroadcastComposer.tsx
+++ b/apps/mobile/features/admin/components/BroadcastComposer.tsx
@@ -58,6 +58,22 @@ interface BroadcastComposerProps {
   onCreated: () => void;
 }
 
+function formatReachable(
+  reachable: { push: number; email: number },
+  enabled: { push: boolean; email: boolean },
+): string {
+  const enabledChannels: Array<{ key: "push" | "email"; label: string }> = [];
+  if (enabled.push) enabledChannels.push({ key: "push", label: "push" });
+  if (enabled.email) enabledChannels.push({ key: "email", label: "email" });
+
+  if (enabledChannels.length === 0) return "No channels selected";
+  if (enabledChannels.length === 1) {
+    const only = enabledChannels[0];
+    return `${reachable[only.key]} reachable via ${only.label}`;
+  }
+  return enabledChannels.map((c) => `${reachable[c.key]} via ${c.label}`).join(" · ");
+}
+
 export function BroadcastComposer({
   communityId,
   onBack,
@@ -70,12 +86,12 @@ export function BroadcastComposer({
   const [body, setBody] = useState("");
   const [pushEnabled, setPushEnabled] = useState(true);
   const [emailEnabled, setEmailEnabled] = useState(false);
-  const [smsEnabled, setSmsEnabled] = useState(false);
   const [deepLink, setDeepLink] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
   const [createdBroadcastId, setCreatedBroadcastId] = useState<string | null>(null);
   const [previewCount, setPreviewCount] = useState<number | null>(null);
+  const [reachable, setReachable] = useState<{ push: number; email: number } | null>(null);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
 
   const targetCriteria = {
@@ -102,11 +118,13 @@ export function BroadcastComposer({
     let cancelled = false;
     setIsLoadingPreview(true);
     setPreviewCount(null);
+    setReachable(null);
 
     // Don't preview if no_group_of_type is selected but no slug chosen
     if (targetType === "no_group_of_type" && !groupTypeSlug) {
       setIsLoadingPreview(false);
       setPreviewCount(0);
+      setReachable({ push: 0, email: 0 });
       return;
     }
 
@@ -114,12 +132,14 @@ export function BroadcastComposer({
       .then((result) => {
         if (!cancelled) {
           setPreviewCount(result.count);
+          setReachable(result.reachable);
           setIsLoadingPreview(false);
         }
       })
       .catch(() => {
         if (!cancelled) {
           setPreviewCount(null);
+          setReachable(null);
           setIsLoadingPreview(false);
         }
       });
@@ -130,7 +150,6 @@ export function BroadcastComposer({
   const channels = [
     ...(pushEnabled ? ["push"] : []),
     ...(emailEnabled ? ["email"] : []),
-    ...(smsEnabled ? ["sms"] : []),
   ];
 
   const handleCreate = async () => {
@@ -277,13 +296,20 @@ export function BroadcastComposer({
       {/* Preview Count */}
       <View style={[styles.previewCard, { backgroundColor: colors.surface }]}>
         <Ionicons name="people-outline" size={20} color={colors.textSecondary} />
-        <Text style={[styles.previewText, { color: colors.text }]}>
-          {isLoadingPreview
-            ? "Calculating..."
-            : previewCount !== null
-              ? `${previewCount} users will receive this`
-              : "Select a target to preview"}
-        </Text>
+        <View style={{ flex: 1 }}>
+          <Text style={[styles.previewText, { color: colors.text }]}>
+            {isLoadingPreview
+              ? "Calculating..."
+              : previewCount !== null
+                ? `${previewCount} users targeted`
+                : "Select a target to preview"}
+          </Text>
+          {!isLoadingPreview && previewCount !== null && reachable !== null && (
+            <Text style={[styles.previewSubtext, { color: colors.textSecondary }]}>
+              {formatReachable(reachable, { push: pushEnabled, email: emailEnabled })}
+            </Text>
+          )}
+        </View>
       </View>
 
       {/* Content */}
@@ -450,6 +476,10 @@ const styles = StyleSheet.create({
   previewText: {
     fontSize: 15,
     fontWeight: "500",
+  },
+  previewSubtext: {
+    fontSize: 13,
+    marginTop: 2,
   },
   channelRow: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- `previewTargeting` returns `{ count, reachable: { push, email } }`; composer now shows the reachable-by-channel breakdown ("N reachable via push" when one channel is selected, "N via push · M via email" when multiple)
- SMS is no longer a supported broadcast channel: `create` rejects it, the composer state/toggle is gone, and the SMS branch + `getUserPhones` helper are removed from `sendToUsers`
- `sendToUsers` now calls `createNotificationsBatch` with one `admin_broadcast` row per user reached (push or email) so the Super Admin Dashboard "Notifications" stats panel actually populates for broadcasts

## Background
Production broadcasts were showing "Sent · 409 users" but most users weren't getting notifications. Root cause was a combination of (a) the composer count was segment size, not reachability — the "No profile picture" and "No dinner_parties" segments are dominated by users who never registered a push token, (b) `sendToUsers` never wrote to the `notifications` table, so the stats dashboard's "By Type" breakdown couldn't surface `admin_broadcast` at all.

## Test plan
- [ ] Create a broadcast in the composer; confirm the reachable breakdown updates when toggling push/email
- [ ] Try to POST a broadcast with `channels: ["sms"]` — should throw "Unsupported channel: sms"
- [ ] Send a push-only test to self; verify an `admin_broadcast` row lands in the `notifications` table for your user
- [ ] Send a real broadcast; verify the Super Admin Dashboard "Notifications" section shows `admin_broadcast` in the by-type list
- [ ] Existing SMS-free broadcast creation still works (push only, email only, push + email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)