### PR TITLE
fix(notifications): remove fallback crons that race with primary scheduler

### DIFF
--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -42,32 +42,6 @@ crons.hourly(
 );
 
 // =============================================================================
-// MEETING REMINDER CHECK (Fallback)
-// =============================================================================
-// Runs every 15 minutes as a fallback to catch any meeting reminders that
-// weren't scheduled at creation time (e.g., migrated data).
-// Primary scheduling happens in meetings.create mutation via ctx.scheduler.runAt()
-
-crons.cron(
-  "meeting-reminder-fallback",
-  "*/15 * * * *", // Every 15 minutes
-  internal.functions.scheduledJobs.processMeetingReminderFallback
-);
-
-// =============================================================================
-// ATTENDANCE CONFIRMATION CHECK (Fallback)
-// =============================================================================
-// Runs every 15 minutes as a fallback to catch any attendance confirmations that
-// weren't scheduled at creation time (e.g., migrated data).
-// Primary scheduling happens in meetings.create mutation via ctx.scheduler.runAt()
-
-crons.cron(
-  "attendance-confirmation-fallback",
-  "*/15 * * * *", // Every 15 minutes
-  internal.functions.scheduledJobs.processAttendanceConfirmationFallback
-);
-
-// =============================================================================
 // EMAIL VERIFICATION CODE CLEANUP
 // =============================================================================
 // Runs hourly to clean up expired email verification codes.

--- a/apps/convex/functions/groups/mutations.ts
+++ b/apps/convex/functions/groups/mutations.ts
@@ -120,20 +120,29 @@ export async function initializeGroupAfterCreation(
       attendanceConfirmationSent: false,
     });
 
+    let reminderJobId = undefined;
     if (reminderAt > timestamp) {
-      await ctx.scheduler.runAt(
+      reminderJobId = await ctx.scheduler.runAt(
         reminderAt,
         internal.functions.scheduledJobs.sendMeetingReminder,
         { meetingId }
       );
     }
 
+    let attendanceConfirmationJobId = undefined;
     if (attendanceConfirmationAt > timestamp) {
-      await ctx.scheduler.runAt(
+      attendanceConfirmationJobId = await ctx.scheduler.runAt(
         attendanceConfirmationAt,
         internal.functions.scheduledJobs.sendAttendanceConfirmation,
         { meetingId }
       );
+    }
+
+    if (reminderJobId || attendanceConfirmationJobId) {
+      await ctx.db.patch(meetingId, {
+        reminderJobId,
+        attendanceConfirmationJobId,
+      });
     }
   }
 

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -426,8 +426,11 @@ export const update = mutation({
       let newReminderJobId = undefined;
       let newAttendanceConfirmationJobId = undefined;
 
-      // Schedule new reminder if in the future and not yet sent
-      if (newReminderAt > timestamp && !meeting.reminderSent) {
+      // Schedule new reminder if in the future. Don't gate on the old
+      // reminderSent value — line 401 just reset it for forward reschedules,
+      // so an already-fired meeting moved to a new future time still needs
+      // a fresh job. The attendance block below already follows this shape.
+      if (newReminderAt > timestamp) {
         newReminderJobId = await ctx.scheduler.runAt(
           newReminderAt,
           internal.functions.scheduledJobs.sendMeetingReminder,

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -638,7 +638,7 @@ interface RsvpRecord {
 
 /**
  * Send a meeting reminder notification.
- * Called by ctx.scheduler.runAt() when meeting is created, or by fallback cron.
+ * Called by ctx.scheduler.runAt() when meeting is created.
  */
 export const sendMeetingReminder = internalAction({
   args: { meetingId: v.id("meetings") },
@@ -723,70 +723,13 @@ export const sendMeetingReminder = internalAction({
   },
 });
 
-/**
- * Fallback cron to process any meeting reminders that weren't scheduled.
- * Runs every 15 minutes to catch migrated data or missed schedules.
- */
-export const processMeetingReminderFallback = internalAction({
-  args: {},
-  handler: async (ctx) => {
-    const currentTime = now();
-    // Look for reminders due in the past 20 minutes (with buffer)
-    const windowStart = currentTime - 20 * 60 * 1000;
-
-    const meetings = await ctx.runQuery(
-      internal.functions.scheduledJobs.getMeetingsWithDueReminders,
-      { windowStart, windowEnd: currentTime },
-    );
-
-    let processed = 0;
-    for (const meeting of meetings) {
-      try {
-        await ctx.runAction(
-          internal.functions.scheduledJobs.sendMeetingReminder,
-          { meetingId: meeting._id },
-        );
-        processed++;
-      } catch (error) {
-        console.error(
-          `[MeetingReminderFallback] Error for meeting ${meeting._id}:`,
-          error,
-        );
-      }
-    }
-
-    return { processed };
-  },
-});
-
-export const getMeetingsWithDueReminders = internalQuery({
-  args: { windowStart: v.number(), windowEnd: v.number() },
-  handler: async (ctx, { windowStart, windowEnd }) => {
-    // Get meetings with reminderAt in the window that haven't been sent
-    const meetings = await ctx.db
-      .query("meetings")
-      .withIndex("by_reminderAt_sent")
-      .filter((q) =>
-        q.and(
-          q.gte(q.field("reminderAt"), windowStart),
-          q.lte(q.field("reminderAt"), windowEnd),
-          q.eq(q.field("reminderSent"), false),
-          q.neq(q.field("status"), "cancelled"),
-        ),
-      )
-      .collect();
-
-    return meetings;
-  },
-});
-
 // ============================================================================
 // ATTENDANCE CONFIRMATIONS
 // ============================================================================
 
 /**
  * Send attendance confirmation requests.
- * Called by ctx.scheduler.runAt() when meeting ends, or by fallback cron.
+ * Called by ctx.scheduler.runAt() when meeting ends.
  */
 export const sendAttendanceConfirmation = internalAction({
   args: { meetingId: v.id("meetings") },
@@ -899,60 +842,6 @@ export const sendAttendanceConfirmation = internalAction({
     );
 
     return { pushSent, emailSent, totalRsvps: rsvps.length };
-  },
-});
-
-/**
- * Fallback cron to process any attendance confirmations that weren't scheduled.
- */
-export const processAttendanceConfirmationFallback = internalAction({
-  args: {},
-  handler: async (ctx) => {
-    const currentTime = now();
-    const windowStart = currentTime - 20 * 60 * 1000;
-
-    const meetings = await ctx.runQuery(
-      internal.functions.scheduledJobs.getMeetingsWithDueAttendanceConfirmation,
-      { windowStart, windowEnd: currentTime },
-    );
-
-    let processed = 0;
-    for (const meeting of meetings) {
-      try {
-        await ctx.runAction(
-          internal.functions.scheduledJobs.sendAttendanceConfirmation,
-          { meetingId: meeting._id },
-        );
-        processed++;
-      } catch (error) {
-        console.error(
-          `[AttendanceConfirmationFallback] Error for meeting ${meeting._id}:`,
-          error,
-        );
-      }
-    }
-
-    return { processed };
-  },
-});
-
-export const getMeetingsWithDueAttendanceConfirmation = internalQuery({
-  args: { windowStart: v.number(), windowEnd: v.number() },
-  handler: async (ctx, { windowStart, windowEnd }) => {
-    const meetings = await ctx.db
-      .query("meetings")
-      .withIndex("by_attendanceConfirmation")
-      .filter((q) =>
-        q.and(
-          q.gte(q.field("attendanceConfirmationAt"), windowStart),
-          q.lte(q.field("attendanceConfirmationAt"), windowEnd),
-          q.eq(q.field("attendanceConfirmationSent"), false),
-          q.neq(q.field("status"), "cancelled"),
-        ),
-      )
-      .collect();
-
-    return meetings;
   },
 });
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -650,11 +650,6 @@ export default defineSchema({
     .index("by_scheduledAt", ["scheduledAt"])
     .index("by_publicSlug", ["publicSlug"])
     .index("by_shortId", ["shortId"])
-    .index("by_reminderAt_sent", ["reminderAt", "reminderSent"])
-    .index("by_attendanceConfirmation", [
-      "attendanceConfirmationAt",
-      "attendanceConfirmationSent",
-    ])
     .index("by_communityWideEvent", ["communityWideEventId"])
     .index("by_series", ["seriesId"])
     .index("by_community", ["communityId"])


### PR DESCRIPTION
## Summary

User reported receiving 3 separate "did you attend?" pings for a single event. Root cause is a dual-path scheduling pattern that races with itself.

- **Removed** `meeting-reminder-fallback` and `attendance-confirmation-fallback` crons. They ran every 15 min sweeping for unsent meetings in a 20-min window. Because the send handlers do check-then-send-then-mark non-atomically, the fallback could fire while the primary scheduled job was still dispatching, producing duplicates. The fallbacks were originally added as a backfill for migrated data with no scheduled job attached — that data no longer exists, so the dual path now only causes duplicates with no benefit.
- **Fixed** `initializeGroupAfterCreation` (community-wide event meetings spawned during group creation) to persist `reminderJobId` and `attendanceConfirmationJobId`. Previously discarded, leaving rescheduled events with orphan jobs that fire on top of the new ones.
- **Removed** the `by_reminderAt_sent` and `by_attendanceConfirmation` indices on `meetings` — they only existed to serve the deleted fallback queries.

## Audit

Spawned an exploration of the remaining 12 crons in `apps/convex/crons.ts`. None have the same dual-path-with-fallback anti-pattern. Bot crons (birthday, task reminder, communication) advance `nextScheduledAt` atomically as part of the send, so they self-bucket without needing a sweeper. Cleanup/recomputation crons don't dispatch notifications.

(One unrelated minor finding: the Slack `nag-check` has a theoretical check-then-set window in `slackServiceBot/configDb.ts`. Once-per-hour-per-config so duplicates are extremely unlikely. Out of scope here.)

## Test plan

- [x] `tsc --noEmit` clean
- [x] Convex test suite green (1031 passed)
- [ ] Manual: create a meeting in dev, confirm reminder fires exactly once
- [ ] Manual: create a meeting via group creation flow (community-wide event), reschedule it, confirm only the new reminder fires (orphan fix)
- [ ] Production observation: monitor next week for any reports of duplicate pings

🤖 Generated with [Claude Code](https://claude.com/claude-code)