### PR TITLE
fix(profile): birthday field fixes (autoformat + modal gate)

### DIFF
--- a/apps/link-preview/cloudflare-worker.test.js
+++ b/apps/link-preview/cloudflare-worker.test.js
@@ -270,19 +270,18 @@ test("/.well-known/apple-app-site-association returns correct JSON for productio
 
   const json = await res.json();
   assert.ok(json.applinks, "should have applinks");
-  assert.ok(Array.isArray(json.applinks.apps), "applinks.apps should be an empty array");
-  assert.equal(json.applinks.apps.length, 0);
   assert.ok(Array.isArray(json.applinks.details), "applinks.details should be an array");
 
-  // Production domain should include production app
-  const appIDs = json.applinks.details.map(d => d.appID);
+  // Production domain should include production app (components format uses appIDs array)
+  const appIDs = json.applinks.details.flatMap(d => d.appIDs);
   assert.ok(appIDs.some(id => id.includes("app.gatherful.mobile")), "should include production bundle ID");
 
-  // Check paths use exclusion pattern (NOT) for landing pages and wildcard for app routes
-  const paths = json.applinks.details[0].paths;
-  assert.ok(paths.includes("*"), "should include wildcard for all app routes");
-  assert.ok(paths.includes("NOT /"), "should exclude root landing page");
-  assert.ok(paths.includes("NOT /android"), "should exclude Android download page");
+  // Check components use exclusion for landing pages and wildcard for app routes
+  const components = json.applinks.details[0].components;
+  assert.ok(Array.isArray(components), "details[0].components should be an array");
+  assert.ok(components.some(c => c["/"] === "*" && !c.exclude), "should include wildcard match for app routes");
+  assert.ok(components.some(c => c["/"] === "/" && c.exclude === true), "should exclude root landing page");
+  assert.ok(components.some(c => c["/"] === "/android" && c.exclude === true), "should exclude Android download page");
 });
 
 test("/.well-known/apple-app-site-association returns correct JSON for staging domain", async () => {
@@ -296,7 +295,7 @@ test("/.well-known/apple-app-site-association returns correct JSON for staging d
   assert.ok(json.applinks, "should have applinks");
 
   // Staging domain should only include staging app
-  const appIDs = json.applinks.details.map(d => d.appID);
+  const appIDs = json.applinks.details.flatMap(d => d.appIDs);
   assert.ok(appIDs.some(id => id.includes("life.togather.staging")), "should include staging bundle ID");
   assert.ok(!appIDs.some(id => id.includes("app.gatherful.mobile")), "should NOT include production bundle ID");
 });

--- a/apps/mobile/components/legal/BirthdayCollectionModal.tsx
+++ b/apps/mobile/components/legal/BirthdayCollectionModal.tsx
@@ -8,7 +8,7 @@
  * - Age-appropriate content filtering
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -23,12 +23,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuth } from '@providers/AuthProvider';
 import { useAuthenticatedMutation, api } from '@services/api/convex';
-import { storage } from '@utils/storage';
 import { useTheme } from '@hooks/useTheme';
-
-// Must match the version in TermsAcceptanceModal
-const CURRENT_TERMS_VERSION = '1.0';
-const TERMS_ACCEPTED_KEY = 'terms_accepted_version';
 
 interface BirthdayCollectionModalProps {
   onCompleted?: () => void;
@@ -43,28 +38,16 @@ export function BirthdayCollectionModal({ onCompleted }: BirthdayCollectionModal
   const [birthday, setBirthday] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [termsAccepted, setTermsAccepted] = useState(false);
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
   // Use mutation hook for auth-aware updates
   const updateUser = useAuthenticatedMutation(api.functions.users.update);
 
-  // Check if terms have been accepted
-  useEffect(() => {
-    const checkTerms = async () => {
-      try {
-        const acceptedVersion = await storage.getItem(TERMS_ACCEPTED_KEY);
-        setTermsAccepted(acceptedVersion === CURRENT_TERMS_VERSION);
-      } catch {
-        setTermsAccepted(false);
-      }
-    };
-    checkTerms();
-  }, []);
-
-  // Show modal only if user is authenticated, has accepted terms, but has no birthday
-  const shouldShow = isAuthenticated && !authLoading && user && !user.date_of_birth && termsAccepted;
+  // Terms acceptance is enforced server-side at signup, so authentication
+  // already implies acceptance. Show the modal whenever an authed user is
+  // missing a date_of_birth.
+  const shouldShow = isAuthenticated && !authLoading && user && !user.date_of_birth;
 
   // Format input as MM/DD/YYYY
   const handleBirthdayChange = useCallback((text: string) => {

--- a/apps/mobile/components/ui/FormInput.tsx
+++ b/apps/mobile/components/ui/FormInput.tsx
@@ -11,6 +11,7 @@ interface FormInputProps extends Omit<TextInputProps, 'style'> {
   required?: boolean;
   containerStyle?: any;
   inputStyle?: any;
+  formatValue?: (text: string) => string;
 }
 
 export function FormInput({
@@ -21,6 +22,7 @@ export function FormInput({
   required = false,
   containerStyle,
   inputStyle,
+  formatValue,
   ...textInputProps
 }: FormInputProps) {
   const { colors } = useTheme();
@@ -52,7 +54,7 @@ export function FormInput({
               <TextInput
                 style={[styles.input, { color: colors.text }, inputStyle]}
                 value={value || ''}
-                onChangeText={onChange}
+                onChangeText={(text) => onChange(formatValue ? formatValue(text) : text)}
                 onBlur={onBlur}
                 placeholderTextColor={colors.inputPlaceholder}
                 {...textInputProps}

--- a/apps/mobile/features/__tests__/birthday.test.tsx
+++ b/apps/mobile/features/__tests__/birthday.test.tsx
@@ -92,15 +92,6 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   }),
 }));
 
-// Mock storage utility
-jest.mock('@utils/storage', () => ({
-  storage: {
-    getItem: jest.fn().mockResolvedValue('1.0'), // Terms accepted
-    setItem: jest.fn().mockResolvedValue(undefined),
-    removeItem: jest.fn().mockResolvedValue(undefined),
-  },
-}));
-
 // Mock expo-router
 jest.mock('expo-router', () => ({
   useRouter: () => ({
@@ -172,20 +163,16 @@ describe('BirthdayCollectionModal', () => {
         { wrapper: Wrapper }
       );
 
-      // Wait for async storage check to complete and modal to appear
-      await waitFor(
-        () => {
-          expect(getByText("When's Your Birthday?")).toBeTruthy();
-        },
-        { timeout: 10000 }
-      );
+      await waitFor(() => {
+        expect(getByText("When's Your Birthday?")).toBeTruthy();
+      });
 
       // Continue button should be present
       expect(getByText('Continue')).toBeTruthy();
       // There should be no X button or close option (non-dismissible modal)
       expect(queryByText('Close')).toBeNull();
       expect(queryByText('Skip')).toBeNull();
-    }, 15000);
+    });
 
     it('hides modal when user has DOB', async () => {
       // Set user with existing DOB
@@ -243,13 +230,9 @@ describe('BirthdayCollectionModal', () => {
         { wrapper: Wrapper }
       );
 
-      // Wait for async storage check to complete and modal to appear
-      await waitFor(
-        () => {
-          expect(getByPlaceholderText('MM/DD/YYYY')).toBeTruthy();
-        },
-        { timeout: 10000 }
-      );
+      await waitFor(() => {
+        expect(getByPlaceholderText('MM/DD/YYYY')).toBeTruthy();
+      });
 
       const input = getByPlaceholderText('MM/DD/YYYY');
 
@@ -260,7 +243,7 @@ describe('BirthdayCollectionModal', () => {
         // Should format as MM/DD/YYYY
         expect(input.props.value).toBe('12/25/2000');
       });
-    }, 15000);
+    });
 
     it('strips non-numeric characters from input', async () => {
       const Wrapper = createTestWrapper();

--- a/apps/mobile/features/profile/components/EditProfileForm.tsx
+++ b/apps/mobile/features/profile/components/EditProfileForm.tsx
@@ -37,6 +37,16 @@ export function EditProfileForm({ onCancel }: EditProfileFormProps) {
     return `${parts[1]}/${parts[2]}/${parts[0]}`;
   };
 
+  // Auto-insert slashes as the user types digits (MM/DD/YYYY).
+  // The birthday field uses a number-pad keyboard that has no "/" key,
+  // so we format on input instead of requiring the user to type it.
+  const formatBirthdayInput = (text: string): string => {
+    const cleaned = text.replace(/\D/g, '');
+    if (cleaned.length <= 2) return cleaned;
+    if (cleaned.length <= 4) return `${cleaned.substring(0, 2)}/${cleaned.substring(2)}`;
+    return `${cleaned.substring(0, 2)}/${cleaned.substring(2, 4)}/${cleaned.substring(4, 8)}`;
+  };
+
   // Validate date string in MM/DD/YYYY format
   const validateDate = useCallback((dateStr: string): { valid: boolean; dateForApi?: string; error?: string } => {
     if (!dateStr) return { valid: true }; // Optional field
@@ -222,6 +232,7 @@ export function EditProfileForm({ onCancel }: EditProfileFormProps) {
           placeholder="MM/DD/YYYY"
           keyboardType="number-pad"
           maxLength={10}
+          formatValue={formatBirthdayInput}
         />
       </View>
 


### PR DESCRIPTION
## Summary
- **Auto-format birthday input** (`EditProfileForm` + new `formatValue` prop on `FormInput`). The Edit Profile birthday field used a number-pad keyboard with no "/" key but required `MM/DD/YYYY`, so typing 8 digits always failed validation. We now auto-insert slashes as the user types — same logic as `BirthdayCollectionModal`.
- **Show `BirthdayCollectionModal` without the local terms-accepted gate.** `shouldShow` required `termsAccepted`, read from device-local storage (`terms_accepted_version`), so users who signed up before the terms modal existed, logged in on a new device, reinstalled the app, or crossed a `CURRENT_TERMS_VERSION` bump saw an empty key and never got the birthday prompt. Terms are enforced server-side at signup, so authentication already implies acceptance — the local gate was doing nothing useful and actively suppressing the modal. Dropped the gate and the now-dead state/effect/constants/storage import.
- **Drive-by:** updated `apps/link-preview`'s AASA tests to match the components-format response the worker has been returning since #139 (they were asserting the legacy `apps`/`paths` shape and failing locally + in pre-push).

## Test plan
- [ ] Open Edit Profile -> Birthday field -> type 8 digits -> verify slashes appear at positions 3 and 6 -> save succeeds.
- [ ] Fresh install (or clear `terms_accepted_version` in storage) -> sign in as a user missing `date_of_birth` -> `BirthdayCollectionModal` appears.
- [ ] Existing user with `date_of_birth` -> modal stays hidden.
- [ ] `pnpm test` in `apps/mobile` passes (all 27 birthday tests green).
- [ ] `pnpm test` in `apps/link-preview` passes (21/21 including both AASA tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)