### PR TITLE
feat: app-wide design themes (Hearth/Console/Conservatory) with inbox swap

### DIFF
--- a/apps/mobile/app/(user)/dev/theme-gallery.tsx
+++ b/apps/mobile/app/(user)/dev/theme-gallery.tsx
@@ -33,6 +33,7 @@ import {
   darkColors,
   type ThemeColors,
 } from "@/theme/colors";
+import { defaultFonts } from "@/theme/fonts";
 import {
   Button,
   Card,
@@ -1050,10 +1051,12 @@ export default function ThemeGalleryScreen() {
   const overrideValue = useMemo(
     () => ({
       colors: effectiveScheme === "dark" ? darkColors : lightColors,
+      fonts: defaultFonts,
       isDark: effectiveScheme === "dark",
       colorScheme: effectiveScheme,
       preference: mode,
       setPreference: () => {},
+      fontsLoading: false,
     }),
     [effectiveScheme, mode]
   );

--- a/apps/mobile/app/design-1.tsx
+++ b/apps/mobile/app/design-1.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Front Porch" — warm editorial magazine · responsive
+const C = {
+  cream: '#FBF6EB',
+  paper: '#F3ECDB',
+  ink: '#1F1A14',
+  terracotta: '#CF5A3A',
+  olive: '#6B7A3A',
+  gold: '#C79A2E',
+  rust: '#8A3A1E',
+  muted: '#6E6253',
+  rule: '#D9CFB7',
+  unreadBg: 'rgba(207,90,58,0.08)',
+  unreadBgSub: 'rgba(207,90,58,0.12)',
+  unreadBorder: 'rgba(207,90,58,0.28)',
+};
+
+const F = {
+  display: 'Fraunces, "Times New Roman", serif',
+  body: 'Manrope, system-ui, sans-serif',
+};
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(107,122,58,0.14)', color: C.olive },
+  Teams: { bg: 'rgba(199,154,46,0.16)', color: C.gold },
+  Classes: { bg: 'rgba(207,90,58,0.14)', color: C.terracotta },
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,700;0,9..144,900;1,9..144,500&family=Manrope:wght@400;500;700&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.paper, borderWidth: 1, borderColor: C.ink }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.terracotta, borderWidth: 2, borderColor: C.cream,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: 'rgba(31,26,20,0.08)', color: C.ink };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.body, fontSize: 10, fontWeight: '700', color: s.color, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const total = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const multi = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = total > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.paper : 'transparent', borderBottomWidth: 1, borderBottomColor: C.rule }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.unreadBg : 'transparent',
+        borderLeftWidth: active ? 3 : 0, borderLeftColor: C.terracotta,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.display, fontSize: 18, fontWeight: hasUnread ? '900' : '700', color: C.ink, flex: 1, marginRight: 8, letterSpacing: -0.3 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.display, fontStyle: 'italic',
+              fontSize: 14, flex: 1, marginRight: 8,
+              color: (multi ? hasUnread : main.unreadCount > 0) ? C.ink : C.muted,
+              fontWeight: (multi ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.body, fontSize: 10, letterSpacing: 2, textTransform: 'uppercase',
+                color: main.unreadCount > 0 ? C.terracotta : C.muted,
+                fontWeight: main.unreadCount > 0 ? '700' : '400',
+              }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {total > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.body, color: C.gold, fontSize: 11, fontWeight: '700' }}>{total > 99 ? '99+' : total}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const ch_ur = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: ch_ur ? C.unreadBgSub : C.paper,
+              borderColor: ch_ur ? C.unreadBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.display, fontSize: 13, fontWeight: ch_ur ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.display, fontStyle: 'italic', fontSize: 13, color: ch_ur ? C.ink : C.muted }}>
+                {preview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.body, fontSize: 9, letterSpacing: 2, textTransform: 'uppercase', marginLeft: 8,
+                  color: ch_ur ? C.terracotta : C.muted, fontWeight: ch_ur ? '700' : '400' }}>{ch.lastWhen}</Text>
+              )}
+              {ch_ur && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.body, color: C.gold, fontSize: 10, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design1() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <DesktopView /> : <MobileView />;
+}
+
+function MobileView() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.cream }}>
+      <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 16, borderBottomWidth: 1, borderBottomColor: C.ink }}>
+        <Text style={{ fontFamily: F.display, fontSize: 28, fontWeight: '900', color: C.ink, letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: 4, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, backgroundColor: C.cream, borderTopWidth: 1, borderTopColor: C.ink }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.terracotta : C.muted} />
+            <Text style={{ fontFamily: F.body, fontSize: 10, letterSpacing: 2, color: t.active ? C.ink : C.muted, textTransform: 'uppercase', fontWeight: t.active ? '700' : '400' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function DesktopView() {
+  const g = groups[0];
+  const ch = g.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.cream }}>
+      <View style={{ width: 80, backgroundColor: C.ink, alignItems: 'center', paddingTop: 28, gap: 8 }}>
+        <Text style={{ fontFamily: F.display, color: C.cream, fontSize: 24, fontWeight: '900', letterSpacing: -1, marginBottom: 16 }}>T.</Text>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 60, paddingVertical: 10, alignItems: 'center', gap: 4, borderRadius: 8, backgroundColor: t.active ? 'rgba(199,154,46,0.15)' : 'transparent' }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.gold : 'rgba(251,246,235,0.6)'} />
+            <Text style={{ fontFamily: F.body, fontSize: 9, letterSpacing: 2, color: t.active ? C.gold : 'rgba(251,246,235,0.55)', textTransform: 'uppercase' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: C.rule }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 28, paddingBottom: 16, borderBottomWidth: 1, borderBottomColor: C.ink }}>
+          <Text style={{ fontFamily: F.display, fontSize: 28, fontWeight: '900', color: C.ink, letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 24, paddingVertical: 16, borderBottomWidth: 1, borderBottomColor: C.ink, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <Image source={{ uri: g.image }} style={{ width: 44, height: 44, borderRadius: 22, borderWidth: 1, borderColor: C.ink }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.display, fontSize: 20, fontWeight: '900', color: C.ink, letterSpacing: -0.5 }}>{g.name}</Text>
+              <TypeBadge label={g.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 13, color: C.rust, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={20} color={C.muted} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 24, paddingTop: 14, gap: 20, borderBottomWidth: 1, borderBottomColor: C.rule, alignItems: 'center' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.terracotta : 'transparent' }}>
+              <Text style={{ fontFamily: F.display, fontSize: 15, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.muted }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 10, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.paper, borderLeftWidth: 3, borderLeftColor: C.terracotta }}>
+                <Ionicons name={s.i} size={13} color={C.muted} />
+                <Text style={{ fontFamily: F.body, fontSize: 11, color: C.ink, fontWeight: '600', letterSpacing: 1, textTransform: 'uppercase' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.body, fontSize: 11, color: C.terracotta, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.terracotta} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.display, fontSize: 22, fontWeight: '700', color: C.ink }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 15, color: C.muted, marginTop: 6, textAlign: 'center' }}>Start a conversation with {g.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 12, borderTopWidth: 1, borderTopColor: C.ink, flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={22} color={C.muted} />
+          </Pressable>
+          <View style={{ flex: 1, backgroundColor: C.paper, borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center', borderWidth: 1, borderColor: C.rule }}>
+            <TextInput
+              placeholder={`Message ${ch.name}`}
+              placeholderTextColor={C.muted}
+              style={{ fontFamily: F.body, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.terracotta, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-10.tsx
+++ b/apps/mobile/app/design-10.tsx
@@ -1,0 +1,275 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Dark Mail" — monochrome dark · restrained amber accent
+const C = {
+  bg: '#0D0D0E',
+  surface: '#161617',
+  surfaceHi: '#1C1C1E',
+  surfaceActive: '#232325',
+  ink: '#F2F2F2',
+  subtle: '#A2A2A5',
+  faint: '#68686C',
+  divider: 'rgba(255,255,255,0.08)',
+  accent: '#E6A96B',
+  accentSoft: 'rgba(230,169,107,0.10)',
+  accentSub: 'rgba(230,169,107,0.16)',
+  accentBorder: 'rgba(230,169,107,0.28)',
+  avatarBg: '#2A2A2C',
+};
+
+const F = {
+  sans: '"DM Sans", system-ui, sans-serif',
+  mono: '"DM Mono", ui-monospace, monospace',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=DM+Mono:wght@400;500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(104, 200, 112, 0.14)', color: '#7FD48B' },
+  Teams: { bg: 'rgba(120, 170, 240, 0.14)', color: '#8FB5F0' },
+  Classes: { bg: 'rgba(230, 169, 107, 0.14)', color: '#E6A96B' },
+};
+
+type Channel = { _id: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, borderWidth: 2, borderColor: C.bg, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color={C.bg} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.surfaceActive : 'transparent' }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 12,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.sans, fontSize: 16, fontWeight: hasUnread ? '700' : '600', color: C.ink, flex: 1, marginRight: 8 }}>{g.name}</Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 14, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 11, color: main.unreadCount > 0 ? C.accent : C.faint, fontWeight: main.unreadCount > 0 ? '600' : '400', letterSpacing: 0.5 }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.sans, color: C.bg, fontSize: 12, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.divider }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.divider }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 10, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              backgroundColor: chUn ? C.accentSub : C.surfaceHi,
+              borderWidth: 1, borderColor: chUn ? C.accentBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, fontWeight: chUn ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.sans, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>{preview(ch)}</Text>
+              {ch.lastWhen && <Text style={{ fontFamily: F.mono, fontSize: 10.5, marginLeft: 8, color: chUn ? C.accent : C.faint, fontWeight: chUn ? '600' : '400', letterSpacing: 0.5 }}>{ch.lastWhen}</Text>}
+              {chUn && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: C.bg, fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design10() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, backgroundColor: C.bg, borderTopWidth: 1, borderTopColor: C.divider }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 4 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.faint} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.faint, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 72, backgroundColor: C.surface, borderRightWidth: 1, borderRightColor: C.divider, alignItems: 'center', paddingTop: 28, gap: 8 }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 56, paddingVertical: 10, borderRadius: 12, alignItems: 'center', gap: 4, backgroundColor: t.active ? C.accentSoft : 'transparent' }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: C.divider }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 30, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.7 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 28, paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: C.divider, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.avatarBg }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 16, color: C.ink, fontWeight: '700' }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.subtle, marginTop: 2, letterSpacing: 1 }}>17 MEMBERS · 11 ONLINE</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={20} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 28, paddingTop: 12, gap: 20, borderBottomWidth: 1, borderBottomColor: C.divider, alignItems: 'flex-end' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, backgroundColor: C.surfaceHi }}>
+                <Ionicons name={s.i} size={13} color={C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.sans, fontSize: 20, color: C.ink, fontWeight: '600', marginBottom: 8 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 15, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 16, borderTopWidth: 1, borderTopColor: C.divider, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 10, backgroundColor: C.surfaceHi, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={20} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, backgroundColor: C.surfaceHi, borderRadius: 10, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }} />
+          </View>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color={C.bg} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-11.tsx
+++ b/apps/mobile/app/design-11.tsx
@@ -1,0 +1,277 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+// "Broadsheet" — editorial serif · cream paper · terracotta rule
+const C = {
+  bg: '#FBF7EF',
+  paper: '#FFFDF6',
+  surfaceHi: '#F4EDDE',
+  ink: '#1A1612',
+  subtle: '#6A6156',
+  faint: '#A59C8E',
+  rule: 'rgba(26,22,18,0.10)',
+  ruleSoft: 'rgba(26,22,18,0.06)',
+  accent: '#B0513A',
+  accentSoft: 'rgba(176,81,58,0.08)',
+  accentSub: 'rgba(176,81,58,0.14)',
+  accentBorder: 'rgba(176,81,58,0.30)',
+  avatarBg: '#E6DFCE',
+};
+
+const F = {
+  serif: '"Newsreader", Georgia, serif',
+  sans: '"DM Sans", system-ui, sans-serif',
+  mono: '"DM Mono", ui-monospace, monospace',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&family=DM+Sans:wght@400;500;600;700&family=DM+Mono:wght@400;500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.12)', color: '#3F8E46' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.12)', color: '#2469B0' },
+  Classes: { bg: 'rgba(176, 81, 58, 0.12)', color: '#B0513A' },
+};
+
+type Channel = { _id: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass' as const },
+  { label: 'Inbox', icon: 'inbox' as const, active: true },
+  { label: 'Admin', icon: 'shield' as const },
+  { label: 'Profile', icon: 'user' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, borderWidth: 2, borderColor: C.paper, alignItems: 'center', justifyContent: 'center' }}>
+          <Feather name="shield" size={10} color={C.paper} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 4, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 10, fontWeight: '600', color: s.color, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.surfaceHi : 'transparent' }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 20, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+        borderBottomWidth: 1, borderBottomColor: C.ruleSoft,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 17, fontWeight: hasUnread ? '700' : '600', color: C.ink, flex: 1, marginRight: 8, letterSpacing: -0.3 }}>{g.name}</Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.serif, fontSize: 14, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 10, color: main.unreadCount > 0 ? C.accent : C.faint, fontWeight: main.unreadCount > 0 ? '600' : '500', letterSpacing: 1, textTransform: 'uppercase' }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.mono, color: C.paper, fontSize: 11, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 20 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 4, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 20, marginBottom: 8, marginTop: 4,
+              backgroundColor: chUn ? C.accentSub : C.surfaceHi,
+              borderWidth: 1, borderColor: chUn ? C.accentBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 13.5, fontWeight: chUn ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.serif, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>{preview(ch)}</Text>
+              {ch.lastWhen && <Text style={{ fontFamily: F.mono, fontSize: 10, marginLeft: 8, color: chUn ? C.accent : C.faint, fontWeight: chUn ? '600' : '500', letterSpacing: 1, textTransform: 'uppercase' }}>{ch.lastWhen}</Text>}
+              {chUn && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.mono, color: C.paper, fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design11() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 24, paddingTop: 56, paddingBottom: 14 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, borderTopWidth: 1, borderTopColor: C.ink, backgroundColor: C.paper }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 4, paddingTop: 6 }}>
+            <Feather name={t.icon} size={20} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.mono, fontSize: 9.5, color: t.active ? C.ink : C.subtle, letterSpacing: 1.5, textTransform: 'uppercase', fontWeight: t.active ? '600' : '400' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 88, borderRightWidth: 1, borderRightColor: C.rule, alignItems: 'center', paddingTop: 32, gap: 10, backgroundColor: C.paper }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 64, paddingVertical: 12, alignItems: 'center', gap: 5, borderLeftWidth: 2, borderLeftColor: t.active ? C.accent : 'transparent' }}>
+            <Feather name={t.icon} size={19} color={t.active ? C.ink : C.subtle} />
+            <Text style={{ fontFamily: F.mono, fontSize: 9, color: t.active ? C.ink : C.faint, letterSpacing: 1.5, textTransform: 'uppercase' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, borderRightWidth: 1, borderRightColor: C.rule, backgroundColor: C.paper }}>
+        <View style={{ paddingHorizontal: 24, paddingTop: 32, paddingBottom: 16 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 32, paddingVertical: 16, borderBottomWidth: 1, borderBottomColor: C.rule, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.avatarBg }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 18, color: C.ink, fontWeight: '700', letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="more-horizontal" size={16} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 32, paddingTop: 12, gap: 20, borderBottomWidth: 1, borderBottomColor: C.rule, alignItems: 'flex-end' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 15, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle, fontStyle: t.active ? 'normal' : 'italic' }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'check-circle' as const },
+              { l: 'People', v: '17', i: 'users' as const },
+              { l: 'Events', v: '3', i: 'calendar' as const },
+              { l: 'Bots', v: null, i: 'cpu' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, borderWidth: 1, borderColor: C.rule, backgroundColor: C.paper }}>
+                <Feather name={s.i} size={12} color={C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Feather name="inbox" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.serif, fontSize: 24, color: C.ink, fontWeight: '600', marginBottom: 8, letterSpacing: -0.5 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 15, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 18, borderTopWidth: 1, borderTopColor: C.rule, backgroundColor: C.paper, flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+          <Pressable style={{ width: 42, height: 42, borderRadius: 21, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="paperclip" size={16} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, borderBottomWidth: 1, borderBottomColor: C.ink, paddingHorizontal: 2, paddingVertical: 10 }}>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.serif, fontSize: 15, color: C.ink, outlineWidth: 0 as any }} />
+          </View>
+          <Pressable style={{ width: 42, height: 42, borderRadius: 21, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="arrow-up" size={18} color={C.paper} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-12.tsx
+++ b/apps/mobile/app/design-12.tsx
@@ -1,0 +1,285 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Blush" — soft pastel · rounded · coral-on-rose
+const C = {
+  bg: '#FBEFE7',
+  card: '#FFF8F2',
+  cardHi: '#FFFFFF',
+  surfaceActive: '#FBDCCF',
+  ink: '#2B1F1A',
+  subtle: '#7A6A62',
+  faint: '#B3A59B',
+  line: 'rgba(43,31,26,0.08)',
+  accent: '#E87A5D',
+  accentInk: '#AC3E22',
+  accentSoft: 'rgba(232,122,93,0.10)',
+  accentSub: '#FBDCCF',
+  accentBorder: 'rgba(232,122,93,0.35)',
+  avatarBg: '#F2E0D3',
+};
+
+const F = {
+  sans: '"Plus Jakarta Sans", system-ui, sans-serif',
+  serif: '"Fraunces", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;1,9..144,500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(143, 169, 139, 0.18)', color: '#5F7D5C' },
+  Teams: { bg: 'rgba(156, 139, 169, 0.18)', color: '#6F5A82' },
+  Classes: { bg: 'rgba(232, 122, 93, 0.16)', color: '#AC3E22' },
+};
+
+type Channel = { _id: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, borderWidth: 2, borderColor: C.cardHi, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 9, paddingVertical: 3, borderRadius: 999, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '700', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+        marginHorizontal: 10, marginVertical: 4,
+        borderRadius: 20,
+        backgroundColor: active ? C.surfaceActive : hasUnread ? C.accentSoft : C.cardHi,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.sans, fontSize: 15.5, fontWeight: '700', color: C.ink, flex: 1, marginRight: 8 }}>{g.name}</Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13.5, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 11.5, color: main.unreadCount > 0 ? C.accentInk : C.faint, fontWeight: main.unreadCount > 0 ? '700' : '500' }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 20 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 18, backgroundColor: C.line }} />
+              <View style={{ position: 'absolute', left: 28, top: 18, width: 12, height: 1.5, backgroundColor: C.line }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 16, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 20, marginBottom: 6, marginTop: 2,
+              backgroundColor: chUn ? C.accentSub : C.card,
+              borderWidth: 1, borderColor: chUn ? C.accentBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, fontWeight: chUn ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.sans, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>{preview(ch)}</Text>
+              {ch.lastWhen && <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chUn ? C.accentInk : C.faint, fontWeight: chUn ? '700' : '500' }}>{ch.lastWhen}</Text>}
+              {chUn && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design12() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 32, color: C.ink, fontWeight: '600', letterSpacing: -1 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 110, paddingTop: 4 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ position: 'absolute' as any, bottom: 14, left: 14, right: 14, flexDirection: 'row', padding: 8, borderRadius: 28, backgroundColor: C.cardHi, shadowColor: '#8A4A33', shadowOpacity: 0.12, shadowRadius: 20, shadowOffset: { width: 0, height: 8 } }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingVertical: 10, borderRadius: 20, backgroundColor: t.active ? C.accentSub : 'transparent', gap: 2 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.accentInk : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg, padding: 18, gap: 18 }}>
+      <View style={{ width: 96, paddingTop: 24, alignItems: 'center', gap: 10 }}>
+        <View style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 20, color: '#fff', fontWeight: '600', fontStyle: 'italic' }}>t</Text>
+        </View>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 72, paddingVertical: 12, borderRadius: 18, alignItems: 'center', gap: 4, backgroundColor: t.active ? C.cardHi : 'transparent' }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.card, borderRadius: 32, paddingTop: 24, paddingBottom: 12 }}>
+        <View style={{ paddingHorizontal: 22, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '600', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.card, borderRadius: 32, overflow: 'hidden' }}>
+        <View style={{ padding: 24, paddingBottom: 18, borderBottomWidth: 1, borderBottomColor: C.line, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 48, height: 48, borderRadius: 24, backgroundColor: C.avatarBg }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, fontWeight: '600', letterSpacing: -0.5 }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.cardHi, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ paddingHorizontal: 24, paddingTop: 14, paddingBottom: 4, flexDirection: 'row', alignItems: 'flex-end', gap: 14 }}>
+          <View style={{ flexDirection: 'row', backgroundColor: C.bg, borderRadius: 12, padding: 4 }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <Pressable key={i} style={{ paddingVertical: 7, paddingHorizontal: 16, borderRadius: 8, backgroundColor: t.active ? C.cardHi : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 13, color: t.active ? C.ink : C.subtle, fontWeight: '600' }}>{t.l}</Text>
+              </Pressable>
+            ))}
+          </View>
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 4 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, backgroundColor: C.cardHi }}>
+                <Ionicons name={s.i} size={13} color={C.accentInk} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <View style={{ width: 90, height: 90, borderRadius: 45, backgroundColor: C.accentSub, alignItems: 'center', justifyContent: 'center', marginBottom: 20 }}>
+            <Ionicons name="chatbubble-ellipses-outline" size={36} color={C.accent} />
+          </View>
+          <Text style={{ fontFamily: F.serif, fontSize: 24, color: C.ink, fontWeight: '600', marginBottom: 8, letterSpacing: -0.6 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 18, paddingTop: 12 }}>
+          <View style={{ flexDirection: 'row', gap: 10, alignItems: 'center', backgroundColor: C.cardHi, borderRadius: 24, paddingLeft: 8, paddingRight: 8, paddingVertical: 8 }}>
+            <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.bg, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ flex: 1, fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any, paddingVertical: 6 }} />
+            <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={20} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-13.tsx
+++ b/apps/mobile/app/design-13.tsx
@@ -1,0 +1,289 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+// "Grid" — Swiss discipline · hard rectangles · honey accent
+const C = {
+  bg: '#F2EFE8',
+  paper: '#FFFFFF',
+  surfaceHi: '#F5F2EB',
+  ink: '#0E0E0E',
+  inkSoft: '#2A2A2A',
+  subtle: '#555555',
+  faint: '#9A9A9A',
+  rule: '#0E0E0E',
+  ruleSoft: 'rgba(14,14,14,0.10)',
+  accent: '#D08A1F',
+  accentSoft: 'rgba(208,138,31,0.10)',
+  accentSub: 'rgba(208,138,31,0.16)',
+  accentBorder: 'rgba(208,138,31,0.35)',
+  avatarBg: '#D9D6CF',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  mono: '"JetBrains Mono", ui-monospace, monospace',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.12)', color: '#3F8E46' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.12)', color: '#2469B0' },
+  Classes: { bg: 'rgba(208, 138, 31, 0.16)', color: '#A06810' },
+};
+
+type Channel = { _id: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass' as const },
+  { label: 'Inbox', icon: 'inbox' as const, active: true },
+  { label: 'Admin', icon: 'shield' as const },
+  { label: 'Profile', icon: 'user' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View style={{ width: 56, height: 56, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+        <Image source={{ uri: g.image }} style={{ width: 56, height: 56 }} />
+      </View>
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, backgroundColor: C.accent, borderWidth: 2, borderColor: C.paper, alignItems: 'center', justifyContent: 'center' }}>
+          <Feather name="shield" size={10} color={C.paper} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 3, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 10, fontWeight: '700', color: s.color, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.surfaceHi : 'transparent', borderBottomWidth: 1, borderBottomColor: C.ruleSoft }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.sans, fontSize: 15, fontWeight: hasUnread ? '800' : '700', color: C.ink, flex: 1, marginRight: 8 }}>{g.name}</Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: main.unreadCount > 0 ? C.accent : C.faint, fontWeight: main.unreadCount > 0 ? '700' : '500', letterSpacing: 0.8 }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 24, height: 22, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.mono, color: C.paper, fontSize: 11, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.ruleSoft }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.ruleSoft }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              backgroundColor: chUn ? C.accentSub : C.surfaceHi,
+              borderWidth: 1, borderColor: chUn ? C.accentBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.mono, fontSize: 11, fontWeight: '700', color: C.ink, marginRight: 8, letterSpacing: 1, textTransform: 'uppercase' }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.sans, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>{preview(ch)}</Text>
+              {ch.lastWhen && <Text style={{ fontFamily: F.mono, fontSize: 10, marginLeft: 8, color: chUn ? C.accent : C.faint, fontWeight: chUn ? '700' : '500', letterSpacing: 0.8 }}>{ch.lastWhen}</Text>}
+              {chUn && (
+                <View style={{ minWidth: 22, height: 20, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.mono, color: C.paper, fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design13() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ backgroundColor: C.paper, flex: 1 }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 14, borderBottomWidth: 2, borderBottomColor: C.rule }}>
+          <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -1 }}>Inbox.</Text>
+        </View>
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 100 }}>
+          {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+        </ScrollView>
+        <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', backgroundColor: C.paper, borderTopWidth: 2, borderTopColor: C.rule }}>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{ flex: 1, paddingVertical: 14, paddingBottom: 22, alignItems: 'center', gap: 4, borderRightWidth: i < tabs.length - 1 ? 1 : 0, borderRightColor: C.ruleSoft, backgroundColor: t.active ? C.ink : C.paper }}>
+              <Feather name={t.icon} size={18} color={t.active ? C.accent : C.subtle} />
+              <Text style={{ fontFamily: F.mono, fontSize: 9, color: t.active ? C.paper : C.subtle, letterSpacing: 1.5, fontWeight: '600', textTransform: 'uppercase' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 108, backgroundColor: C.paper, borderRightWidth: 1, borderRightColor: C.ruleSoft, paddingTop: 28 }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ paddingVertical: 18, paddingHorizontal: 18, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, gap: 6, backgroundColor: t.active ? C.ink : 'transparent' }}>
+            <Feather name={t.icon} size={18} color={t.active ? C.accent : C.inkSoft} />
+            <Text style={{ fontFamily: F.mono, fontSize: 10, color: t.active ? C.paper : C.inkSoft, letterSpacing: 1, fontWeight: '600', textTransform: 'uppercase' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.paper, borderRightWidth: 1, borderRightColor: C.ruleSoft }}>
+        <View style={{ padding: 24, paddingTop: 32, borderBottomWidth: 2, borderBottomColor: C.rule }}>
+          <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -1 }}>Inbox.</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.paper }}>
+        <View style={{ padding: 28, paddingBottom: 14, borderBottomWidth: 2, borderBottomColor: C.rule, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <View style={{ width: 44, height: 44, backgroundColor: C.ink, overflow: 'hidden' }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44 }} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 20, color: C.ink, fontWeight: '800', letterSpacing: -0.6 }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: C.subtle, letterSpacing: 1, marginTop: 3 }}>17 MEMBERS · 11 ONLINE</Text>
+          </View>
+          <Pressable style={{ width: 38, height: 38, borderWidth: 1, borderColor: C.ruleSoft, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="more-horizontal" size={16} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ paddingHorizontal: 28, paddingTop: 14, paddingBottom: 0, flexDirection: 'row', alignItems: 'flex-end', borderBottomWidth: 1, borderBottomColor: C.ruleSoft }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <Pressable key={i} style={{ paddingVertical: 10, paddingHorizontal: 16, borderWidth: 1, borderColor: t.active ? C.ink : C.ruleSoft, backgroundColor: t.active ? C.ink : 'transparent', marginRight: -1 }}>
+              <Text style={{ fontFamily: F.mono, fontSize: 11, color: t.active ? C.paper : C.subtle, fontWeight: '700', letterSpacing: 1.2, textTransform: 'uppercase' }}>{t.l}</Text>
+            </Pressable>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', paddingBottom: 10, gap: 0 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'check-square' as const },
+              { l: 'People', v: '17', i: 'users' as const },
+              { l: 'Events', v: '3', i: 'calendar' as const },
+              { l: 'Bots', v: null, i: 'cpu' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 8, borderWidth: 1, borderColor: C.ruleSoft, marginRight: -1, backgroundColor: C.paper }}>
+                <Feather name={s.i} size={12} color={C.ink} />
+                <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: C.ink, letterSpacing: 0.8, textTransform: 'uppercase', fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <View style={{ backgroundColor: C.accentSoft, paddingHorizontal: 5, paddingVertical: 1 }}>
+                  <Text style={{ fontFamily: F.mono, fontSize: 10, color: C.accent, fontWeight: '700' }}>{s.v}</Text>
+                </View>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <View style={{ borderWidth: 1, borderColor: C.ruleSoft, padding: 28, alignItems: 'center', maxWidth: 360 }}>
+            <Feather name="inbox" size={36} color={C.accent} />
+            <View style={{ height: 2, width: 28, backgroundColor: C.accent, marginTop: 14 }} />
+            <Text style={{ fontFamily: F.sans, fontSize: 22, color: C.ink, fontWeight: '800', letterSpacing: -0.6, marginTop: 16 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 10, lineHeight: 18, textAlign: 'center' }}>
+              Start a conversation with {activeGroup.name}.
+            </Text>
+          </View>
+        </ScrollView>
+
+        <View style={{ borderTopWidth: 2, borderTopColor: C.rule, flexDirection: 'row', alignItems: 'center' }}>
+          <Pressable style={{ width: 56, height: 56, borderRightWidth: 1, borderRightColor: C.ruleSoft, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="plus" size={18} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, height: 56, paddingHorizontal: 18, justifyContent: 'center' }}>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }} />
+          </View>
+          <Pressable style={{ flexDirection: 'row', height: 56, paddingHorizontal: 22, alignItems: 'center', gap: 10, backgroundColor: C.accent }}>
+            <Feather name="arrow-up" size={16} color={C.paper} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-14.tsx
+++ b/apps/mobile/app/design-14.tsx
@@ -1,0 +1,297 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+// "Hearth" — warm dark · serif display · ember glow
+const C = {
+  bg: '#15110E',
+  surface: '#1E1915',
+  surfaceHi: '#2A241F',
+  surfaceGlow: '#352C25',
+  ink: '#F5EEE3',
+  inkSoft: '#D8CFC2',
+  subtle: '#9A8F80',
+  faint: '#6A6058',
+  rule: 'rgba(245,238,227,0.08)',
+  accent: '#E67A3C',
+  accentBright: '#F7A06B',
+  accentSoft: 'rgba(230,122,60,0.14)',
+  accentSub: 'rgba(230,122,60,0.22)',
+  accentBorder: 'rgba(230,122,60,0.40)',
+  avatarBg: '#2A241F',
+};
+
+const F = {
+  serif: '"Fraunces", Georgia, serif',
+  sans: '"DM Sans", system-ui, sans-serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,800;1,9..144,500&family=DM+Sans:wght@400;500;600;700&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(135, 200, 120, 0.14)', color: '#9AD38A' },
+  Teams: { bg: 'rgba(140, 185, 240, 0.14)', color: '#A6C5EE' },
+  Classes: { bg: 'rgba(230, 122, 60, 0.16)', color: '#F7A06B' },
+};
+
+type Channel = { _id: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'email-outline' as const, activeIcon: 'email' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'account-outline' as const, activeIcon: 'account' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.avatarBg, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+        <Image source={{ uri: g.image }} style={{ width: 54, height: 54, borderRadius: 27 }} />
+      </View>
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, borderWidth: 2, borderColor: C.bg, alignItems: 'center', justifyContent: 'center' }}>
+          <MaterialCommunityIcons name="shield" size={11} color={C.bg} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 12,
+        marginHorizontal: 10, marginVertical: 3,
+        borderRadius: 16,
+        backgroundColor: active ? C.surfaceGlow : hasUnread ? C.accentSoft : 'transparent',
+        ...(active ? { shadowColor: C.accent, shadowOpacity: 0.25, shadowRadius: 22, shadowOffset: { width: 0, height: 0 } } : {}),
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 16, fontWeight: hasUnread ? '700' : '600', color: C.ink, flex: 1, marginRight: 8, letterSpacing: -0.3 }}>{g.name}</Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13.5, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 11.5, color: main.unreadCount > 0 ? C.accentBright : C.faint, fontWeight: main.unreadCount > 0 ? '600' : '500' }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.sans, color: C.bg, fontSize: 11, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 20 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 18, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 18, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 20, marginBottom: 6, marginTop: 2,
+              backgroundColor: chUn ? C.accentSub : C.surfaceHi,
+              borderWidth: 1, borderColor: chUn ? C.accentBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 13.5, fontWeight: chUn ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.sans, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>{preview(ch)}</Text>
+              {ch.lastWhen && <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chUn ? C.accentBright : C.faint, fontWeight: chUn ? '600' : '500' }}>{ch.lastWhen}</Text>}
+              {chUn && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: C.bg, fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design14() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 24, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '600', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 110 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ position: 'absolute' as any, bottom: 16, left: 16, right: 16, flexDirection: 'row', padding: 8, borderRadius: 30, backgroundColor: C.surface, borderWidth: 1, borderColor: C.rule }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accentSoft : 'transparent', gap: 3 }}>
+            <MaterialCommunityIcons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentBright : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 84, paddingTop: 32, alignItems: 'center', gap: 10, borderRightWidth: 1, borderRightColor: C.rule }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 60, paddingVertical: 12, alignItems: 'center', borderRadius: 14, gap: 5, backgroundColor: t.active ? C.surfaceHi : 'transparent' }}>
+            <MaterialCommunityIcons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentBright : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 9.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, borderRightWidth: 1, borderRightColor: C.rule }}>
+        <View style={{ paddingHorizontal: 26, paddingTop: 32, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '600', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.bg }}>
+        <View style={{ paddingHorizontal: 32, paddingTop: 22, paddingBottom: 14, borderBottomWidth: 1, borderBottomColor: C.rule, backgroundColor: C.surface, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <View style={{ width: 44, height: 44, borderRadius: 22, borderWidth: 1, borderColor: C.accent, backgroundColor: C.accentSoft, alignItems: 'center', justifyContent: 'center' }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 40, height: 40, borderRadius: 20 }} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 20, color: C.ink, fontWeight: '600', letterSpacing: -0.5 }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.sans, fontSize: 12.5, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.surfaceHi, alignItems: 'center', justifyContent: 'center' }}>
+            <MaterialCommunityIcons name="dots-horizontal" size={20} color={C.inkSoft} />
+          </Pressable>
+        </View>
+
+        <View style={{ paddingHorizontal: 32, paddingTop: 12, flexDirection: 'row', alignItems: 'flex-end', borderBottomWidth: 1, borderBottomColor: C.rule }}>
+          <View style={{ flexDirection: 'row', backgroundColor: C.bg, borderRadius: 12, padding: 4, borderWidth: 1, borderColor: C.rule, marginBottom: 10 }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <Pressable key={i} style={{ paddingVertical: 7, paddingHorizontal: 16, borderRadius: 8, backgroundColor: t.active ? C.surfaceGlow : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 12.5, color: t.active ? C.ink : C.subtle, fontWeight: '600' }}>{t.l}</Text>
+              </Pressable>
+            ))}
+          </View>
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'check-circle-outline' as const },
+              { l: 'People', v: '17', i: 'account-group-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-blank-outline' as const },
+              { l: 'Bots', v: null, i: 'chip' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, backgroundColor: C.surfaceHi, borderWidth: 1, borderColor: C.rule }}>
+                <MaterialCommunityIcons name={s.i as any} size={13} color={C.accentBright} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.inkSoft, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <View style={{
+            width: 96, height: 96, borderRadius: 48,
+            backgroundColor: C.accentSoft,
+            alignItems: 'center', justifyContent: 'center',
+            shadowColor: C.accent, shadowOpacity: 0.4, shadowRadius: 40, shadowOffset: { width: 0, height: 0 },
+            borderWidth: 1, borderColor: C.accent, marginBottom: 20,
+          }}>
+            <MaterialCommunityIcons name="message-outline" size={40} color={C.accentBright} />
+          </View>
+          <Text style={{ fontFamily: F.serif, fontSize: 24, color: C.ink, fontWeight: '600', marginBottom: 8, letterSpacing: -0.6 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 18, borderTopWidth: 1, borderTopColor: C.rule }}>
+          <View style={{ flexDirection: 'row', gap: 10, alignItems: 'center', backgroundColor: C.surface, borderRadius: 24, paddingLeft: 8, paddingRight: 8, paddingVertical: 6, borderWidth: 1, borderColor: C.rule }}>
+            <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.surfaceHi, alignItems: 'center', justifyContent: 'center' }}>
+              <MaterialCommunityIcons name="paperclip" size={18} color={C.inkSoft} />
+            </Pressable>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ flex: 1, fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any, paddingVertical: 8 }} />
+            <Pressable style={{
+              width: 40, height: 40, borderRadius: 20, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center',
+              shadowColor: C.accent, shadowOpacity: 0.5, shadowRadius: 16, shadowOffset: { width: 0, height: 0 },
+            }}>
+              <MaterialCommunityIcons name="arrow-up" size={18} color={C.bg} />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-15.tsx
+++ b/apps/mobile/app/design-15.tsx
@@ -1,0 +1,287 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Ledger" — tactile paper · dashed dividers · coral ink
+const C = {
+  bg: '#F1E8D9',
+  paper: '#FAF3E5',
+  paperHi: '#FFFAEF',
+  surfaceHi: '#F2E9D6',
+  ink: '#241A12',
+  subtle: '#6E5E4E',
+  faint: '#A89A86',
+  rule: 'rgba(36,26,18,0.12)',
+  ruleSoft: 'rgba(36,26,18,0.06)',
+  accent: '#D85C3E',
+  accentInk: '#8C2E18',
+  accentSoft: 'rgba(216,92,62,0.10)',
+  accentSub: 'rgba(216,92,62,0.16)',
+  accentBorder: 'rgba(216,92,62,0.35)',
+  avatarBg: '#E6DCC6',
+};
+
+const F = {
+  serif: '"Source Serif 4", Georgia, serif',
+  sans: '"Manrope", system-ui, sans-serif',
+  mono: '"IBM Plex Mono", ui-monospace, monospace',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;0,8..60,700;1,8..60,500&family=Manrope:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.12)', color: '#3F8E46' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.12)', color: '#2469B0' },
+  Classes: { bg: 'rgba(216, 92, 62, 0.14)', color: '#8C2E18' },
+};
+
+type Channel = { _id: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'mail-outline' as const, activeIcon: 'mail' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View style={{ width: 56, height: 56, borderRadius: 28, borderWidth: 1.5, borderColor: C.ink, backgroundColor: C.paper, alignItems: 'center', justifyContent: 'center' }}>
+        <Image source={{ uri: g.image }} style={{ width: 53, height: 53, borderRadius: 26.5 }} />
+      </View>
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, borderWidth: 2, borderColor: C.paper, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color={C.paper} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 4, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 10, fontWeight: '600', color: s.color, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      backgroundColor: active ? C.surfaceHi : 'transparent',
+      borderBottomWidth: 1, borderBottomStyle: 'dashed' as any, borderBottomColor: C.rule,
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 20, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 17, fontWeight: hasUnread ? '700' : '600', color: C.ink, flex: 1, marginRight: 8, letterSpacing: -0.3 }}>{g.name}</Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.serif, fontSize: 14, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: main.unreadCount > 0 ? C.accent : C.faint, fontWeight: main.unreadCount > 0 ? '700' : '500', letterSpacing: 0.8 }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 24, height: 22, paddingHorizontal: 7, borderWidth: 1.5, borderColor: C.accent, backgroundColor: C.paperHi, alignItems: 'center', justifyContent: 'center', marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.accent, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 20 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 20, marginBottom: 8, marginTop: 4,
+              backgroundColor: chUn ? C.accentSub : C.paperHi,
+              borderWidth: 1, borderStyle: 'dashed' as any, borderColor: chUn ? C.accentBorder : C.rule,
+            }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 13.5, fontWeight: chUn ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.serif, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>{preview(ch)}</Text>
+              {ch.lastWhen && <Text style={{ fontFamily: F.mono, fontSize: 10, marginLeft: 8, color: chUn ? C.accent : C.faint, fontWeight: chUn ? '700' : '500', letterSpacing: 0.8 }}>{ch.lastWhen}</Text>}
+              {chUn && (
+                <View style={{ minWidth: 22, height: 20, paddingHorizontal: 5, borderWidth: 1.5, borderColor: C.accent, backgroundColor: C.paperHi, alignItems: 'center', justifyContent: 'center', marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: C.accent, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design15() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.paper }}>
+      <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 14 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '600', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 110 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', backgroundColor: C.paperHi, paddingVertical: 10, paddingBottom: 22, borderTopWidth: 1, borderTopColor: C.ink }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 4, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.serif, fontSize: 11, fontStyle: t.active ? 'italic' : 'normal', color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 96, paddingTop: 34, alignItems: 'center', gap: 6, borderRightWidth: 1, borderRightColor: C.rule, backgroundColor: C.paperHi }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 70, paddingVertical: 14, alignItems: 'center', gap: 5, borderLeftWidth: 2, borderLeftColor: t.active ? C.accent : 'transparent' }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={19} color={t.active ? C.ink : C.subtle} />
+            <Text style={{ fontFamily: F.serif, fontStyle: t.active ? 'italic' : 'normal', fontSize: 12, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.paper, borderRightWidth: 1, borderRightColor: C.rule }}>
+        <View style={{ paddingHorizontal: 26, paddingTop: 36, paddingBottom: 16 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '600', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <View style={{ height: 1, backgroundColor: C.rule, marginHorizontal: 22 }} />
+        <View style={{ height: 1, backgroundColor: C.rule, marginHorizontal: 22, marginTop: 3 }} />
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.paperHi }}>
+        <View style={{ padding: 32, paddingBottom: 16, borderBottomWidth: 1, borderBottomColor: C.rule, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <View style={{ width: 48, height: 48, borderRadius: 24, borderWidth: 1.5, borderColor: C.ink, alignItems: 'center', justifyContent: 'center', backgroundColor: C.paper }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 45, height: 45, borderRadius: 22.5 }} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, fontWeight: '600', letterSpacing: -0.5 }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={16} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ paddingHorizontal: 32, paddingTop: 14, paddingBottom: 0, flexDirection: 'row', alignItems: 'flex-end', gap: 16, borderBottomWidth: 1, borderBottomColor: C.rule }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 15, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500', fontStyle: t.active ? 'normal' : 'italic' }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderWidth: 1, borderColor: C.rule, borderRadius: 4, backgroundColor: C.paper }}>
+                <Ionicons name={s.i} size={13} color={C.accentInk} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="mail-outline" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.serif, fontSize: 26, color: C.ink, fontWeight: '600', marginBottom: 8, letterSpacing: -0.6 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 15, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 20, borderTopWidth: 1, borderTopColor: C.rule, backgroundColor: C.paper, flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+          <Pressable style={{ width: 42, height: 42, borderRadius: 21, borderWidth: 1, borderColor: C.rule, backgroundColor: C.paperHi, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="attach-outline" size={18} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, borderBottomWidth: 1, borderBottomColor: C.ink, paddingHorizontal: 2, paddingVertical: 10 }}>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.serif, fontSize: 15, color: C.ink, outlineWidth: 0 as any }} />
+          </View>
+          <Pressable style={{ width: 42, height: 42, borderRadius: 21, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={18} color={C.paper} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-16.tsx
+++ b/apps/mobile/app/design-16.tsx
@@ -1,0 +1,325 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+// "Atrium" — frosted translucency · warm peach on cool mist
+const C = {
+  base: '#E8E4EE',
+  tint1: '#F4DDD0',
+  tint2: '#DCD8F0',
+  tint3: '#EFE6DD',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#241C2B',
+  subtle: '#5E5567',
+  faint: '#928A9F',
+  rule: 'rgba(36,28,43,0.10)',
+  ruleSoft: 'rgba(36,28,43,0.05)',
+  accent: '#E26F52',
+  accentInk: '#A94026',
+  accentSoft: 'rgba(226,111,82,0.14)',
+  unreadBg: 'rgba(226,111,82,0.10)',
+  unreadBgSub: 'rgba(226,111,82,0.16)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Instrument Serif", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.14)', color: '#3F8A44' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.14)', color: '#0A63C8' },
+  Classes: { bg: 'rgba(226, 111, 82, 0.16)', color: '#A94026' },
+};
+
+type Channel = {
+  _id: string; slug: string; channelType: 'main' | 'leaders' | string; name: string;
+  lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number;
+};
+type Group = {
+  _id: string; name: string; image: string; groupTypeName: string;
+  userRole: 'leader' | 'member'; channels: Channel[];
+};
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass' as const },
+  { label: 'Inbox', icon: 'inbox' as const, active: true },
+  { label: 'Admin', icon: 'shield' as const },
+  { label: 'Profile', icon: 'user' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' }}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.glassHi }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.base,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Feather name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accentInk };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '700', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      borderRadius: 20, marginBottom: 10, overflow: 'hidden',
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1, borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+    }}>
+      <Pressable style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 14, paddingVertical: 14 }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 20, color: C.ink, fontWeight: '400', letterSpacing: -0.4, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>{messagePreview(mainChannel)}</Text>
+            {mainChannel.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 11, color: mainChannel.unreadCount > 0 ? C.accent : C.faint, fontWeight: mainChannel.unreadCount > 0 ? '700' : '500' }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 7, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.sans, fontSize: 11, color: '#fff', fontWeight: '700' }}>{totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 26, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 26, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 2,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassHi,
+              borderWidth: 1, borderColor: chHasUnread ? C.accent : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, fontWeight: '700', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.sans, fontSize: 13, color: chHasUnread ? C.ink : C.subtle, fontWeight: chHasUnread ? '500' : '400' }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chHasUnread ? C.accent : C.faint, fontWeight: chHasUnread ? '700' : '500' }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design16() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, alignItems: 'center' }}>
+        <View style={{ width: '100%' as any, maxWidth: 520, flex: 1 }}>
+          <View style={{ paddingHorizontal: 18, paddingTop: 56, paddingBottom: 14 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '400', letterSpacing: -0.6 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingBottom: 120, paddingHorizontal: 14 }}>
+            {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+          </ScrollView>
+          <View style={{
+            position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+            flexDirection: 'row', padding: 6, borderRadius: 28,
+            backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+          }}>
+            {tabs.map((t, i) => (
+              <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+                <Feather name={t.icon} size={19} color={t.active ? '#fff' : C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18, minHeight: '100%' as any }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: '#fff', fontStyle: 'italic' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Feather name={t.icon} size={19} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, padding: 20 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '400', letterSpacing: -0.6, marginBottom: 14, paddingHorizontal: 4 }}>Inbox</Text>
+          <ScrollView>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22 }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, fontWeight: '400', letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="more-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'check-circle' as const },
+                { l: 'People', v: '17', i: 'users' as const },
+                { l: 'Events', v: '3', i: 'calendar' as const },
+                { l: 'Bots', v: null as any, i: 'cpu' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Feather name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Feather name="message-circle" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 26, color: C.ink, marginBottom: 8 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center', backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+              <Feather name="paperclip" size={16} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center', borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+              <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }} />
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-17.tsx
+++ b/apps/mobile/app/design-17.tsx
@@ -1,0 +1,308 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+// "Broadside" — brutalist editorial · hazard orange on paperwhite
+const C = {
+  bg: '#F2F2EE',
+  paper: '#FFFFFF',
+  ink: '#0A0A0A',
+  inkSoft: '#1F1F1F',
+  subtle: '#4A4A4A',
+  faint: '#8C8C8C',
+  rule: '#0A0A0A',
+  ruleSoft: 'rgba(10,10,10,0.12)',
+  accent: '#FF5A1F',
+  accentSoft: '#FFE8DC',
+  unreadBg: '#FFF1E9',
+  unreadBgSub: '#FFE0CF',
+};
+
+const F = {
+  display: '"Archivo Black", "Archivo", system-ui, sans-serif',
+  sans: '"Archivo", system-ui, sans-serif',
+  mono: '"JetBrains Mono", ui-monospace, monospace',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Archivo+Black&family=JetBrains+Mono:wght@400;600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: '#0A0A0A', color: '#FF5A1F' },
+  Teams: { bg: '#FF5A1F', color: '#0A0A0A' },
+  Classes: { bg: '#FFE8DC', color: '#0A0A0A' },
+};
+
+type Channel = { _id: string; slug: string; channelType: 'main' | 'leaders' | string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number; };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[]; };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass' as const },
+  { label: 'Inbox', icon: 'inbox' as const, active: true },
+  { label: 'Admin', icon: 'shield' as const },
+  { label: 'Profile', icon: 'user' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 14 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, borderWidth: 2, borderColor: C.ink }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: -2, right: -2,
+          width: 22, height: 22, borderRadius: 11,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.paper,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Feather name="shield" size={11} color={C.ink} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.ink, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 3, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 10, fontWeight: '700', color: scheme.color, letterSpacing: 1.5, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.bg : C.paper, borderBottomWidth: 2, borderBottomColor: C.ink }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 18, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.unreadBg : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4, gap: 8 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.display, fontSize: 17, color: C.ink, letterSpacing: -0.5, flex: 1, textTransform: 'uppercase' }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8, fontWeight: '500',
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+            }}>{messagePreview(mainChannel)}</Text>
+            {mainChannel.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: mainChannel.unreadCount > 0 ? C.accent : C.subtle, fontWeight: '700', letterSpacing: 1.5, textTransform: 'uppercase' }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 26, height: 26, backgroundColor: C.accent, borderWidth: 2, borderColor: C.ink, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.display, fontSize: 13, color: C.ink }}>{totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 18, backgroundColor: hasUnread ? C.unreadBg : 'transparent' }}>
+            <View style={{ width: 44 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 2, height: 22, backgroundColor: C.ink }} />
+              <View style={{ position: 'absolute', left: 28, top: 22, width: 14, height: 2, backgroundColor: C.ink }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 18, marginBottom: 10, marginTop: 4,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.paper,
+              borderWidth: 2, borderColor: C.ink,
+            }}>
+              <Text style={{ fontFamily: F.display, fontSize: 12, color: C.ink, marginRight: 8, textTransform: 'uppercase' }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.sans, fontSize: 13, color: chHasUnread ? C.ink : C.subtle, fontWeight: chHasUnread ? '600' : '500' }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.mono, fontSize: 10, marginLeft: 8, color: chHasUnread ? C.accent : C.subtle, fontWeight: '700', letterSpacing: 1, textTransform: 'uppercase' }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{ minWidth: 22, height: 22, backgroundColor: C.accent, borderWidth: 2, borderColor: C.ink, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.display, color: C.ink, fontSize: 11 }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design17() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg, alignItems: 'center' }}>
+      <View style={{ width: '100%' as any, maxWidth: 540, flex: 1, backgroundColor: C.paper, borderLeftWidth: 2, borderRightWidth: 2, borderColor: C.ink }}>
+        <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 14, borderBottomWidth: 3, borderBottomColor: C.ink }}>
+          <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, letterSpacing: -1 }}>INBOX</Text>
+        </View>
+        <ScrollView contentContainerStyle={{ paddingBottom: 120 }}>
+          {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+        </ScrollView>
+        <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', backgroundColor: C.ink, borderTopWidth: 3, borderTopColor: C.ink }}>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              flex: 1, paddingVertical: 12, paddingBottom: 22, alignItems: 'center', gap: 4,
+              borderRightWidth: i < tabs.length - 1 ? 1 : 0, borderRightColor: 'rgba(255,255,255,0.12)',
+              backgroundColor: t.active ? C.accent : C.ink,
+            }}>
+              <Feather name={t.icon} size={19} color={t.active ? C.ink : C.paper} />
+              <Text style={{ fontFamily: F.mono, fontSize: 9.5, color: t.active ? C.ink : C.paper, letterSpacing: 1.5, fontWeight: '700' }}>{t.label.toUpperCase()}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg, minHeight: '100%' as any }}>
+      <View style={{ width: 96, backgroundColor: C.ink, paddingTop: 24 }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{
+            paddingVertical: 22, paddingHorizontal: 10, alignItems: 'center', gap: 6,
+            borderBottomWidth: 1, borderBottomColor: 'rgba(255,255,255,0.10)',
+            backgroundColor: t.active ? C.accent : 'transparent',
+          }}>
+            <Feather name={t.icon} size={22} color={t.active ? C.ink : C.paper} />
+            <Text style={{ fontFamily: F.display, fontSize: 11, color: t.active ? C.ink : C.paper, letterSpacing: 0.5 }}>{t.label.toUpperCase()}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.paper, borderRightWidth: 2, borderRightColor: C.ink }}>
+        <View style={{ padding: 22, paddingTop: 28, borderBottomWidth: 3, borderBottomColor: C.ink }}>
+          <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, letterSpacing: -1 }}>INBOX</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.paper }}>
+        <View style={{ padding: 22, borderBottomWidth: 3, borderBottomColor: C.ink, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 48, height: 48, borderWidth: 2, borderColor: C.ink }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.display, fontSize: 20, color: C.ink, letterSpacing: -0.6, textTransform: 'uppercase' }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: C.subtle, marginTop: 4, letterSpacing: 1.5, fontWeight: '600' }}>17 MEMBERS · 11 ONLINE</Text>
+          </View>
+          <Pressable style={{ width: 40, height: 40, borderWidth: 2, borderColor: C.ink, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="more-horizontal" size={18} color={C.ink} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', alignItems: 'center', borderBottomWidth: 2, borderBottomColor: C.ink }}>
+          {[{ l: 'GENERAL', active: true }, { l: 'LEADERS' }].map((t, i) => (
+            <Pressable key={i} style={{
+              paddingVertical: 12, paddingHorizontal: 22,
+              borderRightWidth: 2, borderRightColor: C.ink,
+              backgroundColor: t.active ? C.ink : C.paper,
+            }}>
+              <Text style={{ fontFamily: F.display, fontSize: 13, color: t.active ? C.accent : C.ink, letterSpacing: 0.5 }}>{t.l}</Text>
+            </Pressable>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row' }}>
+            {[
+              { l: 'ATTENDANCE', v: '23', i: 'check-square' as const },
+              { l: 'PEOPLE', v: '17', i: 'users' as const },
+              { l: 'EVENTS', v: '3', i: 'calendar' as const },
+              { l: 'BOTS', v: null as any, i: 'cpu' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 14, borderLeftWidth: 2, borderLeftColor: C.ink }}>
+                <Feather name={s.i} size={13} color={C.ink} />
+                <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: C.ink, letterSpacing: 1.5, fontWeight: '700' }}>{s.l}</Text>
+                {s.v && <View style={{ backgroundColor: C.accent, paddingHorizontal: 5, paddingVertical: 1 }}>
+                  <Text style={{ fontFamily: F.mono, fontSize: 10, color: C.ink, fontWeight: '700' }}>{s.v}</Text>
+                </View>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Feather name="inbox" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, letterSpacing: -0.6, marginBottom: 8, textTransform: 'uppercase' }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center', fontWeight: '500' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ borderTopWidth: 3, borderTopColor: C.ink, flexDirection: 'row', alignItems: 'stretch' }}>
+          <Pressable style={{ width: 54, borderRightWidth: 2, borderRightColor: C.ink, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="plus" size={20} color={C.ink} />
+          </Pressable>
+          <View style={{ flex: 1, paddingHorizontal: 16, justifyContent: 'center' }}>
+            <TextInput
+              placeholder={`MESSAGE ${activeChannel.name.toUpperCase()}…`}
+              placeholderTextColor={C.faint}
+              style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, fontWeight: '600', letterSpacing: 0.3, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ flexDirection: 'row', paddingHorizontal: 22, alignItems: 'center', gap: 10, backgroundColor: C.accent }}>
+            <Text style={{ fontFamily: F.display, fontSize: 13, color: C.ink, letterSpacing: 1 }}>SEND</Text>
+            <Feather name="arrow-up-right" size={16} color={C.ink} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-18.tsx
+++ b/apps/mobile/app/design-18.tsx
@@ -1,0 +1,352 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Bauhaus" — primary geometry · brick on bone · indigo support
+const C = {
+  bg: '#EDE7DA',
+  paper: '#F7F2E6',
+  paperHi: '#FFFDF5',
+  ink: '#161514',
+  subtle: '#4A4742',
+  faint: '#8A847A',
+  rule: '#161514',
+  ruleSoft: 'rgba(22,21,20,0.14)',
+  accent: '#C94A2A',
+  accentSoft: '#F2C8B6',
+  support: '#1E2A63',
+  supportSoft: 'rgba(30,42,99,0.12)',
+  ochre: '#D9A441',
+  ochreSoft: 'rgba(217,164,65,0.18)',
+  unreadBg: 'rgba(201,74,42,0.08)',
+  unreadBgSub: 'rgba(201,74,42,0.16)',
+};
+
+const F = {
+  display: '"Bricolage Grotesque", system-ui, sans-serif',
+  sans: '"Manrope", system-ui, sans-serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Manrope:wght@400;500;600;700&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(201,74,42,0.14)', color: '#C94A2A' },
+  Teams: { bg: 'rgba(30,42,99,0.14)', color: '#1E2A63' },
+  Classes: { bg: 'rgba(217,164,65,0.22)', color: '#8E6716' },
+};
+
+type Channel = { _id: string; slug: string; channelType: 'main' | 'leaders' | string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number; };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[]; };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'mail-outline' as const, activeIcon: 'mail' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Shape({ type, color, size = 40 }: any) {
+  if (type === 'square') return <View style={{ width: size, height: size, backgroundColor: color }} />;
+  if (type === 'triangle') {
+    return (
+      <View style={{
+        width: 0, height: 0,
+        borderLeftWidth: size / 2, borderRightWidth: size / 2, borderBottomWidth: size * 0.88,
+        borderLeftColor: 'transparent', borderRightColor: 'transparent', borderBottomColor: color,
+      }} />
+    );
+  }
+  return <View style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: color }} />;
+}
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 14 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28 }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: 22, height: 22, borderRadius: 11,
+          backgroundColor: C.ochre, borderWidth: 2, borderColor: C.paper,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={11} color={C.ink} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.supportSoft, color: C.support };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '700', color: scheme.color, letterSpacing: 0.5 }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.accentSoft : C.paper, borderBottomWidth: 1, borderBottomColor: C.ruleSoft }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 22, paddingVertical: 14,
+        backgroundColor: hasUnread && !active ? C.unreadBg : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4, gap: 8 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.display, fontSize: 17, color: C.ink, fontWeight: '700', letterSpacing: -0.4, flex: 1 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '500',
+            }}>{messagePreview(mainChannel)}</Text>
+            {mainChannel.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 11, color: mainChannel.unreadCount > 0 ? C.accent : C.faint, fontWeight: '600' }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 26, height: 26, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 8, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.display, fontSize: 12, color: C.ochre, fontWeight: '800' }}>{totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 22 }}>
+            <View style={{ width: 46 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 2, height: 22, backgroundColor: C.ink }} />
+              <View style={{ position: 'absolute', left: 28, top: 22, width: 14, height: 2, backgroundColor: C.ink }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 22, marginBottom: 10, marginTop: 4,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.paperHi,
+              borderWidth: 1.5, borderColor: chHasUnread ? C.accent : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.display, fontSize: 13, fontWeight: '700', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.sans, fontSize: 13, color: chHasUnread ? C.ink : C.subtle, fontWeight: chHasUnread ? '600' : '500' }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chHasUnread ? C.accent : C.faint, fontWeight: '600' }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{ minWidth: 22, height: 22, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.display, color: C.ochre, fontSize: 11, fontWeight: '800' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design18() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function HeaderRow() {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -0.8 }}>Inbox</Text>
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+        <Shape type="circle" color={C.accent} size={12} />
+        <Shape type="square" color={C.support} size={12} />
+        <View style={{
+          width: 0, height: 0,
+          borderLeftWidth: 6, borderRightWidth: 6, borderBottomWidth: 10,
+          borderLeftColor: 'transparent', borderRightColor: 'transparent', borderBottomColor: C.ochre,
+        }} />
+      </View>
+    </View>
+  );
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg, alignItems: 'center' }}>
+      <View style={{ width: '100%' as any, maxWidth: 540, flex: 1, backgroundColor: C.paper }}>
+        <View style={{ padding: 22, paddingTop: 56, paddingBottom: 14 }}>
+          <HeaderRow />
+        </View>
+        <View style={{ height: 2, backgroundColor: C.ink }} />
+        <ScrollView contentContainerStyle={{ paddingBottom: 110 }}>
+          {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+        </ScrollView>
+        <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', backgroundColor: C.paperHi, borderTopWidth: 2, borderTopColor: C.ink, paddingVertical: 8, paddingBottom: 20 }}>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 4, paddingVertical: 6 }}>
+              <View style={{
+                width: 36, height: 36, alignItems: 'center', justifyContent: 'center',
+                backgroundColor: t.active ? C.accent : 'transparent',
+                borderRadius: t.active ? 18 : 0,
+              }}>
+                <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.paperHi : C.ink} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg, minHeight: '100%' as any }}>
+      <View style={{ width: 92, backgroundColor: C.ink, paddingTop: 24, alignItems: 'center', gap: 8 }}>
+        <View style={{ marginBottom: 18, alignItems: 'center', gap: 2 }}>
+          <Shape type="circle" color={C.accent} size={16} />
+          <Shape type="square" color={C.ochre} size={16} />
+        </View>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 70, paddingVertical: 14, alignItems: 'center', gap: 5 }}>
+            <View style={{
+              width: 44, height: 44, borderRadius: t.active ? 22 : 0,
+              backgroundColor: t.active ? C.accent : 'transparent',
+              borderWidth: t.active ? 0 : 1, borderColor: 'rgba(255,255,255,0.15)',
+              alignItems: 'center', justifyContent: 'center',
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.ink : C.paper} />
+            </View>
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ochre : C.paper, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.paper, borderRightWidth: 2, borderRightColor: C.ink }}>
+        <View style={{ padding: 22, paddingTop: 28 }}>
+          <HeaderRow />
+        </View>
+        <View style={{ height: 2, backgroundColor: C.ink }} />
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.paperHi }}>
+        <View style={{ padding: 22, borderBottomWidth: 2, borderBottomColor: C.ink, flexDirection: 'row', alignItems: 'center', gap: 16 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 48, height: 48, borderRadius: 24 }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.display, fontSize: 22, color: C.ink, fontWeight: '800', letterSpacing: -0.6 }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 4, fontWeight: '500' }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 40, height: 40, borderWidth: 1.5, borderColor: C.ink, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={18} color={C.ink} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 22, paddingTop: 12, gap: 0, borderBottomWidth: 1, borderBottomColor: C.ruleSoft }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <Pressable key={i} style={{ paddingVertical: 10, paddingHorizontal: 18, backgroundColor: t.active ? C.ink : 'transparent', marginRight: 4 }}>
+              <Text style={{ fontFamily: F.display, fontSize: 13, color: t.active ? C.ochre : C.ink, fontWeight: '700', letterSpacing: 0.3 }}>{t.l}</Text>
+            </Pressable>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const, c: C.accent },
+              { l: 'People', v: '17', i: 'people-outline' as const, c: C.support },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const, c: C.ochre },
+              { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const, c: C.subtle },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderWidth: 1.5, borderColor: s.c, backgroundColor: C.paperHi }}>
+                <Ionicons name={s.i} size={13} color={s.c} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '700' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.display, fontSize: 12, color: s.c, fontWeight: '800' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14, marginBottom: 18 }}>
+            <Shape type="circle" color={C.accent} size={28} />
+            <Shape type="square" color={C.support} size={28} />
+            <Shape type="triangle" color={C.ochre} size={28} />
+          </View>
+          <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -0.6, marginBottom: 8 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center', fontWeight: '500' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ borderTopWidth: 2, borderTopColor: C.ink, flexDirection: 'row', alignItems: 'stretch', backgroundColor: C.paperHi }}>
+          <Pressable style={{ width: 52, height: 52, alignItems: 'center', justifyContent: 'center', borderRightWidth: 1, borderRightColor: C.ruleSoft }}>
+            <Ionicons name="add" size={22} color={C.ink} />
+          </Pressable>
+          <View style={{ flex: 1, paddingHorizontal: 16, height: 52, justifyContent: 'center' }}>
+            <TextInput
+              placeholder={`Message ${activeChannel.name}`}
+              placeholderTextColor={C.faint}
+              style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any, fontWeight: '500' }}
+            />
+          </View>
+          <Pressable style={{ height: 52, paddingHorizontal: 20, backgroundColor: C.accent, flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+            <Text style={{ fontFamily: F.display, fontSize: 13, color: C.paperHi, fontWeight: '700', letterSpacing: 0.5 }}>Send</Text>
+            <Ionicons name="arrow-forward" size={16} color={C.paperHi} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-19.tsx
+++ b/apps/mobile/app/design-19.tsx
@@ -1,0 +1,309 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+// "Atelier" — letterpress quiet · sage on cotton · coral seal
+const C = {
+  bg: '#F6F1E7',
+  paper: '#FBF7ED',
+  ink: '#222621',
+  inkSoft: '#37403A',
+  subtle: '#6C6F66',
+  faint: '#A7A79B',
+  rule: 'rgba(34,38,33,0.10)',
+  ruleSoft: 'rgba(34,38,33,0.05)',
+  accent: '#C95443',
+  accentInk: '#872E21',
+  accentSoft: 'rgba(201,84,67,0.08)',
+  accentSoftHi: 'rgba(201,84,67,0.16)',
+  sage: '#6A8068',
+  sageSoft: 'rgba(106,128,104,0.14)',
+};
+
+const F = {
+  serif: '"Crimson Pro", Georgia, serif',
+  sans: '"Manrope", system-ui, sans-serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,500&family=Manrope:wght@400;500;600;700&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: C.sageSoft, color: C.sage },
+  Teams: { bg: 'rgba(10,90,140,0.12)', color: '#2F5E7E' },
+  Classes: { bg: C.accentSoft, color: C.accentInk },
+};
+
+type Channel = { _id: string; slug: string; channelType: 'main' | 'leaders' | string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number; };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[]; };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass' as const },
+  { label: 'Inbox', icon: 'inbox' as const, active: true },
+  { label: 'Admin', icon: 'shield' as const },
+  { label: 'Profile', icon: 'user' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 14 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, borderWidth: 1, borderColor: C.rule }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.paper,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Feather name="shield" size={10} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.sageSoft, color: C.sage };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 10.5, fontWeight: '700', color: scheme.color, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.accentSoft : 'transparent', borderBottomWidth: 1, borderBottomColor: C.ruleSoft }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 24, paddingVertical: 16,
+        backgroundColor: hasUnread && !active ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4, gap: 8 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, fontWeight: '500', letterSpacing: -0.3, flex: 1 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.serif, fontSize: 15, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '500' : '400',
+            }}>{messagePreview(mainChannel)}</Text>
+            {mainChannel.lastWhen && (
+              <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 12, color: mainChannel.unreadCount > 0 ? C.accent : C.faint }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 24, height: 24, paddingHorizontal: 8, borderRadius: 12, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.paper, fontWeight: '700' }}>{totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 24 }}>
+            <View style={{ width: 46 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1, height: 22, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 22, width: 14, height: 1, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 10, paddingHorizontal: 14, paddingVertical: 10,
+              marginRight: 24, marginBottom: 12, marginTop: 4,
+              backgroundColor: chHasUnread ? C.accentSoftHi : C.paper,
+              borderWidth: 1, borderColor: chHasUnread ? C.accent : C.rule,
+            }}>
+              <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 14, fontWeight: '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.serif, fontSize: 14, color: chHasUnread ? C.ink : C.subtle, fontWeight: chHasUnread ? '500' : '400' }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 11, marginLeft: 8, color: chHasUnread ? C.accent : C.faint }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: C.paper, fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design19() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg, alignItems: 'center' }}>
+      <View style={{ width: '100%' as any, maxWidth: 540, flex: 1, backgroundColor: C.paper }}>
+        <View style={{ paddingHorizontal: 24, paddingTop: 56, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '500', letterSpacing: -0.6 }}>Inbox</Text>
+        </View>
+        <View style={{ height: 1, backgroundColor: C.rule, marginHorizontal: 24 }} />
+        <ScrollView contentContainerStyle={{ paddingBottom: 120 }}>
+          {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+        </ScrollView>
+        <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', backgroundColor: C.paper, borderTopWidth: 1, borderTopColor: C.rule, paddingVertical: 10, paddingBottom: 22 }}>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 5, paddingTop: 8 }}>
+              <Feather name={t.icon} size={19} color={t.active ? C.accent : C.subtle} />
+              <Text style={{ fontFamily: F.serif, fontStyle: t.active ? 'italic' : 'normal', fontSize: 12, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>
+                {t.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg, minHeight: '100%' as any }}>
+      <View style={{ width: 92, backgroundColor: C.paper, borderRightWidth: 1, borderRightColor: C.rule, paddingTop: 36, alignItems: 'center', gap: 4 }}>
+        <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 28, color: C.accent, fontWeight: '500' }}>Tg</Text>
+        <View style={{ width: 20, height: 1, backgroundColor: C.rule, marginTop: 8, marginBottom: 18 }} />
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 72, paddingVertical: 14, alignItems: 'center', gap: 6 }}>
+            <View style={{
+              width: 42, height: 42, borderRadius: 21,
+              borderWidth: 1, borderColor: t.active ? C.accent : 'transparent',
+              backgroundColor: t.active ? C.accentSoft : 'transparent',
+              alignItems: 'center', justifyContent: 'center',
+            }}>
+              <Feather name={t.icon} size={18} color={t.active ? C.accent : C.subtle} />
+            </View>
+            <Text style={{ fontFamily: F.serif, fontStyle: t.active ? 'italic' : 'normal', fontSize: 13, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.paper, borderRightWidth: 1, borderRightColor: C.rule }}>
+        <View style={{ paddingHorizontal: 24, paddingTop: 28, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '500', letterSpacing: -0.6 }}>Inbox</Text>
+        </View>
+        <View style={{ height: 1, backgroundColor: C.rule }} />
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.paper }}>
+        <View style={{ padding: 24, borderBottomWidth: 1, borderBottomColor: C.rule, flexDirection: 'row', alignItems: 'center', gap: 16 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 48, height: 48, borderRadius: 24, borderWidth: 1, borderColor: C.rule }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 26, color: C.ink, fontWeight: '500', letterSpacing: -0.6 }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 14, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 40, height: 40, borderRadius: 20, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="more-horizontal" size={18} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 24, paddingTop: 14, gap: 24, borderBottomWidth: 1, borderBottomColor: C.rule }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 15, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '400', fontStyle: t.active ? 'italic' : 'normal' }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'check-circle' as const },
+              { l: 'People', v: '17', i: 'users' as const },
+              { l: 'Events', v: '3', i: 'calendar' as const },
+              { l: 'Bots', v: null as any, i: 'cpu' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 999, backgroundColor: C.sageSoft }}>
+                <Feather name={s.i} size={13} color={C.sage} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.inkSoft, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 13, color: C.accent, fontWeight: '600' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <View style={{
+            width: 72, height: 72, borderRadius: 36, borderWidth: 1, borderColor: C.accent,
+            alignItems: 'center', justifyContent: 'center', backgroundColor: C.accentSoft, marginBottom: 18,
+          }}>
+            <Feather name="message-circle" size={28} color={C.accent} />
+          </View>
+          <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '500', letterSpacing: -0.6, marginBottom: 8 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 15, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 16, borderTopWidth: 1, borderTopColor: C.rule, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 19, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="paperclip" size={16} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, backgroundColor: C.bg, borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.serif, fontSize: 15, color: C.ink, outlineWidth: 0 as any }} />
+          </View>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Feather name="arrow-up" size={16} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-2.tsx
+++ b/apps/mobile/app/design-2.tsx
@@ -1,0 +1,286 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Sunday Bulletin" — order-of-service newsprint · responsive
+const C = {
+  paper: '#F6F2E7',
+  ink: '#0C0C0C',
+  tomato: '#E24B2A',
+  ash: '#5E5E5E',
+  rule: '#C9C2AE',
+  band: '#EDE7D3',
+  unreadBg: 'rgba(226,75,42,0.08)',
+  unreadBgSub: 'rgba(226,75,42,0.12)',
+  unreadBorder: 'rgba(226,75,42,0.28)',
+};
+
+const F = {
+  display: '"Instrument Serif", "Times New Roman", serif',
+  mono: '"IBM Plex Mono", "Courier New", monospace',
+  body: '"Inter Tight", system-ui, sans-serif',
+};
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(12,12,12,0.08)', color: C.ink },
+  Teams: { bg: 'rgba(226,75,42,0.12)', color: C.tomato },
+  Classes: { bg: 'rgba(94,94,94,0.14)', color: C.ash },
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;500;700&family=Inter+Tight:wght@400;500;700&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+type Channel = { _id: string; slug: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, borderWidth: 1, borderColor: C.ink }} />
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.tomato, borderWidth: 2, borderColor: C.paper, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: 'rgba(0,0,0,0.08)', color: C.ink };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 9, fontWeight: '700', color: s.color, letterSpacing: 2, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const total = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const multi = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = total > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.band : 'transparent', borderTopWidth: 1, borderTopColor: C.ink }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.unreadBg : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.display, fontSize: 22, color: C.ink, flex: 1, marginRight: 8, letterSpacing: -0.4 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.display, fontStyle: 'italic', fontSize: 15, flex: 1, marginRight: 8,
+              color: (multi ? hasUnread : main.unreadCount > 0) ? C.ink : C.ash,
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 10, letterSpacing: 1,
+                color: main.unreadCount > 0 ? C.tomato : C.ash,
+                fontWeight: main.unreadCount > 0 ? '700' : '400',
+              }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {total > 0 && (
+          <View style={{ minWidth: 22, height: 22, backgroundColor: C.tomato, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 7, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.mono, color: C.paper, fontSize: 11, fontWeight: '700' }}>{total > 99 ? '99+' : total}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const cur = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.ink }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.ink }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: cur ? C.unreadBgSub : C.band,
+              borderColor: cur ? C.unreadBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.display, fontSize: 15, color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.display, fontStyle: 'italic', fontSize: 13, color: cur ? C.ink : C.ash }}>{preview(ch)}</Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.mono, fontSize: 9, letterSpacing: 1, marginLeft: 8, color: cur ? C.tomato : C.ash, fontWeight: cur ? '700' : '400' }}>{ch.lastWhen}</Text>
+              )}
+              {cur && (
+                <View style={{ minWidth: 20, height: 20, backgroundColor: C.tomato, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.mono, color: C.paper, fontSize: 10, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design2() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <DesktopView /> : <MobileView />;
+}
+
+function MobileView() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.paper }}>
+      <View style={{ paddingHorizontal: 24, paddingTop: 56, paddingBottom: 14 }}>
+        <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+        <View style={{ borderTopWidth: 1, borderTopColor: C.ink }} />
+      </ScrollView>
+      <View style={{ flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, backgroundColor: C.band, borderTopWidth: 1, borderTopColor: C.ink }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.tomato : C.ash} />
+            <Text style={{ fontFamily: F.mono, fontSize: 9, letterSpacing: 2, color: t.active ? C.ink : C.ash, textTransform: 'uppercase', fontWeight: t.active ? '700' : '400' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function DesktopView() {
+  const g = groups[0];
+  const ch = g.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.paper }}>
+      <View style={{ width: 72, backgroundColor: C.ink, alignItems: 'center', paddingTop: 28, gap: 6 }}>
+        <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 24, color: C.paper, marginBottom: 14 }}>T.</Text>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 56, paddingVertical: 10, alignItems: 'center', gap: 3, borderRadius: 6, backgroundColor: t.active ? 'rgba(226,75,42,0.2)' : 'transparent' }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.tomato : 'rgba(246,242,231,0.6)'} />
+            <Text style={{ fontFamily: F.mono, fontSize: 8, letterSpacing: 2, color: t.active ? C.paper : 'rgba(246,242,231,0.55)', textTransform: 'uppercase' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: C.ink }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 28, paddingBottom: 16 }}>
+          <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          <View style={{ borderTopWidth: 1, borderTopColor: C.ink }} />
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 24, paddingVertical: 16, borderBottomWidth: 1, borderBottomColor: C.ink, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <Image source={{ uri: g.image }} style={{ width: 44, height: 44, borderRadius: 22, borderWidth: 1, borderColor: C.ink }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.display, fontSize: 22, color: C.ink, letterSpacing: -0.6 }}>{g.name}</Text>
+              <TypeBadge label={g.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 14, color: C.ash, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={20} color={C.ash} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 24, paddingTop: 14, gap: 20, borderBottomWidth: 1, borderBottomColor: C.ink, alignItems: 'center' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.tomato : 'transparent' }}>
+              <Text style={{ fontFamily: F.display, fontSize: 17, color: t.active ? C.ink : C.ash, fontStyle: t.active ? 'normal' : 'italic' }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 10, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, backgroundColor: C.band, borderWidth: 1, borderColor: C.rule }}>
+                <Ionicons name={s.i} size={13} color={C.ash} />
+                <Text style={{ fontFamily: F.mono, fontSize: 10, color: C.ink, fontWeight: '700', letterSpacing: 1.5, textTransform: 'uppercase' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.mono, fontSize: 10, color: C.tomato, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.tomato} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, letterSpacing: -0.6 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 16, color: C.ash, marginTop: 8, textAlign: 'center' }}>Start a conversation with {g.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ink, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={22} color={C.ash} />
+          </Pressable>
+          <View style={{ flex: 1, backgroundColor: C.band, paddingHorizontal: 14, height: 40, justifyContent: 'center', borderWidth: 1, borderColor: C.rule }}>
+            <TextInput
+              placeholder={`Message ${ch.name}`}
+              placeholderTextColor={C.ash}
+              style={{ fontFamily: F.display, fontSize: 15, color: C.ink, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ width: 40, height: 40, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color={C.paper} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-20.tsx
+++ b/apps/mobile/app/design-20.tsx
@@ -1,0 +1,329 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Console" — warm monospace · terminal buffer with a beating heart
+const C = {
+  bg: '#F4EFE4',
+  paper: '#FBF7EC',
+  paperHi: '#FFFCF3',
+  ink: '#1C1A16',
+  inkSoft: '#2E2B25',
+  subtle: '#5F594E',
+  faint: '#9A9387',
+  rule: 'rgba(28,26,22,0.10)',
+  ruleSoft: 'rgba(28,26,22,0.05)',
+  accent: '#CC7A1A',
+  accentSoft: 'rgba(204,122,26,0.12)',
+  accentSoftHi: 'rgba(204,122,26,0.20)',
+  green: '#5B7A3E',
+  greenSoft: 'rgba(91,122,62,0.12)',
+  blue: '#3B5E8A',
+  blueSoft: 'rgba(59,94,138,0.14)',
+};
+
+const F = {
+  mono: '"JetBrains Mono", ui-monospace, monospace',
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Fraunces", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Manrope:wght@400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: C.greenSoft, color: C.green },
+  Teams: { bg: C.blueSoft, color: C.blue },
+  Classes: { bg: C.accentSoft, color: C.accent },
+};
+
+type Channel = { _id: string; slug: string; channelType: 'main' | 'leaders' | string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number; };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[]; };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function TrafficDots() {
+  return (
+    <View style={{ flexDirection: 'row', gap: 5 }}>
+      <View style={{ width: 9, height: 9, borderRadius: 4.5, backgroundColor: C.accent }} />
+      <View style={{ width: 9, height: 9, borderRadius: 4.5, backgroundColor: C.green }} />
+      <View style={{ width: 9, height: 9, borderRadius: 4.5, backgroundColor: C.faint }} />
+    </View>
+  );
+}
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 14 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 8, borderWidth: 1, borderColor: C.rule }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: -2, right: -2,
+          width: 20, height: 20, borderRadius: 6,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.paper,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={11} color={C.paperHi} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 7, paddingVertical: 2, borderRadius: 4, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 10.5, fontWeight: '700', color: scheme.color, letterSpacing: 0.3 }}>#{label.toLowerCase().replace(' ', '-')}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.accentSoft : 'transparent', borderBottomWidth: 1, borderBottomColor: C.ruleSoft }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 18, paddingVertical: 14,
+        backgroundColor: hasUnread && !active ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4, gap: 8 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.mono, fontSize: 15, color: C.ink, fontWeight: '600', flex: 1 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.mono, fontSize: 12.5, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}><Text style={{ color: C.faint }}>{'> '}</Text>{messagePreview(mainChannel)}</Text>
+            {mainChannel.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 10.5, color: mainChannel.unreadCount > 0 ? C.accent : C.faint, fontWeight: mainChannel.unreadCount > 0 ? '700' : '500', letterSpacing: 0.5 }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 26, height: 22, borderRadius: 4, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 7, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.paperHi, fontWeight: '700' }}>+{totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 18 }}>
+            <View style={{ width: 44 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 6, paddingHorizontal: 12, paddingVertical: 9,
+              marginRight: 18, marginBottom: 10, marginTop: 4,
+              backgroundColor: chHasUnread ? C.accentSoftHi : C.paperHi,
+              borderWidth: 1, borderColor: chHasUnread ? C.accent : C.rule,
+            }}>
+              <Text style={{ fontFamily: F.mono, fontSize: 12, fontWeight: '700', color: C.ink, marginRight: 8 }}>#{ch.name.toLowerCase()}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.mono, fontSize: 12, color: chHasUnread ? C.ink : C.subtle, fontWeight: chHasUnread ? '500' : '400' }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.mono, fontSize: 10, marginLeft: 8, color: chHasUnread ? C.accent : C.faint, fontWeight: chHasUnread ? '700' : '500' }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{ minWidth: 22, height: 18, borderRadius: 4, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.mono, color: C.paperHi, fontSize: 10, fontWeight: '700' }}>+{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design20() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg, alignItems: 'center' }}>
+      <View style={{ width: '100%' as any, maxWidth: 540, flex: 1, backgroundColor: C.paper }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 14, borderBottomWidth: 1, borderBottomColor: C.rule }}>
+          <Text style={{ fontFamily: F.mono, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -1 }}>
+            inbox<Text style={{ color: C.accent }}>_</Text>
+          </Text>
+        </View>
+        <ScrollView contentContainerStyle={{ paddingBottom: 110 }}>
+          {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+        </ScrollView>
+        <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', backgroundColor: C.paperHi, borderTopWidth: 1, borderTopColor: C.ink, paddingVertical: 8, paddingBottom: 22 }}>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 4, paddingTop: 6 }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.subtle} />
+              <Text style={{ fontFamily: F.mono, fontSize: 10, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg, minHeight: '100%' as any }}>
+      <View style={{ width: 80, backgroundColor: C.paperHi, borderRightWidth: 1, borderRightColor: C.rule, paddingTop: 24, alignItems: 'center', gap: 4 }}>
+        <View style={{ marginBottom: 16 }}>
+          <TrafficDots />
+        </View>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{
+            width: 64, paddingVertical: 12, alignItems: 'center', gap: 4, borderRadius: 8,
+            backgroundColor: t.active ? C.accentSoft : 'transparent',
+            borderWidth: 1, borderColor: t.active ? C.accent : 'transparent',
+          }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.mono, fontSize: 10, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.paper, borderRightWidth: 1, borderRightColor: C.rule }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 28, paddingBottom: 14, borderBottomWidth: 1, borderBottomColor: C.rule }}>
+          <Text style={{ fontFamily: F.mono, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -1 }}>
+            inbox<Text style={{ color: C.accent }}>_</Text>
+          </Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, backgroundColor: C.paperHi }}>
+        <View style={{ padding: 22, borderBottomWidth: 1, borderBottomColor: C.rule, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 48, height: 48, borderRadius: 8, borderWidth: 1, borderColor: C.rule }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ fontFamily: F.mono, fontSize: 18, color: C.ink, fontWeight: '700' }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.mono, fontSize: 12, color: C.subtle, marginTop: 4 }}>
+              <Text style={{ color: C.green }}>●</Text> 17 members · 11 online
+            </Text>
+          </View>
+          <TrafficDots />
+          <Pressable style={{ width: 36, height: 36, borderRadius: 8, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center', marginLeft: 6 }}>
+            <Ionicons name="ellipsis-horizontal" size={16} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 22, paddingTop: 12, gap: 6, borderBottomWidth: 1, borderBottomColor: C.rule }}>
+          {[{ l: 'general', active: true }, { l: 'leaders' }].map((t, i) => (
+            <Pressable key={i} style={{
+              paddingVertical: 7, paddingHorizontal: 14, borderRadius: 6, marginBottom: 10,
+              backgroundColor: t.active ? C.ink : 'transparent',
+              borderWidth: 1, borderColor: t.active ? C.ink : C.rule,
+            }}>
+              <Text style={{ fontFamily: F.mono, fontSize: 12, color: t.active ? C.accent : C.subtle, fontWeight: '600' }}>#{t.l}</Text>
+            </Pressable>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 6, paddingBottom: 10 }}>
+            {[
+              { l: 'attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'people', v: '17', i: 'people-outline' as const },
+              { l: 'events', v: '3', i: 'calendar-outline' as const },
+              { l: 'bots', v: null as any, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 6, backgroundColor: C.paper, borderWidth: 1, borderColor: C.rule }}>
+                <Ionicons name={s.i} size={13} color={C.accent} />
+                <Text style={{ fontFamily: F.mono, fontSize: 11.5, color: C.ink, fontWeight: '500' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.accent, fontWeight: '700' }}>:{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.mono, fontSize: 22, color: C.ink, fontWeight: '700', marginBottom: 8 }}>
+            no messages yet<Text style={{ color: C.accent }}>_</Text>
+          </Text>
+          <Text style={{ fontFamily: F.mono, fontSize: 13, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.rule, flexDirection: 'row', gap: 8, alignItems: 'center', backgroundColor: C.paper }}>
+          <Text style={{ fontFamily: F.mono, fontSize: 14, color: C.accent, fontWeight: '700' }}>❯</Text>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 6, borderWidth: 1, borderColor: C.rule, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={20} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, height: 40, borderRadius: 6, borderWidth: 1, borderColor: C.rule, paddingHorizontal: 12, justifyContent: 'center', backgroundColor: C.paperHi }}>
+            <TextInput
+              placeholder={`message ${activeChannel.name.toLowerCase()}`}
+              placeholderTextColor={C.faint}
+              style={{ fontFamily: F.mono, fontSize: 13, color: C.ink, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ width: 40, height: 40, borderRadius: 6, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={18} color={C.accent} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-21.tsx
+++ b/apps/mobile/app/design-21.tsx
@@ -1,0 +1,318 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+// "Conservatory" — frosted translucency · emerald on celadon · cormorant
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  accentSoftHi: 'rgba(28,107,94,0.22)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Cormorant", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Cormorant:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76,175,80,0.16)', color: '#2F7A3A' },
+  Teams: { bg: 'rgba(28,107,94,0.16)', color: '#0F443B' },
+  Classes: { bg: 'rgba(201,142,40,0.18)', color: '#8A6515' },
+};
+
+type Channel = { _id: string; slug: string; channelType: 'main' | 'leaders' | string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number; };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[]; };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass' as const },
+  { label: 'Inbox', icon: 'inbox' as const, active: true },
+  { label: 'Admin', icon: 'shield' as const },
+  { label: 'Profile', icon: 'user' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' }}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.glassHi }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.base,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Feather name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accentInk };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '700', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      borderRadius: 20, marginBottom: 10, overflow: 'hidden',
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.accentSoft : C.glassDim),
+      borderWidth: 1, borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+    }}>
+      <Pressable style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 14, paddingVertical: 14 }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, fontWeight: '500', letterSpacing: -0.4, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>{messagePreview(mainChannel)}</Text>
+            {mainChannel.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 11, color: mainChannel.unreadCount > 0 ? C.accent : C.faint, fontWeight: mainChannel.unreadCount > 0 ? '700' : '500' }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 7, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.sans, fontSize: 11, color: '#fff', fontWeight: '700' }}>{totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 26, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 26, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 2,
+              backgroundColor: chHasUnread ? C.accentSoftHi : C.glassHi,
+              borderWidth: 1, borderColor: chHasUnread ? C.accent : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 15, fontWeight: '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.sans, fontSize: 13, color: chHasUnread ? C.ink : C.subtle, fontWeight: chHasUnread ? '500' : '400' }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chHasUnread ? C.accent : C.faint, fontWeight: chHasUnread ? '700' : '500' }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design21() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, alignItems: 'center' }}>
+        <View style={{ width: '100%' as any, maxWidth: 520, flex: 1 }}>
+          <View style={{ paddingHorizontal: 18, paddingTop: 56, paddingBottom: 14 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '500', letterSpacing: -0.8 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingBottom: 120, paddingHorizontal: 14 }}>
+            {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+          </ScrollView>
+          <View style={{
+            position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+            flexDirection: 'row', padding: 6, borderRadius: 28,
+            backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+          }}>
+            {tabs.map((t, i) => (
+              <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+                <Feather name={t.icon} size={19} color={t.active ? '#fff' : C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18, minHeight: '100%' as any }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff', fontStyle: 'italic', fontWeight: '600' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Feather name={t.icon} size={19} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, padding: 20 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '500', letterSpacing: -0.8, marginBottom: 14, paddingHorizontal: 4 }}>Inbox</Text>
+          <ScrollView>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22 }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 24, color: C.ink, fontWeight: '500', letterSpacing: -0.6 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="more-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'check-circle' as const },
+                { l: 'People', v: '17', i: 'users' as const },
+                { l: 'Events', v: '3', i: 'calendar' as const },
+                { l: 'Bots', v: null as any, i: 'cpu' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Feather name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Feather name="message-circle" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '500', marginBottom: 8, letterSpacing: -0.6 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center', backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+              <Feather name="paperclip" size={16} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center', borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+              <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }} />
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-22.tsx
+++ b/apps/mobile/app/design-22.tsx
@@ -1,0 +1,344 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+// "Atrium · Nocturne" — frosted translucency · warm peach glow on deep violet
+const C = {
+  base: '#15131C',
+  tint1: '#3E2A24',
+  tint2: '#1F1D33',
+  tint3: '#2B261E',
+  glass: 'rgba(255,255,255,0.06)',
+  glassHi: 'rgba(255,255,255,0.12)',
+  glassDim: 'rgba(255,255,255,0.04)',
+  glassBorder: 'rgba(255,255,255,0.14)',
+  glassBorderHi: 'rgba(255,255,255,0.22)',
+  ink: '#F0E8DD',
+  subtle: '#A89B8D',
+  faint: '#716659',
+  rule: 'rgba(255,255,255,0.10)',
+  ruleSoft: 'rgba(255,255,255,0.05)',
+  accent: '#F0866A',
+  accentInk: '#F8A389',
+  accentSoft: 'rgba(240,134,106,0.18)',
+  accentSoftHi: 'rgba(240,134,106,0.28)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Instrument Serif", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(136,200,120,0.16)', color: '#9DD488' },
+  Teams: { bg: 'rgba(120,180,240,0.16)', color: '#A9CFF5' },
+  Classes: { bg: 'rgba(240,134,106,0.22)', color: '#F8A389' },
+};
+
+type Channel = { _id: string; slug: string; channelType: 'main' | 'leaders' | string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number; };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[]; };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass' as const },
+  { label: 'Inbox', icon: 'inbox' as const, active: true },
+  { label: 'Admin', icon: 'shield' as const },
+  { label: 'Profile', icon: 'user' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' }}>
+      <View style={{ position: 'absolute' as any, width: 560, height: 560, borderRadius: 280, backgroundColor: C.tint1, top: -140, left: -160, opacity: 0.55 }} />
+      <View style={{ position: 'absolute' as any, width: 680, height: 680, borderRadius: 340, backgroundColor: C.tint2, bottom: -240, right: -220, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 400, height: 400, borderRadius: 200, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.35 }} />
+    </View>
+  );
+}
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.glassHi }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.base,
+          alignItems: 'center', justifyContent: 'center',
+          shadowColor: C.accent, shadowOpacity: 0.7, shadowRadius: 8, shadowOffset: { width: 0, height: 0 },
+        }}>
+          <Feather name="shield" size={11} color={C.base} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accentInk };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '700', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      borderRadius: 20, marginBottom: 10, overflow: 'hidden',
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.accentSoft : C.glassDim),
+      borderWidth: 1, borderColor: active ? C.glassBorderHi : (hasUnread ? C.accent : C.glassBorder),
+    }}>
+      <Pressable style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 14, paddingVertical: 14 }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 20, color: C.ink, fontWeight: '400', letterSpacing: -0.4, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>{messagePreview(mainChannel)}</Text>
+            {mainChannel.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 11, color: mainChannel.unreadCount > 0 ? C.accentInk : C.faint, fontWeight: mainChannel.unreadCount > 0 ? '700' : '500' }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center', paddingHorizontal: 7, marginLeft: 10,
+            shadowColor: C.accent, shadowOpacity: 0.6, shadowRadius: 10, shadowOffset: { width: 0, height: 0 },
+          }}>
+            <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.base, fontWeight: '700' }}>{totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 26, top: 0, width: 1.5, height: 20, backgroundColor: C.glassBorder }} />
+              <View style={{ position: 'absolute', left: 26, top: 20, width: 12, height: 1.5, backgroundColor: C.glassBorder }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 2,
+              backgroundColor: chHasUnread ? C.accentSoftHi : C.glassHi,
+              borderWidth: 1, borderColor: chHasUnread ? C.accent : C.glassBorder,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, fontWeight: '700', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.sans, fontSize: 13, color: chHasUnread ? C.ink : C.subtle, fontWeight: chHasUnread ? '500' : '400' }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chHasUnread ? C.accentInk : C.faint, fontWeight: chHasUnread ? '700' : '500' }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8,
+                  shadowColor: C.accent, shadowOpacity: 0.6, shadowRadius: 8, shadowOffset: { width: 0, height: 0 },
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: C.base, fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design22() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, alignItems: 'center' }}>
+        <View style={{ width: '100%' as any, maxWidth: 520, flex: 1 }}>
+          <View style={{ paddingHorizontal: 18, paddingTop: 56, paddingBottom: 14 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '400', letterSpacing: -0.8 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingBottom: 120, paddingHorizontal: 14 }}>
+            {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+          </ScrollView>
+          <View style={{
+            position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+            flexDirection: 'row', padding: 6, borderRadius: 28,
+            backgroundColor: C.glassHi, borderWidth: 1, borderColor: C.glassBorder,
+          }}>
+            {tabs.map((t, i) => (
+              <Pressable key={i} style={{
+                flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, gap: 3,
+                backgroundColor: t.active ? C.accent : 'transparent',
+                ...(t.active ? { shadowColor: C.accent, shadowOpacity: 0.5, shadowRadius: 14, shadowOffset: { width: 0, height: 0 } } : {}),
+              }}>
+                <Feather name={t.icon} size={19} color={t.active ? C.base : C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.base : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18, minHeight: '100%' as any }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{
+            width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18,
+            shadowColor: C.accent, shadowOpacity: 0.55, shadowRadius: 18, shadowOffset: { width: 0, height: 0 },
+          }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.base, fontStyle: 'italic', fontWeight: '600' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? C.glassBorderHi : C.glassBorder,
+            }}>
+              <Feather name={t.icon} size={19} color={t.active ? C.accent : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: C.glassBorder, borderRadius: 32, padding: 20 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '400', letterSpacing: -0.8, marginBottom: 14, paddingHorizontal: 4 }}>Inbox</Text>
+          <ScrollView>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: C.glassBorder, borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22 }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 24, color: C.ink, fontWeight: '400', letterSpacing: -0.6 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.glassHi, borderWidth: 1, borderColor: C.glassBorder, alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="more-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'check-circle' as const },
+                { l: 'People', v: '17', i: 'users' as const },
+                { l: 'Events', v: '3', i: 'calendar' as const },
+                { l: 'Bots', v: null as any, i: 'cpu' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, backgroundColor: C.glassHi, borderWidth: 1, borderColor: C.glassBorder }}>
+                  <Feather name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <View style={{
+              width: 72, height: 72, borderRadius: 36, backgroundColor: C.accentSoft, alignItems: 'center', justifyContent: 'center', marginBottom: 18,
+              shadowColor: C.accent, shadowOpacity: 0.45, shadowRadius: 24, shadowOffset: { width: 0, height: 0 },
+            }}>
+              <Feather name="message-circle" size={32} color={C.accent} />
+            </View>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, color: C.ink, fontWeight: '400', marginBottom: 8, letterSpacing: -0.6 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center', backgroundColor: C.glassHi, borderWidth: 1, borderColor: C.glassBorder }}>
+              <Feather name="paperclip" size={16} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center', borderWidth: 1, borderColor: C.glassBorder }}>
+              <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }} />
+            </View>
+            <Pressable style={{
+              width: 36, height: 36, borderRadius: 18, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center',
+              shadowColor: C.accent, shadowOpacity: 0.55, shadowRadius: 14, shadowOffset: { width: 0, height: 0 },
+            }}>
+              <Feather name="arrow-up" size={18} color={C.base} />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-23.tsx
+++ b/apps/mobile/app/design-23.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// Conservatory — DM Serif Display
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  avatarBg: 'rgba(255,255,255,0.6)',
+  unreadBg: 'rgba(28,107,94,0.08)',
+  unreadBgSub: 'rgba(28,107,94,0.12)',
+  unreadBorder: 'rgba(28,107,94,0.35)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"DM Serif Display", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=DM+Serif+Display:ital@0;1&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: Group; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: badge, height: badge, borderRadius: badge / 2,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: '#fff',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1,
+      borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+      overflow: 'hidden',
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 19, color: C.ink, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontFamily: F.sans, fontSize: 11,
+                color: mainChannel.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '500',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassDim,
+              borderColor: chHasUnread ? C.unreadBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                fontFamily: F.sans, flex: 1, fontSize: 12.5,
+                color: chHasUnread ? C.ink : C.subtle,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontFamily: F.sans, fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.accent : C.faint,
+                  fontWeight: chHasUnread ? '600' : '500',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design23() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingTop: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+        flexDirection: 'row', padding: 6, borderRadius: 28,
+        backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? '#fff' : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18 }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingTop: 8, paddingBottom: 16 }}>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.avatarBg }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Ionicons name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, marginBottom: 8, letterSpacing: -0.4 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${activeChannel.name}`}
+                placeholderTextColor={C.faint}
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-24.tsx
+++ b/apps/mobile/app/design-24.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// Conservatory — Spectral
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  avatarBg: 'rgba(255,255,255,0.6)',
+  unreadBg: 'rgba(28,107,94,0.08)',
+  unreadBgSub: 'rgba(28,107,94,0.12)',
+  unreadBorder: 'rgba(28,107,94,0.35)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Spectral", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Spectral:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: Group; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: badge, height: badge, borderRadius: badge / 2,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: '#fff',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1,
+      borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+      overflow: 'hidden',
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 19, color: C.ink, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontFamily: F.sans, fontSize: 11,
+                color: mainChannel.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '500',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassDim,
+              borderColor: chHasUnread ? C.unreadBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                fontFamily: F.sans, flex: 1, fontSize: 12.5,
+                color: chHasUnread ? C.ink : C.subtle,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontFamily: F.sans, fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.accent : C.faint,
+                  fontWeight: chHasUnread ? '600' : '500',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design24() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingTop: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+        flexDirection: 'row', padding: 6, borderRadius: 28,
+        backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? '#fff' : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18 }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingTop: 8, paddingBottom: 16 }}>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.avatarBg }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Ionicons name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, marginBottom: 8, letterSpacing: -0.4 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${activeChannel.name}`}
+                placeholderTextColor={C.faint}
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-25.tsx
+++ b/apps/mobile/app/design-25.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// Conservatory — Lora
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  avatarBg: 'rgba(255,255,255,0.6)',
+  unreadBg: 'rgba(28,107,94,0.08)',
+  unreadBgSub: 'rgba(28,107,94,0.12)',
+  unreadBorder: 'rgba(28,107,94,0.35)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Lora", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: Group; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: badge, height: badge, borderRadius: badge / 2,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: '#fff',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1,
+      borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+      overflow: 'hidden',
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 19, color: C.ink, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontFamily: F.sans, fontSize: 11,
+                color: mainChannel.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '500',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassDim,
+              borderColor: chHasUnread ? C.unreadBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                fontFamily: F.sans, flex: 1, fontSize: 12.5,
+                color: chHasUnread ? C.ink : C.subtle,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontFamily: F.sans, fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.accent : C.faint,
+                  fontWeight: chHasUnread ? '600' : '500',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design25() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingTop: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+        flexDirection: 'row', padding: 6, borderRadius: 28,
+        backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? '#fff' : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18 }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingTop: 8, paddingBottom: 16 }}>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.avatarBg }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Ionicons name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, marginBottom: 8, letterSpacing: -0.4 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${activeChannel.name}`}
+                placeholderTextColor={C.faint}
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-26.tsx
+++ b/apps/mobile/app/design-26.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// Conservatory — EB Garamond
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  avatarBg: 'rgba(255,255,255,0.6)',
+  unreadBg: 'rgba(28,107,94,0.08)',
+  unreadBgSub: 'rgba(28,107,94,0.12)',
+  unreadBorder: 'rgba(28,107,94,0.35)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"EB Garamond", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: Group; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: badge, height: badge, borderRadius: badge / 2,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: '#fff',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1,
+      borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+      overflow: 'hidden',
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 19, color: C.ink, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontFamily: F.sans, fontSize: 11,
+                color: mainChannel.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '500',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassDim,
+              borderColor: chHasUnread ? C.unreadBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                fontFamily: F.sans, flex: 1, fontSize: 12.5,
+                color: chHasUnread ? C.ink : C.subtle,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontFamily: F.sans, fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.accent : C.faint,
+                  fontWeight: chHasUnread ? '600' : '500',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design26() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingTop: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+        flexDirection: 'row', padding: 6, borderRadius: 28,
+        backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? '#fff' : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18 }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingTop: 8, paddingBottom: 16 }}>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.avatarBg }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Ionicons name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, marginBottom: 8, letterSpacing: -0.4 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${activeChannel.name}`}
+                placeholderTextColor={C.faint}
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-27.tsx
+++ b/apps/mobile/app/design-27.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// Conservatory — Bodoni Moda
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  avatarBg: 'rgba(255,255,255,0.6)',
+  unreadBg: 'rgba(28,107,94,0.08)',
+  unreadBgSub: 'rgba(28,107,94,0.12)',
+  unreadBorder: 'rgba(28,107,94,0.35)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Bodoni Moda", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Bodoni+Moda:ital,opsz,wght@0,6..96,400;0,6..96,500;0,6..96,600;0,6..96,700;1,6..96,400;1,6..96,500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: Group; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: badge, height: badge, borderRadius: badge / 2,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: '#fff',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1,
+      borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+      overflow: 'hidden',
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 19, color: C.ink, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontFamily: F.sans, fontSize: 11,
+                color: mainChannel.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '500',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassDim,
+              borderColor: chHasUnread ? C.unreadBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                fontFamily: F.sans, flex: 1, fontSize: 12.5,
+                color: chHasUnread ? C.ink : C.subtle,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontFamily: F.sans, fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.accent : C.faint,
+                  fontWeight: chHasUnread ? '600' : '500',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design27() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingTop: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+        flexDirection: 'row', padding: 6, borderRadius: 28,
+        backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? '#fff' : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18 }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingTop: 8, paddingBottom: 16 }}>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.avatarBg }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Ionicons name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, marginBottom: 8, letterSpacing: -0.4 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${activeChannel.name}`}
+                placeholderTextColor={C.faint}
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-28.tsx
+++ b/apps/mobile/app/design-28.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// Conservatory — Literata
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  avatarBg: 'rgba(255,255,255,0.6)',
+  unreadBg: 'rgba(28,107,94,0.08)',
+  unreadBgSub: 'rgba(28,107,94,0.12)',
+  unreadBorder: 'rgba(28,107,94,0.35)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Literata", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;0,7..72,700;1,7..72,400;1,7..72,500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: Group; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: badge, height: badge, borderRadius: badge / 2,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: '#fff',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1,
+      borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+      overflow: 'hidden',
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 19, color: C.ink, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontFamily: F.sans, fontSize: 11,
+                color: mainChannel.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '500',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassDim,
+              borderColor: chHasUnread ? C.unreadBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                fontFamily: F.sans, flex: 1, fontSize: 12.5,
+                color: chHasUnread ? C.ink : C.subtle,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontFamily: F.sans, fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.accent : C.faint,
+                  fontWeight: chHasUnread ? '600' : '500',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design28() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingTop: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+        flexDirection: 'row', padding: 6, borderRadius: 28,
+        backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? '#fff' : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18 }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingTop: 8, paddingBottom: 16 }}>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.avatarBg }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Ionicons name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, marginBottom: 8, letterSpacing: -0.4 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${activeChannel.name}`}
+                placeholderTextColor={C.faint}
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-29.tsx
+++ b/apps/mobile/app/design-29.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// Conservatory — Newsreader
+const C = {
+  base: '#E4E8DE',
+  tint1: '#F3E9D2',
+  tint2: '#D0DAE4',
+  tint3: '#E9D5D9',
+  glass: 'rgba(255,255,255,0.55)',
+  glassHi: 'rgba(255,255,255,0.78)',
+  glassDim: 'rgba(255,255,255,0.32)',
+  ink: '#1B2620',
+  subtle: '#4C5A51',
+  faint: '#8A9489',
+  rule: 'rgba(27,38,32,0.10)',
+  ruleSoft: 'rgba(27,38,32,0.05)',
+  accent: '#1C6B5E',
+  accentInk: '#0F443B',
+  accentSoft: 'rgba(28,107,94,0.14)',
+  avatarBg: 'rgba(255,255,255,0.6)',
+  unreadBg: 'rgba(28,107,94,0.08)',
+  unreadBgSub: 'rgba(28,107,94,0.12)',
+  unreadBorder: 'rgba(28,107,94,0.35)',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+  serif: '"Newsreader", Georgia, serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400;1,6..72,500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute' as any, inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute' as any, width: 520, height: 520, borderRadius: 260, backgroundColor: C.tint1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute' as any, width: 640, height: 640, borderRadius: 320, backgroundColor: C.tint2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute' as any, width: 380, height: 380, borderRadius: 190, backgroundColor: C.tint3, top: '35%' as any, left: '40%' as any, opacity: 0.5 }} />
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: Group; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: badge, height: badge, borderRadius: badge / 2,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: '#fff',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{
+      marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+      backgroundColor: active ? C.glassHi : (hasUnread ? C.unreadBg : C.glassDim),
+      borderWidth: 1,
+      borderColor: active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+      overflow: 'hidden',
+    }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 19, color: C.ink, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontFamily: F.sans, fontSize: 11,
+                color: mainChannel.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '500',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.accent,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.rule }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.rule }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 14, marginBottom: 10, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.glassDim,
+              borderColor: chHasUnread ? C.unreadBorder : C.ruleSoft,
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                fontFamily: F.sans, flex: 1, fontSize: 12.5,
+                color: chHasUnread ? C.ink : C.subtle,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontFamily: F.sans, fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.accent : C.faint,
+                  fontWeight: chHasUnread ? '600' : '500',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.accent,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design29() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingTop: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 18, left: 14, right: 14,
+        flexDirection: 'row', padding: 6, borderRadius: 28,
+        backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 22, backgroundColor: t.active ? C.accent : 'transparent', gap: 3 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? '#fff' : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? '#fff' : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.base }}>
+      <Backdrop />
+      <View style={{ flex: 1, flexDirection: 'row', padding: 20, gap: 18 }}>
+        <View style={{ width: 92, paddingTop: 12, alignItems: 'center', gap: 10 }}>
+          <View style={{ width: 46, height: 46, borderRadius: 23, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 24, color: '#fff' }}>t</Text>
+          </View>
+          {tabs.map((t, i) => (
+            <Pressable key={i} style={{
+              width: 76, paddingVertical: 14, alignItems: 'center', gap: 5, borderRadius: 20,
+              backgroundColor: t.active ? C.glassHi : C.glassDim,
+              borderWidth: 1, borderColor: t.active ? 'rgba(255,255,255,0.9)' : C.ruleSoft,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accentInk : C.subtle} />
+              <Text style={{ fontFamily: F.sans, fontSize: 10.5, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={{ width: 400, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+            <Text style={{ fontFamily: F.serif, fontSize: 28, fontWeight: '700', color: C.ink, letterSpacing: -0.5 }}>Inbox</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ paddingTop: 8, paddingBottom: 16 }}>
+            {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+          </ScrollView>
+        </View>
+
+        <View style={{ flex: 1, backgroundColor: C.glass, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 32, overflow: 'hidden' }}>
+          <View style={{ padding: 20, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <Image source={{ uri: activeGroup.image }} style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: C.avatarBg }} />
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, letterSpacing: -0.4 }}>{activeGroup.name}</Text>
+                <TypeBadge label={activeGroup.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={18} color={C.subtle} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.ruleSoft, alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+                <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null as any, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)' }}>
+                  <Ionicons name={s.i} size={13} color={C.accentInk} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                  {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, marginBottom: 8, letterSpacing: -0.4 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.ruleSoft, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.subtle} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: C.glassHi, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)', borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${activeChannel.name}`}
+                placeholderTextColor={C.faint}
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="arrow-up" size={18} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-3.tsx
+++ b/apps/mobile/app/design-3.tsx
@@ -1,0 +1,357 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Potluck Board" — cork bulletin collage · responsive
+const C = {
+  cork: '#B78450',
+  corkDark: '#8E5F33',
+  polaroid: '#FBF8F1',
+  ink: '#2A241C',
+  red: '#D64640',
+  yellow: '#F5C64A',
+  green: '#7FA661',
+  blue: '#4E7AA6',
+  purple: '#B978D6',
+  muted: '#7a6b52',
+  unreadBg: 'rgba(214,70,64,0.10)',
+  unreadBgSub: 'rgba(214,70,64,0.14)',
+  unreadBorder: 'rgba(214,70,64,0.32)',
+};
+
+const F = {
+  hand: '"Caveat", cursive',
+  hand2: '"Kalam", cursive',
+  serif: '"Merriweather", Georgia, serif',
+  sans: '"Work Sans", system-ui, sans-serif',
+};
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(78,122,166,0.15)', color: C.blue },
+  Teams: { bg: 'rgba(245,198,74,0.22)', color: '#9A7418' },
+  Classes: { bg: 'rgba(185,120,214,0.18)', color: C.purple },
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Caveat:wght@500;700&family=Kalam:wght@400;700&family=Merriweather:wght@400;700;900&family=Work+Sans:wght@400;500;600;700&display=swap';
+    document.head.appendChild(link);
+    const style = document.createElement('style');
+    style.textContent = `
+      .corkbg {
+        background-color: ${C.cork};
+        background-image:
+          radial-gradient(circle at 20% 30%, rgba(255,255,255,0.06) 0, transparent 2px),
+          radial-gradient(circle at 70% 80%, rgba(0,0,0,0.08) 0, transparent 2px),
+          radial-gradient(circle at 40% 70%, rgba(255,255,255,0.05) 0, transparent 1.5px),
+          radial-gradient(circle at 90% 20%, rgba(0,0,0,0.07) 0, transparent 2px);
+        background-size: 8px 8px, 11px 11px, 5px 5px, 13px 13px;
+      }
+    `;
+    document.head.appendChild(style);
+    return () => { document.head.removeChild(link); document.head.removeChild(style); };
+  }, []);
+}
+
+type Channel = { _id: string; slug: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+// Polaroid-framed avatar
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View style={{
+        backgroundColor: C.polaroid, padding: 4, paddingBottom: 10,
+        transform: [{ rotate: '-2deg' }] as any,
+        // @ts-expect-error - RN web style
+        boxShadow: '0 2px 6px rgba(0,0,0,0.25)',
+      }}>
+        <Image source={{ uri: g.image }} style={{ width: 48, height: 48 }} />
+      </View>
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: -2, right: -2, width: 20, height: 20, borderRadius: 10, backgroundColor: C.red, borderWidth: 2, borderColor: C.polaroid, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: 'rgba(42,36,28,0.1)', color: C.ink };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 999, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 10, fontWeight: '700', color: s.color, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const total = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const multi = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = total > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? 'rgba(251,248,241,0.4)' : 'transparent' }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12, marginHorizontal: 8, marginVertical: 4,
+        backgroundColor: hasUnread ? C.unreadBg : 'rgba(251,248,241,0.08)',
+        borderRadius: 6,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, paddingLeft: 4 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.hand, fontSize: 24, fontWeight: '700', color: C.polaroid, flex: 1, marginRight: 8, lineHeight: 26 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.hand2, fontSize: 14, flex: 1, marginRight: 8,
+              color: (multi ? hasUnread : main.unreadCount > 0) ? '#FFF6D8' : 'rgba(251,248,241,0.75)',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.hand2, fontSize: 12,
+                color: main.unreadCount > 0 ? C.yellow : 'rgba(251,248,241,0.6)',
+                fontWeight: main.unreadCount > 0 ? '700' : '400',
+              }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {total > 0 && (
+          <View style={{
+            minWidth: 24, height: 24, borderRadius: 12, backgroundColor: C.red,
+            alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 10,
+            transform: [{ rotate: '-6deg' }] as any, borderWidth: 2, borderColor: C.polaroid,
+          }}>
+            <Text style={{ fontFamily: F.sans, color: 'white', fontSize: 11, fontWeight: '700' }}>{total > 99 ? '99+' : total}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const cur = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: 'rgba(251,248,241,0.4)' }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: 'rgba(251,248,241,0.4)' }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: cur ? C.unreadBgSub : 'rgba(251,248,241,0.12)',
+              borderColor: cur ? C.unreadBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.hand, fontSize: 18, color: C.polaroid, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.hand2, fontSize: 13, color: cur ? '#FFF6D8' : 'rgba(251,248,241,0.7)' }}>{preview(ch)}</Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.hand2, fontSize: 11, marginLeft: 8, color: cur ? C.yellow : 'rgba(251,248,241,0.55)', fontWeight: cur ? '700' : '400' }}>{ch.lastWhen}</Text>
+              )}
+              {cur && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.red, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: 'white', fontSize: 10, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design3() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <DesktopView /> : <MobileView />;
+}
+
+function MobileView() {
+  return (
+    <View
+      // @ts-expect-error - RN web style
+      className="corkbg"
+      style={{ flex: 1 }}
+    >
+      <View style={{ paddingHorizontal: 18, paddingTop: 56, paddingBottom: 16 }}>
+        <Text style={{ fontFamily: F.hand, fontSize: 38, color: C.polaroid, fontWeight: '700', letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        flexDirection: 'row', paddingVertical: 10, paddingBottom: 22,
+        backgroundColor: C.polaroid,
+        borderTopWidth: 1, borderTopColor: C.ink,
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.red : C.muted} />
+            <Text style={{ fontFamily: F.hand, fontSize: 14, color: t.active ? C.ink : C.muted }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function DesktopView() {
+  const g = groups[0];
+  const ch = g.channels[0];
+  return (
+    <View
+      // @ts-expect-error - RN web style
+      className="corkbg"
+      style={{ flex: 1, flexDirection: 'row' }}
+    >
+      <View style={{ width: 80, alignItems: 'center', paddingTop: 28, gap: 16 }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ alignItems: 'center', gap: 4 }}>
+            <View style={{
+              width: 52, height: 52, borderRadius: 26,
+              backgroundColor: t.active ? C.polaroid : 'rgba(255,248,225,0.2)',
+              borderWidth: 2, borderColor: C.ink, borderStyle: t.active ? 'solid' : 'dashed',
+              alignItems: 'center', justifyContent: 'center',
+              transform: [{ rotate: `${[-3, 2, -2, 3][i]}deg` }] as any,
+            }}>
+              <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.red : C.polaroid} />
+            </View>
+            <Text style={{ fontFamily: F.hand, fontSize: 14, color: t.active ? C.polaroid : '#F4E7CB' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, paddingTop: 20 }}>
+        <View style={{ paddingHorizontal: 18, paddingBottom: 12 }}>
+          <Text style={{ fontFamily: F.hand, fontSize: 38, color: C.polaroid, fontWeight: '700' }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, padding: 20 }}>
+        <View
+          // @ts-expect-error - RN web style
+          style={{
+            flex: 1, backgroundColor: C.polaroid, borderRadius: 3,
+            // @ts-expect-error - RN web style
+            boxShadow: '0 8px 18px rgba(0,0,0,0.28), 0 2px 4px rgba(0,0,0,0.22)',
+          }}
+        >
+          <View style={{ paddingHorizontal: 24, paddingVertical: 16, borderBottomWidth: 1, borderBottomColor: 'rgba(42,36,28,0.12)', flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+            <View style={{ backgroundColor: 'white', padding: 4, paddingBottom: 10, transform: [{ rotate: '-2deg' }] as any,
+              // @ts-expect-error - RN web style
+              boxShadow: '0 2px 6px rgba(0,0,0,0.2)' }}>
+              <Image source={{ uri: g.image }} style={{ width: 40, height: 40 }} />
+            </View>
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <Text style={{ fontFamily: F.hand, fontSize: 30, color: C.ink, lineHeight: 32 }}>{g.name}</Text>
+                <TypeBadge label={g.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.hand2, fontSize: 13, color: C.muted, marginTop: 2 }}>17 members · 11 online</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={20} color={C.muted} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 24, paddingTop: 14, gap: 14, borderBottomWidth: 1, borderBottomColor: 'rgba(42,36,28,0.12)', alignItems: 'center' }}>
+            {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+              <View key={i} style={{
+                paddingBottom: 10,
+                backgroundColor: t.active ? 'rgba(245,198,74,0.45)' : 'transparent',
+                paddingHorizontal: 12, paddingTop: 6,
+                transform: [{ rotate: `${t.active ? -1 : 1}deg` }] as any,
+              }}>
+                <Text style={{ fontFamily: F.hand, fontSize: 18, color: C.ink }}>{t.l}</Text>
+              </View>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const, c: C.red },
+                { l: 'People', v: '17', i: 'people-outline' as const, c: C.green },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const, c: C.blue },
+                { l: 'Bots', v: null, i: 'hardware-chip-outline' as const, c: C.purple },
+              ].map((s, i) => (
+                <View key={i} style={{
+                  flexDirection: 'row', alignItems: 'center', gap: 6,
+                  paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999,
+                  backgroundColor: 'white', borderWidth: 2, borderColor: C.ink,
+                  transform: [{ rotate: `${[-2, 1, -1, 2][i]}deg` }] as any,
+                }}>
+                  <Ionicons name={s.i} size={13} color={s.c} />
+                  <Text style={{ fontFamily: F.sans, fontSize: 10, color: s.c, fontWeight: '700', letterSpacing: 1 }}>{s.l.toUpperCase()}</Text>
+                  {s.v && <Text style={{ fontFamily: F.hand, fontSize: 16, color: C.ink }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <Ionicons name="chatbubbles-outline" size={52} color={C.red} style={{ marginBottom: 16 }} />
+            <Text style={{ fontFamily: F.hand, fontSize: 42, color: C.ink, lineHeight: 44 }}>No messages yet</Text>
+            <Text style={{ fontFamily: F.hand2, fontSize: 15, color: C.muted, marginTop: 8, textAlign: 'center' }}>Start a conversation with {g.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: 'rgba(42,36,28,0.12)', flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+            <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="add" size={22} color={C.muted} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: '#FFF6D8', borderRadius: 8, paddingHorizontal: 14, height: 40, justifyContent: 'center', borderWidth: 2, borderColor: C.ink, borderStyle: 'dashed' }}>
+              <TextInput
+                placeholder={`Message ${ch.name}`}
+                placeholderTextColor="#8B7A57"
+                style={{ fontFamily: F.hand, fontSize: 18, color: C.ink, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.green, alignItems: 'center', justifyContent: 'center', borderWidth: 2, borderColor: C.ink }}>
+              <Ionicons name="arrow-up" size={20} color="#fff" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-30.tsx
+++ b/apps/mobile/app/design-30.tsx
@@ -1,0 +1,366 @@
+import React from 'react';
+import { ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Production" — matches apps/mobile/features/chat/components/ChatInboxScreen + GroupedInboxItem
+// Uses placeholder images (picsum) for group avatars.
+
+const C = {
+  surface: '#FFFFFF',
+  surfaceSecondary: '#F2F2F7',
+  unreadBg: '#F0F7FF',
+  unreadBgSub: '#EBF3FF',
+  unreadBorder: '#D0E2FF',
+  text: '#0A0A0A',
+  textSecondary: '#6B6B6B',
+  textTertiary: '#8E8E93',
+  border: '#E5E5EA',
+  iconSecondary: '#8E8E93',
+  primary: '#2563EB',
+  link: '#2563EB',
+  avatarBg: '#E5E5E5',
+};
+
+// Mirrors getGroupTypeColorScheme() from constants/groupTypes.ts
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  slug: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: 'https://picsum.photos/seed/togather-ya/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+  {
+    _id: 'sg',
+    name: 'Small Group Alpha',
+    image: 'https://picsum.photos/seed/togather-sg/200/200',
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      { _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: 'https://picsum.photos/seed/togather-wt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ],
+  },
+  {
+    _id: 'tt',
+    name: 'Tech Team',
+    image: 'https://picsum.photos/seed/togather-tt/200/200',
+    groupTypeName: 'Teams',
+    userRole: 'member',
+    channels: [
+      { _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 },
+    ],
+  },
+  {
+    _id: 'nm',
+    name: 'New Members Class',
+    image: 'https://picsum.photos/seed/togather-nm/200/200',
+    groupTypeName: 'Classes',
+    userRole: 'leader',
+    channels: [
+      { _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 },
+    ],
+  },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0,
+          width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.primary, borderWidth: 2, borderColor: C.surface,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={12} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const scheme = TYPE_COLORS[label] || { bg: 'rgba(74,111,243,0.1)', color: C.primary };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: scheme.bg }}>
+      <Text style={{ fontSize: 11, fontWeight: '600', color: scheme.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function messagePreview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const mainChannel = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMultiChannel = g.channels.length > 1;
+  const secondaryChannels = g.channels.filter((c) => c._id !== mainChannel._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.surfaceSecondary : C.surface }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 12,
+        backgroundColor: hasUnread ? C.unreadBg : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontSize: 16, fontWeight: hasUnread ? '700' : '600', color: C.text, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontSize: 14, flex: 1, marginRight: 8,
+              color: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? C.text : C.textSecondary,
+              fontWeight: (isMultiChannel ? hasUnread : mainChannel.unreadCount > 0) ? '600' : '400',
+            }}>
+              {messagePreview(mainChannel)}
+            </Text>
+            {mainChannel.lastWhen && (
+              <Text style={{
+                fontSize: 12,
+                color: mainChannel.unreadCount > 0 ? C.link : C.textTertiary,
+                fontWeight: mainChannel.unreadCount > 0 ? '600' : '400',
+              }}>
+                {mainChannel.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            backgroundColor: C.primary,
+            alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 6, marginLeft: 8,
+          }}>
+            <Text style={{ color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondaryChannels.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.border }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.border }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: chHasUnread ? C.unreadBgSub : C.surfaceSecondary,
+              borderColor: chHasUnread ? C.unreadBorder : 'transparent',
+            }}>
+              <Text style={{ fontSize: 13, fontWeight: chHasUnread ? '700' : '600', color: C.text, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{
+                flex: 1, fontSize: 13,
+                color: chHasUnread ? C.text : C.textSecondary,
+                fontWeight: chHasUnread ? '500' : '400',
+              }}>
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{
+                  fontSize: 11, marginLeft: 8,
+                  color: chHasUnread ? C.link : C.textTertiary,
+                  fontWeight: chHasUnread ? '600' : '400',
+                }}>{ch.lastWhen}</Text>
+              )}
+              {chHasUnread && (
+                <View style={{
+                  minWidth: 20, height: 20, borderRadius: 10,
+                  backgroundColor: C.primary,
+                  alignItems: 'center', justifyContent: 'center',
+                  paddingHorizontal: 5, marginLeft: 8,
+                }}>
+                  <Text style={{ color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design30() {
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.surface }}>
+      <View style={{ paddingHorizontal: 16, paddingTop: 56, paddingBottom: 16 }}>
+        <Text style={{ fontSize: 28, fontWeight: '700', color: C.text }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: 8, paddingBottom: 90 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        position: 'absolute' as any, bottom: 0, left: 0, right: 0,
+        flexDirection: 'row', paddingVertical: 8, paddingBottom: 22,
+        backgroundColor: C.surface, borderTopWidth: 1, borderTopColor: C.border,
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 2, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={24} color={t.active ? C.primary : C.iconSecondary} />
+            <Text style={{ fontSize: 10, color: t.active ? C.primary : C.iconSecondary, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  const typeColor = TYPE_COLORS[activeGroup.groupTypeName] || { bg: 'rgba(74,111,243,0.1)', color: C.primary };
+
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.surface }}>
+      <View style={{ width: 72, borderRightWidth: 1, borderRightColor: C.border, alignItems: 'center', paddingTop: 24, gap: 4 }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 56, paddingVertical: 10, alignItems: 'center', gap: 4, borderRadius: 10 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.primary : C.iconSecondary} />
+            <Text style={{ fontSize: 10, color: t.active ? C.primary : C.iconSecondary, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: C.border }}>
+        <View style={{ paddingHorizontal: 16, paddingTop: 24, paddingBottom: 16 }}>
+          <Text style={{ fontSize: 28, fontWeight: '700', color: C.text }}>Inbox</Text>
+        </View>
+        <ScrollView contentContainerStyle={{ paddingVertical: 8 }}>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 20, paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: C.border, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.avatarBg }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontSize: 16, fontWeight: '700', color: C.text }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontSize: 13, color: C.textSecondary, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={20} color={C.iconSecondary} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 12, gap: 16, borderBottomWidth: 1, borderBottomColor: C.border }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.primary : 'transparent' }}>
+              <Text style={{ fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.text : C.textSecondary }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 12, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.surfaceSecondary }}>
+                <Ionicons name={s.i} size={13} color={C.textSecondary} />
+                <Text style={{ fontSize: 12, color: C.text, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontSize: 11, color: C.primary, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.iconSecondary} style={{ marginBottom: 16 }} />
+          <Text style={{ fontSize: 20, fontWeight: '600', color: C.text, marginBottom: 8 }}>No messages yet</Text>
+          <Text style={{ fontSize: 16, color: C.textSecondary, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 12, borderTopWidth: 1, borderTopColor: C.border, flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={24} color={C.iconSecondary} />
+          </Pressable>
+          <View style={{ flex: 1, backgroundColor: C.surfaceSecondary, borderRadius: 20, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+            <TextInput
+              placeholder={`Message ${activeChannel.name}`}
+              placeholderTextColor={C.textTertiary}
+              style={{ fontSize: 14, color: C.text, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.primary, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-4.tsx
+++ b/apps/mobile/app/design-4.tsx
@@ -1,0 +1,364 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Stoop Night" — 70s block party · responsive
+const C = {
+  cream: '#F1E4C6',
+  mustard: '#E8A82B',
+  orange: '#D86024',
+  rust: '#A93717',
+  olive: '#5B6A2D',
+  brown: '#5B3A1C',
+  ink: '#221712',
+  sky: '#C8D6D1',
+  unreadBg: 'rgba(216,96,36,0.10)',
+  unreadBgSub: 'rgba(216,96,36,0.16)',
+  unreadBorder: 'rgba(216,96,36,0.34)',
+};
+
+const F = {
+  display: '"Archivo Black", "Arial Black", sans-serif',
+  serif: '"Fraunces", Georgia, serif',
+  mono: '"DM Mono", "Courier New", monospace',
+  sans: '"DM Sans", system-ui, sans-serif',
+};
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(91,106,45,0.18)', color: C.olive },
+  Teams: { bg: 'rgba(232,168,43,0.22)', color: C.rust },
+  Classes: { bg: 'rgba(216,96,36,0.18)', color: C.orange },
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Archivo+Black&family=Fraunces:ital,wght@0,400;0,700;1,500&family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;700&display=swap';
+    document.head.appendChild(link);
+    const style = document.createElement('style');
+    style.textContent = `
+      .noise::after {
+        content: ''; position: absolute; inset: 0; pointer-events: none;
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.15'/></svg>");
+        mix-blend-mode: multiply;
+      }
+    `;
+    document.head.appendChild(style);
+    return () => { document.head.removeChild(link); document.head.removeChild(style); };
+  }, []);
+}
+
+type Channel = { _id: string; slug: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View style={{
+        width: 56, height: 56, borderRadius: 28,
+        borderWidth: 3, borderColor: C.ink, overflow: 'hidden',
+        // @ts-expect-error - RN web style
+        boxShadow: `3px 3px 0 ${C.ink}`,
+      }}>
+        <Image source={{ uri: g.image }} style={{ width: 50, height: 50, borderRadius: 25 }} />
+      </View>
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: -2, right: -2,
+          width: 22, height: 22, borderRadius: 11,
+          backgroundColor: C.orange, borderWidth: 2, borderColor: C.ink,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={11} color={C.cream} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: 'rgba(0,0,0,0.1)', color: C.ink };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 3, borderRadius: 999, backgroundColor: s.bg, borderWidth: 1, borderColor: C.ink }}>
+      <Text style={{ fontFamily: F.display, fontSize: 9, color: s.color, letterSpacing: 1.5, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const total = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const multi = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = total > 0;
+
+  return (
+    <View style={{ paddingHorizontal: 14, paddingVertical: 6 }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 14, paddingVertical: 12,
+        backgroundColor: hasUnread ? C.unreadBg : (active ? 'rgba(232,168,43,0.16)' : C.cream),
+        borderWidth: 3, borderColor: C.ink, borderRadius: 14,
+        // @ts-expect-error - RN web style
+        boxShadow: `4px 4px 0 ${C.ink}`,
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.display, fontSize: 18, color: C.ink, flex: 1, marginRight: 8, letterSpacing: -0.5 }}>
+              {g.name.toUpperCase()}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.serif, fontStyle: 'italic', fontSize: 14, flex: 1, marginRight: 8,
+              color: (multi ? hasUnread : main.unreadCount > 0) ? C.ink : C.brown,
+              fontWeight: (multi ? hasUnread : main.unreadCount > 0) ? '700' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.mono, fontSize: 10, letterSpacing: 1.5, textTransform: 'uppercase',
+                color: main.unreadCount > 0 ? C.rust : C.brown,
+                fontWeight: main.unreadCount > 0 ? '700' : '400',
+              }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {total > 0 && (
+          <View style={{
+            minWidth: 26, height: 26, borderRadius: 13, backgroundColor: C.ink,
+            alignItems: 'center', justifyContent: 'center', paddingHorizontal: 7, marginLeft: 10,
+            borderWidth: 2, borderColor: C.cream,
+          }}>
+            <Text style={{ fontFamily: F.display, color: C.mustard, fontSize: 11 }}>{total > 99 ? '99+' : total}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const cur = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', paddingLeft: 16, marginTop: 6 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.ink }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.ink }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 10, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 0, marginBottom: 4, marginTop: 4,
+              borderWidth: 2, borderColor: cur ? C.orange : C.ink,
+              backgroundColor: cur ? C.unreadBgSub : C.cream,
+              // @ts-expect-error - RN web style
+              boxShadow: `2px 2px 0 ${C.ink}`,
+            }}>
+              <Text style={{ fontFamily: F.display, fontSize: 13, color: C.ink, marginRight: 8, letterSpacing: 1 }}>{ch.name.toUpperCase()}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.serif, fontStyle: 'italic', fontSize: 13, color: cur ? C.ink : C.brown }}>{preview(ch)}</Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.mono, fontSize: 9, letterSpacing: 1, marginLeft: 8, color: cur ? C.rust : C.brown, fontWeight: cur ? '700' : '400' }}>{ch.lastWhen}</Text>
+              )}
+              {cur && (
+                <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.ink, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.display, color: C.mustard, fontSize: 10 }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design4() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <DesktopView /> : <MobileView />;
+}
+
+function MobileView() {
+  return (
+    <View
+      // @ts-expect-error - RN web style
+      className="noise"
+      style={{ flex: 1, backgroundColor: C.cream }}
+    >
+      <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 14 }}>
+        <Text style={{ fontFamily: F.display, fontSize: 28, color: C.ink, letterSpacing: -0.8 }}>INBOX.</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{
+        flexDirection: 'row', backgroundColor: C.ink,
+        paddingVertical: 10, paddingBottom: 22,
+      }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{
+            flex: 1, alignItems: 'center', gap: 3, paddingTop: 6,
+          }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.mustard : C.cream} />
+            <Text style={{ fontFamily: F.display, fontSize: 10, color: t.active ? C.mustard : C.cream, letterSpacing: 2 }}>{t.label.toUpperCase()}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function DesktopView() {
+  const g = groups[0];
+  const ch = g.channels[0];
+  return (
+    <View
+      // @ts-expect-error - RN web style
+      className="noise"
+      style={{ flex: 1, flexDirection: 'row', backgroundColor: C.cream }}
+    >
+      <View style={{ width: 88, backgroundColor: C.ink, alignItems: 'center', paddingTop: 24, gap: 10 }}>
+        <View style={{ backgroundColor: C.mustard, width: 48, height: 48, borderRadius: 24, alignItems: 'center', justifyContent: 'center', borderWidth: 3, borderColor: C.cream, marginBottom: 10 }}>
+          <Text style={{ fontFamily: F.display, color: C.ink, fontSize: 20 }}>T</Text>
+        </View>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{
+            width: 64, paddingVertical: 10, borderRadius: 12, alignItems: 'center', gap: 3,
+            backgroundColor: t.active ? C.mustard : 'transparent',
+            borderWidth: t.active ? 2 : 0, borderColor: C.cream,
+          }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.ink : C.cream} />
+            <Text style={{ fontFamily: F.display, fontSize: 8, color: t.active ? C.ink : C.cream, letterSpacing: 1.5 }}>{t.label.toUpperCase()}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400 }}>
+        <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+          <Text style={{ fontFamily: F.display, fontSize: 32, color: C.ink, letterSpacing: -1 }}>INBOX.</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1, padding: 16, paddingLeft: 8 }}>
+        <View style={{
+          flex: 1, backgroundColor: C.ink, borderRadius: 22,
+          borderWidth: 3, borderColor: C.ink,
+        }}>
+          <View style={{ padding: 20, flexDirection: 'row', alignItems: 'center', gap: 14, borderBottomWidth: 1, borderBottomColor: 'rgba(255,255,255,0.12)' }}>
+            <View style={{ width: 48, height: 48, borderRadius: 24, overflow: 'hidden', borderWidth: 3, borderColor: C.cream }}>
+              <Image source={{ uri: g.image }} style={{ width: 42, height: 42, borderRadius: 21 }} />
+            </View>
+            <View style={{ flex: 1 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <Text style={{ fontFamily: F.display, fontSize: 24, color: C.cream, letterSpacing: -0.6 }}>{g.name.toUpperCase()}</Text>
+                <TypeBadge label={g.groupTypeName} />
+              </View>
+              <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.sky, letterSpacing: 1, marginTop: 2 }}>17 MEMBERS · 11 ONLINE</Text>
+            </View>
+            <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+              <Ionicons name="ellipsis-horizontal" size={20} color={C.cream} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: 'row', paddingHorizontal: 20, paddingTop: 14, gap: 8, borderBottomWidth: 1, borderBottomColor: 'rgba(255,255,255,0.12)', alignItems: 'center' }}>
+            {[{ l: 'GENERAL', active: true }, { l: 'LEADERS' }].map((t, i) => (
+              <Pressable key={i} style={{
+                paddingHorizontal: 14, paddingVertical: 7, borderRadius: 999, marginBottom: 10,
+                backgroundColor: t.active ? C.mustard : 'transparent',
+                borderWidth: 2, borderColor: t.active ? C.mustard : 'rgba(255,255,255,0.3)',
+              }}>
+                <Text style={{ fontFamily: F.display, fontSize: 11, color: t.active ? C.ink : C.cream, letterSpacing: 1.5 }}>{t.l}</Text>
+              </Pressable>
+            ))}
+            <View style={{ flex: 1 }} />
+            <View style={{ flexDirection: 'row', gap: 8, marginBottom: 10 }}>
+              {[
+                { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+                { l: 'People', v: '17', i: 'people-outline' as const },
+                { l: 'Events', v: '3', i: 'calendar-outline' as const },
+                { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+              ].map((s, i) => (
+                <View key={i} style={{
+                  flexDirection: 'row', alignItems: 'center', gap: 6,
+                  paddingHorizontal: 10, paddingVertical: 6, borderRadius: 12,
+                  backgroundColor: C.orange, borderWidth: 2, borderColor: C.cream,
+                }}>
+                  <Ionicons name={s.i} size={12} color={C.cream} />
+                  <Text style={{ fontFamily: F.display, fontSize: 9, color: C.cream, letterSpacing: 1 }}>{s.l.toUpperCase()}</Text>
+                  {s.v && <Text style={{ fontFamily: F.mono, fontSize: 10, color: C.cream, fontWeight: '700' }}>{s.v}</Text>}
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+            <View style={{
+              width: 100, height: 100, borderRadius: 50, backgroundColor: C.mustard,
+              borderWidth: 3, borderColor: C.cream, alignItems: 'center', justifyContent: 'center',
+              // @ts-expect-error - RN web style
+              boxShadow: `4px 4px 0 rgba(0,0,0,0.4)`,
+            }}>
+              <Ionicons name="chatbubbles-outline" size={44} color={C.ink} />
+            </View>
+            <Text style={{ fontFamily: F.display, fontSize: 32, color: C.mustard, letterSpacing: -1, marginTop: 22 }}>NO MESSAGES YET</Text>
+            <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 16, color: C.cream, marginTop: 8, textAlign: 'center' }}>Start a conversation with {g.name}.</Text>
+          </ScrollView>
+
+          <View style={{ padding: 14, flexDirection: 'row', alignItems: 'center', gap: 10, borderTopWidth: 1, borderTopColor: 'rgba(255,255,255,0.12)' }}>
+            <Pressable style={{
+              width: 40, height: 40, borderRadius: 20, backgroundColor: C.mustard,
+              alignItems: 'center', justifyContent: 'center', borderWidth: 2, borderColor: C.cream,
+            }}>
+              <Ionicons name="add" size={20} color={C.ink} />
+            </Pressable>
+            <View style={{ flex: 1, backgroundColor: 'rgba(255,255,255,0.08)', borderRadius: 20, borderWidth: 2, borderColor: 'rgba(255,255,255,0.2)', paddingHorizontal: 16, height: 40, justifyContent: 'center' }}>
+              <TextInput
+                placeholder={`Message ${ch.name}`}
+                placeholderTextColor="rgba(255,255,255,0.4)"
+                style={{ fontFamily: F.sans, fontSize: 14, color: C.cream, outlineWidth: 0 as any }}
+              />
+            </View>
+            <Pressable style={{
+              width: 40, height: 40, borderRadius: 20, backgroundColor: C.orange,
+              alignItems: 'center', justifyContent: 'center', borderWidth: 2, borderColor: C.cream,
+            }}>
+              <Ionicons name="arrow-up" size={20} color={C.cream} />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-5.tsx
+++ b/apps/mobile/app/design-5.tsx
@@ -1,0 +1,355 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Campfire Circle" — dark lantern glow · responsive
+const C = {
+  night: '#0B1220',
+  deeper: '#070B14',
+  panel: '#111A2A',
+  panelLight: '#16213A',
+  amber: '#F2A65A',
+  amberDim: '#C38246',
+  ember: '#E87A47',
+  cream: '#F3E5CF',
+  muted: '#8A7A66',
+  sage: '#8AA596',
+  plum: '#B97C9E',
+  unreadBg: 'rgba(242,166,90,0.10)',
+  unreadBgSub: 'rgba(242,166,90,0.14)',
+  unreadBorder: 'rgba(242,166,90,0.38)',
+};
+
+const F = {
+  display: '"Cormorant Garamond", "Times New Roman", serif',
+  body: '"Work Sans", system-ui, sans-serif',
+};
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(138,165,150,0.16)', color: C.sage },
+  Teams: { bg: 'rgba(185,124,158,0.18)', color: C.plum },
+  Classes: { bg: 'rgba(242,166,90,0.16)', color: C.amber },
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,700;1,400;1,500&family=Work+Sans:wght@300;400;500;700&display=swap';
+    document.head.appendChild(link);
+    const style = document.createElement('style');
+    style.textContent = `
+      .campfire-bg {
+        background:
+          radial-gradient(ellipse 700px 500px at 30% 0%, rgba(242,166,90,0.10) 0%, transparent 55%),
+          radial-gradient(ellipse 900px 700px at 85% 100%, rgba(185,124,158,0.12) 0%, transparent 55%),
+          ${C.night};
+      }
+      .lantern { box-shadow: 0 0 30px rgba(242,166,90,0.35), 0 0 60px rgba(232,122,71,0.15); }
+      @keyframes flicker { 0%,100% { opacity: 1; } 50% { opacity: 0.78; } }
+      .flicker { animation: flicker 3.2s ease-in-out infinite; }
+    `;
+    document.head.appendChild(style);
+    return () => { document.head.removeChild(link); document.head.removeChild(style); };
+  }, []);
+}
+
+type Channel = { _id: string; slug: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g, lit }: { g: Group; lit: boolean }) {
+  return (
+    <View
+      // @ts-expect-error - RN web style
+      className={lit ? 'lantern flicker' : ''}
+      style={{ position: 'relative', marginRight: 12 }}
+    >
+      <Image source={{ uri: g.image }} style={{
+        width: 56, height: 56, borderRadius: 28,
+        borderWidth: 1, borderColor: lit ? C.amber : 'rgba(255,255,255,0.1)',
+        opacity: lit ? 1 : 0.55,
+      }} />
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.amber, borderWidth: 2, borderColor: C.deeper, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color={C.deeper} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: 'rgba(255,255,255,0.08)', color: C.cream };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.body, fontSize: 10, fontWeight: '700', color: s.color, letterSpacing: 1.5, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const total = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const multi = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = total > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.panel : 'transparent' }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.unreadBg : 'transparent',
+      }}>
+        <Avatar g={g} lit={hasUnread} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.display, fontSize: 20, color: C.cream, flex: 1, marginRight: 8, letterSpacing: -0.3, fontWeight: hasUnread ? '700' : '500' }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.display, fontStyle: 'italic', fontSize: 14, flex: 1, marginRight: 8,
+              color: (multi ? hasUnread : main.unreadCount > 0) ? C.cream : C.muted,
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.body, fontSize: 10, letterSpacing: 2, textTransform: 'uppercase',
+                color: main.unreadCount > 0 ? C.amber : C.muted,
+                fontWeight: main.unreadCount > 0 ? '700' : '400',
+              }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {total > 0 && (
+          <View
+            // @ts-expect-error - RN web style
+            className="lantern"
+            style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.amber, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 10 }}
+          >
+            <Text style={{ fontFamily: F.body, color: C.deeper, fontSize: 11, fontWeight: '700' }}>{total > 99 ? '99+' : total}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const cur = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: 'rgba(242,166,90,0.3)' }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: 'rgba(242,166,90,0.3)' }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: cur ? C.unreadBgSub : C.panel,
+              borderColor: cur ? C.unreadBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.display, fontSize: 14, color: C.cream, marginRight: 8, fontWeight: '600' }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.display, fontStyle: 'italic', fontSize: 13, color: cur ? C.cream : C.muted }}>{preview(ch)}</Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.body, fontSize: 9, letterSpacing: 2, textTransform: 'uppercase', marginLeft: 8, color: cur ? C.amber : C.muted, fontWeight: cur ? '700' : '400' }}>{ch.lastWhen}</Text>
+              )}
+              {cur && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.amber, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.body, color: C.deeper, fontSize: 10, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design5() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <DesktopView /> : <MobileView />;
+}
+
+function MobileView() {
+  return (
+    <View
+      // @ts-expect-error - RN web style
+      className="campfire-bg"
+      style={{ flex: 1 }}
+    >
+      <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 14 }}>
+        <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 32, color: C.cream, fontWeight: '700', letterSpacing: -0.5 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, backgroundColor: C.deeper, borderTopWidth: 1, borderTopColor: 'rgba(242,166,90,0.2)' }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.amber : C.muted} />
+            <Text style={{ fontFamily: F.body, fontSize: 10, letterSpacing: 2, color: t.active ? C.cream : C.muted, textTransform: 'uppercase', fontWeight: t.active ? '700' : '400' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function DesktopView() {
+  const g = groups[0];
+  const ch = g.channels[0];
+  return (
+    <View
+      // @ts-expect-error - RN web style
+      className="campfire-bg"
+      style={{ flex: 1, flexDirection: 'row' }}
+    >
+      <View style={{ width: 80, backgroundColor: C.deeper, alignItems: 'center', paddingTop: 28, gap: 8, borderRightWidth: 1, borderRightColor: 'rgba(242,166,90,0.12)' }}>
+        <View
+          // @ts-expect-error - RN web style
+          className="flicker"
+          style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.ember, alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}
+        >
+          <Text style={{ fontFamily: F.display, color: C.deeper, fontWeight: '700', fontSize: 18 }}>T</Text>
+        </View>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{
+            width: 60, paddingVertical: 10, alignItems: 'center', gap: 3, borderRadius: 10,
+            backgroundColor: t.active ? 'rgba(242,166,90,0.12)' : 'transparent',
+            borderWidth: 1, borderColor: t.active ? 'rgba(242,166,90,0.4)' : 'transparent',
+          }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.amber : C.muted} />
+            <Text style={{ fontFamily: F.body, fontSize: 9, letterSpacing: 2, color: t.active ? C.cream : C.muted, textTransform: 'uppercase' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: 'rgba(242,166,90,0.1)' }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 28, paddingBottom: 16 }}>
+          <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 32, color: C.cream, fontWeight: '700', letterSpacing: -0.5 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 24, paddingVertical: 16, borderBottomWidth: 1, borderBottomColor: 'rgba(242,166,90,0.12)', flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <View
+            // @ts-expect-error - RN web style
+            className="lantern flicker"
+            style={{ width: 44, height: 44, borderRadius: 22, borderWidth: 1, borderColor: C.amber, overflow: 'hidden' }}
+          >
+            <Image source={{ uri: g.image }} style={{ width: 44, height: 44, borderRadius: 22 }} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 24, color: C.cream, fontWeight: '700' }}>{g.name}</Text>
+              <TypeBadge label={g.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.body, fontSize: 12, color: C.amberDim, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={20} color={C.muted} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 24, paddingTop: 14, gap: 20, borderBottomWidth: 1, borderBottomColor: 'rgba(242,166,90,0.12)', alignItems: 'center' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.amber : 'transparent' }}>
+              <Text style={{ fontFamily: F.display, fontSize: 16, fontStyle: t.active ? 'normal' : 'italic', color: t.active ? C.cream : C.muted, fontWeight: t.active ? '700' : '500' }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 10, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{
+                flexDirection: 'row', alignItems: 'center', gap: 6,
+                paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14,
+                backgroundColor: C.panel, borderWidth: 1, borderColor: 'rgba(242,166,90,0.2)',
+              }}>
+                <Ionicons name={s.i} size={13} color={C.amberDim} />
+                <Text style={{ fontFamily: F.body, fontSize: 11, color: C.cream, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.body, fontSize: 11, color: C.amber, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <View
+            // @ts-expect-error - RN web style
+            className="lantern flicker"
+            style={{ width: 80, height: 80, borderRadius: 40, backgroundColor: C.ember, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: C.amber, marginBottom: 20 }}
+          >
+            <Ionicons name="chatbubbles-outline" size={36} color={C.deeper} />
+          </View>
+          <Text style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 28, color: C.cream, fontWeight: '700' }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.display, fontSize: 16, color: C.amberDim, marginTop: 8, textAlign: 'center' }}>Start a conversation with {g.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 14, flexDirection: 'row', gap: 10, alignItems: 'center', borderTopWidth: 1, borderTopColor: 'rgba(242,166,90,0.12)' }}>
+          <Pressable style={{
+            width: 40, height: 40, borderRadius: 20,
+            borderWidth: 1, borderColor: 'rgba(242,166,90,0.3)',
+            alignItems: 'center', justifyContent: 'center',
+          }}>
+            <Ionicons name="add" size={22} color={C.amber} />
+          </Pressable>
+          <View style={{
+            flex: 1, backgroundColor: C.panel, borderRadius: 20,
+            borderWidth: 1, borderColor: 'rgba(242,166,90,0.15)',
+            paddingHorizontal: 16, height: 40, justifyContent: 'center',
+          }}>
+            <TextInput
+              placeholder={`Message ${ch.name}`}
+              placeholderTextColor={C.muted}
+              style={{ fontFamily: F.display, fontStyle: 'italic', fontSize: 15, color: C.cream, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.amber, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color={C.deeper} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-6.tsx
+++ b/apps/mobile/app/design-6.tsx
@@ -1,0 +1,291 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Mail" — Apple Mail restraint · responsive
+const C = {
+  bg: '#FFFFFF',
+  surface: '#F7F7F5',
+  divider: 'rgba(0,0,0,0.08)',
+  ink: '#0A0A0A',
+  subtle: '#6B6B6B',
+  faint: '#9A9A96',
+  accent: '#C8783B',
+  accentSoft: 'rgba(200,120,59,0.08)',
+  accentSofter: 'rgba(200,120,59,0.12)',
+  unreadBorder: 'rgba(200,120,59,0.3)',
+};
+
+const F = {
+  sans: '"Geist", system-ui, -apple-system, sans-serif',
+  mono: '"Geist Mono", ui-monospace, monospace',
+};
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76,175,80,0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10,132,255,0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255,149,0,0.1)', color: '#FF9500' },
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+type Channel = { _id: string; slug: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.surface }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.bg,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.surface, color: C.subtle };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const total = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const multi = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = total > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.surface : C.bg }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 12,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.sans, fontSize: 15, fontWeight: hasUnread ? '600' : '500', color: C.ink, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 13, flex: 1, marginRight: 8,
+              color: (multi ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (multi ? hasUnread : main.unreadCount > 0) ? '500' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 12,
+                color: main.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: main.unreadCount > 0 ? '600' : '400',
+              }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {total > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '600' }}>{total > 99 ? '99+' : total}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const cur = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.divider }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.divider }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: cur ? C.accentSofter : C.surface,
+              borderColor: cur ? C.unreadBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, fontWeight: cur ? '600' : '500', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.sans, fontSize: 13, color: cur ? C.ink : C.subtle }}>{preview(ch)}</Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: cur ? C.accent : C.faint, fontWeight: cur ? '600' : '400' }}>{ch.lastWhen}</Text>
+              )}
+              {cur && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '600' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design6() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <DesktopView /> : <MobileView />;
+}
+
+function MobileView() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 14 }}>
+        <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.6 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: 4, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, borderTopWidth: 1, borderTopColor: C.divider, backgroundColor: C.bg }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.faint} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.faint, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function DesktopView() {
+  const g = groups[0];
+  const ch = g.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 72, backgroundColor: C.surface, alignItems: 'center', paddingTop: 24, gap: 4 }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{
+            width: 56, paddingVertical: 10, alignItems: 'center', gap: 4, borderRadius: 10,
+            backgroundColor: t.active ? 'rgba(0,0,0,0.06)' : 'transparent',
+          }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: C.divider, borderLeftWidth: 1, borderLeftColor: C.divider }}>
+        <View style={{ paddingHorizontal: 20, paddingTop: 26, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '700', letterSpacing: -0.6 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 24, paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: C.divider, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <Image source={{ uri: g.image }} style={{ width: 40, height: 40, borderRadius: 20 }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 16, color: C.ink, fontWeight: '600' }}>{g.name}</Text>
+              <TypeBadge label={g.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={18} color={C.faint} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 24, paddingTop: 12, gap: 18, borderBottomWidth: 1, borderBottomColor: C.divider, alignItems: 'center' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.surface }}>
+                <Ionicons name={s.i} size={13} color={C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '500' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '600' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.faint} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.sans, fontSize: 18, color: C.ink, fontWeight: '600' }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 14, color: C.subtle, marginTop: 6, textAlign: 'center' }}>Start a conversation with {g.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 14, borderTopWidth: 1, borderTopColor: C.divider, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={22} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, backgroundColor: C.surface, borderRadius: 19, paddingHorizontal: 14, height: 38, justifyContent: 'center' }}>
+            <TextInput
+              placeholder={`Message ${ch.name}`}
+              placeholderTextColor={C.faint}
+              style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-7.tsx
+++ b/apps/mobile/app/design-7.tsx
@@ -1,0 +1,291 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Notes" — Apple Notes paper restraint · serif-led
+const C = {
+  bg: '#FBF9F3',
+  paper: '#FFFDF7',
+  ink: '#1C1A17',
+  subtle: '#6E6A62',
+  faint: '#9B9790',
+  divider: 'rgba(28,26,23,0.08)',
+  accent: '#B8823C',
+  accentSoft: 'rgba(184,130,60,0.08)',
+  accentSofter: 'rgba(184,130,60,0.14)',
+  unreadBorder: 'rgba(184,130,60,0.32)',
+};
+
+const F = {
+  serif: '"Newsreader", "Charter", Georgia, serif',
+  sans: '"Geist", system-ui, sans-serif',
+};
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76,175,80,0.12)', color: '#4C7A3A' },
+  Teams: { bg: 'rgba(10,132,255,0.1)', color: '#3A6FA8' },
+  Classes: { bg: 'rgba(184,130,60,0.14)', color: C.accent },
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&family=Geist:wght@400;500;600&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+type Channel = { _id: string; slug: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', slug: 'general', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.paper, borderWidth: 1, borderColor: C.divider }} />
+      {g.userRole === 'leader' && (
+        <View style={{
+          position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10,
+          backgroundColor: C.accent, borderWidth: 2, borderColor: C.bg,
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 10, fontWeight: '600', color: s.color, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const total = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const multi = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = total > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.accentSoft : 'transparent', borderBottomWidth: 1, borderBottomColor: C.divider }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 18, paddingVertical: 14,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.serif, fontSize: 18, fontWeight: hasUnread ? '700' : '600', color: C.ink, flex: 1, marginRight: 8, letterSpacing: -0.2 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.serif, fontSize: 14, flex: 1, marginRight: 8,
+              color: (multi ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (multi ? hasUnread : main.unreadCount > 0) ? '500' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 11, letterSpacing: 0.3,
+                color: main.unreadCount > 0 ? C.accent : C.faint,
+                fontWeight: main.unreadCount > 0 ? '600' : '400',
+              }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {total > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 10 }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{total > 99 ? '99+' : total}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const cur = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', paddingLeft: 18 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.divider }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.divider }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 8, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 18, marginBottom: 8, marginTop: 4,
+              borderWidth: 1,
+              backgroundColor: cur ? C.accentSofter : C.paper,
+              borderColor: cur ? C.unreadBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 14, fontWeight: cur ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ flex: 1, fontFamily: F.serif, fontSize: 13, color: cur ? C.ink : C.subtle }}>{preview(ch)}</Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.sans, fontSize: 10, marginLeft: 8, color: cur ? C.accent : C.faint, fontWeight: cur ? '600' : '400', letterSpacing: 0.3 }}>{ch.lastWhen}</Text>
+              )}
+              {cur && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 10, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design7() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <DesktopView /> : <MobileView />;
+}
+
+function MobileView() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 22, paddingTop: 56, paddingBottom: 14 }}>
+        <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '700', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, borderTopWidth: 1, borderTopColor: C.divider, backgroundColor: C.paper }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.faint} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.faint, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function DesktopView() {
+  const g = groups[0];
+  const ch = g.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 80, paddingTop: 28, gap: 6, alignItems: 'center' }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{
+            width: 60, paddingVertical: 10, alignItems: 'center', gap: 4, borderRadius: 10,
+            backgroundColor: t.active ? C.accentSoft : 'transparent',
+          }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={20} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 400, backgroundColor: C.paper, borderLeftWidth: 1, borderLeftColor: C.divider, borderRightWidth: 1, borderRightColor: C.divider }}>
+        <View style={{ paddingHorizontal: 22, paddingTop: 30, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.serif, fontSize: 30, color: C.ink, fontWeight: '700', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 28, paddingVertical: 16, borderBottomWidth: 1, borderBottomColor: C.divider, flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <Image source={{ uri: g.image }} style={{ width: 42, height: 42, borderRadius: 21, borderWidth: 1, borderColor: C.divider }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 22, color: C.ink, fontWeight: '700', letterSpacing: -0.5 }}>{g.name}</Text>
+              <TypeBadge label={g.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={18} color={C.faint} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 28, paddingTop: 14, gap: 20, borderBottomWidth: 1, borderBottomColor: C.divider, alignItems: 'center' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.serif, fontSize: 15, color: t.active ? C.ink : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 14, backgroundColor: C.paper, borderWidth: 1, borderColor: C.divider }}>
+                <Ionicons name={s.i} size={13} color={C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '500' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '600' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.serif, fontSize: 24, color: C.ink, fontWeight: '700' }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.serif, fontStyle: 'italic', fontSize: 15, color: C.subtle, marginTop: 6, textAlign: 'center' }}>Start a conversation with {g.name}.</Text>
+        </ScrollView>
+
+        <View style={{ paddingHorizontal: 28, paddingVertical: 14, borderTopWidth: 1, borderTopColor: C.divider, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Pressable style={{ width: 36, height: 36, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={22} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, paddingHorizontal: 4, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: C.divider }}>
+            <TextInput
+              placeholder={`Message ${ch.name}`}
+              placeholderTextColor={C.faint}
+              style={{ fontFamily: F.serif, fontSize: 16, color: C.ink, outlineWidth: 0 as any }}
+            />
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-8.tsx
+++ b/apps/mobile/app/design-8.tsx
@@ -1,0 +1,317 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "iMessage" — clean white, rounded, restrained · terracotta accent
+const C = {
+  bg: '#FFFFFF',
+  surface: '#F2F2F4',
+  surfaceHi: '#ECECEE',
+  ink: '#0E0E0F',
+  subtle: '#6C6C70',
+  faint: '#AEAEB2',
+  divider: 'rgba(0,0,0,0.06)',
+  accent: '#B85C38',
+  accentSoft: 'rgba(184,92,56,0.08)',
+  accentSub: 'rgba(184,92,56,0.14)',
+  accentBorder: 'rgba(184,92,56,0.28)',
+  avatarBg: '#E5E5E5',
+};
+
+const F = {
+  sans: '"Manrope", system-ui, sans-serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const gradients = [
+  { from: '#F3B48A', to: '#B85C38' },
+  { from: '#BFD3A0', to: '#7A9554' },
+  { from: '#C9B1E4', to: '#8670B8' },
+  { from: '#A9C7E0', to: '#5A7FA3' },
+  { from: '#F0C987', to: '#B89554' },
+];
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = {
+  _id: string;
+  channelType: 'main' | 'leaders' | string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null;
+  unreadCount: number;
+};
+
+type Group = {
+  _id: string;
+  name: string;
+  image: string;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: Channel[];
+};
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g, i }: { g: Group; i: number }) {
+  const gr = gradients[i % gradients.length];
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View style={{
+        width: 56, height: 56, borderRadius: 28,
+        // @ts-expect-error - RN web style
+        backgroundImage: `linear-gradient(135deg, ${gr.from}, ${gr.to})`,
+        backgroundColor: gr.to,
+        overflow: 'hidden',
+      }}>
+        <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28 }} />
+      </View>
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, borderWidth: 2, borderColor: C.bg, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, i, active }: { g: Group; i: number; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.surface : 'transparent' }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 12,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} i={i} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.sans, fontSize: 16, fontWeight: hasUnread ? '700' : '600', color: C.ink, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 14, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>
+              {preview(main)}
+            </Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 12, color: main.unreadCount > 0 ? C.accent : C.faint, fontWeight: main.unreadCount > 0 ? '600' : '500' }}>
+                {main.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.divider }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.divider }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              backgroundColor: chUn ? C.accentSub : C.surface,
+              borderWidth: 1, borderColor: chUn ? C.accentBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, fontWeight: chUn ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.sans, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>
+                {preview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chUn ? C.accent : C.faint, fontWeight: chUn ? '600' : '500' }}>{ch.lastWhen}</Text>
+              )}
+              {chUn && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design8() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: 8, paddingBottom: 100 }}>
+        {groups.map((g, i) => <GroupRow key={g._id} g={g} i={i} />)}
+      </ScrollView>
+      <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', paddingVertical: 8, paddingBottom: 22, backgroundColor: C.bg, borderTopWidth: 1, borderTopColor: C.divider }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 2, paddingTop: 6 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={24} color={t.active ? C.accent : C.faint} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.accent : C.faint, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 72, backgroundColor: C.surface, alignItems: 'center', paddingTop: 26, gap: 6 }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 56, paddingVertical: 10, borderRadius: 14, alignItems: 'center', gap: 4, backgroundColor: t.active ? C.bg : 'transparent' }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.accent : C.subtle, fontWeight: t.active ? '600' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: C.divider }}>
+        <View style={{ paddingHorizontal: 20, paddingTop: 28, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView contentContainerStyle={{ paddingVertical: 8 }}>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} i={i} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 28, paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: C.divider, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.avatarBg }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 16, color: C.ink, fontWeight: '700' }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={20} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 28, paddingTop: 12, gap: 20, borderBottomWidth: 1, borderBottomColor: C.divider, alignItems: 'flex-end' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, backgroundColor: C.surface }}>
+                <Ionicons name={s.i} size={13} color={C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.sans, fontSize: 20, color: C.ink, fontWeight: '700', marginBottom: 8 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 15, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 16, borderTopWidth: 1, borderTopColor: C.divider, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.surface, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={22} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, borderRadius: 22, borderWidth: 1, borderColor: C.divider, paddingHorizontal: 16, height: 38, justifyContent: 'center' }}>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }} />
+          </View>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/design-9.tsx
+++ b/apps/mobile/app/design-9.tsx
@@ -1,0 +1,273 @@
+import React, { useEffect } from 'react';
+import { Platform, ScrollView, View, Text, Pressable, TextInput, useWindowDimensions, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// "Reminders" — calm off-white · coral accent
+const C = {
+  bg: '#FAFAF8',
+  surface: '#FFFFFF',
+  surfaceHi: '#F2F0EC',
+  ink: '#0B0B0A',
+  subtle: '#656561',
+  faint: '#9F9F9A',
+  divider: 'rgba(0,0,0,0.07)',
+  accent: '#C86B5A',
+  accentSoft: 'rgba(200,107,90,0.10)',
+  accentSub: 'rgba(200,107,90,0.16)',
+  accentBorder: 'rgba(200,107,90,0.30)',
+  avatarBg: '#E8E6E0',
+};
+
+const F = {
+  sans: '"Plus Jakarta Sans", system-ui, sans-serif',
+};
+
+function useWebFonts() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap';
+    document.head.appendChild(link);
+    return () => { document.head.removeChild(link); };
+  }, []);
+}
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+type Channel = { _id: string; channelType: string; name: string; lastMessagePreview: string | null; lastSender: string | null; lastWhen: string | null; unreadCount: number };
+type Group = { _id: string; name: string; image: string; groupTypeName: string; userRole: 'leader' | 'member'; channels: Channel[] };
+
+const groups: Group[] = [
+  { _id: 'ya', name: 'Young Adults', image: 'https://picsum.photos/seed/togather-ya/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'ya-m', channelType: 'main', name: 'General', lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya', lastWhen: '9m', unreadCount: 3 }] },
+  { _id: 'sg', name: 'Small Group Alpha', image: 'https://picsum.photos/seed/togather-sg/200/200', groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [{ _id: 'sg-m', channelType: 'main', name: 'General', lastMessagePreview: 'Cornbread is covered.', lastSender: 'Ruth', lastWhen: '1h', unreadCount: 0 }] },
+  { _id: 'wt', name: 'Worship Team', image: 'https://picsum.photos/seed/togather-wt/200/200', groupTypeName: 'Teams', userRole: 'leader',
+    channels: [
+      { _id: 'wt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Saturday 10am sharp.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 0 },
+      { _id: 'wt-l', channelType: 'leaders', name: 'Leaders', lastMessagePreview: 'Setlist draft attached.', lastSender: 'Ade', lastWhen: 'Yesterday', unreadCount: 1 },
+    ] },
+  { _id: 'tt', name: 'Tech Team', image: 'https://picsum.photos/seed/togather-tt/200/200', groupTypeName: 'Teams', userRole: 'member',
+    channels: [{ _id: 'tt-m', channelType: 'main', name: 'General', lastMessagePreview: 'Projector keys, vestibule.', lastSender: 'James', lastWhen: 'Tue', unreadCount: 0 }] },
+  { _id: 'nm', name: 'New Members Class', image: 'https://picsum.photos/seed/togather-nm/200/200', groupTypeName: 'Classes', userRole: 'leader',
+    channels: [{ _id: 'nm-m', channelType: 'main', name: 'General', lastMessagePreview: 'Four RSVPs for Sunday.', lastSender: 'Dorothy', lastWhen: 'Sun', unreadCount: 0 }] },
+];
+
+const tabs = [
+  { label: 'Explore', icon: 'compass-outline' as const, activeIcon: 'compass' as const },
+  { label: 'Inbox', icon: 'chatbubbles-outline' as const, activeIcon: 'chatbubbles' as const, active: true },
+  { label: 'Admin', icon: 'shield-outline' as const, activeIcon: 'shield' as const },
+  { label: 'Profile', icon: 'person-outline' as const, activeIcon: 'person' as const },
+];
+
+function Avatar({ g }: { g: Group }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <Image source={{ uri: g.image }} style={{ width: 56, height: 56, borderRadius: 28, backgroundColor: C.avatarBg }} />
+      {g.userRole === 'leader' && (
+        <View style={{ position: 'absolute', bottom: 0, right: 0, width: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, borderWidth: 2, borderColor: C.surface, alignItems: 'center', justifyContent: 'center' }}>
+          <Ionicons name="shield" size={11} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.accentSoft, color: C.accent };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.sans, fontSize: 11, fontWeight: '600', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function preview(ch: Channel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({ g, active }: { g: Group; active?: boolean }) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: active ? C.surfaceHi : 'transparent' }}>
+      <Pressable style={{
+        flexDirection: 'row', alignItems: 'center',
+        paddingHorizontal: 16, paddingVertical: 12,
+        backgroundColor: hasUnread ? C.accentSoft : 'transparent',
+      }}>
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.sans, fontSize: 16, fontWeight: hasUnread ? '700' : '600', color: C.ink, flex: 1, marginRight: 8 }}>{g.name}</Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text numberOfLines={1} style={{
+              fontFamily: F.sans, fontSize: 14, flex: 1, marginRight: 8,
+              color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.ink : C.subtle,
+              fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+            }}>{preview(main)}</Text>
+            {main.lastWhen && (
+              <Text style={{ fontFamily: F.sans, fontSize: 12, color: main.unreadCount > 0 ? C.accent : C.faint, fontWeight: main.unreadCount > 0 ? '600' : '500' }}>{main.lastWhen}</Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View style={{ minWidth: 22, height: 22, borderRadius: 11, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6, marginLeft: 8 }}>
+            <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 12, fontWeight: '700' }}>{totalUnread > 99 ? '99+' : totalUnread}</Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 16 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.divider }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.divider }} />
+            </View>
+            <Pressable style={{
+              flex: 1, flexDirection: 'row', alignItems: 'center',
+              borderRadius: 10, paddingHorizontal: 12, paddingVertical: 10,
+              marginRight: 16, marginBottom: 8, marginTop: 4,
+              backgroundColor: chUn ? C.accentSub : C.surfaceHi,
+              borderWidth: 1, borderColor: chUn ? C.accentBorder : 'transparent',
+            }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 13, fontWeight: chUn ? '700' : '600', color: C.ink, marginRight: 8 }}>{ch.name}</Text>
+              <Text numberOfLines={1} style={{ fontFamily: F.sans, flex: 1, fontSize: 13, color: chUn ? C.ink : C.subtle, fontWeight: chUn ? '500' : '400' }}>{preview(ch)}</Text>
+              {ch.lastWhen && <Text style={{ fontFamily: F.sans, fontSize: 11, marginLeft: 8, color: chUn ? C.accent : C.faint, fontWeight: chUn ? '600' : '500' }}>{ch.lastWhen}</Text>}
+              {chUn && (
+                <View style={{ minWidth: 20, height: 20, borderRadius: 10, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5, marginLeft: 8 }}>
+                  <Text style={{ fontFamily: F.sans, color: '#fff', fontSize: 11, fontWeight: '700' }}>{ch.unreadCount}</Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function Design9() {
+  useWebFonts();
+  const { width } = useWindowDimensions();
+  return width >= 960 ? <Desktop /> : <Mobile />;
+}
+
+function Mobile() {
+  return (
+    <View style={{ flex: 1, backgroundColor: C.bg }}>
+      <View style={{ paddingHorizontal: 20, paddingTop: 56, paddingBottom: 12 }}>
+        <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -0.8 }}>Inbox</Text>
+      </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: 8, paddingBottom: 100 }}>
+        {groups.map((g) => <GroupRow key={g._id} g={g} />)}
+      </ScrollView>
+      <View style={{ position: 'absolute' as any, bottom: 0, left: 0, right: 0, flexDirection: 'row', paddingVertical: 10, paddingBottom: 22, backgroundColor: C.surface, borderTopWidth: 1, borderTopColor: C.divider }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ flex: 1, alignItems: 'center', gap: 3, paddingTop: 4 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.faint} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.accent : C.faint, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function Desktop() {
+  const activeGroup = groups[0];
+  const activeChannel = activeGroup.channels[0];
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: C.bg }}>
+      <View style={{ width: 72, borderRightWidth: 1, borderRightColor: C.divider, alignItems: 'center', paddingTop: 24, gap: 4, backgroundColor: C.surface }}>
+        {tabs.map((t, i) => (
+          <Pressable key={i} style={{ width: 56, paddingVertical: 10, alignItems: 'center', gap: 4, borderRadius: 10 }}>
+            <Ionicons name={(t.active ? t.activeIcon : t.icon) as any} size={22} color={t.active ? C.accent : C.subtle} />
+            <Text style={{ fontFamily: F.sans, fontSize: 10, color: t.active ? C.accent : C.subtle, fontWeight: t.active ? '700' : '500' }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ width: 380, borderRightWidth: 1, borderRightColor: C.divider }}>
+        <View style={{ paddingHorizontal: 20, paddingTop: 28, paddingBottom: 14 }}>
+          <Text style={{ fontFamily: F.sans, fontSize: 28, color: C.ink, fontWeight: '800', letterSpacing: -0.8 }}>Inbox</Text>
+        </View>
+        <ScrollView>
+          {groups.map((g, i) => <GroupRow key={g._id} g={g} active={i === 0} />)}
+        </ScrollView>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 28, paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: C.divider, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <Image source={{ uri: activeGroup.image }} style={{ width: 40, height: 40, borderRadius: 20, backgroundColor: C.avatarBg }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 16, color: C.ink, fontWeight: '700' }}>{activeGroup.name}</Text>
+              <TypeBadge label={activeGroup.groupTypeName} />
+            </View>
+            <Text style={{ fontFamily: F.sans, fontSize: 13, color: C.subtle, marginTop: 2 }}>17 members · 11 online</Text>
+          </View>
+          <Pressable style={{ width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="ellipsis-horizontal" size={20} color={C.subtle} />
+          </Pressable>
+        </View>
+
+        <View style={{ flexDirection: 'row', paddingHorizontal: 28, paddingTop: 12, gap: 20, borderBottomWidth: 1, borderBottomColor: C.divider, alignItems: 'flex-end' }}>
+          {[{ l: 'General', active: true }, { l: 'Leaders' }].map((t, i) => (
+            <View key={i} style={{ paddingBottom: 10, borderBottomWidth: 2, borderBottomColor: t.active ? C.accent : 'transparent' }}>
+              <Text style={{ fontFamily: F.sans, fontSize: 14, fontWeight: t.active ? '700' : '500', color: t.active ? C.ink : C.subtle }}>{t.l}</Text>
+            </View>
+          ))}
+          <View style={{ flex: 1 }} />
+          <View style={{ flexDirection: 'row', gap: 8, paddingBottom: 10 }}>
+            {[
+              { l: 'Attendance', v: '23', i: 'checkmark-circle-outline' as const },
+              { l: 'People', v: '17', i: 'people-outline' as const },
+              { l: 'Events', v: '3', i: 'calendar-outline' as const },
+              { l: 'Bots', v: null, i: 'hardware-chip-outline' as const },
+            ].map((s, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, backgroundColor: C.surfaceHi }}>
+                <Ionicons name={s.i} size={13} color={C.subtle} />
+                <Text style={{ fontFamily: F.sans, fontSize: 12, color: C.ink, fontWeight: '600' }}>{s.l}</Text>
+                {s.v && <Text style={{ fontFamily: F.sans, fontSize: 11, color: C.accent, fontWeight: '700' }}>{s.v}</Text>}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', padding: 40 }}>
+          <Ionicons name="chatbubbles-outline" size={48} color={C.accent} style={{ marginBottom: 16 }} />
+          <Text style={{ fontFamily: F.sans, fontSize: 20, color: C.ink, fontWeight: '700', marginBottom: 8 }}>No messages yet</Text>
+          <Text style={{ fontFamily: F.sans, fontSize: 15, color: C.subtle, textAlign: 'center' }}>Start a conversation with {activeGroup.name}.</Text>
+        </ScrollView>
+
+        <View style={{ padding: 16, borderTopWidth: 1, borderTopColor: C.divider, flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 12, backgroundColor: C.surface, borderWidth: 1, borderColor: C.divider, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="add" size={20} color={C.subtle} />
+          </Pressable>
+          <View style={{ flex: 1, backgroundColor: C.surface, borderWidth: 1, borderColor: C.divider, borderRadius: 12, paddingHorizontal: 14, height: 40, justifyContent: 'center' }}>
+            <TextInput placeholder={`Message ${activeChannel.name}`} placeholderTextColor={C.faint} style={{ fontFamily: F.sans, fontSize: 14, color: C.ink, outlineWidth: 0 as any }} />
+          </View>
+          <Pressable style={{ width: 38, height: 38, borderRadius: 19, backgroundColor: C.accent, alignItems: 'center', justifyContent: 'center' }}>
+            <Ionicons name="arrow-up" size={20} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/components/ui/ThemedHeading.tsx
+++ b/apps/mobile/components/ui/ThemedHeading.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import type { StyleProp, TextProps, TextStyle } from 'react-native';
+import { useTheme } from '@hooks/useTheme';
+
+export type HeadingLevel = 1 | 2 | 3;
+
+interface ThemedHeadingProps extends Omit<TextProps, 'style'> {
+  level?: HeadingLevel;
+  style?: StyleProp<TextStyle>;
+  children: React.ReactNode;
+}
+
+/**
+ * Renders headings in the active theme's display font.
+ * Non-themed themes (auto/light/dark) use system fonts — behaviorally identical
+ * to a plain <Text> at the same size/weight, so adopting <ThemedHeading> is safe
+ * for any heading, even in default mode.
+ *
+ * Levels:
+ *   1 → 28/32 bold, e.g. screen titles
+ *   2 → 20/26 semibold, e.g. section titles
+ *   3 → 16/22 semibold, e.g. card titles
+ */
+export function ThemedHeading({ level = 2, style, children, ...rest }: ThemedHeadingProps) {
+  const { colors, fonts } = useTheme();
+  return (
+    <Text
+      {...rest}
+      style={[
+        styles.base,
+        styles[`level${level}`],
+        { color: colors.text, fontFamily: fonts.display },
+        style,
+      ]}
+    >
+      {children}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    includeFontPadding: false as unknown as undefined,
+  },
+  level1: {
+    fontSize: 28,
+    lineHeight: 32,
+    fontWeight: '700',
+  },
+  level2: {
+    fontSize: 20,
+    lineHeight: 26,
+    fontWeight: '600',
+  },
+  level3: {
+    fontSize: 16,
+    lineHeight: 22,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/components/ui/ThemedMono.tsx
+++ b/apps/mobile/components/ui/ThemedMono.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Text } from 'react-native';
+import type { StyleProp, TextProps, TextStyle } from 'react-native';
+import { useTheme } from '@hooks/useTheme';
+
+interface ThemedMonoProps extends Omit<TextProps, 'style'> {
+  style?: StyleProp<TextStyle>;
+  children: React.ReactNode;
+}
+
+/**
+ * Renders text in the active theme's mono font. Most themes fall back to the
+ * platform's system monospace; Console promotes JetBrains Mono.
+ */
+export function ThemedMono({ style, children, ...rest }: ThemedMonoProps) {
+  const { colors, fonts } = useTheme();
+  return (
+    <Text
+      {...rest}
+      style={[
+        { color: colors.text, fontFamily: fonts.mono },
+        style,
+      ]}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/apps/mobile/components/ui/__tests__/ThemedHeading.test.tsx
+++ b/apps/mobile/components/ui/__tests__/ThemedHeading.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { ThemedHeading } from '../ThemedHeading';
+import { ThemeContext } from '@providers/ThemeProvider';
+import {
+  hearthColors,
+  consoleColors,
+  conservatoryColors,
+  lightColors,
+} from '@/theme/colors';
+import { hearthFonts, consoleFonts, conservatoryFonts, defaultFonts } from '@/theme/fonts';
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  theme: {
+    colors: typeof lightColors;
+    fonts: typeof defaultFonts;
+    preference: 'auto' | 'light' | 'dark' | 'hearth' | 'console' | 'conservatory';
+    isDark: boolean;
+  },
+) {
+  return render(
+    <ThemeContext.Provider
+      value={{
+        colors: theme.colors,
+        fonts: theme.fonts,
+        isDark: theme.isDark,
+        colorScheme: theme.isDark ? 'dark' : 'light',
+        preference: theme.preference,
+        setPreference: () => {},
+        fontsLoading: false,
+      }}
+    >
+      {ui}
+    </ThemeContext.Provider>,
+  );
+}
+
+function findStyleFontFamily(el: any): string | undefined {
+  const s = el.props.style;
+  const arr = Array.isArray(s) ? s.flat(Infinity) : [s];
+  const match = arr.find((x) => x && typeof x === 'object' && 'fontFamily' in x);
+  return match?.fontFamily;
+}
+
+describe('ThemedHeading', () => {
+  test('uses theme display font (Hearth)', () => {
+    const { UNSAFE_getByType } = renderWithTheme(
+      <ThemedHeading>Hello</ThemedHeading>,
+      { colors: hearthColors, fonts: hearthFonts, preference: 'hearth', isDark: true },
+    );
+    expect(findStyleFontFamily(UNSAFE_getByType(Text))).toBe(hearthFonts.display);
+  });
+
+  test('uses theme display font (Console)', () => {
+    const { UNSAFE_getByType } = renderWithTheme(
+      <ThemedHeading>Hello</ThemedHeading>,
+      { colors: consoleColors, fonts: consoleFonts, preference: 'console', isDark: false },
+    );
+    expect(findStyleFontFamily(UNSAFE_getByType(Text))).toBe(consoleFonts.display);
+  });
+
+  test('uses theme display font (Conservatory)', () => {
+    const { UNSAFE_getByType } = renderWithTheme(
+      <ThemedHeading>Hello</ThemedHeading>,
+      { colors: conservatoryColors, fonts: conservatoryFonts, preference: 'conservatory', isDark: false },
+    );
+    expect(findStyleFontFamily(UNSAFE_getByType(Text))).toBe(conservatoryFonts.display);
+  });
+
+  test('falls back to system font for default themes', () => {
+    const { UNSAFE_getByType } = renderWithTheme(
+      <ThemedHeading>Hello</ThemedHeading>,
+      { colors: lightColors, fonts: defaultFonts, preference: 'light', isDark: false },
+    );
+    expect(findStyleFontFamily(UNSAFE_getByType(Text))).toBe(defaultFonts.display);
+  });
+
+  test('caller style wins over theme style', () => {
+    const { UNSAFE_getByType } = renderWithTheme(
+      <ThemedHeading style={{ color: '#ff00ff' }}>Hi</ThemedHeading>,
+      { colors: hearthColors, fonts: hearthFonts, preference: 'hearth', isDark: true },
+    );
+    const styles = (UNSAFE_getByType(Text).props.style as any[]).flat(Infinity);
+    // theme font present, caller color override present
+    expect(styles.find((s) => s?.fontFamily)?.fontFamily).toBe(hearthFonts.display);
+    expect(styles.find((s) => s?.color === '#ff00ff')).toBeTruthy();
+  });
+});

--- a/apps/mobile/features/__tests__/__snapshots__/safe-area-insets.test.tsx.snap
+++ b/apps/mobile/features/__tests__/__snapshots__/safe-area-insets.test.tsx.snap
@@ -383,13 +383,27 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
               style={
                 [
                   {
+                    "includeFontPadding": false,
+                  },
+                  {
                     "fontSize": 20,
                     "fontWeight": "600",
-                    "marginBottom": 4,
+                    "lineHeight": 26,
                   },
                   {
                     "color": "#1a1a1a",
+                    "fontFamily": "System",
                   },
+                  [
+                    {
+                      "fontSize": 20,
+                      "fontWeight": "600",
+                      "marginBottom": 4,
+                    },
+                    {
+                      "color": "#1a1a1a",
+                    },
+                  ],
                 ]
               }
             >
@@ -1342,13 +1356,27 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
               style={
                 [
                   {
+                    "includeFontPadding": false,
+                  },
+                  {
                     "fontSize": 20,
                     "fontWeight": "600",
-                    "marginBottom": 4,
+                    "lineHeight": 26,
                   },
                   {
                     "color": "#1a1a1a",
+                    "fontFamily": "System",
                   },
+                  [
+                    {
+                      "fontSize": 20,
+                      "fontWeight": "600",
+                      "marginBottom": 4,
+                    },
+                    {
+                      "color": "#1a1a1a",
+                    },
+                  ],
                 ]
               }
             >

--- a/apps/mobile/features/chat/components/ChatHeader.tsx
+++ b/apps/mobile/features/chat/components/ChatHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { AppImage } from "@components/ui";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { useTheme } from "@hooks/useTheme";
 import { getGroupTypeColorScheme } from "../../../constants/groupTypes";
 import { useIsDesktopWeb } from "../../../hooks/useIsDesktopWeb";
@@ -63,9 +64,9 @@ export const ChatHeader = memo(function ChatHeader({
 
       {/* Group Info */}
       <View style={styles.headerInfo}>
-        <Text style={[styles.groupName, { color: themeColors.text }]} numberOfLines={1}>
+        <ThemedHeading level={3} style={[styles.groupName, { color: themeColors.text }]} numberOfLines={1}>
           {displayName}
-        </Text>
+        </ThemedHeading>
         {displayType && (
           <View style={[styles.headerBadge, { backgroundColor: badgeColors.bg }]}>
             <Text style={[styles.headerBadgeText, { color: badgeColors.text }]}>

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -26,6 +26,8 @@ import { useTheme } from "@hooks/useTheme";
 import { GroupedInboxItem } from "./GroupedInboxItem";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
+import { toDesignGroups } from "../utils/inboxDesignAdapter";
+import { HearthInbox, ConsoleInbox, ConservatoryInbox } from "./inbox-designs";
 
 // Type for the grouped inbox data from getInboxChannels query
 type InboxGroup = {
@@ -69,7 +71,8 @@ export function ChatInboxScreen({
   const { user, community } = useAuth();
   const token = useStoredAuthToken();
   const { primaryColor } = useCommunityTheme();
-  const { colors } = useTheme();
+  const { colors, preference } = useTheme();
+  const isDesignTheme = preference === 'hearth' || preference === 'console' || preference === 'conservatory';
   const hasCommunity = !!community?.id;
   const { isGroupExpanded, toggleGroupExpanded } = useExpandedGroups();
   const { getInboxChannels, setInboxChannels } = useInboxCache();
@@ -203,7 +206,10 @@ export function ChatInboxScreen({
 
   const showLoadingSpinner = isLoading && !isStale;
 
-  if (showLoadingSpinner) {
+  // For default themes, render the production loading + empty states. Design themes
+  // pass `loading` / `items: []` into the design component so they can render their
+  // own native-language equivalents below.
+  if (showLoadingSpinner && !isDesignTheme) {
     return (
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
@@ -219,7 +225,7 @@ export function ChatInboxScreen({
     );
   }
 
-  if (!displayChannels || displayChannels.length === 0) {
+  if ((!displayChannels || displayChannels.length === 0) && !isDesignTheme) {
     return (
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
@@ -239,6 +245,62 @@ export function ChatInboxScreen({
             </Text>
           </ScrollView>
         </View>
+      </Wrapper>
+    );
+  }
+
+  if (isDesignTheme) {
+    const items = toDesignGroups(displayChannels);
+    const handleGroupPress = (groupId: string) => {
+      const entry = displayChannels?.find((g) => String(g.group._id) === groupId);
+      if (!entry) return;
+      const main = entry.channels.find((c) => c.channelType === 'main') ?? entry.channels[0];
+      if (!main) return;
+      router.push({
+        pathname: `/inbox/${entry.group._id}/${main.slug}` as any,
+        params: {
+          groupName: entry.group.name,
+          groupType: entry.group.groupTypeName || '',
+          groupTypeId: entry.group.groupTypeId,
+          imageUrl: entry.group.preview || '',
+          isLeader: entry.userRole === 'leader' ? '1' : '0',
+          isAnnouncementGroup: entry.group.isAnnouncementGroup ? '1' : '0',
+          channelId: main._id,
+        },
+      });
+    };
+    const handleChannelPress = (groupId: string, channelSlug: string) => {
+      const entry = displayChannels?.find((g) => String(g.group._id) === groupId);
+      if (!entry) return;
+      const ch = entry.channels.find((c) => c.slug === channelSlug);
+      if (!ch) return;
+      router.push({
+        pathname: `/inbox/${entry.group._id}/${ch.slug}` as any,
+        params: {
+          groupName: entry.group.name,
+          groupType: entry.group.groupTypeName || '',
+          groupTypeId: entry.group.groupTypeId,
+          imageUrl: entry.group.preview || '',
+          isLeader: entry.userRole === 'leader' ? '1' : '0',
+          isAnnouncementGroup: entry.group.isAnnouncementGroup ? '1' : '0',
+          channelId: ch._id,
+        },
+      });
+    };
+    const designProps = {
+      items,
+      loading: showLoadingSpinner,
+      sidebarMode,
+      activeGroupId: sidebarMode ? activeGroupId : undefined,
+      activeChannelSlug: sidebarMode ? activeChannelSlug : undefined,
+      onGroupPress: handleGroupPress,
+      onChannelPress: handleChannelPress,
+    };
+    return (
+      <Wrapper>
+        {preference === 'hearth' && <HearthInbox {...designProps} />}
+        {preference === 'console' && <ConsoleInbox {...designProps} />}
+        {preference === 'conservatory' && <ConservatoryInbox {...designProps} />}
       </Wrapper>
     );
   }

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -23,6 +23,7 @@ import { useQuery, api, useStoredAuthToken } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { GroupedInboxItem } from "./GroupedInboxItem";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
@@ -171,7 +172,7 @@ export function ChatInboxScreen({
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
           <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+            <ThemedHeading level={1} style={[styles.headerTitle, { color: colors.text }]}>Inbox</ThemedHeading>
           </View>
           <View style={styles.centered}>
             <Ionicons
@@ -214,7 +215,7 @@ export function ChatInboxScreen({
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
           <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+            <ThemedHeading level={1} style={[styles.headerTitle, { color: colors.text }]}>Inbox</ThemedHeading>
           </View>
           <View style={styles.centered}>
             <ActivityIndicator size="large" color={primaryColor} />
@@ -230,7 +231,7 @@ export function ChatInboxScreen({
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
           <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+            <ThemedHeading level={1} style={[styles.headerTitle, { color: colors.text }]}>Inbox</ThemedHeading>
           </View>
           <ScrollView contentContainerStyle={styles.centeredScrollContent}>
             <Ionicons
@@ -309,7 +310,7 @@ export function ChatInboxScreen({
     <Wrapper>
       <View style={[styles.container, { backgroundColor: colors.surface }]}>
         <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-          <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+          <ThemedHeading level={1} style={[styles.headerTitle, { color: colors.text }]}>Inbox</ThemedHeading>
         </View>
         <FlatList
           data={displayChannels}

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -27,6 +27,7 @@ import { useTheme } from "@hooks/useTheme";
 import { getGroupTypeColorScheme } from "../../../constants/groupTypes";
 import type { Id } from "@services/api/convex";
 import { useAwaitPrefetch, useTriggerPrefetch } from "../hooks/usePrefetchChannel";
+import { formatInboxTime } from "../utils/formatInboxTime";
 
 // Type for channel data from getInboxChannels query
 interface ChannelData {
@@ -73,34 +74,7 @@ function getBadgeColors(typeId: string): { bg: string; text: string } {
   return { bg: scheme.bg, text: scheme.color };
 }
 
-// Format relative time (e.g., "2h", "Yesterday", "Jan 15")
-function formatRelativeTime(timestamp: number): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diff = now.getTime() - date.getTime();
-  const minutes = Math.floor(diff / (1000 * 60));
-  const hours = Math.floor(diff / (1000 * 60 * 60));
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-
-  if (minutes < 1) return "now";
-  if (minutes < 60) return `${minutes}m`;
-  if (hours < 24) return `${hours}h`;
-  if (days === 1) return "Yesterday";
-  if (days < 7) return `${days}d`;
-
-  const months = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-  ];
-  const month = months[date.getMonth()];
-  const day = date.getDate();
-
-  if (date.getFullYear() !== now.getFullYear()) {
-    return `${month} ${day}, ${date.getFullYear()}`;
-  }
-
-  return `${month} ${day}`;
-}
+const formatRelativeTime = (timestamp: number) => formatInboxTime(timestamp);
 
 function GroupedInboxItemInner({
   group,

--- a/apps/mobile/features/chat/components/inbox-designs/ConservatoryInbox.tsx
+++ b/apps/mobile/features/chat/components/inbox-designs/ConservatoryInbox.tsx
@@ -1,0 +1,302 @@
+/**
+ * ConservatoryInbox — production inbox rendered in the Conservatory design.
+ * Extracted from app/design-28.tsx. Consumes DesignGroup[] via inboxDesignAdapter.
+ *
+ * Identity: pastel base + frosted-glass cards + Literata serif + teal accent +
+ * decorative pastel circles in the background.
+ */
+import React from 'react';
+import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { AppImage } from '@components/ui';
+import { conservatoryColors as C } from '@/theme/palettes/conservatoryColors';
+import { conservatoryFonts as F } from '@/theme/fonts';
+import type { DesignChannel, DesignGroup } from '../../utils/inboxDesignAdapter';
+import type { InboxDesignProps } from './types';
+
+const TINT_1 = '#F3E9D2';
+const TINT_2 = '#D0DAE4';
+const TINT_3 = '#E9D5D9';
+const GLASS_HI = 'rgba(255,255,255,0.78)';
+const GLASS_DIM = 'rgba(255,255,255,0.32)';
+const UNREAD_BG = 'rgba(28,107,94,0.08)';
+const UNREAD_BG_SUB = 'rgba(28,107,94,0.12)';
+const UNREAD_BORDER = 'rgba(28,107,94,0.35)';
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(76, 175, 80, 0.1)', color: '#4CAF50' },
+  Teams: { bg: 'rgba(10, 132, 255, 0.1)', color: '#0A84FF' },
+  Classes: { bg: 'rgba(255, 149, 0, 0.1)', color: '#FF9500' },
+};
+
+function Backdrop() {
+  return (
+    <View pointerEvents="none" style={{ position: 'absolute', inset: 0, overflow: 'hidden' } as any}>
+      <View style={{ position: 'absolute', width: 520, height: 520, borderRadius: 260, backgroundColor: TINT_1, top: -120, left: -140, opacity: 0.75 }} />
+      <View style={{ position: 'absolute', width: 640, height: 640, borderRadius: 320, backgroundColor: TINT_2, bottom: -220, right: -200, opacity: 0.85 }} />
+      <View style={{ position: 'absolute', width: 380, height: 380, borderRadius: 190, backgroundColor: TINT_3, top: '35%', left: '40%', opacity: 0.5 } as any} />
+    </View>
+  );
+}
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.selectedBackground, color: C.link };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.body, fontSize: 11, fontWeight: '600', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function Avatar({ g, size = 56 }: { g: DesignGroup; size?: number }) {
+  const badge = Math.round(size * 0.36);
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View style={{ width: size, height: size, borderRadius: size / 2, overflow: 'hidden', backgroundColor: 'rgba(255,255,255,0.6)' }}>
+        <AppImage
+          source={g.image}
+          style={{ width: size, height: size, borderRadius: size / 2 }}
+          optimizedWidth={120}
+          placeholder={{ type: 'initials', name: g.name, backgroundColor: 'rgba(255,255,255,0.6)' }}
+        />
+      </View>
+      {g.userRole === 'leader' && (
+        <View
+          style={{
+            position: 'absolute', bottom: 0, right: 0,
+            width: badge, height: badge, borderRadius: badge / 2,
+            backgroundColor: C.link, borderWidth: 2, borderColor: '#fff',
+            alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          <Ionicons name="shield" size={Math.round(badge * 0.6)} color="#fff" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function preview(ch: DesignChannel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({
+  g,
+  isActive,
+  activeChannelSlug,
+  onGroupPress,
+  onChannelPress,
+}: {
+  g: DesignGroup;
+  isActive: boolean;
+  activeChannelSlug?: string;
+  onGroupPress: (groupId: string) => void;
+  onChannelPress: (groupId: string, channelSlug: string) => void;
+}) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View
+      style={{
+        marginHorizontal: 12, marginBottom: 8, borderRadius: 20,
+        backgroundColor: isActive ? GLASS_HI : hasUnread ? UNREAD_BG : GLASS_DIM,
+        borderWidth: 1,
+        borderColor: isActive ? 'rgba(255,255,255,0.9)' : C.borderLight,
+        overflow: 'hidden',
+      }}
+    >
+      <Pressable
+        onPress={() => onGroupPress(g._id)}
+        style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 14, paddingVertical: 12 }}
+      >
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.display, fontSize: 19, color: C.text, letterSpacing: -0.3, flex: 1, marginRight: 8 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text
+              numberOfLines={1}
+              style={{
+                fontFamily: F.body, fontSize: 13, flex: 1, marginRight: 8,
+                color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.text : C.textSecondary,
+                fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+              }}
+            >
+              {preview(main)}
+            </Text>
+            {main.lastWhen && (
+              <Text
+                style={{
+                  fontFamily: F.body, fontSize: 11,
+                  color: main.unreadCount > 0 ? C.link : C.textTertiary,
+                  fontWeight: main.unreadCount > 0 ? '600' : '500',
+                }}
+              >
+                {main.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View
+            style={{
+              minWidth: 22, height: 22, borderRadius: 11,
+              backgroundColor: C.link, alignItems: 'center', justifyContent: 'center',
+              paddingHorizontal: 6, marginLeft: 8,
+            }}
+          >
+            <Text style={{ fontFamily: F.body, color: '#fff', fontSize: 12, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        const channelActive = activeChannelSlug === ch.slug && isActive;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 14 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.border }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.border }} />
+            </View>
+            <Pressable
+              onPress={() => onChannelPress(g._id, ch.slug)}
+              style={{
+                flex: 1, flexDirection: 'row', alignItems: 'center',
+                borderRadius: 14, paddingHorizontal: 12, paddingVertical: 10,
+                marginRight: 14, marginBottom: 10, marginTop: 4,
+                borderWidth: 1,
+                backgroundColor: channelActive ? GLASS_HI : chHasUnread ? UNREAD_BG_SUB : GLASS_DIM,
+                borderColor: chHasUnread ? UNREAD_BORDER : C.borderLight,
+              }}
+            >
+              <Text style={{ fontFamily: F.body, fontSize: 12.5, fontWeight: chHasUnread ? '700' : '600', color: C.text, marginRight: 8 }}>
+                {ch.name}
+              </Text>
+              <Text
+                numberOfLines={1}
+                style={{
+                  fontFamily: F.body, flex: 1, fontSize: 12.5,
+                  color: chHasUnread ? C.text : C.textSecondary,
+                  fontWeight: chHasUnread ? '500' : '400',
+                }}
+              >
+                {preview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text
+                  style={{
+                    fontFamily: F.body, fontSize: 11, marginLeft: 8,
+                    color: chHasUnread ? C.link : C.textTertiary,
+                    fontWeight: chHasUnread ? '600' : '500',
+                  }}
+                >
+                  {ch.lastWhen}
+                </Text>
+              )}
+              {chHasUnread && (
+                <View
+                  style={{
+                    minWidth: 20, height: 20, borderRadius: 10,
+                    backgroundColor: C.link, alignItems: 'center', justifyContent: 'center',
+                    paddingHorizontal: 5, marginLeft: 8,
+                  }}
+                >
+                  <Text style={{ fontFamily: F.body, color: '#fff', fontSize: 11, fontWeight: '700' }}>
+                    {ch.unreadCount}
+                  </Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function LoadingState() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+      <ActivityIndicator size="small" color={C.link} />
+    </View>
+  );
+}
+
+function EmptyState() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+      <View
+        style={{
+          width: 96, height: 96, borderRadius: 48,
+          backgroundColor: GLASS_HI, borderWidth: 1, borderColor: 'rgba(255,255,255,0.9)',
+          alignItems: 'center', justifyContent: 'center', marginBottom: 16,
+        }}
+      >
+        <Ionicons name="leaf-outline" size={36} color={C.link} />
+      </View>
+      <Text style={{ fontFamily: F.display, fontSize: 22, color: C.text, fontWeight: '700', marginBottom: 6, letterSpacing: -0.4 }}>
+        Quiet here
+      </Text>
+      <Text style={{ fontFamily: F.body, fontSize: 13, color: C.textSecondary, textAlign: 'center' }}>
+        Join a group to begin a conversation.
+      </Text>
+    </View>
+  );
+}
+
+export function ConservatoryInbox({
+  items,
+  loading,
+  sidebarMode,
+  activeGroupId,
+  activeChannelSlug,
+  onGroupPress,
+  onChannelPress,
+}: InboxDesignProps) {
+  const content = loading
+    ? <LoadingState />
+    : items.length === 0
+    ? <EmptyState />
+    : items.map((g) => (
+        <GroupRow
+          key={g._id}
+          g={g}
+          isActive={activeGroupId === g._id}
+          activeChannelSlug={activeChannelSlug}
+          onGroupPress={onGroupPress}
+          onChannelPress={onChannelPress}
+        />
+      ));
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.background }}>
+      <Backdrop />
+      {!sidebarMode && (
+        <View style={{ paddingHorizontal: 20, paddingTop: 24, paddingBottom: 12 }}>
+          <Text style={{ fontFamily: F.display, fontSize: 28, fontWeight: '700', color: C.text, letterSpacing: -0.5 }}>
+            Inbox
+          </Text>
+        </View>
+      )}
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingTop: 8, paddingBottom: sidebarMode ? 24 : 32, flexGrow: items.length === 0 && !loading ? 1 : undefined }}
+      >
+        {content}
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/features/chat/components/inbox-designs/ConsoleInbox.tsx
+++ b/apps/mobile/features/chat/components/inbox-designs/ConsoleInbox.tsx
@@ -1,0 +1,272 @@
+/**
+ * ConsoleInbox — production inbox rendered in the Console design.
+ * Extracted from app/design-20.tsx. Consumes DesignGroup[] via inboxDesignAdapter.
+ *
+ * Identity: warm light "terminal buffer" with mono type, > prompts, #tag-style badges.
+ */
+import React from 'react';
+import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { AppImage } from '@components/ui';
+import { consoleColors as C } from '@/theme/palettes/consoleColors';
+import { consoleFonts as F } from '@/theme/fonts';
+import type { DesignChannel, DesignGroup } from '../../utils/inboxDesignAdapter';
+import type { InboxDesignProps } from './types';
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(91,122,62,0.12)', color: '#5B7A3E' },
+  Teams: { bg: 'rgba(59,94,138,0.14)', color: '#3B5E8A' },
+  Classes: { bg: 'rgba(204,122,26,0.12)', color: C.link },
+};
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.selectedBackground, color: C.link };
+  return (
+    <View style={{ paddingHorizontal: 7, paddingVertical: 2, borderRadius: 4, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 10.5, fontWeight: '700', color: s.color, letterSpacing: 0.3 }}>
+        #{label.toLowerCase().replace(' ', '-')}
+      </Text>
+    </View>
+  );
+}
+
+function Avatar({ g }: { g: DesignGroup }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 14 }}>
+      <View style={{ width: 56, height: 56, borderRadius: 8, borderWidth: 1, borderColor: C.border, overflow: 'hidden', backgroundColor: C.surface }}>
+        <AppImage
+          source={g.image}
+          style={{ width: 54, height: 54 }}
+          optimizedWidth={120}
+          placeholder={{ type: 'initials', name: g.name, backgroundColor: C.surface }}
+        />
+      </View>
+      {g.userRole === 'leader' && (
+        <View
+          style={{
+            position: 'absolute', bottom: -2, right: -2,
+            width: 20, height: 20, borderRadius: 6,
+            backgroundColor: C.link, borderWidth: 2, borderColor: C.surface,
+            alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          <Ionicons name="shield" size={11} color={C.surfaceSecondary} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function messagePreview(ch: DesignChannel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({
+  g,
+  isActive,
+  activeChannelSlug,
+  onGroupPress,
+  onChannelPress,
+}: {
+  g: DesignGroup;
+  isActive: boolean;
+  activeChannelSlug?: string;
+  onGroupPress: (groupId: string) => void;
+  onChannelPress: (groupId: string, channelSlug: string) => void;
+}) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View style={{ backgroundColor: isActive ? C.selectedBackground : 'transparent', borderBottomWidth: 1, borderBottomColor: C.borderLight }}>
+      <Pressable
+        onPress={() => onGroupPress(g._id)}
+        style={{
+          flexDirection: 'row', alignItems: 'center',
+          paddingHorizontal: 18, paddingVertical: 14,
+          backgroundColor: hasUnread && !isActive ? C.selectedBackground : 'transparent',
+        }}
+      >
+        <Avatar g={g} />
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4, gap: 8 }}>
+            <Text numberOfLines={1} style={{ fontFamily: F.mono, fontSize: 15, color: C.text, fontWeight: '600', flex: 1 }}>
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text
+              numberOfLines={1}
+              style={{
+                fontFamily: F.mono, fontSize: 12.5, flex: 1, marginRight: 8,
+                color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.text : C.textSecondary,
+                fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+              }}
+            >
+              <Text style={{ color: C.textTertiary }}>{'> '}</Text>
+              {messagePreview(main)}
+            </Text>
+            {main.lastWhen && (
+              <Text
+                style={{
+                  fontFamily: F.mono, fontSize: 10.5,
+                  color: main.unreadCount > 0 ? C.link : C.textTertiary,
+                  fontWeight: main.unreadCount > 0 ? '700' : '500',
+                  letterSpacing: 0.5,
+                }}
+              >
+                {main.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View
+            style={{
+              minWidth: 26, height: 22, borderRadius: 4,
+              backgroundColor: C.link, alignItems: 'center', justifyContent: 'center',
+              paddingHorizontal: 7, marginLeft: 10,
+            }}
+          >
+            <Text style={{ fontFamily: F.mono, fontSize: 11, color: C.surfaceSecondary, fontWeight: '700' }}>
+              +{totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chHasUnread = ch.unreadCount > 0;
+        const channelActive = activeChannelSlug === ch.slug && isActive;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 18 }}>
+            <View style={{ width: 44 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 20, backgroundColor: C.border }} />
+              <View style={{ position: 'absolute', left: 28, top: 20, width: 12, height: 1.5, backgroundColor: C.border }} />
+            </View>
+            <Pressable
+              onPress={() => onChannelPress(g._id, ch.slug)}
+              style={{
+                flex: 1, flexDirection: 'row', alignItems: 'center',
+                borderRadius: 6, paddingHorizontal: 12, paddingVertical: 9,
+                marginRight: 18, marginBottom: 10, marginTop: 4,
+                backgroundColor: channelActive ? C.selectedBackground : chHasUnread ? 'rgba(204,122,26,0.20)' : C.surfaceSecondary,
+                borderWidth: 1, borderColor: chHasUnread ? C.link : C.border,
+              }}
+            >
+              <Text style={{ fontFamily: F.mono, fontSize: 12, fontWeight: '700', color: C.text, marginRight: 8 }}>
+                #{ch.name.toLowerCase()}
+              </Text>
+              <Text
+                numberOfLines={1}
+                style={{
+                  flex: 1, fontFamily: F.mono, fontSize: 12,
+                  color: chHasUnread ? C.text : C.textSecondary,
+                  fontWeight: chHasUnread ? '500' : '400',
+                }}
+              >
+                {messagePreview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text
+                  style={{
+                    fontFamily: F.mono, fontSize: 10, marginLeft: 8,
+                    color: chHasUnread ? C.link : C.textTertiary,
+                    fontWeight: chHasUnread ? '700' : '500',
+                  }}
+                >
+                  {ch.lastWhen}
+                </Text>
+              )}
+              {chHasUnread && (
+                <View
+                  style={{
+                    minWidth: 22, height: 18, borderRadius: 4,
+                    backgroundColor: C.link, alignItems: 'center', justifyContent: 'center',
+                    paddingHorizontal: 5, marginLeft: 8,
+                  }}
+                >
+                  <Text style={{ fontFamily: F.mono, color: C.surfaceSecondary, fontSize: 10, fontWeight: '700' }}>
+                    +{ch.unreadCount}
+                  </Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function LoadingState() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+      <ActivityIndicator size="small" color={C.link} />
+    </View>
+  );
+}
+
+function EmptyState() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+      <Text style={{ fontFamily: F.mono, fontSize: 18, color: C.text, fontWeight: '700', marginBottom: 8 }}>
+        $ inbox.list <Text style={{ color: C.link }}>--empty</Text>
+      </Text>
+      <Text style={{ fontFamily: F.mono, fontSize: 12, color: C.textSecondary, textAlign: 'center' }}>
+        // no conversations yet — join a group to begin
+      </Text>
+    </View>
+  );
+}
+
+export function ConsoleInbox({
+  items,
+  loading,
+  sidebarMode,
+  activeGroupId,
+  activeChannelSlug,
+  onGroupPress,
+  onChannelPress,
+}: InboxDesignProps) {
+  const content = loading
+    ? <LoadingState />
+    : items.length === 0
+    ? <EmptyState />
+    : items.map((g) => (
+        <GroupRow
+          key={g._id}
+          g={g}
+          isActive={activeGroupId === g._id}
+          activeChannelSlug={activeChannelSlug}
+          onGroupPress={onGroupPress}
+          onChannelPress={onChannelPress}
+        />
+      ));
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.background }}>
+      <View style={{ flex: 1, backgroundColor: C.surface }}>
+        {!sidebarMode && (
+          <View style={{ paddingHorizontal: 22, paddingTop: 24, paddingBottom: 14, borderBottomWidth: 1, borderBottomColor: C.border }}>
+            <Text style={{ fontFamily: F.mono, fontSize: 28, color: C.text, fontWeight: '700', letterSpacing: -1 }}>
+              inbox<Text style={{ color: C.link }}>_</Text>
+            </Text>
+          </View>
+        )}
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingBottom: sidebarMode ? 24 : 32, flexGrow: items.length === 0 && !loading ? 1 : undefined }}
+        >
+          {content}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/features/chat/components/inbox-designs/HearthInbox.tsx
+++ b/apps/mobile/features/chat/components/inbox-designs/HearthInbox.tsx
@@ -1,0 +1,298 @@
+/**
+ * HearthInbox — production inbox rendered in the Hearth design.
+ * Extracted from app/design-14.tsx. Consumes DesignGroup[] via inboxDesignAdapter.
+ *
+ * Palette + fonts come from the Hearth theme directly (not useTheme), so this
+ * component looks correct regardless of which preference is active. That lets
+ * it be snapshot-tested without a provider.
+ */
+import React from 'react';
+import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { AppImage } from '@components/ui';
+import { hearthColors as C } from '@/theme/palettes/hearthColors';
+import { hearthFonts as F } from '@/theme/fonts';
+import type { DesignChannel, DesignGroup } from '../../utils/inboxDesignAdapter';
+import type { InboxDesignProps } from './types';
+
+// Group-type badge colors (match design-14 swatches).
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  'Small Groups': { bg: 'rgba(135, 200, 120, 0.14)', color: '#9AD38A' },
+  Teams: { bg: 'rgba(140, 185, 240, 0.14)', color: '#A6C5EE' },
+  Classes: { bg: 'rgba(230, 122, 60, 0.16)', color: '#F7A06B' },
+};
+
+function TypeBadge({ label }: { label: string }) {
+  const s = TYPE_COLORS[label] || { bg: C.selectedBackground, color: C.link };
+  return (
+    <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 12, backgroundColor: s.bg }}>
+      <Text style={{ fontFamily: F.body, fontSize: 11, fontWeight: '600', color: s.color }}>{label}</Text>
+    </View>
+  );
+}
+
+function Avatar({ g }: { g: DesignGroup }) {
+  return (
+    <View style={{ position: 'relative', marginRight: 12 }}>
+      <View
+        style={{
+          width: 56, height: 56, borderRadius: 28,
+          backgroundColor: C.surfaceSecondary, borderWidth: 1, borderColor: C.border,
+          alignItems: 'center', justifyContent: 'center', overflow: 'hidden',
+        }}
+      >
+        <AppImage
+          source={g.image}
+          style={{ width: 54, height: 54, borderRadius: 27 }}
+          optimizedWidth={120}
+          placeholder={{ type: 'initials', name: g.name, backgroundColor: C.surfaceSecondary }}
+        />
+      </View>
+      {g.userRole === 'leader' && (
+        <View
+          style={{
+            position: 'absolute', bottom: 0, right: 0,
+            width: 20, height: 20, borderRadius: 10,
+            backgroundColor: C.link, borderWidth: 2, borderColor: C.background,
+            alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          <MaterialCommunityIcons name="shield" size={11} color={C.background} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function preview(ch: DesignChannel) {
+  if (!ch.lastMessagePreview) return 'No messages yet';
+  if (ch.lastSender) return `${ch.lastSender}: ${ch.lastMessagePreview}`;
+  return ch.lastMessagePreview;
+}
+
+function GroupRow({
+  g,
+  isActive,
+  activeChannelSlug,
+  onGroupPress,
+  onChannelPress,
+}: {
+  g: DesignGroup;
+  isActive: boolean;
+  activeChannelSlug?: string;
+  onGroupPress: (groupId: string) => void;
+  onChannelPress: (groupId: string, channelSlug: string) => void;
+}) {
+  const totalUnread = g.channels.reduce((s, c) => s + c.unreadCount, 0);
+  const main = g.channels.find((c) => c.channelType === 'main') || g.channels[0];
+  const isMulti = g.channels.length > 1;
+  const secondary = g.channels.filter((c) => c._id !== main._id && c.unreadCount > 0);
+  const hasUnread = totalUnread > 0;
+
+  return (
+    <View>
+      <Pressable
+        onPress={() => onGroupPress(g._id)}
+        style={{
+          flexDirection: 'row', alignItems: 'center',
+          paddingHorizontal: 16, paddingVertical: 12,
+          marginHorizontal: 10, marginVertical: 3,
+          borderRadius: 16,
+          backgroundColor: isActive ? C.surfaceSecondary : hasUnread ? 'rgba(230,122,60,0.14)' : 'transparent',
+          ...(isActive
+            ? { shadowColor: C.link, shadowOpacity: 0.25, shadowRadius: 22, shadowOffset: { width: 0, height: 0 } }
+            : {}),
+        }}
+      >
+        <Avatar g={g} />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text
+              numberOfLines={1}
+              style={{
+                fontFamily: F.display, fontSize: 16, fontWeight: hasUnread ? '700' : '600',
+                color: C.text, flex: 1, marginRight: 8, letterSpacing: -0.3,
+              }}
+            >
+              {g.name}
+            </Text>
+            <TypeBadge label={g.groupTypeName} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text
+              numberOfLines={1}
+              style={{
+                fontFamily: F.body, fontSize: 13.5, flex: 1, marginRight: 8,
+                color: (isMulti ? hasUnread : main.unreadCount > 0) ? C.text : C.textSecondary,
+                fontWeight: (isMulti ? hasUnread : main.unreadCount > 0) ? '600' : '400',
+              }}
+            >
+              {preview(main)}
+            </Text>
+            {main.lastWhen && (
+              <Text
+                style={{
+                  fontFamily: F.body, fontSize: 11.5,
+                  color: main.unreadCount > 0 ? '#F7A06B' : C.textTertiary,
+                  fontWeight: main.unreadCount > 0 ? '600' : '500',
+                }}
+              >
+                {main.lastWhen}
+              </Text>
+            )}
+          </View>
+        </View>
+        {totalUnread > 0 && (
+          <View
+            style={{
+              minWidth: 22, height: 22, borderRadius: 11,
+              backgroundColor: C.link, alignItems: 'center', justifyContent: 'center',
+              paddingHorizontal: 6, marginLeft: 8,
+            }}
+          >
+            <Text style={{ fontFamily: F.body, color: C.background, fontSize: 11, fontWeight: '700' }}>
+              {totalUnread > 99 ? '99+' : totalUnread}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      {secondary.map((ch) => {
+        const chUn = ch.unreadCount > 0;
+        const channelActive = activeChannelSlug === ch.slug && isActive;
+        return (
+          <View key={ch._id} style={{ flexDirection: 'row', alignItems: 'stretch', paddingLeft: 20 }}>
+            <View style={{ width: 40 }}>
+              <View style={{ position: 'absolute', left: 28, top: 0, width: 1.5, height: 18, backgroundColor: C.border }} />
+              <View style={{ position: 'absolute', left: 28, top: 18, width: 12, height: 1.5, backgroundColor: C.border }} />
+            </View>
+            <Pressable
+              onPress={() => onChannelPress(g._id, ch.slug)}
+              style={{
+                flex: 1, flexDirection: 'row', alignItems: 'center',
+                borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10,
+                marginRight: 20, marginBottom: 6, marginTop: 2,
+                backgroundColor: channelActive ? C.surfaceSecondary : chUn ? 'rgba(230,122,60,0.22)' : C.surface,
+                borderWidth: 1,
+                borderColor: chUn ? 'rgba(230,122,60,0.40)' : 'transparent',
+              }}
+            >
+              <Text style={{ fontFamily: F.display, fontSize: 13.5, fontWeight: chUn ? '700' : '600', color: C.text, marginRight: 8 }}>
+                {ch.name}
+              </Text>
+              <Text
+                numberOfLines={1}
+                style={{
+                  fontFamily: F.body, flex: 1, fontSize: 13,
+                  color: chUn ? C.text : C.textSecondary,
+                  fontWeight: chUn ? '500' : '400',
+                }}
+              >
+                {preview(ch)}
+              </Text>
+              {ch.lastWhen && (
+                <Text
+                  style={{
+                    fontFamily: F.body, fontSize: 11, marginLeft: 8,
+                    color: chUn ? '#F7A06B' : C.textTertiary,
+                    fontWeight: chUn ? '600' : '500',
+                  }}
+                >
+                  {ch.lastWhen}
+                </Text>
+              )}
+              {chUn && (
+                <View
+                  style={{
+                    minWidth: 20, height: 20, borderRadius: 10,
+                    backgroundColor: C.link, alignItems: 'center', justifyContent: 'center',
+                    paddingHorizontal: 5, marginLeft: 8,
+                  }}
+                >
+                  <Text style={{ fontFamily: F.body, color: C.background, fontSize: 11, fontWeight: '700' }}>
+                    {ch.unreadCount}
+                  </Text>
+                </View>
+              )}
+            </Pressable>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function LoadingState() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+      <ActivityIndicator size="small" color={C.link} />
+    </View>
+  );
+}
+
+function EmptyState() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+      <View
+        style={{
+          width: 96, height: 96, borderRadius: 48,
+          backgroundColor: 'rgba(230,122,60,0.14)',
+          alignItems: 'center', justifyContent: 'center',
+          shadowColor: C.link, shadowOpacity: 0.4, shadowRadius: 40, shadowOffset: { width: 0, height: 0 },
+          borderWidth: 1, borderColor: C.link, marginBottom: 20,
+        }}
+      >
+        <MaterialCommunityIcons name="message-outline" size={40} color="#F7A06B" />
+      </View>
+      <Text style={{ fontFamily: F.display, fontSize: 22, color: C.text, fontWeight: '600', marginBottom: 8, letterSpacing: -0.6 }}>
+        No messages yet
+      </Text>
+      <Text style={{ fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center' }}>
+        Join a group to start seeing conversations here.
+      </Text>
+    </View>
+  );
+}
+
+export function HearthInbox({
+  items,
+  loading,
+  sidebarMode,
+  activeGroupId,
+  activeChannelSlug,
+  onGroupPress,
+  onChannelPress,
+}: InboxDesignProps) {
+  const content = loading
+    ? <LoadingState />
+    : items.length === 0
+    ? <EmptyState />
+    : items.map((g) => (
+        <GroupRow
+          key={g._id}
+          g={g}
+          isActive={activeGroupId === g._id}
+          activeChannelSlug={activeChannelSlug}
+          onGroupPress={onGroupPress}
+          onChannelPress={onChannelPress}
+        />
+      ));
+
+  return (
+    <View style={{ flex: 1, backgroundColor: C.background }}>
+      {!sidebarMode && (
+        <View style={{ paddingHorizontal: 24, paddingTop: 24, paddingBottom: 12 }}>
+          <Text style={{ fontFamily: F.display, fontSize: 30, color: C.text, fontWeight: '600', letterSpacing: -0.8 }}>
+            Inbox
+          </Text>
+        </View>
+      )}
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: sidebarMode ? 24 : 32, flexGrow: items.length === 0 && !loading ? 1 : undefined }}
+      >
+        {content}
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/features/chat/components/inbox-designs/__tests__/ConservatoryInbox.test.tsx
+++ b/apps/mobile/features/chat/components/inbox-designs/__tests__/ConservatoryInbox.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Icon = (props: any) => React.createElement(View, { ...props });
+  return { Ionicons: Icon, MaterialCommunityIcons: Icon };
+});
+
+jest.mock('@components/ui', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { AppImage: () => React.createElement(View, { testID: 'AppImage-mock' }) };
+});
+
+import { ConservatoryInbox } from '../ConservatoryInbox';
+import type { DesignGroup } from '../../../utils/inboxDesignAdapter';
+
+const fixture: DesignGroup[] = [
+  {
+    _id: 'ya', name: 'Young Adults', image: null, groupTypeName: 'Small Groups', userRole: 'member',
+    channels: [
+      { _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General',
+        lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya',
+        lastWhen: '9m', unreadCount: 3 },
+    ],
+  },
+];
+
+describe('ConservatoryInbox', () => {
+  test('renders the title in full-screen mode', () => {
+    const { getByText } = render(
+      <ConservatoryInbox items={fixture} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(getByText('Inbox')).toBeTruthy();
+  });
+
+  test('hides the title in sidebar mode', () => {
+    const { queryByText } = render(
+      <ConservatoryInbox items={fixture} loading={false} sidebarMode onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(queryByText('Inbox')).toBeNull();
+  });
+
+  test('renders empty state', () => {
+    const { getByText } = render(
+      <ConservatoryInbox items={[]} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(getByText('Quiet here')).toBeTruthy();
+  });
+
+  test('tapping a group fires onGroupPress', () => {
+    const onGroup = jest.fn();
+    const { getByText } = render(
+      <ConservatoryInbox items={fixture} loading={false} onGroupPress={onGroup} onChannelPress={jest.fn()} />,
+    );
+    let node: any = getByText('Young Adults');
+    while (node && !node.props?.onPress) node = node.parent;
+    node?.props?.onPress?.();
+    expect(onGroup).toHaveBeenCalledWith('ya');
+  });
+});

--- a/apps/mobile/features/chat/components/inbox-designs/__tests__/ConsoleInbox.test.tsx
+++ b/apps/mobile/features/chat/components/inbox-designs/__tests__/ConsoleInbox.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Icon = (props: any) => React.createElement(View, { ...props });
+  return { Ionicons: Icon, MaterialCommunityIcons: Icon };
+});
+
+jest.mock('@components/ui', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { AppImage: () => React.createElement(View, { testID: 'AppImage-mock' }) };
+});
+
+import { ConsoleInbox } from '../ConsoleInbox';
+import type { DesignGroup } from '../../../utils/inboxDesignAdapter';
+
+const fixture: DesignGroup[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: null,
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      {
+        _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General',
+        lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya',
+        lastWhen: '9m', unreadCount: 3,
+      },
+    ],
+  },
+];
+
+describe('ConsoleInbox', () => {
+  test('renders the terminal-style title in full-screen mode', () => {
+    const { queryAllByText } = render(
+      <ConsoleInbox items={fixture} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    // The header is "inbox_" composed as nested Text nodes; both halves should appear.
+    expect(queryAllByText(/inbox/).length).toBeGreaterThan(0);
+  });
+
+  test('hides the title in sidebar mode', () => {
+    const { queryAllByText } = render(
+      <ConsoleInbox items={fixture} loading={false} sidebarMode onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(queryAllByText(/inbox/)).toHaveLength(0);
+  });
+
+  test('renders #tag-style group type badge', () => {
+    const { getByText } = render(
+      <ConsoleInbox items={fixture} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(getByText('#small-groups')).toBeTruthy();
+  });
+
+  test('shows empty state with terminal copy', () => {
+    const { getByText } = render(
+      <ConsoleInbox items={[]} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(getByText(/inbox\.list/)).toBeTruthy();
+  });
+
+  test('tapping a group fires onGroupPress', () => {
+    const onGroup = jest.fn();
+    const { getByText } = render(
+      <ConsoleInbox items={fixture} loading={false} onGroupPress={onGroup} onChannelPress={jest.fn()} />,
+    );
+    let node: any = getByText('Young Adults');
+    while (node && !node.props?.onPress) node = node.parent;
+    node?.props?.onPress?.();
+    expect(onGroup).toHaveBeenCalledWith('ya');
+  });
+});

--- a/apps/mobile/features/chat/components/inbox-designs/__tests__/HearthInbox.test.tsx
+++ b/apps/mobile/features/chat/components/inbox-designs/__tests__/HearthInbox.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Icon = (props: any) => React.createElement(View, { ...props });
+  return { Ionicons: Icon, MaterialCommunityIcons: Icon };
+});
+
+jest.mock('@components/ui', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { AppImage: (props: any) => React.createElement(View, { testID: 'AppImage-mock' }) };
+});
+
+import { HearthInbox } from '../HearthInbox';
+import type { DesignGroup } from '../../../utils/inboxDesignAdapter';
+
+const fixture: DesignGroup[] = [
+  {
+    _id: 'ya',
+    name: 'Young Adults',
+    image: null,
+    groupTypeName: 'Small Groups',
+    userRole: 'member',
+    channels: [
+      {
+        _id: 'ya-m', slug: 'general', channelType: 'main', name: 'General',
+        lastMessagePreview: 'Bring a chair Thursday.', lastSender: 'Maya',
+        lastWhen: '9m', unreadCount: 3,
+      },
+    ],
+  },
+  {
+    _id: 'wt',
+    name: 'Worship Team',
+    image: null,
+    groupTypeName: 'Teams',
+    userRole: 'leader',
+    channels: [
+      {
+        _id: 'wt-m', slug: 'general', channelType: 'main', name: 'General',
+        lastMessagePreview: 'Saturday 10am.', lastSender: 'Ade',
+        lastWhen: 'Yesterday', unreadCount: 0,
+      },
+      {
+        _id: 'wt-l', slug: 'leaders', channelType: 'leaders', name: 'Leaders',
+        lastMessagePreview: 'Setlist draft.', lastSender: 'Ade',
+        lastWhen: 'Yesterday', unreadCount: 1,
+      },
+    ],
+  },
+];
+
+describe('HearthInbox', () => {
+  test('renders group names', () => {
+    const { getByText } = render(
+      <HearthInbox items={fixture} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(getByText('Young Adults')).toBeTruthy();
+    expect(getByText('Worship Team')).toBeTruthy();
+  });
+
+  test('renders the "Inbox" title in full-screen mode', () => {
+    const { getByText } = render(
+      <HearthInbox items={fixture} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(getByText('Inbox')).toBeTruthy();
+  });
+
+  test('hides the title in sidebar mode', () => {
+    const { queryByText } = render(
+      <HearthInbox items={fixture} loading={false} sidebarMode onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(queryByText('Inbox')).toBeNull();
+  });
+
+  test('empty state renders a friendly message', () => {
+    const { getByText } = render(
+      <HearthInbox items={[]} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    expect(getByText('No messages yet')).toBeTruthy();
+  });
+
+  test('renders secondary channels only when they have unread messages', () => {
+    const { getByText, queryByText } = render(
+      <HearthInbox items={fixture} loading={false} onGroupPress={jest.fn()} onChannelPress={jest.fn()} />,
+    );
+    // Worship Team's leader channel has unread=1 → visible
+    expect(getByText('Leaders')).toBeTruthy();
+    // Young Adults main preview with sender prefix is visible
+    expect(queryByText(/Maya:/)).toBeTruthy();
+  });
+
+  test('tapping a group fires onGroupPress with the id', () => {
+    const onGroup = jest.fn();
+    const { getByText } = render(
+      <HearthInbox items={fixture} loading={false} onGroupPress={onGroup} onChannelPress={jest.fn()} />,
+    );
+    // Press the group row by tapping its name's containing Pressable
+    const groupName = getByText('Young Adults');
+    // Walk up to the nearest Pressable and invoke onPress via props
+    let node: any = groupName;
+    while (node && !node.props?.onPress) node = node.parent;
+    node?.props?.onPress?.();
+    expect(onGroup).toHaveBeenCalledWith('ya');
+  });
+});

--- a/apps/mobile/features/chat/components/inbox-designs/index.ts
+++ b/apps/mobile/features/chat/components/inbox-designs/index.ts
@@ -1,0 +1,4 @@
+export { HearthInbox } from './HearthInbox';
+export { ConsoleInbox } from './ConsoleInbox';
+export { ConservatoryInbox } from './ConservatoryInbox';
+export type { InboxDesignProps } from './types';

--- a/apps/mobile/features/chat/components/inbox-designs/types.ts
+++ b/apps/mobile/features/chat/components/inbox-designs/types.ts
@@ -1,0 +1,11 @@
+import type { DesignGroup } from '../../utils/inboxDesignAdapter';
+
+export interface InboxDesignProps {
+  items: DesignGroup[];
+  loading: boolean;
+  sidebarMode?: boolean;
+  activeGroupId?: string;
+  activeChannelSlug?: string;
+  onGroupPress: (groupId: string) => void;
+  onChannelPress: (groupId: string, channelSlug: string) => void;
+}

--- a/apps/mobile/features/chat/utils/__tests__/formatInboxTime.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/formatInboxTime.test.ts
@@ -1,0 +1,44 @@
+import { formatInboxTime } from '../formatInboxTime';
+
+const now = new Date('2026-04-20T14:00:00Z');
+
+describe('formatInboxTime', () => {
+  test('empty for null/undefined/NaN', () => {
+    expect(formatInboxTime(null)).toBe('');
+    expect(formatInboxTime(undefined)).toBe('');
+    expect(formatInboxTime(NaN)).toBe('');
+  });
+
+  test('"now" for under a minute', () => {
+    expect(formatInboxTime(now.getTime() - 30 * 1000, now)).toBe('now');
+  });
+
+  test('"{N}m" for minutes', () => {
+    expect(formatInboxTime(now.getTime() - 9 * 60 * 1000, now)).toBe('9m');
+    expect(formatInboxTime(now.getTime() - 59 * 60 * 1000, now)).toBe('59m');
+  });
+
+  test('"{N}h" for hours same day', () => {
+    expect(formatInboxTime(now.getTime() - 2 * 60 * 60 * 1000, now)).toBe('2h');
+    expect(formatInboxTime(now.getTime() - 23 * 60 * 60 * 1000, now)).toBe('23h');
+  });
+
+  test('"Yesterday" for ~24h prior', () => {
+    expect(formatInboxTime(now.getTime() - 25 * 60 * 60 * 1000, now)).toBe('Yesterday');
+  });
+
+  test('"{N}d" for 2–6 days', () => {
+    expect(formatInboxTime(now.getTime() - 3 * 24 * 60 * 60 * 1000, now)).toBe('3d');
+    expect(formatInboxTime(now.getTime() - 6 * 24 * 60 * 60 * 1000, now)).toBe('6d');
+  });
+
+  test('"MMM D" for >= 7 days in the same year', () => {
+    const stamp = new Date('2026-01-15T10:00:00Z').getTime();
+    expect(formatInboxTime(stamp, now)).toBe('Jan 15');
+  });
+
+  test('"MMM D, YYYY" for previous years', () => {
+    const stamp = new Date('2024-11-30T10:00:00Z').getTime();
+    expect(formatInboxTime(stamp, now)).toBe('Nov 30, 2024');
+  });
+});

--- a/apps/mobile/features/chat/utils/__tests__/inboxDesignAdapter.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/inboxDesignAdapter.test.ts
@@ -1,0 +1,140 @@
+import { toDesignGroups, type InboxGroup } from '../inboxDesignAdapter';
+
+const now = new Date('2026-04-20T14:00:00Z');
+
+function buildGroup(overrides: Partial<InboxGroup> = {}): InboxGroup {
+  return {
+    group: {
+      _id: 'group-1' as any,
+      name: 'Young Adults',
+      preview: 'https://example.com/ya.jpg',
+      groupTypeId: 'gt-1' as any,
+      groupTypeName: 'Small Groups',
+      groupTypeSlug: 'small-groups',
+      isAnnouncementGroup: false,
+    },
+    channels: [
+      {
+        _id: 'ch-1' as any,
+        slug: 'general',
+        channelType: 'main',
+        name: 'General',
+        lastMessagePreview: 'Bring a chair Thursday.',
+        lastMessageAt: now.getTime() - 9 * 60 * 1000,
+        lastMessageSenderName: 'Maya',
+        lastMessageSenderId: 'user-1' as any,
+        unreadCount: 3,
+      },
+    ],
+    userRole: 'member',
+    ...overrides,
+  };
+}
+
+describe('toDesignGroups', () => {
+  test('returns [] for null / undefined', () => {
+    expect(toDesignGroups(null)).toEqual([]);
+    expect(toDesignGroups(undefined)).toEqual([]);
+  });
+
+  test('returns [] for empty input', () => {
+    expect(toDesignGroups([])).toEqual([]);
+  });
+
+  test('maps a single group with a main channel', () => {
+    const out = toDesignGroups([buildGroup()], now);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      _id: 'group-1',
+      name: 'Young Adults',
+      image: 'https://example.com/ya.jpg',
+      groupTypeName: 'Small Groups',
+      userRole: 'member',
+      channels: [
+        {
+          _id: 'ch-1',
+          slug: 'general',
+          channelType: 'main',
+          name: 'General',
+          lastMessagePreview: 'Bring a chair Thursday.',
+          lastSender: 'Maya',
+          lastWhen: '9m',
+          unreadCount: 3,
+        },
+      ],
+    });
+  });
+
+  test('preserves unread counts', () => {
+    const out = toDesignGroups(
+      [
+        buildGroup({
+          channels: [
+            {
+              _id: 'a' as any, slug: 'general', channelType: 'main', name: 'General',
+              lastMessagePreview: null, lastMessageAt: null, lastMessageSenderName: null,
+              lastMessageSenderId: null, unreadCount: 7,
+            },
+          ],
+        }),
+      ],
+      now,
+    );
+    expect(out[0].channels[0].unreadCount).toBe(7);
+  });
+
+  test('handles leader role + multi-channel group', () => {
+    const out = toDesignGroups(
+      [
+        buildGroup({
+          userRole: 'leader',
+          channels: [
+            {
+              _id: 'main' as any, slug: 'general', channelType: 'main', name: 'General',
+              lastMessagePreview: 'Sat 10am sharp.', lastMessageAt: now.getTime() - 25 * 60 * 60 * 1000,
+              lastMessageSenderName: 'Ade', lastMessageSenderId: 'u' as any, unreadCount: 0,
+            },
+            {
+              _id: 'leaders' as any, slug: 'leaders', channelType: 'leaders', name: 'Leaders',
+              lastMessagePreview: 'Setlist draft.', lastMessageAt: now.getTime() - 26 * 60 * 60 * 1000,
+              lastMessageSenderName: 'Ade', lastMessageSenderId: 'u' as any, unreadCount: 1,
+            },
+          ],
+        }),
+      ],
+      now,
+    );
+    expect(out[0].userRole).toBe('leader');
+    expect(out[0].channels).toHaveLength(2);
+    expect(out[0].channels[0].lastWhen).toBe('Yesterday');
+    expect(out[0].channels[1].lastWhen).toBe('Yesterday');
+  });
+
+  test('nullifies image when group has no preview url', () => {
+    const out = toDesignGroups([buildGroup({ group: { ...buildGroup().group, preview: undefined } })], now);
+    expect(out[0].image).toBeNull();
+  });
+
+  test('falls back to "Groups" when groupTypeName is missing', () => {
+    const out = toDesignGroups([buildGroup({ group: { ...buildGroup().group, groupTypeName: undefined } })], now);
+    expect(out[0].groupTypeName).toBe('Groups');
+  });
+
+  test('emits null lastWhen when lastMessageAt is null', () => {
+    const out = toDesignGroups(
+      [
+        buildGroup({
+          channels: [
+            {
+              _id: 'x' as any, slug: 'general', channelType: 'main', name: 'General',
+              lastMessagePreview: null, lastMessageAt: null, lastMessageSenderName: null,
+              lastMessageSenderId: null, unreadCount: 0,
+            },
+          ],
+        }),
+      ],
+      now,
+    );
+    expect(out[0].channels[0].lastWhen).toBeNull();
+  });
+});

--- a/apps/mobile/features/chat/utils/formatInboxTime.ts
+++ b/apps/mobile/features/chat/utils/formatInboxTime.ts
@@ -1,0 +1,43 @@
+/**
+ * Format a last-message timestamp for inbox rows.
+ *
+ *   < 1 min         → "now"
+ *   < 1 hr          → "{N}m"
+ *   < 24 hr         → "{N}h"
+ *   yesterday       → "Yesterday"
+ *   < 7 days        → "{N}d"
+ *   current year    → "MMM D" (e.g., "Jan 15")
+ *   other           → "MMM D, YYYY"
+ *
+ * Shared by the production GroupedInboxItem and the design-theme inbox
+ * components (Hearth/Console/Conservatory) so both render identical labels.
+ *
+ * Accepts millisecond timestamps; returns "" for null/undefined/NaN so callers
+ * don't need to branch.
+ */
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+export function formatInboxTime(timestamp: number | null | undefined, now: Date = new Date()): string {
+  if (timestamp == null || Number.isNaN(timestamp)) return '';
+  const date = new Date(timestamp);
+  const diff = now.getTime() - date.getTime();
+  const minutes = Math.floor(diff / (1000 * 60));
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+  if (hours < 24) return `${hours}h`;
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return `${days}d`;
+
+  const month = MONTHS[date.getMonth()];
+  const day = date.getDate();
+  if (date.getFullYear() !== now.getFullYear()) {
+    return `${month} ${day}, ${date.getFullYear()}`;
+  }
+  return `${month} ${day}`;
+}

--- a/apps/mobile/features/chat/utils/inboxDesignAdapter.ts
+++ b/apps/mobile/features/chat/utils/inboxDesignAdapter.ts
@@ -1,0 +1,92 @@
+/**
+ * Adapt the production `getInboxChannels` query result into the shape expected
+ * by the design-theme inbox components (HearthInbox / ConsoleInbox / ConservatoryInbox).
+ *
+ * The design components were prototyped against a slightly richer mock shape;
+ * this adapter is the bridge. All three designs consume the same output, so
+ * they stay in sync with real data by construction.
+ */
+import type { Id } from '@services/api/convex';
+import { formatInboxTime } from './formatInboxTime';
+
+// Matches the `inboxChannels` result from api.functions.messaging.channels.getInboxChannels.
+// Mirrored here (not imported) because this utility is platform-agnostic and
+// shouldn't drag in Convex generated types.
+export type InboxGroupChannel = {
+  _id: Id<'chatChannels'>;
+  slug: string;
+  channelType: string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastMessageAt: number | null;
+  lastMessageSenderName: string | null;
+  lastMessageSenderId: Id<'users'> | null;
+  unreadCount: number;
+  isShared?: boolean;
+};
+
+export type InboxGroup = {
+  group: {
+    _id: Id<'groups'>;
+    name: string;
+    preview: string | undefined;
+    groupTypeId: Id<'groupTypes'>;
+    groupTypeName: string | undefined;
+    groupTypeSlug: string | undefined;
+    isAnnouncementGroup: boolean | undefined;
+  };
+  channels: InboxGroupChannel[];
+  userRole: 'leader' | 'member';
+};
+
+// The shape design components render from.
+export type DesignChannel = {
+  _id: string;
+  slug: string;
+  channelType: string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastSender: string | null;
+  lastWhen: string | null; // human-readable ("9m", "Yesterday", "Jan 15")
+  unreadCount: number;
+};
+
+export type DesignGroup = {
+  _id: string;
+  name: string;
+  /** Image URL or null if the group has no cover image (callers show initials). */
+  image: string | null;
+  groupTypeName: string;
+  userRole: 'leader' | 'member';
+  channels: DesignChannel[];
+};
+
+/**
+ * Convert a production inbox query result into the design shape.
+ *
+ * @param inboxGroups  Result from `getInboxChannels`. Undefined / null yield [].
+ * @param now          Injectable clock for deterministic tests; defaults to `new Date()`.
+ */
+export function toDesignGroups(
+  inboxGroups: InboxGroup[] | undefined | null,
+  now: Date = new Date(),
+): DesignGroup[] {
+  if (!inboxGroups) return [];
+  return inboxGroups.map((entry) => ({
+    _id: String(entry.group._id),
+    name: entry.group.name,
+    image: entry.group.preview ?? null,
+    groupTypeName: entry.group.groupTypeName ?? 'Groups',
+    userRole: entry.userRole,
+    channels: entry.channels.map((ch) => ({
+      _id: String(ch._id),
+      slug: ch.slug,
+      channelType: ch.channelType,
+      name: ch.name,
+      lastMessagePreview: ch.lastMessagePreview,
+      lastSender: ch.lastMessageSenderName,
+      lastWhen: ch.lastMessageAt != null ? formatInboxTime(ch.lastMessageAt, now) : null,
+      unreadCount: ch.unreadCount,
+    })),
+  }));
+}

--- a/apps/mobile/features/explore/components/GroupPreviewCard.tsx
+++ b/apps/mobile/features/explore/components/GroupPreviewCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, Text, StyleSheet, TouchableOpacity, Platform } from "react-native";
 import { useRouter } from "expo-router";
 import { Avatar, AppImage } from "@components/ui";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { getGroupTypeLabel } from "@features/groups/utils";
 import { useAuth } from "@providers/AuthProvider";
 import { Group, GroupMember } from "@features/groups/types";
@@ -101,9 +102,9 @@ export function GroupPreviewCard({ group }: GroupPreviewCardProps) {
         )}
 
         {/* Group Name */}
-        <Text style={styles.groupName} numberOfLines={2}>
+        <ThemedHeading level={3} style={styles.groupName} numberOfLines={2}>
           {groupName}
-        </Text>
+        </ThemedHeading>
 
         {/* Location */}
         {locationString && (

--- a/apps/mobile/features/groups/components/GroupHeader.tsx
+++ b/apps/mobile/features/groups/components/GroupHeader.tsx
@@ -12,6 +12,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Group } from "../types";
 import { formatCadence } from "../utils";
 import { AppImageBackground } from "@components/ui/AppImageBackground";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { useTheme } from "@hooks/useTheme";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
@@ -68,16 +69,17 @@ export function GroupHeader({ group, onMenuPress, showMenu = true }: GroupHeader
 
       {/* Group name and cadence */}
       <View style={styles.textContainer}>
-        <Text 
+        <ThemedHeading
+          level={1}
           style={[
-            styles.groupName, 
+            styles.groupName,
             { color: textColor },
-            !hasImage && styles.groupNameNoImage
-          ]} 
+            !hasImage && styles.groupNameNoImage,
+          ]}
           numberOfLines={2}
         >
           {groupName}
-        </Text>
+        </ThemedHeading>
         {cadence && (
           <Text 
             style={[

--- a/apps/mobile/features/leader-tools/components/EventDetails.tsx
+++ b/apps/mobile/features/leader-tools/components/EventDetails.tsx
@@ -32,6 +32,7 @@ import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { DOMAIN_CONFIG } from "@togather/shared";
 import * as Clipboard from "expo-clipboard";
 import { DragHandle } from "@components/ui/DragHandle";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { useTheme } from "@hooks/useTheme";
 import { EventBlastSheet } from "./EventBlastSheet";
 import { EventBlastHistory } from "./EventBlastHistory";
@@ -333,9 +334,9 @@ export function EventDetails({
           <Ionicons name="arrow-back" size={24} color={colors.text} />
         </TouchableOpacity>
         <View style={styles.headerContent}>
-          <Text style={[styles.headerTitle, { color: colors.text }]} numberOfLines={1}>
+          <ThemedHeading level={2} style={[styles.headerTitle, { color: colors.text }]} numberOfLines={1}>
             {displayTitle}
-          </Text>
+          </ThemedHeading>
         </View>
         {/* Share Button */}
         <TouchableOpacity

--- a/apps/mobile/features/profile/components/ProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/ProfileHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Avatar, Card } from '@components/ui';
+import { ThemedHeading } from '@components/ui/ThemedHeading';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@hooks/useTheme';
 import { useRouter } from 'expo-router';
@@ -31,9 +32,9 @@ export function ProfileHeader({ user }: ProfileHeaderProps) {
           size={80}
         />
         <View style={styles.profileInfo}>
-          <Text style={[styles.name, { color: colors.text }]}>
+          <ThemedHeading level={2} style={[styles.name, { color: colors.text }]}>
             {user?.first_name} {user?.last_name}
-          </Text>
+          </ThemedHeading>
           <Text style={[styles.email, { color: colors.textSecondary }]}>{user?.email}</Text>
           {user?.phone && (
             <View style={styles.phoneContainer}>

--- a/apps/mobile/features/settings/components/AppInfoSection.tsx
+++ b/apps/mobile/features/settings/components/AppInfoSection.tsx
@@ -26,6 +26,7 @@ import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { Environment } from "@services/environment";
 import { useDevToolsEscapeHatch } from "@hooks/useDevToolsEscapeHatch";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 
 const DEVELOPER_EMAIL = "togather@supa.media";
 
@@ -246,7 +247,7 @@ ${logs || "No logs captured yet. Try reproducing the issue first."}`;
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>App Info</Text>
+      <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>App Info</ThemedHeading>
 
       {/* Version row - tappable for dev tools escape hatch */}
       <TouchableOpacity

--- a/apps/mobile/features/settings/components/AppearanceSection.tsx
+++ b/apps/mobile/features/settings/components/AppearanceSection.tsx
@@ -3,11 +3,35 @@ import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import type { ThemePreference } from "@providers/ThemeProvider";
+import {
+  hearthColors,
+  consoleColors,
+  conservatoryColors,
+} from "@/theme/colors";
 
-const OPTIONS: { value: ThemePreference; label: string; icon: keyof typeof Ionicons.glyphMap }[] = [
+type SystemOption = {
+  value: Extract<ThemePreference, "auto" | "light" | "dark">;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+};
+
+type DesignOption = {
+  value: Extract<ThemePreference, "hearth" | "console" | "conservatory">;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  swatch: string;
+};
+
+const SYSTEM_OPTIONS: SystemOption[] = [
   { value: "auto", label: "Auto", icon: "phone-portrait-outline" },
   { value: "light", label: "Light", icon: "sunny-outline" },
   { value: "dark", label: "Dark", icon: "moon-outline" },
+];
+
+const DESIGN_OPTIONS: DesignOption[] = [
+  { value: "hearth", label: "Hearth", icon: "flame-outline", swatch: hearthColors.link },
+  { value: "console", label: "Console", icon: "terminal-outline", swatch: consoleColors.link },
+  { value: "conservatory", label: "Conservatory", icon: "leaf-outline", swatch: conservatoryColors.link },
 ];
 
 export function AppearanceSection() {
@@ -15,15 +39,14 @@ export function AppearanceSection() {
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>
-        Appearance
-      </Text>
+      <Text style={[styles.sectionTitle, { color: colors.text }]}>Appearance</Text>
       <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
-        Choose how Togather looks. Auto follows your device setting.
+        Choose how Togather looks. Auto follows your device setting; designs apply custom colors and fonts across the app.
       </Text>
 
+      <Text style={[styles.groupLabel, { color: colors.textTertiary }]}>System</Text>
       <View style={styles.optionsRow}>
-        {OPTIONS.map((option) => {
+        {SYSTEM_OPTIONS.map((option) => {
           const isSelected = preference === option.value;
           return (
             <TouchableOpacity
@@ -35,12 +58,55 @@ export function AppearanceSection() {
               ]}
               onPress={() => setPreference(option.value)}
               activeOpacity={0.7}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: isSelected }}
+              accessibilityLabel={option.label}
             >
               <Ionicons
                 name={option.icon}
                 size={24}
                 color={isSelected ? colors.buttonPrimary : colors.textSecondary}
               />
+              <Text
+                style={[
+                  styles.optionLabel,
+                  { color: isSelected ? colors.buttonPrimary : colors.text },
+                  isSelected && styles.optionLabelSelected,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      <Text style={[styles.groupLabel, { color: colors.textTertiary, marginTop: 20 }]}>Designs</Text>
+      <View style={styles.optionsRow}>
+        {DESIGN_OPTIONS.map((option) => {
+          const isSelected = preference === option.value;
+          return (
+            <TouchableOpacity
+              key={option.value}
+              style={[
+                styles.option,
+                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                isSelected && { borderColor: colors.buttonPrimary, backgroundColor: colors.selectedBackground },
+              ]}
+              onPress={() => setPreference(option.value)}
+              activeOpacity={0.7}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: isSelected }}
+              accessibilityLabel={option.label}
+            >
+              <View style={styles.designIconRow}>
+                <Ionicons
+                  name={option.icon}
+                  size={22}
+                  color={isSelected ? colors.buttonPrimary : colors.textSecondary}
+                />
+                <View style={[styles.swatch, { backgroundColor: option.swatch }]} />
+              </View>
               <Text
                 style={[
                   styles.optionLabel,
@@ -72,6 +138,13 @@ const styles = StyleSheet.create({
     fontSize: 14,
     marginBottom: 16,
   },
+  groupLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    marginBottom: 8,
+  },
   optionsRow: {
     flexDirection: "row",
     gap: 10,
@@ -90,5 +163,15 @@ const styles = StyleSheet.create({
   },
   optionLabelSelected: {
     fontWeight: "700",
+  },
+  designIconRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  swatch: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
   },
 });

--- a/apps/mobile/features/settings/components/AppearanceSection.tsx
+++ b/apps/mobile/features/settings/components/AppearanceSection.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import type { ThemePreference } from "@providers/ThemeProvider";
 import {
   hearthColors,
@@ -39,7 +40,7 @@ export function AppearanceSection() {
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>Appearance</Text>
+      <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Appearance</ThemedHeading>
       <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
         Choose how Togather looks. Auto follows your device setting; designs apply custom colors and fonts across the app.
       </Text>

--- a/apps/mobile/features/settings/components/BlockedUsersSection.tsx
+++ b/apps/mobile/features/settings/components/BlockedUsersSection.tsx
@@ -10,6 +10,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useTheme } from '@hooks/useTheme';
+import { ThemedHeading } from '@components/ui/ThemedHeading';
 
 export function BlockedUsersSection() {
   const router = useRouter();
@@ -18,7 +19,7 @@ export function BlockedUsersSection() {
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>Privacy</Text>
+      <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Privacy</ThemedHeading>
 
       <TouchableOpacity
         style={[styles.menuItem, { backgroundColor: colors.surfaceSecondary }]}

--- a/apps/mobile/features/settings/components/DeleteAccountSection.tsx
+++ b/apps/mobile/features/settings/components/DeleteAccountSection.tsx
@@ -8,6 +8,7 @@ import React, { useState } from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { DeleteAccountModal } from "./DeleteAccountModal";
 
 export function DeleteAccountSection() {
@@ -16,7 +17,7 @@ export function DeleteAccountSection() {
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>Account</Text>
+      <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Account</ThemedHeading>
 
       <View style={[styles.warningContainer, { backgroundColor: colors.destructive + '10' }]}>
         <Ionicons

--- a/apps/mobile/features/settings/components/LeaderToolsSection.tsx
+++ b/apps/mobile/features/settings/components/LeaderToolsSection.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { useAuth } from "@providers/AuthProvider";
 import { api, Id, useAuthenticatedQuery } from "@services/api/convex";
 
@@ -30,7 +31,7 @@ export function LeaderToolsSection() {
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>Leader Tools</Text>
+      <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Leader Tools</ThemedHeading>
 
       <TouchableOpacity
         style={[styles.menuItem, { backgroundColor: colors.surfaceSecondary }]}

--- a/apps/mobile/features/settings/components/NotificationPreferencesSection.tsx
+++ b/apps/mobile/features/settings/components/NotificationPreferencesSection.tsx
@@ -21,6 +21,7 @@ import { useNotifications } from '@providers/NotificationProvider';
 import { useQuery, useAuthenticatedMutation, useMutation, api } from '@services/api/convex';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useTheme } from '@hooks/useTheme';
+import { ThemedHeading } from '@components/ui/ThemedHeading';
 import { useAuth } from '@providers/AuthProvider';
 import type { Id } from '@services/api/convex';
 
@@ -130,7 +131,7 @@ export const NotificationPreferencesSection: React.FC = () => {
   if (isLoading) {
     return (
       <View style={[styles.section, { backgroundColor: colors.surface }]}>
-        <Text style={[styles.sectionTitle, { color: colors.text }]}>Notifications</Text>
+        <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Notifications</ThemedHeading>
         <ActivityIndicator style={styles.loader} />
       </View>
     );
@@ -139,7 +140,7 @@ export const NotificationPreferencesSection: React.FC = () => {
   if (!preferences) {
     return (
       <View style={[styles.section, { backgroundColor: colors.surface }]}>
-        <Text style={[styles.sectionTitle, { color: colors.text }]}>Notifications</Text>
+        <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Notifications</ThemedHeading>
         <Text style={[styles.errorText, { color: colors.error }]}>Failed to load notification settings</Text>
         <TouchableOpacity
           style={[styles.retryButton, { backgroundColor: colors.surfaceSecondary }]}

--- a/apps/mobile/features/settings/components/QuickLinksSection.tsx
+++ b/apps/mobile/features/settings/components/QuickLinksSection.tsx
@@ -9,6 +9,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { useAuth } from "@providers/AuthProvider";
 
 export function QuickLinksSection() {
@@ -22,7 +23,7 @@ export function QuickLinksSection() {
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>Quick Links</Text>
+      <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Quick Links</ThemedHeading>
 
       <TouchableOpacity
         style={[styles.menuItem, { backgroundColor: colors.surfaceSecondary }]}

--- a/apps/mobile/features/settings/components/SettingsScreen.tsx
+++ b/apps/mobile/features/settings/components/SettingsScreen.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import { SettingsForm } from "./SettingsForm";
 import { TimezoneSection } from "./TimezoneSection";
 import { NotificationPreferencesSection } from "./NotificationPreferencesSection";
@@ -40,7 +41,7 @@ export function SettingsScreen() {
         >
           <Ionicons name="arrow-back" size={24} color={colors.text} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text }]}>Settings</Text>
+        <ThemedHeading level={1} style={[styles.headerTitle, { color: colors.text }]}>Settings</ThemedHeading>
       </View>
 
       <SettingsForm />

--- a/apps/mobile/features/settings/components/TimezoneSection.tsx
+++ b/apps/mobile/features/settings/components/TimezoneSection.tsx
@@ -14,6 +14,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuthenticatedMutation, api } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { useTheme } from "@hooks/useTheme";
+import { ThemedHeading } from "@components/ui/ThemedHeading";
 import {
   COMMON_TIMEZONES,
   getTimezoneAbbreviation,
@@ -58,7 +59,7 @@ export function TimezoneSection() {
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.sectionTitle, { color: colors.text }]}>Time Zone</Text>
+      <ThemedHeading level={2} style={[styles.sectionTitle, { color: colors.text }]}>Time Zone</ThemedHeading>
       <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
         Events and meetings will be displayed in your selected time zone.
       </Text>

--- a/apps/mobile/hooks/useCommunityTheme.ts
+++ b/apps/mobile/hooks/useCommunityTheme.ts
@@ -9,6 +9,7 @@
  */
 import { useMemo } from 'react';
 import { useAuth } from '@providers/AuthProvider';
+import { useTheme } from '@hooks/useTheme';
 import { DEFAULT_PRIMARY_COLOR, DEFAULT_SECONDARY_COLOR } from '@utils/styles';
 
 interface CommunityTheme {
@@ -53,11 +54,18 @@ export function darkenColor(hex: string, factor: number = 0.4): string {
 
 export function useCommunityTheme(): CommunityTheme {
   const { user } = useAuth();
+  const { preference, colors } = useTheme();
+
+  // When a design theme is active, its accent supersedes the community color
+  // so primary buttons, tab tints, link colors, etc. flow with the theme.
+  const isDesignTheme =
+    preference === 'hearth' || preference === 'console' || preference === 'conservatory';
 
   return useMemo(() => {
-    const primaryColor = user?.community_primary_color || DEFAULT_PRIMARY_COLOR;
+    const baseCommunityColor = user?.community_primary_color || DEFAULT_PRIMARY_COLOR;
+    const primaryColor = isDesignTheme ? colors.link : baseCommunityColor;
     const secondaryColor = user?.community_secondary_color || DEFAULT_SECONDARY_COLOR;
-    const isCustomTheme = !!(user?.community_primary_color || user?.community_secondary_color);
+    const isCustomTheme = isDesignTheme || !!(user?.community_primary_color || user?.community_secondary_color);
 
     return {
       primaryColor,
@@ -66,5 +74,5 @@ export function useCommunityTheme(): CommunityTheme {
       primaryColorDark: darkenColor(primaryColor, 0.4),
       isCustomTheme,
     };
-  }, [user?.community_primary_color, user?.community_secondary_color]);
+  }, [user?.community_primary_color, user?.community_secondary_color, isDesignTheme, colors.link]);
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -70,6 +70,11 @@
   },
   "dependencies": {
     "@bacons/apple-targets": "^4.0.6",
+    "@expo-google-fonts/dm-sans": "^0.4.2",
+    "@expo-google-fonts/fraunces": "^0.4.1",
+    "@expo-google-fonts/jetbrains-mono": "^0.4.1",
+    "@expo-google-fonts/literata": "^0.4.3",
+    "@expo-google-fonts/manrope": "^0.4.2",
     "@expo/metro-runtime": "~6.1.2",
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5.2.8",

--- a/apps/mobile/providers/ThemeProvider.tsx
+++ b/apps/mobile/providers/ThemeProvider.tsx
@@ -1,41 +1,97 @@
 /**
- * ThemeProvider - Provides theme colors based on system appearance or user preference.
+ * ThemeProvider — provides theme colors and fonts based on system appearance or user preference.
  *
- * Supports three modes:
- * - 'auto': follows the device's dark/light setting (default)
- * - 'light': forces light mode
- * - 'dark': forces dark mode
+ * Preferences:
+ *   - 'auto': follows the device's dark/light setting (default) — system fonts
+ *   - 'light' / 'dark': forces that system mode — system fonts
+ *   - 'hearth' / 'console' / 'conservatory': full design themes — palette + web fonts
  *
- * User preference is persisted to AsyncStorage.
+ * Persistence: AsyncStorage (@togather/theme-preference).
  * All components access theme via `useTheme()` hook.
  */
 import React, { createContext, useMemo, useState, useEffect, useCallback } from 'react';
-import { useColorScheme } from 'react-native';
+import { Text, useColorScheme } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { lightColors, darkColors, type ThemeColors } from '@/theme/colors';
+import {
+  lightColors,
+  darkColors,
+  hearthColors,
+  consoleColors,
+  conservatoryColors,
+  type ThemeColors,
+} from '@/theme/colors';
+import {
+  defaultFonts,
+  hearthFonts,
+  consoleFonts,
+  conservatoryFonts,
+  type ThemeFonts,
+} from '@/theme/fonts';
+import { useThemeFonts } from '@/theme/fontLoader';
+import { isThemePreference, type ThemePreference } from '@/theme/preferences';
 
+export type { ThemePreference } from '@/theme/preferences';
 export type ColorScheme = 'light' | 'dark';
-export type ThemePreference = 'auto' | 'light' | 'dark';
 
 const THEME_STORAGE_KEY = '@togather/theme-preference';
 
 export interface ThemeContextValue {
   colors: ThemeColors;
+  fonts: ThemeFonts;
   isDark: boolean;
   colorScheme: ColorScheme;
-  /** The user's preference: 'auto' follows system, 'light'/'dark' forces that mode */
+  /** The user's preference. 'auto' follows system; named design themes force their look. */
   preference: ThemePreference;
-  /** Update the theme preference (persisted to storage) */
+  /** Update the theme preference (persisted to storage). */
   setPreference: (pref: ThemePreference) => void;
+  /** True while the native font pack for a design theme is still loading. */
+  fontsLoading: boolean;
 }
 
 export const ThemeContext = createContext<ThemeContextValue>({
   colors: lightColors,
+  fonts: defaultFonts,
   isDark: false,
   colorScheme: 'light',
   preference: 'auto',
   setPreference: () => {},
+  fontsLoading: false,
 });
+
+type ResolvedTheme = {
+  colors: ThemeColors;
+  fonts: ThemeFonts;
+  isDark: boolean;
+  colorScheme: ColorScheme;
+};
+
+function resolveTheme(
+  preference: ThemePreference,
+  systemScheme: ColorScheme | null | undefined,
+): ResolvedTheme {
+  switch (preference) {
+    case 'hearth':
+      return { colors: hearthColors, fonts: hearthFonts, isDark: true, colorScheme: 'dark' };
+    case 'console':
+      return { colors: consoleColors, fonts: consoleFonts, isDark: false, colorScheme: 'light' };
+    case 'conservatory':
+      return { colors: conservatoryColors, fonts: conservatoryFonts, isDark: false, colorScheme: 'light' };
+    case 'light':
+      return { colors: lightColors, fonts: defaultFonts, isDark: false, colorScheme: 'light' };
+    case 'dark':
+      return { colors: darkColors, fonts: defaultFonts, isDark: true, colorScheme: 'dark' };
+    case 'auto':
+    default: {
+      const isDark = systemScheme === 'dark';
+      return {
+        colors: isDark ? darkColors : lightColors,
+        fonts: defaultFonts,
+        isDark,
+        colorScheme: isDark ? 'dark' : 'light',
+      };
+    }
+  }
+}
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const systemScheme = useColorScheme();
@@ -44,7 +100,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // Load saved preference on mount
   useEffect(() => {
     AsyncStorage.getItem(THEME_STORAGE_KEY).then((stored) => {
-      if (stored === 'light' || stored === 'dark' || stored === 'auto') {
+      if (isThemePreference(stored)) {
         setPreferenceState(stored);
       }
     });
@@ -55,24 +111,41 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     AsyncStorage.setItem(THEME_STORAGE_KEY, pref);
   }, []);
 
-  const value = useMemo<ThemeContextValue>(() => {
-    const effectiveScheme: ColorScheme =
-      preference === 'auto'
-        ? (systemScheme === 'dark' ? 'dark' : 'light')
-        : preference;
+  const resolved = useMemo(() => resolveTheme(preference, systemScheme), [preference, systemScheme]);
 
-    return {
-      colors: effectiveScheme === 'dark' ? darkColors : lightColors,
-      isDark: effectiveScheme === 'dark',
-      colorScheme: effectiveScheme,
+  // Kick off font loading (no-op for auto/light/dark)
+  const { loaded: fontsLoaded } = useThemeFonts(preference);
+
+  // Propagate body font to every <Text> via defaultProps. Safe app-wide because
+  // no existing component sets its own `fontFamily` (voting gallery aside).
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const TextAny = Text as any;
+    const prev = TextAny.defaultProps?.style;
+    TextAny.defaultProps = {
+      ...(TextAny.defaultProps ?? {}),
+      style: [{ fontFamily: resolved.fonts.body }],
+    };
+    return () => {
+      TextAny.defaultProps = {
+        ...(TextAny.defaultProps ?? {}),
+        style: prev,
+      };
+    };
+  }, [resolved.fonts.body]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      colors: resolved.colors,
+      fonts: resolved.fonts,
+      isDark: resolved.isDark,
+      colorScheme: resolved.colorScheme,
       preference,
       setPreference,
-    };
-  }, [systemScheme, preference, setPreference]);
-
-  return (
-    <ThemeContext.Provider value={value}>
-      {children}
-    </ThemeContext.Provider>
+      fontsLoading: !fontsLoaded,
+    }),
+    [resolved, preference, setPreference, fontsLoaded],
   );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/apps/mobile/providers/__tests__/ThemeProvider.test.tsx
+++ b/apps/mobile/providers/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,127 @@
+import React, { useContext } from 'react';
+import { Text } from 'react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { ThemeProvider, ThemeContext } from '../ThemeProvider';
+import {
+  hearthColors,
+  consoleColors,
+  conservatoryColors,
+  lightColors,
+  darkColors,
+} from '@/theme/colors';
+import { hearthFonts, consoleFonts, conservatoryFonts, defaultFonts } from '@/theme/fonts';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+// Font loader is a real module but its native side-effects (expo-font) are not
+// available in the jest env. Stub it to resolve immediately.
+jest.mock('@/theme/fontLoader', () => ({
+  useThemeFonts: () => ({ loaded: true }),
+}));
+
+const getItemMock = AsyncStorage.getItem as jest.Mock;
+const setItemMock = AsyncStorage.setItem as jest.Mock;
+
+function TestConsumer({ onValue }: { onValue: (ctx: ReturnType<typeof useContext<typeof ThemeContext>>) => void }) {
+  const ctx = useContext(ThemeContext);
+  onValue(ctx);
+  return <Text>ok</Text>;
+}
+
+async function mountWithStoredPreference(stored: string | null) {
+  getItemMock.mockResolvedValueOnce(stored);
+  let captured: any;
+  const result = render(
+    <ThemeProvider>
+      <TestConsumer onValue={(v) => (captured = v)} />
+    </ThemeProvider>,
+  );
+  // Flush effects that read AsyncStorage
+  await waitFor(() => expect(getItemMock).toHaveBeenCalled());
+  return { result, read: () => captured };
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('defaults to auto + lightColors + defaultFonts when no stored preference', async () => {
+    const { read } = await mountWithStoredPreference(null);
+    await waitFor(() => {
+      const ctx = read();
+      expect(ctx.preference).toBe('auto');
+      expect(ctx.colors).toBe(lightColors);
+      expect(ctx.fonts).toBe(defaultFonts);
+    });
+  });
+
+  test.each([
+    ['hearth', hearthColors, hearthFonts, true],
+    ['console', consoleColors, consoleFonts, false],
+    ['conservatory', conservatoryColors, conservatoryFonts, false],
+    ['light', lightColors, defaultFonts, false],
+    ['dark', darkColors, defaultFonts, true],
+  ])('loads stored preference %s → expected palette + fonts', async (pref, expectedColors, expectedFonts, expectedIsDark) => {
+    const { read } = await mountWithStoredPreference(pref);
+    await waitFor(() => {
+      const ctx = read();
+      expect(ctx.preference).toBe(pref);
+      expect(ctx.colors).toBe(expectedColors);
+      expect(ctx.fonts).toBe(expectedFonts);
+      expect(ctx.isDark).toBe(expectedIsDark);
+    });
+  });
+
+  test('ignores unknown stored values (falls back to auto)', async () => {
+    const { read } = await mountWithStoredPreference('totally-bogus-theme');
+    await waitFor(() => {
+      expect(read().preference).toBe('auto');
+    });
+  });
+
+  test('setPreference persists to AsyncStorage', async () => {
+    const { read } = await mountWithStoredPreference(null);
+    await waitFor(() => expect(read()).toBeDefined());
+
+    act(() => {
+      read().setPreference('hearth');
+    });
+
+    expect(setItemMock).toHaveBeenCalledWith('@togather/theme-preference', 'hearth');
+    await waitFor(() => {
+      expect(read().colors).toBe(hearthColors);
+      expect(read().fonts).toBe(hearthFonts);
+    });
+  });
+
+  test('applies body font to Text.defaultProps for the active theme', async () => {
+    const { read } = await mountWithStoredPreference('hearth');
+    await waitFor(() => expect(read().colors).toBe(hearthColors));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const defaultStyle = (Text as any).defaultProps?.style;
+    const flat = Array.isArray(defaultStyle) ? Object.assign({}, ...defaultStyle) : defaultStyle;
+    expect(flat?.fontFamily).toBe(hearthFonts.body);
+  });
+
+  test('switching theme updates Text.defaultProps body font', async () => {
+    const { read } = await mountWithStoredPreference('hearth');
+    await waitFor(() => expect(read().colors).toBe(hearthColors));
+
+    act(() => {
+      read().setPreference('console');
+    });
+
+    await waitFor(() => expect(read().colors).toBe(consoleColors));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const defaultStyle = (Text as any).defaultProps?.style;
+    const flat = Array.isArray(defaultStyle) ? Object.assign({}, ...defaultStyle) : defaultStyle;
+    expect(flat?.fontFamily).toBe(consoleFonts.body);
+  });
+});

--- a/apps/mobile/providers/__tests__/ThemeProvider.test.tsx
+++ b/apps/mobile/providers/__tests__/ThemeProvider.test.tsx
@@ -3,7 +3,7 @@ import { Text } from 'react-native';
 import { act, render, waitFor } from '@testing-library/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import { ThemeProvider, ThemeContext } from '../ThemeProvider';
+import { ThemeProvider, ThemeContext, type ThemeContextValue } from '../ThemeProvider';
 import {
   hearthColors,
   consoleColors,
@@ -27,7 +27,7 @@ jest.mock('@/theme/fontLoader', () => ({
 const getItemMock = AsyncStorage.getItem as jest.Mock;
 const setItemMock = AsyncStorage.setItem as jest.Mock;
 
-function TestConsumer({ onValue }: { onValue: (ctx: ReturnType<typeof useContext<typeof ThemeContext>>) => void }) {
+function TestConsumer({ onValue }: { onValue: (ctx: ThemeContextValue) => void }) {
   const ctx = useContext(ThemeContext);
   onValue(ctx);
   return <Text>ok</Text>;
@@ -35,7 +35,7 @@ function TestConsumer({ onValue }: { onValue: (ctx: ReturnType<typeof useContext
 
 async function mountWithStoredPreference(stored: string | null) {
   getItemMock.mockResolvedValueOnce(stored);
-  let captured: any;
+  let captured: ThemeContextValue | undefined;
   const result = render(
     <ThemeProvider>
       <TestConsumer onValue={(v) => (captured = v)} />
@@ -43,7 +43,7 @@ async function mountWithStoredPreference(stored: string | null) {
   );
   // Flush effects that read AsyncStorage
   await waitFor(() => expect(getItemMock).toHaveBeenCalled());
-  return { result, read: () => captured };
+  return { result, read: () => captured! };
 }
 
 describe('ThemeProvider', () => {

--- a/apps/mobile/theme/__tests__/palettes.test.ts
+++ b/apps/mobile/theme/__tests__/palettes.test.ts
@@ -1,0 +1,64 @@
+import {
+  lightColors,
+  darkColors,
+  hearthColors,
+  consoleColors,
+  conservatoryColors,
+  type ThemeColors,
+} from '../colors';
+
+// The full list of keys that every palette MUST provide. Derived from lightColors —
+// if a new token is added to the contract, lightColors will have it and this list
+// will catch palettes that forgot.
+const REQUIRED_KEYS = Object.keys(lightColors) as Array<keyof ThemeColors>;
+
+const PALETTES: Array<{ name: string; palette: ThemeColors }> = [
+  { name: 'lightColors', palette: lightColors },
+  { name: 'darkColors', palette: darkColors },
+  { name: 'hearthColors', palette: hearthColors },
+  { name: 'consoleColors', palette: consoleColors },
+  { name: 'conservatoryColors', palette: conservatoryColors },
+];
+
+describe('theme palettes', () => {
+  PALETTES.forEach(({ name, palette }) => {
+    describe(name, () => {
+      test('implements every ThemeColors key', () => {
+        const missing = REQUIRED_KEYS.filter((key) => palette[key] === undefined);
+        expect(missing).toEqual([]);
+      });
+
+      test('every value is a non-empty string', () => {
+        const bad: string[] = [];
+        for (const key of REQUIRED_KEYS) {
+          const value = palette[key];
+          if (typeof value !== 'string' || value.length === 0) {
+            bad.push(`${key}=${String(value)}`);
+          }
+        }
+        expect(bad).toEqual([]);
+      });
+
+      test('every value is a valid CSS color (hex or rgba)', () => {
+        const cssColor = /^(#[0-9a-fA-F]{3,8}|rgba?\([^)]+\))$/;
+        const bad: string[] = [];
+        for (const key of REQUIRED_KEYS) {
+          if (!cssColor.test(palette[key])) {
+            bad.push(`${key}=${palette[key]}`);
+          }
+        }
+        expect(bad).toEqual([]);
+      });
+    });
+  });
+
+  test('all palettes share the exact same key set', () => {
+    const reference = new Set(REQUIRED_KEYS);
+    for (const { name, palette } of PALETTES) {
+      const keys = new Set(Object.keys(palette));
+      const extra = [...keys].filter((k) => !reference.has(k as keyof ThemeColors));
+      const missing = [...reference].filter((k) => !keys.has(k));
+      expect({ name, extra, missing }).toEqual({ name, extra: [], missing: [] });
+    }
+  });
+});

--- a/apps/mobile/theme/colors.ts
+++ b/apps/mobile/theme/colors.ts
@@ -177,3 +177,8 @@ export const darkColors: ThemeColors = {
   modalBackground: '#1f2c34',
   modalCloseBackground: 'rgba(31, 44, 52, 0.9)',
 };
+
+// Design-theme palettes
+export { hearthColors } from './palettes/hearthColors';
+export { consoleColors } from './palettes/consoleColors';
+export { conservatoryColors } from './palettes/conservatoryColors';

--- a/apps/mobile/theme/fontLoader.ts
+++ b/apps/mobile/theme/fontLoader.ts
@@ -1,0 +1,188 @@
+/**
+ * Theme font loader.
+ *
+ * Native (iOS/Android): loads the required TTF variants for the active theme via
+ * expo-font. Returns `{ loaded: false }` until all TTFs are registered, so the
+ * provider can hold the tree until text renders in the right typeface.
+ *
+ * Web: expo-font's web shim technically works, but we instead inject the
+ * appropriate Google Fonts <link> so CSS handles weight selection naturally
+ * (matching how the static design explorations load fonts in useWebFonts).
+ * Web always returns `loaded: true` immediately — the <link> swap is async but
+ * non-blocking, and pre-paint text renders in the fallback CSS stack.
+ */
+import { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+import * as Font from 'expo-font';
+import type { ThemePreference } from './preferences';
+
+// ---- Native font asset registration ---------------------------------------
+
+// Lazy requires so the bundler only pulls in what's needed for the active theme.
+// Each map registers weights at keys that match the strings in fonts.ts.
+function hearthNativeFonts(): Record<string, number> {
+  const {
+    Fraunces_400Regular,
+    Fraunces_600SemiBold,
+    Fraunces_700Bold,
+  } = require('@expo-google-fonts/fraunces');
+  const {
+    DMSans_400Regular,
+    DMSans_500Medium,
+    DMSans_700Bold,
+  } = require('@expo-google-fonts/dm-sans');
+  return {
+    Fraunces_400Regular,
+    Fraunces_600SemiBold,
+    Fraunces_700Bold,
+    DMSans_400Regular,
+    DMSans_500Medium,
+    DMSans_700Bold,
+  };
+}
+
+function consoleNativeFonts(): Record<string, number> {
+  const {
+    JetBrainsMono_400Regular,
+    JetBrainsMono_500Medium,
+    JetBrainsMono_600SemiBold,
+    JetBrainsMono_700Bold,
+  } = require('@expo-google-fonts/jetbrains-mono');
+  const {
+    Manrope_400Regular,
+    Manrope_500Medium,
+    Manrope_700Bold,
+  } = require('@expo-google-fonts/manrope');
+  return {
+    JetBrainsMono_400Regular,
+    JetBrainsMono_500Medium,
+    JetBrainsMono_600SemiBold,
+    JetBrainsMono_700Bold,
+    Manrope_400Regular,
+    Manrope_500Medium,
+    Manrope_700Bold,
+  };
+}
+
+function conservatoryNativeFonts(): Record<string, number> {
+  const {
+    Literata_400Regular,
+    Literata_500Medium,
+    Literata_600SemiBold,
+    Literata_700Bold,
+  } = require('@expo-google-fonts/literata');
+  const {
+    Manrope_400Regular,
+    Manrope_500Medium,
+    Manrope_700Bold,
+  } = require('@expo-google-fonts/manrope');
+  return {
+    Literata_400Regular,
+    Literata_500Medium,
+    Literata_600SemiBold,
+    Literata_700Bold,
+    Manrope_400Regular,
+    Manrope_500Medium,
+    Manrope_700Bold,
+  };
+}
+
+function getNativeFontMap(preference: ThemePreference): Record<string, number> | null {
+  switch (preference) {
+    case 'hearth':
+      return hearthNativeFonts();
+    case 'console':
+      return consoleNativeFonts();
+    case 'conservatory':
+      return conservatoryNativeFonts();
+    default:
+      return null; // system fonts only
+  }
+}
+
+// ---- Web font <link> injection -------------------------------------------
+
+const WEB_FONT_HREFS: Record<ThemePreference, string | null> = {
+  auto: null,
+  light: null,
+  dark: null,
+  hearth:
+    'https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=DM+Sans:wght@400;500;700&display=swap',
+  console:
+    'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Manrope:wght@400;500;700&display=swap',
+  conservatory:
+    'https://fonts.googleapis.com/css2?family=Literata:opsz,wght@7..72,400;7..72,500;7..72,600;7..72,700&family=Manrope:wght@400;500;700&display=swap',
+};
+
+const WEB_LINK_ID = 'togather-theme-fonts';
+
+function applyWebFontLink(preference: ThemePreference): void {
+  if (Platform.OS !== 'web' || typeof document === 'undefined') return;
+  const href = WEB_FONT_HREFS[preference];
+  const existing = document.getElementById(WEB_LINK_ID) as HTMLLinkElement | null;
+  if (!href) {
+    if (existing) existing.remove();
+    return;
+  }
+  if (existing) {
+    if (existing.href !== href) existing.href = href;
+    return;
+  }
+  const link = document.createElement('link');
+  link.id = WEB_LINK_ID;
+  link.rel = 'stylesheet';
+  link.href = href;
+  document.head.appendChild(link);
+}
+
+// ---- Hook -----------------------------------------------------------------
+
+/**
+ * Loads the fonts for the active theme preference.
+ *
+ * - Native: resolves `loaded` to `true` once all TTFs are registered (or an
+ *   error occurs; in which case we fall back to system fonts gracefully).
+ * - Web: `loaded` is `true` immediately; the <link> is injected as a side effect.
+ * - Default/light/dark themes: no fonts to load, `loaded` is `true` immediately.
+ */
+export function useThemeFonts(preference: ThemePreference): { loaded: boolean } {
+  const needsNativeLoad = Platform.OS !== 'web' && (
+    preference === 'hearth' || preference === 'console' || preference === 'conservatory'
+  );
+  const [nativeLoaded, setNativeLoaded] = useState(!needsNativeLoad);
+
+  // Web <link> injection (side-effect, non-blocking)
+  useEffect(() => {
+    applyWebFontLink(preference);
+  }, [preference]);
+
+  // Native TTF registration
+  useEffect(() => {
+    if (!needsNativeLoad) {
+      setNativeLoaded(true);
+      return;
+    }
+    const map = getNativeFontMap(preference);
+    if (!map) {
+      setNativeLoaded(true);
+      return;
+    }
+    let cancelled = false;
+    setNativeLoaded(false);
+    Font.loadAsync(map)
+      .then(() => {
+        if (!cancelled) setNativeLoaded(true);
+      })
+      .catch((err) => {
+        // Fail open: if font loading errors, render in system fonts rather than
+        // blocking the app. expo-font logs the error internally.
+        if (__DEV__) console.warn('[useThemeFonts] load failed', err);
+        if (!cancelled) setNativeLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [preference, needsNativeLoad]);
+
+  return { loaded: nativeLoaded };
+}

--- a/apps/mobile/theme/fonts.ts
+++ b/apps/mobile/theme/fonts.ts
@@ -1,0 +1,57 @@
+/**
+ * Theme font tokens. Each palette pairs with a font set; `defaultFonts` uses the
+ * platform's system fonts (current behavior).
+ *
+ * Font family names are Platform-aware:
+ *   - native: the exact key we load via expo-font (see fontLoader.ts). We load
+ *     one regular-weight variant per role; bold Text renders as faux-bold on iOS
+ *     (and approximately so on Android) — a v1 trade-off documented in the plan.
+ *   - web: a CSS font stack. Google Fonts <link> is injected by the provider so
+ *     the browser picks any weight from the stack.
+ */
+import { Platform } from 'react-native';
+
+export type ThemeFonts = {
+  /** Display / headings */
+  display: string;
+  /** Body text — applied app-wide via Text.defaultProps */
+  body: string;
+  /** Monospace / code / tag-like text */
+  mono: string;
+};
+
+const SYSTEM_SANS = Platform.select({ default: 'System', web: 'system-ui, sans-serif' })!;
+const SYSTEM_MONO = Platform.select({
+  ios: 'Menlo',
+  android: 'monospace',
+  default: 'monospace',
+  web: 'ui-monospace, monospace',
+})!;
+
+/** Current behavior: system fonts everywhere. */
+export const defaultFonts: ThemeFonts = {
+  display: SYSTEM_SANS,
+  body: SYSTEM_SANS,
+  mono: SYSTEM_MONO,
+};
+
+/** Hearth — warm dark serif. Display: Fraunces; body: DM Sans. */
+export const hearthFonts: ThemeFonts = {
+  display: Platform.select({ default: 'Fraunces_600SemiBold', web: '"Fraunces", Georgia, serif' })!,
+  body: Platform.select({ default: 'DMSans_400Regular', web: '"DM Sans", system-ui, sans-serif' })!,
+  mono: SYSTEM_MONO,
+};
+
+/** Console — light terminal. Body: Manrope; display/mono: JetBrains Mono. */
+export const consoleFonts: ThemeFonts = {
+  display: Platform.select({ default: 'JetBrainsMono_600SemiBold', web: '"JetBrains Mono", ui-monospace, monospace' })!,
+  body: Platform.select({ default: 'Manrope_400Regular', web: '"Manrope", system-ui, sans-serif' })!,
+  mono: Platform.select({ default: 'JetBrainsMono_500Medium', web: '"JetBrains Mono", ui-monospace, monospace' })!,
+};
+
+/** Conservatory — pastel glass. Display: Literata; body: Manrope. */
+export const conservatoryFonts: ThemeFonts = {
+  display: Platform.select({ default: 'Literata_600SemiBold', web: '"Literata", Georgia, serif' })!,
+  body: Platform.select({ default: 'Manrope_400Regular', web: '"Manrope", system-ui, sans-serif' })!,
+  mono: SYSTEM_MONO,
+};

--- a/apps/mobile/theme/palettes/conservatoryColors.ts
+++ b/apps/mobile/theme/palettes/conservatoryColors.ts
@@ -1,0 +1,64 @@
+/**
+ * Conservatory palette — pastel glass with teal accent.
+ * Derived from app/design-28.tsx ("Conservatory"). Implements the full ThemeColors contract.
+ * Note: the design's translucent `glass*` tokens are opaquified here for surfaces
+ * used across the app that don't sit over a photo backdrop.
+ */
+import type { ThemeColors } from '../colors';
+
+export const conservatoryColors: ThemeColors = {
+  // Backgrounds
+  background: '#E4E8DE',
+  backgroundSecondary: '#D8DED2',
+  surface: '#F0F2EC',
+  surfaceSecondary: '#F7F8F4',
+
+  // Text
+  text: '#1B2620',
+  textSecondary: '#4C5A51',
+  textTertiary: '#8A9489',
+  textInverse: '#F0F2EC',
+
+  // Borders
+  border: 'rgba(27,38,32,0.10)',
+  borderLight: 'rgba(27,38,32,0.05)',
+
+  // Buttons
+  buttonPrimary: '#1C6B5E',
+  buttonPrimaryText: '#F0F2EC',
+  buttonSecondary: '#F0F2EC',
+  buttonSecondaryText: '#1B2620',
+  buttonDisabled: 'rgba(27,38,32,0.10)',
+  buttonDisabledText: '#8A9489',
+
+  // Chat
+  chatBubbleOwn: 'rgba(28,107,94,0.14)',
+  chatBubbleOther: '#F0F2EC',
+  chatBubbleOwnText: '#1B2620',
+  chatBubbleOtherText: '#1B2620',
+
+  // Status (semantic)
+  error: '#A43A3A',
+  success: '#1C6B5E',
+  warning: '#B08B3C',
+
+  // System
+  tabBar: '#E4E8DE',
+  tabBarBorder: 'rgba(27,38,32,0.10)',
+  tabBarInactive: '#8A9489',
+  overlay: 'rgba(27,38,32,0.5)',
+  shadow: '#1B2620',
+  inputBackground: '#F7F8F4',
+  inputBorder: 'rgba(27,38,32,0.10)',
+  inputBorderFocused: '#1C6B5E',
+  inputPlaceholder: '#8A9489',
+  skeleton: 'rgba(27,38,32,0.08)',
+  icon: '#4C5A51',
+  iconSecondary: '#8A9489',
+  link: '#1C6B5E',
+  destructive: '#A43A3A',
+  selectedBackground: 'rgba(28,107,94,0.14)',
+  landing: '#1B2620',
+  modalBackground: '#F0F2EC',
+  modalCloseBackground: 'rgba(240,242,236,0.9)',
+};

--- a/apps/mobile/theme/palettes/consoleColors.ts
+++ b/apps/mobile/theme/palettes/consoleColors.ts
@@ -1,0 +1,62 @@
+/**
+ * Console palette — warm light monospace/terminal with tan accent.
+ * Derived from app/design-20.tsx ("Console"). Implements the full ThemeColors contract.
+ */
+import type { ThemeColors } from '../colors';
+
+export const consoleColors: ThemeColors = {
+  // Backgrounds
+  background: '#F4EFE4',
+  backgroundSecondary: '#EBE5D6',
+  surface: '#FBF7EC',
+  surfaceSecondary: '#FFFCF3',
+
+  // Text
+  text: '#1C1A16',
+  textSecondary: '#5F594E',
+  textTertiary: '#9A9387',
+  textInverse: '#FBF7EC',
+
+  // Borders
+  border: 'rgba(28,26,22,0.10)',
+  borderLight: 'rgba(28,26,22,0.05)',
+
+  // Buttons
+  buttonPrimary: '#1C1A16',
+  buttonPrimaryText: '#FBF7EC',
+  buttonSecondary: '#FBF7EC',
+  buttonSecondaryText: '#1C1A16',
+  buttonDisabled: 'rgba(28,26,22,0.10)',
+  buttonDisabledText: '#9A9387',
+
+  // Chat
+  chatBubbleOwn: 'rgba(204,122,26,0.20)',
+  chatBubbleOther: '#FBF7EC',
+  chatBubbleOwnText: '#1C1A16',
+  chatBubbleOtherText: '#1C1A16',
+
+  // Status (semantic)
+  error: '#B03030',
+  success: '#5B7A3E',
+  warning: '#CC7A1A',
+
+  // System
+  tabBar: '#FBF7EC',
+  tabBarBorder: 'rgba(28,26,22,0.10)',
+  tabBarInactive: '#9A9387',
+  overlay: 'rgba(28,26,22,0.5)',
+  shadow: '#1C1A16',
+  inputBackground: '#FFFCF3',
+  inputBorder: 'rgba(28,26,22,0.10)',
+  inputBorderFocused: '#CC7A1A',
+  inputPlaceholder: '#9A9387',
+  skeleton: 'rgba(28,26,22,0.08)',
+  icon: '#5F594E',
+  iconSecondary: '#9A9387',
+  link: '#CC7A1A',
+  destructive: '#B03030',
+  selectedBackground: 'rgba(204,122,26,0.12)',
+  landing: '#1C1A16',
+  modalBackground: '#FBF7EC',
+  modalCloseBackground: 'rgba(251,247,236,0.9)',
+};

--- a/apps/mobile/theme/palettes/hearthColors.ts
+++ b/apps/mobile/theme/palettes/hearthColors.ts
@@ -1,0 +1,62 @@
+/**
+ * Hearth palette — warm dark serif with ember accent.
+ * Derived from app/design-14.tsx ("Hearth"). Implements the full ThemeColors contract.
+ */
+import type { ThemeColors } from '../colors';
+
+export const hearthColors: ThemeColors = {
+  // Backgrounds
+  background: '#15110E',
+  backgroundSecondary: '#1A150F',
+  surface: '#1E1915',
+  surfaceSecondary: '#2A241F',
+
+  // Text
+  text: '#F5EEE3',
+  textSecondary: '#9A8F80',
+  textTertiary: '#6A6058',
+  textInverse: '#15110E',
+
+  // Borders
+  border: 'rgba(245,238,227,0.08)',
+  borderLight: 'rgba(245,238,227,0.04)',
+
+  // Buttons
+  buttonPrimary: '#E67A3C',
+  buttonPrimaryText: '#15110E',
+  buttonSecondary: '#2A241F',
+  buttonSecondaryText: '#F5EEE3',
+  buttonDisabled: '#2A241F',
+  buttonDisabledText: '#6A6058',
+
+  // Chat
+  chatBubbleOwn: 'rgba(230,122,60,0.22)',
+  chatBubbleOther: '#2A241F',
+  chatBubbleOwnText: '#F5EEE3',
+  chatBubbleOtherText: '#F5EEE3',
+
+  // Status (semantic)
+  error: '#FF6B4A',
+  success: '#9AD38A',
+  warning: '#F7A06B',
+
+  // System
+  tabBar: '#15110E',
+  tabBarBorder: 'rgba(245,238,227,0.08)',
+  tabBarInactive: '#6A6058',
+  overlay: 'rgba(0,0,0,0.7)',
+  shadow: '#000000',
+  inputBackground: '#1E1915',
+  inputBorder: 'rgba(245,238,227,0.08)',
+  inputBorderFocused: 'rgba(230,122,60,0.40)',
+  inputPlaceholder: '#6A6058',
+  skeleton: '#2A241F',
+  icon: '#9A8F80',
+  iconSecondary: '#6A6058',
+  link: '#E67A3C',
+  destructive: '#FF6B4A',
+  selectedBackground: 'rgba(230,122,60,0.14)',
+  landing: '#15110E',
+  modalBackground: '#1E1915',
+  modalCloseBackground: 'rgba(30,25,21,0.9)',
+};

--- a/apps/mobile/theme/preferences.ts
+++ b/apps/mobile/theme/preferences.ts
@@ -1,0 +1,22 @@
+/**
+ * The full set of values the user can store in the theme preference.
+ *   - auto/light/dark: system-font themes backed by lightColors/darkColors.
+ *   - hearth/console/conservatory: full design themes (palette + fonts).
+ *
+ * Kept in a separate file from ThemeProvider so both the provider and font
+ * loader can import it without a circular dependency.
+ */
+export type ThemePreference = 'auto' | 'light' | 'dark' | 'hearth' | 'console' | 'conservatory';
+
+export const ALL_THEME_PREFERENCES: ThemePreference[] = [
+  'auto',
+  'light',
+  'dark',
+  'hearth',
+  'console',
+  'conservatory',
+];
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return typeof value === 'string' && ALL_THEME_PREFERENCES.includes(value as ThemePreference);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,11 @@ overrides:
   '@smithy/middleware-stack': 4.2.7
   '@smithy/util-stream': 4.5.8
 
+patchedDependencies:
+  expo-notifications@0.32.16:
+    hash: ophlp4g3xfanrcofgl4odqbbnm
+    path: patches/expo-notifications@0.32.16.patch
+
 importers:
 
   .:
@@ -164,6 +169,21 @@ importers:
       '@bacons/apple-targets':
         specifier: ^4.0.6
         version: 4.0.6(expo@54.0.33)
+      '@expo-google-fonts/dm-sans':
+        specifier: ^0.4.2
+        version: 0.4.2
+      '@expo-google-fonts/fraunces':
+        specifier: ^0.4.1
+        version: 0.4.1
+      '@expo-google-fonts/jetbrains-mono':
+        specifier: ^0.4.1
+        version: 0.4.1
+      '@expo-google-fonts/literata':
+        specifier: ^0.4.3
+        version: 0.4.3
+      '@expo-google-fonts/manrope':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@expo/metro-runtime':
         specifier: ~6.1.2
         version: 6.1.2(expo@54.0.33)(react-dom@19.1.0)(react-native@0.81.5)(react@19.1.0)
@@ -289,7 +309,7 @@ importers:
         version: 18.2.1(expo@54.0.33)(react-native@0.81.5)
       expo-notifications:
         specifier: ~0.32.15
-        version: 0.32.16(expo@54.0.33)(react-native@0.81.5)(react@19.1.0)
+        version: 0.32.16(patch_hash=ophlp4g3xfanrcofgl4odqbbnm)(expo@54.0.33)(react-native@0.81.5)(react@19.1.0)
       expo-router:
         specifier: ~6.0.14
         version: 6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@12.9.0)(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0)(react-native-gesture-handler@2.28.0)(react-native-reanimated@4.1.6)(react-native-safe-area-context@5.6.2)(react-native-screens@4.16.0)(react-native-web@0.21.2)(react-native@0.81.5)(react@19.1.0)
@@ -3688,6 +3708,26 @@ packages:
       '@eslint/core': 0.17.0
       levn: 0.4.1
     dev: true
+
+  /@expo-google-fonts/dm-sans@0.4.2:
+    resolution: {integrity: sha512-e/fLH5aCJzkEenz7axvEn8N7IJAKhUwNjIxS75h9j+Ip1M9S7d22M19gJN3A7QW4egVkBJRyQh1hQFhngQn9yA==}
+    dev: false
+
+  /@expo-google-fonts/fraunces@0.4.1:
+    resolution: {integrity: sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==}
+    dev: false
+
+  /@expo-google-fonts/jetbrains-mono@0.4.1:
+    resolution: {integrity: sha512-CslACrtMOcRwoWXCO7OMEI+9w3fukWSoBtvNz46OqPoogEuuoY0tkDY1O8sFumk8t0pC6Cx0Xr95O0TOQhpkug==}
+    dev: false
+
+  /@expo-google-fonts/literata@0.4.3:
+    resolution: {integrity: sha512-AuxE7NB6Ae1laRK8uTcap5xI2MYTZOXrAWul4SNGBiq4igP7r/q8IO3vdvO/P1MGiRczuyZ1zhTwSm/CaYeq9A==}
+    dev: false
+
+  /@expo-google-fonts/manrope@0.4.2:
+    resolution: {integrity: sha512-BZsKe8d9BJrVnIQIZcTS7/Kac0TbXnqs/+8EBSiQxrmK6GoCO6eTkmr50D1weIk/EoF20pTmAkpWICnovATr/g==}
+    dev: false
 
   /@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5):
     resolution: {integrity: sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==}
@@ -9780,7 +9820,7 @@ packages:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
-  /expo-notifications@0.32.16(expo@54.0.33)(react-native@0.81.5)(react@19.1.0):
+  /expo-notifications@0.32.16(patch_hash=ophlp4g3xfanrcofgl4odqbbnm)(expo@54.0.33)(react-native@0.81.5)(react@19.1.0):
     resolution: {integrity: sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==}
     peerDependencies:
       expo: '*'
@@ -9800,6 +9840,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+    patched: true
 
   /expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@12.9.0)(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0)(react-native-gesture-handler@2.28.0)(react-native-reanimated@4.1.6)(react-native-safe-area-context@5.6.2)(react-native-screens@4.16.0)(react-native-web@0.21.2)(react-native@0.81.5)(react@19.1.0):
     resolution: {integrity: sha512-qCxVAiCrCyu0npky6azEZ6dJDMt77OmCzEbpF6RbUTlfkaCA417LvY14SBkk0xyGruSxy/7pvJOI6tuThaUVCA==}


### PR DESCRIPTION
## Summary
- Adds three full-app design themes — **Hearth** (warm dark serif, ember accent), **Console** (light mono, terminal vibe, tan accent), **Conservatory** (pastel glass, teal accent) — selectable from Settings → Appearance alongside Auto / Light / Dark.
- Default behavior is unchanged. Picking a design theme re-skins every screen via the existing `ThemeColors` token system, applies a body font app-wide via `Text.defaultProps`, and swaps the inbox to the matching design's full layout fed with real Convex data.

## Branch contents
This PR contains **four commits**:
1. `7e59c55` — the 30-design exploration gallery (was on a local `feat/inbox-design-explorations` branch; included here as the foundation since the three themes are extracted from designs 14, 20, 28).
2. `60040f2` — theme foundation (palettes, fonts, ThemeProvider extension, ThemedHeading/ThemedMono).
3. `c1b3793` — per-theme inbox components + adapter + ChatInboxScreen wiring + expanded settings picker.
4. `77a57d5` — heading migration (top-of-funnel `<Text>` → `<ThemedHeading>`).

If you'd rather review the gallery and the theme system separately, say the word and I'll split commit 1 into its own PR and rebase this one on top.

## What ships
- **Theme foundation** — three palettes in `theme/palettes/`, `ThemeFonts` tokens with cross-platform font handling, font loader using `@expo-google-fonts/*` (native bundles TTFs, web injects `<link>`), `ThemedHeading` / `ThemedMono` opt-in display/mono components.
- **`ThemeProvider`** extended to a single 6-value preference (`auto | light | dark | hearth | console | conservatory`). Resolves palette + fonts from one map and applies body font via `Text.defaultProps` (safe because no app screen sets `fontFamily` today — checked).
- **Settings picker** expanded from 3 to 6 options, laid out as System (Auto/Light/Dark) + Designs (Hearth/Console/Conservatory) sub-rows with accent swatches.
- **Inbox** — `ChatInboxScreen` branches on preference; design themes render `HearthInbox` / `ConsoleInbox` / `ConservatoryInbox` (extracted from `app/design-14|20|28.tsx`) with real data via `inboxDesignAdapter.toDesignGroups`. Each design has its own loading + empty state and a sidebar variant for desktop split-pane.
- **Heading migration** — top-of-funnel headings migrated to `<ThemedHeading>` so display fonts show up where users look first: chat header, group header, profile name, event title, explore card titles, settings section titles.

## Tests
- 112 suites / 1062 tests passing (was 110 / 1052; net +2 suites, +10 tests).
- New unit coverage: palette completeness across all 5 palettes, ThemeProvider preference round-trip + Text.defaultProps propagation, ThemedHeading per-theme font resolution, `formatInboxTime` cases, `toDesignGroups` mapping, snapshot/interaction tests for each of the three inbox design components.
- Updated one existing snapshot to absorb the additional `<ThemedHeading>` style array shape on ProfileHeader (no rendered-text change).

## Test plan
- [x] Unit tests + tsc clean (filtering pre-existing errors)
- [ ] Manual mobile (iOS): tour every tab in each theme; confirm palette + body font app-wide; inbox swaps to themed layout; tap-to-open works; cold-start preference persists; switch back to Default restores current behavior
- [ ] Manual web: desktop split-pane shows themed sidebar variant; verify Google Fonts `<link>` injection; switch themes inline without refresh
- [ ] Layout regression sweep on each theme — tab labels, button labels, card titles, modals (font-metric shifts can affect spacing)

## Native dep classification
Five `@expo-google-fonts/*` packages added. They ride on top of `expo-font` (already classified `core`); the asset packages themselves don't match the `native-deps.json` regex patterns, so the `check-native-imports` script doesn't require classification. Verified locally.

## Out of scope (follow-ups)
- App-wide migration of every `<Text>` heading to `<ThemedHeading>` — v1 covers ~10 high-visibility instances; the rest receive body font automatically and can adopt incrementally.
- Cross-device theme sync (this is local-only AsyncStorage).
- Applying design-specific motifs (glass cards, ember glow, terminal prompt) to non-inbox screens.
- Promoting/consolidating the remaining 27 design routes (left as the voting gallery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)