### PR TITLE
fix(people): return communityPeopleId from quickAddRow so detail sheet opens after add

### DIFF
--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -2990,8 +2990,47 @@ export const quickAddRow = mutation({
       );
     }
 
-    // Schedule communityPeople upsert so the People table is immediately populated
+    // Ensure a communityPeople record exists synchronously so the client can
+    // open the detail sheet with a valid communityPeopleId immediately.
+    // The scheduled upsertFromSubmission below will fill in denormalized
+    // score/status fields once the background score computation completes.
+    let communityPeopleId: Id<"communityPeople"> | undefined;
     if (group.communityId) {
+      const existingCp = await ctx.db
+        .query("communityPeople")
+        .withIndex("by_group_user", (q: any) =>
+          q.eq("groupId", group._id).eq("userId", userId),
+        )
+        .first();
+      if (existingCp) {
+        communityPeopleId = existingCp._id;
+      } else {
+        const user = await ctx.db.get(userId);
+        communityPeopleId = await ctx.db.insert("communityPeople", {
+          communityId: group.communityId,
+          groupId: group._id,
+          userId,
+          firstName: user?.firstName || prepared.row.firstName || "",
+          lastName: user?.lastName || prepared.row.lastName,
+          email: user?.email || prepared.row.email,
+          phone: user?.phone || prepared.row.phone,
+          zipCode: user?.zipCode || prepared.row.zipCode,
+          searchText: [
+            user?.firstName || prepared.row.firstName,
+            user?.lastName || prepared.row.lastName,
+            user?.email || prepared.row.email,
+            user?.phone || prepared.row.phone,
+          ]
+            .filter(Boolean)
+            .join(" "),
+          addedAt: timestamp,
+          addedAtInv: Number.MAX_SAFE_INTEGER - timestamp,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        });
+      }
+
+      // Schedule communityPeople upsert so denormalized fields catch up
       await ctx.scheduler.runAfter(0, internal.functions.communityPeople.upsertFromSubmission, {
         communityId: group.communityId,
         userId,
@@ -3000,6 +3039,7 @@ export const quickAddRow = mutation({
 
     return {
       groupMemberId,
+      communityPeopleId,
       userId,
       createdUser,
       row: report,

--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -2765,9 +2765,11 @@ export function FollowupDesktopTable({
                 leaderOptions={leaderOptions}
                 primaryColor={primaryColor}
                 onCancel={() => setShowQuickAddPanel(false)}
-                onCreated={({ groupMemberId }) => {
+                onCreated={({ groupMemberId, communityPeopleId }) => {
                   setShowQuickAddPanel(false);
-                  setSelectedMemberId(groupMemberId);
+                  // Prefer communityPeopleId (matches adaptCommunityPerson row shape).
+                  // Fall back to groupMemberId only if backend didn't return it.
+                  setSelectedMemberId(communityPeopleId ?? groupMemberId);
                   setScrollToNotes(false);
                   setScrollToTasks(false);
                 }}

--- a/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupMobileGrid.tsx
@@ -2213,9 +2213,10 @@ export function FollowupMobileGrid({
               leaderOptions={leaderOptions}
               primaryColor={primaryColor}
               onCancel={() => setShowQuickAddModal(false)}
-              onCreated={({ groupMemberId }) => {
+              onCreated={({ groupMemberId, communityPeopleId }) => {
                 setShowQuickAddModal(false);
-                router.push(`/(user)/leader-tools/${groupId}/followup/${groupMemberId}`);
+                // Route param is a communityPeopleId (matches adaptCommunityPerson row shape).
+                router.push(`/(user)/leader-tools/${groupId}/followup/${communityPeopleId ?? groupMemberId}`);
               }}
             />
           </View>

--- a/apps/mobile/features/leader-tools/components/FollowupQuickAddPanel.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupQuickAddPanel.tsx
@@ -31,7 +31,7 @@ type Props = {
   leaderOptions: LeaderOption[];
   primaryColor: string;
   onCancel: () => void;
-  onCreated?: (result: { groupMemberId: string; userId: string }) => void;
+  onCreated?: (result: { groupMemberId: string; communityPeopleId?: string; userId: string }) => void;
 };
 
 const STATUS_OPTIONS: Array<{ value: string; label: string }> = [
@@ -124,6 +124,7 @@ export function FollowupQuickAddPanel({
       Alert.alert("Person added", "They were added to the group and people list.");
       onCreated?.({
         groupMemberId: String(result.groupMemberId),
+        communityPeopleId: result.communityPeopleId ? String(result.communityPeopleId) : undefined,
         userId: String(result.userId),
       });
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary

- Adding a person via the side sheet crashed the detail view with `ArgumentValidationError: Found ID "..." from table groupMembers, which does not match the table name in validator v.id("communityPeople")`.
- Existing rows worked because `adaptCommunityPerson` aliases `cp._id` as `groupMemberId`, so `item.groupMemberId` was actually a communityPeople ID. The Add flow had no such adapter step — it returned a real `groupMembers` ID, and callers passed it straight to `communityPeople.history` as a `communityPeopleId`.
- `quickAddRow` now synchronously ensures a `communityPeople` record exists for the added user in the current group and returns its ID. The scheduled `upsertFromSubmission` still fills in denormalized score/status fields once background score computation completes.

## Test plan

- [ ] In the People tool, click **Add Person**, fill in required fields, click **Add person** — confirm the detail side sheet opens without the "Something went wrong" error.
- [ ] On mobile, confirm the same flow navigates to `/(user)/leader-tools/{groupId}/followup/{communityPeopleId}` and renders detail.
- [ ] Confirm the new row also shows in the People list (no regression in the existing reactive update).
- [ ] Reported by Manny (FOUNT) — verify with him after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)