### PR TITLE
feat(ota): auto-apply updates on open and foreground

### DIFF
--- a/apps/mobile/components/ui/OTAUpdateModal.tsx
+++ b/apps/mobile/components/ui/OTAUpdateModal.tsx
@@ -1,12 +1,12 @@
 /**
- * OTAUpdateModal - Blocking modal for OTA updates
+ * OTAUpdateModal - Downloading indicator for OTA updates
  *
- * Shows a non-dismissible modal when an OTA update is downloading or ready.
- * This ensures users always run the latest OTA version.
+ * Shows a non-dismissible modal while an OTA update is downloading. Once the
+ * update is ready, OTAUpdateProvider auto-applies it via Updates.reloadAsync,
+ * so there's no "Restart Now" step — the app just refreshes itself.
  *
- * Safety: Only shown when status is 'downloading' or 'ready' — never during
- * 'checking', 'error', or 'idle'. Offline users won't see this modal because
- * the update check fails silently and status stays 'idle'.
+ * Offline users never see this modal because the check fails silently and
+ * status stays 'idle'.
  */
 import React from 'react';
 import {
@@ -14,11 +14,8 @@ import {
   Text,
   StyleSheet,
   Modal,
-  TouchableOpacity,
   ActivityIndicator,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
-import * as Updates from 'expo-updates';
 import { DEFAULT_PRIMARY_COLOR } from '@utils/styles';
 import { useOTAUpdateStatus } from '@providers/OTAUpdateProvider';
 import { useTheme } from '@hooks/useTheme';
@@ -26,23 +23,10 @@ import { useTheme } from '@hooks/useTheme';
 export function OTAUpdateModal() {
   const { colors } = useTheme();
   const { status } = useOTAUpdateStatus();
-  const [isRestarting, setIsRestarting] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
 
-  // Only block on downloading or ready — never checking, error, or idle
+  // Visible while actively downloading, and during the brief 'ready' tick
+  // before reloadAsync tears the app down.
   const isVisible = !__DEV__ && (status === 'downloading' || status === 'ready');
-  const isReady = status === 'ready';
-
-  const handleInstall = async () => {
-    setError(null);
-    setIsRestarting(true);
-    try {
-      await Updates.reloadAsync();
-    } catch (e) {
-      setIsRestarting(false);
-      setError('Failed to restart. Please close and reopen the app.');
-    }
-  };
 
   if (!isVisible) return null;
 
@@ -56,42 +40,14 @@ export function OTAUpdateModal() {
       <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
         <View style={[styles.modal, { backgroundColor: colors.modalBackground }]}>
           <View style={[styles.iconContainer, { backgroundColor: colors.surfaceSecondary }]}>
-            {isReady ? (
-              <Ionicons name="checkmark-circle" size={48} color={colors.success} />
-            ) : (
-              <ActivityIndicator size="large" color={DEFAULT_PRIMARY_COLOR} />
-            )}
+            <ActivityIndicator size="large" color={DEFAULT_PRIMARY_COLOR} />
           </View>
 
-          <Text style={[styles.title, { color: colors.text }]}>
-            {isReady ? 'Update Ready' : 'Updating'}
-          </Text>
+          <Text style={[styles.title, { color: colors.text }]}>Updating</Text>
 
           <Text style={[styles.message, { color: colors.textSecondary }]}>
-            {isReady
-              ? 'A new update has been downloaded. Restart to apply it.'
-              : 'Downloading the latest update. This will only take a moment.'}
+            Downloading the latest update. The app will refresh in a moment.
           </Text>
-
-          {error && <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>}
-
-          {isReady && (
-            <TouchableOpacity
-              style={[styles.installButton, isRestarting && styles.installButtonDisabled]}
-              onPress={handleInstall}
-              activeOpacity={0.8}
-              disabled={isRestarting}
-            >
-              {isRestarting ? (
-                <ActivityIndicator size="small" color={colors.textInverse} />
-              ) : (
-                <>
-                  <Ionicons name="refresh-outline" size={20} color={colors.textInverse} />
-                  <Text style={[styles.installButtonText, { color: colors.textInverse }]}>{error ? 'Retry' : 'Restart Now'}</Text>
-                </>
-              )}
-            </TouchableOpacity>
-          )}
         </View>
       </View>
     </Modal>
@@ -135,29 +91,5 @@ const styles = StyleSheet.create({
     fontSize: 15,
     textAlign: 'center',
     lineHeight: 22,
-    marginBottom: 16,
-  },
-  installButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: DEFAULT_PRIMARY_COLOR,
-    paddingVertical: 14,
-    paddingHorizontal: 24,
-    borderRadius: 12,
-    width: '100%',
-    gap: 8,
-  },
-  installButtonDisabled: {
-    opacity: 0.7,
-  },
-  installButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  errorText: {
-    fontSize: 14,
-    textAlign: 'center',
-    marginBottom: 12,
   },
 });

--- a/apps/mobile/components/ui/StatusBar.tsx
+++ b/apps/mobile/components/ui/StatusBar.tsx
@@ -107,15 +107,6 @@ function getActiveConfig(
     };
   }
 
-  // Priority 7: OTA error (auto-dismisses via provider transitioning to idle)
-  if (otaStatus.status === 'error') {
-    return {
-      backgroundColor: themeColors.textTertiary,
-      icon: 'alert-circle-outline',
-      text: "Couldn't check for updates",
-    };
-  }
-
   // No active status — hide the bar
   return null;
 }

--- a/apps/mobile/components/ui/StatusBar.tsx
+++ b/apps/mobile/components/ui/StatusBar.tsx
@@ -1,12 +1,13 @@
 /**
- * StatusBar - Animated bottom status bar for connection and OTA update state
+ * StatusBar - Animated bottom status bar for connection state
  *
- * Displays a prioritized status overlay at the bottom of the screen:
- * - Connection issues take highest priority (disconnected > no internet > slow > reconnecting > reconnected)
- * - OTA update states shown when connection is healthy (checking > error)
- * - Hidden when everything is nominal (connected + OTA idle)
+ * Displays a prioritized status overlay at the bottom of the screen for
+ * connection issues (disconnected > no internet > slow > reconnecting >
+ * reconnected). Hidden when everything is nominal.
  *
- * Note: OTA "downloading" and "ready" states are handled by OTAUpdateModal instead.
+ * OTA update states are intentionally not shown here — 'downloading' and
+ * 'ready' are handled by OTAUpdateModal, and 'checking' is silent because
+ * the check runs on every foreground.
  *
  * The bar sits at the very bottom of the screen, filling through the safe area.
  * The tab bar uses useStatusBarVisible() to add extra padding when the bar is shown,
@@ -23,7 +24,6 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useConnectionStatus } from '@providers/ConnectionProvider';
-import { useOTAUpdateStatus } from '@providers/OTAUpdateProvider';
 
 /** Height of the status bar content area (excluding safe area padding) */
 export const STATUS_BAR_CONTENT_HEIGHT = 24;
@@ -44,7 +44,6 @@ function getActiveConfig(
     isNetworkAvailable: boolean;
     isInternetReachable: boolean;
   },
-  otaStatus: { status: string },
   themeColors: { error: string; warning: string; success: string; textTertiary: string },
 ): StatusConfig | null {
   // Cold start grace period: suppress all banners while connecting
@@ -98,14 +97,9 @@ function getActiveConfig(
     };
   }
 
-  // Priority 6: OTA checking
-  if (otaStatus.status === 'checking') {
-    return {
-      backgroundColor: themeColors.textTertiary,
-      icon: 'refresh-outline',
-      text: 'Checking for updates...',
-    };
-  }
+  // OTA 'checking' is intentionally not surfaced — checks run on every
+  // foreground and a "Checking for updates..." banner would flicker on
+  // every healthy resume. Downloading/ready are handled by OTAUpdateModal.
 
   // No active status — hide the bar
   return null;
@@ -117,18 +111,16 @@ function getActiveConfig(
  */
 export function useStatusBarVisible(): boolean {
   const connectionStatus = useConnectionStatus();
-  const otaStatus = useOTAUpdateStatus();
   const { colors } = useTheme();
-  return getActiveConfig(connectionStatus, otaStatus, colors) !== null;
+  return getActiveConfig(connectionStatus, colors) !== null;
 }
 
 export function StatusBar() {
   const connectionStatus = useConnectionStatus();
-  const otaStatus = useOTAUpdateStatus();
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const config = getActiveConfig(connectionStatus, otaStatus, colors);
+  const config = getActiveConfig(connectionStatus, colors);
 
   // Remember the last visible config so the slide-out animation
   // retains the correct colors instead of flashing to a fallback

--- a/apps/mobile/components/ui/__tests__/StatusBar.test.tsx
+++ b/apps/mobile/components/ui/__tests__/StatusBar.test.tsx
@@ -136,28 +136,15 @@ describe('StatusBar', () => {
     expect(queryByText('Update ready')).toBeNull();
   });
 
-  it('shows OTA checking state', () => {
+  it('does not show OTA checking state (runs silently on every foreground)', () => {
     mockOTAStatus = { status: 'checking', errorMessage: null };
-    const { getByText, getByTestId } = render(<StatusBar />);
-    expect(getByTestId('status-bar')).toBeTruthy();
-    expect(getByText('Checking for updates...')).toBeTruthy();
+    const { queryByText } = render(<StatusBar />);
+    expect(queryByText('Checking for updates...')).toBeNull();
   });
 
   it('does not show OTA error state (failures are silent)', () => {
     mockOTAStatus = { status: 'error', errorMessage: 'Network error' };
     const { queryByText } = render(<StatusBar />);
     expect(queryByText("Couldn't check for updates")).toBeNull();
-  });
-
-  it('prioritizes connection status over OTA status', () => {
-    mockConnectionStatus = {
-      status: 'disconnected',
-      isNetworkAvailable: false,
-      isInternetReachable: false,
-    };
-    mockOTAStatus = { status: 'checking', errorMessage: null };
-    const { getByText, queryByText } = render(<StatusBar />);
-    expect(getByText('No internet connection')).toBeTruthy();
-    expect(queryByText('Checking for updates...')).toBeNull();
   });
 });

--- a/apps/mobile/components/ui/__tests__/StatusBar.test.tsx
+++ b/apps/mobile/components/ui/__tests__/StatusBar.test.tsx
@@ -143,11 +143,10 @@ describe('StatusBar', () => {
     expect(getByText('Checking for updates...')).toBeTruthy();
   });
 
-  it('shows OTA error state', () => {
+  it('does not show OTA error state (failures are silent)', () => {
     mockOTAStatus = { status: 'error', errorMessage: 'Network error' };
-    const { getByText, getByTestId } = render(<StatusBar />);
-    expect(getByTestId('status-bar')).toBeTruthy();
-    expect(getByText("Couldn't check for updates")).toBeTruthy();
+    const { queryByText } = render(<StatusBar />);
+    expect(queryByText("Couldn't check for updates")).toBeNull();
   });
 
   it('prioritizes connection status over OTA status', () => {

--- a/apps/mobile/providers/OTAUpdateProvider.tsx
+++ b/apps/mobile/providers/OTAUpdateProvider.tsx
@@ -1,14 +1,14 @@
 /**
- * OTAUpdateProvider - Non-blocking OTA update provider
+ * OTAUpdateProvider - Auto-applying OTA update provider
  *
- * Replaces the old blocking OTAUpdateGate. Always renders children
- * immediately and checks for updates in the background.
+ * Checks for updates on mount and every time the app returns to the
+ * foreground. If an update exists, downloads it and auto-applies it via
+ * Updates.reloadAsync — no user action required. Check failures (including
+ * offline) are silent: status returns to 'idle' and the user keeps using the
+ * current build.
  *
  * State machine:
- *   idle -> checking -> downloading -> ready | error | idle
- *
- * When an update is ready and the app is backgrounded for 30+ seconds,
- * it will auto-apply the update on next foreground via Updates.reloadAsync().
+ *   idle -> checking -> (downloading -> ready -> reload) | idle
  */
 import React, { createContext, useContext, useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { AppState } from 'react-native';
@@ -28,81 +28,53 @@ const OTAUpdateContext = createContext<OTAUpdateContextType>({
 
 export const useOTAUpdateStatus = () => useContext(OTAUpdateContext);
 
-/** Error codes that should skip the error state and go straight to idle */
-const SILENT_ERROR_CODES = [
-  'ERR_NOT_COMPATIBLE',
-  'ERR_UPDATES_DISABLED',
-  'ERR_UPDATES_NOT_INITIALIZED',
-];
-
-function isSilentError(error: any): boolean {
-  if (SILENT_ERROR_CODES.includes(error?.code)) return true;
-  const message = error?.message ?? '';
-  if (message.includes('not supported') || message.includes('Updates is not enabled')) return true;
-  return false;
-}
-
-const BACKGROUND_RELOAD_DELAY_MS = 30_000;
-
 export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [status, setStatus] = useState<OTAStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const backgroundTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const shouldReloadOnForegroundRef = useRef(false);
   const statusRef = useRef(status);
   statusRef.current = status;
 
-  // --- Background update check ---
-  const checkForUpdates = useCallback(async () => {
-    console.log('[OTAUpdate] Starting update check (v3)...');
+  const checkAndApply = useCallback(async () => {
+    // Don't re-enter if a check / download / reload is already in flight.
+    if (statusRef.current !== 'idle') return;
+
+    console.log('[OTAUpdate] Starting update check...');
     setStatus('checking');
     setErrorMessage(null);
 
     try {
-      console.log('[OTAUpdate] Calling checkForUpdateAsync...');
       const checkResult = await Updates.checkForUpdateAsync();
-      console.log('[OTAUpdate] Check result:', checkResult);
 
-      if (checkResult.isAvailable) {
-        console.log('[OTAUpdate] Update available, downloading...');
-        setStatus('downloading');
-
-        const fetchResult = await Updates.fetchUpdateAsync();
-        console.log('[OTAUpdate] Fetch result:', fetchResult);
-
-        if (fetchResult.isNew) {
-          console.log('[OTAUpdate] Update downloaded and ready');
-          setStatus('ready');
-          return;
-        }
-      }
-
-      console.log('[OTAUpdate] No update needed');
-      setStatus('idle');
-    } catch (error: any) {
-      console.error('[OTAUpdate] Update check failed:', error);
-
-      if (isSilentError(error)) {
-        console.log('[OTAUpdate] Known non-critical error, proceeding normally');
+      if (!checkResult.isAvailable) {
+        console.log('[OTAUpdate] No update available');
         setStatus('idle');
         return;
       }
 
-      const message = error?.message || 'Failed to check for updates';
-      console.log('[OTAUpdate] Showing error state:', message);
-      setStatus('error');
-      setErrorMessage(message);
+      console.log('[OTAUpdate] Update available, downloading...');
+      setStatus('downloading');
+      const fetchResult = await Updates.fetchUpdateAsync();
 
-      // Auto-dismiss error after 5 seconds
-      setTimeout(() => {
-        setStatus((current) => (current === 'error' ? 'idle' : current));
-        setErrorMessage((current) => (current ? null : current));
-      }, 5000);
+      if (!fetchResult.isNew) {
+        console.log('[OTAUpdate] Fetched, but not new — staying idle');
+        setStatus('idle');
+        return;
+      }
+
+      console.log('[OTAUpdate] Update ready, auto-applying');
+      setStatus('ready');
+      await Updates.reloadAsync();
+    } catch (error: any) {
+      // All failures — offline, disabled, server errors — are silent.
+      // The user keeps using the current build; we'll try again next foreground.
+      console.log('[OTAUpdate] Update check/apply failed (silent):', error?.message ?? error);
+      setStatus('idle');
+      setErrorMessage(null);
     }
   }, []);
 
-  // --- Mount: check for updates (skip in dev) ---
+  // Run on mount.
   useEffect(() => {
     if (__DEV__) {
       console.log('[OTAUpdate] Development mode - skipping update check');
@@ -110,43 +82,21 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       return;
     }
 
-    checkForUpdates();
-  }, [checkForUpdates]);
+    checkAndApply();
+  }, [checkAndApply]);
 
-  // --- Auto-apply on background ---
+  // Re-check every time the app returns to foreground.
   useEffect(() => {
-    const subscription = AppState.addEventListener('change', (nextAppState: string) => {
-      if (nextAppState === 'background' && statusRef.current === 'ready') {
-        console.log('[OTAUpdate] App backgrounded with update ready, starting 30s timer');
-        backgroundTimerRef.current = setTimeout(() => {
-          console.log('[OTAUpdate] 30s passed in background, will reload on foreground');
-          shouldReloadOnForegroundRef.current = true;
-          backgroundTimerRef.current = null;
-        }, BACKGROUND_RELOAD_DELAY_MS);
-      } else if (nextAppState === 'active') {
-        // Cancel timer if user returns before 30s
-        if (backgroundTimerRef.current) {
-          console.log('[OTAUpdate] Returned to foreground before 30s, cancelling timer');
-          clearTimeout(backgroundTimerRef.current);
-          backgroundTimerRef.current = null;
-        }
+    if (__DEV__) return;
 
-        // Reload if flag was set
-        if (shouldReloadOnForegroundRef.current) {
-          console.log('[OTAUpdate] Reloading app with new update');
-          shouldReloadOnForegroundRef.current = false;
-          Updates.reloadAsync();
-        }
+    const subscription = AppState.addEventListener('change', (nextAppState: string) => {
+      if (nextAppState === 'active') {
+        checkAndApply();
       }
     });
 
-    return () => {
-      subscription.remove();
-      if (backgroundTimerRef.current) {
-        clearTimeout(backgroundTimerRef.current);
-      }
-    };
-  }, []);
+    return () => subscription.remove();
+  }, [checkAndApply]);
 
   const contextValue = useMemo(
     () => ({ status, errorMessage }),

--- a/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
+++ b/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for OTAUpdateProvider
- * Tests the non-blocking OTA update state machine and auto-apply logic.
+ * Tests the auto-applying OTA update state machine.
  */
 import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
@@ -35,13 +35,8 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
 
 describe('OTAUpdateProvider', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
     jest.clearAllMocks();
     appStateChangeHandler = null;
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
   });
 
   it('skips update check in dev mode and stays idle', () => {
@@ -52,6 +47,7 @@ describe('OTAUpdateProvider', () => {
     expect(result.current.errorMessage).toBeNull();
     expect(mockCheckForUpdate).not.toHaveBeenCalled();
     expect(mockFetchUpdate).not.toHaveBeenCalled();
+    expect(mockReload).not.toHaveBeenCalled();
   });
 
   describe('with __DEV__ = false', () => {
@@ -79,50 +75,31 @@ describe('OTAUpdateProvider', () => {
 
       expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
       expect(mockFetchUpdate).not.toHaveBeenCalled();
+      expect(mockReload).not.toHaveBeenCalled();
       expect(result.current.errorMessage).toBeNull();
     });
 
-    it('transitions checking -> downloading -> ready when update is available', async () => {
+    it('auto-applies update when one is available', async () => {
       mockCheckForUpdate.mockResolvedValue({ isAvailable: true });
       mockFetchUpdate.mockResolvedValue({ isNew: true });
+      mockReload.mockResolvedValue(undefined);
 
       const { result } = renderHook(() => useOTAUpdateStatus(), { wrapper });
 
       expect(result.current.status).toBe('checking');
 
       await waitFor(() => {
-        expect(result.current.status).toBe('ready');
+        expect(mockReload).toHaveBeenCalledTimes(1);
       });
 
       expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
       expect(mockFetchUpdate).toHaveBeenCalledTimes(1);
+      expect(result.current.status).toBe('ready');
       expect(result.current.errorMessage).toBeNull();
     });
 
-    it('transitions to error on failure, then auto-dismisses to idle after 5s', async () => {
+    it('silently returns to idle on check failure (e.g. offline)', async () => {
       mockCheckForUpdate.mockRejectedValue(new Error('Network error'));
-
-      const { result } = renderHook(() => useOTAUpdateStatus(), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.status).toBe('error');
-      });
-
-      expect(result.current.errorMessage).toBe('Network error');
-
-      // Auto-dismiss after 5 seconds
-      act(() => {
-        jest.advanceTimersByTime(5000);
-      });
-
-      expect(result.current.status).toBe('idle');
-      expect(result.current.errorMessage).toBeNull();
-    });
-
-    it('skips error state for known error codes (ERR_UPDATES_DISABLED)', async () => {
-      const error = new Error('Updates are disabled');
-      (error as any).code = 'ERR_UPDATES_DISABLED';
-      mockCheckForUpdate.mockRejectedValue(error);
 
       const { result } = renderHook(() => useOTAUpdateStatus(), { wrapper });
 
@@ -130,45 +107,52 @@ describe('OTAUpdateProvider', () => {
         expect(result.current.status).toBe('idle');
       });
 
-      // Should never have gone to error
       expect(result.current.errorMessage).toBeNull();
+      expect(mockFetchUpdate).not.toHaveBeenCalled();
+      expect(mockReload).not.toHaveBeenCalled();
     });
 
-    it('auto-applies update when app is backgrounded for 30+ seconds', async () => {
-      mockCheckForUpdate.mockResolvedValue({ isAvailable: true });
-      mockFetchUpdate.mockResolvedValue({ isNew: true });
+    it('re-checks for updates when the app returns to foreground', async () => {
+      mockCheckForUpdate.mockResolvedValue({ isAvailable: false });
 
       renderHook(() => useOTAUpdateStatus(), { wrapper });
 
-      // Wait for update to be ready
       await waitFor(() => {
-        expect(appStateChangeHandler).not.toBeNull();
+        expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
       });
 
-      // Need to wait for status to become 'ready' so the AppState listener
-      // is registered with the correct status closure
-      await waitFor(() => {
-        // The status should be ready by now
-        expect(mockFetchUpdate).toHaveBeenCalled();
-      });
+      // Ensure the listener was registered.
+      expect(appStateChangeHandler).not.toBeNull();
 
-      // Re-render to pick up the effect with status='ready'
-      // Simulate going to background
+      // Simulate background -> active transition.
       act(() => {
         appStateChangeHandler!('background');
       });
-
-      // Advance past the 30s background timer
-      act(() => {
-        jest.advanceTimersByTime(30000);
-      });
-
-      // Simulate coming back to foreground
       act(() => {
         appStateChangeHandler!('active');
       });
 
-      expect(mockReload).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockCheckForUpdate).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('does not re-enter while a check is already in flight', async () => {
+      // Never resolves — first check stays in flight.
+      mockCheckForUpdate.mockReturnValue(new Promise(() => {}));
+
+      renderHook(() => useOTAUpdateStatus(), { wrapper });
+
+      await waitFor(() => {
+        expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
+      });
+
+      // Foreground event during the in-flight check should be ignored.
+      act(() => {
+        appStateChangeHandler!('active');
+      });
+
+      expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Check for OTA updates on mount AND on every foreground (AppState → active); download silently; auto-apply via `Updates.reloadAsync` as soon as the update is ready — no "Restart Now" modal.
- All failures (offline, disabled, server errors) are silent; status returns to `idle` and the user keeps using the current build.
- Remove 30s background-reload timer (superseded by unconditional auto-apply) and the dead OTA `error` branch in StatusBar.

## Motivation
User report via iMessage: opening the app after a while shows a blocking "Update Ready / Restart Now" modal and users think the app is broken. They asked for a silent fast check that auto-refreshes when an update exists and does nothing otherwise.

## Behavior
- **No update / offline:** zero UI.
- **Update available:** brief "Downloading…" overlay → app refreshes itself.
- **Foreground return:** same check runs again.

## Test plan
- [x] `OTAUpdateProvider.test.ts` — 6 passing: dev-mode skip, no-update → idle, auto-apply on ready, silent on network error, re-check on foreground, no re-entry while in flight.
- [x] `StatusBar.test.tsx` — 13 passing; error branch test inverted to assert the banner is suppressed.
- [x] Full mobile jest suite — 1031 passed / 9 skipped.
- [ ] Manual: cold start with update available → verify "Downloading…" then auto-reload.
- [ ] Manual: cold start offline → verify no modal, no status banner.
- [ ] Manual: foreground after background with update available → verify auto-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)