### PR TITLE
fix(events): keep events visible and RSVPable for 3h after start

### DIFF
--- a/apps/convex/functions/meetingRsvps.ts
+++ b/apps/convex/functions/meetingRsvps.ts
@@ -14,6 +14,7 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { now, getMediaUrl } from "../lib/utils";
 import { requireAuth, getOptionalAuth } from "../lib/auth";
+import { PAST_EVENT_BUFFER_MS } from "../lib/meetingConfig";
 import {
   getMaxGuestsForMeeting,
   isGoingOption,
@@ -401,8 +402,9 @@ export const submit = mutation({
       throw new Error("Cannot RSVP to cancelled event");
     }
 
-    // Check if meeting is in the past
-    if (meeting.scheduledAt < timestamp) {
+    // Check if meeting is past its grace window. Late arrivals can still RSVP
+    // for PAST_EVENT_BUFFER_MS after start.
+    if (meeting.scheduledAt < timestamp - PAST_EVENT_BUFFER_MS) {
       throw new Error("Cannot RSVP to past event");
     }
 

--- a/apps/convex/functions/meetings/events.ts
+++ b/apps/convex/functions/meetings/events.ts
@@ -20,6 +20,7 @@ import { query, QueryCtx } from "../../_generated/server";
 import { Id, Doc } from "../../_generated/dataModel";
 import { getMediaUrl } from "../../lib/utils";
 import { getOptionalAuth } from "../../lib/auth";
+import { PAST_EVENT_BUFFER_MS } from "../../lib/meetingConfig";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
@@ -144,11 +145,14 @@ export const listForEventsTab = query({
       isVisible(m, userId, userGroupIds, isCommunityMember)
     );
 
-    // nextUp: upcoming within 48h. Both types; CWE-collapsed.
+    // nextUp: upcoming within 48h. Both types; CWE-collapsed. Past floor is
+    // pulled back by PAST_EVENT_BUFFER_MS so events still in their grace
+    // window keep appearing.
+    const pastFloor = currentTime - PAST_EVENT_BUFFER_MS;
     const nextUpCutoff = currentTime + TWO_DAYS_MS;
     const nextUp = visibleInWindow
       .filter(
-        (m) => m.scheduledAt > currentTime && m.scheduledAt < nextUpCutoff
+        (m) => m.scheduledAt > pastFloor && m.scheduledAt < nextUpCutoff
       )
       .sort((a, b) => a.scheduledAt - b.scheduledAt);
 
@@ -157,7 +161,7 @@ export const listForEventsTab = query({
     // where. No exclusion filter (that's what caused the CWE "0 going"
     // miscount in the old design).
     const thisWeek = visibleInWindow
-      .filter((m) => m.scheduledAt > currentTime)
+      .filter((m) => m.scheduledAt > pastFloor)
       .sort((a, b) => a.scheduledAt - b.scheduledAt);
 
     // myEvents: upcoming meetings the user RSVP'd to OR is hosting. Not
@@ -454,7 +458,7 @@ async function loadMyEventsMeetings(
     (m) =>
       m.status !== "cancelled" &&
       m.communityId === communityId &&
-      m.scheduledAt > now
+      m.scheduledAt > now - PAST_EVENT_BUFFER_MS
   );
 
   const groupIds = [...new Set(upcoming.map((m) => m.groupId))];

--- a/apps/convex/lib/meetingConfig.ts
+++ b/apps/convex/lib/meetingConfig.ts
@@ -30,6 +30,14 @@ export const DEFAULT_MEETING_DURATION_MS = 60 * 60 * 1000; // 1 hour
  */
 export const DEFAULT_ATTENDANCE_CONFIRMATION_OFFSET_MS = 30 * 60 * 1000; // 30 minutes
 
+/**
+ * Grace window after an event's start time during which it should still be
+ * treated as "active" — visible in the events list, openable from the detail
+ * page, and accepting RSVPs. Without this, late arrivals immediately stop
+ * seeing events they could still attend.
+ */
+export const PAST_EVENT_BUFFER_MS = 3 * 60 * 60 * 1000; // 3 hours
+
 // ============================================================================
 // RSVP Configuration
 // ============================================================================

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -440,9 +440,15 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
 
   const rsvpOptions = (eventData.rsvpOptions as unknown as RsvpOption[]) ?? [];
   const eventDate = eventData.scheduledAt ? parseISO(eventData.scheduledAt) : null;
-  // Keep mirroring PAST_EVENT_BUFFER_MS in apps/convex/lib/meetingConfig.ts.
+  // isPastEvent: the event has started. Drives the "event has passed" banner
+  // and the leader's "Record Attendance" CTA — both should fire as soon as
+  // the event begins, not after the RSVP grace window.
+  // isRsvpClosed: RSVPs are no longer accepted. Late arrivals can still RSVP
+  // for PAST_EVENT_BUFFER_MS after start; mirror this constant in
+  // apps/convex/lib/meetingConfig.ts.
   const PAST_EVENT_BUFFER_MS = 3 * 60 * 60 * 1000;
-  const isPastEvent = eventDate
+  const isPastEvent = eventDate ? eventDate < new Date() : false;
+  const isRsvpClosed = eventDate
     ? eventDate.getTime() < Date.now() - PAST_EVENT_BUFFER_MS
     : false;
   const maxGuestsPerRsvp =
@@ -459,7 +465,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   const canRSVP =
     eventData.rsvpEnabled &&
     rsvpOptions.length > 0 &&
-    !isPastEvent &&
+    !isRsvpClosed &&
     hasEventAccess;
 
   // Show the read-only guest list preview even after the event has passed —
@@ -738,7 +744,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
               )}
             </View>
           )}
-          {!canRSVP && eventData.rsvpEnabled && eventData.status !== 'cancelled' && !isPastEvent && !eventData.hasAccess && eventData.visibility === 'group' && (
+          {!canRSVP && eventData.rsvpEnabled && eventData.status !== 'cancelled' && !isRsvpClosed && !eventData.hasAccess && eventData.visibility === 'group' && (
             <View style={[styles.statusContainer, { backgroundColor: '#FEF3C7' }]}>
               <Text style={[styles.statusText, { color: '#92400E' }]}>You must be a member of this group to RSVP</Text>
             </View>

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -440,7 +440,11 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
 
   const rsvpOptions = (eventData.rsvpOptions as unknown as RsvpOption[]) ?? [];
   const eventDate = eventData.scheduledAt ? parseISO(eventData.scheduledAt) : null;
-  const isPastEvent = eventDate ? eventDate < new Date() : false;
+  // Keep mirroring PAST_EVENT_BUFFER_MS in apps/convex/lib/meetingConfig.ts.
+  const PAST_EVENT_BUFFER_MS = 3 * 60 * 60 * 1000;
+  const isPastEvent = eventDate
+    ? eventDate.getTime() < Date.now() - PAST_EVENT_BUFFER_MS
+    : false;
   const maxGuestsPerRsvp =
     ((eventData as any)?.maxGuestsPerRsvp as number | undefined) ??
     DEFAULT_MAX_GUESTS_PER_RSVP;


### PR DESCRIPTION
## Summary

Late arrivals were locked out of events the moment \`scheduledAt\` passed: cards vanished from the events list, the detail page flipped to "This event has passed", and the RSVP mutation rejected with "Cannot RSVP to past event."

Adds a \`PAST_EVENT_BUFFER_MS\` of 3 hours and applies it in four places:

- \`apps/convex/functions/meetings/events.ts\` — \`nextUp\`, \`thisWeek\`, and \`loadMyEventsMeetings\` filters
- \`apps/mobile/app/e/[shortId]/EventPageClient.tsx\` — \`isPastEvent\` derived flag
- \`apps/convex/functions/meetingRsvps.ts\` — server-side gate

The constant lives in \`apps/convex/lib/meetingConfig.ts\`. The mobile side mirrors the literal locally with a comment pointing at the source — keeping the cross-package import surface flat.

### Side effect: fixes a card-time bug for community-wide events

When a parent CWE has children with overridden times (real example today: 19 children at 7:00 PM, 1 at 7:30 PM), the events list aggregates to the chronologically earliest surviving child. Without the buffer, at 7:19 PM the 7:00 children were already filtered out, leaving only the 7:30 override — so the card surfaced 7:30 PM even though most users' actual meeting was at 7:00. The buffer keeps the 7:00 children in the candidate set, so the card now shows the correct earliest time.

## Test plan

- [x] \`tsc --noEmit\` clean on convex package
- [x] Mobile typecheck — only pre-existing unrelated errors (AudioPlayer, MessageInput, tasks tests, NotificationProvider); nothing new from this PR
- [x] Pre-push test suite green
- [ ] Manual: open the events tab between an event's \`scheduledAt\` and \`scheduledAt + 3h\`, confirm card stays visible
- [ ] Manual: open the event detail page within that window, confirm RSVP still works
- [ ] Manual: 3h+1m after \`scheduledAt\`, confirm card disappears and RSVP is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)