### PR TITLE
feat(ui): zoomable profile photo + scrollable reactions list

### DIFF
--- a/apps/mobile/components/ui/ImageViewer.tsx
+++ b/apps/mobile/components/ui/ImageViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -15,6 +15,17 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler';
+import Reanimated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+} from 'react-native-reanimated';
 import { saveImageToLibrary } from '@/utils/saveImage';
 import { ToastManager } from './Toast';
 import { useTheme } from '@hooks/useTheme';
@@ -24,12 +35,99 @@ const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 // Separate component for rendering individual images
 interface ImageSlideProps {
   imageUrl: string;
+  onZoomStateChange?: (zoomed: boolean) => void;
 }
 
-function ImageSlide({ imageUrl }: ImageSlideProps) {
+const MIN_SCALE = 1;
+const MAX_SCALE = 5;
+const DOUBLE_TAP_SCALE = 2.5;
+
+function ImageSlide({ imageUrl, onZoomStateChange }: ImageSlideProps) {
   const { colors } = useTheme();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+  const savedTranslateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const savedTranslateY = useSharedValue(0);
+
+  const notifyZoomState = useCallback(
+    (zoomed: boolean) => {
+      onZoomStateChange?.(zoomed);
+    },
+    [onZoomStateChange],
+  );
+
+  const pinch = Gesture.Pinch()
+    .onUpdate((e) => {
+      const next = savedScale.value * e.scale;
+      scale.value = Math.min(Math.max(next, MIN_SCALE * 0.8), MAX_SCALE);
+    })
+    .onEnd(() => {
+      if (scale.value < MIN_SCALE) {
+        scale.value = withTiming(MIN_SCALE);
+        translateX.value = withTiming(0);
+        translateY.value = withTiming(0);
+        savedScale.value = MIN_SCALE;
+        savedTranslateX.value = 0;
+        savedTranslateY.value = 0;
+        runOnJS(notifyZoomState)(false);
+      } else {
+        savedScale.value = scale.value;
+        runOnJS(notifyZoomState)(scale.value > MIN_SCALE);
+      }
+    });
+
+  const pan = Gesture.Pan()
+    .averageTouches(true)
+    .minPointers(1)
+    .onUpdate((e) => {
+      if (scale.value > MIN_SCALE) {
+        translateX.value = savedTranslateX.value + e.translationX;
+        translateY.value = savedTranslateY.value + e.translationY;
+      }
+    })
+    .onEnd(() => {
+      savedTranslateX.value = translateX.value;
+      savedTranslateY.value = translateY.value;
+    });
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .maxDelay(250)
+    .onEnd(() => {
+      if (scale.value > MIN_SCALE) {
+        scale.value = withTiming(MIN_SCALE);
+        translateX.value = withTiming(0);
+        translateY.value = withTiming(0);
+        savedScale.value = MIN_SCALE;
+        savedTranslateX.value = 0;
+        savedTranslateY.value = 0;
+        runOnJS(notifyZoomState)(false);
+      } else {
+        scale.value = withTiming(DOUBLE_TAP_SCALE);
+        savedScale.value = DOUBLE_TAP_SCALE;
+        runOnJS(notifyZoomState)(true);
+      }
+    });
+
+  // Pan only activates when zoomed, so it won't fight the FlatList's
+  // horizontal swipe at scale=1. Double-tap races pinch+pan so it wins fast.
+  const composed = Gesture.Race(
+    doubleTap,
+    Gesture.Simultaneous(pinch, pan),
+  );
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+  }));
 
   return (
     <View style={styles.imageSlide}>
@@ -44,17 +142,21 @@ function ImageSlide({ imageUrl }: ImageSlideProps) {
           <Text style={[styles.errorText, { color: colors.textSecondary }]}>Failed to load image</Text>
         </View>
       ) : (
-        <Image
-          source={{ uri: imageUrl }}
-          style={styles.image}
-          resizeMode="contain"
-          onLoadStart={() => setLoading(true)}
-          onLoadEnd={() => setLoading(false)}
-          onError={() => {
-            setLoading(false);
-            setError(true);
-          }}
-        />
+        <GestureDetector gesture={composed}>
+          <Reanimated.View style={[styles.imageWrap, animatedStyle]}>
+            <Image
+              source={{ uri: imageUrl }}
+              style={styles.image}
+              resizeMode="contain"
+              onLoadStart={() => setLoading(true)}
+              onLoadEnd={() => setLoading(false)}
+              onError={() => {
+                setLoading(false);
+                setError(true);
+              }}
+            />
+          </Reanimated.View>
+        </GestureDetector>
       )}
     </View>
   );
@@ -80,12 +182,14 @@ export function ImageViewer({
   const flatListRef = useRef<FlatList>(null);
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [isSaving, setIsSaving] = useState(false);
+  const [isZoomed, setIsZoomed] = useState(false);
   const insets = useSafeAreaInsets();
 
   useEffect(() => {
     if (visible) {
       // Reset to initial index when opening
       setCurrentIndex(initialIndex);
+      setIsZoomed(false);
 
       // Reset animation values
       fadeAnim.setValue(0);
@@ -164,7 +268,7 @@ export function ImageViewer({
   };
 
   const renderImage = ({ item }: { item: string }) => {
-    return <ImageSlide imageUrl={item} />;
+    return <ImageSlide imageUrl={item} onZoomStateChange={setIsZoomed} />;
   };
 
   const renderDotIndicators = () => {
@@ -216,6 +320,9 @@ export function ImageViewer({
       onRequestClose={onClose}
       statusBarTranslucent
     >
+      {/* GestureHandlerRootView is required inside Modal on Android for
+          gesture-handler gestures (pinch/pan/double-tap) to fire. */}
+      <GestureHandlerRootView style={{ flex: 1 }}>
       <TouchableWithoutFeedback onPress={onClose}>
         <Animated.View style={[styles.container, { opacity: fadeAnim }]}>
           {/* Dark Backdrop */}
@@ -250,7 +357,7 @@ export function ImageViewer({
             )}
           </View>
 
-          {/* Image Carousel */}
+          {/* Image Carousel — paging disabled while zoomed so pan gesture works */}
           <FlatList
             pointerEvents="auto"
             ref={flatListRef}
@@ -259,6 +366,7 @@ export function ImageViewer({
             keyExtractor={(item, index) => `${item}-${index}`}
             horizontal
             pagingEnabled
+            scrollEnabled={!isZoomed}
             showsHorizontalScrollIndicator={false}
             initialScrollIndex={initialIndex}
             getItemLayout={(data, index) => ({
@@ -332,6 +440,7 @@ export function ImageViewer({
         </Animated.View>
       </Animated.View>
       </TouchableWithoutFeedback>
+      </GestureHandlerRootView>
     </Modal>
   );
 }
@@ -380,6 +489,10 @@ const styles = StyleSheet.create({
     height: SCREEN_HEIGHT,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  imageWrap: {
+    width: '100%',
+    height: '100%',
   },
   image: {
     width: '100%',

--- a/apps/mobile/components/ui/ImageViewer.tsx
+++ b/apps/mobile/components/ui/ImageViewer.tsx
@@ -185,6 +185,14 @@ export function ImageViewer({
   const [isZoomed, setIsZoomed] = useState(false);
   const insets = useSafeAreaInsets();
 
+  // Reset zoom whenever the visible slide changes. Without this, navigating
+  // past a zoomed slide (via the arrow buttons) leaves `isZoomed` stuck true,
+  // so `scrollEnabled={!isZoomed}` keeps the carousel swipe disabled on the
+  // next slide until the user toggles zoom again or closes the viewer.
+  useEffect(() => {
+    setIsZoomed(false);
+  }, [currentIndex]);
+
   useEffect(() => {
     if (visible) {
       // Reset to initial index when opening

--- a/apps/mobile/features/__tests__/__snapshots__/safe-area-insets.test.tsx.snap
+++ b/apps/mobile/features/__tests__/__snapshots__/safe-area-insets.test.tsx.snap
@@ -176,46 +176,81 @@ exports[`Safe Area Insets Profile Screen adapts header padding to different safe
           }
         >
           <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": true,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
-              [
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                },
-                {
-                  "backgroundColor": "#F56848",
-                },
+              {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
                 [
                   {
                     "alignItems": "center",
                     "justifyContent": "center",
+                    "overflow": "hidden",
                   },
                   {
-                    "borderRadius": 40,
-                    "height": 80,
-                    "width": 80,
+                    "backgroundColor": "#F56848",
                   },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "fontWeight": "600",
-                  },
-                  {
-                    "color": "#ffffff",
-                    "fontSize": 32,
-                  },
+                  [
+                    {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                    {
+                      "borderRadius": 40,
+                      "height": 80,
+                      "width": 80,
+                    },
+                    undefined,
+                  ],
                 ]
               }
             >
-              TU
-            </Text>
+              <Text
+                style={
+                  [
+                    {
+                      "fontWeight": "600",
+                    },
+                    {
+                      "color": "#ffffff",
+                      "fontSize": 32,
+                    },
+                  ]
+                }
+              >
+                TU
+              </Text>
+            </View>
           </View>
           <View
             style={
@@ -1295,46 +1330,81 @@ exports[`Safe Area Insets Profile Screen matches snapshot with safe area padding
           }
         >
           <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": true,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
-              [
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                },
-                {
-                  "backgroundColor": "#F56848",
-                },
+              {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
                 [
                   {
                     "alignItems": "center",
                     "justifyContent": "center",
+                    "overflow": "hidden",
                   },
                   {
-                    "borderRadius": 40,
-                    "height": 80,
-                    "width": 80,
+                    "backgroundColor": "#F56848",
                   },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "fontWeight": "600",
-                  },
-                  {
-                    "color": "#ffffff",
-                    "fontSize": 32,
-                  },
+                  [
+                    {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                    {
+                      "borderRadius": 40,
+                      "height": 80,
+                      "width": 80,
+                    },
+                    undefined,
+                  ],
                 ]
               }
             >
-              TU
-            </Text>
+              <Text
+                style={
+                  [
+                    {
+                      "fontWeight": "600",
+                    },
+                    {
+                      "color": "#ffffff",
+                      "fontSize": 32,
+                    },
+                  ]
+                }
+              >
+                TU
+              </Text>
+            </View>
           </View>
           <View
             style={

--- a/apps/mobile/features/chat/components/ReactionDetailsModal.tsx
+++ b/apps/mobile/features/chat/components/ReactionDetailsModal.tsx
@@ -72,6 +72,7 @@ export function ReactionDetailsModal({
         data={users}
         renderItem={renderUserItem}
         keyExtractor={(item) => item.userId}
+        style={styles.list}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
       />
@@ -152,6 +153,9 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     fontSize: 14,
+  },
+  list: {
+    flexShrink: 1,
   },
   listContent: {
     paddingVertical: 8,

--- a/apps/mobile/features/profile/components/ProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/ProfileHeader.tsx
@@ -4,6 +4,7 @@ import { Avatar, Card } from '@components/ui';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@hooks/useTheme';
 import { useRouter } from 'expo-router';
+import { ImageViewerManager } from '@/providers/ImageViewerProvider';
 import { Profile } from '../types';
 
 interface ProfileHeaderProps {
@@ -25,11 +26,21 @@ export function ProfileHeader({ user }: ProfileHeaderProps) {
     >
     <Card style={styles.profileCard}>
       <View style={styles.profileHeader}>
-        <Avatar
-          name={`${user?.first_name || ""} ${user?.last_name || ""}`.trim()}
-          imageUrl={user?.profile_photo}
-          size={80}
-        />
+        <TouchableOpacity
+          activeOpacity={0.8}
+          disabled={!user?.profile_photo}
+          onPress={() => {
+            if (user?.profile_photo) {
+              ImageViewerManager.show([user.profile_photo], 0);
+            }
+          }}
+        >
+          <Avatar
+            name={`${user?.first_name || ""} ${user?.last_name || ""}`.trim()}
+            imageUrl={user?.profile_photo}
+            size={80}
+          />
+        </TouchableOpacity>
         <View style={styles.profileInfo}>
           <Text style={[styles.name, { color: colors.text }]}>
             {user?.first_name} {user?.last_name}

--- a/apps/mobile/features/profile/components/UserProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/UserProfileHeader.tsx
@@ -3,11 +3,11 @@
  * Role badges live in `UserProfileBadges` for clarity.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { AppImage } from '@components/ui';
+import { ImageViewer } from '@components/ui/ImageViewer';
 import { useTheme } from '@hooks/useTheme';
-import { ImageViewerManager } from '@/providers/ImageViewerProvider';
 
 import type { UserProfile } from '../hooks/useUserProfile';
 
@@ -17,6 +17,12 @@ interface UserProfileHeaderProps {
 
 export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
   const { colors } = useTheme();
+  // Local viewer state — rendering the Modal via the root-level
+  // ImageViewerProvider doesn't work here because this screen is pushed
+  // inside a React Native Screens Stack on iOS, which obscures the
+  // root-level Modal. Keeping the Modal colocated with this screen puts
+  // it in the same UIViewController hierarchy.
+  const [viewerVisible, setViewerVisible] = useState(false);
 
   const displayName =
     [profile.firstName, profile.lastName].filter(Boolean).join(' ').trim() ||
@@ -32,9 +38,7 @@ export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
         activeOpacity={0.8}
         disabled={!profile.profilePhoto}
         onPress={() => {
-          if (profile.profilePhoto) {
-            ImageViewerManager.show([profile.profilePhoto], 0);
-          }
+          if (profile.profilePhoto) setViewerVisible(true);
         }}
       >
         <AppImage
@@ -53,6 +57,14 @@ export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
         <Text style={[styles.memberSince, { color: colors.textSecondary }]}>
           Member since {memberSinceLabel}
         </Text>
+      )}
+      {profile.profilePhoto && (
+        <ImageViewer
+          visible={viewerVisible}
+          images={[profile.profilePhoto]}
+          initialIndex={0}
+          onClose={() => setViewerVisible(false)}
+        />
       )}
     </View>
   );

--- a/apps/mobile/features/profile/components/UserProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/UserProfileHeader.tsx
@@ -4,9 +4,10 @@
  */
 
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { AppImage } from '@components/ui';
 import { useTheme } from '@hooks/useTheme';
+import { ImageViewerManager } from '@/providers/ImageViewerProvider';
 
 import type { UserProfile } from '../hooks/useUserProfile';
 
@@ -27,16 +28,26 @@ export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.surface }]}>
-      <AppImage
-        source={profile.profilePhoto ?? undefined}
-        style={styles.avatar}
-        optimizedWidth={200}
-        placeholder={{
-          type: 'initials',
-          name: displayName,
-          backgroundColor: '#E5E5E5',
+      <TouchableOpacity
+        activeOpacity={0.8}
+        disabled={!profile.profilePhoto}
+        onPress={() => {
+          if (profile.profilePhoto) {
+            ImageViewerManager.show([profile.profilePhoto], 0);
+          }
         }}
-      />
+      >
+        <AppImage
+          source={profile.profilePhoto ?? undefined}
+          style={styles.avatar}
+          optimizedWidth={200}
+          placeholder={{
+            type: 'initials',
+            name: displayName,
+            backgroundColor: '#E5E5E5',
+          }}
+        />
+      </TouchableOpacity>
       <Text style={[styles.name, { color: colors.text }]}>{displayName}</Text>
       {memberSinceLabel && (
         <Text style={[styles.memberSince, { color: colors.textSecondary }]}>


### PR DESCRIPTION
## Summary
- Tap any profile avatar (own Profile tab **or** other user's profile page from #335) to open the full-screen `ImageViewer` with pinch, pan, and double-tap zoom.
- `ImageViewer` disables the carousel's horizontal paging while a slide is zoomed, so pan doesn't fight the swipe.
- `ReactionDetailsModal`'s FlatList now shrinks inside the 60% maxHeight parent instead of overflowing — lists with >8 reactors scroll internally (was clipped, see screenshot that started this).

## Files
- `apps/mobile/components/ui/ImageViewer.tsx` — add pinch + pan + double-tap gestures to `ImageSlide` via `react-native-gesture-handler` + `react-native-reanimated` (both already installed). Track zoom state to toggle FlatList `scrollEnabled`. Wrap Modal in `GestureHandlerRootView` for Android.
- `apps/mobile/features/profile/components/ProfileHeader.tsx` — wrap Avatar in `TouchableOpacity` that opens the viewer (doesn't bubble to outer Edit Profile nav).
- `apps/mobile/features/profile/components/UserProfileHeader.tsx` — same treatment for the other-user profile page added in #335.
- `apps/mobile/features/chat/components/ReactionDetailsModal.tsx` — add `flexShrink: 1` to the FlatList so it scrolls inside the bounded modal.
- Snapshot update for `safe-area-insets` Profile Screen (just the new `TouchableOpacity` wrapper).

## Test plan
- [ ] Profile tab → tap own avatar → viewer opens full-screen
- [ ] Pinch to zoom up to 5×, double-tap toggles 1× ↔ 2.5×, pan works when zoomed
- [ ] Carousel swipe still works at 1× (for chat attachments with >1 image)
- [ ] Carousel swipe disabled when zoomed (pan doesn't trigger page change)
- [ ] Other-user profile page (from #335) → tap avatar → same behavior
- [ ] Chat message with >8 reactors → open reaction details modal → list scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)