### PR TITLE
fix(admin/dashboard): repair notification stats, respect user timezone, show community proposals

### DIFF
--- a/apps/convex/functions/admin/stats.ts
+++ b/apps/convex/functions/admin/stats.ts
@@ -37,6 +37,79 @@ function utcMonthStart(timestamp: number): number {
   return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
 }
 
+const DEFAULT_TZ = "America/New_York";
+
+/** Offset of `timeZone` from UTC at `timestampMs`, in milliseconds. */
+function tzOffsetMs(timestampMs: number, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date(timestampMs));
+  const pick = (t: string) => parts.find((p) => p.type === t)!.value;
+  // Intl's hour12:false sometimes returns "24" for midnight.
+  const hour = Number(pick("hour")) % 24;
+  const localAsUtc = Date.UTC(
+    Number(pick("year")),
+    Number(pick("month")) - 1,
+    Number(pick("day")),
+    hour,
+    Number(pick("minute")),
+    Number(pick("second"))
+  );
+  return localAsUtc - timestampMs;
+}
+
+/** UTC timestamp at the start of the given (y, m, d) calendar day in `timeZone`. */
+function tzMidnightUtc(year: number, month: number, day: number, timeZone: string): number {
+  const utcGuess = Date.UTC(year, month - 1, day);
+  return utcGuess - tzOffsetMs(utcGuess, timeZone);
+}
+
+/**
+ * Returns the `timeZone` calendar-day window that contains `timestampMs`.
+ * `start`/`end` are UTC timestamps (inclusive/exclusive), `ymd` is "YYYY-MM-DD".
+ */
+function dayWindow(timestampMs: number, timeZone: string): {
+  ymd: string;
+  start: number;
+  end: number;
+} {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(timestampMs));
+  const pick = (t: string) => parts.find((p) => p.type === t)!.value;
+  const ymd = `${pick("year")}-${pick("month")}-${pick("day")}`;
+  const y = Number(pick("year"));
+  const m = Number(pick("month"));
+  const d = Number(pick("day"));
+  return {
+    ymd,
+    start: tzMidnightUtc(y, m, d, timeZone),
+    end: tzMidnightUtc(y, m, d + 1, timeZone),
+  };
+}
+
+/** Validate a timezone string; fall back to America/New_York if invalid. */
+function resolveTimeZone(tz: string | undefined): string {
+  if (!tz) return DEFAULT_TZ;
+  try {
+    // Intl throws RangeError on unknown zones
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return tz;
+  } catch {
+    return DEFAULT_TZ;
+  }
+}
+
 function nextBucketStart(timestamp: number, granularity: SuperAdminGranularity): number {
   const d = new Date(timestamp);
   if (granularity === "month") {
@@ -1177,6 +1250,8 @@ export const getDailySummary = query({
     token: v.string(),
     /** Days offset from today (0 = today, 1 = yesterday, 2 = day before, etc.) */
     daysAgo: v.optional(v.number()),
+    /** IANA time zone for day boundaries (e.g. "America/New_York"). */
+    timeZone: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -1187,8 +1262,11 @@ export const getDailySummary = query({
 
     const offset = args.daysAgo ?? 0;
     const nowMs = now();
-    const dayStart = utcDayStart(nowMs - offset * DAY_MS);
-    const dayEnd = dayStart + DAY_MS;
+    const tz = resolveTimeZone(args.timeZone ?? user.timezone);
+    const { start: dayStart, end: dayEnd, ymd: dateLabel } = dayWindow(
+      nowMs - offset * DAY_MS,
+      tz
+    );
 
     // Scan the day's messages using the by_createdAt index
     const dayMessages = await ctx.db
@@ -1329,12 +1407,8 @@ export const getDailySummary = query({
       })
     );
 
-    // Format date as YYYY-MM-DD in UTC
-    const d = new Date(dayStart);
-    const date = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
-
     return {
-      date,
+      date: dateLabel,
       messages: {
         total: totalMessages,
         uniqueSenders: uniqueSenders.size,
@@ -1352,12 +1426,20 @@ export const getDailySummary = query({
 // ============================================================================
 
 /**
- * Get notification impression and click statistics for a community on a given day
+ * Get notification sent/impression/click counts for a single day in the
+ * caller's time zone.
+ *
+ * Reads from `notificationHourlyStats` (one row per hour per type) so cost is
+ * O(hours × types) — ~24 × ~types regardless of daily send volume. Counters
+ * are populated incrementally from `incrementNotificationHourlyStat`; history
+ * starts from first-deploy time (no backfill).
  */
 export const getNotificationStats = query({
   args: {
     token: v.string(),
     daysAgo: v.number(),
+    /** IANA time zone for day boundaries (e.g. "America/New_York"). */
+    timeZone: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -1366,46 +1448,36 @@ export const getNotificationStats = query({
       throw new Error("Togather internal access required");
     }
 
-    // Calculate day boundaries
-    const targetDate = new Date();
-    targetDate.setDate(targetDate.getDate() - args.daysAgo);
-    targetDate.setHours(0, 0, 0, 0);
-    const dayStart = targetDate.getTime();
-    const dayEnd = dayStart + DAY_MS;
+    const tz = resolveTimeZone(args.timeZone ?? user.timezone);
+    const { start: dayStart, end: dayEnd } = dayWindow(
+      now() - args.daysAgo * DAY_MS,
+      tz
+    );
 
-    // Get all notifications for this day
-    const notifications = await ctx.db
-      .query("notifications")
-      .withIndex("by_createdAt")
-      .filter((q) =>
-        q.and(
-          q.gte(q.field("createdAt"), dayStart),
-          q.lt(q.field("createdAt"), dayEnd)
-        )
+    const rows = await ctx.db
+      .query("notificationHourlyStats")
+      .withIndex("by_hour", (q) =>
+        q.gte("hourStartMs", dayStart).lt("hourStartMs", dayEnd)
       )
       .collect();
 
-    // Aggregate by type
-    const byType: Record<string, { sent: number; impressed: number; clicked: number }> = {};
+    const byType: Record<
+      string,
+      { sent: number; impressed: number; clicked: number }
+    > = {};
     let totalSent = 0;
     let totalImpressed = 0;
     let totalClicked = 0;
 
-    for (const n of notifications) {
-      const type = n.notificationType;
-      if (!byType[type]) byType[type] = { sent: 0, impressed: 0, clicked: 0 };
-      if (n.status === "sent") {
-        byType[type].sent++;
-        totalSent++;
-      }
-      if (n.impressedAt) {
-        byType[type].impressed++;
-        totalImpressed++;
-      }
-      if (n.clickedAt) {
-        byType[type].clicked++;
-        totalClicked++;
-      }
+    for (const row of rows) {
+      const entry = byType[row.type] ?? { sent: 0, impressed: 0, clicked: 0 };
+      entry.sent += row.sent;
+      entry.impressed += row.impressed;
+      entry.clicked += row.clicked;
+      byType[row.type] = entry;
+      totalSent += row.sent;
+      totalImpressed += row.impressed;
+      totalClicked += row.clicked;
     }
 
     return {

--- a/apps/convex/functions/notifications/mutations.ts
+++ b/apps/convex/functions/notifications/mutations.ts
@@ -8,6 +8,7 @@ import { v } from "convex/values";
 import { mutation, internalMutation } from "../../_generated/server";
 import { now } from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
+import { incrementNotificationHourlyStat } from "../../lib/notificationStats";
 
 /**
  * Mark a specific notification as read
@@ -114,7 +115,7 @@ export const createNotification = internalMutation({
   handler: async (ctx, args) => {
     const timestamp = now();
 
-    return await ctx.db.insert("notifications", {
+    const id = await ctx.db.insert("notifications", {
       userId: args.userId,
       communityId: args.communityId,
       groupId: args.groupId,
@@ -128,6 +129,16 @@ export const createNotification = internalMutation({
       sentAt: args.status === "sent" ? timestamp : undefined,
       trackingId: args.trackingId,
     });
+
+    if (args.status === "sent") {
+      await incrementNotificationHourlyStat(ctx, {
+        type: args.notificationType,
+        ts: timestamp,
+        field: "sent",
+      });
+    }
+
+    return id;
   },
 });
 
@@ -172,6 +183,14 @@ export const createNotificationsBatch = internalMutation({
         trackingId: notification.trackingId,
       });
       insertedIds.push(id);
+
+      if (notification.status === "sent") {
+        await incrementNotificationHourlyStat(ctx, {
+          type: notification.notificationType,
+          ts: timestamp,
+          field: "sent",
+        });
+      }
     }
 
     return insertedIds;
@@ -191,7 +210,13 @@ export const recordImpression = mutation({
       .first();
     if (!notification || notification.userId !== userId) return;
     if (!notification.impressedAt) {
-      await ctx.db.patch(notification._id, { impressedAt: now() });
+      const ts = now();
+      await ctx.db.patch(notification._id, { impressedAt: ts });
+      await incrementNotificationHourlyStat(ctx, {
+        type: notification.notificationType,
+        ts,
+        field: "impressed",
+      });
     }
   },
 });
@@ -208,8 +233,23 @@ export const recordClick = mutation({
       .withIndex("by_trackingId", (q) => q.eq("trackingId", args.trackingId))
       .first();
     if (!notification || notification.userId !== userId) return;
-    const updates: Record<string, number> = { clickedAt: now() };
-    if (!notification.impressedAt) updates.impressedAt = now();
+    const ts = now();
+    const updates: Record<string, number> = { clickedAt: ts };
+    const firstImpression = !notification.impressedAt;
+    if (firstImpression) updates.impressedAt = ts;
     await ctx.db.patch(notification._id, updates);
+
+    await incrementNotificationHourlyStat(ctx, {
+      type: notification.notificationType,
+      ts,
+      field: "clicked",
+    });
+    if (firstImpression) {
+      await incrementNotificationHourlyStat(ctx, {
+        type: notification.notificationType,
+        ts,
+        field: "impressed",
+      });
+    }
   },
 });

--- a/apps/convex/lib/notificationStats.ts
+++ b/apps/convex/lib/notificationStats.ts
@@ -1,0 +1,49 @@
+/**
+ * Notification rollup counters.
+ *
+ * Maintains O(hours × types) counter rows in `notificationHourlyStats` so the
+ * admin dashboard can read per-day totals without scanning the full
+ * notifications table. Hourly granularity lets any viewer timezone slice
+ * "today" exactly.
+ *
+ * Call `incrementNotificationHourlyStat` from any mutation that registers a
+ * notification event. No backfill of pre-existing notifications — rollup
+ * history starts from the first call.
+ */
+
+import type { MutationCtx } from "../_generated/server";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export type NotificationStatField = "sent" | "impressed" | "clicked";
+
+export async function incrementNotificationHourlyStat(
+  ctx: MutationCtx,
+  params: { type: string; ts: number; field: NotificationStatField }
+): Promise<void> {
+  const hourStartMs = Math.floor(params.ts / HOUR_MS) * HOUR_MS;
+
+  const existing = await ctx.db
+    .query("notificationHourlyStats")
+    .withIndex("by_hour_type", (q) =>
+      q.eq("hourStartMs", hourStartMs).eq("type", params.type)
+    )
+    .first();
+
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      [params.field]: (existing[params.field] ?? 0) + 1,
+      updatedAt: Date.now(),
+    });
+    return;
+  }
+
+  await ctx.db.insert("notificationHourlyStats", {
+    hourStartMs,
+    type: params.type,
+    sent: params.field === "sent" ? 1 : 0,
+    impressed: params.field === "impressed" ? 1 : 0,
+    clicked: params.field === "clicked" ? 1 : 0,
+    updatedAt: Date.now(),
+  });
+}

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -822,6 +822,26 @@ export default defineSchema({
     .index("by_trackingId", ["trackingId"]),
 
   // =============================================================================
+  // NOTIFICATION HOURLY ROLLUPS
+  // =============================================================================
+  // Incremental counters keyed by (hourStartMs, notificationType). Updated on
+  // send/impression/click so the admin dashboard can read O(hours × types)
+  // instead of scanning the notifications table. Hourly granularity lets any
+  // viewer timezone slice "today" exactly.
+
+  notificationHourlyStats: defineTable({
+    hourStartMs: v.number(), // UTC timestamp at the start of the hour
+    type: v.string(),        // notificationType
+    sent: v.number(),
+    impressed: v.number(),
+    clicked: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_hour", ["hourStartMs"])
+    .index("by_hour_type", ["hourStartMs", "type"])
+    .index("by_type_hour", ["type", "hourStartMs"]),
+
+  // =============================================================================
   // PUSH TOKENS
   // =============================================================================
 

--- a/apps/mobile/features/admin/components/SuperAdminDashboardContent.tsx
+++ b/apps/mobile/features/admin/components/SuperAdminDashboardContent.tsx
@@ -32,6 +32,18 @@ function formatDate(dateStr: string): string {
   });
 }
 
+function formatRelativeDate(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const days = Math.floor(diffMs / 86400000);
+  if (days < 1) {
+    const hours = Math.floor(diffMs / 3600000);
+    if (hours < 1) return "just now";
+    return `${hours}h ago`;
+  }
+  if (days < 7) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
 export function SuperAdminDashboardContent() {
   const { user, token } = useAuth();
   const { primaryColor } = useCommunityTheme();
@@ -40,14 +52,28 @@ export function SuperAdminDashboardContent() {
 
   const isInternalUser = user?.is_staff === true || user?.is_superuser === true;
 
+  // Prefer the user's saved timezone preference (Settings → Time Zone); fall
+  // back to the device's current zone so day boundaries still match what the
+  // viewer expects if they haven't set one.
+  const timeZone =
+    user?.timezone ??
+    (typeof Intl !== "undefined"
+      ? Intl.DateTimeFormat().resolvedOptions().timeZone
+      : undefined);
+
   const data = useQuery(
     api.functions.admin.stats.getDailySummary,
-    token && isInternalUser ? { token, daysAgo } : "skip"
+    token && isInternalUser ? { token, daysAgo, timeZone } : "skip"
   );
 
   const notifStats = useQuery(
     api.functions.admin.stats.getNotificationStats,
-    token && isInternalUser ? { token, daysAgo } : "skip"
+    token && isInternalUser ? { token, daysAgo, timeZone } : "skip"
+  );
+
+  const pendingProposals = useQuery(
+    api.functions.ee.proposals.list,
+    token && isInternalUser ? { token, status: "pending" } : "skip"
   );
 
   if (!isInternalUser) {
@@ -95,6 +121,59 @@ export function SuperAdminDashboardContent() {
           <Ionicons name="chevron-forward" size={18} color={colors.text} />
         </TouchableOpacity>
       </View>
+
+      {/* Community Proposals (pending) — action items, not day-scoped */}
+      {pendingProposals && pendingProposals.length > 0 && (
+        <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+          <View style={styles.proposalHeader}>
+            <Text style={[styles.sectionTitle, { color: colors.text, marginBottom: 0 }]}>
+              Community Proposals
+            </Text>
+            <View style={[styles.badge, { backgroundColor: primaryColor }]}>
+              <Text style={styles.badgeText}>{pendingProposals.length}</Text>
+            </View>
+          </View>
+          {pendingProposals.map((proposal: any, index: number) => (
+            <View
+              key={proposal._id}
+              style={[
+                styles.proposalRow,
+                index < pendingProposals.length - 1 && {
+                  borderBottomWidth: 1,
+                  borderBottomColor: colors.borderLight,
+                },
+              ]}
+            >
+              <View style={styles.proposalTopRow}>
+                <Text style={[styles.proposalName, { color: colors.text }]} numberOfLines={1}>
+                  {proposal.communityName}
+                </Text>
+                <Text style={[styles.proposalPrice, { color: primaryColor }]}>
+                  ${proposal.proposedMonthlyPrice}/mo
+                </Text>
+              </View>
+              <Text style={[styles.proposalMeta, { color: colors.textSecondary }]} numberOfLines={1}>
+                {proposal.proposerName ?? "Unknown proposer"}
+                {proposal.proposerEmail ? ` · ${proposal.proposerEmail}` : ""}
+              </Text>
+              <Text style={[styles.proposalMeta, { color: colors.textTertiary }]} numberOfLines={1}>
+                ~{proposal.estimatedSize} people
+                {proposal.needsMigration ? " · needs migration" : ""}
+                {" · "}
+                {formatRelativeDate(proposal.createdAt)}
+              </Text>
+              {proposal.notes ? (
+                <Text
+                  style={[styles.proposalNotes, { color: colors.textSecondary }]}
+                  numberOfLines={2}
+                >
+                  {proposal.notes}
+                </Text>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      )}
 
       {!data ? (
         <View style={styles.loadingRow}>
@@ -417,5 +496,51 @@ const styles = StyleSheet.create({
   },
   notifTypeStats: {
     fontSize: 12,
+  },
+  proposalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 8,
+  },
+  badge: {
+    minWidth: 22,
+    height: 22,
+    borderRadius: 11,
+    paddingHorizontal: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  badgeText: {
+    color: "white",
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  proposalRow: {
+    paddingVertical: 10,
+  },
+  proposalTopRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  proposalName: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "600",
+    marginRight: 8,
+  },
+  proposalPrice: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  proposalMeta: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  proposalNotes: {
+    fontSize: 12,
+    marginTop: 4,
+    fontStyle: "italic",
   },
 });

--- a/apps/mobile/features/admin/components/__tests__/SuperAdminDashboardContent.test.tsx
+++ b/apps/mobile/features/admin/components/__tests__/SuperAdminDashboardContent.test.tsx
@@ -19,6 +19,11 @@ jest.mock("@services/api/convex", () => ({
           getNotificationStats: "api.functions.admin.stats.getNotificationStats",
         },
       },
+      ee: {
+        proposals: {
+          list: "api.functions.ee.proposals.list",
+        },
+      },
     },
   },
 }));
@@ -148,6 +153,8 @@ describe("SuperAdminDashboardContent", () => {
     const calls = (useQuery as jest.Mock).mock.calls.filter(
       ([fn]: [string]) => fn === "api.functions.admin.stats.getDailySummary"
     );
-    expect(calls[0][1]).toEqual({ token: "token", daysAgo: 0 });
+    expect(calls[0][1]).toEqual(
+      expect.objectContaining({ token: "token", daysAgo: 0 })
+    );
   });
 });


### PR DESCRIPTION
## Summary

- **Fixes the server error on the admin dashboard.** `getNotificationStats` was scanning the full `notifications` table (`.withIndex("by_createdAt").filter(...)`) — OK on small instances, blew up on busy days. Replaced with a `notificationHourlyStats` rollup table: O(hours × types) reads regardless of daily volume.
- **Day boundaries now respect the viewer's timezone.** `getDailySummary` and `getNotificationStats` take a `timeZone` arg; the mobile dashboard passes `user.timezone` (falling back to `Intl.DateTimeFormat().resolvedOptions().timeZone`). The hardcoded EDT logic is gone.
- **Adds a read-only "Community Proposals" section** to the SuperAdmin dashboard, listing pending `communityProposals` via the existing `ee.proposals.list` query.

## How the rollup works

- New `notificationHourlyStats` table keyed by `(hourStartMs, type)` with `sent`/`impressed`/`clicked` counters.
- `incrementNotificationHourlyStat(ctx, { type, ts, field })` helper upserts the row for `floor(ts / HOUR_MS) * HOUR_MS`.
- Wired into all four notification mutation sites (`createNotification`, `createNotificationsBatch`, `recordImpression`, `recordClick`).
- Hourly granularity lets any viewer timezone slice "today" exactly — ~24 × types rows per dashboard load.

**No backfill.** History starts from deploy time — "Today" will read 0 until the first event lands post-deploy. Worth calling out in the rollout.

## Test plan

- [x] `pnpm --filter @togather/convex test` — admin-super-dashboard + 4 notification tests pass
- [x] `pnpm --filter mobile test -- --testPathPattern=SuperAdminDashboardContent` — 4 tests pass
- [x] `pnpm --filter mobile test` — 1031 pass (0 fail)
- [x] `pnpm --filter @togather/convex tsc --noEmit` — clean
- [ ] Smoke-test on staging: open Admin → Dashboard, verify no error, check day navigation, confirm "Community Proposals" section renders when a pending proposal exists
- [ ] Verify rollup writes on staging: send a test notification, check `notificationHourlyStats` has a new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)