### PR TITLE
fix(chat/web): derive image MIME from blob.type instead of defaulting to jpeg

### DIFF
--- a/apps/mobile/features/chat/hooks/__tests__/useImageUpload.test.ts
+++ b/apps/mobile/features/chat/hooks/__tests__/useImageUpload.test.ts
@@ -12,21 +12,31 @@ jest.mock('@services/api/convex', () => ({
   api: { functions: { uploads: { getR2UploadUrl: 'getR2UploadUrl' } } },
 }));
 
-// Mock fetch for web upload path
-const mockFetch = jest.fn().mockResolvedValue({
-  ok: true,
-  blob: () => Promise.resolve(new Blob(['fake-image'], { type: 'image/jpeg' })),
-});
+const mockFetch = jest.fn();
 global.fetch = mockFetch;
+
+/**
+ * Set up fetch mocks for the web upload path:
+ *   1st call: blob: URI fetch → returns a Blob with the given MIME
+ *   2nd call: PUT to R2 presigned URL → returns ok
+ */
+function mockWebUpload(blobType: string) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (init?.method === 'PUT') {
+      return Promise.resolve({ ok: true, statusText: 'OK' });
+    }
+    return Promise.resolve({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(['fake-image'], { type: blobType })),
+    });
+  });
+}
 
 import { useImageUpload } from '../useImageUpload';
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockFetch.mockResolvedValue({
-    ok: true,
-    blob: () => Promise.resolve(new Blob(['fake-image'], { type: 'image/jpeg' })),
-  });
+  mockFetch.mockReset();
 });
 
 describe('useImageUpload', () => {
@@ -42,22 +52,6 @@ describe('useImageUpload', () => {
         expect.objectContaining({
           fileName: 'vacation.png',
           contentType: 'image/png',
-        })
-      );
-    });
-
-    test('appends .jpg extension for blob URIs without extension (web)', async () => {
-      const { result } = renderHook(() => useImageUpload());
-
-      await act(async () => {
-        await result.current.uploadImage('blob:http://localhost:8081/f533135f-e039-4303-bf23-fad810cc9e73');
-      });
-
-      // The blob URI segment has no extension, so .jpg should be appended
-      expect(mockGetR2UploadUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fileName: expect.stringMatching(/\.jpg$/),
-          contentType: 'image/jpeg',
         })
       );
     });
@@ -89,20 +83,84 @@ describe('useImageUpload', () => {
       (Platform as any).OS = originalPlatform;
     });
 
-    test('uses fetch with PUT for web uploads', async () => {
+    test('derives contentType and extension from blob.type for JPEG blob URIs', async () => {
+      mockWebUpload('image/jpeg');
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage('blob:http://localhost:8081/f533135f-e039-4303-bf23-fad810cc9e73');
+      });
+
+      expect(mockGetR2UploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/\.jpeg$/),
+          contentType: 'image/jpeg',
+        })
+      );
+    });
+
+    test('uses image/png and .png for PNG blob URIs (not hardcoded jpeg)', async () => {
+      mockWebUpload('image/png');
       const { result } = renderHook(() => useImageUpload());
 
       await act(async () => {
         await result.current.uploadImage('blob:http://localhost:8081/abc-123');
       });
 
-      // First fetch: blob URI to get blob data
-      // Second fetch: PUT to R2 presigned URL
-      const putCall = mockFetch.mock.calls.find(
-        (call) => call[1]?.method === 'PUT'
+      expect(mockGetR2UploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/\.png$/),
+          contentType: 'image/png',
+        })
       );
+    });
+
+    test('uses image/webp and .webp for WebP blob URIs', async () => {
+      mockWebUpload('image/webp');
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage('blob:http://localhost:8081/webp-asset');
+      });
+
+      expect(mockGetR2UploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/\.webp$/),
+          contentType: 'image/webp',
+        })
+      );
+    });
+
+    test('PUTs blob to the presigned URL with the blob-derived Content-Type', async () => {
+      mockWebUpload('image/png');
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage('blob:http://localhost:8081/abc-123');
+      });
+
+      const putCall = mockFetch.mock.calls.find((call) => call[1]?.method === 'PUT');
       expect(putCall).toBeDefined();
       expect(putCall![0]).toBe('https://r2.example.com/presigned-url');
+      expect((putCall![1] as RequestInit).headers).toEqual(
+        expect.objectContaining({ 'Content-Type': 'image/png' })
+      );
+    });
+
+    test('falls back to image/jpeg when blob.type is empty', async () => {
+      mockWebUpload('');
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage('blob:http://localhost:8081/no-type');
+      });
+
+      expect(mockGetR2UploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/\.jpeg$/),
+          contentType: 'image/jpeg',
+        })
+      );
     });
   });
 

--- a/apps/mobile/features/chat/hooks/useImageUpload.ts
+++ b/apps/mobile/features/chat/hooks/useImageUpload.ts
@@ -61,18 +61,26 @@ export function useImageUpload(): UseImageUploadResult {
     setProgress(0);
 
     try {
-      // Extract filename and content type
-      let filename = imageUri.split('/').pop() || 'chat-image.jpg';
-      const match = /\.(\w+)$/.exec(filename);
-      const ext = match ? match[1].toLowerCase() : 'jpg';
-      const contentType = `image/${ext === 'jpg' ? 'jpeg' : ext}`;
+      let filename: string;
+      let contentType: string;
+      let webBlob: Blob | null = null;
 
-      // On web, blob URIs have no file extension — append one so the backend accepts it
-      if (!match) {
-        filename = `${filename}.${ext}`;
+      if (Platform.OS === 'web') {
+        // Fetch the blob first so we can read its real MIME (expo-image-picker on web
+        // returns extensionless blob: URIs, but the Blob object carries the correct type).
+        const response = await fetch(imageUri);
+        webBlob = await response.blob();
+        contentType = webBlob.type || 'image/jpeg';
+        const ext = contentType.split('/')[1] || 'jpg';
+        const rawName = imageUri.split('/').pop() || 'chat-image';
+        filename = /\.\w+$/.test(rawName) ? rawName : `${rawName}.${ext}`;
+      } else {
+        filename = imageUri.split('/').pop() || 'chat-image.jpg';
+        const match = /\.(\w+)$/.exec(filename);
+        const ext = match ? match[1].toLowerCase() : 'jpg';
+        contentType = `image/${ext === 'jpg' ? 'jpeg' : ext}`;
       }
 
-      // Step 1: Get R2 presigned upload URL
       setProgress(10);
       const { uploadUrl, storagePath } = await getR2UploadUrl({
         fileName: filename,
@@ -80,17 +88,13 @@ export function useImageUpload(): UseImageUploadResult {
         folder: 'chat',
       });
 
-      // Step 2: Upload file to R2 (requires R2 CORS to be configured for web)
+      // Upload file to R2 (web requires R2 CORS to be configured)
       setProgress(20);
 
       if (Platform.OS === 'web') {
-        // Web: Use fetch/blob
-        const response = await fetch(imageUri);
-        const blob = await response.blob();
-
         const uploadResponse = await fetch(uploadUrl, {
           method: 'PUT',
-          body: blob,
+          body: webBlob!,
           headers: {
             'Content-Type': contentType,
           },


### PR DESCRIPTION
## Summary
- On web, follow-up to #325 so PNG/WebP picks from `expo-image-picker` no longer get uploaded as `image/jpeg`.
- `useImageUpload` now fetches the blob first on web and derives `contentType` + filename extension from `blob.type` (with `image/jpeg` only as a last-resort fallback when `blob.type` is empty). Native path unchanged — still derives from the `file://` extension.
- R2 persists the `Content-Type` header on the object, so mislabeling images broke downstream handlers that trust MIME/extension consistency (e.g., Cloudflare Images transformations).

## Test plan
- [x] `pnpm --filter mobile test features/chat/hooks/__tests__/useImageUpload.test.ts` — 8 tests pass, covering JPEG/PNG/WebP blob inputs, the PUT `Content-Type` header, and the empty-`blob.type` fallback.
- [x] Full mobile test suite passes via pre-push hook (108 suites, 1024 tests).
- [ ] Manual: pick a PNG from the web chat composer and confirm the uploaded R2 object's `Content-Type` is `image/png` (not `image/jpeg`).
- [ ] Manual: confirm iOS/Android uploads still work (native path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)