### PR TITLE
fix(chat): derive BlockedUsersContext from query to stop render loop

### DIFF
--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -93,7 +93,6 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const token = useStoredAuthToken();
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
-  const { addBlockedUser } = useBlockedUsersContext();
 
   // Mutations
   const flagMessageMutation = useMutation(api.functions.messaging.flagging.flagMessage);
@@ -862,7 +861,6 @@ const ConvexChatRoomScreenInner: React.FC = () => {
                 token,
                 blockedId: targetUserId,
               });
-              addBlockedUser(targetUserId);
               Alert.alert(
                 "User Blocked",
                 `${targetUserName} has been blocked. You can unblock them from your settings.`,
@@ -881,7 +879,7 @@ const ConvexChatRoomScreenInner: React.FC = () => {
         },
       ]
     );
-  }, [selectedMessageSenderId, token, blockUserMutation, addBlockedUser]);
+  }, [selectedMessageSenderId, token, blockUserMutation]);
 
   const handleCancelReply = useCallback(() => {
     setReplyToMessageId(null);

--- a/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
@@ -177,10 +177,9 @@ jest.mock('@features/groups/hooks/useLeaveGroup', () => ({
 jest.mock('../../context/BlockedUsersContext', () => ({
   BlockedUsersProvider: ({ children }: { children: React.ReactNode }) => children,
   useBlockedUsersContext: () => ({
-    blockedUsers: new Set(),
-    addBlockedUser: jest.fn(),
-    removeBlockedUser: jest.fn(),
-    isBlocked: jest.fn(() => false),
+    blockedUserIds: new Set(),
+    isLoading: false,
+    isUserBlocked: jest.fn(() => false),
   }),
 }));
 

--- a/apps/mobile/features/chat/context/BlockedUsersContext.tsx
+++ b/apps/mobile/features/chat/context/BlockedUsersContext.tsx
@@ -3,93 +3,50 @@
  *
  * Provides:
  * - Set of blocked user IDs (Convex user IDs)
- * - Functions to check if a user is blocked
- * - Functions to update blocked users list
+ * - Function to check if a user is blocked
  *
- * Uses Convex messaging blocking functions instead of StreamChat.
+ * State is derived directly from the Convex query. Convex's useQuery is
+ * reactive — mutations trigger automatic re-fetches, so local optimistic
+ * updates are unnecessary and would be overwritten on the next render.
  */
-import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react';
+import React, { createContext, useContext, useCallback, useMemo, ReactNode } from 'react';
 import { useQuery, api, useStoredAuthToken } from '@services/api/convex';
-import type { Id } from '@services/api/convex';
 
 interface BlockedUsersContextValue {
   blockedUserIds: Set<string>;
   isLoading: boolean;
   isUserBlocked: (userId: string | undefined) => boolean;
-  addBlockedUser: (userId: string) => void;
-  removeBlockedUser: (userId: string) => void;
-  refreshBlockedUsers: () => Promise<void>;
 }
 
 const BlockedUsersContext = createContext<BlockedUsersContextValue | null>(null);
 
 export function BlockedUsersProvider({ children }: { children: ReactNode }) {
   const token = useStoredAuthToken();
-  const [blockedUserIds, setBlockedUserIds] = useState<Set<string>>(new Set());
-  const [isLoading, setIsLoading] = useState(true);
 
-  // Fetch blocked users from Convex
-  // useQuery returns data directly (or undefined when loading)
   const blockedUsers = useQuery(
     api.functions.messaging.blocking.getBlockedUsers,
     token ? { token } : "skip"
   );
 
-  // Update local state when query data changes
-  useEffect(() => {
-    // Loading state: undefined means loading, defined means loaded (even if empty array)
-    setIsLoading(blockedUsers === undefined && !!token);
-    
-    if (blockedUsers) {
-      // blockedUsers is an array of user objects with _id
-      const ids = new Set(blockedUsers.map(u => u._id));
-      setBlockedUserIds(ids);
-      console.log('[BlockedUsersContext] Loaded blocked users:', ids.size);
-    }
-  }, [blockedUsers, token]);
+  const blockedUserIds = useMemo(
+    () => new Set<string>(blockedUsers?.map(u => u._id as string) ?? []),
+    [blockedUsers]
+  );
 
-  // Refresh blocked users (re-fetch from Convex)
-  const refreshBlockedUsers = useCallback(async () => {
-    // The query will automatically refetch when token changes
-    // This is mainly for manual refresh scenarios
-    setIsLoading(true);
-    // Query will update automatically via useQuery
-  }, []);
+  const isLoading = blockedUsers === undefined && !!token;
 
-  // Check if a user ID is blocked (accepts Convex ID or legacy ID)
-  const isUserBlocked = useCallback((userId: string | undefined): boolean => {
-    if (!userId) return false;
-    return blockedUserIds.has(userId);
-  }, [blockedUserIds]);
+  const isUserBlocked = useCallback(
+    (userId: string | undefined): boolean => {
+      if (!userId) return false;
+      return blockedUserIds.has(userId);
+    },
+    [blockedUserIds]
+  );
 
-  // Add a user to blocked list (optimistic update)
-  const addBlockedUser = useCallback((userId: string) => {
-    setBlockedUserIds(prev => {
-      const next = new Set(prev);
-      next.add(userId);
-      return next;
-    });
-    console.log('[BlockedUsersContext] Added blocked user:', userId);
-  }, []);
-
-  // Remove a user from blocked list (optimistic update)
-  const removeBlockedUser = useCallback((userId: string) => {
-    setBlockedUserIds(prev => {
-      const next = new Set(prev);
-      next.delete(userId);
-      return next;
-    });
-    console.log('[BlockedUsersContext] Removed blocked user:', userId);
-  }, []);
-
-  const value = useMemo(() => ({
-    blockedUserIds,
-    isLoading,
-    isUserBlocked,
-    addBlockedUser,
-    removeBlockedUser,
-    refreshBlockedUsers,
-  }), [blockedUserIds, isLoading, isUserBlocked, addBlockedUser, removeBlockedUser, refreshBlockedUsers]);
+  const value = useMemo(
+    () => ({ blockedUserIds, isLoading, isUserBlocked }),
+    [blockedUserIds, isLoading, isUserBlocked]
+  );
 
   return (
     <BlockedUsersContext.Provider value={value}>


### PR DESCRIPTION
## Summary

- Rewrite `BlockedUsersProvider` to derive `blockedUserIds` directly from the Convex query via `useMemo` instead of syncing it into local state with `useState + useEffect`
- Remove the now-unnecessary `addBlockedUser` / `removeBlockedUser` / `refreshBlockedUsers` helpers from the context API (Convex's reactive subscription handles the update)
- Drop the one caller in `ConvexChatRoomScreen` and update the test mock

## Why

Sentry has been firing "Maximum update depth exceeded" on Android during background/resume and orientation changes (foldable). The visible component stack points at `BottomTabNavigator` / `TabsLayout`, but the real loop is inside `BlockedUsersProvider`, inside the chat room subtree.

The broken pattern:

```tsx
useEffect(() => {
  if (blockedUsers) {
    const ids = new Set(blockedUsers.map(u => u._id));
    setBlockedUserIds(ids);              // new Set every run
    console.log('[BlockedUsersContext] Loaded blocked users:', ids.size);
  }
}, [blockedUsers, token]);
```

Every effect run produces a brand-new `Set` reference. React's `Object.is` state bail-out never triggers, so every effect fire schedules another render. Combined with the `value` `useMemo` deps including unstable callback references, the provider cascades into its subtree — which during a commit-phase re-render under React 19 concurrent mode can re-enter React Navigation's `getRehydratedState` repeatedly, tripping the max-update-depth guard.

**Smoking gun**: breadcrumbs on Sentry issue `REACT-NATIVE-44` show the `[BlockedUsersContext] Loaded blocked users: 0` log line printed four times consecutively immediately before the crash.

This is a textbook [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect) case: `blockedUserIds` is derivable from `blockedUsers`, so it should be computed during render (via `useMemo`), not synced into state via an effect.

## What changed

- **`BlockedUsersContext.tsx`** — replaced `useState + useEffect` with a single `useMemo`. Removed `addBlockedUser`/`removeBlockedUser`/`refreshBlockedUsers` (broken-by-design once state is derived, and redundant given Convex reactivity). Removed the noisy console.log that was spamming Sentry breadcrumbs.
- **`ConvexChatRoomScreen.tsx`** — removed the `addBlockedUser` call in the block-user handler; the Convex subscription updates the set automatically after the mutation resolves.
- **`LeaderChatNavigation.test.tsx`** — updated the context mock to match the new shape.

## Scope

Only the Android-foldable DrawerRouter-stack family of "Maximum update depth" crashes (Sentry `REACT-NATIVE-44`, `REACT-NATIVE-3Y`). The iPhone `useRouteCache` / `EnsureSingleNavigator.register` family (`REACT-NATIVE-43`, `REACT-NATIVE-3X`) has a different stack signature and is likely a separate bug — watching Sentry for 24-48h after this ships will tell us.

## Test plan

- [x] `npx tsc --noEmit` — no new type errors in touched files
- [x] `npx jest features/chat` — 11 suites, 68 tests pass
- [x] `npx jest` (pre-push hook) — 104 suites, 1000 tests pass
- [ ] After merge, the auto-OTA job publishes the fix on the next daily run (~03:50 UTC)
- [ ] Watch Sentry `REACT-NATIVE-44` / `REACT-NATIVE-3Y` for 24-48h — expect zero new events on builds that pick up the OTA
- [ ] Manual smoke test: send a message in a chat, block the sender, confirm blocked state applies within ~1s without the UI flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)