### PR TITLE
fix(auth/registration): validate DOB before burning phone token, reject bad calendar dates on client

### DIFF
--- a/apps/convex/functions/auth/registration.ts
+++ b/apps/convex/functions/auth/registration.ts
@@ -64,12 +64,20 @@ export const registerNewUser = action({
       throw new Error("Invalid verification code format");
     }
 
-    // Require and verify the phone verification token
+    // Require the phone verification token before any other work.
     if (!args.phoneVerificationToken) {
       throw new Error(
         "Phone verification token is required. Please complete phone verification first."
       );
     }
+
+    // Validate dateOfBirth BEFORE consuming the phone verification token.
+    // verifyPhoneToken is single-use; if we consumed it first and then
+    // threw on a bad date, the user's retry would fail with "Token already
+    // used" and they'd have to restart phone OTP for a fixable client error.
+    const dateOfBirth = args.dateOfBirth
+      ? parseAndValidateDate(args.dateOfBirth)
+      : undefined;
 
     const tokenResult = await ctx.runMutation(
       internal.functions.authInternal.verifyPhoneToken,
@@ -87,11 +95,6 @@ export const registerNewUser = action({
         "Phone verification failed. Please verify your phone number again."
       );
     }
-
-    // Validate dateOfBirth if provided
-    const dateOfBirth = args.dateOfBirth
-      ? parseAndValidateDate(args.dateOfBirth)
-      : undefined;
 
     // Check if user already exists (handles race conditions and retries)
     const existingUser = await ctx.runQuery(

--- a/apps/mobile/app/(auth)/new-user-profile/index.tsx
+++ b/apps/mobile/app/(auth)/new-user-profile/index.tsx
@@ -76,6 +76,25 @@ export default function NewUserProfilePage() {
       newErrors.birthday = "Birthday is required";
     } else if (birthday.length !== 10) {
       newErrors.birthday = "Please enter a complete date (MM/DD/YYYY)";
+    } else {
+      const [mm, dd, yyyy] = birthday.split("/");
+      const month = parseInt(mm, 10);
+      const day = parseInt(dd, 10);
+      const year = parseInt(yyyy, 10);
+      const reconstructed = new Date(year, month - 1, day);
+      const isValidCalendarDate =
+        reconstructed.getFullYear() === year &&
+        reconstructed.getMonth() === month - 1 &&
+        reconstructed.getDate() === day;
+      const now = new Date();
+      const currentYear = now.getFullYear();
+      if (!isValidCalendarDate) {
+        newErrors.birthday = "Please enter a valid date";
+      } else if (year < 1900 || year > currentYear) {
+        newErrors.birthday = "Please enter a valid year";
+      } else if (reconstructed.getTime() > now.getTime()) {
+        newErrors.birthday = "Birthday can't be in the future";
+      }
     }
 
     setErrors(newErrors);


### PR DESCRIPTION
## Summary

Two linked bugs caused unrecoverable signup failures (observed in prod logs on `artful-echidna-883` for jnmcdaniel24@gmail.com):

- **Server (`apps/convex/functions/auth/registration.ts`)**: `registerNewUser` consumed the single-use `phoneVerificationToken` via `verifyPhoneToken` *before* validating `dateOfBirth`. When the DOB check threw, the token was already gone, so retrying with a corrected date failed with *"Phone verification token invalid: Token already used"* and forced the user to restart the phone OTP flow from scratch. Reordered so `parseAndValidateDate` runs first.
- **Client (`apps/mobile/app/(auth)/new-user-profile/index.tsx`)**: the form only checked `birthday.length === 10`, so calendar-invalid dates (`02/30/1990`, `13/01/1990`, future years, year < 1900) passed the client, were converted to a plausible `YYYY-MM-DD`, and surfaced to the user as a raw *"CONVEX A(functions/auth/registration:registerNewUser) Server Error"* modal on the community-select screen. Added round-trip `Date` reconstruction plus range checks so users see an inline field error before submission.

## Observed prod log trail

```
8:27:05 AM [registerNewUser] Uncaught Error: Invalid date format for dateOfBirth
8:27:16 AM [registerNewUser] Phone verification token invalid: Token already used
```

## Test plan

- [ ] Sign up with an **invalid calendar date** (e.g. `02/30/1990`) → client shows "Please enter a valid date" inline; no server call.
- [ ] Sign up with a **future year** → client shows "Birthday can't be in the future" inline.
- [ ] Sign up with a **year < 1900** (e.g. `01/01/1899`) → client shows "Please enter a valid year" inline.
- [ ] Sign up with a **valid** MM/DD/YYYY (e.g. `06/15/1992`) → registration completes normally.
- [ ] Artificially bypass client (e.g. by sending a bad DOB via a direct action call) → server throws without consuming `phoneVerificationToken`; a subsequent call with the same token + a valid DOB succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)