### PR TITLE
fix(chat/web): Enter sends, Shift+Enter newlines in message composers

### DIFF
--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -23,6 +23,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import type { Id } from '@services/api/convex';
 import { useImageUpload } from '../hooks/useImageUpload';
+import { useWebEnterToSend } from '../hooks/useWebEnterToSend';
 import { useFileUpload, type SelectedFile } from '../hooks/useFileUpload';
 import { useSendMessage } from '../hooks/useConvexSendMessage';
 import { useConnectionStatus } from '@providers/ConnectionProvider';
@@ -795,6 +796,9 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
   }, [setTyping]);
 
   const canSend = (text.trim().length > 0 || uploadedImageUrls.length > 0 || uploadedFile !== null || uploadedVideo !== null) && !isSending && !uploading;
+
+  // Web: Enter sends, Shift+Enter newlines. Detached while the voice recorder replaces the input.
+  useWebEnterToSend(textInputRef, canSend, handleSend, !isVoiceRecording);
 
   // Build attachment panel options (WhatsApp-style grid)
   const attachmentOptions = React.useMemo(() => {

--- a/apps/mobile/features/chat/components/ReachOutScreen.tsx
+++ b/apps/mobile/features/chat/components/ReachOutScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import {
   View,
   Text,
@@ -16,6 +16,7 @@ import type { Id } from "@services/api/convex";
 import { useQuery, useAuthenticatedMutation, api, useStoredAuthToken } from "@services/api/convex";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { ReachOutTaskCard } from "./ReachOutTaskCard";
+import { useWebEnterToSend } from "../hooks/useWebEnterToSend";
 
 interface ReachOutScreenProps {
   channelId: Id<"chatChannels">;
@@ -70,6 +71,9 @@ export function ReachOutScreen({ channelId, groupId }: ReachOutScreenProps) {
 
   const canSend = content.trim().length > 0 && !submitting;
 
+  const textInputRef = useRef<TextInput>(null);
+  useWebEnterToSend(textInputRef, canSend, handleSubmit);
+
   return (
     <KeyboardAvoidingView
       style={styles.container}
@@ -81,6 +85,7 @@ export function ReachOutScreen({ channelId, groupId }: ReachOutScreenProps) {
         <Text style={styles.inputLabel}>What would you like to reach out about?</Text>
         <View style={styles.inputRow}>
           <TextInput
+            ref={textInputRef}
             style={styles.textInput}
             placeholder="Type your message..."
             placeholderTextColor="#999"

--- a/apps/mobile/features/chat/hooks/__tests__/useWebEnterToSend.test.ts
+++ b/apps/mobile/features/chat/hooks/__tests__/useWebEnterToSend.test.ts
@@ -1,0 +1,45 @@
+import { shouldSendOnEnter } from '../useWebEnterToSend';
+
+function keyEvent(overrides: Partial<Parameters<typeof shouldSendOnEnter>[0]> = {}) {
+  return {
+    key: 'Enter',
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    isComposing: false,
+    ...overrides,
+  };
+}
+
+describe('shouldSendOnEnter', () => {
+  test('sends on plain Enter', () => {
+    expect(shouldSendOnEnter(keyEvent())).toBe(true);
+  });
+
+  test('does not send on Shift+Enter (newline)', () => {
+    expect(shouldSendOnEnter(keyEvent({ shiftKey: true }))).toBe(false);
+  });
+
+  test('does not send on Ctrl+Enter', () => {
+    expect(shouldSendOnEnter(keyEvent({ ctrlKey: true }))).toBe(false);
+  });
+
+  test('does not send on Meta+Enter (Cmd+Enter on macOS)', () => {
+    expect(shouldSendOnEnter(keyEvent({ metaKey: true }))).toBe(false);
+  });
+
+  test('does not send on Alt+Enter', () => {
+    expect(shouldSendOnEnter(keyEvent({ altKey: true }))).toBe(false);
+  });
+
+  test('does not send while IME composition is in progress', () => {
+    expect(shouldSendOnEnter(keyEvent({ isComposing: true }))).toBe(false);
+  });
+
+  test('does not send for keys other than Enter', () => {
+    expect(shouldSendOnEnter(keyEvent({ key: 'a' }))).toBe(false);
+    expect(shouldSendOnEnter(keyEvent({ key: 'Tab' }))).toBe(false);
+    expect(shouldSendOnEnter(keyEvent({ key: 'Escape' }))).toBe(false);
+  });
+});

--- a/apps/mobile/features/chat/hooks/useWebEnterToSend.ts
+++ b/apps/mobile/features/chat/hooks/useWebEnterToSend.ts
@@ -1,0 +1,49 @@
+import { RefObject, useEffect } from 'react';
+import { Platform, TextInput } from 'react-native';
+
+/**
+ * On web, bind an Enter-to-send keyboard handler to a TextInput's DOM node.
+ * - Enter (no modifiers)        → calls `onSend` (if `canSend`) and prevents the default newline
+ * - Shift+Enter                 → default (inserts newline)
+ * - Ctrl/Meta/Alt + Enter       → ignored (do not send)
+ * - Enter during IME composition → ignored (do not break CJK input)
+ * - Native (iOS/Android)        → no-op
+ *
+ * Pass `enabled=false` to temporarily detach the listener, e.g. when a voice recorder
+ * replaces the text input and the ref is no longer mounted.
+ */
+export function useWebEnterToSend(
+  ref: RefObject<TextInput | null>,
+  canSend: boolean,
+  onSend: () => void,
+  enabled: boolean = true,
+): void {
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !enabled) return;
+    const node = ref.current as unknown as HTMLTextAreaElement | null;
+    if (!node || typeof node.addEventListener !== 'function') return;
+    const handler = (e: KeyboardEvent) => {
+      if (!shouldSendOnEnter(e)) return;
+      e.preventDefault();
+      if (canSend) onSend();
+    };
+    node.addEventListener('keydown', handler);
+    return () => node.removeEventListener('keydown', handler);
+  }, [ref, canSend, onSend, enabled]);
+}
+
+type KeyEventLike = Pick<
+  KeyboardEvent,
+  'key' | 'shiftKey' | 'ctrlKey' | 'metaKey' | 'altKey' | 'isComposing'
+>;
+
+/**
+ * Pure predicate: true when an Enter keypress should trigger send.
+ * Exported for unit tests.
+ */
+export function shouldSendOnEnter(e: KeyEventLike): boolean {
+  if (e.key !== 'Enter') return false;
+  if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return false;
+  if (e.isComposing) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- Web users previously had to click the Send button — pressing Enter just inserted a newline into RN's multiline `TextInput`.
- Added a shared `useWebEnterToSend` hook that binds a DOM `keydown` listener to the composer's TextInput and sends on plain Enter, while leaving Shift+Enter to insert a newline.
- Guards Ctrl/Meta/Alt+Enter (ignored) and IME composition / `isComposing` (don't send while typing CJK).
- Native (iOS/Android) is unchanged — the hook is a no-op off-web.

## Scope
Applied to every chat surface where Enter-to-send is expected:
- `MessageInput.tsx` (main chat composer + threads via `ThreadPage.tsx`)
- `ReachOutScreen.tsx` (reach-out composer)

Deliberately **not** applied to:
- `ReachOutResolveModal.tsx` (multiline resolution notes, not a send-on-enter surface)
- `BroadcastComposer.tsx` (multi-step admin form)
- `ConvexMessagingTest.tsx` (dev harness)

## Implementation notes
- Extracted the keydown predicate (`shouldSendOnEnter`) into a pure function so both call sites share it and it's unit-testable without a DOM.
- In `MessageInput`, the hook detaches itself while the voice recorder replaces the input (`enabled = !isVoiceRecording`).

## Test plan
- [x] Unit tests for `shouldSendOnEnter` (7 cases: plain Enter, Shift/Ctrl/Meta/Alt+Enter, IME composition, non-Enter keys).
- [x] `MessageInput.test.tsx` still passes (platform-gated hook is a no-op in the RN test renderer).
- [x] Manual web check: type a message, press Enter → sends. Press Shift+Enter → newline. Press Cmd/Ctrl+Enter → nothing (doesn't double-send).
- [x] Manual web check: same in threads (`ThreadPage`) and the Reach Out screen.
- [ ] Manual iOS/Android check: no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)