### PR TITLE
feat(workflows): group + placeholder person targets (#307)

### DIFF
--- a/apps/convex/__tests__/tasks.test.ts
+++ b/apps/convex/__tests__/tasks.test.ts
@@ -594,7 +594,7 @@ describe("tasks functions", () => {
         targetMemberId: memberId,
       }),
     ).rejects.toThrow(
-      "targetMemberId and targetGroupId must be omitted when targetType=none",
+      "targetMemberId, targetGroupId, and placeholder fields must be omitted when targetType=none",
     );
 
     await expect(

--- a/apps/convex/functions/authInternal.ts
+++ b/apps/convex/functions/authInternal.ts
@@ -228,6 +228,14 @@ export const createUserInternal = internalMutation({
       updatedAt: timestamp,
     });
 
+    // Link any placeholder workflow tasks that were addressed to this phone
+    // before the user signed up. Runs after commit; failures do not block signup.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.tasks.index.linkPlaceholderTasksForUser,
+      { userId },
+    );
+
     return userId;
   },
 });
@@ -305,6 +313,13 @@ export const createUserWithPasswordInternal = internalMutation({
       createdAt: timestamp,
       updatedAt: timestamp,
     });
+
+    // Link any placeholder workflow tasks addressed to this phone.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.tasks.index.linkPlaceholderTasksForUser,
+      { userId },
+    );
 
     return userId;
   },

--- a/apps/convex/functions/communities.ts
+++ b/apps/convex/functions/communities.ts
@@ -500,6 +500,14 @@ export const join = mutation({
     // Add user to announcement group
     await addUserToAnnouncementGroup(ctx, args.communityId, userId, 1); // roles=1 is MEMBER
 
+    // Link any placeholder workflow tasks addressed to this user's phone in
+    // groups that belong to this community.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.tasks.index.linkPlaceholderTasksForUser,
+      { userId },
+    );
+
     return membershipId;
   },
 });

--- a/apps/convex/functions/communities.ts
+++ b/apps/convex/functions/communities.ts
@@ -466,6 +466,13 @@ export const join = mutation({
 
         // Re-add user to announcement group
         await addUserToAnnouncementGroup(ctx, args.communityId, userId, existing.roles ?? 1);
+
+        // Link any placeholder workflow tasks addressed to this user.
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.tasks.index.linkPlaceholderTasksForUser,
+          { userId },
+        );
       } else {
         console.log("[communities.join] User already active member, skipping sync", {
           userId,

--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -327,6 +327,14 @@ export const joinCommunityInternal = internalMutation({
       });
       await syncUserChannelMembershipsLogic(ctx, args.userId, announcementGroup!._id);
     }
+
+    // Link any placeholder workflow tasks addressed to this user (by phone
+    // or email). Covers landing-page signup flow which bypasses communities.join.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.tasks.index.linkPlaceholderTasksForUser,
+      { userId: args.userId },
+    );
   },
 });
 

--- a/apps/convex/functions/tasks/index.ts
+++ b/apps/convex/functions/tasks/index.ts
@@ -1616,6 +1616,11 @@ export const createFromTemplate = mutation({
       ) {
         throw new ConvexError("Target group must be in the same community");
       }
+      // Require the caller to lead the target group too, not just the
+      // template's own group. Prevents a leader of one group from
+      // applying workflows to another group in the same community they
+      // do not lead.
+      await getLeaderMembership(ctx, args.targetGroupId!, userId);
       targetLabel = targetGroup.name ?? "Group";
     } else {
       // placeholder

--- a/apps/convex/functions/tasks/index.ts
+++ b/apps/convex/functions/tasks/index.ts
@@ -973,6 +973,49 @@ export const searchRelevantMembers = query({
   },
 });
 
+/**
+ * Groups in the template's community that the caller actively leads.
+ * Used by the apply-workflow modal to scope the group-target picker to
+ * the right community (important for multi-community leaders viewing
+ * `taskTemplates.listAll`, which spans communities).
+ */
+export const listGroupTargetCandidates = query({
+  args: {
+    token: v.string(),
+    templateId: v.id("taskTemplates"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const template = await ctx.db.get(args.templateId);
+    if (!template) {
+      throw new ConvexError("Template not found");
+    }
+    const templateGroup = await ctx.db.get(template.groupId);
+    if (!templateGroup) {
+      throw new ConvexError("Template group not found");
+    }
+
+    const leaderGroupIds = await getActiveLeaderGroupIds(ctx, userId);
+    if (leaderGroupIds.length === 0) return [];
+
+    const groups = await Promise.all(
+      leaderGroupIds.map((id) => ctx.db.get(id)),
+    );
+    return groups
+      .filter(
+        (g): g is NonNullable<typeof g> =>
+          !!g &&
+          "communityId" in g &&
+          g.communityId === templateGroup.communityId,
+      )
+      .map((g) => ({
+        _id: g._id,
+        name: ("name" in g && g.name) || "Group",
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  },
+});
+
 export const getTaskCard = query({
   args: {
     token: v.string(),

--- a/apps/convex/functions/tasks/index.ts
+++ b/apps/convex/functions/tasks/index.ts
@@ -4,6 +4,7 @@ import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isActiveMembership, isLeaderRole } from "../../lib/helpers";
 import { searchCommunityMembersInternal } from "../../lib/memberSearch";
+import { normalizePhone } from "../../lib/phoneNormalize";
 import { now } from "../../lib/utils";
 
 const openStatuses = new Set(["open", "snoozed"]);
@@ -25,6 +26,7 @@ const targetTypeValidator = v.union(
   v.literal("none"),
   v.literal("member"),
   v.literal("group"),
+  v.literal("placeholder"),
 );
 
 const snoozePresetValidator = v.union(
@@ -140,30 +142,80 @@ async function requireTargetUserInGroupCommunity(
   }
 }
 
+type PlaceholderFields = {
+  name?: string;
+  phone?: string;
+  email?: string;
+};
+
 function assertTargetArgs(
-  targetType: "none" | "member" | "group",
+  targetType: "none" | "member" | "group" | "placeholder",
   targetMemberId: Id<"users"> | undefined,
   targetGroupId: Id<"groups"> | undefined,
+  placeholder?: PlaceholderFields,
 ) {
-  if (targetType === "none" && (targetMemberId || targetGroupId)) {
+  const hasPlaceholder =
+    (placeholder?.name ?? placeholder?.phone ?? placeholder?.email) !==
+    undefined;
+
+  if (targetType === "none") {
+    if (targetMemberId || targetGroupId || hasPlaceholder) {
+      throw new ConvexError(
+        "targetMemberId, targetGroupId, and placeholder fields must be omitted when targetType=none",
+      );
+    }
+    return;
+  }
+  if (targetType === "member") {
+    if (!targetMemberId) {
+      throw new ConvexError(
+        "targetMemberId is required when targetType=member",
+      );
+    }
+    if (targetGroupId) {
+      throw new ConvexError(
+        "targetGroupId is not allowed when targetType=member",
+      );
+    }
+    if (hasPlaceholder) {
+      throw new ConvexError(
+        "placeholder fields are not allowed when targetType=member",
+      );
+    }
+    return;
+  }
+  if (targetType === "group") {
+    if (!targetGroupId) {
+      throw new ConvexError("targetGroupId is required when targetType=group");
+    }
+    if (targetMemberId) {
+      throw new ConvexError(
+        "targetMemberId is not allowed when targetType=group",
+      );
+    }
+    if (hasPlaceholder) {
+      throw new ConvexError(
+        "placeholder fields are not allowed when targetType=group",
+      );
+    }
+    return;
+  }
+  // targetType === "placeholder"
+  if (targetMemberId || targetGroupId) {
     throw new ConvexError(
-      "targetMemberId and targetGroupId must be omitted when targetType=none",
+      "targetMemberId and targetGroupId must be omitted when targetType=placeholder",
     );
   }
-  if (targetType === "member" && !targetMemberId) {
-    throw new ConvexError("targetMemberId is required when targetType=member");
-  }
-  if (targetType === "member" && targetGroupId) {
+  const name = placeholder?.name?.trim();
+  if (!name) {
     throw new ConvexError(
-      "targetGroupId is not allowed when targetType=member",
+      "targetPlaceholderName is required when targetType=placeholder",
     );
   }
-  if (targetType === "group" && !targetGroupId) {
-    throw new ConvexError("targetGroupId is required when targetType=group");
-  }
-  if (targetType === "group" && targetMemberId) {
+  // Require phone OR email so later association has something to match on.
+  if (!placeholder?.phone?.trim() && !placeholder?.email?.trim()) {
     throw new ConvexError(
-      "targetMemberId is not allowed when targetType=group",
+      "targetPlaceholderPhone or targetPlaceholderEmail is required when targetType=placeholder",
     );
   }
 }
@@ -186,6 +238,7 @@ type FilterableTask = {
   groupName?: string;
   targetMemberName?: string;
   targetGroupName?: string;
+  targetPlaceholderName?: string;
 };
 
 function applyTaskFilters<T extends FilterableTask>(
@@ -209,6 +262,7 @@ function applyTaskFilters<T extends FilterableTask>(
         task.groupName,
         task.targetMemberName,
         task.targetGroupName,
+        task.targetPlaceholderName,
         ...(task.tags ?? []),
       ]
         .filter((value): value is string => Boolean(value))
@@ -959,10 +1013,14 @@ export const getTaskCard = query({
       responsibilityType: task.responsibilityType,
       assignedToId: task.assignedToId,
       assignedToName: assigneeUser ? formatUserName(assigneeUser) : undefined,
+      targetType: task.targetType,
       targetMemberId: task.targetMemberId,
       targetMemberName: targetMemberUser
         ? formatUserName(targetMemberUser)
         : undefined,
+      targetPlaceholderName: task.targetPlaceholderName,
+      targetPlaceholderPhone: task.targetPlaceholderPhone,
+      targetPlaceholderEmail: task.targetPlaceholderEmail,
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
       viewerCanManage: isLeader,
@@ -1452,7 +1510,15 @@ export const createFromTemplate = mutation({
   args: {
     token: v.string(),
     templateId: v.id("taskTemplates"),
-    targetMemberId: v.id("users"),
+    // Target is now a discriminated union across member / group / placeholder.
+    // targetType defaults to "member" for back-compat with older clients that
+    // still only send targetMemberId.
+    targetType: v.optional(targetTypeValidator),
+    targetMemberId: v.optional(v.id("users")),
+    targetGroupId: v.optional(v.id("groups")),
+    targetPlaceholderName: v.optional(v.string()),
+    targetPlaceholderPhone: v.optional(v.string()),
+    targetPlaceholderEmail: v.optional(v.string()),
     assignedToId: v.optional(v.id("users")),
   },
   handler: async (ctx, args) => {
@@ -1463,25 +1529,79 @@ export const createFromTemplate = mutation({
     }
     await getLeaderMembership(ctx, template.groupId, userId);
 
-    await requireTargetUserInGroupCommunity(
-      ctx,
-      template.groupId,
-      args.targetMemberId,
-    );
+    const targetType = args.targetType ?? "member";
+    if (targetType === "none") {
+      throw new ConvexError(
+        "Workflow templates must target a member, group, or placeholder",
+      );
+    }
+
+    const placeholderName = args.targetPlaceholderName?.trim();
+    const placeholderPhoneRaw = args.targetPlaceholderPhone?.trim();
+    const placeholderEmailRaw = args.targetPlaceholderEmail?.trim();
+    const placeholderPhone = placeholderPhoneRaw
+      ? normalizePhone(placeholderPhoneRaw)
+      : undefined;
+    const placeholderEmail = placeholderEmailRaw
+      ? placeholderEmailRaw.toLowerCase()
+      : undefined;
+
+    assertTargetArgs(targetType, args.targetMemberId, args.targetGroupId, {
+      name: placeholderName,
+      phone: placeholderPhone,
+      email: placeholderEmail,
+    });
+
+    let targetLabel: string;
+    if (targetType === "member") {
+      await requireTargetUserInGroupCommunity(
+        ctx,
+        template.groupId,
+        args.targetMemberId!,
+      );
+      const targetUser = await ctx.db.get(args.targetMemberId!);
+      targetLabel = targetUser ? formatUserName(targetUser) : "Member";
+    } else if (targetType === "group") {
+      const targetGroup = await ctx.db.get(args.targetGroupId!);
+      if (!targetGroup) {
+        throw new ConvexError("Target group not found");
+      }
+      const currentGroup = await ctx.db.get(template.groupId);
+      if (
+        !currentGroup ||
+        targetGroup.communityId !== currentGroup.communityId
+      ) {
+        throw new ConvexError("Target group must be in the same community");
+      }
+      targetLabel = targetGroup.name ?? "Group";
+    } else {
+      // placeholder
+      targetLabel = placeholderName!;
+    }
 
     if (args.assignedToId) {
       await getLeaderMembership(ctx, template.groupId, args.assignedToId);
     }
 
-    const targetUser = await ctx.db.get(args.targetMemberId);
-    const memberName = targetUser ? formatUserName(targetUser) : "Member";
-    const parentTitle = `${template.title}: ${memberName}`;
-
+    const parentTitle = `${template.title}: ${targetLabel}`;
     const responsibilityType = args.assignedToId ? "person" : "group";
     const timestamp = now();
     const sourceRef = args.templateId.toString();
     const templateTags = normalizeTags(template.tags);
     const tagsValue = templateTags.length > 0 ? templateTags : undefined;
+
+    const sharedTargetFields = {
+      targetType,
+      targetMemberId:
+        targetType === "member" ? args.targetMemberId : undefined,
+      targetGroupId: targetType === "group" ? args.targetGroupId : undefined,
+      targetPlaceholderName:
+        targetType === "placeholder" ? placeholderName : undefined,
+      targetPlaceholderPhone:
+        targetType === "placeholder" ? placeholderPhone : undefined,
+      targetPlaceholderEmail:
+        targetType === "placeholder" ? placeholderEmail : undefined,
+    };
 
     const parentTaskId = await ctx.db.insert("tasks", {
       groupId: template.groupId,
@@ -1494,9 +1614,7 @@ export const createFromTemplate = mutation({
       sourceType: "workflow_template",
       sourceRef,
       sourceKey: undefined,
-      targetType: "member",
-      targetMemberId: args.targetMemberId,
-      targetGroupId: undefined,
+      ...sharedTargetFields,
       tags: tagsValue,
       parentTaskId: undefined,
       orderKey: undefined,
@@ -1532,9 +1650,7 @@ export const createFromTemplate = mutation({
         sourceType: "workflow_template",
         sourceRef,
         sourceKey: undefined,
-        targetType: "member",
-        targetMemberId: args.targetMemberId,
-        targetGroupId: undefined,
+        ...sharedTargetFields,
         tags: tagsValue,
         parentTaskId,
         orderKey: step.orderIndex,
@@ -1931,5 +2047,89 @@ export const createFromBotReminder = internalMutation({
     });
 
     return taskId;
+  },
+});
+
+/**
+ * Auto-link placeholder workflow tasks to a newly-registered user.
+ *
+ * Scheduled from signup flows after a user row is created. Scans
+ * `tasks` by the placeholder-phone index, and for each placeholder
+ * task whose group belongs to a community the new user has joined,
+ * rewrites the target to point at the real user. We update both
+ * parent and child tasks (they share the same placeholder fields).
+ */
+export const linkPlaceholderTasksForUser = internalMutation({
+  args: {
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const user = await ctx.db.get(args.userId);
+    if (!user?.phone) return { linked: 0 };
+
+    const normalizedPhone = normalizePhone(user.phone);
+    if (!normalizedPhone) return { linked: 0 };
+
+    const candidates = await ctx.db
+      .query("tasks")
+      .withIndex("by_target_placeholder_phone", (q) =>
+        q.eq("targetPlaceholderPhone", normalizedPhone),
+      )
+      .collect();
+    if (candidates.length === 0) return { linked: 0 };
+
+    // Load groups once to resolve communityId per task.
+    const groupIds = [
+      ...new Set(candidates.map((task) => task.groupId.toString())),
+    ];
+    const groups = await Promise.all(
+      groupIds.map((id) => ctx.db.get(id as Id<"groups">)),
+    );
+    const groupById = new Map<string, any>();
+    groups.forEach((group, index) => {
+      if (group) groupById.set(groupIds[index], group);
+    });
+
+    // Find the user's active communities.
+    const userCommunities = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user", (q: any) => q.eq("userId", args.userId))
+      .collect();
+    const activeCommunityIds = new Set(
+      userCommunities
+        .filter((uc: any) => uc.status === 1)
+        .map((uc: any) => uc.communityId.toString()),
+    );
+    if (activeCommunityIds.size === 0) return { linked: 0 };
+
+    const timestamp = now();
+    let linked = 0;
+    for (const task of candidates) {
+      if (task.targetType !== "placeholder") continue;
+      const group = groupById.get(task.groupId.toString());
+      if (!group) continue;
+      if (!activeCommunityIds.has(group.communityId.toString())) continue;
+
+      await ctx.db.patch(task._id, {
+        targetType: "member",
+        targetMemberId: args.userId,
+        targetPlaceholderName: undefined,
+        targetPlaceholderPhone: undefined,
+        targetPlaceholderEmail: undefined,
+        updatedAt: timestamp,
+      });
+      await appendTaskEvent(ctx, {
+        taskId: task._id,
+        groupId: task.groupId,
+        type: "updated",
+        payload: {
+          placeholderLinked: true,
+          linkedUserId: args.userId,
+        },
+      });
+      linked += 1;
+    }
+
+    return { linked };
   },
 });

--- a/apps/convex/functions/tasks/index.ts
+++ b/apps/convex/functions/tasks/index.ts
@@ -2053,11 +2053,11 @@ export const createFromBotReminder = internalMutation({
 /**
  * Auto-link placeholder workflow tasks to a newly-registered user.
  *
- * Scheduled from signup flows after a user row is created. Scans
- * `tasks` by the placeholder-phone index, and for each placeholder
- * task whose group belongs to a community the new user has joined,
- * rewrites the target to point at the real user. We update both
- * parent and child tasks (they share the same placeholder fields).
+ * Scheduled from signup and community-join flows. Scans `tasks` by the
+ * placeholder-phone and placeholder-email indexes, and for each placeholder
+ * task whose group belongs to a community the user has joined, rewrites
+ * the target to point at the real user. We update both parent and child
+ * tasks (they share the same placeholder fields).
  */
 export const linkPlaceholderTasksForUser = internalMutation({
   args: {
@@ -2065,17 +2065,33 @@ export const linkPlaceholderTasksForUser = internalMutation({
   },
   handler: async (ctx, args) => {
     const user = await ctx.db.get(args.userId);
-    if (!user?.phone) return { linked: 0 };
+    if (!user) return { linked: 0 };
 
-    const normalizedPhone = normalizePhone(user.phone);
-    if (!normalizedPhone) return { linked: 0 };
+    const normalizedPhone = user.phone ? normalizePhone(user.phone) : undefined;
+    const normalizedEmail = user.email ? user.email.toLowerCase() : undefined;
+    if (!normalizedPhone && !normalizedEmail) return { linked: 0 };
 
-    const candidates = await ctx.db
-      .query("tasks")
-      .withIndex("by_target_placeholder_phone", (q) =>
-        q.eq("targetPlaceholderPhone", normalizedPhone),
-      )
-      .collect();
+    // Collect candidates from both indexes and dedupe by task id.
+    const byId = new Map<string, any>();
+    if (normalizedPhone) {
+      const phoneHits = await ctx.db
+        .query("tasks")
+        .withIndex("by_target_placeholder_phone", (q) =>
+          q.eq("targetPlaceholderPhone", normalizedPhone),
+        )
+        .collect();
+      for (const task of phoneHits) byId.set(task._id.toString(), task);
+    }
+    if (normalizedEmail) {
+      const emailHits = await ctx.db
+        .query("tasks")
+        .withIndex("by_target_placeholder_email", (q) =>
+          q.eq("targetPlaceholderEmail", normalizedEmail),
+        )
+        .collect();
+      for (const task of emailHits) byId.set(task._id.toString(), task);
+    }
+    const candidates = [...byId.values()];
     if (candidates.length === 0) return { linked: 0 };
 
     // Load groups once to resolve communityId per task.

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -933,9 +933,15 @@ export default defineSchema({
     sourceType: v.string(), // "manual" | "bot_task_reminder" | "reach_out" | "followup" | "workflow_template"
     sourceRef: v.optional(v.string()),
     sourceKey: v.optional(v.string()), // idempotency key for generated tasks
-    targetType: v.string(), // "none" | "member" | "group"
+    targetType: v.string(), // "none" | "member" | "group" | "placeholder"
     targetMemberId: v.optional(v.id("users")),
     targetGroupId: v.optional(v.id("groups")),
+    // Placeholder contact used when a workflow is applied to a person who has not
+    // signed up yet. On registration we auto-match by normalized phone and rewrite
+    // targetMemberId / targetType. See functions/tasks.linkPlaceholderTasksForUser.
+    targetPlaceholderName: v.optional(v.string()),
+    targetPlaceholderPhone: v.optional(v.string()), // E.164, normalized
+    targetPlaceholderEmail: v.optional(v.string()),
     tags: v.optional(v.array(v.string())),
     parentTaskId: v.optional(v.id("tasks")),
     orderKey: v.optional(v.number()),
@@ -954,7 +960,8 @@ export default defineSchema({
     .index("by_parent", ["parentTaskId"])
     .index("by_sourceKey", ["sourceKey"])
     .index("by_target_member", ["targetMemberId"])
-    .index("by_target_group", ["targetGroupId"]),
+    .index("by_target_group", ["targetGroupId"])
+    .index("by_target_placeholder_phone", ["targetPlaceholderPhone"]),
 
   // =============================================================================
   // TASK EVENTS

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -961,7 +961,8 @@ export default defineSchema({
     .index("by_sourceKey", ["sourceKey"])
     .index("by_target_member", ["targetMemberId"])
     .index("by_target_group", ["targetGroupId"])
-    .index("by_target_placeholder_phone", ["targetPlaceholderPhone"]),
+    .index("by_target_placeholder_phone", ["targetPlaceholderPhone"])
+    .index("by_target_placeholder_email", ["targetPlaceholderEmail"]),
 
   // =============================================================================
   // TASK EVENTS

--- a/apps/mobile/features/tasks/components/TaskDetailScreen.tsx
+++ b/apps/mobile/features/tasks/components/TaskDetailScreen.tsx
@@ -46,9 +46,14 @@ type TaskDetail = {
   tags?: string[];
   assignedToId?: Id<"users">;
   assignedToName?: string;
-  targetType: "none" | "member" | "group";
+  targetType: "none" | "member" | "group" | "placeholder";
   targetMemberId?: Id<"users">;
   targetMemberName?: string;
+  targetGroupId?: Id<"groups">;
+  targetGroupName?: string;
+  targetPlaceholderName?: string;
+  targetPlaceholderPhone?: string;
+  targetPlaceholderEmail?: string;
   parentTaskId?: Id<"tasks">;
   parentTaskTitle?: string;
   createdByName?: string;
@@ -390,6 +395,36 @@ export function TaskDetailScreen({ groupIdProp, taskIdProp, embedded }: TaskDeta
         >
           <View style={[styles.metaCard, { borderColor: colors.borderLight, backgroundColor: colors.surfaceSecondary }]}>
             <Text style={[styles.metaRow, { color: colors.text }]}>Group: {task.groupName ?? "Group"}</Text>
+            {task.targetType === "member" && task.targetMemberName ? (
+              <Text style={[styles.metaRow, { color: colors.text }]}>
+                Target member: {task.targetMemberName}
+              </Text>
+            ) : null}
+            {task.targetType === "group" && task.targetGroupName ? (
+              <Text style={[styles.metaRow, { color: colors.text }]}>
+                Target group: {task.targetGroupName}
+              </Text>
+            ) : null}
+            {task.targetType === "placeholder" ? (
+              <>
+                <Text style={[styles.metaRow, { color: colors.text }]}>
+                  Target (pending signup): {task.targetPlaceholderName ?? "—"}
+                </Text>
+                {task.targetPlaceholderPhone ? (
+                  <Text style={[styles.metaRow, { color: colors.textSecondary }]}>
+                    Phone: {task.targetPlaceholderPhone}
+                  </Text>
+                ) : null}
+                {task.targetPlaceholderEmail ? (
+                  <Text style={[styles.metaRow, { color: colors.textSecondary }]}>
+                    Email: {task.targetPlaceholderEmail}
+                  </Text>
+                ) : null}
+                <Text style={[styles.metaRow, { color: colors.textSecondary, fontStyle: "italic" }]}>
+                  Will auto-link when they sign up with this phone.
+                </Text>
+              </>
+            ) : null}
             <Text style={[styles.metaRow, { color: colors.text }]}>
               Created by: {task.createdByName ?? "System"}
             </Text>
@@ -454,46 +489,50 @@ export function TaskDetailScreen({ groupIdProp, taskIdProp, embedded }: TaskDeta
             placeholderTextColor={colors.inputPlaceholder}
           />
 
-          <Text style={[styles.helperText, { color: colors.textSecondary }]}>
-            Target defaults to group. Pick anyone in the community, including people not in this group yet.
-          </Text>
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Associated member</Text>
-          <TextInput
-            value={relevantSearch}
-            onChangeText={setRelevantSearch}
-            style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
-            placeholder="Search community members"
-            placeholderTextColor={colors.inputPlaceholder}
-          />
-          {relevantMemberId && relevantMemberName ? (
-            <Pressable
-              onPress={() => {
-                setRelevantMemberId(null);
-                setRelevantMemberName(null);
-              }}
-              style={[styles.selectionPill, { borderColor: colors.link, backgroundColor: colors.selectedBackground }]}
-            >
-              <Text style={[styles.selectionPillText, { color: colors.link }]}>
-                {relevantMemberName} • Tap to clear
+          {task.targetType !== "placeholder" ? (
+            <>
+              <Text style={[styles.helperText, { color: colors.textSecondary }]}>
+                Target defaults to group. Pick anyone in the community, including people not in this group yet.
               </Text>
-            </Pressable>
-          ) : null}
-          {relevantSearch.trim().length >= 2 ? (
-            <ScrollView style={[styles.searchResultsList, { borderColor: colors.borderLight, backgroundColor: colors.surface }]} nestedScrollEnabled>
-              {(relevantMemberResults ?? []).map((member) => (
+              <Text style={[styles.inputLabel, { color: colors.text }]}>Associated member</Text>
+              <TextInput
+                value={relevantSearch}
+                onChangeText={setRelevantSearch}
+                style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+                placeholder="Search community members"
+                placeholderTextColor={colors.inputPlaceholder}
+              />
+              {relevantMemberId && relevantMemberName ? (
                 <Pressable
-                  key={member.userId}
                   onPress={() => {
-                    setRelevantMemberId(member.userId);
-                    setRelevantMemberName(member.name);
-                    setRelevantSearch("");
+                    setRelevantMemberId(null);
+                    setRelevantMemberName(null);
                   }}
-                  style={[styles.searchResultRow, { borderBottomColor: colors.borderLight }]}
+                  style={[styles.selectionPill, { borderColor: colors.link, backgroundColor: colors.selectedBackground }]}
                 >
-                  <Text style={[styles.searchResultText, { color: colors.text }]}>{member.name}</Text>
+                  <Text style={[styles.selectionPillText, { color: colors.link }]}>
+                    {relevantMemberName} • Tap to clear
+                  </Text>
                 </Pressable>
-              ))}
-            </ScrollView>
+              ) : null}
+              {relevantSearch.trim().length >= 2 ? (
+                <ScrollView style={[styles.searchResultsList, { borderColor: colors.borderLight, backgroundColor: colors.surface }]} nestedScrollEnabled>
+                  {(relevantMemberResults ?? []).map((member) => (
+                    <Pressable
+                      key={member.userId}
+                      onPress={() => {
+                        setRelevantMemberId(member.userId);
+                        setRelevantMemberName(member.name);
+                        setRelevantSearch("");
+                      }}
+                      style={[styles.searchResultRow, { borderBottomColor: colors.borderLight }]}
+                    >
+                      <Text style={[styles.searchResultText, { color: colors.text }]}>{member.name}</Text>
+                    </Pressable>
+                  ))}
+                </ScrollView>
+              ) : null}
+            </>
           ) : null}
 
           <Text style={[styles.inputLabel, { color: colors.text }]}>Assigned to</Text>

--- a/apps/mobile/features/tasks/components/TasksTabScreen.tsx
+++ b/apps/mobile/features/tasks/components/TasksTabScreen.tsx
@@ -504,6 +504,16 @@ export function TasksTabScreen() {
       : "skip",
   ) as LeaderSearchResult[] | undefined;
 
+  // Groups in the template's community the user leads — scoped to the
+  // template (not the currently-active community) so multi-community
+  // leaders viewing listAll get the right candidates.
+  const applyGroupTargetCandidates = useAuthenticatedQuery(
+    api.functions.tasks.index.listGroupTargetCandidates,
+    applyTarget
+      ? { templateId: applyTarget.templateId as Id<"taskTemplates"> }
+      : "skip",
+  ) as Array<{ _id: string; name: string }> | undefined;
+
   const templatesByGroup = useMemo(() => {
     const list = workflowTemplates;
     if (!list?.length) {
@@ -2264,7 +2274,7 @@ export function TasksTabScreen() {
                 nestedScrollEnabled
                 keyboardShouldPersistTaps="handled"
               >
-                {leaderGroups.map((g) => {
+                {(applyGroupTargetCandidates ?? []).map((g) => {
                   const selected = applyTargetGroupId === g._id;
                   return (
                     <Pressable
@@ -2290,9 +2300,10 @@ export function TasksTabScreen() {
                     </Pressable>
                   );
                 })}
-                {leaderGroups.length === 0 ? (
+                {applyGroupTargetCandidates !== undefined &&
+                applyGroupTargetCandidates.length === 0 ? (
                   <Text style={[styles.searchHelperText, { color: colors.textSecondary, padding: 12 }]}>
-                    No groups available.
+                    No groups available in this community.
                   </Text>
                 ) : null}
               </ScrollView>

--- a/apps/mobile/features/tasks/components/TasksTabScreen.tsx
+++ b/apps/mobile/features/tasks/components/TasksTabScreen.tsx
@@ -172,10 +172,22 @@ export function TasksTabScreen() {
     templateId: string;
     groupId: string;
   } | null>(null);
+  const [applyTargetType, setApplyTargetType] = useState<
+    "member" | "group" | "placeholder"
+  >("member");
   const [applyMemberSearch, setApplyMemberSearch] = useState("");
   const [debouncedApplyMemberSearch, setDebouncedApplyMemberSearch] = useState("");
   const [applyMemberId, setApplyMemberId] = useState<string | null>(null);
   const [applyMemberName, setApplyMemberName] = useState<string | null>(null);
+  const [applyTargetGroupId, setApplyTargetGroupId] = useState<string | null>(
+    null,
+  );
+  const [applyTargetGroupName, setApplyTargetGroupName] = useState<
+    string | null
+  >(null);
+  const [applyPlaceholderName, setApplyPlaceholderName] = useState("");
+  const [applyPlaceholderPhone, setApplyPlaceholderPhone] = useState("");
+  const [applyPlaceholderEmail, setApplyPlaceholderEmail] = useState("");
   const [applyAssignSearch, setApplyAssignSearch] = useState("");
   const [debouncedApplyAssignSearch, setDebouncedApplyAssignSearch] = useState("");
   const [applyAssigneeId, setApplyAssigneeId] = useState<string | null>(null);
@@ -635,21 +647,48 @@ export function TasksTabScreen() {
   }
 
   async function handleApplyTemplate() {
-    if (!applyTarget || !applyMemberId) {
+    if (!applyTarget) return;
+    if (applyTargetType === "member" && !applyMemberId) {
       setApplyError("Select an associated member");
       return;
+    }
+    if (applyTargetType === "group" && !applyTargetGroupId) {
+      setApplyError("Select a group");
+      return;
+    }
+    if (applyTargetType === "placeholder") {
+      if (!applyPlaceholderName.trim()) {
+        setApplyError("Enter the person's name");
+        return;
+      }
+      if (!applyPlaceholderPhone.trim() && !applyPlaceholderEmail.trim()) {
+        setApplyError("Enter a phone number or email so we can link them later");
+        return;
+      }
     }
     const groupId = applyTarget.groupId;
     setApplyBusy(true);
     setApplyError(null);
     try {
-      const parentId = await createFromTemplateMutation({
+      const mutationArgs: Parameters<typeof createFromTemplateMutation>[0] = {
         templateId: applyTarget.templateId as Id<"taskTemplates">,
-        targetMemberId: applyMemberId as Id<"users">,
+        targetType: applyTargetType,
         assignedToId: applyAssigneeId
           ? (applyAssigneeId as Id<"users">)
           : undefined,
-      });
+      };
+      if (applyTargetType === "member") {
+        mutationArgs.targetMemberId = applyMemberId as Id<"users">;
+      } else if (applyTargetType === "group") {
+        mutationArgs.targetGroupId = applyTargetGroupId as Id<"groups">;
+      } else {
+        mutationArgs.targetPlaceholderName = applyPlaceholderName.trim();
+        const phone = applyPlaceholderPhone.trim();
+        const email = applyPlaceholderEmail.trim();
+        if (phone) mutationArgs.targetPlaceholderPhone = phone;
+        if (email) mutationArgs.targetPlaceholderEmail = email;
+      }
+      const parentId = await createFromTemplateMutation(mutationArgs);
       setApplyTarget(null);
       setActionSuccess("Workflow applied");
       router.push(
@@ -1003,7 +1042,9 @@ export function TasksTabScreen() {
               <Text style={[styles.targetPillText, { color: colors.link }]}>
                 {task.targetType === "member"
                   ? `Member: ${task.targetMemberName ?? "Unknown"}`
-                  : `Group: ${task.targetGroupName ?? "Group"}`}
+                  : task.targetType === "group"
+                    ? `Group: ${task.targetGroupName ?? "Group"}`
+                    : `Pending: ${task.targetPlaceholderName ?? "Unknown"}`}
               </Text>
             </View>
           ) : null}
@@ -1468,19 +1509,25 @@ export function TasksTabScreen() {
                           templateId: t._id.toString(),
                           groupId: t.groupId.toString(),
                         });
+                        setApplyTargetType("member");
                         setApplyMemberSearch("");
                         setDebouncedApplyMemberSearch("");
                         setApplyMemberId(null);
-                      setApplyMemberName(null);
-                      setApplyAssignSearch("");
-                      setDebouncedApplyAssignSearch("");
-                      setApplyAssigneeId(null);
-                      setApplyAssigneeName(null);
-                      setApplyError(null);
-                    }}
+                        setApplyMemberName(null);
+                        setApplyTargetGroupId(null);
+                        setApplyTargetGroupName(null);
+                        setApplyPlaceholderName("");
+                        setApplyPlaceholderPhone("");
+                        setApplyPlaceholderEmail("");
+                        setApplyAssignSearch("");
+                        setDebouncedApplyAssignSearch("");
+                        setApplyAssigneeId(null);
+                        setApplyAssigneeName(null);
+                        setApplyError(null);
+                      }}
                     >
                       <Text style={[styles.primaryActionText, { color: colors.textInverse }]}>
-                        Apply to Person
+                        Apply Workflow
                       </Text>
                     </Pressable>
                   </View>
@@ -2118,55 +2165,174 @@ export function TasksTabScreen() {
             </Pressable>
           </View>
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Associated member *</Text>
-          <Text style={[styles.searchHelperText, { color: colors.textSecondary, marginBottom: 6 }]}>
-            Anyone in this community counts, even if they are not in this group yet.
-          </Text>
-          <TextInput
-            value={applyMemberSearch}
-            onChangeText={setApplyMemberSearch}
-            placeholder="Search community members"
-            placeholderTextColor={colors.inputPlaceholder}
-            style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
-          />
-          {applyMemberId && applyMemberName ? (
-            <Pressable
-              onPress={() => {
-                setApplyMemberId(null);
-                setApplyMemberName(null);
-              }}
-              style={[styles.selectionPill, { borderColor: colors.link, backgroundColor: colors.selectedBackground }]}
-            >
-              <Text style={[styles.selectionPillText, { color: colors.link }]}>
-                {applyMemberName} • Tap to clear
-              </Text>
-            </Pressable>
-          ) : null}
-          {applyMemberSearch.trim().length >= 2 ? (
-            <ScrollView
-              style={[styles.searchResultsList, { borderColor: colors.borderLight, backgroundColor: colors.surface }]}
-              nestedScrollEnabled
-              keyboardShouldPersistTaps="handled"
-            >
-              {(applyMemberResults ?? []).map((member) => (
-                <Pressable
-                  key={member.userId}
-                  onPress={() => {
-                    setApplyMemberId(member.userId);
-                    setApplyMemberName(member.name);
-                    setApplyMemberSearch("");
-                  }}
-                  style={[styles.searchResultRow, { borderBottomColor: colors.borderLight }]}
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Apply to *</Text>
+          <View style={[styles.segmentRow, { gap: 6, marginBottom: 10 }]}>
+            {(
+              [
+                { key: "member", label: "Member" },
+                { key: "group", label: "Group" },
+                { key: "placeholder", label: "Not yet on app" },
+              ] as const
+            ).map((opt) => (
+              <Pressable
+                key={opt.key}
+                onPress={() => {
+                  setApplyTargetType(opt.key);
+                  setApplyError(null);
+                }}
+                style={[
+                  styles.segmentButton,
+                  { backgroundColor: colors.surfaceSecondary },
+                  applyTargetType === opt.key && { backgroundColor: primaryColor },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.segmentText,
+                    { color: colors.text },
+                    applyTargetType === opt.key && { color: colors.textInverse },
+                  ]}
                 >
-                  <Text style={[styles.searchResultText, { color: colors.text }]}>{member.name}</Text>
+                  {opt.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+
+          {applyTargetType === "member" ? (
+            <>
+              <Text style={[styles.inputLabel, { color: colors.text }]}>Associated member *</Text>
+              <Text style={[styles.searchHelperText, { color: colors.textSecondary, marginBottom: 6 }]}>
+                Anyone in this community counts, even if they are not in this group yet.
+              </Text>
+              <TextInput
+                value={applyMemberSearch}
+                onChangeText={setApplyMemberSearch}
+                placeholder="Search community members"
+                placeholderTextColor={colors.inputPlaceholder}
+                style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+              />
+              {applyMemberId && applyMemberName ? (
+                <Pressable
+                  onPress={() => {
+                    setApplyMemberId(null);
+                    setApplyMemberName(null);
+                  }}
+                  style={[styles.selectionPill, { borderColor: colors.link, backgroundColor: colors.selectedBackground }]}
+                >
+                  <Text style={[styles.selectionPillText, { color: colors.link }]}>
+                    {applyMemberName} • Tap to clear
+                  </Text>
                 </Pressable>
-              ))}
-            </ScrollView>
-          ) : (
-            <Text style={[styles.searchHelperText, { color: colors.textSecondary }]}>
-              Type at least 2 characters.
-            </Text>
-          )}
+              ) : null}
+              {applyMemberSearch.trim().length >= 2 ? (
+                <ScrollView
+                  style={[styles.searchResultsList, { borderColor: colors.borderLight, backgroundColor: colors.surface }]}
+                  nestedScrollEnabled
+                  keyboardShouldPersistTaps="handled"
+                >
+                  {(applyMemberResults ?? []).map((member) => (
+                    <Pressable
+                      key={member.userId}
+                      onPress={() => {
+                        setApplyMemberId(member.userId);
+                        setApplyMemberName(member.name);
+                        setApplyMemberSearch("");
+                      }}
+                      style={[styles.searchResultRow, { borderBottomColor: colors.borderLight }]}
+                    >
+                      <Text style={[styles.searchResultText, { color: colors.text }]}>{member.name}</Text>
+                    </Pressable>
+                  ))}
+                </ScrollView>
+              ) : (
+                <Text style={[styles.searchHelperText, { color: colors.textSecondary }]}>
+                  Type at least 2 characters.
+                </Text>
+              )}
+            </>
+          ) : null}
+
+          {applyTargetType === "group" ? (
+            <>
+              <Text style={[styles.inputLabel, { color: colors.text }]}>Target group *</Text>
+              <Text style={[styles.searchHelperText, { color: colors.textSecondary, marginBottom: 6 }]}>
+                Pick a group in this community for workflows that apply to the whole group.
+              </Text>
+              <ScrollView
+                style={[styles.searchResultsList, { borderColor: colors.borderLight, backgroundColor: colors.surface }]}
+                nestedScrollEnabled
+                keyboardShouldPersistTaps="handled"
+              >
+                {leaderGroups.map((g) => {
+                  const selected = applyTargetGroupId === g._id;
+                  return (
+                    <Pressable
+                      key={g._id}
+                      onPress={() => {
+                        setApplyTargetGroupId(g._id);
+                        setApplyTargetGroupName(g.name);
+                      }}
+                      style={[
+                        styles.searchResultRow,
+                        { borderBottomColor: colors.borderLight },
+                        selected && { backgroundColor: colors.selectedBackground },
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.searchResultText,
+                          { color: selected ? colors.link : colors.text },
+                        ]}
+                      >
+                        {g.name}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+                {leaderGroups.length === 0 ? (
+                  <Text style={[styles.searchHelperText, { color: colors.textSecondary, padding: 12 }]}>
+                    No groups available.
+                  </Text>
+                ) : null}
+              </ScrollView>
+            </>
+          ) : null}
+
+          {applyTargetType === "placeholder" ? (
+            <>
+              <Text style={[styles.inputLabel, { color: colors.text }]}>Person's name *</Text>
+              <TextInput
+                value={applyPlaceholderName}
+                onChangeText={setApplyPlaceholderName}
+                placeholder="First Last"
+                placeholderTextColor={colors.inputPlaceholder}
+                style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+              />
+              <Text style={[styles.inputLabel, { color: colors.text }]}>Phone</Text>
+              <Text style={[styles.searchHelperText, { color: colors.textSecondary, marginBottom: 6 }]}>
+                If they sign up with this phone later, we'll link the workflow to their account automatically.
+              </Text>
+              <TextInput
+                value={applyPlaceholderPhone}
+                onChangeText={setApplyPlaceholderPhone}
+                placeholder="(555) 123-4567"
+                placeholderTextColor={colors.inputPlaceholder}
+                keyboardType="phone-pad"
+                style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+              />
+              <Text style={[styles.inputLabel, { color: colors.text }]}>Email (optional)</Text>
+              <TextInput
+                value={applyPlaceholderEmail}
+                onChangeText={setApplyPlaceholderEmail}
+                placeholder="person@example.com"
+                placeholderTextColor={colors.inputPlaceholder}
+                autoCapitalize="none"
+                keyboardType="email-address"
+                style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+              />
+            </>
+          ) : null}
 
           <Text style={[styles.inputLabel, { color: colors.text }]}>Assigned to (optional)</Text>
           <TextInput

--- a/apps/mobile/features/tasks/components/__tests__/TasksTabScreen.test.tsx
+++ b/apps/mobile/features/tasks/components/__tests__/TasksTabScreen.test.tsx
@@ -390,6 +390,6 @@ describe("TasksTabScreen", () => {
     const { getByText } = render(<TasksTabScreen />);
     fireEvent.press(getByText("Workflows"));
     expect(getByText("Demo workflow")).toBeTruthy();
-    expect(getByText("Apply to Person")).toBeTruthy();
+    expect(getByText("Apply Workflow")).toBeTruthy();
   });
 });

--- a/apps/mobile/features/tasks/components/taskHelpers.ts
+++ b/apps/mobile/features/tasks/components/taskHelpers.ts
@@ -6,7 +6,7 @@ export type TaskSourceType =
   | "reach_out"
   | "followup"
   | "workflow_template";
-export type TargetType = "none" | "member" | "group";
+export type TargetType = "none" | "member" | "group" | "placeholder";
 
 export type SubtaskItem = {
   _id: string;
@@ -30,6 +30,9 @@ export type TaskListItem = {
   targetMemberName?: string;
   targetGroupId?: Id<"groups">;
   targetGroupName?: string;
+  targetPlaceholderName?: string;
+  targetPlaceholderPhone?: string;
+  targetPlaceholderEmail?: string;
   tags?: string[];
   parentTaskId?: Id<"tasks">;
   subtaskProgress?: { total: number; completed: number } | null;


### PR DESCRIPTION
Closes #307.

## Summary

- Workflows (task templates) can now be applied to **a group** or to **a placeholder person not yet on the app**, in addition to existing community members.
- Placeholder tasks store the pending person's name, phone, and email inline on the task row. When that person later registers or joins the community, a scheduled internal mutation matches on normalized phone and rewrites the target from placeholder to member automatically.
- Group targets wire through the existing (previously unused) `targetGroupId` schema fields.

## What changed

**Schema (`apps/convex/schema.ts`)**
- New `targetType = "placeholder"` variant.
- New optional fields on `tasks`: `targetPlaceholderName`, `targetPlaceholderPhone`, `targetPlaceholderEmail`.
- New index `by_target_placeholder_phone`.

**Backend (`apps/convex/functions/tasks/index.ts`)**
- `createFromTemplate` accepts a discriminated target (member / group / placeholder). `targetMemberId` defaulted to back-compat "member" when `targetType` is omitted.
- `assertTargetArgs` extended for the placeholder branch (requires name + phone or email).
- New internal mutation `linkPlaceholderTasksForUser` scans `by_target_placeholder_phone` and rewrites placeholder targets to real users, scoped to communities the user has joined.

**Auto-link hooks**
- `authInternal.createUserInternal` (phone OTP signup) schedules `linkPlaceholderTasksForUser`.
- `authInternal.createUserWithPasswordInternal` (legacy email/password) schedules it.
- `communities.join` schedules it (covers the case where a user existed before placeholder tasks were created).

**Frontend**
- `TasksTabScreen` apply-workflow modal: 3-way segmented selector (Member / Group / Not yet on app) with a group picker and placeholder name/phone/email inputs. CTA renamed from "Apply to Person" → "Apply Workflow".
- Task list cards and `TaskDetailScreen` render placeholder targets with a pending-signup callout; the member editor is hidden on placeholder tasks so it can't accidentally overwrite them (auto-link handles the conversion).
- `taskHelpers.ts` type updates.

## Test plan

- [x] `apps/convex` — `tasks.test.ts`, `auth.test.ts`, `community-membership.test.ts`, `communityPeople-convert-followup.test.ts`, `permissions.test.ts` all pass (96/96).
- [x] `apps/mobile` — `tsc --noEmit` shows zero new errors in touched files (pre-existing baseline errors unchanged).
- [ ] Manual: apply workflow to a member — behaves as before.
- [ ] Manual: apply workflow to a group — parent + child tasks created with target group, visible in task list.
- [ ] Manual: apply workflow to a placeholder person (name + phone) — tasks created, card shows "Pending: Name", detail shows contact block + auto-link callout.
- [ ] Manual: register a new user with the placeholder's phone — placeholder tasks flip to `targetType="member"`, `targetMemberId` set.
- [ ] Manual: existing user joins the community — same placeholder-to-member conversion happens for tasks in that community's groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)