### PR TITLE
feat(events): event chat for RSVPers + text-blast mirror

### DIFF
--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -1,0 +1,942 @@
+/**
+ * Event Chat Tests (TDD spec)
+ *
+ * Codifies the spec for the new "event chat" feature: channels scoped to
+ * individual meetings, auto-seeded with the host and RSVPers, toggleable by
+ * the event creator / group leaders, and mirrored from text blasts.
+ *
+ * NOTE: These tests are written in TDD-first style. Several of the functions
+ * under test (addEventChannelMember/removeEventChannelMember wiring into
+ * meetingRsvps:submit, text blast chat mirror) may not yet be implemented.
+ * Failures here describe the spec — do not "fix" them by mocking.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/messaging/event-chat.test.ts
+ */
+
+import { vi, expect, test, describe, afterEach } from "vitest";
+
+vi.mock("jose", () => ({
+  jwtVerify: vi.fn(async (token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) throw new Error("Invalid token");
+    return { payload: { userId: match[1], type: "access" } };
+  }),
+  SignJWT: vi.fn(() => ({
+    setProtectedHeader: vi.fn().mockReturnThis(),
+    setIssuedAt: vi.fn().mockReturnThis(),
+    setExpirationTime: vi.fn().mockReturnThis(),
+    sign: vi.fn().mockResolvedValue("mock-signed-token"),
+  })),
+  decodeJwt: vi.fn((token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) return null;
+    return { userId: match[1], type: "access" };
+  }),
+}));
+
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import type { Id } from "../../_generated/dataModel";
+import { modules } from "../../test.setup";
+import { internal } from "../../_generated/api";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface TestData {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  meetingId: Id<"meetings">;
+  hostId: Id<"users">;
+  leaderId: Id<"users">;
+  goingId: Id<"users">;
+  notGoingId: Id<"users">;
+  maybeDisabledId: Id<"users">;
+  outsiderId: Id<"users">;
+  hostToken: string;
+  leaderToken: string;
+  goingToken: string;
+  outsiderToken: string;
+}
+
+async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData> {
+  return await t.run(async (ctx) => {
+    const ts = Date.now();
+    const future = ts + 86_400_000;
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug: "test-event-chat",
+      isPublic: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "General",
+      slug: "general",
+      isActive: true,
+      displayOrder: 0,
+      createdAt: ts,
+    });
+
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      name: "Dinner Club",
+      groupTypeId,
+      isArchived: false,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const hostId = await ctx.db.insert("users", {
+      firstName: "Host",
+      lastName: "Creator",
+      phone: "+15551110001",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Other",
+      lastName: "Leader",
+      phone: "+15551110002",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const goingId = await ctx.db.insert("users", {
+      firstName: "Going",
+      lastName: "Attendee",
+      phone: "+15551110003",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const notGoingId = await ctx.db.insert("users", {
+      firstName: "NotGoing",
+      lastName: "Attendee",
+      phone: "+15551110004",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const maybeDisabledId = await ctx.db.insert("users", {
+      firstName: "MaybeDisabled",
+      lastName: "Attendee",
+      phone: "+15551110005",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const outsiderId = await ctx.db.insert("users", {
+      firstName: "Outsider",
+      lastName: "Person",
+      phone: "+15551110006",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    // Community memberships (everyone except outsiderId).
+    for (const uid of [hostId, leaderId, goingId, notGoingId, maybeDisabledId]) {
+      await ctx.db.insert("userCommunities", {
+        userId: uid,
+        communityId,
+        roles: 1,
+        status: 1,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+    }
+
+    // Group memberships — host + leader as leaders, going/notGoing as members.
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: hostId,
+      role: "leader",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: leaderId,
+      role: "leader",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: goingId,
+      role: "member",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: notGoingId,
+      role: "member",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: maybeDisabledId,
+      role: "member",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+
+    const meetingId = await ctx.db.insert("meetings", {
+      groupId,
+      title: "Dinner Party",
+      scheduledAt: future,
+      status: "scheduled",
+      meetingType: 1,
+      createdAt: ts,
+      rsvpEnabled: true,
+      visibility: "public",
+      shortId: "dinner123",
+      createdById: hostId,
+      rsvpOptions: [
+        { id: 1, label: "Going", enabled: true },
+        { id: 2, label: "Not Going", enabled: true },
+        { id: 3, label: "Maybe", enabled: false },
+      ],
+      communityId,
+    });
+
+    // RSVPs
+    await ctx.db.insert("meetingRsvps", {
+      meetingId,
+      userId: goingId,
+      rsvpOptionId: 1,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await ctx.db.insert("meetingRsvps", {
+      meetingId,
+      userId: notGoingId,
+      rsvpOptionId: 2,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await ctx.db.insert("meetingRsvps", {
+      meetingId,
+      userId: maybeDisabledId,
+      rsvpOptionId: 3,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    return {
+      communityId,
+      groupId,
+      meetingId,
+      hostId,
+      leaderId,
+      goingId,
+      notGoingId,
+      maybeDisabledId,
+      outsiderId,
+      hostToken: `test-token-${hostId}`,
+      leaderToken: `test-token-${leaderId}`,
+      goingToken: `test-token-${goingId}`,
+      outsiderToken: `test-token-${outsiderId}`,
+    };
+  });
+}
+
+// ============================================================================
+// ensureEventChannel
+// ============================================================================
+
+describe("ensureEventChannel", () => {
+  test("creates a chatChannels row with channelType 'event', meetingId, and slug 'event-{shortId}'", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const channel = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .unique();
+    });
+
+    expect(channel).not.toBeNull();
+    expect(channel?.channelType).toBe("event");
+    expect(channel?.meetingId).toBe(data.meetingId);
+    expect(channel?.slug).toBe("event-dinner123");
+    expect(channel?.groupId).toBe(data.groupId);
+  });
+
+  test("is idempotent — second call returns same channel _id", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const firstId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+    const secondId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    expect(firstId).toBe(secondId);
+
+    const channels = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .collect();
+    });
+    expect(channels).toHaveLength(1);
+  });
+
+  test("seeds host as admin with syncSource 'event_rsvp'", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const hostMembership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", data.hostId),
+        )
+        .unique();
+    });
+
+    expect(hostMembership).not.toBeNull();
+    expect(hostMembership?.role).toBe("admin");
+    expect(hostMembership?.syncSource).toBe("event_rsvp");
+  });
+
+  test("seeds users with RSVPs to enabled options as members", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const rows = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect();
+    });
+
+    const userIds = rows.map((r) => r.userId);
+    expect(userIds).toContain(data.goingId);
+    expect(userIds).toContain(data.notGoingId);
+    // Maybe option is disabled — this user should NOT be seeded.
+    expect(userIds).not.toContain(data.maybeDisabledId);
+  });
+
+  test("memberCount equals host + enabled-option RSVPers", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    // host (1) + goingId + notGoingId = 3. maybeDisabledId is excluded.
+    expect(channel?.memberCount).toBe(3);
+  });
+
+  test("throws when meeting has no shortId", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    // Create a bare meeting with no shortId.
+    const bareMeetingId = await t.run(async (ctx) => {
+      return await ctx.db.insert("meetings", {
+        groupId: data.groupId,
+        title: "No ShortId",
+        scheduledAt: Date.now() + 86_400_000,
+        status: "scheduled",
+        meetingType: 1,
+        createdAt: Date.now(),
+        createdById: data.hostId,
+        communityId: data.communityId,
+      });
+    });
+
+    await expect(
+      t.mutation(
+        (internal as any).functions.messaging.eventChat.ensureEventChannel,
+        { meetingId: bareMeetingId },
+      ),
+    ).rejects.toThrow(/shortId/i);
+  });
+});
+
+// ============================================================================
+// getChannelByMeetingId
+// ============================================================================
+
+describe("getChannelByMeetingId", () => {
+  test("returns null when no channel exists", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const result = await t.query(
+      "functions/messaging/eventChat:getChannelByMeetingId" as any,
+      { token: data.hostToken, meetingId: data.meetingId },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns the channel for the host", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const result = await t.query(
+      "functions/messaging/eventChat:getChannelByMeetingId" as any,
+      { token: data.hostToken, meetingId: data.meetingId },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result.meetingId).toBe(data.meetingId);
+    expect(result.channelType).toBe("event");
+  });
+
+  test("returns the channel for a user with enabled RSVP (going)", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const result = await t.query(
+      "functions/messaging/eventChat:getChannelByMeetingId" as any,
+      { token: data.goingToken, meetingId: data.meetingId },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result.meetingId).toBe(data.meetingId);
+  });
+
+  test("returns null for outsider (no RSVP, not host)", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const result = await t.query(
+      "functions/messaging/eventChat:getChannelByMeetingId" as any,
+      { token: data.outsiderToken, meetingId: data.meetingId },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for user whose RSVP option is disabled", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const maybeToken = `test-token-${data.maybeDisabledId}`;
+    const result = await t.query(
+      "functions/messaging/eventChat:getChannelByMeetingId" as any,
+      { token: maybeToken, meetingId: data.meetingId },
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// setEventChannelEnabled
+// ============================================================================
+
+describe("setEventChannelEnabled", () => {
+  test("event creator can disable the channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const result = await t.mutation(
+      "functions/messaging/eventChat:setEventChannelEnabled" as any,
+      { token: data.hostToken, meetingId: data.meetingId, enabled: false },
+    );
+
+    expect(result.channelId).toBe(channelId);
+    expect(result.enabled).toBe(false);
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.isEnabled).toBe(false);
+    expect(channel?.disabledByUserId).toBe(data.hostId);
+  });
+
+  test("group leader (non-creator) can disable the channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const result = await t.mutation(
+      "functions/messaging/eventChat:setEventChannelEnabled" as any,
+      { token: data.leaderToken, meetingId: data.meetingId, enabled: false },
+    );
+
+    expect(result.enabled).toBe(false);
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.isEnabled).toBe(false);
+    expect(channel?.disabledByUserId).toBe(data.leaderId);
+  });
+
+  test("regular member (goingId) cannot disable", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    await expect(
+      t.mutation(
+        "functions/messaging/eventChat:setEventChannelEnabled" as any,
+        { token: data.goingToken, meetingId: data.meetingId, enabled: false },
+      ),
+    ).rejects.toThrow(/creator|leader|admin/i);
+  });
+
+  test("re-enabling clears disabledByUserId", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    // Disable first.
+    await t.mutation(
+      "functions/messaging/eventChat:setEventChannelEnabled" as any,
+      { token: data.hostToken, meetingId: data.meetingId, enabled: false },
+    );
+
+    // Re-enable.
+    await t.mutation(
+      "functions/messaging/eventChat:setEventChannelEnabled" as any,
+      { token: data.hostToken, meetingId: data.meetingId, enabled: true },
+    );
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.isEnabled).toBe(true);
+    expect(channel?.disabledByUserId).toBeUndefined();
+  });
+
+  test("returns { channelId: null, enabled } when no channel exists yet", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const result = await t.mutation(
+      "functions/messaging/eventChat:setEventChannelEnabled" as any,
+      { token: data.hostToken, meetingId: data.meetingId, enabled: false },
+    );
+
+    expect(result.channelId).toBeNull();
+    expect(result.enabled).toBe(false);
+  });
+});
+
+// ============================================================================
+// addEventChannelMember / removeEventChannelMember
+// ============================================================================
+
+describe("addEventChannelMember / removeEventChannelMember", () => {
+  test("addEventChannelMember is a no-op when no channel exists", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.addEventChannelMember,
+      { meetingId: data.meetingId, userId: data.goingId },
+    );
+
+    const rows = await t.run(async (ctx) => {
+      return await ctx.db.query("chatChannelMembers").collect();
+    });
+    expect(rows).toHaveLength(0);
+
+    const channels = await t.run(async (ctx) => {
+      return await ctx.db.query("chatChannels").collect();
+    });
+    expect(channels).toHaveLength(0);
+  });
+
+  test("addEventChannelMember adds row and increments memberCount", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const before = await t.run(async (ctx) => ctx.db.get(channelId));
+    const beforeCount = before?.memberCount ?? 0;
+
+    // Add a brand new user not previously seated.
+    const newUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        firstName: "Late",
+        lastName: "Joiner",
+        phone: "+15552220099",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.addEventChannelMember,
+      { meetingId: data.meetingId, userId: newUserId },
+    );
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", newUserId),
+        )
+        .unique();
+    });
+    expect(membership).not.toBeNull();
+
+    const after = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(after?.memberCount).toBe(beforeCount + 1);
+  });
+
+  test("addEventChannelMember is idempotent", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const newUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        firstName: "Twice",
+        lastName: "Added",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.addEventChannelMember,
+      { meetingId: data.meetingId, userId: newUserId },
+    );
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.addEventChannelMember,
+      { meetingId: data.meetingId, userId: newUserId },
+    );
+
+    const rows = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", newUserId),
+        )
+        .collect();
+    });
+    expect(rows).toHaveLength(1);
+  });
+
+  test("removeEventChannelMember removes row and decrements memberCount", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const before = await t.run(async (ctx) => ctx.db.get(channelId));
+    const beforeCount = before?.memberCount ?? 0;
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.removeEventChannelMember,
+      { meetingId: data.meetingId, userId: data.goingId },
+    );
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", data.goingId),
+        )
+        .unique();
+    });
+    expect(membership).toBeNull();
+
+    const after = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(after?.memberCount).toBe(Math.max(0, beforeCount - 1));
+  });
+
+  test("removeEventChannelMember does NOT remove the host", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.removeEventChannelMember,
+      { meetingId: data.meetingId, userId: data.hostId },
+    );
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", data.hostId),
+        )
+        .unique();
+    });
+    expect(membership).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// RSVP sync via meetingRsvps.submit
+// ============================================================================
+
+describe("RSVP sync via meetingRsvps.submit", () => {
+  test("submitting an RSVP to an existing event channel adds the user as a channel member", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    // Create a brand new user with community + group membership but no RSVP yet.
+    const newUserId = await t.run(async (ctx) => {
+      const ts = Date.now();
+      const uid = await ctx.db.insert("users", {
+        firstName: "New",
+        lastName: "RSVPer",
+        phone: "+15553330042",
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: uid,
+        communityId: data.communityId,
+        roles: 1,
+        status: 1,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: data.groupId,
+        userId: uid,
+        role: "member",
+        joinedAt: ts,
+        notificationsEnabled: true,
+      });
+      return uid;
+    });
+
+    // Submit an RSVP to option 1 (Going — enabled).
+    await t.mutation("functions/meetingRsvps:submit" as any, {
+      token: `test-token-${newUserId}`,
+      meetingId: data.meetingId,
+      optionId: 1,
+    });
+
+    // meetingRsvps.submit schedules addEventChannelMember via scheduler.runAfter(0, ...)
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", newUserId),
+        )
+        .unique();
+    });
+    expect(membership).not.toBeNull();
+    expect(membership?.syncSource).toBe("event_rsvp");
+  });
+
+  test("removing an RSVP (via meetingRsvps.remove) removes the user from the channel", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    // goingId was seeded as a channel member by ensureEventChannel.
+    // Calling meetingRsvps.remove should remove them from the channel.
+    // Note: submit rejects disabled options upstream, so "change to disabled
+    // to drop from chat" isn't a reachable path — remove is.
+    await t.mutation("functions/meetingRsvps:remove" as any, {
+      token: data.goingToken,
+      meetingId: data.meetingId,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", data.goingId),
+        )
+        .unique();
+    });
+    expect(membership).toBeNull();
+  });
+
+  test("submitting an RSVP when no event channel exists is a silent no-op (no channel created)", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    // Existing goingId updates their RSVP — but ensureEventChannel was never
+    // called. The chat module should stay quiet; no channel should spring up.
+    await t.mutation("functions/meetingRsvps:submit" as any, {
+      token: data.goingToken,
+      meetingId: data.meetingId,
+      optionId: 2,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const channels = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .collect();
+    });
+    expect(channels).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Text blast mirror
+// ============================================================================
+
+describe("text blast mirror", () => {
+  test("eventBlasts.initiate with no existing channel creates one and inserts a chatMessages row", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation("functions/eventBlasts:initiate" as any, {
+      token: data.hostToken,
+      meetingId: data.meetingId,
+      message: "Dinner is still on!",
+      channels: ["push"],
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const channel = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .unique();
+    });
+    expect(channel).not.toBeNull();
+
+    const messages = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channel!._id))
+        .collect();
+    });
+
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    const mirrored = messages.find((m) => m.blastId != null);
+    expect(mirrored).toBeDefined();
+    expect(mirrored?.senderId).toBe(data.hostId);
+    expect(mirrored?.content).toBe("Dinner is still on!");
+    expect(mirrored?.contentType).toBe("text");
+    expect(mirrored?.blastId).toBeTruthy();
+  });
+
+  test("mirrored message updates channel.lastMessageAt and lastMessagePreview", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await t.mutation("functions/eventBlasts:initiate" as any, {
+      token: data.hostToken,
+      meetingId: data.meetingId,
+      message: "See you at 7pm!",
+      channels: ["push"],
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const channel = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .unique();
+    });
+
+    expect(channel).not.toBeNull();
+    expect(channel?.lastMessageAt).toBeGreaterThan(0);
+    expect(channel?.lastMessagePreview).toContain("See you at 7pm");
+  });
+});

--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -38,7 +38,7 @@ import { convexTest } from "convex-test";
 import schema from "../../schema";
 import type { Id } from "../../_generated/dataModel";
 import { modules } from "../../test.setup";
-import { internal } from "../../_generated/api";
+import { api, internal } from "../../_generated/api";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
@@ -1039,5 +1039,265 @@ describe("text blast mirror", () => {
     expect(channel).not.toBeNull();
     expect(channel?.lastMessageAt).toBeGreaterThan(0);
     expect(channel?.lastMessagePreview).toContain("See you at 7pm");
+  });
+
+  test("onMessageSent skips push fanout for blast-mirrored messages", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    // Send a blast — this mirrors into the event chat with blastId set.
+    await t.mutation("functions/eventBlasts:initiate" as any, {
+      token: data.hostToken,
+      meetingId: data.meetingId,
+      message: "No duplicate push please",
+      channels: ["push"],
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const channel = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .unique();
+    });
+    expect(channel).not.toBeNull();
+
+    const mirrored = await t.run(async (ctx) => {
+      const rows = await ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channel!._id))
+        .collect();
+      return rows.find((m) => m.blastId != null);
+    });
+    expect(mirrored).toBeDefined();
+    expect(mirrored!.blastId).toBeTruthy();
+
+    // Call onMessageSent directly for the mirrored message. Under the fix,
+    // it must short-circuit and not schedule sendMessageNotifications.
+    const scheduledBefore = await t.run(async (ctx) => {
+      return await ctx.db.system.query("_scheduled_functions").collect();
+    });
+
+    await t.mutation(
+      (internal as any).functions.messaging.events.onMessageSent,
+      {
+        messageId: mirrored!._id,
+        channelId: channel!._id,
+        senderId: data.hostId,
+      },
+    );
+
+    const scheduledAfter = await t.run(async (ctx) => {
+      return await ctx.db.system.query("_scheduled_functions").collect();
+    });
+
+    // No new scheduled sendMessageNotifications entries — onMessageSent
+    // bails out when message.blastId is set.
+    const newNotifJobs = scheduledAfter
+      .filter((j) => !scheduledBefore.some((b) => b._id === j._id))
+      .filter((j) => String(j.name).includes("sendMessageNotifications"));
+    expect(newNotifJobs).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Reactions auth on event channels
+// ============================================================================
+
+describe("reactions auth on event channels", () => {
+  test("RSVPer with access but no chatChannelMembers row can toggleReaction", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    // Host opens chat → channel created + host seated. goingId is NOT
+    // seated yet under the lazy-seed model (they have an enabled RSVP
+    // but haven't called openEventChat).
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    // Verify goingId has no chatChannelMembers row.
+    const noMembership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", data.goingId),
+        )
+        .unique();
+    });
+    expect(noMembership).toBeNull();
+
+    // Host posts a message. Insert directly to avoid pulling in the
+    // full sendMessage path.
+    const messageId = await t.run(async (ctx) => {
+      return await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: data.hostId,
+        content: "Anyone bringing dessert?",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+        lastActivityAt: Date.now(),
+      });
+    });
+
+    // goingId (RSVPer with enabled option, but no chatChannelMembers row)
+    // should be allowed to react.
+    await t.mutation(api.functions.messaging.reactions.toggleReaction, {
+      token: data.goingToken,
+      messageId,
+      emoji: "🍰",
+    });
+
+    const reaction = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatMessageReactions")
+        .withIndex("by_message_user", (q) =>
+          q.eq("messageId", messageId).eq("userId", data.goingId),
+        )
+        .first();
+    });
+    expect(reaction).not.toBeNull();
+    expect(reaction?.emoji).toBe("🍰");
+  });
+
+  test("user without event-channel access is rejected from toggleReaction", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const messageId = await t.run(async (ctx) => {
+      return await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: data.hostId,
+        content: "Private event chatter",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+        lastActivityAt: Date.now(),
+      });
+    });
+
+    // outsiderId has no RSVP and isn't the host — must be rejected.
+    await expect(
+      t.mutation(api.functions.messaging.reactions.toggleReaction, {
+        token: data.outsiderToken,
+        messageId,
+        emoji: "👍",
+      }),
+    ).rejects.toThrow(/Not a member of this channel/);
+  });
+});
+
+// ============================================================================
+// Inline RSVP sync (no scheduler flush needed)
+// ============================================================================
+
+describe("inline RSVP chat sync", () => {
+  test("submit adds chatChannelMembers row in the same transaction", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    // Fresh user with group membership but no RSVP yet.
+    const newUserId = await t.run(async (ctx) => {
+      const ts = Date.now();
+      const uid = await ctx.db.insert("users", {
+        firstName: "Inline",
+        lastName: "Syncer",
+        phone: "+15554440099",
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: uid,
+        communityId: data.communityId,
+        roles: 1,
+        status: 1,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: data.groupId,
+        userId: uid,
+        role: "member",
+        joinedAt: ts,
+        notificationsEnabled: true,
+      });
+      return uid;
+    });
+
+    await t.mutation("functions/meetingRsvps:submit" as any, {
+      token: `test-token-${newUserId}`,
+      meetingId: data.meetingId,
+      optionId: 1,
+    });
+
+    // Assert row exists immediately, WITHOUT calling
+    // finishInProgressScheduledFunctions — the sync runs inline via
+    // ctx.runMutation, so it must be durable by the time submit returns.
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", newUserId),
+        )
+        .unique();
+    });
+    expect(membership).not.toBeNull();
+    expect(membership?.syncSource).toBe("event_rsvp");
+  });
+
+  test("remove deletes chatChannelMembers row in the same transaction", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    // Seat goingId (lazy-seed model: they're not seeded by ensureEventChannel).
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.addEventChannelMember,
+      { meetingId: data.meetingId, userId: data.goingId },
+    );
+
+    const membershipBefore = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", data.goingId),
+        )
+        .unique();
+    });
+    expect(membershipBefore).not.toBeNull();
+
+    await t.mutation("functions/meetingRsvps:remove" as any, {
+      token: data.goingToken,
+      meetingId: data.meetingId,
+    });
+
+    // No scheduler flush — inline sync.
+    const membershipAfter = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", data.goingId),
+        )
+        .unique();
+    });
+    expect(membershipAfter).toBeNull();
   });
 });

--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -870,6 +870,94 @@ describe("RSVP sync via meetingRsvps.submit", () => {
 });
 
 // ============================================================================
+// openEventChat (public mutation)
+// ============================================================================
+
+describe("openEventChat", () => {
+  test("host can open the chat — creates channel and returns channelId + slug", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const result = await t.mutation(
+      "functions/messaging/eventChat:openEventChat" as any,
+      { token: data.hostToken, meetingId: data.meetingId },
+    );
+
+    expect(result.channelId).toBeDefined();
+    expect(result.slug).toBe("event-dinner123");
+
+    const channel = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .unique();
+    });
+    expect(channel?._id).toBe(result.channelId);
+  });
+
+  test("RSVPer with enabled option can open the chat", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const result = await t.mutation(
+      "functions/messaging/eventChat:openEventChat" as any,
+      { token: data.goingToken, meetingId: data.meetingId },
+    );
+
+    expect(result.channelId).toBeDefined();
+    expect(result.slug).toBe("event-dinner123");
+  });
+
+  test("outsider (no RSVP, not host) cannot open the chat", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await expect(
+      t.mutation("functions/messaging/eventChat:openEventChat" as any, {
+        token: data.outsiderToken,
+        meetingId: data.meetingId,
+      }),
+    ).rejects.toThrow(/access/i);
+  });
+
+  test("user whose RSVP option is disabled cannot open the chat", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    await expect(
+      t.mutation("functions/messaging/eventChat:openEventChat" as any, {
+        token: `test-token-${data.maybeDisabledId}`,
+        meetingId: data.meetingId,
+      }),
+    ).rejects.toThrow(/access/i);
+  });
+
+  test("is idempotent — second call returns same channelId without duplicating", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    const first = await t.mutation(
+      "functions/messaging/eventChat:openEventChat" as any,
+      { token: data.hostToken, meetingId: data.meetingId },
+    );
+    const second = await t.mutation(
+      "functions/messaging/eventChat:openEventChat" as any,
+      { token: data.goingToken, meetingId: data.meetingId },
+    );
+
+    expect(second.channelId).toBe(first.channelId);
+
+    const channels = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannels")
+        .withIndex("by_meetingId", (q) => q.eq("meetingId", data.meetingId))
+        .collect();
+    });
+    expect(channels).toHaveLength(1);
+  });
+});
+
+// ============================================================================
 // Text blast mirror
 // ============================================================================
 

--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -569,7 +569,7 @@ describe("setEventChannelEnabled", () => {
     expect(channel?.disabledByUserId).toBeUndefined();
   });
 
-  test("returns { channelId: null, enabled } when no channel exists yet", async () => {
+  test("materializes the channel as disabled when the host disables before any messages exist", async () => {
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
@@ -578,8 +578,15 @@ describe("setEventChannelEnabled", () => {
       { token: data.hostToken, meetingId: data.meetingId, enabled: false },
     );
 
-    expect(result.channelId).toBeNull();
+    // Channel is created now so the host's disable persists — the old
+    // early-return-when-missing path silently lost the host's action on the
+    // next lazy create (which would default back to isEnabled: true).
+    expect(result.channelId).not.toBeNull();
     expect(result.enabled).toBe(false);
+
+    const channel = await t.run(async (ctx) => ctx.db.get(result.channelId));
+    expect(channel?.isEnabled).toBe(false);
+    expect(channel?.disabledByUserId).toBe(data.hostId);
   });
 });
 
@@ -1041,12 +1048,25 @@ describe("text blast mirror", () => {
     expect(channel?.lastMessagePreview).toContain("See you at 7pm");
   });
 
-  test("onMessageSent skips push fanout for blast-mirrored messages", async () => {
+  test("onMessageSent increments unread but skips push for blast-mirrored messages", async () => {
     vi.useFakeTimers();
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
-    // Send a blast — this mirrors into the event chat with blastId set.
+    // Seat the Going RSVPer as a channel member so unread-count behavior is
+    // observable. Under the Phase-1 lazy-seat model, this happens when the
+    // user opens the event page via openEventChat.
+    await t.mutation("functions/messaging/eventChat:openEventChat" as any, {
+      token: data.goingToken,
+      meetingId: data.meetingId,
+    });
+
+    const scheduledBeforeBlast = await t.run(async (ctx) => {
+      return await ctx.db.system.query("_scheduled_functions").collect();
+    });
+
+    // Send a blast — this mirrors into the event chat with blastId set and
+    // (under the fix) also runs onMessageSent for unread increments.
     await t.mutation("functions/eventBlasts:initiate" as any, {
       token: data.hostToken,
       meetingId: data.meetingId,
@@ -1074,31 +1094,31 @@ describe("text blast mirror", () => {
     expect(mirrored).toBeDefined();
     expect(mirrored!.blastId).toBeTruthy();
 
-    // Call onMessageSent directly for the mirrored message. Under the fix,
-    // it must short-circuit and not schedule sendMessageNotifications.
-    const scheduledBefore = await t.run(async (ctx) => {
+    // No sendMessageNotifications was scheduled at any point — onMessageSent
+    // short-circuits the push fanout when message.blastId is set. The original
+    // blast "push" channel would normally schedule batch pushes too; verify
+    // specifically that chat-layer push fanout was skipped.
+    const scheduledAfterBlast = await t.run(async (ctx) => {
       return await ctx.db.system.query("_scheduled_functions").collect();
     });
-
-    await t.mutation(
-      (internal as any).functions.messaging.events.onMessageSent,
-      {
-        messageId: mirrored!._id,
-        channelId: channel!._id,
-        senderId: data.hostId,
-      },
-    );
-
-    const scheduledAfter = await t.run(async (ctx) => {
-      return await ctx.db.system.query("_scheduled_functions").collect();
-    });
-
-    // No new scheduled sendMessageNotifications entries — onMessageSent
-    // bails out when message.blastId is set.
-    const newNotifJobs = scheduledAfter
-      .filter((j) => !scheduledBefore.some((b) => b._id === j._id))
+    const newNotifJobs = scheduledAfterBlast
+      .filter((j) => !scheduledBeforeBlast.some((b) => b._id === j._id))
       .filter((j) => String(j.name).includes("sendMessageNotifications"));
     expect(newNotifJobs).toHaveLength(0);
+
+    // Unread count for the seated Going RSVPer was incremented by
+    // onMessageSent — the Activity feed's inbox badge reflects the new
+    // message even though push was skipped.
+    const readState = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatReadState")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channel!._id).eq("userId", data.goingId),
+        )
+        .unique();
+    });
+    expect(readState).not.toBeNull();
+    expect(readState!.unreadCount).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -324,7 +324,7 @@ describe("ensureEventChannel", () => {
     expect(hostMembership?.syncSource).toBe("event_rsvp");
   });
 
-  test("seeds users with RSVPs to enabled options as members", async () => {
+  test("does NOT bulk-seed RSVPers — only the host is seated initially", async () => {
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
@@ -341,13 +341,15 @@ describe("ensureEventChannel", () => {
     });
 
     const userIds = rows.map((r) => r.userId);
-    expect(userIds).toContain(data.goingId);
-    expect(userIds).toContain(data.notGoingId);
-    // Maybe option is disabled — this user should NOT be seeded.
+    // Lazy-seed model: only the host is seated by ensureEventChannel.
+    // Non-host RSVPers become members when they call openEventChat.
+    expect(userIds).toEqual([data.hostId]);
+    expect(userIds).not.toContain(data.goingId);
+    expect(userIds).not.toContain(data.notGoingId);
     expect(userIds).not.toContain(data.maybeDisabledId);
   });
 
-  test("memberCount equals host + enabled-option RSVPers", async () => {
+  test("memberCount starts at 1 (just the host)", async () => {
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
@@ -357,8 +359,7 @@ describe("ensureEventChannel", () => {
     );
 
     const channel = await t.run(async (ctx) => ctx.db.get(channelId));
-    // host (1) + goingId + notGoingId = 3. maybeDisabledId is excluded.
-    expect(channel?.memberCount).toBe(3);
+    expect(channel?.memberCount).toBe(1);
   });
 
   test("throws when meeting has no shortId", async () => {
@@ -696,6 +697,13 @@ describe("addEventChannelMember / removeEventChannelMember", () => {
       { meetingId: data.meetingId },
     );
 
+    // Lazy-seed model: seat goingId first (simulating an openEventChat
+    // or RSVP-sync add) before testing the removal path.
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.addEventChannelMember,
+      { meetingId: data.meetingId, userId: data.goingId },
+    );
+
     const before = await t.run(async (ctx) => ctx.db.get(channelId));
     const beforeCount = before?.memberCount ?? 0;
 
@@ -811,7 +819,6 @@ describe("RSVP sync via meetingRsvps.submit", () => {
   });
 
   test("removing an RSVP (via meetingRsvps.remove) removes the user from the channel", async () => {
-    vi.useFakeTimers();
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
@@ -820,7 +827,14 @@ describe("RSVP sync via meetingRsvps.submit", () => {
       { meetingId: data.meetingId },
     );
 
-    // goingId was seeded as a channel member by ensureEventChannel.
+    // Lazy-seed model: seat goingId as a channel member before testing
+    // removal on un-RSVP. (Simulates the user having opened the chat or
+    // been added via a previous RSVP sync.)
+    await t.mutation(
+      (internal as any).functions.messaging.eventChat.addEventChannelMember,
+      { meetingId: data.meetingId, userId: data.goingId },
+    );
+
     // Calling meetingRsvps.remove should remove them from the channel.
     // Note: submit rejects disabled options upstream, so "change to disabled
     // to drop from chat" isn't a reachable path — remove is.
@@ -829,8 +843,7 @@ describe("RSVP sync via meetingRsvps.submit", () => {
       meetingId: data.meetingId,
     });
 
-    vi.runAllTimers();
-    await t.finishInProgressScheduledFunctions();
+    // Inline sync — no scheduled functions to flush.
 
     const membership = await t.run(async (ctx) => {
       return await ctx.db

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -74,6 +74,7 @@ import type * as functions_memberFollowups from "../functions/memberFollowups.js
 import type * as functions_messaging_blocking from "../functions/messaging/blocking.js";
 import type * as functions_messaging_channelInvites from "../functions/messaging/channelInvites.js";
 import type * as functions_messaging_channels from "../functions/messaging/channels.js";
+import type * as functions_messaging_eventChat from "../functions/messaging/eventChat.js";
 import type * as functions_messaging_events from "../functions/messaging/events.js";
 import type * as functions_messaging_flagging from "../functions/messaging/flagging.js";
 import type * as functions_messaging_helpers from "../functions/messaging/helpers.js";
@@ -243,6 +244,7 @@ declare const fullApi: ApiFromModules<{
   "functions/messaging/blocking": typeof functions_messaging_blocking;
   "functions/messaging/channelInvites": typeof functions_messaging_channelInvites;
   "functions/messaging/channels": typeof functions_messaging_channels;
+  "functions/messaging/eventChat": typeof functions_messaging_eventChat;
   "functions/messaging/events": typeof functions_messaging_events;
   "functions/messaging/flagging": typeof functions_messaging_flagging;
   "functions/messaging/helpers": typeof functions_messaging_helpers;

--- a/apps/convex/functions/eventBlasts.ts
+++ b/apps/convex/functions/eventBlasts.ts
@@ -335,7 +335,13 @@ export const getUserPhones = internalQuery({
 });
 
 /**
- * Record a blast in the database
+ * Record a blast in the database and mirror it into the event chat channel.
+ *
+ * The mirror appears as a real text message from the sender (not a system
+ * message), carries `blastId` so the mobile UI can render an "Also sent via
+ * SMS" badge, and denormalizes lastMessage* on the channel like `sendMessage`
+ * does. If the event channel is disabled we skip the mirror silently — the
+ * blast still delivers via SMS/push.
  */
 export const recordBlast = internalMutation({
   args: {
@@ -350,7 +356,9 @@ export const recordBlast = internalMutation({
     results: v.any(),
   },
   handler: async (ctx, args) => {
-    await ctx.db.insert("eventBlasts", {
+    const ts = now();
+
+    const blastId = await ctx.db.insert("eventBlasts", {
       meetingId: args.meetingId,
       groupId: args.groupId,
       communityId: args.communityId,
@@ -360,7 +368,50 @@ export const recordBlast = internalMutation({
       recipientCount: args.recipientCount,
       status: args.status,
       results: args.results,
-      createdAt: now(),
+      createdAt: ts,
+    });
+
+    // Mirror the blast into the event chat channel as a real text message
+    // from the sender. Ensure the channel exists first — a blast is a
+    // legitimate trigger for lazy channel creation.
+    const channelId = await ctx.runMutation(
+      internal.functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: args.meetingId },
+    );
+
+    const channel = await ctx.db.get(channelId);
+    if (!channel) return;
+
+    // If a leader has explicitly disabled the event chat, skip the mirror
+    // but don't fail the blast — SMS/push still went out.
+    if (channel.isEnabled === false) return;
+
+    const sender = await ctx.db.get(args.sentById);
+    const senderName = sender
+      ? `${sender.firstName || ""} ${sender.lastName || ""}`.trim() || "Someone"
+      : "Someone";
+    const senderProfilePhoto = sender ? getMediaUrl(sender.profilePhoto) : undefined;
+
+    await ctx.db.insert("chatMessages", {
+      channelId,
+      senderId: args.sentById,
+      content: args.message,
+      contentType: "text",
+      attachments: undefined,
+      createdAt: ts,
+      isDeleted: false,
+      senderName,
+      senderProfilePhoto,
+      lastActivityAt: ts,
+      blastId,
+    });
+
+    await ctx.db.patch(channelId, {
+      lastMessageAt: ts,
+      lastMessagePreview: args.message.slice(0, 100),
+      lastMessageSenderId: args.sentById,
+      lastMessageSenderName: senderName,
+      updatedAt: ts,
     });
   },
 });

--- a/apps/convex/functions/eventBlasts.ts
+++ b/apps/convex/functions/eventBlasts.ts
@@ -392,7 +392,7 @@ export const recordBlast = internalMutation({
       : "Someone";
     const senderProfilePhoto = sender ? getMediaUrl(sender.profilePhoto) : undefined;
 
-    await ctx.db.insert("chatMessages", {
+    const messageId = await ctx.db.insert("chatMessages", {
       channelId,
       senderId: args.sentById,
       content: args.message,
@@ -412,6 +412,16 @@ export const recordBlast = internalMutation({
       lastMessageSenderId: args.sentById,
       lastMessageSenderName: senderName,
       updatedAt: ts,
+    });
+
+    // Run onMessageSent so channel members' unread counts increment and the
+    // Activity feed shows an inbox badge. onMessageSent short-circuits the
+    // push fanout for blast-mirror messages (blastId set), so recipients
+    // don't get a duplicate push after the SMS.
+    await ctx.runMutation(internal.functions.messaging.events.onMessageSent, {
+      messageId,
+      channelId,
+      senderId: args.sentById,
     });
   },
 });

--- a/apps/convex/functions/meetingRsvps.ts
+++ b/apps/convex/functions/meetingRsvps.ts
@@ -515,6 +515,21 @@ export const submit = mutation({
         });
       }
 
+      // Sync event chat channel membership based on whether the final
+      // option is enabled. Channels are lazy-created, so these calls
+      // are no-ops if no channel exists yet.
+      if (selectedOption.enabled) {
+        await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.addEventChannelMember, {
+          meetingId: args.meetingId,
+          userId,
+        });
+      } else {
+        await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.removeEventChannelMember, {
+          meetingId: args.meetingId,
+          userId,
+        });
+      }
+
       return {
         success: true,
         optionId: args.optionId,
@@ -537,6 +552,14 @@ export const submit = mutation({
       meetingId: args.meetingId,
       userId,
       rsvpOptionLabel: selectedOption.label,
+    });
+
+    // Sync event chat channel membership. Submit only allows enabled
+    // options (validated above), so new inserts always add. The channel
+    // is lazy-created, so this is a no-op if no channel exists yet.
+    await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.addEventChannelMember, {
+      meetingId: args.meetingId,
+      userId,
     });
 
     return {
@@ -568,6 +591,13 @@ export const remove = mutation({
 
     if (rsvp) {
       await ctx.db.delete(rsvp._id);
+
+      // Remove from event chat channel membership. No-op if the
+      // channel hasn't been lazy-created or the user isn't a member.
+      await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.removeEventChannelMember, {
+        meetingId: args.meetingId,
+        userId,
+      });
     }
 
     return { success: true };
@@ -634,6 +664,14 @@ export const batchUpdate = mutation({
           updatedAt: timestamp,
         });
       }
+
+      // Sync event chat channel membership. batchUpdate only allows
+      // enabled options (filtered via validOptionIds above), so we
+      // always add here. No-op if no channel exists yet.
+      await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.addEventChannelMember, {
+        meetingId: args.meetingId,
+        userId: rsvpUpdate.userId,
+      });
     }
 
     return { success: true };

--- a/apps/convex/functions/meetingRsvps.ts
+++ b/apps/convex/functions/meetingRsvps.ts
@@ -516,15 +516,19 @@ export const submit = mutation({
       }
 
       // Sync event chat channel membership based on whether the final
-      // option is enabled. Channels are lazy-created, so these calls
-      // are no-ops if no channel exists yet.
+      // option is enabled. Runs inline (same transaction) so the RSVP
+      // write and the chat-member row stay consistent — fire-and-forget
+      // via the scheduler could leave the two rows out of sync if the
+      // scheduled mutation failed, with no reconciliation path. Channels
+      // are lazy-created, so these calls are no-ops if no channel exists
+      // yet.
       if (selectedOption.enabled) {
-        await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.addEventChannelMember, {
+        await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
           meetingId: args.meetingId,
           userId,
         });
       } else {
-        await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.removeEventChannelMember, {
+        await ctx.runMutation(internal.functions.messaging.eventChat.removeEventChannelMember, {
           meetingId: args.meetingId,
           userId,
         });
@@ -557,7 +561,8 @@ export const submit = mutation({
     // Sync event chat channel membership. Submit only allows enabled
     // options (validated above), so new inserts always add. The channel
     // is lazy-created, so this is a no-op if no channel exists yet.
-    await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.addEventChannelMember, {
+    // Runs inline so RSVP + chat membership stay consistent.
+    await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
       meetingId: args.meetingId,
       userId,
     });
@@ -594,7 +599,9 @@ export const remove = mutation({
 
       // Remove from event chat channel membership. No-op if the
       // channel hasn't been lazy-created or the user isn't a member.
-      await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.removeEventChannelMember, {
+      // Runs inline so the RSVP delete and chat membership removal are
+      // atomic — avoids stale "member" rows for users who un-RSVPed.
+      await ctx.runMutation(internal.functions.messaging.eventChat.removeEventChannelMember, {
         meetingId: args.meetingId,
         userId,
       });
@@ -667,8 +674,9 @@ export const batchUpdate = mutation({
 
       // Sync event chat channel membership. batchUpdate only allows
       // enabled options (filtered via validOptionIds above), so we
-      // always add here. No-op if no channel exists yet.
-      await ctx.scheduler.runAfter(0, internal.functions.messaging.eventChat.addEventChannelMember, {
+      // always add here. No-op if no channel exists yet. Runs inline so
+      // the RSVP writes and chat membership stay consistent.
+      await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
         meetingId: args.meetingId,
         userId: rsvpUpdate.userId,
       });

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -23,6 +23,7 @@ import { internal } from "../../_generated/api";
 import { syncUserChannelMembershipsLogic } from "../sync/memberships";
 import { updateChannelMemberCount } from "./helpers";
 import { matchesSearchTerms, parseSearchTerms } from "../../lib/memberSearch";
+import { canAccessEventChannel } from "./eventChat";
 
 // ============================================================================
 // Helper Functions
@@ -200,6 +201,18 @@ export const getChannel = query({
     const channel = await ctx.db.get(args.channelId);
     if (!channel) {
       return null;
+    }
+
+    // Event channels use meeting-based access (non-group-members may participate
+    // via RSVP). Short-circuit the group-membership gate below.
+    if (channel.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        return null;
+      }
+      return {
+        ...channel,
+        slug: getChannelSlug(channel),
+      };
     }
 
     // Check channel membership
@@ -465,6 +478,11 @@ export const getChannelsByGroup = query({
     const isLeader = isLeaderRole(groupMembership.role);
 
     const filteredChannels = channels.filter((channel) => {
+      // Event channels are scoped to meetings, not surfaced on the group page.
+      // They appear via getChannelByMeetingId / inbox.
+      if (channel.channelType === "event") {
+        return false;
+      }
       // Leaders channel requires leader/admin role
       if (channel.channelType === "leaders") {
         return isLeader;
@@ -861,6 +879,11 @@ export const listGroupChannels = query({
 
     // Filter channels based on access permissions
     channels = channels.filter((ch) => {
+      // Event channels are scoped to meetings, not surfaced on the group page.
+      // They appear via getChannelByMeetingId / inbox.
+      if (ch.channelType === "event") {
+        return false;
+      }
       // Leaders channel only visible to leaders/admins
       if (ch.channelType === "leaders" && !userIsLeaderOrAdmin) {
         return false;
@@ -991,9 +1014,9 @@ export const getInboxChannels = query({
       )
       .collect();
 
-    if (groupMemberships.length === 0) {
-      return [];
-    }
+    // NOTE: don't early-return on empty groupMemberships — a user with no group
+    // memberships may still have event-channel memberships (event channels
+    // allow non-group-members to participate via RSVP).
 
     // Build a map of groupId -> role
     const groupRoleMap = new Map<Id<"groups">, string>();
@@ -1089,10 +1112,23 @@ export const getInboxChannels = query({
     // Find shared channels from user's memberships that aren't already in allChannels.
     // These are channels owned by other groups but shared with one of the user's groups.
     const allChannelIds = new Set(allChannels.map((ch) => ch._id));
+    // Track event channels picked up from chatChannelMembers so we can ensure
+    // their owning group appears in validGroups / groupRoleMap below.
+    const eventChannelsToInclude: Doc<"chatChannels">[] = [];
     for (const membership of userChannelMemberships) {
       if (allChannelIds.has(membership.channelId)) continue;
       const candidateChannel = await ctx.db.get(membership.channelId);
       if (!candidateChannel || candidateChannel.isArchived) continue;
+
+      // Event channels: user can see the channel via their chatChannelMembers
+      // row regardless of whether they're in the owning group. Disabled event
+      // channels are hidden from the inbox.
+      if (candidateChannel.channelType === "event") {
+        if (candidateChannel.isEnabled === false) continue;
+        eventChannelsToInclude.push(candidateChannel);
+        continue;
+      }
+
       if (!candidateChannel.isShared || !candidateChannel.sharedGroups) continue;
 
       // Check if any of the user's valid groups appear in sharedGroups with "accepted" status
@@ -1123,6 +1159,34 @@ export const getInboxChannels = query({
         // Also add to userChannelIds since we know user is a member
         userChannelIds.add(candidateChannel._id);
       }
+    }
+
+    // Event channels: surface every enabled event channel the user is a member
+    // of, even when they're not a member of the owning group. We fetch the
+    // owning group (and its group type) on demand and add it to validGroups
+    // so the normal grouping step picks the channel up.
+    for (const eventChannel of eventChannelsToInclude) {
+      const owningGroup = allGroups.find((g) => g && g._id === eventChannel.groupId)
+        ?? (await ctx.db.get(eventChannel.groupId));
+      if (!owningGroup || owningGroup.isArchived) continue;
+      if (args.communityId && owningGroup.communityId !== args.communityId) continue;
+
+      if (!validGroupIds.has(owningGroup._id)) {
+        validGroups.push(owningGroup);
+        validGroupIds.add(owningGroup._id);
+        // Non-group-members default to "member" userRole for grouping only.
+        if (!groupRoleMap.has(owningGroup._id)) {
+          groupRoleMap.set(owningGroup._id, "member");
+        }
+        // Fetch missing group type for display metadata.
+        if (owningGroup.groupTypeId && !groupTypeMap.has(owningGroup.groupTypeId)) {
+          const gt = await ctx.db.get(owningGroup.groupTypeId);
+          if (gt) groupTypeMap.set(gt._id, gt);
+        }
+      }
+      allChannels.push(eventChannel);
+      allChannelIds.add(eventChannel._id);
+      userChannelIds.add(eventChannel._id);
     }
 
     // Build the result grouped by group

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1189,6 +1189,27 @@ export const getInboxChannels = query({
       userChannelIds.add(eventChannel._id);
     }
 
+    // Pre-fetch meetings referenced by event channels so the inbox can show
+    // event scheduling info (used by mobile to hide stale event channels).
+    const eventMeetingIds = Array.from(
+      new Set(
+        allChannels
+          .filter((ch) => ch.channelType === "event" && ch.meetingId)
+          .map((ch) => ch.meetingId as Id<"meetings">),
+      ),
+    );
+    const eventMeetingDocs = await Promise.all(
+      eventMeetingIds.map((id) => ctx.db.get(id)),
+    );
+    const eventMeetingMap = new Map<Id<"meetings">, number | null>();
+    for (let i = 0; i < eventMeetingIds.length; i++) {
+      const m = eventMeetingDocs[i];
+      eventMeetingMap.set(
+        eventMeetingIds[i],
+        m && typeof m.scheduledAt === "number" ? m.scheduledAt : null,
+      );
+    }
+
     // Build the result grouped by group
     const result: Array<{
       group: {
@@ -1211,6 +1232,9 @@ export const getInboxChannels = query({
         lastMessageSenderId: Id<"users"> | null;
         unreadCount: number;
         isShared: boolean | undefined;
+        isEnabled: boolean | undefined;
+        meetingId: Id<"meetings"> | undefined;
+        meetingScheduledAt: number | null;
       }>;
       userRole: "leader" | "member";
     }> = [];
@@ -1293,6 +1317,12 @@ export const getInboxChannels = query({
           lastMessageSenderId: ch.lastMessageSenderId || null,
           unreadCount: unreadCounts.get(ch._id) || 0,
           isShared: ch.isShared || undefined,
+          isEnabled: ch.isEnabled,
+          meetingId: ch.meetingId,
+          meetingScheduledAt:
+            ch.channelType === "event" && ch.meetingId
+              ? eventMeetingMap.get(ch.meetingId) ?? null
+              : null,
         };
       });
 

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1207,6 +1207,7 @@ export const getInboxChannels = query({
         scheduledAt: number | null;
         shortId: string | null;
         coverImage: string | null;
+        location: string | null;
       }
     >();
     for (let i = 0; i < eventMeetingIds.length; i++) {
@@ -1215,6 +1216,10 @@ export const getInboxChannels = query({
         scheduledAt: m && typeof m.scheduledAt === "number" ? m.scheduledAt : null,
         shortId: m && typeof m.shortId === "string" ? m.shortId : null,
         coverImage: m && m.coverImage ? getMediaUrl(m.coverImage) ?? null : null,
+        location:
+          m && typeof m.locationOverride === "string" && m.locationOverride.trim().length > 0
+            ? m.locationOverride
+            : null,
       });
     }
 
@@ -1255,6 +1260,11 @@ export const getInboxChannels = query({
          * preview image.
          */
         meetingCoverImage: string | null;
+        /**
+         * For event channels, the meeting's free-form location (address or
+         * place name). Powers the Maps shortcut on the inbox row.
+         */
+        meetingLocation: string | null;
       }>;
       userRole: "leader" | "member";
     }> = [];
@@ -1350,6 +1360,10 @@ export const getInboxChannels = query({
           meetingCoverImage:
             ch.channelType === "event" && ch.meetingId
               ? eventMeetingMap.get(ch.meetingId)?.coverImage ?? null
+              : null,
+          meetingLocation:
+            ch.channelType === "event" && ch.meetingId
+              ? eventMeetingMap.get(ch.meetingId)?.location ?? null
               : null,
         };
       });

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1201,13 +1201,16 @@ export const getInboxChannels = query({
     const eventMeetingDocs = await Promise.all(
       eventMeetingIds.map((id) => ctx.db.get(id)),
     );
-    const eventMeetingMap = new Map<Id<"meetings">, number | null>();
+    const eventMeetingMap = new Map<
+      Id<"meetings">,
+      { scheduledAt: number | null; shortId: string | null }
+    >();
     for (let i = 0; i < eventMeetingIds.length; i++) {
       const m = eventMeetingDocs[i];
-      eventMeetingMap.set(
-        eventMeetingIds[i],
-        m && typeof m.scheduledAt === "number" ? m.scheduledAt : null,
-      );
+      eventMeetingMap.set(eventMeetingIds[i], {
+        scheduledAt: m && typeof m.scheduledAt === "number" ? m.scheduledAt : null,
+        shortId: m && typeof m.shortId === "string" ? m.shortId : null,
+      });
     }
 
     // Build the result grouped by group
@@ -1235,6 +1238,12 @@ export const getInboxChannels = query({
         isEnabled: boolean | undefined;
         meetingId: Id<"meetings"> | undefined;
         meetingScheduledAt: number | null;
+        /**
+         * For event channels, the meeting's shareable shortId. Lets the mobile
+         * inbox route event rows to `/e/{shortId}` (the event page with inline
+         * Activity) instead of the standalone chat room.
+         */
+        meetingShortId: string | null;
       }>;
       userRole: "leader" | "member";
     }> = [];
@@ -1321,7 +1330,11 @@ export const getInboxChannels = query({
           meetingId: ch.meetingId,
           meetingScheduledAt:
             ch.channelType === "event" && ch.meetingId
-              ? eventMeetingMap.get(ch.meetingId) ?? null
+              ? eventMeetingMap.get(ch.meetingId)?.scheduledAt ?? null
+              : null,
+          meetingShortId:
+            ch.channelType === "event" && ch.meetingId
+              ? eventMeetingMap.get(ch.meetingId)?.shortId ?? null
               : null,
         };
       });

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1203,13 +1203,18 @@ export const getInboxChannels = query({
     );
     const eventMeetingMap = new Map<
       Id<"meetings">,
-      { scheduledAt: number | null; shortId: string | null }
+      {
+        scheduledAt: number | null;
+        shortId: string | null;
+        coverImage: string | null;
+      }
     >();
     for (let i = 0; i < eventMeetingIds.length; i++) {
       const m = eventMeetingDocs[i];
       eventMeetingMap.set(eventMeetingIds[i], {
         scheduledAt: m && typeof m.scheduledAt === "number" ? m.scheduledAt : null,
         shortId: m && typeof m.shortId === "string" ? m.shortId : null,
+        coverImage: m && m.coverImage ? getMediaUrl(m.coverImage) ?? null : null,
       });
     }
 
@@ -1244,6 +1249,12 @@ export const getInboxChannels = query({
          * Activity) instead of the standalone chat room.
          */
         meetingShortId: string | null;
+        /**
+         * For event channels, the meeting's cover image URL (resolved through
+         * R2). The inbox uses this for the row avatar instead of the group's
+         * preview image.
+         */
+        meetingCoverImage: string | null;
       }>;
       userRole: "leader" | "member";
     }> = [];
@@ -1335,6 +1346,10 @@ export const getInboxChannels = query({
           meetingShortId:
             ch.channelType === "event" && ch.meetingId
               ? eventMeetingMap.get(ch.meetingId)?.shortId ?? null
+              : null,
+          meetingCoverImage:
+            ch.channelType === "event" && ch.meetingId
+              ? eventMeetingMap.get(ch.meetingId)?.coverImage ?? null
               : null,
         };
       });

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -1,0 +1,328 @@
+/**
+ * Event Chat functions
+ *
+ * Event chat channels let users who RSVP to an event access a chat scoped to
+ * that event, reusing the existing `chatChannels` / `chatChannelMembers`
+ * infrastructure. The event creator is the host (admin) and RSVPers are
+ * auto-added as members. Channels are created on-demand via
+ * `ensureEventChannel` and stay hidden from the inbox once an event is
+ * sufficiently in the past (see `HIDE_AFTER_MS`).
+ *
+ * Permission model (v1):
+ *   - Host: `meeting.createdById`.
+ *   - Members: any user with a `meetingRsvps` row whose `rsvpOptionId`
+ *     references an enabled option on the meeting.
+ *
+ * See ADR-022 and the event-chat spec for background.
+ */
+
+import { v } from "convex/values";
+import { query, mutation, internalMutation } from "../../_generated/server";
+import type { QueryCtx, MutationCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { canEditMeeting } from "../../lib/meetingPermissions";
+import { now } from "../../lib/utils";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** How long after an event's scheduledAt AND lastMessageAt before the channel is hidden from the inbox. Tune here. */
+export const HIDE_AFTER_MS = 2 * 24 * 60 * 60 * 1000;
+
+// ============================================================================
+// Access helpers
+// ============================================================================
+
+/**
+ * Does this user have access to this event chat channel?
+ *
+ * Returns false (caller should fall back to group-based access) if the
+ * channel isn't an event channel or is missing its `meetingId`.
+ *
+ * v1: treat any RSVP row (with an enabled option) as chat access. Narrow
+ * later if hosts want going-only.
+ */
+export async function canAccessEventChannel(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+  channel: Doc<"chatChannels">,
+): Promise<boolean> {
+  if (channel.channelType !== "event") return false;
+  if (!channel.meetingId) return false;
+
+  const meeting = await ctx.db.get(channel.meetingId);
+  if (!meeting) return false;
+
+  // Host (event creator) always has access.
+  if (meeting.createdById && userId === meeting.createdById) return true;
+
+  // Otherwise, the user must have an RSVP row whose option is still enabled
+  // on the meeting. v1: treat any RSVP row (with an enabled option) as chat
+  // access. Narrow later if hosts want going-only.
+  const rsvp = await ctx.db
+    .query("meetingRsvps")
+    .withIndex("by_meeting_user", (q) =>
+      q.eq("meetingId", channel.meetingId!).eq("userId", userId),
+    )
+    .first();
+  if (!rsvp) return false;
+
+  const options = meeting.rsvpOptions ?? [];
+  const matched = options.find((opt) => opt.id === rsvp.rsvpOptionId);
+  return Boolean(matched && matched.enabled);
+}
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+/**
+ * Return the event chat channel for a given meeting, if the caller can see it.
+ * Returns null when no channel exists yet or when the caller lacks access.
+ */
+export const getChannelByMeetingId = query({
+  args: {
+    token: v.string(),
+    meetingId: v.id("meetings"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const channel = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_meetingId", (q) => q.eq("meetingId", args.meetingId))
+      .first();
+
+    if (!channel) return null;
+
+    if (!(await canAccessEventChannel(ctx, userId, channel))) {
+      return null;
+    }
+
+    return channel;
+  },
+});
+
+// ============================================================================
+// Internal mutations
+// ============================================================================
+
+/**
+ * Idempotently create the chat channel for an event and seed its members.
+ *
+ * Call this the first time we need a channel for a meeting (e.g. on first
+ * RSVP, or lazily when a host opens the chat UI). Safe to call repeatedly —
+ * if a channel already exists for the meeting, the existing id is returned.
+ */
+export const ensureEventChannel = internalMutation({
+  args: {
+    meetingId: v.id("meetings"),
+  },
+  handler: async (ctx, args): Promise<Id<"chatChannels">> => {
+    // Idempotency check.
+    const existing = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_meetingId", (q) => q.eq("meetingId", args.meetingId))
+      .first();
+    if (existing) return existing._id;
+
+    const meeting = await ctx.db.get(args.meetingId);
+    if (!meeting) throw new Error("Meeting not found");
+
+    if (!meeting.shortId) {
+      throw new Error("Event is missing shortId — cannot create chat channel");
+    }
+
+    if (!meeting.createdById) {
+      // createdById is optional in the schema but every modern meeting has one;
+      // without it we can't seat a host and later permission checks break.
+      throw new Error("Event is missing createdById — cannot create chat channel");
+    }
+    const hostUserId = meeting.createdById;
+
+    const ts = now();
+
+    const channelId = await ctx.db.insert("chatChannels", {
+      groupId: meeting.groupId,
+      slug: `event-${meeting.shortId}`,
+      channelType: "event",
+      name: meeting.title || "Event chat",
+      createdById: hostUserId,
+      createdAt: ts,
+      updatedAt: ts,
+      isArchived: false,
+      isEnabled: true,
+      meetingId: args.meetingId,
+      memberCount: 0,
+    });
+
+    // Seat the host as admin.
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: hostUserId,
+      role: "admin",
+      syncSource: "event_rsvp",
+      joinedAt: ts,
+      isMuted: false,
+    });
+
+    // Seat every current RSVPer whose option is enabled.
+    const rsvps = await ctx.db
+      .query("meetingRsvps")
+      .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
+      .collect();
+
+    const enabledOptionIds = new Set(
+      (meeting.rsvpOptions ?? [])
+        .filter((opt) => opt.enabled)
+        .map((opt) => opt.id),
+    );
+
+    let rsvpMemberCount = 0;
+    for (const rsvp of rsvps) {
+      if (rsvp.userId === hostUserId) continue; // host already seated
+      if (!enabledOptionIds.has(rsvp.rsvpOptionId)) continue;
+
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: rsvp.userId,
+        role: "member",
+        syncSource: "event_rsvp",
+        joinedAt: ts,
+        isMuted: false,
+      });
+      rsvpMemberCount += 1;
+    }
+
+    await ctx.db.patch(channelId, {
+      memberCount: 1 + rsvpMemberCount,
+    });
+
+    return channelId;
+  },
+});
+
+/**
+ * Add a user to the event chat for a meeting (e.g. when they RSVP).
+ * No-op when the channel doesn't exist yet or the user is already a member.
+ */
+export const addEventChannelMember = internalMutation({
+  args: {
+    meetingId: v.id("meetings"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const channel = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_meetingId", (q) => q.eq("meetingId", args.meetingId))
+      .first();
+    if (!channel) return;
+
+    const existing = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", channel._id).eq("userId", args.userId),
+      )
+      .first();
+    if (existing) return;
+
+    await ctx.db.insert("chatChannelMembers", {
+      channelId: channel._id,
+      userId: args.userId,
+      role: "member",
+      syncSource: "event_rsvp",
+      joinedAt: now(),
+      isMuted: false,
+    });
+
+    await ctx.db.patch(channel._id, {
+      memberCount: channel.memberCount + 1,
+    });
+  },
+});
+
+/**
+ * Remove a user from the event chat for a meeting (e.g. when they un-RSVP).
+ * The host is never removed. No-op when the channel or membership doesn't exist.
+ */
+export const removeEventChannelMember = internalMutation({
+  args: {
+    meetingId: v.id("meetings"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const channel = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_meetingId", (q) => q.eq("meetingId", args.meetingId))
+      .first();
+    if (!channel) return;
+
+    // Host always stays in the event chat.
+    if (channel.createdById === args.userId) return;
+
+    const member = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", channel._id).eq("userId", args.userId),
+      )
+      .first();
+    if (!member) return;
+
+    await ctx.db.delete(member._id);
+    await ctx.db.patch(channel._id, {
+      memberCount: Math.max(0, channel.memberCount - 1),
+    });
+  },
+});
+
+// ============================================================================
+// Mutations (client-facing)
+// ============================================================================
+
+/**
+ * Enable or disable an event chat channel. Disabling hides it from members
+ * without destroying history; re-enabling restores access. Only the event
+ * creator, group leaders, or community admins can toggle this (per ADR-022).
+ */
+export const setEventChannelEnabled = mutation({
+  args: {
+    token: v.string(),
+    meetingId: v.id("meetings"),
+    enabled: v.boolean(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ channelId: Id<"chatChannels"> | null; enabled: boolean }> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const meeting = await ctx.db.get(args.meetingId);
+    if (!meeting) throw new Error("Meeting not found");
+
+    if (!(await canEditMeeting(ctx, userId, meeting))) {
+      throw new Error(
+        "Only the event creator, group leaders, or community admins can manage the event chat",
+      );
+    }
+
+    const channel = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_meetingId", (q) => q.eq("meetingId", args.meetingId))
+      .first();
+
+    // Nothing to toggle if the channel hasn't been created yet.
+    if (!channel) {
+      return { channelId: null, enabled: args.enabled };
+    }
+
+    await ctx.db.patch(channel._id, {
+      isEnabled: args.enabled,
+      disabledByUserId: args.enabled ? undefined : userId,
+      updatedAt: now(),
+    });
+
+    return { channelId: channel._id, enabled: args.enabled };
+  },
+});

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -370,22 +370,21 @@ export const setEventChannelEnabled = mutation({
       );
     }
 
-    const channel = await ctx.db
-      .query("chatChannels")
-      .withIndex("by_meetingId", (q) => q.eq("meetingId", args.meetingId))
-      .first();
+    // Materialize the channel before patching so a host disabling chat
+    // before any message has been sent still persists. Otherwise ensureEventChannel
+    // would lazy-create it with isEnabled: true on the first later send,
+    // silently undoing the host's action.
+    const channelId = await ctx.runMutation(
+      internal.functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: args.meetingId },
+    );
 
-    // Nothing to toggle if the channel hasn't been created yet.
-    if (!channel) {
-      return { channelId: null, enabled: args.enabled };
-    }
-
-    await ctx.db.patch(channel._id, {
+    await ctx.db.patch(channelId, {
       isEnabled: args.enabled,
       disabledByUserId: args.enabled ? undefined : userId,
       updatedAt: now(),
     });
 
-    return { channelId: channel._id, enabled: args.enabled };
+    return { channelId, enabled: args.enabled };
   },
 });

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -111,11 +111,16 @@ export const getChannelByMeetingId = query({
 // ============================================================================
 
 /**
- * Idempotently create the chat channel for an event and seed its members.
+ * Idempotently create the chat channel for an event and seat the host.
  *
- * Call this the first time we need a channel for a meeting (e.g. on first
- * RSVP, or lazily when a host opens the chat UI). Safe to call repeatedly —
+ * Call this the first time we need a channel for a meeting (e.g. when a
+ * host opens the chat UI, or on the first blast). Safe to call repeatedly —
  * if a channel already exists for the meeting, the existing id is returned.
+ *
+ * Seating model: only the host is seated here. Non-host members are added
+ * lazily by `openEventChat` (they only become subscribers after explicitly
+ * opening the chat), which prevents unrelated-to-them push notifications
+ * and caps the write set for this mutation regardless of RSVP scale.
  */
 export const ensureEventChannel = internalMutation({
   args: {
@@ -156,10 +161,11 @@ export const ensureEventChannel = internalMutation({
       isArchived: false,
       isEnabled: true,
       meetingId: args.meetingId,
-      memberCount: 0,
+      memberCount: 1,
     });
 
-    // Seat the host as admin.
+    // Seat the host as admin. Non-host RSVPers are seated lazily when they
+    // call openEventChat — see the comment at the top of this mutation.
     await ctx.db.insert("chatChannelMembers", {
       channelId,
       userId: hostUserId,
@@ -167,38 +173,6 @@ export const ensureEventChannel = internalMutation({
       syncSource: "event_rsvp",
       joinedAt: ts,
       isMuted: false,
-    });
-
-    // Seat every current RSVPer whose option is enabled.
-    const rsvps = await ctx.db
-      .query("meetingRsvps")
-      .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
-      .collect();
-
-    const enabledOptionIds = new Set(
-      (meeting.rsvpOptions ?? [])
-        .filter((opt) => opt.enabled)
-        .map((opt) => opt.id),
-    );
-
-    let rsvpMemberCount = 0;
-    for (const rsvp of rsvps) {
-      if (rsvp.userId === hostUserId) continue; // host already seated
-      if (!enabledOptionIds.has(rsvp.rsvpOptionId)) continue;
-
-      await ctx.db.insert("chatChannelMembers", {
-        channelId,
-        userId: rsvp.userId,
-        role: "member",
-        syncSource: "event_rsvp",
-        joinedAt: ts,
-        isMuted: false,
-      });
-      rsvpMemberCount += 1;
-    }
-
-    await ctx.db.patch(channelId, {
-      memberCount: 1 + rsvpMemberCount,
     });
 
     return channelId;
@@ -335,6 +309,36 @@ export const openEventChat = mutation({
       internal.functions.messaging.eventChat.ensureEventChannel,
       { meetingId: args.meetingId },
     );
+
+    // Lazily seat the caller as a channel member if they aren't already
+    // (the host was seated by ensureEventChannel; non-host RSVPers are
+    // seated only on their first openEventChat so they don't start
+    // receiving push notifications for events they haven't looked at).
+    if (!isHost) {
+      const existingMembership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", userId),
+        )
+        .first();
+
+      if (!existingMembership) {
+        await ctx.db.insert("chatChannelMembers", {
+          channelId,
+          userId,
+          role: "member",
+          syncSource: "event_rsvp",
+          joinedAt: now(),
+          isMuted: false,
+        });
+        const channel = await ctx.db.get(channelId);
+        if (channel) {
+          await ctx.db.patch(channelId, {
+            memberCount: (channel.memberCount ?? 0) + 1,
+          });
+        }
+      }
+    }
 
     return { channelId, slug: `event-${meeting.shortId}` };
   },

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -20,6 +20,7 @@ import { v } from "convex/values";
 import { query, mutation, internalMutation } from "../../_generated/server";
 import type { QueryCtx, MutationCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
 import { requireAuth } from "../../lib/auth";
 import { canEditMeeting } from "../../lib/meetingPermissions";
 import { now } from "../../lib/utils";
@@ -280,6 +281,64 @@ export const removeEventChannelMember = internalMutation({
 // ============================================================================
 // Mutations (client-facing)
 // ============================================================================
+
+/**
+ * Ensure the event chat channel exists and return its id + slug so the client
+ * can route to the chat room. Called when a user taps "Chat" on the event
+ * page — we eagerly materialize the channel here (rather than on first send)
+ * because the chat room screen resolves channels by (groupId, slug) and has
+ * no way to render a composer for a channel that doesn't exist yet.
+ *
+ * Access mirrors `canAccessEventChannel`: host OR any RSVPer whose option is
+ * still enabled on the meeting.
+ */
+export const openEventChat = mutation({
+  args: {
+    token: v.string(),
+    meetingId: v.id("meetings"),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ channelId: Id<"chatChannels">; slug: string }> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const meeting = await ctx.db.get(args.meetingId);
+    if (!meeting) throw new Error("Meeting not found");
+    if (!meeting.shortId) {
+      throw new Error("Event is missing shortId — cannot create chat channel");
+    }
+
+    // Access check — same rule as canAccessEventChannel but keyed off the
+    // meeting since the channel may not exist yet.
+    const isHost = meeting.createdById && meeting.createdById === userId;
+    let hasAccess = Boolean(isHost);
+    if (!hasAccess) {
+      const rsvp = await ctx.db
+        .query("meetingRsvps")
+        .withIndex("by_meeting_user", (q) =>
+          q.eq("meetingId", args.meetingId).eq("userId", userId),
+        )
+        .first();
+      if (rsvp) {
+        const matched = (meeting.rsvpOptions ?? []).find(
+          (opt) => opt.id === rsvp.rsvpOptionId,
+        );
+        hasAccess = Boolean(matched && matched.enabled);
+      }
+    }
+    if (!hasAccess) {
+      throw new Error("You don't have access to this event's chat");
+    }
+
+    const channelId: Id<"chatChannels"> = await ctx.runMutation(
+      internal.functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: args.meetingId },
+    );
+
+    return { channelId, slug: `event-${meeting.shortId}` };
+  },
+});
 
 /**
  * Enable or disable an event chat channel. Disabling hides it from members

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -102,6 +102,16 @@ export const onMessageSent = internalMutation({
       const senderAvatarUrl = message.senderProfilePhoto;
       const channelSlug = channel ? getChannelSlug(channel) : "general";
 
+      // For event channels, look up the meeting's shortId so the push
+      // notification can deep-link to /e/{shortId} instead of /inbox/...
+      // (which was routing tappers into the group-chat stack and had no
+      // event context).
+      let meetingShortId: string | undefined = undefined;
+      if (channel?.channelType === "event" && channel.meetingId) {
+        const meeting = await ctx.db.get(channel.meetingId);
+        if (meeting?.shortId) meetingShortId = meeting.shortId;
+      }
+
       // For shared channels, each member may belong to a different group.
       // We need to route notifications to each member's actual group so tapping
       // the notification opens the correct group context.
@@ -188,6 +198,7 @@ export const onMessageSent = internalMutation({
             channelName: channel.name,
             channelType: channel.channelType || "main",
             channelSlug,
+            meetingShortId,
             mentionRecipients: bucket.mentionRecipients,
             regularRecipients: bucket.regularRecipients,
           });
@@ -223,6 +234,7 @@ export const onMessageSent = internalMutation({
           channelName: channel?.name,
           channelType: channel?.channelType || "main",
           channelSlug,
+          meetingShortId,
           mentionRecipients,
           regularRecipients,
         });
@@ -248,11 +260,35 @@ export const sendMessageNotifications = internalAction({
     channelName: v.optional(v.string()),
     channelType: v.optional(v.string()),
     channelSlug: v.optional(v.string()),
+    /** For event-channel messages, the owning meeting's shortId. Lets us
+     *  deep-link the push to `/e/{shortId}` instead of the inbox route. */
+    meetingShortId: v.optional(v.string()),
     mentionRecipients: v.array(v.id("users")),
     regularRecipients: v.array(v.id("users")),
   },
   handler: async (ctx, args) => {
-    console.log(`[sendMessageNotifications] Starting with channelId=${args.channelId}, groupId=${args.groupId}, messageId=${args.messageId}, channelType=${args.channelType}, channelSlug=${args.channelSlug}`);
+    console.log(`[sendMessageNotifications] Starting with channelId=${args.channelId}, groupId=${args.groupId}, messageId=${args.messageId}, channelType=${args.channelType}, channelSlug=${args.channelSlug}, meetingShortId=${args.meetingShortId}`);
+
+    // Event-channel messages deep-link to the event page rather than the
+    // inbox chat room. The mobile app's notification handler prefers `url`
+    // over `type`/`channelType` routing, so setting it here is sufficient.
+    const isEventChannel = args.channelType === "event";
+    const eventUrl =
+      isEventChannel && args.meetingShortId
+        ? `/e/${args.meetingShortId}?source=app`
+        : undefined;
+
+    // Preserve "event" in channelType for notifications from event channels so
+    // the mobile fallback path doesn't mis-route them through `general`.
+    const dataChannelType = isEventChannel
+      ? "event"
+      : args.channelType === "leaders"
+        ? "leaders"
+        : "general";
+    const dataChannelSlug =
+      args.channelSlug ||
+      (args.channelType === "leaders" ? "leaders" : "general");
+
     // Send mention notifications (push + email)
     if (args.mentionRecipients.length > 0) {
       await notifyBatch(ctx, {
@@ -267,9 +303,9 @@ export const sendMessageNotifications = internalAction({
           channelId: args.channelId,
           channelName: args.channelName,
           communityId: args.communityId,
-          // Map channel type to expected format: "main" -> "general", "leaders" -> "leaders"
-          channelType: args.channelType === "leaders" ? "leaders" : "general",
-          channelSlug: args.channelSlug || (args.channelType === "leaders" ? "leaders" : "general"),
+          channelType: dataChannelType,
+          channelSlug: dataChannelSlug,
+          ...(eventUrl ? { url: eventUrl, shortId: args.meetingShortId } : {}),
         },
         groupId: args.groupId,
         communityId: args.communityId,
@@ -290,10 +326,9 @@ export const sendMessageNotifications = internalAction({
           channelId: args.channelId,
           channelName: args.channelName,
           communityId: args.communityId,
-          // Map channel type to expected format: "main" -> "general", "leaders" -> "leaders"
-          // This ensures the mobile app navigates to the correct channel tab (Issue #302)
-          channelType: args.channelType === "leaders" ? "leaders" : "general",
-          channelSlug: args.channelSlug || (args.channelType === "leaders" ? "leaders" : "general"),
+          channelType: dataChannelType,
+          channelSlug: dataChannelSlug,
+          ...(eventUrl ? { url: eventUrl, shortId: args.meetingShortId } : {}),
         },
         groupId: args.groupId,
         communityId: args.communityId,

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -39,6 +39,13 @@ export const onMessageSent = internalMutation({
     const message = await ctx.db.get(args.messageId);
     if (!message) return;
 
+    // Blast-mirror messages carry blastId and are inserted by
+    // eventBlasts.recordBlast, which already delivers the SMS + push via its
+    // own channels. Short-circuit here so the chat fanout doesn't push the
+    // same content again ~5s later. The mirrored chatMessages row stays
+    // visible in the Activity feed.
+    if (message.blastId) return;
+
     // Generate preview for notifications (but don't update channel - sendMessage already does it
     // with smart previews like "Sent a photo" or "Sent X files")
     const preview = message.content.slice(0, MAX_PREVIEW_LENGTH);

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -39,13 +39,6 @@ export const onMessageSent = internalMutation({
     const message = await ctx.db.get(args.messageId);
     if (!message) return;
 
-    // Blast-mirror messages carry blastId and are inserted by
-    // eventBlasts.recordBlast, which already delivers the SMS + push via its
-    // own channels. Short-circuit here so the chat fanout doesn't push the
-    // same content again ~5s later. The mirrored chatMessages row stays
-    // visible in the Activity feed.
-    if (message.blastId) return;
-
     // Generate preview for notifications (but don't update channel - sendMessage already does it
     // with smart previews like "Sent a photo" or "Sent X files")
     const preview = message.content.slice(0, MAX_PREVIEW_LENGTH);
@@ -93,6 +86,13 @@ export const onMessageSent = internalMutation({
         });
       }
     }
+
+    // Blast-mirror messages carry blastId and are inserted by
+    // eventBlasts.recordBlast, which already delivers the SMS via its own
+    // channel. Skip the chat push fanout so recipients don't get a
+    // duplicate push ~5s after the SMS. Unread increments above still run
+    // so the Activity feed's inbox badge reflects the new message.
+    if (message.blastId) return;
 
     // Send push notifications via centralized notification system
     // Schedule an action to send notifications (actions can make external API calls)

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -6,6 +6,7 @@
 
 import { v } from "convex/values";
 import { query, mutation, internalMutation } from "../../_generated/server";
+import type { QueryCtx, MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
@@ -19,6 +20,32 @@ import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { isCommunityAdmin } from "../../lib/permissions";
 import { checkRateLimit } from "../../lib/rateLimit";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
+import { canAccessEventChannel } from "./eventChat";
+
+/**
+ * Same access check as `canAccessEventChannel` but keyed off a meeting doc
+ * directly — used when the caller hasn't resolved a channel yet (e.g. the
+ * first `sendMessage` call that lazy-creates the event channel).
+ */
+async function canAccessMeetingChat(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+  meeting: Doc<"meetings">,
+): Promise<boolean> {
+  if (meeting.createdById && userId === meeting.createdById) return true;
+
+  const rsvp = await ctx.db
+    .query("meetingRsvps")
+    .withIndex("by_meeting_user", (q) =>
+      q.eq("meetingId", meeting._id).eq("userId", userId),
+    )
+    .first();
+  if (!rsvp) return false;
+
+  const options = meeting.rsvpOptions ?? [];
+  const matched = options.find((opt) => opt.id === rsvp.rsvpOptionId);
+  return Boolean(matched && matched.enabled);
+}
 
 // ============================================================================
 // Constants
@@ -118,6 +145,16 @@ export const getMessage = query({
         return null;
       }
 
+      // Event channels use meeting-based access rather than chatChannelMembers
+      // (non-group-members can still participate via RSVP).
+      const channel = await ctx.db.get(message.channelId);
+      if (channel?.channelType === "event") {
+        if (!(await canAccessEventChannel(ctx, userId, channel))) {
+          return null;
+        }
+        return message;
+      }
+
       // Check if user has access to the channel
       const membership = await ctx.db
         .query("chatChannelMembers")
@@ -161,67 +198,75 @@ export const getMessages = query({
       throw new Error("Channel not found");
     }
 
-    // Check channel membership
-    const channelMembership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", args.channelId).eq("userId", userId)
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
-
-    // Validate viewingGroupId is actually related to this channel
-    let contextGroupId = channel.groupId;
-    if (args.viewingGroupId) {
-      const isOwningGroup = args.viewingGroupId === channel.groupId;
-      const isAcceptedSharedGroup = channel.sharedGroups?.some(
-        (sg) => sg.groupId === args.viewingGroupId && sg.status === "accepted"
-      );
-      if (isOwningGroup || isAcceptedSharedGroup) {
-        contextGroupId = args.viewingGroupId;
+    // Event channels use meeting-based access (RSVPers may not be group members).
+    // Short-circuit the group-membership gate below.
+    if (channel.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        throw new Error("Not a member of this channel");
       }
-      // If viewingGroupId is not valid, fall back to channel.groupId for auth check
-    }
-    const groupMembership = await ctx.db
-      .query("groupMembers")
-      .withIndex("by_group_user", (q) =>
-        q.eq("groupId", contextGroupId).eq("userId", userId)
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
+    } else {
+      // Check channel membership
+      const channelMembership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", args.channelId).eq("userId", userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
 
-    // If not a channel member, only group leaders/admins may load messages
-    if (!channelMembership && !isLeaderRole(groupMembership?.role)) {
-      throw new Error("Not a member of this channel");
-    }
+      // Validate viewingGroupId is actually related to this channel
+      let contextGroupId = channel.groupId;
+      if (args.viewingGroupId) {
+        const isOwningGroup = args.viewingGroupId === channel.groupId;
+        const isAcceptedSharedGroup = channel.sharedGroups?.some(
+          (sg) => sg.groupId === args.viewingGroupId && sg.status === "accepted"
+        );
+        if (isOwningGroup || isAcceptedSharedGroup) {
+          contextGroupId = args.viewingGroupId;
+        }
+        // If viewingGroupId is not valid, fall back to channel.groupId for auth check
+      }
+      const groupMembership = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", contextGroupId).eq("userId", userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
 
-    // For bypassing global disabled check, consider leadership in owning group OR linked group
-    const owningGroupMembership = args.viewingGroupId
-      ? await ctx.db
-          .query("groupMembers")
-          .withIndex("by_group_user", (q) =>
-            q.eq("groupId", channel.groupId).eq("userId", userId)
-          )
-          .filter((q) => q.eq(q.field("leftAt"), undefined))
-          .first()
-      : groupMembership;
-    const isOwningGroupLeader = isLeaderRole(owningGroupMembership?.role);
-    // Also check linked group leadership when viewing from a linked group
-    const isLinkedGroupLeader =
-      args.viewingGroupId && args.viewingGroupId !== channel.groupId
-        ? isLeaderRole(groupMembership?.role)
-        : false;
+      // If not a channel member, only group leaders/admins may load messages
+      if (!channelMembership && !isLeaderRole(groupMembership?.role)) {
+        throw new Error("Not a member of this channel");
+      }
 
-    const effectiveEnabled = args.viewingGroupId
-      ? channelEffectiveEnabledForGroup(channel, args.viewingGroupId)
-      : channelIsLeaderEnabled(channel);
-    if (
-      (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
-      !effectiveEnabled &&
-      !isOwningGroupLeader &&
-      !isLinkedGroupLeader
-    ) {
-      throw new Error("Channel is not available");
+      // For bypassing global disabled check, consider leadership in owning group OR linked group
+      const owningGroupMembership = args.viewingGroupId
+        ? await ctx.db
+            .query("groupMembers")
+            .withIndex("by_group_user", (q) =>
+              q.eq("groupId", channel.groupId).eq("userId", userId)
+            )
+            .filter((q) => q.eq(q.field("leftAt"), undefined))
+            .first()
+        : groupMembership;
+      const isOwningGroupLeader = isLeaderRole(owningGroupMembership?.role);
+      // Also check linked group leadership when viewing from a linked group
+      const isLinkedGroupLeader =
+        args.viewingGroupId && args.viewingGroupId !== channel.groupId
+          ? isLeaderRole(groupMembership?.role)
+          : false;
+
+      const effectiveEnabled = args.viewingGroupId
+        ? channelEffectiveEnabledForGroup(channel, args.viewingGroupId)
+        : channelIsLeaderEnabled(channel);
+      if (
+        (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
+        !effectiveEnabled &&
+        !isOwningGroupLeader &&
+        !isLinkedGroupLeader
+      ) {
+        throw new Error("Channel is not available");
+      }
     }
 
     // Get blocked users to filter out their messages
@@ -381,17 +426,25 @@ export const getThreadReplies = query({
       throw new Error("Parent message not found");
     }
 
-    // Check channel membership
-    const membership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", parentMessage.channelId).eq("userId", userId)
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
+    // Event channels use meeting-based access (RSVPers may not be group members).
+    const channel = await ctx.db.get(parentMessage.channelId);
+    if (channel?.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        throw new Error("Not a member of this channel");
+      }
+    } else {
+      // Check channel membership
+      const membership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", parentMessage.channelId).eq("userId", userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
 
-    if (!membership) {
-      throw new Error("Not a member of this channel");
+      if (!membership) {
+        throw new Error("Not a member of this channel");
+      }
     }
 
     const replies = await ctx.db
@@ -418,11 +471,17 @@ export const getThreadReplies = query({
 
 /**
  * Send a message to a channel.
+ *
+ * Accepts EITHER `channelId` (existing callers, all channel types) OR
+ * `meetingId` (event-chat lazy-create path). Exactly one must be provided.
+ * When `meetingId` is passed, the event channel is created if it doesn't
+ * exist yet and the message is sent into it.
  */
 export const sendMessage = mutation({
   args: {
     token: v.string(),
-    channelId: v.id("chatChannels"),
+    channelId: v.optional(v.id("chatChannels")),
+    meetingId: v.optional(v.id("meetings")),
     content: v.string(),
     attachments: v.optional(
       v.array(
@@ -446,39 +505,77 @@ export const sendMessage = mutation({
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
 
+    // Require exactly one of channelId / meetingId.
+    if (!args.channelId && !args.meetingId) {
+      throw new Error("sendMessage requires either channelId or meetingId");
+    }
+    if (args.channelId && args.meetingId) {
+      throw new Error("sendMessage accepts channelId or meetingId, not both");
+    }
+
     // Global rate limit: 20 messages per minute per user
     await checkRateLimit(ctx, `msg:${userId}`, 20, 60_000);
 
-    // Check channel membership
-    const membership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", args.channelId).eq("userId", userId)
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
-
-    if (!membership) {
-      throw new Error("Not a member of this channel");
+    // Resolve the target channelId. For event-chat lazy-create, we verify
+    // meeting access first, then ensure the channel exists, then proceed.
+    let channelId: Id<"chatChannels">;
+    if (args.meetingId) {
+      const meeting = await ctx.db.get(args.meetingId);
+      if (!meeting) {
+        throw new Error("Meeting not found");
+      }
+      if (!(await canAccessMeetingChat(ctx, userId, meeting))) {
+        throw new Error("Not a member of this channel");
+      }
+      channelId = await ctx.runMutation(
+        internal.functions.messaging.eventChat.ensureEventChannel,
+        { meetingId: args.meetingId },
+      );
+    } else {
+      channelId = args.channelId!;
     }
 
-    const channel = await ctx.db.get(args.channelId);
+    const channel = await ctx.db.get(channelId);
     if (!channel) {
       throw new Error("Channel not found");
     }
-    if (args.viewingGroupId) {
-      if (
-        (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
-        !channelEffectiveEnabledForGroup(channel, args.viewingGroupId)
-      ) {
-        throw new Error("This channel is disabled");
+
+    // Event channel permission path: meeting-based access, not group-based.
+    if (channel.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        throw new Error("Not a member of this channel");
+      }
+      if (channel.isEnabled === false) {
+        throw new Error("Event chat is disabled");
       }
     } else {
-      if (
-        (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
-        !channelIsLeaderEnabled(channel)
-      ) {
-        throw new Error("This channel is disabled");
+      // Check channel membership
+      const membership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
+
+      if (!membership) {
+        throw new Error("Not a member of this channel");
+      }
+
+      if (args.viewingGroupId) {
+        if (
+          (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
+          !channelEffectiveEnabledForGroup(channel, args.viewingGroupId)
+        ) {
+          throw new Error("This channel is disabled");
+        }
+      } else {
+        if (
+          (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
+          !channelIsLeaderEnabled(channel)
+        ) {
+          throw new Error("This channel is disabled");
+        }
       }
     }
 
@@ -503,7 +600,7 @@ export const sendMessage = mutation({
     }
 
     const messageId = await ctx.db.insert("chatMessages", {
-      channelId: args.channelId,
+      channelId,
       senderId: userId,
       content: args.content,
       contentType,
@@ -526,7 +623,7 @@ export const sendMessage = mutation({
       attachments: args.attachments,
     });
 
-    await ctx.db.patch(args.channelId, {
+    await ctx.db.patch(channelId, {
       lastMessageAt: now,
       lastMessagePreview: preview,
       lastMessageSenderId: userId,
@@ -548,7 +645,7 @@ export const sendMessage = mutation({
     // Trigger notification and unread count logic
     await ctx.scheduler.runAfter(0, internal.functions.messaging.events.onMessageSent, {
       messageId,
-      channelId: args.channelId,
+      channelId,
       senderId: userId,
     });
 

--- a/apps/convex/functions/messaging/reactions.ts
+++ b/apps/convex/functions/messaging/reactions.ts
@@ -8,6 +8,7 @@ import { v } from "convex/values";
 import { query, mutation } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
+import { canAccessEventChannel } from "./eventChat";
 
 // ============================================================================
 // Queries
@@ -29,17 +30,26 @@ export const getReactions = query({
       return [];
     }
 
-    // Check channel membership
-    const membership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", message.channelId).eq("userId", userId)
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
+    // Event channels use RSVP-based access, not chatChannelMembers — RSVPers
+    // who haven't explicitly opened the chat can still see and react.
+    const channel = await ctx.db.get(message.channelId);
+    if (channel?.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        return [];
+      }
+    } else {
+      // Check channel membership
+      const membership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", message.channelId).eq("userId", userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
 
-    if (!membership) {
-      return [];
+      if (!membership) {
+        return [];
+      }
     }
 
     // Get all reactions for this message
@@ -110,9 +120,16 @@ export const getReactionsForMessages = query({
       }
     }
 
-    // Check membership for all channels
+    // Check access for all channels. Event channels use RSVP-based access
+    // (canAccessEventChannel); non-event channels use chatChannelMembers.
+    // One channel fetch + access check per distinct channel id.
     const membershipChecks = await Promise.all(
       Array.from(channelIds).map(async (channelId) => {
+        const channel = await ctx.db.get(channelId);
+        if (channel?.channelType === "event") {
+          const hasAccess = await canAccessEventChannel(ctx, userId, channel);
+          return { channelId, isMember: hasAccess };
+        }
         const membership = await ctx.db
           .query("chatChannelMembers")
           .withIndex("by_channel_user", (q) =>
@@ -213,17 +230,25 @@ export const getReactionDetails = query({
       return [];
     }
 
-    // Check channel membership
-    const membership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", message.channelId).eq("userId", userId)
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
+    // Event channels use RSVP-based access, not chatChannelMembers.
+    const channel = await ctx.db.get(message.channelId);
+    if (channel?.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        return [];
+      }
+    } else {
+      // Check channel membership
+      const membership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", message.channelId).eq("userId", userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
 
-    if (!membership) {
-      return [];
+      if (!membership) {
+        return [];
+      }
     }
 
     // Get all reactions for this message with the specified emoji
@@ -282,17 +307,26 @@ export const toggleReaction = mutation({
       throw new Error("Cannot react to a deleted message");
     }
 
-    // Check channel membership
-    const membership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", message.channelId).eq("userId", userId)
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
+    // Event channels use RSVP-based access — RSVPers can react without
+    // being in chatChannelMembers (they're seated lazily on openEventChat).
+    const channel = await ctx.db.get(message.channelId);
+    if (channel?.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        throw new Error("Not a member of this channel");
+      }
+    } else {
+      // Check channel membership
+      const membership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", message.channelId).eq("userId", userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
 
-    if (!membership) {
-      throw new Error("Not a member of this channel");
+      if (!membership) {
+        throw new Error("Not a member of this channel");
+      }
     }
 
     // Check if user already has this reaction

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1431,7 +1431,7 @@ export default defineSchema({
   chatChannels: defineTable({
     groupId: v.id("groups"),
     slug: v.optional(v.string()), // URL-friendly, unique per group, immutable (optional for migration)
-    channelType: v.string(), // "main" | "leaders" | "dm" | "custom" | "pco_services"
+    channelType: v.string(), // "main" | "leaders" | "dm" | "custom" | "pco_services" | "event"
     name: v.string(),
     description: v.optional(v.string()),
     createdById: v.id("users"),
@@ -1441,6 +1441,10 @@ export default defineSchema({
     archivedAt: v.optional(v.number()), // Unix timestamp ms
     /** false = leader hid channel from members; memberships stay (unlike archive). undefined/true = active. */
     isEnabled: v.optional(v.boolean()),
+    /** For channelType === "event": the meeting this channel is scoped to. */
+    meetingId: v.optional(v.id("meetings")),
+    /** Who toggled isEnabled=false (audit trail for disabling event chats). */
+    disabledByUserId: v.optional(v.id("users")),
     // Denormalized for performance
     lastMessageAt: v.optional(v.number()), // Unix timestamp ms
     lastMessagePreview: v.optional(v.string()), // First 100 chars
@@ -1476,7 +1480,8 @@ export default defineSchema({
     .index("by_lastMessageAt", ["lastMessageAt"])
     .index("by_archived", ["isArchived"])
     .index("by_isShared", ["isShared"])
-    .index("by_inviteShortId", ["inviteShortId"]),
+    .index("by_inviteShortId", ["inviteShortId"])
+    .index("by_meetingId", ["meetingId"]),
 
   /**
    * Chat Channel Members
@@ -1494,7 +1499,7 @@ export default defineSchema({
     displayName: v.optional(v.string()),
     profilePhoto: v.optional(v.string()),
     // Auto-sync tracking (for auto channels like PCO Services)
-    syncSource: v.optional(v.string()), // "pco_services" | null (manual)
+    syncSource: v.optional(v.string()), // "pco_services" | "event_rsvp" | null (manual)
     syncEventId: v.optional(v.string()), // External event/plan ID that added them
     scheduledRemovalAt: v.optional(v.number()), // Unix timestamp ms for auto-removal
     // Additional sync metadata (team, position, service date for display)
@@ -1582,6 +1587,9 @@ export default defineSchema({
     taskId: v.optional(v.id("tasks")),
     // Optional idempotency key for generated bot/task posts
     sourceKey: v.optional(v.string()),
+    // For mirrored text blasts — backlink to the eventBlasts row so the UI
+    // can render an "Also sent via SMS" badge and deep-link to delivery stats.
+    blastId: v.optional(v.id("eventBlasts")),
   })
     .index("by_channel", ["channelId"])
     .index("by_channel_createdAt", ["channelId", "createdAt"])

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -42,6 +42,9 @@ export interface EventActivityProps {
   meetingId: Id<"meetings">;
   groupId: Id<"groups">;
   shortId: string;
+  /** Event title — threaded down to EventComment so the thread header reads
+   *  "Thread / #My Event" instead of the generic "Thread / #event". */
+  eventTitle: string;
   currentUserId: Id<"users">;
   /** Host + RSVPer-with-enabled-option. Caller computes this. */
   canAccess: boolean;
@@ -56,6 +59,7 @@ export function EventActivity({
   meetingId: _meetingId,
   groupId,
   shortId,
+  eventTitle,
   currentUserId,
   canAccess,
   isChatEnabled,
@@ -243,6 +247,7 @@ export function EventActivity({
                 currentUserId={currentUserId}
                 groupId={groupId}
                 eventShortId={shortId}
+                eventTitle={eventTitle}
               />
             ))}
           </View>

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -31,9 +31,10 @@ import {
 } from "@services/api/convex";
 import { useTheme } from "@hooks/useTheme";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
-import { MessageItem } from "@/features/chat/components/MessageItem";
-import { MessageInput } from "@/features/chat/components/MessageInput";
 import { ReactionsProvider } from "@/features/chat/context/ReactionsContext";
+import { Ionicons } from "@expo/vector-icons";
+import { EventComment } from "./EventComment";
+import { EventCommentSheet } from "./EventCommentSheet";
 
 const PAGE_SIZE = 100;
 
@@ -82,6 +83,7 @@ export function EventActivity({
   const [olderCursor, setOlderCursor] = useState<string | undefined>(undefined);
   const [hasMoreOlder, setHasMoreOlder] = useState(false);
   const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const [showCommentSheet, setShowCommentSheet] = useState(false);
   const [loadOlderCursor, setLoadOlderCursor] = useState<string | undefined>(
     undefined
   );
@@ -164,61 +166,63 @@ export function EventActivity({
   const isLoadingMessages =
     channelId !== null && canAccess && messagesResult === undefined;
 
+  // Partiful-style: newest first. The paginated query returns ascending; reverse
+  // for display without mutating the source array.
+  const displayMessages = [...messages].reverse();
+
   return (
     <View style={styles.root}>
       <View style={styles.headingRow}>
-        <Text style={[styles.heading, { color: colors.text }]}>Activity</Text>
-        {messageCount > 0 && (
-          <Text style={[styles.subLabel, { color: colors.textSecondary }]}>
-            {messageCount} {messageCount === 1 ? "update" : "updates"}
-          </Text>
+        <View style={styles.headingLabelGroup}>
+          <Text style={[styles.heading, { color: colors.text }]}>Activity</Text>
+          {messageCount > 0 && (
+            <Text style={[styles.subLabel, { color: colors.textSecondary }]}>
+              {messageCount} {messageCount === 1 ? "update" : "updates"}
+            </Text>
+          )}
+        </View>
+        {isChatEnabled && (
+          <TouchableOpacity
+            style={[
+              styles.commentButton,
+              { borderColor: colors.border },
+            ]}
+            onPress={() => setShowCommentSheet(true)}
+            accessibilityLabel="Leave a comment"
+          >
+            <Ionicons
+              name="chatbubble-ellipses-outline"
+              size={16}
+              color={colors.text}
+            />
+            <Text style={[styles.commentButtonText, { color: colors.text }]}>
+              Comment
+            </Text>
+          </TouchableOpacity>
         )}
       </View>
 
-      {/* Load earlier */}
-      {hasMoreOlder && !isLoadingMessages && (
-        <TouchableOpacity
-          style={styles.loadEarlierButton}
-          onPress={handleLoadOlder}
-          disabled={isLoadingOlder}
-        >
-          {isLoadingOlder ? (
-            <ActivityIndicator size="small" color={DEFAULT_PRIMARY_COLOR} />
-          ) : (
-            <Text
-              style={[
-                styles.loadEarlierText,
-                { color: DEFAULT_PRIMARY_COLOR },
-              ]}
-            >
-              Load earlier messages
-            </Text>
-          )}
-        </TouchableOpacity>
-      )}
-
-      {/* Messages list (ascending). Wrap in ReactionsProvider so MessageItem's
-          useReactions reads from the batched context (one query for all
-          messages, not one per message). */}
+      {/* Messages list (newest-first). Wrap in ReactionsProvider so
+          EventComment's useReactions reads from the batched context. */}
       <ReactionsProvider messageIds={messageIds} channelId={channelId}>
         {isLoadingMessages ? (
           <View style={styles.loadingBlock}>
             <ActivityIndicator size="small" color={DEFAULT_PRIMARY_COLOR} />
           </View>
-        ) : messages.length === 0 ? (
+        ) : displayMessages.length === 0 ? (
           <View style={styles.emptyBlock}>
             <Text
               style={[styles.emptyText, { color: colors.textSecondary }]}
             >
               {isChatEnabled
-                ? "No messages yet. Be the first to say something."
-                : "Chat is disabled"}
+                ? "No comments yet. Be the first to say something."
+                : "Comments are disabled"}
             </Text>
           </View>
         ) : (
           <View style={styles.messagesList}>
-            {messages.map((msg: any) => (
-              <MessageItem
+            {displayMessages.map((msg: any) => (
+              <EventComment
                 key={msg._id}
                 message={{
                   _id: msg._id,
@@ -234,9 +238,6 @@ export function EventActivity({
                   senderProfilePhoto: msg.senderProfilePhoto,
                   mentionedUserIds: msg.mentionedUserIds,
                   threadReplyCount: msg.threadReplyCount,
-                  hideLinkPreview: msg.hideLinkPreview,
-                  reachOutRequestId: msg.reachOutRequestId,
-                  taskId: msg.taskId,
                   blastId: msg.blastId,
                 }}
                 currentUserId={currentUserId}
@@ -247,55 +248,33 @@ export function EventActivity({
         )}
       </ReactionsProvider>
 
-      {/* Composer rendered inline at the end of the Activity section —
-          scrolls with the page rather than pinning at the viewport bottom.
-          Skipped entirely when chat is disabled. */}
-      {isChatEnabled && (
-        <View style={styles.inlineComposer}>
-          <MessageInput channelId={channelId} />
-        </View>
+      {/* Load earlier — appears at the BOTTOM in newest-first layout. */}
+      {hasMoreOlder && !isLoadingMessages && (
+        <TouchableOpacity
+          style={styles.loadEarlierButton}
+          onPress={handleLoadOlder}
+          disabled={isLoadingOlder}
+        >
+          {isLoadingOlder ? (
+            <ActivityIndicator size="small" color={DEFAULT_PRIMARY_COLOR} />
+          ) : (
+            <Text
+              style={[
+                styles.loadEarlierText,
+                { color: DEFAULT_PRIMARY_COLOR },
+              ]}
+            >
+              Load earlier comments
+            </Text>
+          )}
+        </TouchableOpacity>
       )}
-    </View>
-  );
-}
 
-/**
- * EventActivityComposer
- *
- * Sticky bottom composer for the event chat. Rendered by `EventPageClient`
- * as an absolutely-positioned sibling (not inside the ScrollView) so it
- * stays pinned to the viewport and lifts above the keyboard via the
- * surrounding `KeyboardAvoidingView`.
- *
- * Reuses the full-featured `MessageInput` (images, camera, GIFs, voice,
- * typing indicators, drafts). If the channel hasn't been materialized yet
- * `channelId` will be null — `MessageInput` disables itself in that state.
- */
-export interface EventActivityComposerProps {
-  channelId: Id<"chatChannels"> | null;
-  onLayout?: (height: number) => void;
-  style?: any;
-}
-
-export function EventActivityComposer({
-  channelId,
-  onLayout,
-  style,
-}: EventActivityComposerProps) {
-  const { colors } = useTheme();
-  // MessageInput paints its own surface + top border, so the wrapper just
-  // provides position (via `style` from the parent) and matches the surface
-  // background for the safe-area inset.
-  return (
-    <View
-      style={[{ backgroundColor: colors.surface }, style]}
-      onLayout={
-        onLayout
-          ? (e) => onLayout(e.nativeEvent.layout.height)
-          : undefined
-      }
-    >
-      <MessageInput channelId={channelId} />
+      <EventCommentSheet
+        visible={showCommentSheet}
+        onClose={() => setShowCommentSheet(false)}
+        channelId={channelId}
+      />
     </View>
   );
 }
@@ -306,9 +285,15 @@ const styles = StyleSheet.create({
   },
   headingRow: {
     flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 12,
+  },
+  headingLabelGroup: {
+    flexDirection: "row",
     alignItems: "baseline",
     gap: 8,
-    marginBottom: 12,
+    flexShrink: 1,
   },
   heading: {
     fontSize: 18,
@@ -316,6 +301,19 @@ const styles = StyleSheet.create({
   },
   subLabel: {
     fontSize: 13,
+  },
+  commentButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  commentButtonText: {
+    fontSize: 14,
+    fontWeight: "500",
   },
   loadEarlierButton: {
     paddingVertical: 10,
@@ -338,12 +336,6 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   messagesList: {
-    // Leave MessageItem's own spacing intact. Messages render in ascending
-    // order top-to-bottom (newest at the bottom, like Partiful).
-  },
-  inlineComposer: {
-    // The composer scrolls with the page — breathing room above so it
-    // doesn't hug the last message.
-    marginTop: 16,
+    // EventComment owns its own padding. Newest comment on top.
   },
 });

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -246,6 +246,15 @@ export function EventActivity({
           </View>
         )}
       </ReactionsProvider>
+
+      {/* Composer rendered inline at the end of the Activity section —
+          scrolls with the page rather than pinning at the viewport bottom.
+          Skipped entirely when chat is disabled. */}
+      {isChatEnabled && (
+        <View style={styles.inlineComposer}>
+          <MessageInput channelId={channelId} />
+        </View>
+      )}
     </View>
   );
 }
@@ -331,5 +340,10 @@ const styles = StyleSheet.create({
   messagesList: {
     // Leave MessageItem's own spacing intact. Messages render in ascending
     // order top-to-bottom (newest at the bottom, like Partiful).
+  },
+  inlineComposer: {
+    // The composer scrolls with the page — breathing room above so it
+    // doesn't hug the last message.
+    marginTop: 16,
   },
 });

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -55,7 +55,7 @@ export interface EventActivityProps {
 export function EventActivity({
   meetingId: _meetingId,
   groupId,
-  shortId: _shortId,
+  shortId,
   currentUserId,
   canAccess,
   isChatEnabled,
@@ -242,6 +242,7 @@ export function EventActivity({
                 }}
                 currentUserId={currentUserId}
                 groupId={groupId}
+                eventShortId={shortId}
               />
             ))}
           </View>

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -2,18 +2,15 @@
  * EventActivity
  *
  * Inline "Activity" feed that lives on the event page (Partiful-style) —
- * renders chat messages below the event details with a sticky bottom composer.
- * Replaces the previous standalone chat-room route (`/inbox/{groupId}/event-…`).
+ * renders chat messages below the event details. The composer is rendered
+ * separately by the parent (`EventActivityComposer` below) so it can be
+ * sticky at the bottom of the viewport and move with the keyboard via the
+ * parent's `KeyboardAvoidingView`.
  *
  * Embedded inside the event page's ScrollView, so this uses a plain mapped
  * message list (not a virtualized FlatList) to avoid nesting VirtualizedLists.
  * For v1 we cap at 100 messages per page and expose a "Load earlier messages"
  * button when the server reports more.
- *
- * Sending flow:
- *   - If no channel exists yet (getChannelByMeetingId returned null), calls
- *     openEventChat on first send to materialize the channel row, then sends.
- *   - Subsequent sends reuse the channelId.
  *
  * Permission gate: `canAccess` is computed by the parent (host + RSVPer with
  * an enabled option). The backend is authoritative — this is just UI gating.
@@ -23,26 +20,20 @@ import React, { useCallback, useMemo, useState } from "react";
 import {
   View,
   Text,
-  TextInput,
   TouchableOpacity,
   ActivityIndicator,
   StyleSheet,
-  Alert,
-  Platform,
 } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
 import {
   useQuery,
-  useAuthenticatedMutation,
-  useMutation,
   api,
   type Id,
 } from "@services/api/convex";
 import { useTheme } from "@hooks/useTheme";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { MessageItem } from "@/features/chat/components/MessageItem";
+import { MessageInput } from "@/features/chat/components/MessageInput";
 import { ReactionsProvider } from "@/features/chat/context/ReactionsContext";
-import { useAuth } from "@/providers/AuthProvider";
 
 const PAGE_SIZE = 100;
 
@@ -55,37 +46,22 @@ export interface EventActivityProps {
   canAccess: boolean;
   /** From getChannelByMeetingId → channel.isEnabled; defaults true when no channel yet. */
   isChatEnabled: boolean;
-  /** Pre-resolved channel id (if the channel exists). Null = no channel yet; will materialize on first send. */
+  /** Pre-resolved channel id (if the channel exists). Null = still materializing. */
   channelId: Id<"chatChannels"> | null;
   authToken: string;
 }
 
 export function EventActivity({
-  meetingId,
+  meetingId: _meetingId,
   groupId,
   shortId: _shortId,
   currentUserId,
   canAccess,
   isChatEnabled,
-  channelId: initialChannelId,
+  channelId,
   authToken,
 }: EventActivityProps) {
   const { colors } = useTheme();
-  const { user } = useAuth();
-
-  // Locally track the channelId so that after openEventChat materializes a
-  // channel, the message list can start subscribing without waiting for the
-  // parent's getChannelByMeetingId query to re-resolve.
-  const [channelId, setChannelId] = useState<Id<"chatChannels"> | null>(
-    initialChannelId
-  );
-
-  // Keep channelId in sync if the parent's query resolves later.
-  React.useEffect(() => {
-    if (initialChannelId && !channelId) {
-      setChannelId(initialChannelId);
-    }
-  }, [initialChannelId, channelId]);
 
   // Fetch messages (single-page, ascending). Re-queries reactively as new
   // messages come in since we're watching the latest page.
@@ -179,60 +155,6 @@ export function EventActivity({
     setLoadOlderCursor(olderCursor);
   }, [olderCursor, hasMoreOlder, isLoadingOlder]);
 
-  // -------------------- Composer --------------------
-  const [text, setText] = useState("");
-  const [isSending, setIsSending] = useState(false);
-  const openEventChatMutation = useAuthenticatedMutation(
-    api.functions.messaging.eventChat.openEventChat
-  );
-  const sendMessageMutation = useMutation(
-    api.functions.messaging.messages.sendMessage
-  );
-
-  const handleSend = useCallback(async () => {
-    const trimmed = text.trim();
-    if (!trimmed) return;
-    if (isSending) return;
-
-    setIsSending(true);
-    try {
-      // Materialize channel if needed
-      let cid = channelId;
-      if (!cid) {
-        const { channelId: newChannelId } = await openEventChatMutation({
-          meetingId,
-        });
-        cid = newChannelId;
-        setChannelId(newChannelId);
-      }
-
-      await sendMessageMutation({
-        token: authToken,
-        channelId: cid,
-        content: trimmed,
-      });
-      setText("");
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Could not send message";
-      if (Platform.OS === "web") {
-        window.alert(message);
-      } else {
-        Alert.alert("Message failed", message);
-      }
-    } finally {
-      setIsSending(false);
-    }
-  }, [
-    text,
-    isSending,
-    channelId,
-    openEventChatMutation,
-    sendMessageMutation,
-    authToken,
-    meetingId,
-  ]);
-
   // -------------------- Render --------------------
   if (!canAccess) return null;
 
@@ -288,7 +210,9 @@ export function EventActivity({
             <Text
               style={[styles.emptyText, { color: colors.textSecondary }]}
             >
-              No messages yet. Be the first to say something.
+              {isChatEnabled
+                ? "No messages yet. Be the first to say something."
+                : "Chat is disabled"}
             </Text>
           </View>
         ) : (
@@ -322,56 +246,47 @@ export function EventActivity({
           </View>
         )}
       </ReactionsProvider>
+    </View>
+  );
+}
 
-      {/* Composer (hidden when chat disabled). v1: plain text only, no
-          attachments / GIFs / voice — parity with the brief. */}
-      {isChatEnabled ? (
-        <View
-          style={[
-            styles.composer,
-            {
-              backgroundColor: colors.surfaceSecondary,
-              borderColor: colors.border,
-            },
-          ]}
-        >
-          <TextInput
-            value={text}
-            onChangeText={setText}
-            placeholder="Say something…"
-            placeholderTextColor={colors.textSecondary}
-            style={[styles.composerInput, { color: colors.text }]}
-            multiline
-            editable={!isSending}
-          />
-          <TouchableOpacity
-            onPress={handleSend}
-            disabled={!text.trim() || isSending}
-            style={[
-              styles.sendButton,
-              {
-                backgroundColor:
-                  text.trim() && !isSending
-                    ? DEFAULT_PRIMARY_COLOR
-                    : colors.border,
-              },
-            ]}
-            accessibilityLabel="Send message"
-          >
-            {isSending ? (
-              <ActivityIndicator size="small" color="#fff" />
-            ) : (
-              <Ionicons name="arrow-up" size={20} color="#fff" />
-            )}
-          </TouchableOpacity>
-        </View>
-      ) : (
-        <Text
-          style={[styles.disabledText, { color: colors.textSecondary }]}
-        >
-          Chat is disabled
-        </Text>
-      )}
+/**
+ * EventActivityComposer
+ *
+ * Sticky bottom composer for the event chat. Rendered by `EventPageClient`
+ * as an absolutely-positioned sibling (not inside the ScrollView) so it
+ * stays pinned to the viewport and lifts above the keyboard via the
+ * surrounding `KeyboardAvoidingView`.
+ *
+ * Reuses the full-featured `MessageInput` (images, camera, GIFs, voice,
+ * typing indicators, drafts). If the channel hasn't been materialized yet
+ * `channelId` will be null — `MessageInput` disables itself in that state.
+ */
+export interface EventActivityComposerProps {
+  channelId: Id<"chatChannels"> | null;
+  onLayout?: (height: number) => void;
+  style?: any;
+}
+
+export function EventActivityComposer({
+  channelId,
+  onLayout,
+  style,
+}: EventActivityComposerProps) {
+  const { colors } = useTheme();
+  // MessageInput paints its own surface + top border, so the wrapper just
+  // provides position (via `style` from the parent) and matches the surface
+  // background for the safe-area inset.
+  return (
+    <View
+      style={[{ backgroundColor: colors.surface }, style]}
+      onLayout={
+        onLayout
+          ? (e) => onLayout(e.nativeEvent.layout.height)
+          : undefined
+      }
+    >
+      <MessageInput channelId={channelId} />
     </View>
   );
 }
@@ -416,35 +331,5 @@ const styles = StyleSheet.create({
   messagesList: {
     // Leave MessageItem's own spacing intact. Messages render in ascending
     // order top-to-bottom (newest at the bottom, like Partiful).
-  },
-  composer: {
-    marginTop: 16,
-    flexDirection: "row",
-    alignItems: "flex-end",
-    gap: 8,
-    padding: 8,
-    borderRadius: 24,
-    borderWidth: StyleSheet.hairlineWidth,
-  },
-  composerInput: {
-    flex: 1,
-    fontSize: 15,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    maxHeight: 120,
-    minHeight: 36,
-  },
-  sendButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  disabledText: {
-    marginTop: 16,
-    fontSize: 14,
-    textAlign: "center",
-    fontStyle: "italic",
   },
 });

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -1,0 +1,450 @@
+/**
+ * EventActivity
+ *
+ * Inline "Activity" feed that lives on the event page (Partiful-style) —
+ * renders chat messages below the event details with a sticky bottom composer.
+ * Replaces the previous standalone chat-room route (`/inbox/{groupId}/event-…`).
+ *
+ * Embedded inside the event page's ScrollView, so this uses a plain mapped
+ * message list (not a virtualized FlatList) to avoid nesting VirtualizedLists.
+ * For v1 we cap at 100 messages per page and expose a "Load earlier messages"
+ * button when the server reports more.
+ *
+ * Sending flow:
+ *   - If no channel exists yet (getChannelByMeetingId returned null), calls
+ *     openEventChat on first send to materialize the channel row, then sends.
+ *   - Subsequent sends reuse the channelId.
+ *
+ * Permission gate: `canAccess` is computed by the parent (host + RSVPer with
+ * an enabled option). The backend is authoritative — this is just UI gating.
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  StyleSheet,
+  Alert,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import {
+  useQuery,
+  useAuthenticatedMutation,
+  useMutation,
+  api,
+  type Id,
+} from "@services/api/convex";
+import { useTheme } from "@hooks/useTheme";
+import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
+import { MessageItem } from "@/features/chat/components/MessageItem";
+import { ReactionsProvider } from "@/features/chat/context/ReactionsContext";
+import { useAuth } from "@/providers/AuthProvider";
+
+const PAGE_SIZE = 100;
+
+export interface EventActivityProps {
+  meetingId: Id<"meetings">;
+  groupId: Id<"groups">;
+  shortId: string;
+  currentUserId: Id<"users">;
+  /** Host + RSVPer-with-enabled-option. Caller computes this. */
+  canAccess: boolean;
+  /** From getChannelByMeetingId → channel.isEnabled; defaults true when no channel yet. */
+  isChatEnabled: boolean;
+  /** Pre-resolved channel id (if the channel exists). Null = no channel yet; will materialize on first send. */
+  channelId: Id<"chatChannels"> | null;
+  authToken: string;
+}
+
+export function EventActivity({
+  meetingId,
+  groupId,
+  shortId: _shortId,
+  currentUserId,
+  canAccess,
+  isChatEnabled,
+  channelId: initialChannelId,
+  authToken,
+}: EventActivityProps) {
+  const { colors } = useTheme();
+  const { user } = useAuth();
+
+  // Locally track the channelId so that after openEventChat materializes a
+  // channel, the message list can start subscribing without waiting for the
+  // parent's getChannelByMeetingId query to re-resolve.
+  const [channelId, setChannelId] = useState<Id<"chatChannels"> | null>(
+    initialChannelId
+  );
+
+  // Keep channelId in sync if the parent's query resolves later.
+  React.useEffect(() => {
+    if (initialChannelId && !channelId) {
+      setChannelId(initialChannelId);
+    }
+  }, [initialChannelId, channelId]);
+
+  // Fetch messages (single-page, ascending). Re-queries reactively as new
+  // messages come in since we're watching the latest page.
+  const messagesResult = useQuery(
+    api.functions.messaging.messages.getMessages,
+    channelId && canAccess
+      ? {
+          token: authToken,
+          channelId,
+          limit: PAGE_SIZE,
+          viewingGroupId: groupId,
+        }
+      : "skip"
+  );
+
+  // Pagination (older messages)
+  const [olderMessages, setOlderMessages] = useState<any[]>([]);
+  const [olderCursor, setOlderCursor] = useState<string | undefined>(undefined);
+  const [hasMoreOlder, setHasMoreOlder] = useState(false);
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const [loadOlderCursor, setLoadOlderCursor] = useState<string | undefined>(
+    undefined
+  );
+
+  const olderResult = useQuery(
+    api.functions.messaging.messages.getMessages,
+    channelId && canAccess && loadOlderCursor
+      ? {
+          token: authToken,
+          channelId,
+          limit: PAGE_SIZE,
+          cursor: loadOlderCursor,
+          viewingGroupId: groupId,
+        }
+      : "skip"
+  );
+
+  React.useEffect(() => {
+    // Seed pagination state from the live page (only on first resolve)
+    if (messagesResult && olderCursor === undefined && !loadOlderCursor) {
+      setHasMoreOlder(messagesResult.hasMore ?? false);
+      setOlderCursor(messagesResult.cursor);
+    }
+  }, [messagesResult, olderCursor, loadOlderCursor]);
+
+  React.useEffect(() => {
+    if (olderResult && loadOlderCursor) {
+      const existing = new Set(olderMessages.map((m: any) => m._id));
+      const fresh = (olderResult.messages ?? []).filter(
+        (m: any) => !existing.has(m._id)
+      );
+      setOlderMessages((prev) => [...fresh, ...prev]);
+      setHasMoreOlder(olderResult.hasMore ?? false);
+      setOlderCursor(olderResult.cursor);
+      setLoadOlderCursor(undefined);
+      setIsLoadingOlder(false);
+    }
+  }, [olderResult, loadOlderCursor, olderMessages]);
+
+  const liveMessages = messagesResult?.messages ?? [];
+
+  // Merged list, ascending chronological (oldest first)
+  const messages = useMemo(() => {
+    if (olderMessages.length === 0) return liveMessages;
+    const seen = new Set<string>();
+    const merged: any[] = [];
+    for (const m of olderMessages) {
+      if (!seen.has(m._id)) {
+        seen.add(m._id);
+        merged.push(m);
+      }
+    }
+    for (const m of liveMessages) {
+      if (!seen.has(m._id)) {
+        seen.add(m._id);
+        merged.push(m);
+      }
+    }
+    merged.sort((a, b) => a.createdAt - b.createdAt);
+    return merged;
+  }, [liveMessages, olderMessages]);
+
+  const messageIds = useMemo<Id<"chatMessages">[]>(
+    () => messages.map((m: any) => m._id),
+    [messages]
+  );
+
+  const handleLoadOlder = useCallback(() => {
+    if (isLoadingOlder || !olderCursor || !hasMoreOlder) return;
+    setIsLoadingOlder(true);
+    setLoadOlderCursor(olderCursor);
+  }, [olderCursor, hasMoreOlder, isLoadingOlder]);
+
+  // -------------------- Composer --------------------
+  const [text, setText] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const openEventChatMutation = useAuthenticatedMutation(
+    api.functions.messaging.eventChat.openEventChat
+  );
+  const sendMessageMutation = useMutation(
+    api.functions.messaging.messages.sendMessage
+  );
+
+  const handleSend = useCallback(async () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    if (isSending) return;
+
+    setIsSending(true);
+    try {
+      // Materialize channel if needed
+      let cid = channelId;
+      if (!cid) {
+        const { channelId: newChannelId } = await openEventChatMutation({
+          meetingId,
+        });
+        cid = newChannelId;
+        setChannelId(newChannelId);
+      }
+
+      await sendMessageMutation({
+        token: authToken,
+        channelId: cid,
+        content: trimmed,
+      });
+      setText("");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Could not send message";
+      if (Platform.OS === "web") {
+        window.alert(message);
+      } else {
+        Alert.alert("Message failed", message);
+      }
+    } finally {
+      setIsSending(false);
+    }
+  }, [
+    text,
+    isSending,
+    channelId,
+    openEventChatMutation,
+    sendMessageMutation,
+    authToken,
+    meetingId,
+  ]);
+
+  // -------------------- Render --------------------
+  if (!canAccess) return null;
+
+  const messageCount = messages.length;
+  // Hide the query-loading state before the channel exists — that's just the
+  // "no channel yet" state, not a spinner case.
+  const isLoadingMessages =
+    channelId !== null && canAccess && messagesResult === undefined;
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.headingRow}>
+        <Text style={[styles.heading, { color: colors.text }]}>Activity</Text>
+        {messageCount > 0 && (
+          <Text style={[styles.subLabel, { color: colors.textSecondary }]}>
+            {messageCount} {messageCount === 1 ? "update" : "updates"}
+          </Text>
+        )}
+      </View>
+
+      {/* Load earlier */}
+      {hasMoreOlder && !isLoadingMessages && (
+        <TouchableOpacity
+          style={styles.loadEarlierButton}
+          onPress={handleLoadOlder}
+          disabled={isLoadingOlder}
+        >
+          {isLoadingOlder ? (
+            <ActivityIndicator size="small" color={DEFAULT_PRIMARY_COLOR} />
+          ) : (
+            <Text
+              style={[
+                styles.loadEarlierText,
+                { color: DEFAULT_PRIMARY_COLOR },
+              ]}
+            >
+              Load earlier messages
+            </Text>
+          )}
+        </TouchableOpacity>
+      )}
+
+      {/* Messages list (ascending). Wrap in ReactionsProvider so MessageItem's
+          useReactions reads from the batched context (one query for all
+          messages, not one per message). */}
+      <ReactionsProvider messageIds={messageIds} channelId={channelId}>
+        {isLoadingMessages ? (
+          <View style={styles.loadingBlock}>
+            <ActivityIndicator size="small" color={DEFAULT_PRIMARY_COLOR} />
+          </View>
+        ) : messages.length === 0 ? (
+          <View style={styles.emptyBlock}>
+            <Text
+              style={[styles.emptyText, { color: colors.textSecondary }]}
+            >
+              No messages yet. Be the first to say something.
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.messagesList}>
+            {messages.map((msg: any) => (
+              <MessageItem
+                key={msg._id}
+                message={{
+                  _id: msg._id,
+                  channelId: msg.channelId,
+                  senderId: msg.senderId,
+                  content: msg.content || "",
+                  contentType: msg.contentType || "text",
+                  attachments: msg.attachments,
+                  createdAt: msg.createdAt,
+                  editedAt: msg.editedAt,
+                  isDeleted: msg.isDeleted,
+                  senderName: msg.senderName,
+                  senderProfilePhoto: msg.senderProfilePhoto,
+                  mentionedUserIds: msg.mentionedUserIds,
+                  threadReplyCount: msg.threadReplyCount,
+                  hideLinkPreview: msg.hideLinkPreview,
+                  reachOutRequestId: msg.reachOutRequestId,
+                  taskId: msg.taskId,
+                  blastId: msg.blastId,
+                }}
+                currentUserId={currentUserId}
+                groupId={groupId}
+              />
+            ))}
+          </View>
+        )}
+      </ReactionsProvider>
+
+      {/* Composer (hidden when chat disabled). v1: plain text only, no
+          attachments / GIFs / voice — parity with the brief. */}
+      {isChatEnabled ? (
+        <View
+          style={[
+            styles.composer,
+            {
+              backgroundColor: colors.surfaceSecondary,
+              borderColor: colors.border,
+            },
+          ]}
+        >
+          <TextInput
+            value={text}
+            onChangeText={setText}
+            placeholder="Say something…"
+            placeholderTextColor={colors.textSecondary}
+            style={[styles.composerInput, { color: colors.text }]}
+            multiline
+            editable={!isSending}
+          />
+          <TouchableOpacity
+            onPress={handleSend}
+            disabled={!text.trim() || isSending}
+            style={[
+              styles.sendButton,
+              {
+                backgroundColor:
+                  text.trim() && !isSending
+                    ? DEFAULT_PRIMARY_COLOR
+                    : colors.border,
+              },
+            ]}
+            accessibilityLabel="Send message"
+          >
+            {isSending ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Ionicons name="arrow-up" size={20} color="#fff" />
+            )}
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <Text
+          style={[styles.disabledText, { color: colors.textSecondary }]}
+        >
+          Chat is disabled
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    marginTop: 24,
+  },
+  headingRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 8,
+    marginBottom: 12,
+  },
+  heading: {
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  subLabel: {
+    fontSize: 13,
+  },
+  loadEarlierButton: {
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  loadEarlierText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  loadingBlock: {
+    padding: 24,
+    alignItems: "center",
+  },
+  emptyBlock: {
+    padding: 24,
+    alignItems: "center",
+  },
+  emptyText: {
+    fontSize: 14,
+    textAlign: "center",
+  },
+  messagesList: {
+    // Leave MessageItem's own spacing intact. Messages render in ascending
+    // order top-to-bottom (newest at the bottom, like Partiful).
+  },
+  composer: {
+    marginTop: 16,
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 8,
+    padding: 8,
+    borderRadius: 24,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  composerInput: {
+    flex: 1,
+    fontSize: 15,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    maxHeight: 120,
+    minHeight: 36,
+  },
+  sendButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  disabledText: {
+    marginTop: 16,
+    fontSize: 14,
+    textAlign: "center",
+    fontStyle: "italic",
+  },
+});

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -185,7 +185,7 @@ export function EventActivity({
             </Text>
           )}
         </View>
-        {isChatEnabled && (
+        {isChatEnabled && channelId !== null && (
           <TouchableOpacity
             style={[
               styles.commentButton,

--- a/apps/mobile/app/e/[shortId]/EventComment.tsx
+++ b/apps/mobile/app/e/[shortId]/EventComment.tsx
@@ -59,6 +59,9 @@ export interface EventCommentProps {
   groupId: Id<'groups'>;
   /** Event shortId, used to route Reply to the event-scoped thread page. */
   eventShortId: string;
+  /** Event title, displayed as the thread header (otherwise the header
+   *  would read "Thread / #event" which is meaningless). */
+  eventTitle: string;
 }
 
 /**
@@ -96,7 +99,7 @@ function formatRelativeTime(timestamp: number): string {
   return `${month} ${day_}`;
 }
 
-function EventCommentInner({ message, currentUserId, groupId, eventShortId }: EventCommentProps) {
+function EventCommentInner({ message, currentUserId, groupId, eventShortId, eventTitle }: EventCommentProps) {
   const router = useRouter();
   const { colors: themeColors } = useTheme();
 
@@ -177,9 +180,9 @@ function EventCommentInner({ message, currentUserId, groupId, eventShortId }: Ev
   // component so functionality is identical.
   const handleReplyPress = useCallback(() => {
     router.push(
-      `/e/${eventShortId}/thread/${message._id}?groupId=${groupId}&channelName=event` as any,
+      `/e/${eventShortId}/thread/${message._id}?groupId=${groupId}&channelName=${encodeURIComponent(eventTitle)}` as any,
     );
-  }, [router, eventShortId, groupId, message._id]);
+  }, [router, eventShortId, groupId, message._id, eventTitle]);
 
   // ---- Rendering ----
 

--- a/apps/mobile/app/e/[shortId]/EventComment.tsx
+++ b/apps/mobile/app/e/[shortId]/EventComment.tsx
@@ -168,13 +168,14 @@ function EventCommentInner({ message, currentUserId, groupId }: EventCommentProp
     setImageViewerVisible(true);
   }, []);
 
-  // Reply — route to the shared thread page used by group chat. Mirrors
-  // MessageItem's `handleThreadPress`. No channelName param here — the
-  // thread page falls back to a default label.
+  // Reply — route to the shared thread page used by group chat. Plain
+  // string form (not the `pathname` object form) because on native the
+  // event page (/e/[shortId]) and the inbox stack are separate, and the
+  // object form doesn't always cross-stack navigate reliably.
   const handleReplyPress = useCallback(() => {
-    router.push({
-      pathname: `/inbox/${groupId}/thread/${message._id}` as any,
-    });
+    router.push(
+      `/inbox/${groupId}/thread/${message._id}?channelName=event` as any,
+    );
   }, [router, groupId, message._id]);
 
   // ---- Rendering ----

--- a/apps/mobile/app/e/[shortId]/EventComment.tsx
+++ b/apps/mobile/app/e/[shortId]/EventComment.tsx
@@ -1,0 +1,533 @@
+/**
+ * EventComment - Partiful-style comment card for the event page's Activity
+ * section.
+ *
+ * Unlike `MessageItem` (which renders iMessage-style bubbles with owner-based
+ * alignment), this component renders a flat, left-aligned card:
+ *
+ *   [avatar] [Name]  [13d]              <- header row
+ *            Body content with @mentions / links
+ *            [image thumbnail(s)]
+ *            [Also sent via SMS]         <- blast badge (when applicable)
+ *            [👍 2] [🎉 1]               <- reaction pills
+ *            Reply                       <- opens thread page
+ *
+ * Consumed by `EventActivity` inside a `ReactionsProvider`, so `useReactions`
+ * transparently reads from the batched context.
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Linking,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import type { Id } from '@services/api/convex';
+import { AppImage, ImageViewer } from '@components/ui';
+import { useReactions, type Reaction } from '@features/chat/hooks/useReactions';
+import { parseMessageContent } from '@features/shared/utils/linkify';
+import { getMediaUrl } from '@/utils/media';
+import { useTheme } from '@hooks/useTheme';
+
+export interface EventCommentProps {
+  message: {
+    _id: Id<'chatMessages'>;
+    channelId: Id<'chatChannels'>;
+    senderId?: Id<'users'>;
+    content: string;
+    contentType: string;
+    attachments?: Array<{
+      type: string;
+      url: string;
+      name?: string;
+      mimeType?: string;
+      thumbnailUrl?: string;
+    }>;
+    createdAt: number;
+    editedAt?: number;
+    isDeleted: boolean;
+    senderName?: string;
+    senderProfilePhoto?: string;
+    mentionedUserIds?: Id<'users'>[];
+    threadReplyCount?: number;
+    blastId?: Id<'eventBlasts'>;
+  };
+  currentUserId: Id<'users'>;
+  groupId: Id<'groups'>;
+}
+
+/**
+ * Format timestamp as a compact relative string:
+ *   <1m  -> "Just now"
+ *   <1h  -> "5m"
+ *   <1d  -> "3h"
+ *   <7d  -> "4d"
+ *   else -> "Jan 15" or "Jan 15, 2024" (if different year)
+ */
+function formatRelativeTime(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+
+  if (diff < minute) return 'Just now';
+  if (diff < hour) return `${Math.floor(diff / minute)}m`;
+  if (diff < day) return `${Math.floor(diff / hour)}h`;
+  if (diff < week) return `${Math.floor(diff / day)}d`;
+
+  const date = new Date(timestamp);
+  const nowDate = new Date(now);
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  const month = months[date.getMonth()];
+  const day_ = date.getDate();
+  if (date.getFullYear() !== nowDate.getFullYear()) {
+    return `${month} ${day_}, ${date.getFullYear()}`;
+  }
+  return `${month} ${day_}`;
+}
+
+function EventCommentInner({ message, currentUserId, groupId }: EventCommentProps) {
+  const router = useRouter();
+  const { colors: themeColors } = useTheme();
+
+  // Reactions — reads from ReactionsProvider batch when wrapped, otherwise
+  // falls back to a per-message query. Matches MessageItem.
+  const { reactions, toggleReaction, isLoading: reactionsLoading } = useReactions(
+    message._id,
+  );
+
+  // Image viewer for tap-to-expand on attachments.
+  const [imageViewerVisible, setImageViewerVisible] = useState(false);
+  const [imageViewerInitialIndex, setImageViewerInitialIndex] = useState(0);
+
+  // Categorize attachments — v1 only renders images.
+  const { validImageAttachments, imageUrls } = useMemo(() => {
+    const emptyResult = {
+      validImageAttachments: [] as NonNullable<EventCommentProps['message']['attachments']>,
+      imageUrls: [] as string[],
+    };
+    if (!message.attachments) return emptyResult;
+
+    const validImages: NonNullable<EventCommentProps['message']['attachments']> = [];
+    const urls: string[] = [];
+    for (const attachment of message.attachments) {
+      if (attachment.type !== 'image') continue;
+      const url = getMediaUrl(attachment.url);
+      if (url) {
+        validImages.push(attachment);
+        urls.push(url);
+      }
+    }
+    return { validImageAttachments: validImages, imageUrls: urls };
+  }, [message.attachments]);
+
+  // Mention tap — mirror MessageItem's approach. When the message has
+  // exactly one mentioned user id we can resolve a tap to a profile; with
+  // multiple mentions we bail out because the server doesn't persist a
+  // name→id map.
+  const handleMentionTap = useCallback(
+    (mention: string) => {
+      const displayName = mention.replace(/^@\[/, '').replace(/\]$/, '').trim();
+      const ids = message.mentionedUserIds;
+      if (!ids || ids.length === 0 || !displayName) return;
+      const targetId = ids.length === 1 ? ids[0] : null;
+      if (!targetId) return;
+      if (targetId === currentUserId) return;
+      router.push(`/profile/${targetId}` as any);
+    },
+    [router, message.mentionedUserIds, currentUserId],
+  );
+
+  const handleUrlTap = useCallback((url: string) => {
+    Linking.openURL(url).catch((err) => {
+      console.error('[EventComment] Failed to open URL:', err);
+    });
+  }, []);
+
+  const handleReactionTap = useCallback(
+    async (emoji: string) => {
+      try {
+        await toggleReaction(emoji);
+      } catch (err) {
+        console.error('[EventComment] Failed to toggle reaction:', err);
+      }
+    },
+    [toggleReaction],
+  );
+
+  const handleImagePress = useCallback((index: number) => {
+    setImageViewerInitialIndex(index);
+    setImageViewerVisible(true);
+  }, []);
+
+  // Reply — route to the shared thread page used by group chat. Mirrors
+  // MessageItem's `handleThreadPress`. No channelName param here — the
+  // thread page falls back to a default label.
+  const handleReplyPress = useCallback(() => {
+    router.push({
+      pathname: `/inbox/${groupId}/thread/${message._id}` as any,
+    });
+  }, [router, groupId, message._id]);
+
+  // ---- Rendering ----
+
+  const renderContent = () => {
+    if (message.isDeleted) {
+      return (
+        <Text style={[styles.deletedText, { color: themeColors.textTertiary }]}>
+          Deleted.
+        </Text>
+      );
+    }
+
+    if (message.content.trim().length === 0) return null;
+
+    const parts = parseMessageContent(message.content);
+    return (
+      <Text style={[styles.bodyText, { color: themeColors.text }]}>
+        {parts.map((part, index) => {
+          if (part.type === 'mention') {
+            return (
+              <Text
+                key={index}
+                style={styles.mention}
+                onPress={() => handleMentionTap(part.value)}
+              >
+                {part.displayValue || part.value}
+              </Text>
+            );
+          }
+          if (part.type === 'url') {
+            return (
+              <Text
+                key={index}
+                style={[styles.urlLink, { color: themeColors.link }]}
+                onPress={() => handleUrlTap(part.value)}
+              >
+                {part.value}
+              </Text>
+            );
+          }
+          return <Text key={index}>{part.value}</Text>;
+        })}
+      </Text>
+    );
+  };
+
+  const renderAttachments = () => {
+    if (message.isDeleted || validImageAttachments.length === 0) return null;
+
+    // Single image: larger thumbnail. Multiple: simple 2-column grid.
+    if (validImageAttachments.length === 1) {
+      return (
+        <Pressable
+          style={styles.singleImageWrapper}
+          onPress={() => handleImagePress(0)}
+        >
+          <AppImage
+            source={validImageAttachments[0].url}
+            style={styles.singleImage}
+            optimizedWidth={600}
+          />
+        </Pressable>
+      );
+    }
+
+    return (
+      <View style={styles.imageGrid}>
+        {validImageAttachments.map((attachment, index) => (
+          <Pressable
+            key={`${attachment.url}-${index}`}
+            style={styles.gridImageWrapper}
+            onPress={() => handleImagePress(index)}
+          >
+            <AppImage
+              source={attachment.url}
+              style={styles.gridImage}
+              optimizedWidth={400}
+            />
+          </Pressable>
+        ))}
+      </View>
+    );
+  };
+
+  const renderBlastBadge = () => {
+    if (!message.blastId || message.isDeleted) return null;
+    return (
+      <View
+        style={[
+          styles.blastBadge,
+          { backgroundColor: themeColors.surfaceSecondary },
+        ]}
+        accessibilityLabel="This message was also sent as an SMS and push notification"
+      >
+        <Ionicons
+          name="megaphone-outline"
+          size={11}
+          color={themeColors.textSecondary}
+          style={styles.blastBadgeIcon}
+        />
+        <Text style={[styles.blastBadgeText, { color: themeColors.textSecondary }]}>
+          Also sent via SMS
+        </Text>
+      </View>
+    );
+  };
+
+  const renderReactions = () => {
+    if (message.isDeleted) return null;
+    // Skip while loading to avoid flicker (matches MessageItem behavior).
+    if (reactionsLoading && reactions.length === 0) return null;
+    if (reactions.length === 0) return null;
+
+    return (
+      <View style={styles.reactionsRow}>
+        {reactions.map((reaction: Reaction) => (
+          <Pressable
+            key={reaction.emoji}
+            style={[
+              styles.reactionPill,
+              {
+                backgroundColor: themeColors.surfaceSecondary,
+                borderColor: themeColors.border,
+              },
+              reaction.hasReacted && {
+                backgroundColor: '#E3F2FD',
+                borderColor: '#1976D2',
+              },
+            ]}
+            onPress={() => handleReactionTap(reaction.emoji)}
+          >
+            <Text style={styles.reactionEmoji}>{reaction.emoji}</Text>
+            {reaction.count > 1 && (
+              <Text
+                style={[styles.reactionCount, { color: themeColors.textSecondary }]}
+              >
+                {reaction.count}
+              </Text>
+            )}
+          </Pressable>
+        ))}
+      </View>
+    );
+  };
+
+  const isEdited =
+    message.editedAt != null && message.editedAt !== message.createdAt;
+
+  return (
+    <View style={styles.container}>
+      {/* Avatar */}
+      <View style={styles.avatarContainer}>
+        <AppImage
+          source={message.senderProfilePhoto}
+          style={styles.avatar}
+          optimizedWidth={72}
+          placeholder={{
+            type: 'initials',
+            name: message.senderName || 'User',
+            backgroundColor: '#E5E5E5',
+          }}
+        />
+      </View>
+
+      {/* Body column */}
+      <View style={styles.body}>
+        {/* Header: name + relative time (+ edited) */}
+        <View style={styles.headerRow}>
+          <Text
+            style={[styles.senderName, { color: themeColors.text }]}
+            numberOfLines={1}
+          >
+            {message.senderName || 'Unknown'}
+          </Text>
+          <Text style={[styles.timestamp, { color: themeColors.textTertiary }]}>
+            {formatRelativeTime(message.createdAt)}
+            {isEdited && !message.isDeleted ? ' · edited' : ''}
+          </Text>
+        </View>
+
+        {/* Text content (or "Deleted." stub) */}
+        {renderContent()}
+
+        {/* Image attachments */}
+        {renderAttachments()}
+
+        {/* SMS blast badge */}
+        {renderBlastBadge()}
+
+        {/* Reactions */}
+        {renderReactions()}
+
+        {/* Reply button — hidden on deleted messages so there's no affordance
+            to thread off a removed comment. */}
+        {!message.isDeleted && (
+          <Pressable
+            onPress={handleReplyPress}
+            hitSlop={8}
+            style={styles.replyButton}
+            accessibilityRole="button"
+            accessibilityLabel="Reply to this comment"
+          >
+            <Text style={[styles.replyText, { color: themeColors.textSecondary }]}>
+              {message.threadReplyCount && message.threadReplyCount > 0
+                ? `Reply · ${message.threadReplyCount}`
+                : 'Reply'}
+            </Text>
+          </Pressable>
+        )}
+      </View>
+
+      {/* Fullscreen image gallery */}
+      <ImageViewer
+        visible={imageViewerVisible}
+        images={imageUrls}
+        initialIndex={imageViewerInitialIndex}
+        onClose={() => setImageViewerVisible(false)}
+      />
+    </View>
+  );
+}
+
+export const EventComment = React.memo(EventCommentInner);
+
+const AVATAR_SIZE = 36;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    alignItems: 'flex-start',
+  },
+  avatarContainer: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    marginRight: 10,
+    flexShrink: 0,
+  },
+  avatar: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: AVATAR_SIZE / 2,
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 8,
+    marginBottom: 2,
+  },
+  senderName: {
+    fontSize: 14,
+    fontWeight: '600',
+    flexShrink: 1,
+  },
+  timestamp: {
+    fontSize: 12,
+    flexShrink: 0,
+  },
+  bodyText: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 2,
+  },
+  deletedText: {
+    fontSize: 14,
+    fontStyle: 'italic',
+    marginTop: 2,
+  },
+  mention: {
+    backgroundColor: '#E3F2FD',
+    color: '#1976D2',
+    fontWeight: '600',
+    paddingHorizontal: 2,
+    borderRadius: 2,
+  },
+  urlLink: {
+    textDecorationLine: 'underline',
+  },
+  singleImageWrapper: {
+    marginTop: 8,
+    borderRadius: 10,
+    overflow: 'hidden',
+    maxWidth: 320,
+  },
+  singleImage: {
+    width: '100%',
+    aspectRatio: 4 / 3,
+  },
+  imageGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+    marginTop: 8,
+  },
+  gridImageWrapper: {
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  gridImage: {
+    width: 140,
+    height: 140,
+  },
+  blastBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    marginTop: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  blastBadgeIcon: {
+    marginRight: 3,
+  },
+  blastBadgeText: {
+    fontSize: 10,
+    fontWeight: '500',
+  },
+  reactionsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 6,
+  },
+  reactionPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    marginRight: 4,
+    marginBottom: 4,
+    borderWidth: 1,
+  },
+  reactionEmoji: {
+    fontSize: 13,
+  },
+  reactionCount: {
+    fontSize: 12,
+    fontWeight: '600',
+    marginLeft: 4,
+  },
+  replyButton: {
+    marginTop: 6,
+    alignSelf: 'flex-start',
+  },
+  replyText: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});

--- a/apps/mobile/app/e/[shortId]/EventComment.tsx
+++ b/apps/mobile/app/e/[shortId]/EventComment.tsx
@@ -57,6 +57,8 @@ export interface EventCommentProps {
   };
   currentUserId: Id<'users'>;
   groupId: Id<'groups'>;
+  /** Event shortId, used to route Reply to the event-scoped thread page. */
+  eventShortId: string;
 }
 
 /**
@@ -94,7 +96,7 @@ function formatRelativeTime(timestamp: number): string {
   return `${month} ${day_}`;
 }
 
-function EventCommentInner({ message, currentUserId, groupId }: EventCommentProps) {
+function EventCommentInner({ message, currentUserId, groupId, eventShortId }: EventCommentProps) {
   const router = useRouter();
   const { colors: themeColors } = useTheme();
 
@@ -168,15 +170,16 @@ function EventCommentInner({ message, currentUserId, groupId }: EventCommentProp
     setImageViewerVisible(true);
   }, []);
 
-  // Reply — route to the shared thread page used by group chat. Plain
-  // string form (not the `pathname` object form) because on native the
-  // event page (/e/[shortId]) and the inbox stack are separate, and the
-  // object form doesn't always cross-stack navigate reliably.
+  // Reply — route to the event-scoped thread page so the push stays
+  // inside the /e/[shortId] stack. The previous /inbox/... target mounted
+  // the thread in a different stack and rendered BEHIND the event page
+  // on native. The event-scoped route imports the same ThreadPage
+  // component so functionality is identical.
   const handleReplyPress = useCallback(() => {
     router.push(
-      `/inbox/${groupId}/thread/${message._id}?channelName=event` as any,
+      `/e/${eventShortId}/thread/${message._id}?groupId=${groupId}&channelName=event` as any,
     );
-  }, [router, groupId, message._id]);
+  }, [router, eventShortId, groupId, message._id]);
 
   // ---- Rendering ----
 

--- a/apps/mobile/app/e/[shortId]/EventCommentSheet.tsx
+++ b/apps/mobile/app/e/[shortId]/EventCommentSheet.tsx
@@ -1,0 +1,139 @@
+/**
+ * EventCommentSheet
+ *
+ * Bottom-sheet composer for posting a comment on an event page.
+ *
+ * Follows the modal + overlay pattern used in EventBlastSheet. The sheet
+ * surface is fixed to the bottom of the screen with rounded top corners and a
+ * visual drag handle (drag-to-dismiss gesture is out of scope for v1).
+ *
+ * Embeds the shared `MessageInput` so @mentions, attachments, and link
+ * previews work out of the box. We wire `externalSendMessage` to wrap the
+ * internal send hook and auto-close the sheet after a successful send — this
+ * matches the Partiful-style "write, send, dismiss" flow and avoids leaving
+ * the sheet floating over the newly posted comment.
+ */
+
+import React, { useCallback } from "react";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { Id } from "@services/api/convex";
+import { useTheme } from "@hooks/useTheme";
+import { MessageInput } from "@/features/chat/components/MessageInput";
+import { useSendMessage } from "@/features/chat/hooks/useConvexSendMessage";
+
+interface EventCommentSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  channelId: Id<"chatChannels"> | null;
+}
+
+export function EventCommentSheet({
+  visible,
+  onClose,
+  channelId,
+}: EventCommentSheetProps) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  // Drive sending through the standard hook so optimistic updates, offline
+  // queueing, and attachment handling all behave exactly like a regular chat
+  // send. We then wrap `sendMessage` to close the sheet on success.
+  const { sendMessage, isSending } = useSendMessage(channelId);
+
+  const handleExternalSend = useCallback(
+    async (content: string, options?: any) => {
+      await sendMessage(content, options);
+      // Only closes on resolve; if sendMessage throws, the sheet stays open so
+      // MessageInput can surface the error and let the user retry.
+      onClose();
+    },
+    [sendMessage, onClose],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <Pressable
+          style={[styles.overlay, { backgroundColor: colors.overlay }]}
+          onPress={onClose}
+        >
+          {/**
+           * Inner Pressable swallows taps on the sheet itself so they don't
+           * bubble up to the overlay and trigger `onClose`.
+           */}
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
+            style={[
+              styles.sheet,
+              {
+                backgroundColor: colors.surface,
+                paddingBottom: Math.max(insets.bottom, 12),
+              },
+            ]}
+          >
+            <View style={styles.handleContainer}>
+              <View
+                style={[styles.handle, { backgroundColor: colors.border }]}
+              />
+            </View>
+
+            <View style={styles.inputWrapper}>
+              <MessageInput
+                channelId={channelId}
+                externalSendMessage={handleExternalSend}
+                externalIsSending={isSending}
+              />
+            </View>
+          </Pressable>
+        </Pressable>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+export default EventCommentSheet;
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    // Cap height so extreme-keyboard scenarios don't push the handle off-screen.
+    maxHeight: "90%",
+  },
+  handleContainer: {
+    alignItems: "center",
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+  },
+  inputWrapper: {
+    paddingTop: 4,
+  },
+});

--- a/apps/mobile/app/e/[shortId]/EventCommentSheet.tsx
+++ b/apps/mobile/app/e/[shortId]/EventCommentSheet.tsx
@@ -65,51 +65,46 @@ export function EventCommentSheet({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <View style={styles.flex}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
         {/**
-         * Overlay is a sibling of the sheet (not a parent). On RN Web, wrapping
-         * the TextInput inside a Pressable with `stopPropagation` intercepts
-         * click events before they reach the input, so the composer won't
-         * accept focus. Keeping them as siblings means clicks on the sheet
-         * never touch the overlay Pressable.
+         * Flex column where the overlay fills the space above and the sheet
+         * hugs the bottom naturally. No absolute positioning on the sheet —
+         * on RN Web, `position: absolute; bottom: 0` inside Modal doesn't
+         * always anchor to the viewport and the sheet can render below fold.
+         * The overlay is a sibling so clicks on it don't pass through to the
+         * sheet contents (TextInput can receive focus normally).
          */}
         <Pressable
-          style={[
-            StyleSheet.absoluteFillObject,
-            { backgroundColor: colors.overlay },
-          ]}
+          style={[styles.overlay, { backgroundColor: colors.overlay }]}
           onPress={onClose}
         />
-        <KeyboardAvoidingView
-          style={styles.sheetContainer}
-          behavior={Platform.OS === "ios" ? "padding" : undefined}
-          pointerEvents="box-none"
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: colors.surface,
+              paddingBottom: Math.max(insets.bottom, 12),
+            },
+          ]}
         >
-          <View
-            style={[
-              styles.sheet,
-              {
-                backgroundColor: colors.surface,
-                paddingBottom: Math.max(insets.bottom, 12),
-              },
-            ]}
-          >
-            <View style={styles.handleContainer}>
-              <View
-                style={[styles.handle, { backgroundColor: colors.border }]}
-              />
-            </View>
-
-            <View style={styles.inputWrapper}>
-              <MessageInput
-                channelId={channelId}
-                externalSendMessage={handleExternalSend}
-                externalIsSending={isSending}
-              />
-            </View>
+          <View style={styles.handleContainer}>
+            <View
+              style={[styles.handle, { backgroundColor: colors.border }]}
+            />
           </View>
-        </KeyboardAvoidingView>
-      </View>
+
+          <View style={styles.inputWrapper}>
+            <MessageInput
+              channelId={channelId}
+              externalSendMessage={handleExternalSend}
+              externalIsSending={isSending}
+            />
+          </View>
+        </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
@@ -117,22 +112,19 @@ export function EventCommentSheet({
 export default EventCommentSheet;
 
 const styles = StyleSheet.create({
+  // Full-screen flex column. Overlay stretches to fill empty space, sheet
+  // takes its natural content height at the bottom.
   flex: {
     flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-end",
   },
-  // Sheet container pins the actual sheet to the bottom of the screen without
-  // wrapping the overlay as a parent — avoids the RN Web click-interception
-  // issue documented above.
-  sheetContainer: {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    bottom: 0,
+  overlay: {
+    flex: 1,
   },
   sheet: {
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
-    maxHeight: "90%",
   },
   handleContainer: {
     alignItems: "center",

--- a/apps/mobile/app/e/[shortId]/EventCommentSheet.tsx
+++ b/apps/mobile/app/e/[shortId]/EventCommentSheet.tsx
@@ -65,20 +65,27 @@ export function EventCommentSheet({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <KeyboardAvoidingView
-        style={styles.flex}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-      >
+      <View style={styles.flex}>
+        {/**
+         * Overlay is a sibling of the sheet (not a parent). On RN Web, wrapping
+         * the TextInput inside a Pressable with `stopPropagation` intercepts
+         * click events before they reach the input, so the composer won't
+         * accept focus. Keeping them as siblings means clicks on the sheet
+         * never touch the overlay Pressable.
+         */}
         <Pressable
-          style={[styles.overlay, { backgroundColor: colors.overlay }]}
+          style={[
+            StyleSheet.absoluteFillObject,
+            { backgroundColor: colors.overlay },
+          ]}
           onPress={onClose}
+        />
+        <KeyboardAvoidingView
+          style={styles.sheetContainer}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          pointerEvents="box-none"
         >
-          {/**
-           * Inner Pressable swallows taps on the sheet itself so they don't
-           * bubble up to the overlay and trigger `onClose`.
-           */}
-          <Pressable
-            onPress={(e) => e.stopPropagation()}
+          <View
             style={[
               styles.sheet,
               {
@@ -100,9 +107,9 @@ export function EventCommentSheet({
                 externalIsSending={isSending}
               />
             </View>
-          </Pressable>
-        </Pressable>
-      </KeyboardAvoidingView>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 }
@@ -113,14 +120,18 @@ const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
-  overlay: {
-    flex: 1,
-    justifyContent: "flex-end",
+  // Sheet container pins the actual sheet to the bottom of the screen without
+  // wrapping the overlay as a parent — avoids the RN Web click-interception
+  // issue documented above.
+  sheetContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
   sheet: {
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
-    // Cap height so extreme-keyboard scenarios don't push the handle off-screen.
     maxHeight: "90%",
   },
   handleContainer: {

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -81,6 +81,7 @@ import { DOMAIN_CONFIG } from "@togather/shared";
 import * as Clipboard from "expo-clipboard";
 import { EventBlastSheet } from "@/features/leader-tools/components/EventBlastSheet";
 import { EventBlastHistory } from "@/features/leader-tools/components/EventBlastHistory";
+import { EventActivity } from "./EventActivity";
 
 /**
  * Initial event data passed from Server Component
@@ -262,10 +263,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   const setEventChannelEnabledMutation = useAuthenticatedMutation(
     api.functions.messaging.eventChat.setEventChannelEnabled
   );
-  const openEventChatMutation = useAuthenticatedMutation(
-    api.functions.messaging.eventChat.openEventChat
-  );
-  const [isOpeningChat, setIsOpeningChat] = useState(false);
 
   // Whether the chat is currently enabled. When the channel row doesn't exist
   // yet, default to enabled (new channels are created with isEnabled: true).
@@ -273,7 +270,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
 
   // Whether the user can access the event chat at all (host or RSVPer with an
   // enabled option). Mirrors the backend `canAccessEventChannel` check so the
-  // UI doesn't show a button that would route into a chat the user can't open.
+  // inline Activity feed doesn't render for users the server would reject.
   const hasRsvp = !!myRsvp?.optionId;
   const rsvpOptionEnabled = myRsvp?.optionId != null
     ? ((eventData?.rsvpOptions as unknown as RsvpOption[] | undefined)?.find(
@@ -281,29 +278,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
       )?.enabled ?? false)
     : false;
   const canAccessChat = isCreator || (hasRsvp && rsvpOptionEnabled);
-
-  const handleOpenChat = async () => {
-    if (!eventData?.id || !eventData?.groupId || !eventData?.shortId) return;
-    if (!isChatEnabled) {
-      Alert.alert("Chat disabled", "The host turned off this event's chat.");
-      return;
-    }
-    // Materialize the channel row before navigating — the chat room resolves
-    // by (groupId, slug) and can't render for a nonexistent channel. openEventChat
-    // is idempotent; it returns the existing channel if one already exists.
-    setIsOpeningChat(true);
-    try {
-      const { slug } = await openEventChatMutation({
-        meetingId: eventData.id as Id<"meetings">,
-      });
-      router.push(`/inbox/${eventData.groupId}/${slug}` as any);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Could not open chat";
-      Alert.alert("Chat unavailable", message);
-    } finally {
-      setIsOpeningChat(false);
-    }
-  };
 
   const handleToggleEventChat = async (enabled: boolean) => {
     if (!eventData?.id) return;
@@ -858,37 +832,28 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
             />
           )}
 
-          {/* Event Chat button — visible to host + RSVPers with an enabled option.
-              Tapping calls openEventChat which ensures the channel row exists,
-              then navigates. When isEnabled === false, shows a muted
-              "Chat disabled" label that fires an alert instead. */}
-          {canAccessChat && eventData.groupId && eventData.shortId && (
-            <TouchableOpacity
-              style={[
-                styles.messageAttendeesButton,
-                {
-                  backgroundColor: colors.surfaceSecondary,
-                  opacity: isChatEnabled && !isOpeningChat ? 1 : 0.6,
-                },
-              ]}
-              onPress={handleOpenChat}
-              disabled={isOpeningChat}
-            >
-              <Ionicons
-                name="chatbubble-ellipses-outline"
-                size={20}
-                color={isChatEnabled ? DEFAULT_PRIMARY_COLOR : colors.textSecondary}
+          {/* Inline Activity feed (Partiful-style). Replaces the old "Chat"
+              button that routed to a standalone /inbox/{groupId}/event-{slug}
+              room. Messages render below the event details, composer at the
+              bottom of this component. Gated on canAccessChat (host + RSVPer
+              with enabled option). Backend is authoritative. */}
+          {canAccessChat &&
+            eventData.id &&
+            eventData.groupId &&
+            eventData.shortId &&
+            user?.id &&
+            authToken && (
+              <EventActivity
+                meetingId={eventData.id as Id<"meetings">}
+                groupId={eventData.groupId as Id<"groups">}
+                shortId={eventData.shortId}
+                currentUserId={user.id as Id<"users">}
+                canAccess={canAccessChat}
+                isChatEnabled={isChatEnabled}
+                channelId={(eventChannel?._id ?? null) as Id<"chatChannels"> | null}
+                authToken={authToken}
               />
-              <Text
-                style={[
-                  styles.messageAttendeesText,
-                  { color: isChatEnabled ? DEFAULT_PRIMARY_COLOR : colors.textSecondary },
-                ]}
-              >
-                {isOpeningChat ? "Opening…" : isChatEnabled ? "Chat" : "Chat disabled"}
-              </Text>
-            </TouchableOpacity>
-          )}
+            )}
 
           {/* Leader: jump into the attendance recorder for past events */}
           {isLeader && isPastEvent && eventData.id && eventData.groupId && eventData.scheduledAt && (

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -82,7 +82,7 @@ import { DOMAIN_CONFIG } from "@togather/shared";
 import * as Clipboard from "expo-clipboard";
 import { EventBlastSheet } from "@/features/leader-tools/components/EventBlastSheet";
 import { EventBlastHistory } from "@/features/leader-tools/components/EventBlastHistory";
-import { EventActivity, EventActivityComposer } from "./EventActivity";
+import { EventActivity } from "./EventActivity";
 
 /**
  * Initial event data passed from Server Component
@@ -692,12 +692,9 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   // ============================================================================
 
   // The composer is only rendered when the user has chat access AND chat is
-  // enabled. Composer + floating RSVP pill share one absolute-positioned
-  // bottom dock (stacked vertically) so they're guaranteed to coexist on iOS
-  // — previously independent absolute siblings raced and the composer could
-  // become invisible.
-  const showComposer = canAccessChat && isChatEnabled && !!authToken;
-  const composerBottomOffset = shouldShowTabBar ? 64 : 0;
+  // The composer lives INSIDE the Activity section (scrolls with the page);
+  // the bottom dock is just for the floating RSVP pill / option buttons.
+  const dockBottomOffset = shouldShowTabBar ? 64 : 0;
 
   // Branch for which floating RSVP UI to show (or none).
   const showFloatingRsvpCard =
@@ -706,8 +703,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     canRSVP && (eventData.hasAccess || !eventData.accessPrompt) && myRsvp?.optionId == null;
   const showFloatingPrompt =
     canRSVP && !eventData.hasAccess && !!eventData.accessPrompt;
-  const showBottomDock =
-    showComposer || showFloatingRsvpCard || showFloatingRsvpButtons;
+  const showBottomDock = showFloatingRsvpCard || showFloatingRsvpButtons;
 
   return (
     <KeyboardAvoidingView
@@ -1051,16 +1047,13 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
           style={[
             styles.bottomDock,
             {
-              bottom: composerBottomOffset,
+              bottom: dockBottomOffset,
               paddingBottom: insets.bottom,
               backgroundColor: colors.surface,
               borderTopColor: colors.border,
             },
           ]}
         >
-          {showComposer && (
-            <EventActivityComposer channelId={resolvedChannelId} />
-          )}
           {showFloatingRsvpCard && myRsvp?.optionId != null && (
             <FloatingRsvpCard
               response={{ optionId: myRsvp.optionId, guestCount: myRsvp.guestCount ?? 0 }}

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -920,6 +920,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                 meetingId={eventData.id as Id<"meetings">}
                 groupId={eventData.groupId as Id<"groups">}
                 shortId={eventData.shortId}
+                eventTitle={eventData.title || "Event"}
                 currentUserId={user.id as Id<"users">}
                 canAccess={canAccessChat}
                 isChatEnabled={isChatEnabled}

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -192,6 +192,16 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
       : "skip"
   );
 
+  // Fetch event chat channel state. Returns null if no channel exists yet or
+  // the caller lacks access (not host and no RSVP). We use this for both the
+  // Chat button visibility and the leader-only enable/disable toggle.
+  const eventChannel = useQuery(
+    api.functions.messaging.eventChat.getChannelByMeetingId,
+    eventData?.id && isAuthenticated && authToken
+      ? { meetingId: eventData.id as Id<"meetings">, token: authToken }
+      : "skip"
+  );
+
   // Fetch RSVP list using Convex
   // Pass token if available to get full access (if user has RSVPed), but also works without token
   const rsvpData = useQuery(
@@ -244,6 +254,73 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     !!(eventData as any)?.createdById &&
     String(user.id) === String((eventData as any).createdById);
   const canEdit = isLeader || isCreator;
+
+  // ============================================================================
+  // Event Chat Mutations
+  // ============================================================================
+
+  const setEventChannelEnabledMutation = useAuthenticatedMutation(
+    api.functions.messaging.eventChat.setEventChannelEnabled
+  );
+
+  // Whether the chat is currently enabled. When the channel row doesn't exist
+  // yet, default to enabled (new channels are created with isEnabled: true).
+  const isChatEnabled = eventChannel ? eventChannel.isEnabled !== false : true;
+
+  // Whether the user can access the event chat at all (host or RSVPer with an
+  // enabled option). Mirrors the backend `canAccessEventChannel` check so the
+  // UI doesn't show a button that would route into a chat the user can't open.
+  const hasRsvp = !!myRsvp?.optionId;
+  const rsvpOptionEnabled = myRsvp?.optionId != null
+    ? ((eventData?.rsvpOptions as unknown as RsvpOption[] | undefined)?.find(
+        (o) => o.id === myRsvp.optionId
+      )?.enabled ?? false)
+    : false;
+  const canAccessChat = isCreator || (hasRsvp && rsvpOptionEnabled);
+
+  const handleOpenChat = () => {
+    if (!eventData?.groupId || !eventData?.shortId) return;
+    if (!isChatEnabled) {
+      Alert.alert(
+        "Chat disabled",
+        "The host turned off this event's chat."
+      );
+      return;
+    }
+    // Route format is /inbox/{groupId}/event-{shortId}. The channel slug is
+    // hard-coded by the backend (ensureEventChannel). The first send will
+    // lazy-create the channel if it doesn't exist yet.
+    router.push(`/inbox/${eventData.groupId}/event-${eventData.shortId}` as any);
+  };
+
+  const handleToggleEventChat = async (enabled: boolean) => {
+    if (!eventData?.id) return;
+    const applyToggle = async () => {
+      try {
+        await setEventChannelEnabledMutation({
+          meetingId: eventData.id as Id<"meetings">,
+          enabled,
+        });
+      } catch (err) {
+        console.error("Failed to toggle event chat:", err);
+        Alert.alert("Error", "Failed to update event chat. Please try again.");
+      }
+    };
+
+    // Confirm before disabling; re-enabling is a straight call.
+    if (!enabled) {
+      Alert.alert(
+        "Disable event chat?",
+        "Attendees won't be able to message the group.",
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Disable", style: "destructive", onPress: applyToggle },
+        ]
+      );
+      return;
+    }
+    await applyToggle();
+  };
 
   // ============================================================================
   // Loading & Error States
@@ -769,6 +846,37 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
             />
           )}
 
+          {/* Event Chat button — visible to host + RSVPers with an enabled option.
+              When the channel exists AND isEnabled === false, show a muted
+              "Chat disabled" label that fires an alert instead of navigating.
+              If no channel exists yet, the first send lazy-creates it. */}
+          {canAccessChat && eventData.groupId && eventData.shortId && (
+            <TouchableOpacity
+              style={[
+                styles.messageAttendeesButton,
+                {
+                  backgroundColor: colors.surfaceSecondary,
+                  opacity: isChatEnabled ? 1 : 0.6,
+                },
+              ]}
+              onPress={handleOpenChat}
+            >
+              <Ionicons
+                name="chatbubble-ellipses-outline"
+                size={20}
+                color={isChatEnabled ? DEFAULT_PRIMARY_COLOR : colors.textSecondary}
+              />
+              <Text
+                style={[
+                  styles.messageAttendeesText,
+                  { color: isChatEnabled ? DEFAULT_PRIMARY_COLOR : colors.textSecondary },
+                ]}
+              >
+                {isChatEnabled ? "Chat" : "Chat disabled"}
+              </Text>
+            </TouchableOpacity>
+          )}
+
           {/* Leader: jump into the attendance recorder for past events */}
           {isLeader && isPastEvent && eventData.id && eventData.groupId && eventData.scheduledAt && (
             <TouchableOpacity
@@ -802,6 +910,24 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                 <Switch
                   value={rsvpNotifyLeaders}
                   onValueChange={handleToggleRsvpNotify}
+                  trackColor={{ false: colors.border, true: DEFAULT_PRIMARY_COLOR }}
+                />
+              </View>
+            </View>
+          )}
+
+          {/* Host/Leader: enable/disable event chat. Backend enforces the same
+              permission (event creator, group leader, or community admin). */}
+          {canEdit && (
+            <View style={[styles.leaderCard, { backgroundColor: colors.surfaceSecondary }]}>
+              <View style={styles.leaderCardRow}>
+                <Ionicons name="chatbubble-ellipses-outline" size={20} color={colors.textSecondary} />
+                <Text style={[styles.leaderCardText, { color: colors.text }]}>
+                  Event chat
+                </Text>
+                <Switch
+                  value={isChatEnabled}
+                  onValueChange={handleToggleEventChat}
                   trackColor={{ false: colors.border, true: DEFAULT_PRIMARY_COLOR }}
                 />
               </View>

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -81,7 +81,6 @@ import { AttendanceConfirmationModal } from "@/features/events/components/Attend
 import { DOMAIN_CONFIG } from "@togather/shared";
 import * as Clipboard from "expo-clipboard";
 import { EventBlastSheet } from "@/features/leader-tools/components/EventBlastSheet";
-import { EventBlastHistory } from "@/features/leader-tools/components/EventBlastHistory";
 import { EventActivity } from "./EventActivity";
 
 /**
@@ -999,10 +998,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                 Text Blast
               </Text>
             </TouchableOpacity>
-          )}
-
-          {canEdit && eventData.id && (
-            <EventBlastHistory meetingId={eventData.id as string} />
           )}
         </View>
       </ScrollView>

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -14,6 +14,7 @@ import {
   Alert,
   Share,
   Switch,
+  KeyboardAvoidingView,
 } from "react-native";
 import { useLocalSearchParams, useRouter, useSegments } from "expo-router";
 import { useQuery, useAuthenticatedMutation, api, Id } from "@services/api/convex";
@@ -81,7 +82,7 @@ import { DOMAIN_CONFIG } from "@togather/shared";
 import * as Clipboard from "expo-clipboard";
 import { EventBlastSheet } from "@/features/leader-tools/components/EventBlastSheet";
 import { EventBlastHistory } from "@/features/leader-tools/components/EventBlastHistory";
-import { EventActivity } from "./EventActivity";
+import { EventActivity, EventActivityComposer } from "./EventActivity";
 
 /**
  * Initial event data passed from Server Component
@@ -263,6 +264,20 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   const setEventChannelEnabledMutation = useAuthenticatedMutation(
     api.functions.messaging.eventChat.setEventChannelEnabled
   );
+  const openEventChatMutation = useAuthenticatedMutation(
+    api.functions.messaging.eventChat.openEventChat
+  );
+
+  // Channel materialization. On mount (or whenever the user becomes chat-
+  // accessible), ensure a channel row exists so the composer can subscribe
+  // and send without a "first-send creates the channel" delay. The backend
+  // is idempotent, so safe to call once per page visit.
+  const [materializedChannelId, setMaterializedChannelId] =
+    useState<Id<"chatChannels"> | null>(null);
+  const resolvedChannelId =
+    (eventChannel?._id as Id<"chatChannels"> | undefined) ??
+    materializedChannelId ??
+    null;
 
   // Whether the chat is currently enabled. When the channel row doesn't exist
   // yet, default to enabled (new channels are created with isEnabled: true).
@@ -278,6 +293,46 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
       )?.enabled ?? false)
     : false;
   const canAccessChat = isCreator || (hasRsvp && rsvpOptionEnabled);
+
+  // Materialize the channel once per page visit when we know the user can
+  // access chat. Skipping until `eventChannel === null` (i.e. the query
+  // resolved with "no channel yet") — `undefined` means still loading. Once
+  // the mutation returns, cache the id locally so the composer can send
+  // immediately without waiting for `getChannelByMeetingId` to re-resolve.
+  const meetingIdForChannel = eventData?.id as Id<"meetings"> | undefined;
+  useEffect(() => {
+    if (!meetingIdForChannel) return;
+    if (!canAccessChat || !isChatEnabled) return;
+    if (eventChannel !== null) return; // still loading, or channel exists
+    if (materializedChannelId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { channelId } = await openEventChatMutation({
+          meetingId: meetingIdForChannel,
+        });
+        if (!cancelled) setMaterializedChannelId(channelId);
+      } catch (err) {
+        // Backend enforces access; a failure here just means the composer
+        // stays disabled. Don't alert — this runs on mount.
+        console.warn("[EventPageClient] openEventChat failed", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    meetingIdForChannel,
+    canAccessChat,
+    isChatEnabled,
+    eventChannel,
+    materializedChannelId,
+    openEventChatMutation,
+  ]);
+
+  // Measured composer height — used so FloatingRsvpCard can sit above the
+  // composer without overlapping. Default to 0 when composer isn't rendered.
+  const [composerHeight, setComposerHeight] = useState(0);
 
   const handleToggleEventChat = async (enabled: boolean) => {
     if (!eventData?.id) return;
@@ -640,7 +695,21 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   // Render
   // ============================================================================
 
+  // The composer is only rendered when the user has chat access AND chat is
+  // enabled. When rendered it sits absolutely above the FloatingRsvpCard; the
+  // card's tabBarOffset is pushed up by the measured composer height so they
+  // stack instead of overlapping.
+  const showComposer = canAccessChat && isChatEnabled && !!authToken;
+  const composerBottomOffset = shouldShowTabBar ? 64 : 0;
+  const rsvpStackOffset =
+    composerBottomOffset + (showComposer ? composerHeight : 0);
+
   return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={0}
+    >
     <SafeAreaView style={[styles.container, { backgroundColor: colors.surface }]} edges={["top"]}>
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
@@ -677,6 +746,9 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
         contentContainerStyle={[
           styles.scrollContent,
           shouldShowTabBar && { paddingBottom: 200 }, // Extra padding for tab bar
+          // Extra bottom padding so the last message isn't hidden behind the
+          // sticky composer. Uses measured composer height when visible.
+          showComposer && { paddingBottom: 200 + composerHeight },
         ]}
       >
         {/* Cover Image - falls back to group image if no event cover */}
@@ -850,7 +922,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                 currentUserId={user.id as Id<"users">}
                 canAccess={canAccessChat}
                 isChatEnabled={isChatEnabled}
-                channelId={(eventChannel?._id ?? null) as Id<"chatChannels"> | null}
+                channelId={resolvedChannelId}
                 authToken={authToken}
               />
             )}
@@ -973,7 +1045,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
               onGuestCountChange={handleGuestCountChange}
               maxGuests={maxGuestsPerRsvp}
               insets={insets}
-              tabBarOffset={shouldShowTabBar ? 64 : 0}
+              tabBarOffset={rsvpStackOffset}
             />
           ) : (
             <FloatingRsvpButtons
@@ -981,7 +1053,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
               loadingOptionId={loadingOptionId}
               onSelect={handleRsvpSelect}
               insets={insets}
-              tabBarOffset={shouldShowTabBar ? 64 : 0}
+              tabBarOffset={rsvpStackOffset}
             />
           )}
         </>
@@ -1028,7 +1100,27 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
           isAdmin={isAdmin}
         />
       )}
+
+      {/* Sticky event-chat composer. Absolutely positioned above the tab bar
+          so it stays pinned at the viewport bottom; the surrounding
+          KeyboardAvoidingView lifts the whole tree when the keyboard is
+          shown. FloatingRsvpCard/Buttons stack on top of this via the
+          measured composerHeight (see `rsvpStackOffset`). */}
+      {showComposer && (
+        <EventActivityComposer
+          channelId={resolvedChannelId}
+          onLayout={setComposerHeight}
+          style={[
+            styles.stickyComposer,
+            {
+              bottom: composerBottomOffset,
+              paddingBottom: insets.bottom,
+            },
+          ]}
+        />
+      )}
     </SafeAreaView>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -1209,5 +1301,13 @@ const styles = StyleSheet.create({
   messageAttendeesText: {
     fontSize: 16,
     fontWeight: "600",
+  },
+
+  // Sticky composer (absolute bottom bar). `bottom` is set dynamically so the
+  // composer sits above the shared-link tab bar when present.
+  stickyComposer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
   },
 });

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -344,7 +344,16 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     };
 
     // Confirm before disabling; re-enabling is a straight call.
+    // RN Web's Alert.alert is window.alert and can't fire multi-button
+    // callbacks — use window.confirm on web.
     if (!enabled) {
+      const confirmMessage = "Disable event chat? Attendees won't be able to message the group.";
+      if (Platform.OS === "web") {
+        if (typeof window !== "undefined" && window.confirm(confirmMessage)) {
+          await applyToggle();
+        }
+        return;
+      }
       Alert.alert(
         "Disable event chat?",
         "Attendees won't be able to message the group.",

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -996,7 +996,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
             >
               <Ionicons name="megaphone-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
               <Text style={[styles.messageAttendeesText, { color: DEFAULT_PRIMARY_COLOR }]}>
-                Message Attendees
+                Text Blast
               </Text>
             </TouchableOpacity>
           )}

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -330,10 +330,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     openEventChatMutation,
   ]);
 
-  // Measured composer height — used so FloatingRsvpCard can sit above the
-  // composer without overlapping. Default to 0 when composer isn't rendered.
-  const [composerHeight, setComposerHeight] = useState(0);
-
   const handleToggleEventChat = async (enabled: boolean) => {
     if (!eventData?.id) return;
     const applyToggle = async () => {
@@ -696,13 +692,22 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   // ============================================================================
 
   // The composer is only rendered when the user has chat access AND chat is
-  // enabled. When rendered it sits absolutely above the FloatingRsvpCard; the
-  // card's tabBarOffset is pushed up by the measured composer height so they
-  // stack instead of overlapping.
+  // enabled. Composer + floating RSVP pill share one absolute-positioned
+  // bottom dock (stacked vertically) so they're guaranteed to coexist on iOS
+  // — previously independent absolute siblings raced and the composer could
+  // become invisible.
   const showComposer = canAccessChat && isChatEnabled && !!authToken;
   const composerBottomOffset = shouldShowTabBar ? 64 : 0;
-  const rsvpStackOffset =
-    composerBottomOffset + (showComposer ? composerHeight : 0);
+
+  // Branch for which floating RSVP UI to show (or none).
+  const showFloatingRsvpCard =
+    canRSVP && (eventData.hasAccess || !eventData.accessPrompt) && myRsvp?.optionId != null;
+  const showFloatingRsvpButtons =
+    canRSVP && (eventData.hasAccess || !eventData.accessPrompt) && myRsvp?.optionId == null;
+  const showFloatingPrompt =
+    canRSVP && !eventData.hasAccess && !!eventData.accessPrompt;
+  const showBottomDock =
+    showComposer || showFloatingRsvpCard || showFloatingRsvpButtons;
 
   return (
     <KeyboardAvoidingView
@@ -745,10 +750,10 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
         style={styles.scroll}
         contentContainerStyle={[
           styles.scrollContent,
-          shouldShowTabBar && { paddingBottom: 200 }, // Extra padding for tab bar
-          // Extra bottom padding so the last message isn't hidden behind the
-          // sticky composer. Uses measured composer height when visible.
-          showComposer && { paddingBottom: 200 + composerHeight },
+          // Static generous padding so the last message isn't hidden behind
+          // the sticky composer + RSVP dock. The dock floats via absolute
+          // positioning, so no dynamic measurement needed.
+          (showBottomDock || shouldShowTabBar) && { paddingBottom: 220 },
         ]}
       >
         {/* Cover Image - falls back to group image if no event cover */}
@@ -1005,39 +1010,58 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
         </View>
       </ScrollView>
 
-      {/* Floating RSVP Section */}
-      {canRSVP && (
-        <>
-          {!eventData.hasAccess && eventData.accessPrompt ? (
-            // User can view event but needs to sign in or join to RSVP
-            <View style={[
-              styles.floatingPrompt,
-              {
-                paddingBottom: insets.bottom + 16,
-                bottom: shouldShowTabBar ? 64 : 0, // Offset for tab bar
-                backgroundColor: colors.surface,
-                borderTopColor: colors.border,
+      {/* Sign-in prompt — separate standalone dock, shown when the viewer
+          can see the event but needs to sign in to RSVP. */}
+      {showFloatingPrompt && (
+        <View
+          style={[
+            styles.floatingPrompt,
+            {
+              paddingBottom: insets.bottom + 16,
+              bottom: shouldShowTabBar ? 64 : 0,
+              backgroundColor: colors.surface,
+              borderTopColor: colors.border,
+            },
+          ]}
+        >
+          <TouchableOpacity
+            style={styles.signInButton}
+            onPress={() => {
+              const defaultOption = rsvpOptions.find((o) => o.enabled);
+              if (defaultOption) {
+                router.push(`/e/${shortId}/rsvp/phone?optionId=${defaultOption.id}`);
+              } else {
+                router.push("/(auth)/signin" as any);
               }
-            ]}>
-              <TouchableOpacity
-                style={styles.signInButton}
-                onPress={() => {
-                  // For public events, use the new phone-based RSVP flow
-                  // Get the first enabled RSVP option as default
-                  const defaultOption = rsvpOptions.find((o) => o.enabled);
-                  if (defaultOption) {
-                    router.push(`/e/${shortId}/rsvp/phone?optionId=${defaultOption.id}`);
-                  } else {
-                    router.push("/(auth)/signin" as any);
-                  }
-                }}
-              >
-                <Text style={styles.signInButtonText}>
-                  {eventData.accessPrompt.message}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          ) : myRsvp?.optionId != null ? (
+            }}
+          >
+            <Text style={styles.signInButtonText}>
+              {eventData.accessPrompt?.message}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Unified bottom dock. Stacks the chat composer (if any) on top of the
+          floating RSVP pill/buttons (if any) inside a single absolutely-
+          positioned container. Two independent absolute children used to race
+          on iOS, leaving the composer invisible. */}
+      {showBottomDock && (
+        <View
+          style={[
+            styles.bottomDock,
+            {
+              bottom: composerBottomOffset,
+              paddingBottom: insets.bottom,
+              backgroundColor: colors.surface,
+              borderTopColor: colors.border,
+            },
+          ]}
+        >
+          {showComposer && (
+            <EventActivityComposer channelId={resolvedChannelId} />
+          )}
+          {showFloatingRsvpCard && myRsvp?.optionId != null && (
             <FloatingRsvpCard
               response={{ optionId: myRsvp.optionId, guestCount: myRsvp.guestCount ?? 0 }}
               options={rsvpOptions}
@@ -1045,18 +1069,19 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
               onGuestCountChange={handleGuestCountChange}
               maxGuests={maxGuestsPerRsvp}
               insets={insets}
-              tabBarOffset={rsvpStackOffset}
+              embedded
             />
-          ) : (
+          )}
+          {showFloatingRsvpButtons && (
             <FloatingRsvpButtons
               options={rsvpOptions}
               loadingOptionId={loadingOptionId}
               onSelect={handleRsvpSelect}
               insets={insets}
-              tabBarOffset={rsvpStackOffset}
+              embedded
             />
           )}
-        </>
+        </View>
       )}
 
       {/* RSVP Edit Modal */}
@@ -1101,24 +1126,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
         />
       )}
 
-      {/* Sticky event-chat composer. Absolutely positioned above the tab bar
-          so it stays pinned at the viewport bottom; the surrounding
-          KeyboardAvoidingView lifts the whole tree when the keyboard is
-          shown. FloatingRsvpCard/Buttons stack on top of this via the
-          measured composerHeight (see `rsvpStackOffset`). */}
-      {showComposer && (
-        <EventActivityComposer
-          channelId={resolvedChannelId}
-          onLayout={setComposerHeight}
-          style={[
-            styles.stickyComposer,
-            {
-              bottom: composerBottomOffset,
-              paddingBottom: insets.bottom,
-            },
-          ]}
-        />
-      )}
     </SafeAreaView>
     </KeyboardAvoidingView>
   );
@@ -1303,11 +1310,13 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
 
-  // Sticky composer (absolute bottom bar). `bottom` is set dynamically so the
-  // composer sits above the shared-link tab bar when present.
-  stickyComposer: {
+  // Unified bottom dock. Single absolute-positioned column that holds the
+  // chat composer (on top) and the floating RSVP pill/buttons (below). See
+  // the render-site comment for why this is a single container on iOS.
+  bottomDock: {
     position: "absolute",
     left: 0,
     right: 0,
+    borderTopWidth: 1,
   },
 });

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -262,6 +262,10 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   const setEventChannelEnabledMutation = useAuthenticatedMutation(
     api.functions.messaging.eventChat.setEventChannelEnabled
   );
+  const openEventChatMutation = useAuthenticatedMutation(
+    api.functions.messaging.eventChat.openEventChat
+  );
+  const [isOpeningChat, setIsOpeningChat] = useState(false);
 
   // Whether the chat is currently enabled. When the channel row doesn't exist
   // yet, default to enabled (new channels are created with isEnabled: true).
@@ -278,19 +282,27 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     : false;
   const canAccessChat = isCreator || (hasRsvp && rsvpOptionEnabled);
 
-  const handleOpenChat = () => {
-    if (!eventData?.groupId || !eventData?.shortId) return;
+  const handleOpenChat = async () => {
+    if (!eventData?.id || !eventData?.groupId || !eventData?.shortId) return;
     if (!isChatEnabled) {
-      Alert.alert(
-        "Chat disabled",
-        "The host turned off this event's chat."
-      );
+      Alert.alert("Chat disabled", "The host turned off this event's chat.");
       return;
     }
-    // Route format is /inbox/{groupId}/event-{shortId}. The channel slug is
-    // hard-coded by the backend (ensureEventChannel). The first send will
-    // lazy-create the channel if it doesn't exist yet.
-    router.push(`/inbox/${eventData.groupId}/event-${eventData.shortId}` as any);
+    // Materialize the channel row before navigating — the chat room resolves
+    // by (groupId, slug) and can't render for a nonexistent channel. openEventChat
+    // is idempotent; it returns the existing channel if one already exists.
+    setIsOpeningChat(true);
+    try {
+      const { slug } = await openEventChatMutation({
+        meetingId: eventData.id as Id<"meetings">,
+      });
+      router.push(`/inbox/${eventData.groupId}/${slug}` as any);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Could not open chat";
+      Alert.alert("Chat unavailable", message);
+    } finally {
+      setIsOpeningChat(false);
+    }
   };
 
   const handleToggleEventChat = async (enabled: boolean) => {
@@ -847,19 +859,20 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
           )}
 
           {/* Event Chat button — visible to host + RSVPers with an enabled option.
-              When the channel exists AND isEnabled === false, show a muted
-              "Chat disabled" label that fires an alert instead of navigating.
-              If no channel exists yet, the first send lazy-creates it. */}
+              Tapping calls openEventChat which ensures the channel row exists,
+              then navigates. When isEnabled === false, shows a muted
+              "Chat disabled" label that fires an alert instead. */}
           {canAccessChat && eventData.groupId && eventData.shortId && (
             <TouchableOpacity
               style={[
                 styles.messageAttendeesButton,
                 {
                   backgroundColor: colors.surfaceSecondary,
-                  opacity: isChatEnabled ? 1 : 0.6,
+                  opacity: isChatEnabled && !isOpeningChat ? 1 : 0.6,
                 },
               ]}
               onPress={handleOpenChat}
+              disabled={isOpeningChat}
             >
               <Ionicons
                 name="chatbubble-ellipses-outline"
@@ -872,7 +885,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                   { color: isChatEnabled ? DEFAULT_PRIMARY_COLOR : colors.textSecondary },
                 ]}
               >
-                {isChatEnabled ? "Chat" : "Chat disabled"}
+                {isOpeningChat ? "Opening…" : isChatEnabled ? "Chat" : "Chat disabled"}
               </Text>
             </TouchableOpacity>
           )}

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -293,16 +293,18 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     : false;
   const canAccessChat = isCreator || (hasRsvp && rsvpOptionEnabled);
 
-  // Materialize the channel once per page visit when we know the user can
-  // access chat. Skipping until `eventChannel === null` (i.e. the query
-  // resolved with "no channel yet") — `undefined` means still loading. Once
-  // the mutation returns, cache the id locally so the composer can send
-  // immediately without waiting for `getChannelByMeetingId` to re-resolve.
+  // Materialize the channel and seat the caller as a member once per page
+  // visit when they have chat access. Skip while `eventChannel === undefined`
+  // (query still loading). When the channel already exists (`eventChannel`
+  // is a doc), we must still call `openEventChat` — attendees who RSVPed
+  // before the channel existed (e.g. host sent a blast first) are never
+  // seated otherwise, and membership-driven paths (inbox rows, push fanout)
+  // would silently skip them.
   const meetingIdForChannel = eventData?.id as Id<"meetings"> | undefined;
   useEffect(() => {
     if (!meetingIdForChannel) return;
     if (!canAccessChat || !isChatEnabled) return;
-    if (eventChannel !== null) return; // still loading, or channel exists
+    if (eventChannel === undefined) return; // still loading
     if (materializedChannelId) return;
     let cancelled = false;
     (async () => {

--- a/apps/mobile/app/e/[shortId]/thread/[messageId].tsx
+++ b/apps/mobile/app/e/[shortId]/thread/[messageId].tsx
@@ -1,0 +1,44 @@
+/**
+ * Event Thread Route
+ *
+ * Route: /e/[shortId]/thread/[messageId]
+ *
+ * Event-scoped thread view. Reuses the shared ThreadPage component so
+ * functionality matches the inbox thread route at /inbox/[groupId]/thread/...
+ *
+ * Why a separate route: pushing from /e/[shortId] to /inbox/... crosses
+ * route stacks on native, which caused the thread page to render behind
+ * the event page. Keeping the thread inside the /e/[shortId] stack lets
+ * expo-router handle the push as a normal forward navigation.
+ *
+ * The owning group's id is passed via query param since the route only
+ * knows the event shortId; EventComment forwards it when building the URL.
+ */
+import { useLocalSearchParams } from "expo-router";
+import type { Id } from "@services/api/convex";
+import { ThreadPage } from "@features/chat/components/ThreadPage";
+
+type EventThreadRouteParams = {
+  shortId: string;
+  messageId: string;
+  groupId?: string;
+  channelName?: string;
+};
+
+export default function EventThreadRoute() {
+  const params = useLocalSearchParams<EventThreadRouteParams>();
+
+  const { messageId, groupId, channelName } = params;
+
+  if (!groupId || !messageId) {
+    return null;
+  }
+
+  return (
+    <ThreadPage
+      messageId={messageId as Id<"chatMessages">}
+      groupId={groupId as Id<"groups">}
+      channelName={channelName}
+    />
+  );
+}

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -696,7 +696,7 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
           {messagePreview}
         </Text>
 
-        {/* Line 3: small muted meta — absolute time + optional location chip. */}
+        {/* Line 3: muted time + prominent Directions button. */}
         <View style={styles.eventMetaRow}>
           <Text
             style={[
@@ -708,42 +708,46 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
             {eventWhen ? eventWhen.when : "Scheduled"}
           </Text>
           {locationShort ? (
-            <>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${channel.meetingLocation} in Maps`}
+              onPress={(e) => {
+                e.stopPropagation?.();
+                openMapsForLocation(channel.meetingLocation!);
+              }}
+              hitSlop={6}
+              style={({ pressed }) => [
+                styles.directionsButton,
+                {
+                  backgroundColor: isPast
+                    ? colors.surfaceSecondary
+                    : isDark
+                      ? primaryColor + "22"
+                      : primaryColor + "14",
+                  borderColor: isPast
+                    ? colors.border
+                    : isDark
+                      ? primaryColor + "44"
+                      : primaryColor + "33",
+                },
+                pressed && { opacity: 0.65 },
+              ]}
+            >
+              <Ionicons
+                name="navigate"
+                size={14}
+                color={isPast ? colors.textTertiary : primaryColor}
+              />
               <Text
-                style={[styles.eventMetaSeparator, { color: colors.textTertiary }]}
-                accessibilityElementsHidden
-              >
-                {"·"}
-              </Text>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={`Open ${channel.meetingLocation} in Maps`}
-                onPress={(e) => {
-                  e.stopPropagation?.();
-                  openMapsForLocation(channel.meetingLocation!);
-                }}
-                hitSlop={{ top: 10, bottom: 10, left: 6, right: 6 }}
-                style={({ pressed }) => [
-                  styles.locationChip,
-                  pressed && { opacity: 0.6 },
+                style={[
+                  styles.directionsButtonText,
+                  { color: isPast ? colors.textTertiary : primaryColor },
                 ]}
+                numberOfLines={1}
               >
-                <Ionicons
-                  name="location-outline"
-                  size={12}
-                  color={isPast ? colors.textTertiary : primaryColor}
-                />
-                <Text
-                  style={[
-                    styles.locationChipText,
-                    { color: isPast ? colors.textTertiary : primaryColor },
-                  ]}
-                  numberOfLines={1}
-                >
-                  {locationShort}
-                </Text>
-              </Pressable>
-            </>
+                {locationShort}
+              </Text>
+            </Pressable>
           ) : null}
         </View>
       </View>
@@ -923,7 +927,8 @@ const styles = StyleSheet.create({
   eventMetaRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginTop: 2,
+    marginTop: 6,
+    gap: 10,
   },
   eventMetaText: {
     fontSize: 12,
@@ -932,6 +937,23 @@ const styles = StyleSheet.create({
   eventMetaSeparator: {
     fontSize: 12,
     marginHorizontal: 6,
+  },
+  // Prominent filled pill next to the time — reads as a CTA. Primary-tinted
+  // background so it doesn't blend into the surrounding muted row.
+  directionsButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+    flexShrink: 1,
+  },
+  directionsButtonText: {
+    fontSize: 13,
+    fontWeight: "600",
+    flexShrink: 1,
   },
   // Inline location chip — no border, no background, just icon + text tinted
   // with primary color. Reads as "tappable" via the primary tint.

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -57,6 +57,12 @@ type InboxChannel = {
   isEnabled?: boolean;
   meetingId?: Id<"meetings">;
   meetingScheduledAt?: number | null;
+  /**
+   * For event channels, the owning meeting's shortId. Used by event rows in
+   * the inbox to navigate to `/e/{shortId}` (event page with inline Activity)
+   * rather than the legacy standalone chat room.
+   */
+  meetingShortId?: string | null;
 };
 
 // Type for the grouped inbox data from getInboxChannels query
@@ -400,7 +406,15 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
   const { channel, group, userRole } = row;
   const hasUnread = channel.unreadCount > 0;
 
+  // Event rows route to the event page with inline Activity (Partiful-style).
+  // The `/inbox/{groupId}/event-{slug}` standalone room was removed — chat
+  // now lives on `/e/{shortId}`. If a channel somehow lacks meetingShortId
+  // (legacy data), fall back to the old route so the row still opens.
   const handlePress = useCallback(() => {
+    if (channel.meetingShortId) {
+      router.push(`/e/${channel.meetingShortId}?source=app` as any);
+      return;
+    }
     router.push({
       pathname: `/inbox/${group._id}/${channel.slug}` as any,
       params: {

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -377,14 +377,11 @@ interface EventsSectionProps {
 }
 
 function EventsSection({ rows, activeChannelSlug }: EventsSectionProps) {
-  const { colors } = useTheme();
+  // No section header — event rows sit alongside group rows, differentiated by
+  // the small calendar badge on the avatar. A header made everything above it
+  // look generically "event-y" and confused the mix with group rows below.
   return (
     <View>
-      <View style={styles.sectionHeader}>
-        <Text style={[styles.sectionHeaderText, { color: colors.textSecondary }]}>
-          Events
-        </Text>
-      </View>
       {rows.map((row) => (
         <EventInboxRowItem
           key={row.channel._id}
@@ -463,6 +460,16 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
             backgroundColor: isDark ? "#333" : "#E5E5E5",
           }}
         />
+        {/* Small calendar badge differentiates event rows from group rows
+            now that the Events section header is gone. */}
+        <View
+          style={[
+            styles.eventIconBadge,
+            { backgroundColor: primaryColor, borderColor: colors.surface },
+          ]}
+        >
+          <Ionicons name="calendar" size={12} color="#fff" />
+        </View>
       </View>
 
       <View style={styles.eventContent}>
@@ -475,10 +482,7 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
             ]}
             numberOfLines={1}
           >
-            <Text style={{ color: colors.textSecondary, fontWeight: "400" }}>
-              {group.name}:{" "}
-            </Text>
-            {channel.name}
+            {group.name}: {channel.name}
           </Text>
         </View>
         <View style={styles.eventBottomRow}>

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -18,6 +18,8 @@ import {
   FlatList,
   ScrollView,
   Pressable,
+  Linking,
+  Platform,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter, usePathname } from "expo-router";
@@ -68,6 +70,11 @@ type InboxChannel = {
    * renders this as the avatar so events look distinct from group channels.
    */
   meetingCoverImage?: string | null;
+  /**
+   * For event channels, the meeting's free-form location (address or place
+   * name). Drives the Maps shortcut on the row.
+   */
+  meetingLocation?: string | null;
 };
 
 // Type for the grouped inbox data from getInboxChannels query
@@ -398,6 +405,80 @@ interface EventInboxRowItemProps {
   isActive: boolean;
 }
 
+/**
+ * Format the event's scheduled time in two parts for the inbox row:
+ *   - `when`: short absolute — "Today 5:30 PM", "Tomorrow 5:30 PM",
+ *     "Sat 5:30 PM" (this week), "Apr 28 5:30 PM" (same year), or
+ *     "Apr 28, 2026" (other year).
+ *   - `relative`: "in 45 min", "in 3h", "in 2d", "1d ago", "just now",
+ *     etc. Undefined when the absolute label already makes it obvious
+ *     (e.g. > 14 days away or > 14 days past).
+ */
+function formatEventWhen(
+  scheduledAt: number,
+  now: number,
+): { when: string; relative?: string } {
+  const diffMs = scheduledAt - now;
+  const diffMin = Math.round(diffMs / 60_000);
+  const diffHour = Math.round(diffMs / 3_600_000);
+  const diffDay = Math.round(diffMs / 86_400_000);
+
+  const scheduled = new Date(scheduledAt);
+  const today = new Date(now);
+  const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+  const startOfScheduled = new Date(
+    scheduled.getFullYear(),
+    scheduled.getMonth(),
+    scheduled.getDate(),
+  ).getTime();
+  const dayDelta = Math.round((startOfScheduled - startOfToday) / 86_400_000);
+
+  const timeStr = scheduled.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  let when: string;
+  if (dayDelta === 0) when = `Today ${timeStr}`;
+  else if (dayDelta === 1) when = `Tomorrow ${timeStr}`;
+  else if (dayDelta === -1) when = `Yesterday ${timeStr}`;
+  else if (dayDelta > 1 && dayDelta < 7) {
+    when = `${scheduled.toLocaleDateString(undefined, { weekday: "short" })} ${timeStr}`;
+  } else if (scheduled.getFullYear() === today.getFullYear()) {
+    when = `${scheduled.toLocaleDateString(undefined, { month: "short", day: "numeric" })} ${timeStr}`;
+  } else {
+    when = scheduled.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  // Relative — only when the absolute phrasing doesn't already convey it.
+  let relative: string | undefined;
+  if (Math.abs(diffMin) < 1) relative = "happening now";
+  else if (diffMin > 0 && diffMin < 60) relative = `in ${diffMin} min`;
+  else if (diffMin < 0 && diffMin > -60) relative = `${-diffMin} min ago`;
+  else if (diffHour > 0 && diffHour < 24) relative = `in ${diffHour}h`;
+  else if (diffHour < 0 && diffHour > -24) relative = `${-diffHour}h ago`;
+  else if (diffDay > 1 && diffDay <= 14) relative = `in ${diffDay}d`;
+  else if (diffDay < -1 && diffDay >= -14) relative = `${-diffDay}d ago`;
+
+  return { when, relative };
+}
+
+function openMapsForLocation(location: string) {
+  const q = encodeURIComponent(location);
+  const url =
+    Platform.OS === "ios"
+      ? `http://maps.apple.com/?q=${q}`
+      : `https://maps.google.com/?q=${q}`;
+  Linking.openURL(url).catch(() => {
+    // Fallback to Google Maps web if the native handler refuses.
+    Linking.openURL(`https://maps.google.com/?q=${q}`);
+  });
+}
+
 function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
   const router = useRouter();
   const { user } = useAuth();
@@ -431,6 +512,13 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
     });
   }, [router, group, channel, userRole]);
 
+  // On an event row the time + location are more useful than the last message
+  // preview (the event page shows comments anyway). Fall back to preview when
+  // the event has no scheduledAt — should be rare.
+  const eventWhen =
+    typeof channel.meetingScheduledAt === "number"
+      ? formatEventWhen(channel.meetingScheduledAt, Date.now())
+      : null;
   const messagePreview = (() => {
     if (!channel.lastMessagePreview) return "No messages yet";
     const isOwn = userId && channel.lastMessageSenderId === userId;
@@ -494,8 +582,36 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
             ]}
             numberOfLines={1}
           >
-            {messagePreview}
+            {eventWhen ? (
+              <>
+                {eventWhen.when}
+                {eventWhen.relative ? (
+                  <Text style={{ color: primaryColor, fontWeight: "600" }}>
+                    {" · "}{eventWhen.relative}
+                  </Text>
+                ) : null}
+              </>
+            ) : (
+              messagePreview
+            )}
           </Text>
+          {channel.meetingLocation ? (
+            <Pressable
+              accessibilityLabel="Open in Maps"
+              onPress={(e) => {
+                // Prevent the row's onPress (open event page) from firing too.
+                e.stopPropagation?.();
+                openMapsForLocation(channel.meetingLocation!);
+              }}
+              hitSlop={8}
+              style={[
+                styles.mapsButton,
+                { borderColor: colors.border, backgroundColor: colors.surface },
+              ]}
+            >
+              <Ionicons name="location" size={14} color={primaryColor} />
+            </Pressable>
+          ) : null}
         </View>
       </View>
 
@@ -622,11 +738,20 @@ const styles = StyleSheet.create({
   eventBottomRow: {
     flexDirection: "row",
     alignItems: "center",
+    gap: 8,
   },
   eventPreview: {
     fontSize: 14,
     flex: 1,
     marginRight: 8,
+  },
+  mapsButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
   },
   eventUnreadBadge: {
     minWidth: 22,

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -9,7 +9,7 @@
  * groups into a dedicated "Events" section pinned to the top of the list.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -513,6 +513,82 @@ function shortLocation(loc: string): string {
   return `${parts[0]}, ${parts[1]}`;
 }
 
+interface DirectionsButtonProps {
+  label: string;
+  location: string;
+  isPast: boolean;
+  isDark: boolean;
+  primaryColor: string;
+  borderColor: string;
+  surfaceSecondary: string;
+  textTertiary: string;
+  onOpenMaps: (location: string) => void;
+}
+
+// Small inner Pressable. Layout lives on the inner View because
+// Pressable's function-style `style` is silently dropped on RN Web —
+// see the pressed-state comment in EventInboxRowItem.
+function DirectionsButton({
+  label,
+  location,
+  isPast,
+  isDark,
+  primaryColor,
+  borderColor,
+  surfaceSecondary,
+  textTertiary,
+  onOpenMaps,
+}: DirectionsButtonProps) {
+  const [isPressed, setIsPressed] = useState(false);
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${location} in Maps`}
+      onPress={(e) => {
+        e.stopPropagation?.();
+        onOpenMaps(location);
+      }}
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      hitSlop={6}
+    >
+      <View
+        style={[
+          styles.directionsButton,
+          {
+            backgroundColor: isPast
+              ? surfaceSecondary
+              : isDark
+                ? primaryColor + "22"
+                : primaryColor + "14",
+            borderColor: isPast
+              ? borderColor
+              : isDark
+                ? primaryColor + "44"
+                : primaryColor + "33",
+          },
+          isPressed && { opacity: 0.65 },
+        ]}
+      >
+        <Ionicons
+          name="navigate"
+          size={14}
+          color={isPast ? textTertiary : primaryColor}
+        />
+        <Text
+          style={[
+            styles.directionsButtonText,
+            { color: isPast ? textTertiary : primaryColor },
+          ]}
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
 function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
   const router = useRouter();
   const { user } = useAuth();
@@ -593,18 +669,29 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
     return colors.surface;
   })();
 
+  // Track pressed state manually. We can't use Pressable's function-form
+  // `style` prop because RN Web silently drops layout styles (padding,
+  // flexDirection, gap) returned from that function — the row would collapse
+  // on web. Instead, layout lives on the inner View and we flip the bg via
+  // state + onPressIn/Out.
+  const [isPressed, setIsPressed] = useState(false);
+
   return (
     <Pressable
       onPress={handlePress}
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
       accessibilityRole="button"
       accessibilityLabel={`${group.name} — ${channel.name}${
         eventWhen ? `, ${eventWhen.when}` : ""
       }${hasUnread ? `, ${channel.unreadCount} unread` : ""}`}
-      style={({ pressed }) => [
-        styles.eventRow,
-        { backgroundColor: pressed ? colors.surfaceSecondary : rowBackground },
-      ]}
     >
+      <View
+        style={[
+          styles.eventRow,
+          { backgroundColor: isPressed ? colors.surfaceSecondary : rowBackground },
+        ]}
+      >
       {/* Left accent bar — the primary imminence signal. Hidden for past rows
           and for events more than a week out; those rows read as "regular". */}
       <View
@@ -708,46 +795,17 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
             {eventWhen ? eventWhen.when : "Scheduled"}
           </Text>
           {locationShort ? (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={`Open ${channel.meetingLocation} in Maps`}
-              onPress={(e) => {
-                e.stopPropagation?.();
-                openMapsForLocation(channel.meetingLocation!);
-              }}
-              hitSlop={6}
-              style={({ pressed }) => [
-                styles.directionsButton,
-                {
-                  backgroundColor: isPast
-                    ? colors.surfaceSecondary
-                    : isDark
-                      ? primaryColor + "22"
-                      : primaryColor + "14",
-                  borderColor: isPast
-                    ? colors.border
-                    : isDark
-                      ? primaryColor + "44"
-                      : primaryColor + "33",
-                },
-                pressed && { opacity: 0.65 },
-              ]}
-            >
-              <Ionicons
-                name="navigate"
-                size={14}
-                color={isPast ? colors.textTertiary : primaryColor}
-              />
-              <Text
-                style={[
-                  styles.directionsButtonText,
-                  { color: isPast ? colors.textTertiary : primaryColor },
-                ]}
-                numberOfLines={1}
-              >
-                {locationShort}
-              </Text>
-            </Pressable>
+            <DirectionsButton
+              label={locationShort}
+              location={channel.meetingLocation!}
+              isPast={isPast}
+              isDark={isDark}
+              primaryColor={primaryColor}
+              borderColor={colors.border}
+              surfaceSecondary={colors.surfaceSecondary}
+              textTertiary={colors.textTertiary}
+              onOpenMaps={openMapsForLocation}
+            />
           ) : null}
         </View>
       </View>
@@ -764,6 +822,7 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
           </Text>
         </View>
       ) : null}
+      </View>
     </Pressable>
   );
 }

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -406,18 +406,31 @@ interface EventInboxRowItemProps {
 }
 
 /**
- * Format the event's scheduled time in two parts for the inbox row:
+ * Imminence tiers drive the row's visual treatment (accent bar color, tag
+ * pill visibility, muted styling). Kept as a small enum so the styling logic
+ * below can switch on it without re-deriving from raw ms deltas.
+ */
+type EventUrgency =
+  | "live" // scheduled start is within +/- 5 min, or event is in-progress
+  | "imminent" // starts in < 60 min
+  | "today" // same calendar day, > 60 min away
+  | "soon" // within 7 days
+  | "later" // more than 7 days away
+  | "past"; // scheduledAt has passed (and we're still in the 2-day grace window)
+
+/**
+ * Format the event's scheduled time for the inbox row.
  *   - `when`: short absolute — "Today 5:30 PM", "Tomorrow 5:30 PM",
  *     "Sat 5:30 PM" (this week), "Apr 28 5:30 PM" (same year), or
  *     "Apr 28, 2026" (other year).
- *   - `relative`: "in 45 min", "in 3h", "in 2d", "1d ago", "just now",
- *     etc. Undefined when the absolute label already makes it obvious
- *     (e.g. > 14 days away or > 14 days past).
+ *   - `relative`: compact hint like "in 28 min", "in 3h", "2d ago". Undefined
+ *     when the absolute label is already precise enough (>14 days out/past).
+ *   - `urgency`: tier used by the row to pick its visual treatment.
  */
 function formatEventWhen(
   scheduledAt: number,
   now: number,
-): { when: string; relative?: string } {
+): { when: string; relative?: string; urgency: EventUrgency } {
   const diffMs = scheduledAt - now;
   const diffMin = Math.round(diffMs / 60_000);
   const diffHour = Math.round(diffMs / 3_600_000);
@@ -456,7 +469,7 @@ function formatEventWhen(
 
   // Relative — only when the absolute phrasing doesn't already convey it.
   let relative: string | undefined;
-  if (Math.abs(diffMin) < 1) relative = "happening now";
+  if (Math.abs(diffMin) < 5) relative = undefined; // "Live" takes over the slot
   else if (diffMin > 0 && diffMin < 60) relative = `in ${diffMin} min`;
   else if (diffMin < 0 && diffMin > -60) relative = `${-diffMin} min ago`;
   else if (diffHour > 0 && diffHour < 24) relative = `in ${diffHour}h`;
@@ -464,7 +477,17 @@ function formatEventWhen(
   else if (diffDay > 1 && diffDay <= 14) relative = `in ${diffDay}d`;
   else if (diffDay < -1 && diffDay >= -14) relative = `${-diffDay}d ago`;
 
-  return { when, relative };
+  // Urgency — broad buckets chosen so the row's styling stays stable for at
+  // least a few minutes at a time (no flashing as the clock ticks).
+  let urgency: EventUrgency;
+  if (Math.abs(diffMin) < 5) urgency = "live";
+  else if (diffMin > 0 && diffMin < 60) urgency = "imminent";
+  else if (dayDelta === 0) urgency = "today";
+  else if (diffMs < 0) urgency = "past";
+  else if (diffDay >= 0 && diffDay <= 7) urgency = "soon";
+  else urgency = "later";
+
+  return { when, relative, urgency };
 }
 
 function openMapsForLocation(location: string) {
@@ -479,15 +502,35 @@ function openMapsForLocation(location: string) {
   });
 }
 
+/**
+ * Compress a free-form address into something that fits on the meta line.
+ * e.g. "123 Main St, Springfield, IL 62701, USA" -> "123 Main St, Springfield".
+ * The event page shows the full address; this is just a scanning aid.
+ */
+function shortLocation(loc: string): string {
+  const parts = loc.split(",").map((p) => p.trim()).filter(Boolean);
+  if (parts.length <= 2) return loc.trim();
+  return `${parts[0]}, ${parts[1]}`;
+}
+
 function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
   const router = useRouter();
   const { user } = useAuth();
   const { colors, isDark } = useTheme();
   const { primaryColor } = useCommunityTheme();
-  const userId = user?.id as Id<"users"> | undefined;
 
   const { channel, group, userRole } = row;
   const hasUnread = channel.unreadCount > 0;
+  const userId = user?.id as Id<"users"> | undefined;
+
+  // Last message preview in the same "Sender: text" shape group rows use, so
+  // event rows slot naturally into the mixed list.
+  const messagePreview = (() => {
+    if (!channel.lastMessagePreview) return "No messages yet";
+    const isOwn = userId && channel.lastMessageSenderId === userId;
+    const prefix = isOwn ? "Me" : channel.lastMessageSenderName;
+    return prefix ? `${prefix}: ${channel.lastMessagePreview}` : channel.lastMessagePreview;
+  })();
 
   // Event rows route to the event page with inline Activity (Partiful-style).
   // The `/inbox/{groupId}/event-{slug}` standalone room was removed — chat
@@ -512,35 +555,73 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
     });
   }, [router, group, channel, userRole]);
 
-  // On an event row the time + location are more useful than the last message
-  // preview (the event page shows comments anyway). Fall back to preview when
-  // the event has no scheduledAt — should be rare.
+  // Compute time + urgency. Undefined only for legacy rows with no scheduledAt.
   const eventWhen =
     typeof channel.meetingScheduledAt === "number"
       ? formatEventWhen(channel.meetingScheduledAt, Date.now())
       : null;
-  const messagePreview = (() => {
-    if (!channel.lastMessagePreview) return "No messages yet";
-    const isOwn = userId && channel.lastMessageSenderId === userId;
-    const prefix = isOwn ? "Me" : channel.lastMessageSenderName;
-    return prefix ? `${prefix}: ${channel.lastMessagePreview}` : channel.lastMessagePreview;
+
+  const urgency: EventUrgency = eventWhen?.urgency ?? "later";
+  const isPast = urgency === "past";
+  const isLive = urgency === "live";
+  const isImminent = urgency === "imminent";
+
+  // Accent bar color: strong primary for live/imminent, soft primary for
+  // "today", barely-there border tint for soon/later, fully invisible for past.
+  const accentColor = (() => {
+    if (isPast) return "transparent";
+    if (isLive || isImminent) return primaryColor;
+    if (urgency === "today") return primaryColor + "66"; // ~40% alpha
+    return "transparent";
+  })();
+
+  // Right-side relative tag: only rendered when the imminence is the point.
+  // For "soon"/"later"/"past" the absolute `when` string already tells the
+  // full story, so we don't pile on extra chrome.
+  const showRelativeTag = isLive || isImminent || urgency === "today";
+  const relativeTagLabel = isLive ? "Live now" : eventWhen?.relative;
+
+  const locationShort = channel.meetingLocation
+    ? shortLocation(channel.meetingLocation)
+    : null;
+
+  // Background: unread tint (as before), active (sidebar) tint, or surface.
+  // Past events get no tint — we want them to recede, not attract.
+  const rowBackground = (() => {
+    if (isActive) return colors.surfaceSecondary;
+    if (hasUnread && !isPast) return isDark ? colors.surfaceSecondary : "#F0F7FF";
+    return colors.surface;
   })();
 
   return (
     <Pressable
       onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={`${group.name} — ${channel.name}${
+        eventWhen ? `, ${eventWhen.when}` : ""
+      }${hasUnread ? `, ${channel.unreadCount} unread` : ""}`}
       style={({ pressed }) => [
         styles.eventRow,
-        { backgroundColor: colors.surface },
-        hasUnread && { backgroundColor: isDark ? colors.surfaceSecondary : "#F0F7FF" },
-        pressed && { backgroundColor: colors.surfaceSecondary },
-        isActive && { backgroundColor: colors.surfaceSecondary },
+        { backgroundColor: pressed ? colors.surfaceSecondary : rowBackground },
       ]}
     >
+      {/* Left accent bar — the primary imminence signal. Hidden for past rows
+          and for events more than a week out; those rows read as "regular". */}
+      <View
+        style={[
+          styles.eventAccentBar,
+          { backgroundColor: accentColor },
+        ]}
+        pointerEvents="none"
+      />
+
       <View style={styles.eventAvatarContainer}>
         <AppImage
           source={channel.meetingCoverImage || group.preview}
-          style={styles.eventAvatarImage}
+          style={[
+            styles.eventAvatarImage,
+            isPast && styles.eventAvatarMuted,
+          ]}
           optimizedWidth={150}
           placeholder={{
             type: "initials",
@@ -553,7 +634,10 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
         <View
           style={[
             styles.eventIconBadge,
-            { backgroundColor: primaryColor, borderColor: colors.surface },
+            {
+              backgroundColor: isPast ? colors.textTertiary : primaryColor,
+              borderColor: colors.surface,
+            },
           ]}
         >
           <Ionicons name="calendar" size={12} color="#fff" />
@@ -561,62 +645,116 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
       </View>
 
       <View style={styles.eventContent}>
+        {/* Line 1: "Group name: Event name" title + right-side urgency tag. */}
         <View style={styles.eventTopRow}>
           <Text
             style={[
               styles.eventName,
-              { color: colors.text },
-              hasUnread && styles.eventNameUnread,
+              { color: isPast ? colors.textSecondary : colors.text },
+              hasUnread && !isPast && styles.eventNameUnread,
             ]}
             numberOfLines={1}
           >
             {group.name}: {channel.name}
           </Text>
+          {showRelativeTag && relativeTagLabel ? (
+            <View
+              style={[
+                styles.eventUrgencyTag,
+                isLive
+                  ? { backgroundColor: primaryColor }
+                  : {
+                      backgroundColor: isDark
+                        ? primaryColor + "22"
+                        : primaryColor + "14",
+                    },
+              ]}
+            >
+              {isLive ? <View style={styles.eventLiveDot} /> : null}
+              <Text
+                style={[
+                  styles.eventUrgencyTagText,
+                  { color: isLive ? "#fff" : primaryColor },
+                ]}
+              >
+                {relativeTagLabel}
+              </Text>
+            </View>
+          ) : null}
         </View>
-        <View style={styles.eventBottomRow}>
+
+        {/* Line 2: last message preview — same vertical slot as group rows so
+            the list reads uniformly. */}
+        <Text
+          style={[
+            styles.eventPreview,
+            { color: isPast ? colors.textTertiary : colors.textSecondary },
+            hasUnread && !isPast && { fontWeight: "600", color: colors.text },
+          ]}
+          numberOfLines={1}
+        >
+          {messagePreview}
+        </Text>
+
+        {/* Line 3: small muted meta — absolute time + optional location chip. */}
+        <View style={styles.eventMetaRow}>
           <Text
             style={[
-              styles.eventPreview,
-              { color: colors.textSecondary },
-              hasUnread && { fontWeight: "600", color: colors.text },
+              styles.eventMetaText,
+              { color: isPast ? colors.textTertiary : colors.textSecondary },
             ]}
             numberOfLines={1}
           >
-            {eventWhen ? (
-              <>
-                {eventWhen.when}
-                {eventWhen.relative ? (
-                  <Text style={{ color: primaryColor, fontWeight: "600" }}>
-                    {" · "}{eventWhen.relative}
-                  </Text>
-                ) : null}
-              </>
-            ) : (
-              messagePreview
-            )}
+            {eventWhen ? eventWhen.when : "Scheduled"}
           </Text>
-          {channel.meetingLocation ? (
-            <Pressable
-              accessibilityLabel="Open in Maps"
-              onPress={(e) => {
-                // Prevent the row's onPress (open event page) from firing too.
-                e.stopPropagation?.();
-                openMapsForLocation(channel.meetingLocation!);
-              }}
-              hitSlop={8}
-              style={[
-                styles.mapsButton,
-                { borderColor: colors.border, backgroundColor: colors.surface },
-              ]}
-            >
-              <Ionicons name="location" size={14} color={primaryColor} />
-            </Pressable>
+          {locationShort ? (
+            <>
+              <Text
+                style={[styles.eventMetaSeparator, { color: colors.textTertiary }]}
+                accessibilityElementsHidden
+              >
+                {"·"}
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Open ${channel.meetingLocation} in Maps`}
+                onPress={(e) => {
+                  e.stopPropagation?.();
+                  openMapsForLocation(channel.meetingLocation!);
+                }}
+                hitSlop={{ top: 10, bottom: 10, left: 6, right: 6 }}
+                style={({ pressed }) => [
+                  styles.locationChip,
+                  pressed && { opacity: 0.6 },
+                ]}
+              >
+                <Ionicons
+                  name="location-outline"
+                  size={12}
+                  color={isPast ? colors.textTertiary : primaryColor}
+                />
+                <Text
+                  style={[
+                    styles.locationChipText,
+                    { color: isPast ? colors.textTertiary : primaryColor },
+                  ]}
+                  numberOfLines={1}
+                >
+                  {locationShort}
+                </Text>
+              </Pressable>
+            </>
           ) : null}
         </View>
       </View>
 
       {hasUnread ? (
-        <View style={[styles.eventUnreadBadge, { backgroundColor: primaryColor }]}>
+        <View
+          style={[
+            styles.eventUnreadBadge,
+            { backgroundColor: isPast ? colors.textTertiary : primaryColor },
+          ]}
+        >
           <Text style={styles.eventUnreadBadgeText}>
             {channel.unreadCount > 99 ? "99+" : channel.unreadCount}
           </Text>
@@ -685,8 +823,22 @@ const styles = StyleSheet.create({
   eventRow: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: 16,
+    // Left padding is slightly reduced (13 vs 16) to make room for the 3px
+    // accent bar so overall row padding still reads as 16. Group rows use
+    // 16 — the delta here is negligible (~1–2px) and keeps the avatar's
+    // horizontal position aligned with the group rows above/below.
+    paddingLeft: 13,
+    paddingRight: 16,
     paddingVertical: 12,
+  },
+  // Thin left accent bar — the primary imminence signal.
+  eventAccentBar: {
+    width: 3,
+    alignSelf: "stretch",
+    borderRadius: 2,
+    marginRight: 10,
+    // When there's no accent color the bar still occupies space so avatars
+    // stay aligned with accented siblings.
   },
   eventAvatarContainer: {
     position: "relative",
@@ -696,6 +848,9 @@ const styles = StyleSheet.create({
     width: 56,
     height: 56,
     borderRadius: 28,
+  },
+  eventAvatarMuted: {
+    opacity: 0.55,
   },
   eventIconBadge: {
     position: "absolute",
@@ -712,10 +867,18 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
   },
+  // Small muted group-name caption above the event title.
+  eventGroupCaption: {
+    fontSize: 11,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    marginBottom: 2,
+  },
   eventTopRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 4,
+    marginBottom: 3,
   },
   eventName: {
     fontSize: 16,
@@ -726,32 +889,65 @@ const styles = StyleSheet.create({
   eventNameUnread: {
     fontWeight: "700",
   },
-  eventPill: {
+  // Urgency pill — rendered only for live/imminent/today events.
+  eventUrgencyTag: {
+    flexDirection: "row",
+    alignItems: "center",
     paddingHorizontal: 8,
     paddingVertical: 2,
-    borderRadius: 12,
+    borderRadius: 10,
+    gap: 5,
   },
-  eventPillText: {
+  eventUrgencyTagText: {
     fontSize: 11,
-    fontWeight: "600",
+    fontWeight: "700",
+    letterSpacing: 0.2,
+  },
+  // "Live" pulsing-looking dot. No actual animation — animating on every
+  // visible row in the inbox is overkill; the solid dot + "Live now" label
+  // reads clearly enough.
+  eventLiveDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: "#fff",
   },
   eventBottomRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
   },
   eventPreview: {
     fontSize: 14,
-    flex: 1,
-    marginRight: 8,
+    marginTop: 2,
   },
-  mapsButton: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    borderWidth: 1,
+  eventMetaRow: {
+    flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
+    marginTop: 2,
+  },
+  eventMetaText: {
+    fontSize: 12,
+    flexShrink: 0,
+  },
+  eventMetaSeparator: {
+    fontSize: 12,
+    marginHorizontal: 6,
+  },
+  // Inline location chip — no border, no background, just icon + text tinted
+  // with primary color. Reads as "tappable" via the primary tint.
+  locationChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 3,
+    flexShrink: 1,
+    // Compensate for the small icon by keeping a healthy top/bottom hit area
+    // (see hitSlop on the Pressable).
+    paddingVertical: 2,
+  },
+  locationChipText: {
+    fontSize: 13,
+    fontWeight: "500",
+    flexShrink: 1,
   },
   eventUnreadBadge: {
     minWidth: 22,

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -63,6 +63,11 @@ type InboxChannel = {
    * rather than the legacy standalone chat room.
    */
   meetingShortId?: string | null;
+  /**
+   * For event channels, the owning meeting's cover image URL. The row
+   * renders this as the avatar so events look distinct from group channels.
+   */
+  meetingCoverImage?: string | null;
 };
 
 // Type for the grouped inbox data from getInboxChannels query
@@ -449,7 +454,7 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
     >
       <View style={styles.eventAvatarContainer}>
         <AppImage
-          source={group.preview}
+          source={channel.meetingCoverImage || group.preview}
           style={styles.eventAvatarImage}
           optimizedWidth={150}
           placeholder={{
@@ -458,14 +463,6 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
             backgroundColor: isDark ? "#333" : "#E5E5E5",
           }}
         />
-        <View
-          style={[
-            styles.eventIconBadge,
-            { backgroundColor: primaryColor, borderColor: colors.surface },
-          ]}
-        >
-          <Ionicons name="calendar" size={12} color="#fff" />
-        </View>
       </View>
 
       <View style={styles.eventContent}>
@@ -480,18 +477,6 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
           >
             {channel.name}
           </Text>
-          <View
-            style={[
-              styles.eventPill,
-              {
-                backgroundColor: isDark ? colors.surfaceSecondary : "#E5E7EB",
-              },
-            ]}
-          >
-            <Text style={[styles.eventPillText, { color: colors.textSecondary }]}>
-              Event
-            </Text>
-          </View>
         </View>
         <View style={styles.eventBottomRow}>
           <Text

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -475,6 +475,9 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
             ]}
             numberOfLines={1}
           >
+            <Text style={{ color: colors.textSecondary, fontWeight: "400" }}>
+              {group.name}:{" "}
+            </Text>
             {channel.name}
           </Text>
         </View>

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -4,6 +4,9 @@
  * Lists all user's groups with their channels, using grouped display.
  * Shows channels grouped by group - single channels show simple row,
  * multiple channels (e.g., main + leaders) show group header with indented channel rows.
+ *
+ * In addition, collects event-channels (channelType === "event") across all
+ * groups into a dedicated "Events" section pinned to the top of the list.
  */
 
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
@@ -14,6 +17,7 @@ import {
   ActivityIndicator,
   FlatList,
   ScrollView,
+  Pressable,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter, usePathname } from "expo-router";
@@ -21,11 +25,39 @@ import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@providers/AuthProvider";
 import { useQuery, api, useStoredAuthToken } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { AppImage } from "@components/ui";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { GroupedInboxItem } from "./GroupedInboxItem";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
+
+/**
+ * How long after an event's scheduledAt AND lastMessageAt before the channel
+ * is hidden from the inbox. Kept in sync with the backend source of truth at
+ * `apps/convex/functions/messaging/eventChat.ts` (exported as HIDE_AFTER_MS).
+ * Duplicated here (rather than imported across the mobile/convex package
+ * boundary) so the mobile bundle doesn't pull in convex server code. If you
+ * change one, change the other.
+ */
+const HIDE_AFTER_MS = 2 * 24 * 60 * 60 * 1000;
+
+// Type for a channel as returned by getInboxChannels
+type InboxChannel = {
+  _id: Id<"chatChannels">;
+  slug: string;
+  channelType: string;
+  name: string;
+  lastMessagePreview: string | null;
+  lastMessageAt: number | null;
+  lastMessageSenderName: string | null;
+  lastMessageSenderId: Id<"users"> | null;
+  unreadCount: number;
+  isShared?: boolean;
+  isEnabled?: boolean;
+  meetingId?: Id<"meetings">;
+  meetingScheduledAt?: number | null;
+};
 
 // Type for the grouped inbox data from getInboxChannels query
 type InboxGroup = {
@@ -38,17 +70,14 @@ type InboxGroup = {
     groupTypeSlug: string | undefined;
     isAnnouncementGroup: boolean | undefined;
   };
-  channels: Array<{
-    _id: Id<"chatChannels">;
-    slug: string;
-    channelType: string;
-    name: string;
-    lastMessagePreview: string | null;
-    lastMessageAt: number | null;
-    lastMessageSenderName: string | null;
-    lastMessageSenderId: Id<"users"> | null;
-    unreadCount: number;
-  }>;
+  channels: InboxChannel[];
+  userRole: "leader" | "member";
+};
+
+// An event row combines the channel with its owning group (for avatar + nav)
+type EventInboxRow = {
+  channel: InboxChannel;
+  group: InboxGroup["group"];
   userRole: "leader" | "member";
 };
 
@@ -162,6 +191,76 @@ export function ChatInboxScreen({
     });
   }, [sidebarMode, inboxChannels, pathname, router]);
 
+  // Resolve which channels we'll actually render. Use stale cached data while
+  // the live query is loading (stale-while-revalidate).
+  const isLoading = inboxChannels === undefined;
+  let displayChannels: InboxGroup[] | undefined = inboxChannels as
+    | InboxGroup[]
+    | undefined;
+  let isStale = false;
+  if (isLoading && communityId) {
+    const cached = getInboxChannels(communityId) as InboxGroup[] | undefined;
+    if (cached && cached.length > 0) {
+      displayChannels = cached;
+      isStale = true;
+    }
+  }
+
+  // Partition inbox channels into a flat "Events" list and the normal groups
+  // list. This must run before any early returns to keep hook order stable.
+  const now = Date.now();
+  const { eventRows, groupsForList } = useMemo(() => {
+    const eventRowsAcc: EventInboxRow[] = [];
+    const groupsAcc: InboxGroup[] = [];
+
+    if (!displayChannels) {
+      return { eventRows: eventRowsAcc, groupsForList: groupsAcc };
+    }
+
+    for (const g of displayChannels) {
+      const nonEventChannels: InboxChannel[] = [];
+      for (const ch of g.channels) {
+        // Hide disabled channels entirely (no muted label — keeps the inbox clean).
+        if (ch.isEnabled === false) continue;
+
+        if (ch.channelType === "event") {
+          // Hide stale event channels: both the event is >2d past AND the chat
+          // has been quiet for >2d. A new message bumps lastMessageAt and the
+          // row reappears automatically.
+          const scheduledAt = ch.meetingScheduledAt ?? 0;
+          const lastMessageAt = ch.lastMessageAt ?? 0;
+          const eventIsStale = scheduledAt + HIDE_AFTER_MS < now;
+          const chatIsStale = lastMessageAt + HIDE_AFTER_MS < now;
+          if (eventIsStale && chatIsStale) continue;
+
+          eventRowsAcc.push({
+            channel: ch,
+            group: g.group,
+            userRole: g.userRole,
+          });
+        } else {
+          nonEventChannels.push(ch);
+        }
+      }
+
+      if (nonEventChannels.length > 0) {
+        groupsAcc.push({ ...g, channels: nonEventChannels });
+      }
+    }
+
+    // Sort events by lastMessageAt desc; if neither side has a last message,
+    // fall back to meeting scheduledAt; no-data rows sink to the bottom.
+    eventRowsAcc.sort((a, b) => {
+      const aTime =
+        a.channel.lastMessageAt ?? a.channel.meetingScheduledAt ?? 0;
+      const bTime =
+        b.channel.lastMessageAt ?? b.channel.meetingScheduledAt ?? 0;
+      return bTime - aTime;
+    });
+
+    return { eventRows: eventRowsAcc, groupsForList: groupsAcc };
+  }, [displayChannels, now]);
+
   // Show message when user has no community context
   if (!hasCommunity) {
     return (
@@ -187,20 +286,6 @@ export function ChatInboxScreen({
     );
   }
 
-  const isLoading = inboxChannels === undefined;
-
-  // Stale-while-revalidate: show cached data while loading
-  let displayChannels = inboxChannels;
-  let isStale = false;
-
-  if (isLoading && communityId) {
-    const cached = getInboxChannels(communityId);
-    if (cached && cached.length > 0) {
-      displayChannels = cached;
-      isStale = true;
-    }
-  }
-
   const showLoadingSpinner = isLoading && !isStale;
 
   if (showLoadingSpinner) {
@@ -219,7 +304,9 @@ export function ChatInboxScreen({
     );
   }
 
-  if (!displayChannels || displayChannels.length === 0) {
+  const hasAnyContent = eventRows.length > 0 || groupsForList.length > 0;
+
+  if (!hasAnyContent) {
     return (
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
@@ -250,14 +337,170 @@ export function ChatInboxScreen({
           <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
         </View>
         <FlatList
-          data={displayChannels}
+          data={groupsForList}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           contentContainerStyle={styles.listContainer}
           style={styles.list}
+          ListHeaderComponent={
+            eventRows.length > 0 ? (
+              <EventsSection
+                rows={eventRows}
+                activeChannelSlug={sidebarMode ? activeChannelSlug : undefined}
+              />
+            ) : null
+          }
         />
       </View>
     </Wrapper>
+  );
+}
+
+// ============================================================================
+// Events section
+// ============================================================================
+
+interface EventsSectionProps {
+  rows: EventInboxRow[];
+  activeChannelSlug?: string;
+}
+
+function EventsSection({ rows, activeChannelSlug }: EventsSectionProps) {
+  const { colors } = useTheme();
+  return (
+    <View>
+      <View style={styles.sectionHeader}>
+        <Text style={[styles.sectionHeaderText, { color: colors.textSecondary }]}>
+          Events
+        </Text>
+      </View>
+      {rows.map((row) => (
+        <EventInboxRowItem
+          key={row.channel._id}
+          row={row}
+          isActive={activeChannelSlug === row.channel.slug}
+        />
+      ))}
+    </View>
+  );
+}
+
+interface EventInboxRowItemProps {
+  row: EventInboxRow;
+  isActive: boolean;
+}
+
+function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { colors, isDark } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const userId = user?.id as Id<"users"> | undefined;
+
+  const { channel, group, userRole } = row;
+  const hasUnread = channel.unreadCount > 0;
+
+  const handlePress = useCallback(() => {
+    router.push({
+      pathname: `/inbox/${group._id}/${channel.slug}` as any,
+      params: {
+        groupName: group.name,
+        groupType: group.groupTypeName || "",
+        groupTypeId: group.groupTypeId,
+        imageUrl: group.preview || "",
+        isLeader: userRole === "leader" ? "1" : "0",
+        isAnnouncementGroup: group.isAnnouncementGroup ? "1" : "0",
+        channelId: channel._id,
+      },
+    });
+  }, [router, group, channel, userRole]);
+
+  const messagePreview = (() => {
+    if (!channel.lastMessagePreview) return "No messages yet";
+    const isOwn = userId && channel.lastMessageSenderId === userId;
+    const prefix = isOwn ? "Me" : channel.lastMessageSenderName;
+    return prefix ? `${prefix}: ${channel.lastMessagePreview}` : channel.lastMessagePreview;
+  })();
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={({ pressed }) => [
+        styles.eventRow,
+        { backgroundColor: colors.surface },
+        hasUnread && { backgroundColor: isDark ? colors.surfaceSecondary : "#F0F7FF" },
+        pressed && { backgroundColor: colors.surfaceSecondary },
+        isActive && { backgroundColor: colors.surfaceSecondary },
+      ]}
+    >
+      <View style={styles.eventAvatarContainer}>
+        <AppImage
+          source={group.preview}
+          style={styles.eventAvatarImage}
+          optimizedWidth={150}
+          placeholder={{
+            type: "initials",
+            name: channel.name,
+            backgroundColor: isDark ? "#333" : "#E5E5E5",
+          }}
+        />
+        <View
+          style={[
+            styles.eventIconBadge,
+            { backgroundColor: primaryColor, borderColor: colors.surface },
+          ]}
+        >
+          <Ionicons name="calendar" size={12} color="#fff" />
+        </View>
+      </View>
+
+      <View style={styles.eventContent}>
+        <View style={styles.eventTopRow}>
+          <Text
+            style={[
+              styles.eventName,
+              { color: colors.text },
+              hasUnread && styles.eventNameUnread,
+            ]}
+            numberOfLines={1}
+          >
+            {channel.name}
+          </Text>
+          <View
+            style={[
+              styles.eventPill,
+              {
+                backgroundColor: isDark ? colors.surfaceSecondary : "#E5E7EB",
+              },
+            ]}
+          >
+            <Text style={[styles.eventPillText, { color: colors.textSecondary }]}>
+              Event
+            </Text>
+          </View>
+        </View>
+        <View style={styles.eventBottomRow}>
+          <Text
+            style={[
+              styles.eventPreview,
+              { color: colors.textSecondary },
+              hasUnread && { fontWeight: "600", color: colors.text },
+            ]}
+            numberOfLines={1}
+          >
+            {messagePreview}
+          </Text>
+        </View>
+      </View>
+
+      {hasUnread ? (
+        <View style={[styles.eventUnreadBadge, { backgroundColor: primaryColor }]}>
+          <Text style={styles.eventUnreadBadgeText}>
+            {channel.unreadCount > 99 ? "99+" : channel.unreadCount}
+          </Text>
+        </View>
+      ) : null}
+    </Pressable>
   );
 }
 
@@ -303,5 +546,94 @@ const styles = StyleSheet.create({
   },
   listContainer: {
     paddingVertical: 8,
+  },
+
+  // Events section
+  sectionHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 6,
+  },
+  sectionHeaderText: {
+    fontSize: 12,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  eventRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  eventAvatarContainer: {
+    position: "relative",
+    marginRight: 12,
+  },
+  eventAvatarImage: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+  },
+  eventIconBadge: {
+    position: "absolute",
+    bottom: 0,
+    right: 0,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 2,
+  },
+  eventContent: {
+    flex: 1,
+    justifyContent: "center",
+  },
+  eventTopRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  eventName: {
+    fontSize: 16,
+    fontWeight: "600",
+    flex: 1,
+    marginRight: 8,
+  },
+  eventNameUnread: {
+    fontWeight: "700",
+  },
+  eventPill: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+  },
+  eventPillText: {
+    fontSize: 11,
+    fontWeight: "600",
+  },
+  eventBottomRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  eventPreview: {
+    fontSize: 14,
+    flex: 1,
+    marginRight: 8,
+  },
+  eventUnreadBadge: {
+    minWidth: 22,
+    height: 22,
+    borderRadius: 11,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 6,
+    marginLeft: 8,
+  },
+  eventUnreadBadgeText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "700",
   },
 });

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -40,6 +40,9 @@ interface ChannelData {
   lastMessageSenderId: Id<"users"> | null;
   unreadCount: number;
   isShared?: boolean;
+  isEnabled?: boolean;
+  meetingId?: Id<"meetings">;
+  meetingScheduledAt?: number | null;
 }
 
 // Type for group data from getInboxChannels query

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -72,6 +72,8 @@ interface MessageItemProps {
     hideLinkPreview?: boolean;
     reachOutRequestId?: Id<"reachOutRequests">;
     taskId?: Id<"tasks">;
+    /** Present only on messages that mirror an event text blast (SMS + push). */
+    blastId?: Id<"eventBlasts">;
   };
   currentUserId: Id<"users">;
   groupId?: Id<"groups">;
@@ -977,6 +979,24 @@ function MessageItemInner({
                 {renderAudioAttachments()}
                 {renderVideoAttachments()}
 
+                {/* SMS blast badge — shown on messages mirrored from an event text blast */}
+                {message.blastId && !message.isDeleted && (
+                  <View
+                    style={styles.blastBadge}
+                    accessibilityLabel="This message was also sent as an SMS and push notification"
+                  >
+                    <Ionicons
+                      name="megaphone-outline"
+                      size={11}
+                      color={themeColors.textSecondary}
+                      style={styles.blastBadgeIcon}
+                    />
+                    <Text style={[styles.blastBadgeText, { color: themeColors.textSecondary }]}>
+                      Also sent via SMS
+                    </Text>
+                  </View>
+                )}
+
                 {/* Timestamp and edited badge */}
                 <View style={[styles.messageFooter, styles.bubbleFooter]}>
                   <Text
@@ -1192,6 +1212,24 @@ const styles = StyleSheet.create({
     fontSize: 10,
     marginLeft: 4,
     fontStyle: 'italic',
+  },
+  blastBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    marginHorizontal: 10,
+    marginTop: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 10,
+    backgroundColor: 'rgba(0,0,0,0.06)',
+  },
+  blastBadgeIcon: {
+    marginRight: 3,
+  },
+  blastBadgeText: {
+    fontSize: 10,
+    fontWeight: '500',
   },
   attachmentsContainer: {
     marginTop: 4,

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -67,6 +67,8 @@ interface Message {
   reachOutRequestId?: Id<"reachOutRequests">;
   // Canonical task reference for task cards
   taskId?: Id<"tasks">;
+  // Present only on messages mirrored from an event text blast (SMS + push).
+  blastId?: Id<"eventBlasts">;
 }
 
 interface MessageListProps {
@@ -345,6 +347,7 @@ export function MessageList({
             hideLinkPreview: message.hideLinkPreview,
             reachOutRequestId: message.reachOutRequestId,
             taskId: message.taskId,
+            blastId: message.blastId,
           }}
           currentUserId={currentUserId}
           groupId={groupId}

--- a/apps/mobile/features/events/components/EventRsvpSection.tsx
+++ b/apps/mobile/features/events/components/EventRsvpSection.tsx
@@ -55,6 +55,12 @@ interface FloatingRsvpButtonsProps {
   onSelect: (id: number) => void;
   insets: { bottom: number };
   tabBarOffset?: number;
+  /**
+   * When true, the component renders as a regular flex child (no absolute
+   * positioning, no top border, no safe-area padding). Used when embedded
+   * inside a shared bottom dock that handles those concerns.
+   */
+  embedded?: boolean;
 }
 
 interface FloatingRsvpCardProps {
@@ -69,6 +75,12 @@ interface FloatingRsvpCardProps {
   maxGuests?: number;
   insets: { bottom: number };
   tabBarOffset?: number;
+  /**
+   * When true, the component renders as a regular flex child (no absolute
+   * positioning, no top border, no safe-area padding). Used when embedded
+   * inside a shared bottom dock that handles those concerns.
+   */
+  embedded?: boolean;
 }
 
 interface RsvpEditModalProps {
@@ -256,12 +268,27 @@ export function FloatingRsvpButtons({
   onSelect,
   insets,
   tabBarOffset = 0,
+  embedded = false,
 }: FloatingRsvpButtonsProps) {
   const { colors } = useTheme();
   const enabledOptions = options.filter((opt) => opt.enabled).slice(0, 3);
 
   return (
-    <View style={[styles.container, { paddingBottom: insets.bottom + 20, bottom: tabBarOffset, backgroundColor: colors.surface, borderTopColor: colors.border }]}>
+    <View
+      style={
+        embedded
+          ? styles.embeddedContainer
+          : [
+              styles.container,
+              {
+                paddingBottom: insets.bottom + 20,
+                bottom: tabBarOffset,
+                backgroundColor: colors.surface,
+                borderTopColor: colors.border,
+              },
+            ]
+      }
+    >
       <View style={styles.buttonRow}>
         {enabledOptions.map((option) => {
           const emoji = getEmojiForLabel(option.label);
@@ -304,6 +331,7 @@ export function FloatingRsvpCard({
   maxGuests = DEFAULT_MAX_GUESTS_PER_RSVP,
   insets,
   tabBarOffset = 0,
+  embedded = false,
 }: FloatingRsvpCardProps) {
   const { colors } = useTheme();
   const selectedOption = options.find((opt) => opt.id === response.optionId);
@@ -360,38 +388,67 @@ export function FloatingRsvpCard({
     run(next);
   };
 
+  const showInlineStepper = isGoing && !!onGuestCountChange;
+
   return (
-    <View style={[styles.cardContainer, { paddingBottom: insets.bottom + 20, bottom: tabBarOffset, backgroundColor: colors.surface, borderTopColor: colors.border }]}>
+    <View
+      style={
+        embedded
+          ? styles.embeddedContainer
+          : [
+              styles.cardContainer,
+              {
+                paddingBottom: insets.bottom + 20,
+                bottom: tabBarOffset,
+                backgroundColor: colors.surface,
+                borderTopColor: colors.border,
+              },
+            ]
+      }
+    >
       <View style={styles.card}>
-        <TouchableOpacity
-          testID="floating-rsvp-card"
-          style={styles.cardContent}
-          onPress={onEdit}
-          activeOpacity={0.7}
-        >
-          <Text style={styles.cardEmoji}>{emoji}</Text>
-          <View style={styles.cardTextContent}>
-            <Text style={styles.statusLabel}>
-              {label}
-              {isGoing && displayedGuestCount > 0
-                ? ` · +${displayedGuestCount} guest${displayedGuestCount === 1 ? "" : "s"}`
-                : ""}
-            </Text>
-            <Text style={[styles.editPrompt, { color: colors.textSecondary }]}>Edit your RSVP</Text>
-          </View>
-          <Ionicons name="create-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
-        </TouchableOpacity>
-        {isGoing && onGuestCountChange && (
-          <View style={styles.cardStepperRow}>
+        <View style={styles.cardContent}>
+          {/* Left side (emoji + label stack) is the edit target. */}
+          <TouchableOpacity
+            testID="floating-rsvp-card"
+            style={styles.cardEditTarget}
+            onPress={onEdit}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.cardEmoji}>{emoji}</Text>
+            <View style={styles.cardTextContent}>
+              <Text style={styles.statusLabel} numberOfLines={1}>
+                {label}
+              </Text>
+              <Text
+                style={[styles.editPrompt, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                Edit your RSVP
+              </Text>
+            </View>
+          </TouchableOpacity>
+
+          {/* Inline stepper — its taps must NOT trigger the edit modal. */}
+          {showInlineStepper && (
             <GuestStepper
               value={displayedGuestCount}
               onChange={handleGuestChange}
               max={maxGuests}
-              label={displayedGuestCount === 0 ? "Bringing guests?" : "Guests"}
+              label=""
               compact
             />
-          </View>
-        )}
+          )}
+
+          <TouchableOpacity
+            onPress={onEdit}
+            activeOpacity={0.7}
+            hitSlop={8}
+            style={styles.cardEditIcon}
+          >
+            <Ionicons name="create-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
   );
@@ -623,14 +680,25 @@ const styles = StyleSheet.create({
   cardContent: {
     flexDirection: "row",
     alignItems: "center",
-    padding: 16,
-    gap: 12,
+    padding: 12,
+    gap: 10,
+  },
+  cardEditTarget: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  cardEditIcon: {
+    padding: 4,
   },
   cardEmoji: {
     fontSize: 28,
   },
   cardTextContent: {
-    flex: 1,
+    flexShrink: 1,
+    minWidth: 0,
   },
   statusLabel: {
     fontSize: 16,
@@ -713,12 +781,10 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
 
-  // Card stepper row
-  cardStepperRow: {
-    paddingHorizontal: 16,
+  // Embedded mode — the parent dock handles surface, padding, and position.
+  embeddedContainer: {
+    paddingTop: 12,
+    paddingHorizontal: 20,
     paddingBottom: 12,
-    borderTopWidth: 1,
-    borderTopColor: "rgba(0, 0, 0, 0.06)",
-    marginTop: -4,
   },
 });

--- a/apps/mobile/features/events/components/EventRsvpSection.tsx
+++ b/apps/mobile/features/events/components/EventRsvpSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -169,16 +169,18 @@ export function GuestStepper({
 
   return (
     <View style={[stepperStyles.row, compact && stepperStyles.rowCompact]}>
-      <Text
-        style={[
-          stepperStyles.label,
-          { color: colors.textSecondary },
-          compact && stepperStyles.labelCompact,
-        ]}
-        numberOfLines={1}
-      >
-        {label}
-      </Text>
+      {label ? (
+        <Text
+          style={[
+            stepperStyles.label,
+            { color: colors.textSecondary },
+            compact && stepperStyles.labelCompact,
+          ]}
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
+      ) : null}
       <View style={[stepperStyles.controls, { borderColor: colors.border }]}>
         <TouchableOpacity
           testID="guest-stepper-decrement"
@@ -338,57 +340,7 @@ export function FloatingRsvpCard({
   const emoji = selectedOption ? getEmojiForLabel(selectedOption.label) : "👍";
   const label = selectedOption ? getCleanLabel(selectedOption.label) : "Going";
   const isGoing = selectedOption ? isGoingOptionLabel(selectedOption.label) : false;
-  const guestCount = response.guestCount ?? 0;
-  const [pendingGuestCount, setPendingGuestCount] = useState<number | null>(null);
-
-  // Clear local pending state once the query result catches up.
-  useEffect(() => {
-    if (pendingGuestCount !== null && pendingGuestCount === guestCount) {
-      setPendingGuestCount(null);
-    }
-  }, [guestCount, pendingGuestCount]);
-
-  const displayedGuestCount = pendingGuestCount ?? guestCount;
-
-  // Serialize stepper writes. Rapid taps used to fire concurrent mutations
-  // and, because the backend applies last-write-by-arrival, an earlier
-  // request that finished later could overwrite the user's latest intent.
-  // Instead: at most one request in flight; newer taps stash the latest
-  // value in `queuedRef` and are drained once the current write settles.
-  const inFlightRef = useRef(false);
-  const queuedRef = useRef<number | null>(null);
-
-  const handleGuestChange = (next: number) => {
-    if (!onGuestCountChange) return;
-    setPendingGuestCount(next);
-
-    if (inFlightRef.current) {
-      queuedRef.current = next;
-      return;
-    }
-
-    const run = (value: number) => {
-      inFlightRef.current = true;
-      Promise.resolve(onGuestCountChange(value))
-        .then(() => {
-          inFlightRef.current = false;
-          const queued = queuedRef.current;
-          queuedRef.current = null;
-          if (queued !== null && queued !== value) {
-            run(queued);
-          }
-        })
-        .catch(() => {
-          inFlightRef.current = false;
-          queuedRef.current = null;
-          setPendingGuestCount(null);
-        });
-    };
-
-    run(next);
-  };
-
-  const showInlineStepper = isGoing && !!onGuestCountChange;
+  const displayedGuestCount = response.guestCount ?? 0;
 
   return (
     <View
@@ -407,48 +359,29 @@ export function FloatingRsvpCard({
       }
     >
       <View style={styles.card}>
-        <View style={styles.cardContent}>
-          {/* Left side (emoji + label stack) is the edit target. */}
-          <TouchableOpacity
-            testID="floating-rsvp-card"
-            style={styles.cardEditTarget}
-            onPress={onEdit}
-            activeOpacity={0.7}
-          >
-            <Text style={styles.cardEmoji}>{emoji}</Text>
-            <View style={styles.cardTextContent}>
-              <Text style={styles.statusLabel} numberOfLines={1}>
-                {label}
-              </Text>
-              <Text
-                style={[styles.editPrompt, { color: colors.textSecondary }]}
-                numberOfLines={1}
-              >
-                Edit your RSVP
-              </Text>
-            </View>
-          </TouchableOpacity>
-
-          {/* Inline stepper — its taps must NOT trigger the edit modal. */}
-          {showInlineStepper && (
-            <GuestStepper
-              value={displayedGuestCount}
-              onChange={handleGuestChange}
-              max={maxGuests}
-              label=""
-              compact
-            />
-          )}
-
-          <TouchableOpacity
-            onPress={onEdit}
-            activeOpacity={0.7}
-            hitSlop={8}
-            style={styles.cardEditIcon}
-          >
-            <Ionicons name="create-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          testID="floating-rsvp-card"
+          style={styles.cardContent}
+          onPress={onEdit}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.cardEmoji}>{emoji}</Text>
+          <View style={styles.cardTextContent}>
+            <Text style={styles.statusLabel} numberOfLines={1}>
+              {label}
+              {isGoing && displayedGuestCount > 0
+                ? ` · +${displayedGuestCount} guest${displayedGuestCount === 1 ? "" : "s"}`
+                : ""}
+            </Text>
+            <Text
+              style={[styles.editPrompt, { color: colors.textSecondary }]}
+              numberOfLines={1}
+            >
+              Edit your RSVP
+            </Text>
+          </View>
+          <Ionicons name="create-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
+        </TouchableOpacity>
       </View>
     </View>
   );

--- a/apps/mobile/features/events/components/EventRsvpSection.tsx
+++ b/apps/mobile/features/events/components/EventRsvpSection.tsx
@@ -366,20 +366,12 @@ export function FloatingRsvpCard({
           activeOpacity={0.7}
         >
           <Text style={styles.cardEmoji}>{emoji}</Text>
-          <View style={styles.cardTextContent}>
-            <Text style={styles.statusLabel} numberOfLines={1}>
-              {label}
-              {isGoing && displayedGuestCount > 0
-                ? ` · +${displayedGuestCount} guest${displayedGuestCount === 1 ? "" : "s"}`
-                : ""}
-            </Text>
-            <Text
-              style={[styles.editPrompt, { color: colors.textSecondary }]}
-              numberOfLines={1}
-            >
-              Edit your RSVP
-            </Text>
-          </View>
+          <Text style={styles.statusLabel} numberOfLines={1}>
+            {label}
+            {isGoing && displayedGuestCount > 0
+              ? ` · +${displayedGuestCount} guest${displayedGuestCount === 1 ? "" : "s"}`
+              : ""}
+          </Text>
           <Ionicons name="create-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
         </TouchableOpacity>
       </View>
@@ -613,34 +605,18 @@ const styles = StyleSheet.create({
   cardContent: {
     flexDirection: "row",
     alignItems: "center",
-    padding: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
     gap: 10,
-  },
-  cardEditTarget: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    flexShrink: 1,
-    minWidth: 0,
-  },
-  cardEditIcon: {
-    padding: 4,
   },
   cardEmoji: {
-    fontSize: 28,
-  },
-  cardTextContent: {
-    flexShrink: 1,
-    minWidth: 0,
+    fontSize: 22,
   },
   statusLabel: {
+    flex: 1,
     fontSize: 16,
     fontWeight: "600",
     color: DEFAULT_PRIMARY_COLOR,
-    marginBottom: 2,
-  },
-  editPrompt: {
-    fontSize: 13,
   },
 
   // Modal

--- a/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
@@ -44,34 +44,26 @@ export function EventBlastSheet({
       return;
     }
 
-    Alert.alert(
-      "Send Text Blast",
-      `Text all attendees of ${eventTitle}? The message will also post to the event's Activity feed.`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Send",
-          onPress: async () => {
-            setIsSending(true);
-            try {
-              await initiateBlast({
-                meetingId: meetingId as Id<"meetings">,
-                message: message.trim(),
-                channels: ["sms"],
-              });
-              setMessage("");
-              onSent();
-              onClose();
-            } catch (error) {
-              Alert.alert("Error", "Failed to send message. Please try again.");
-              console.error("Blast send error:", error);
-            } finally {
-              setIsSending(false);
-            }
-          },
-        },
-      ]
-    );
+    // Note: no confirm dialog. RN Web's Alert.alert is window.alert and does
+    // not support multi-button callbacks, so a second confirm silently no-ops
+    // on web. The sheet + Send button is already the explicit action.
+    setIsSending(true);
+    try {
+      await initiateBlast({
+        meetingId: meetingId as Id<"meetings">,
+        message: message.trim(),
+        channels: ["sms"],
+      });
+      setMessage("");
+      onSent();
+      onClose();
+      Alert.alert("Text blast sent", "Your message is on its way.");
+    } catch (error) {
+      Alert.alert("Error", "Failed to send message. Please try again.");
+      console.error("Blast send error:", error);
+    } finally {
+      setIsSending(false);
+    }
   };
 
   return (

--- a/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
@@ -8,7 +8,6 @@ import {
   ActivityIndicator,
   Alert,
   Modal,
-  Switch,
   KeyboardAvoidingView,
   Platform,
 } from "react-native";
@@ -35,8 +34,6 @@ export function EventBlastSheet({
 }: EventBlastSheetProps) {
   const { colors } = useTheme();
   const [message, setMessage] = useState("");
-  const [pushEnabled, setPushEnabled] = useState(true);
-  const [smsEnabled, setSmsEnabled] = useState(false);
   const [isSending, setIsSending] = useState(false);
 
   const initiateBlast = useAuthenticatedMutation(api.functions.eventBlasts.initiate);
@@ -47,18 +44,9 @@ export function EventBlastSheet({
       return;
     }
 
-    const channels: string[] = [];
-    if (pushEnabled) channels.push("push");
-    if (smsEnabled) channels.push("sms");
-
-    if (channels.length === 0) {
-      Alert.alert("No Channel", "Please select at least one channel (Push or SMS).");
-      return;
-    }
-
     Alert.alert(
-      "Send Message",
-      `Send this message to all attendees via ${channels.join(" & ")}?`,
+      "Send Text Blast",
+      `Text all attendees of ${eventTitle}? The message will also post to the event's Activity feed.`,
       [
         { text: "Cancel", style: "cancel" },
         {
@@ -69,7 +57,7 @@ export function EventBlastSheet({
               await initiateBlast({
                 meetingId: meetingId as Id<"meetings">,
                 message: message.trim(),
-                channels,
+                channels: ["sms"],
               });
               setMessage("");
               onSent();
@@ -110,7 +98,7 @@ export function EventBlastSheet({
             {/* Header */}
             <View style={[styles.header, { borderBottomColor: colors.border }]}>
               <Text style={[styles.title, { color: colors.text }]}>
-                Message Attendees
+                Text Blast
               </Text>
               <TouchableOpacity onPress={onClose}>
                 <Ionicons name="close" size={24} color={colors.text} />
@@ -119,7 +107,7 @@ export function EventBlastSheet({
 
             <View style={styles.body}>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                Send a message to everyone going to {eventTitle}
+                Text everyone going to {eventTitle}. The message will also post to the event's Activity feed.
               </Text>
 
               {/* Message Input */}
@@ -144,37 +132,6 @@ export function EventBlastSheet({
                 {message.length}/500
               </Text>
 
-              {/* Channel Selection */}
-              <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
-                SEND VIA
-              </Text>
-              <View style={[styles.channelRow, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
-                <View style={styles.channelInfo}>
-                  <Ionicons name="notifications-outline" size={20} color={colors.text} />
-                  <Text style={[styles.channelLabel, { color: colors.text }]}>
-                    Push Notification
-                  </Text>
-                </View>
-                <Switch
-                  value={pushEnabled}
-                  onValueChange={setPushEnabled}
-                  trackColor={{ false: colors.border, true: DEFAULT_PRIMARY_COLOR }}
-                />
-              </View>
-              <View style={[styles.channelRow, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
-                <View style={styles.channelInfo}>
-                  <Ionicons name="chatbubble-outline" size={20} color={colors.text} />
-                  <Text style={[styles.channelLabel, { color: colors.text }]}>
-                    SMS Text Message
-                  </Text>
-                </View>
-                <Switch
-                  value={smsEnabled}
-                  onValueChange={setSmsEnabled}
-                  trackColor={{ false: colors.border, true: DEFAULT_PRIMARY_COLOR }}
-                />
-              </View>
-
               {/* Send Button */}
               <TouchableOpacity
                 style={[
@@ -188,7 +145,7 @@ export function EventBlastSheet({
                 {isSending ? (
                   <ActivityIndicator color="#fff" />
                 ) : (
-                  <Text style={styles.sendButtonText}>Send Message</Text>
+                  <Text style={styles.sendButtonText}>Send Text Blast</Text>
                 )}
               </TouchableOpacity>
             </View>
@@ -239,29 +196,6 @@ const styles = StyleSheet.create({
     textAlign: "right",
     marginTop: 4,
     marginBottom: 16,
-  },
-  sectionLabel: {
-    fontSize: 12,
-    fontWeight: "600",
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  channelRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    padding: 14,
-    borderRadius: 12,
-    borderWidth: 1,
-    marginBottom: 8,
-  },
-  channelInfo: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-  },
-  channelLabel: {
-    fontSize: 16,
   },
   sendButton: {
     borderRadius: 12,

--- a/apps/mobile/features/leader-tools/components/EventDetails.tsx
+++ b/apps/mobile/features/leader-tools/components/EventDetails.tsx
@@ -690,7 +690,7 @@ export function EventDetails({
               >
                 <Ionicons name="megaphone-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
                 <Text style={[styles.messageAttendeesText, { color: DEFAULT_PRIMARY_COLOR }]}>
-                  Message Attendees
+                  Text Blast
                 </Text>
               </TouchableOpacity>
             )}


### PR DESCRIPTION
## Summary

- **New event chat**: users who RSVP to an event (plus the host) get access to a chat channel scoped to that event. Reuses the existing `chatChannels` / `chatChannelMembers` / `chatMessages` infrastructure — one new `channelType: "event"` with a `meetingId` backlink, no parallel schema.
- **Works for non-group-members**: the whole point. Public event RSVPers aren't in the host's group, and now they can message the host to confirm the address (which was the original ask — see the screenshot on issue/DM thread).
- **Text blasts mirror into the chat**: when a host sends a text blast, the message now also appears in the event chat as a real text from the host, with an "Also sent via SMS" badge on the bubble. Chat becomes the durable record of everything sent to attendees.

## Design notes

- **Lazy create**: the channel row doesn't exist until someone sends the first message (or the first blast goes out). Events nobody talks about don't clutter the DB.
- **Access = host + any enabled-option RSVPer**. For v1, every RSVP counts as access (even "Not Going") — the `rsvpOptions` array is free-form per-event, so there's no fixed Going/Maybe/NotGoing enum to gate on. Easy to narrow later.
- **Disable**: event creator or group leader can disable the chat from the event page. Disabled channels are hidden from the inbox and `sendMessage` is rejected.
- **Inbox hide rule**: event channels auto-hide when `scheduledAt + 2d` AND `lastMessageAt + 2d` are both in the past. A new message bumps `lastMessageAt` and the channel reappears. `HIDE_AFTER_MS` is a single tunable constant (mirrored on mobile with a pointer comment).

## Changes

**Backend**
- `apps/convex/schema.ts`: `chatChannels.meetingId` + `disabledByUserId` + `by_meetingId` index; `chatMessages.blastId`.
- `apps/convex/functions/messaging/eventChat.ts` (new): `getChannelByMeetingId`, `ensureEventChannel`, `setEventChannelEnabled`, `addEventChannelMember`, `removeEventChannelMember`, `canAccessEventChannel`, `HIDE_AFTER_MS`.
- `apps/convex/functions/messaging/messages.ts`: `sendMessage` accepts `{ meetingId }` as a first-send lazy-create path; event channels bypass group-membership gating and use `canAccessEventChannel`.
- `apps/convex/functions/messaging/channels.ts`: `getInboxChannels` surfaces event channels to non-group-members who are `chatChannelMembers`, and includes `isEnabled`/`meetingId`/`meetingScheduledAt` so mobile can apply the hide rule.
- `apps/convex/functions/meetingRsvps.ts`: `submit` / `remove` / `batchUpdate` call `add/removeEventChannelMember` to keep chat membership in sync with RSVP state.
- `apps/convex/functions/eventBlasts.ts`: `recordBlast` mirrors the blast into the chat as a real text message with `blastId` set.

**Mobile**
- `apps/mobile/app/e/[shortId]/EventPageClient.tsx`: Chat button for host + RSVPers; inline enable/disable toggle for host/leaders with confirm dialog.
- `apps/mobile/features/chat/components/ChatInboxScreen.tsx`: new "Events" section with the stale-channel hide rule.
- `apps/mobile/features/chat/components/MessageItem.tsx`: "Also sent via SMS" megaphone badge on mirrored blast messages.

## Test plan

- [x] `pnpm test` (convex): 1342/1342 pass including 26 new `event-chat.test.ts` tests covering ensure/get/setEnabled/add+remove/RSVP sync/blast mirror.
- [x] `tsc --noEmit` clean on convex and on the mobile files touched.
- [ ] Manual: host sends a text blast → chat channel is created + shows the message with SMS badge.
- [ ] Manual: non-group-member RSVPs to a public event → finds the chat in their inbox under "Events" and can message the host.
- [ ] Manual: RSVP → chat appears in inbox. Un-RSVP (via remove) → chat drops out of inbox.
- [ ] Manual: host disables chat from event page → attendees see no chat button, inbox row hides, sendMessage rejected.
- [ ] Manual: event > 2 days in the past with no recent messages → hidden from inbox. Send a message → reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)