### PR TITLE
feat(events): move chat toggle to edit page + add hide-RSVP-count option

### DIFF
--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -233,6 +233,7 @@ export const update = mutation({
         })
       )
     ),
+    hideRsvpCount: v.optional(v.boolean()),
     visibility: v.optional(v.string()),
     scope: v.optional(v.union(v.literal("this_date_all_groups"), v.literal("all_in_series"))),
   },
@@ -342,6 +343,7 @@ export const update = mutation({
     // cover of its own.
     if (args.rsvpEnabled !== undefined) childUpdates.rsvpEnabled = args.rsvpEnabled;
     if (args.rsvpOptions !== undefined) childUpdates.rsvpOptions = args.rsvpOptions;
+    if (args.hideRsvpCount !== undefined) childUpdates.hideRsvpCount = args.hideRsvpCount;
     if (args.visibility !== undefined) childUpdates.visibility = args.visibility;
 
     // Update all non-overridden child meetings
@@ -592,6 +594,7 @@ export const createSeries = mutation({
     meetingLink: v.optional(v.string()),
     note: v.optional(v.string()),
     coverImage: v.optional(v.string()),
+    hideRsvpCount: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -686,6 +689,7 @@ export const createSeries = mutation({
           visibility: "community",
           rsvpEnabled: true,
           rsvpOptions: DEFAULT_RSVP_OPTIONS,
+          hideRsvpCount: args.hideRsvpCount,
           communityId: args.communityId,
           searchText: buildMeetingSearchText({
             title: args.title,

--- a/apps/convex/functions/meetings/communityEvents.ts
+++ b/apps/convex/functions/meetings/communityEvents.ts
@@ -48,6 +48,7 @@ export const createCommunityWideEvent = mutation({
         })
       )
     ),
+    hideRsvpCount: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -140,6 +141,7 @@ export const createCommunityWideEvent = mutation({
         createdAt: timestamp,
         rsvpEnabled: effectiveRsvpEnabled,
         rsvpOptions: effectiveRsvpOptions,
+        hideRsvpCount: args.hideRsvpCount,
         communityId: args.communityId,
         searchText: buildMeetingSearchText({
           title: args.title,

--- a/apps/convex/functions/meetings/events.ts
+++ b/apps/convex/functions/meetings/events.ts
@@ -74,6 +74,9 @@ type SingleEventCard = {
       profileImage: string | null;
     }>;
   };
+  hideRsvpCount: boolean;
+  createdById: Id<"users"> | null;
+  viewerIsLeader: boolean;
 };
 
 type CommunityWideCard = {
@@ -105,6 +108,7 @@ export const listForEventsTab = query({
 
     const {
       userGroupIds,
+      userLeaderGroupIds,
       isCommunityMember,
       userRsvpMeetingIds,
       userHostedMeetingIds,
@@ -204,7 +208,10 @@ export const listForEventsTab = query({
         )
       ).values()
     );
-    const enrichment = await buildEnrichment(ctx, uniqueForEnrichment);
+    const enrichment = await buildEnrichment(ctx, uniqueForEnrichment, {
+      userId,
+      leaderGroupIds: userLeaderGroupIds,
+    });
 
     return {
       myEvents: myEventsCandidates.map((m) => buildSingleCard(m, enrichment)),
@@ -228,7 +235,7 @@ export const getCommunityWideEventChildren = query({
     const parent = await ctx.db.get(args.parentId);
     if (!parent) return { parent: null, children: [] };
 
-    const { userGroupIds, isCommunityMember } =
+    const { userGroupIds, userLeaderGroupIds, isCommunityMember } =
       await loadVisibilityContext(ctx, userId, parent.communityId);
 
     const children = await ctx.db
@@ -259,7 +266,10 @@ export const getCommunityWideEventChildren = query({
     );
     visible.sort((a, b) => a.scheduledAt - b.scheduledAt);
 
-    const enrichment = await buildEnrichment(ctx, visible);
+    const enrichment = await buildEnrichment(ctx, visible, {
+      userId,
+      leaderGroupIds: userLeaderGroupIds,
+    });
     const cards = visible.map((m) => buildSingleCard(m, enrichment));
 
     return {
@@ -295,11 +305,8 @@ export const listLaterEvents = query({
   },
   handler: async (ctx, args) => {
     const userId = await getOptionalAuth(ctx, args.token);
-    const { userGroupIds, isCommunityMember } = await loadVisibilityContext(
-      ctx,
-      userId,
-      args.communityId
-    );
+    const { userGroupIds, userLeaderGroupIds, isCommunityMember } =
+      await loadVisibilityContext(ctx, userId, args.communityId);
 
     const weekCutoff = args.now + SEVEN_DAYS_MS;
     const page = await ctx.db
@@ -327,7 +334,10 @@ export const listLaterEvents = query({
       isVisible(m, userId, userGroupIds, isCommunityMember)
     );
 
-    const enrichment = await buildEnrichment(ctx, visible);
+    const enrichment = await buildEnrichment(ctx, visible, {
+      userId,
+      leaderGroupIds: userLeaderGroupIds,
+    });
     // Use a limit equal to the fetched count so buildBucket never truncates
     // a page — Convex pagination controls the size upstream.
     const cards = buildBucket(visible, visible.length, enrichment);
@@ -500,11 +510,21 @@ type Enrichment = {
   // Reading this prevents the old bug where a CWE card showed "0 going"
   // when the RSVP'd child was routed to a different section.
   totalGoingByParent: Map<Id<"communityWideEvents">, number>;
+  // Viewer context — used to stamp each SingleEventCard with
+  // `viewerIsLeader` so the client can decide whether to reveal a hidden
+  // RSVP count. Populated only when enrichment is built inside a query
+  // that knows the viewer; defaults to empty sets when not.
+  viewerId?: Id<"users"> | null;
+  viewerLeaderGroupIds?: Set<string>;
 };
 
 export async function buildEnrichment(
   ctx: QueryCtx,
-  meetings: MeetingWithGroup[]
+  meetings: MeetingWithGroup[],
+  viewer?: {
+    userId: Id<"users"> | null;
+    leaderGroupIds: Set<string>;
+  }
 ): Promise<Enrichment> {
   const groupTypeIds = [
     ...new Set(meetings.map((m) => m.group.groupTypeId)),
@@ -606,6 +626,8 @@ export async function buildEnrichment(
     usersMap,
     parentsMap,
     totalGoingByParent,
+    viewerId: viewer?.userId ?? null,
+    viewerLeaderGroupIds: viewer?.leaderGroupIds ?? new Set(),
   };
 }
 
@@ -742,5 +764,10 @@ function buildSingleCard(
       totalGoing: goingRsvps.length,
       topGoingGuests,
     },
+    hideRsvpCount: m.hideRsvpCount === true,
+    createdById: m.createdById ?? null,
+    viewerIsLeader:
+      (e.viewerLeaderGroupIds?.has(m.group._id) ?? false) ||
+      (!!e.viewerId && !!m.createdById && e.viewerId === m.createdById),
   };
 }

--- a/apps/convex/functions/meetings/explore.ts
+++ b/apps/convex/functions/meetings/explore.ts
@@ -10,6 +10,7 @@ import { query } from "../../_generated/server";
 import { Id, Doc } from "../../_generated/dataModel";
 import { now, getMediaUrl } from "../../lib/utils";
 import { getOptionalAuth } from "../../lib/auth";
+import { isLeaderRole } from "../../lib/helpers";
 
 /**
  * Resolve effective cover images for a batch of meetings, using the CWE
@@ -81,6 +82,9 @@ export const communityEvents = query({
 
     // Get user's group memberships for visibility filtering
     const userGroupIds: Set<string> = new Set();
+    // Groups where the viewer has a leader role — used to decide whether they
+    // can see RSVP counts on events with `hideRsvpCount` enabled.
+    const leaderGroupIds: Set<string> = new Set();
     // Get user's community memberships for visibility filtering
     const userCommunityIds: Set<string> = new Set();
     if (userId) {
@@ -100,6 +104,9 @@ export const communityEvents = query({
 
       for (const m of memberships) {
         userGroupIds.add(m.groupId);
+        if (isLeaderRole(m.role)) {
+          leaderGroupIds.add(m.groupId);
+        }
       }
 
       // Get user's community memberships
@@ -321,6 +328,14 @@ export const communityEvents = query({
           totalGoing: goingRsvps.length,
           topGoingGuests,
         },
+        // RSVP count visibility. `hideRsvpCount` is the event-level flag;
+        // `viewerIsLeader` is true when the viewer can see the count/badge
+        // (event creator or a leader of the hosting group).
+        hideRsvpCount: meeting.hideRsvpCount === true,
+        createdById: meeting.createdById ?? null,
+        viewerIsLeader:
+          leaderGroupIds.has(meeting.group._id) ||
+          (!!userId && meeting.createdById === userId),
       };
     });
 

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -125,6 +125,7 @@ export const create = mutation({
         })
       )
     ),
+    hideRsvpCount: v.optional(v.boolean()),
     visibility: v.optional(v.string()),
     seriesId: v.optional(v.id("eventSeries")),
   },
@@ -210,6 +211,7 @@ export const create = mutation({
       createdAt: timestamp,
       rsvpEnabled: effectiveRsvpEnabled,
       rsvpOptions: effectiveRsvpOptions,
+      hideRsvpCount: args.hideRsvpCount,
       visibility: args.visibility,
       seriesId: args.seriesId,
       // Scheduled job fields
@@ -302,6 +304,7 @@ export const update = mutation({
         })
       )
     ),
+    hideRsvpCount: v.optional(v.boolean()),
     visibility: v.optional(v.string()),
     scope: v.optional(v.union(v.literal("this_only"), v.literal("all_in_series"))),
   },
@@ -525,6 +528,7 @@ export const update = mutation({
       }
       if (updates.rsvpEnabled !== undefined) seriesUpdates.rsvpEnabled = updates.rsvpEnabled;
       if (updates.rsvpOptions !== undefined) seriesUpdates.rsvpOptions = updates.rsvpOptions;
+      if (updates.hideRsvpCount !== undefined) seriesUpdates.hideRsvpCount = updates.hideRsvpCount;
       if (updates.visibility !== undefined) seriesUpdates.visibility = updates.visibility;
       if (updates.locationOverride !== undefined) seriesUpdates.locationOverride = updates.locationOverride;
 
@@ -695,6 +699,7 @@ export const createSeriesEvents = mutation({
         })
       )
     ),
+    hideRsvpCount: v.optional(v.boolean()),
     visibility: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -764,6 +769,7 @@ export const createSeriesEvents = mutation({
         createdAt: timestamp,
         rsvpEnabled: effectiveRsvpEnabled,
         rsvpOptions: effectiveRsvpOptions,
+        hideRsvpCount: args.hideRsvpCount,
         visibility: args.visibility,
         seriesId,
         reminderAt,

--- a/apps/convex/functions/meetings/queries.ts
+++ b/apps/convex/functions/meetings/queries.ts
@@ -12,7 +12,7 @@ import { now, normalizePagination, getMediaUrl } from "../../lib/utils";
 import { paginationArgs, meetingStatusValidator } from "../../lib/validators";
 import { getOptionalAuth } from "../../lib/auth";
 import { getSeriesNumber } from "../eventSeries";
-import { isActiveLeader } from "../../lib/helpers";
+import { isActiveLeader, isLeaderRole } from "../../lib/helpers";
 
 /**
  * "Hosted by [name]" (ADR-022) only applies to *member-led* events — i.e.
@@ -152,6 +152,12 @@ export const getByShortId = query({
       };
     }
 
+    // Viewer is treated as a leader (and thus can see the hidden RSVP count)
+    // when they lead the hosting group OR are the event creator.
+    const viewerIsLeader =
+      isLeaderRole(userRole) ||
+      (!!userId && !!meeting.createdById && userId === meeting.createdById);
+
     // Return full meeting data if user has access, limited data otherwise
     return {
       id: meeting._id,
@@ -174,6 +180,11 @@ export const getByShortId = query({
       rsvpEnabled: meeting.rsvpEnabled ?? true,
       rsvpOptions: meeting.rsvpOptions || [],
       rsvpCounts,
+      // When true, attendees can RSVP but the count is hidden from non-leaders.
+      hideRsvpCount: meeting.hideRsvpCount === true,
+      // True when the viewer should see the hidden count (leader of the
+      // hosting group or the event creator).
+      viewerIsLeader,
       // Group info
       groupId: group._id,
       groupName: group.name,

--- a/apps/convex/functions/meetings/queries.ts
+++ b/apps/convex/functions/meetings/queries.ts
@@ -76,6 +76,33 @@ export const getByShortId = query({
     let hasAccess = false;
     let userRole: string | null = null;
 
+    // Look up the viewer's group membership up front so we always know their
+    // role, independent of how access is granted. Without this, leaders who
+    // view public/community events (where hasAccess is granted by visibility
+    // alone) would never populate userRole, and `viewerIsLeader` below would
+    // incorrectly flip to false — causing group leaders to lose hidden-count
+    // visibility on their own group's public events.
+    const groupMembership = userId
+      ? await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", meeting.groupId).eq("userId", userId)
+          )
+          .filter((q) =>
+            q.and(
+              q.eq(q.field("leftAt"), undefined),
+              q.or(
+                q.eq(q.field("requestStatus"), undefined),
+                q.eq(q.field("requestStatus"), "accepted")
+              )
+            )
+          )
+          .first()
+      : null;
+    if (groupMembership) {
+      userRole = groupMembership.role || "member";
+    }
+
     // Check visibility-based access
     const visibility = meeting.visibility || "group";
     if (visibility === "public") {
@@ -89,28 +116,8 @@ export const getByShortId = query({
         )
         .first();
       hasAccess = !!communityMembership;
-    } else if (userId) {
-      // Check if user is a member of the group
-      const groupMembership = await ctx.db
-        .query("groupMembers")
-        .withIndex("by_group_user", (q) =>
-          q.eq("groupId", meeting.groupId).eq("userId", userId)
-        )
-        .filter((q) =>
-          q.and(
-            q.eq(q.field("leftAt"), undefined),
-            q.or(
-              q.eq(q.field("requestStatus"), undefined),
-              q.eq(q.field("requestStatus"), "accepted")
-            )
-          )
-        )
-        .first();
-
-      if (groupMembership) {
-        hasAccess = true;
-        userRole = groupMembership.role || "member";
-      }
+    } else if (groupMembership) {
+      hasAccess = true;
     }
 
     // Get group type name

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -106,6 +106,49 @@ export const getChannelByMeetingId = query({
   },
 });
 
+/**
+ * Editor-only view of the channel state. Returns the real `isEnabled`
+ * value regardless of whether the caller can access the chat itself —
+ * leaders/admins who can edit the meeting may not be RSVPers/hosts and
+ * would otherwise see `null` from `getChannelByMeetingId` whether the
+ * channel is disabled or nonexistent. Without this distinction the edit
+ * form defaults to "enabled" and a no-op toggle never fires the persist
+ * mutation, making re-enable impossible from that screen.
+ *
+ * Returns `{ exists: false, isEnabled: true }` when no channel row exists
+ * yet (matches the default state on first materialization).
+ */
+export const getChannelStateForEditor = query({
+  args: {
+    token: v.string(),
+    meetingId: v.id("meetings"),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ exists: boolean; isEnabled: boolean } | null> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const meeting = await ctx.db.get(args.meetingId);
+    if (!meeting) return null;
+
+    if (!(await canEditMeeting(ctx, userId, meeting))) {
+      return null;
+    }
+
+    const channel = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_meetingId", (q) => q.eq("meetingId", args.meetingId))
+      .first();
+
+    if (!channel) {
+      return { exists: false, isEnabled: true };
+    }
+
+    return { exists: true, isEnabled: channel.isEnabled !== false };
+  },
+});
+
 // ============================================================================
 // Internal mutations
 // ============================================================================

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -609,6 +609,9 @@ export default defineSchema({
         }),
       ),
     ),
+    // When true, attendees can RSVP but the count is hidden from non-leaders.
+    // Leaders/host still see the count with a "Leaders only" badge.
+    hideRsvpCount: v.optional(v.boolean()),
 
     // Visibility
     visibility: v.optional(v.string()), // 'group' | 'community' | 'public'

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -260,9 +260,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   // Event Chat Mutations
   // ============================================================================
 
-  const setEventChannelEnabledMutation = useAuthenticatedMutation(
-    api.functions.messaging.eventChat.setEventChannelEnabled
-  );
   const openEventChatMutation = useAuthenticatedMutation(
     api.functions.messaging.eventChat.openEventChat
   );
@@ -330,44 +327,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     materializedChannelId,
     openEventChatMutation,
   ]);
-
-  const handleToggleEventChat = async (enabled: boolean) => {
-    if (!eventData?.id) return;
-    const applyToggle = async () => {
-      try {
-        await setEventChannelEnabledMutation({
-          meetingId: eventData.id as Id<"meetings">,
-          enabled,
-        });
-      } catch (err) {
-        console.error("Failed to toggle event chat:", err);
-        Alert.alert("Error", "Failed to update event chat. Please try again.");
-      }
-    };
-
-    // Confirm before disabling; re-enabling is a straight call.
-    // RN Web's Alert.alert is window.alert and can't fire multi-button
-    // callbacks — use window.confirm on web.
-    if (!enabled) {
-      const confirmMessage = "Disable event chat? Attendees won't be able to message the group.";
-      if (Platform.OS === "web") {
-        if (typeof window !== "undefined" && window.confirm(confirmMessage)) {
-          await applyToggle();
-        }
-        return;
-      }
-      Alert.alert(
-        "Disable event chat?",
-        "Attendees won't be able to message the group.",
-        [
-          { text: "Cancel", style: "cancel" },
-          { text: "Disable", style: "destructive", onPress: applyToggle },
-        ]
-      );
-      return;
-    }
-    await applyToggle();
-  };
 
   // ============================================================================
   // Loading & Error States
@@ -912,6 +871,8 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
               rsvpData={rsvpData as RsvpData}
               rsvpOptions={rsvpOptions}
               onViewAll={handleViewGuestList}
+              hideRsvpCount={(eventData as any)?.hideRsvpCount === true}
+              canSeeCount={canEdit}
             />
           )}
 
@@ -972,24 +933,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                 <Switch
                   value={rsvpNotifyLeaders}
                   onValueChange={handleToggleRsvpNotify}
-                  trackColor={{ false: colors.border, true: DEFAULT_PRIMARY_COLOR }}
-                />
-              </View>
-            </View>
-          )}
-
-          {/* Host/Leader: enable/disable event chat. Backend enforces the same
-              permission (event creator, group leader, or community admin). */}
-          {canEdit && (
-            <View style={[styles.leaderCard, { backgroundColor: colors.surfaceSecondary }]}>
-              <View style={styles.leaderCardRow}>
-                <Ionicons name="chatbubble-ellipses-outline" size={20} color={colors.textSecondary} />
-                <Text style={[styles.leaderCardText, { color: colors.text }]}>
-                  Event chat
-                </Text>
-                <Switch
-                  value={isChatEnabled}
-                  onValueChange={handleToggleEventChat}
                   trackColor={{ false: colors.border, true: DEFAULT_PRIMARY_COLOR }}
                 />
               </View>

--- a/apps/mobile/features/chat/components/EventLinkCard.tsx
+++ b/apps/mobile/features/chat/components/EventLinkCard.tsx
@@ -95,6 +95,8 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
       accessPrompt: data.accessPrompt,
       status: data.status as string | undefined,
       cancellationReason: data.cancellationReason as string | undefined,
+      hideRsvpCount: data.hideRsvpCount === true,
+      viewerIsLeader: data.viewerIsLeader === true,
     };
   }, [eventData]);
 
@@ -265,8 +267,10 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
     };
   };
 
-  // Avatar stack component
-  const AvatarStack = ({ users }: { users: RsvpUser[] }) => {
+  // Avatar stack component. When the RSVP count is private (hidden from
+  // non-leaders), render "+ more" instead of a numeric overflow so we don't
+  // leak the headcount through the stack.
+  const AvatarStack = ({ users, hideOverflowCount }: { users: RsvpUser[]; hideOverflowCount?: boolean }) => {
     if (users.length === 0) return null;
 
     const displayUsers = users.slice(0, 3);
@@ -284,7 +288,9 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
           />
         ))}
         {remainingCount > 0 && (
-          <Text style={[styles.remainingCount, { color: colors.textSecondary }]}>+{remainingCount}</Text>
+          <Text style={[styles.remainingCount, { color: colors.textSecondary }]}>
+            {hideOverflowCount ? 'and more' : `+${remainingCount}`}
+          </Text>
         )}
       </View>
     );
@@ -296,6 +302,11 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
       <View style={[styles.progressBar, { width: `${percentage}%` }]} />
     </View>
   );
+
+  // Whether the numeric RSVP count should be suppressed for this viewer.
+  // Avatars stay visible either way so there's still some social proof.
+  const countIsHidden = !!event?.hideRsvpCount && !event?.viewerIsLeader;
+  const showLeaderBadge = !!event?.hideRsvpCount && !!event?.viewerIsLeader;
 
   // RSVP option row
   const RsvpOptionRow = ({ option }: { option: RsvpOption }) => {
@@ -348,11 +359,13 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
             </Text>
           </View>
           <View style={styles.rsvpStats}>
-            <AvatarStack users={stats.users} />
-            <Text style={[styles.rsvpCount, { color: colors.textSecondary }]}>{stats.count}</Text>
+            <AvatarStack users={stats.users} hideOverflowCount={countIsHidden} />
+            {!countIsHidden && (
+              <Text style={[styles.rsvpCount, { color: colors.textSecondary }]}>{stats.count}</Text>
+            )}
           </View>
         </View>
-        <ProgressBar percentage={stats.percentage} />
+        {!countIsHidden && <ProgressBar percentage={stats.percentage} />}
       </TouchableOpacity>
     );
   };
@@ -519,6 +532,14 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
         {/* RSVP Options - hide when cancelled or past */}
         {!isCancelled && !isPastEvent && event.rsvpEnabled && rsvpOptions.length > 0 && (
           <View style={styles.rsvpSection}>
+            {showLeaderBadge && (
+              <View style={[styles.leaderBadge, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
+                <Ionicons name="eye-outline" size={12} color={colors.textSecondary} />
+                <Text style={[styles.leaderBadgeText, { color: colors.textSecondary }]}>
+                  RSVP count hidden from attendees · only you see this
+                </Text>
+              </View>
+            )}
             {rsvpsLoading ? (
               <View style={styles.loadingContainer}>
                 <ActivityIndicator size="small" color={DEFAULT_PRIMARY_COLOR} />
@@ -650,6 +671,20 @@ const styles = StyleSheet.create({
   rsvpSection: {
     padding: 16,
     gap: 12,
+  },
+  leaderBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+  },
+  leaderBadgeText: {
+    fontSize: 11,
+    fontWeight: '500',
   },
   guestStepperRow: {
     paddingTop: 12,

--- a/apps/mobile/features/events/components/CommunityWideEventSheet.tsx
+++ b/apps/mobile/features/events/components/CommunityWideEventSheet.tsx
@@ -75,6 +75,9 @@ function toCommunityEvent(child: any): CommunityEvent {
       totalGoing: child.rsvpSummary.totalGoing,
       topGoingGuests: child.rsvpSummary.topGoingGuests,
     },
+    hideRsvpCount: child.hideRsvpCount === true,
+    createdById: child.createdById ?? null,
+    viewerIsLeader: child.viewerIsLeader === true,
   };
 }
 

--- a/apps/mobile/features/events/components/EventCard.tsx
+++ b/apps/mobile/features/events/components/EventCard.tsx
@@ -59,6 +59,15 @@ export function EventCard({ event, onPress }: EventCardProps) {
   const visibleGuests = topGoingGuests.slice(0, maxVisibleAvatars);
   const remainingCount = totalGoing > maxVisibleAvatars ? totalGoing - maxVisibleAvatars : 0;
 
+  // When hideRsvpCount is on, non-leaders see avatars + a generic "+ more"
+  // overflow instead of the numeric count. We still hide the whole section
+  // if there isn't a full stack of avatars to show — a single avatar next to
+  // "+ more" would telegraph roughly-how-many as clearly as a number.
+  const countIsHidden = event.hideRsvpCount && !event.viewerIsLeader;
+  const showRsvpSection = countIsHidden
+    ? visibleGuests.length >= maxVisibleAvatars
+    : totalGoing > 0;
+
   return (
     <TouchableOpacity
       style={styles.container}
@@ -133,7 +142,7 @@ export function EventCard({ event, onPress }: EventCardProps) {
         )}
 
         {/* RSVP Summary */}
-        {totalGoing > 0 && (
+        {showRsvpSection && (
           <View style={styles.rsvpSection}>
             <View style={styles.avatarsRow}>
               {visibleGuests.map((guest, index) => (
@@ -151,15 +160,25 @@ export function EventCard({ event, onPress }: EventCardProps) {
                   />
                 </View>
               ))}
-              {remainingCount > 0 && (
+              {remainingCount > 0 && !countIsHidden && (
                 <View style={[styles.avatarWrapper, styles.avatarWrapperOverlap, styles.countBadge]}>
                   <Text style={styles.countText}>+{remainingCount}</Text>
                 </View>
               )}
+              {remainingCount > 0 && countIsHidden && (
+                <Text style={styles.moreText}>and more</Text>
+              )}
             </View>
-            <Text style={styles.rsvpText}>
-              {totalGoing} {totalGoing === 1 ? 'person' : 'people'} going
-            </Text>
+            {!countIsHidden && (
+              <Text style={styles.rsvpText}>
+                {totalGoing} {totalGoing === 1 ? 'person' : 'people'} going
+              </Text>
+            )}
+            {event.hideRsvpCount && event.viewerIsLeader && (
+              <View style={styles.leaderBadge}>
+                <Text style={styles.leaderBadgeText}>Leaders only</Text>
+              </View>
+            )}
           </View>
         )}
       </View>
@@ -309,6 +328,12 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     borderColor: '#fff',
   },
+  moreText: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: COLORS.textMuted,
+    marginLeft: 8,
+  },
   countText: {
     fontSize: 9,
     fontWeight: '600',
@@ -318,5 +343,19 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: COLORS.textMuted,
     fontWeight: '500',
+  },
+  leaderBadge: {
+    marginLeft: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#e5e5e5',
+    backgroundColor: '#f5f5f5',
+  },
+  leaderBadgeText: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: COLORS.textMuted,
   },
 });

--- a/apps/mobile/features/events/components/EventGuestList.tsx
+++ b/apps/mobile/features/events/components/EventGuestList.tsx
@@ -40,7 +40,16 @@ interface GuestListPreviewProps {
   rsvpData: RsvpData;
   rsvpOptions: RsvpOption[];
   onViewAll: () => void;
+  /** When true, the RSVP count is considered private. */
+  hideRsvpCount?: boolean;
+  /** When true, the viewer is a leader/host and sees the count + "Leaders only" badge. */
+  canSeeCount?: boolean;
 }
+
+// Threshold: when hideRsvpCount is on, only show the avatar stack to
+// non-leaders if there are at least this many attendees. Below the threshold,
+// a sparse row would telegraph the low count — hide the whole section instead.
+const AVATAR_ROW_MIN_FOR_HIDDEN_COUNT = 5;
 
 // ============================================================================
 // Component
@@ -54,8 +63,15 @@ export function GuestListPreview({
   rsvpData,
   rsvpOptions,
   onViewAll,
+  hideRsvpCount = false,
+  canSeeCount = false,
 }: GuestListPreviewProps) {
   const { colors } = useTheme();
+  // When the flag is on and the viewer isn't a leader/host, suppress the
+  // count/subtitle/view-all button. We still render the avatar stack if
+  // there are enough attendees to fill the row (otherwise the sparse stack
+  // would leak roughly how many RSVP'd).
+  const countIsHidden = hideRsvpCount && !canSeeCount;
   // Find the "Going" option to show those guests. Uses the same heuristic
   // as isGoingOption in apps/convex/lib/rsvpGuests.ts so decline variants
   // ("Not Going") aren't mistakenly treated as Going.
@@ -97,16 +113,34 @@ export function GuestListPreview({
     return null;
   }
 
+  // Non-leaders with hidden count: drop the whole section when we don't have
+  // enough avatars to present a "full" stack without revealing the small
+  // headcount.
+  if (countIsHidden && totalCount < AVATAR_ROW_MIN_FOR_HIDDEN_COUNT) {
+    return null;
+  }
+
   return (
     <View style={[styles.container, { borderTopColor: colors.border }]}>
       <View style={styles.header}>
-        <View>
-          <Text style={[styles.title, { color: colors.text }]}>Guest List</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{subtitleText}</Text>
+        <View style={{ flex: 1 }}>
+          <View style={styles.titleRow}>
+            <Text style={[styles.title, { color: colors.text }]}>Guest List</Text>
+            {hideRsvpCount && canSeeCount && (
+              <View style={[styles.leaderBadge, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
+                <Text style={[styles.leaderBadgeText, { color: colors.textSecondary }]}>Leaders only</Text>
+              </View>
+            )}
+          </View>
+          {!countIsHidden && (
+            <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{subtitleText}</Text>
+          )}
         </View>
-        <TouchableOpacity style={[styles.viewAllButton, { backgroundColor: colors.surfaceSecondary }]} onPress={onViewAll}>
-          <Text style={[styles.viewAllText, { color: colors.text }]}>View all</Text>
-        </TouchableOpacity>
+        {!countIsHidden && (
+          <TouchableOpacity style={[styles.viewAllButton, { backgroundColor: colors.surfaceSecondary }]} onPress={onViewAll}>
+            <Text style={[styles.viewAllText, { color: colors.text }]}>View all</Text>
+          </TouchableOpacity>
+        )}
       </View>
       <View style={styles.avatarStack}>
         {displayUsers.map((user, index) => (
@@ -126,12 +160,15 @@ export function GuestListPreview({
             />
           </View>
         ))}
-        {overflowCount > 0 && (
+        {overflowCount > 0 && !countIsHidden && (
           <View style={[styles.avatarWrapper, { marginLeft: -8 }]}>
             <View style={styles.overflowBadge}>
               <Text style={styles.overflowText}>+{overflowCount}</Text>
             </View>
           </View>
+        )}
+        {overflowCount > 0 && countIsHidden && (
+          <Text style={[styles.moreText, { color: colors.textSecondary }]}>and more</Text>
         )}
       </View>
     </View>
@@ -154,10 +191,26 @@ const styles = StyleSheet.create({
     alignItems: "flex-start",
     marginBottom: 16,
   },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 4,
+    flexWrap: "wrap",
+  },
   title: {
     fontSize: 18,
     fontWeight: "600",
-    marginBottom: 4,
+  },
+  leaderBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+    borderWidth: 1,
+  },
+  leaderBadgeText: {
+    fontSize: 11,
+    fontWeight: "600",
   },
   subtitle: {
     fontSize: 14,
@@ -195,5 +248,13 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 12,
     fontWeight: "600",
+  },
+  // Inline "and more" label beside the avatar stack when the numeric count is
+  // hidden from the viewer. No chrome — a pill badge next to circular avatars
+  // reads awkwardly.
+  moreText: {
+    fontSize: 14,
+    fontWeight: "500",
+    marginLeft: 10,
   },
 });

--- a/apps/mobile/features/events/components/EventsScreen.tsx
+++ b/apps/mobile/features/events/components/EventsScreen.tsx
@@ -80,6 +80,9 @@ function toCommunityEvent(card: any): CommunityEvent {
       totalGoing: card.rsvpSummary.totalGoing,
       topGoingGuests: card.rsvpSummary.topGoingGuests,
     },
+    hideRsvpCount: card.hideRsvpCount === true,
+    createdById: card.createdById ?? null,
+    viewerIsLeader: card.viewerIsLeader === true,
   };
 }
 

--- a/apps/mobile/features/events/hooks/useCommunityEvents.ts
+++ b/apps/mobile/features/events/hooks/useCommunityEvents.ts
@@ -54,6 +54,11 @@ export interface CommunityEvent {
       profileImage: string | null;
     }>;
   };
+  /** When true, RSVP count is hidden from non-leaders. Leaders still see it with a "Leaders only" badge. */
+  hideRsvpCount: boolean;
+  createdById: string | null;
+  /** True when the viewer is a leader of the hosting group or the event creator. */
+  viewerIsLeader: boolean;
 }
 
 // Stable empty arrays/objects to prevent infinite re-renders

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -487,25 +487,6 @@ export function CreateEventScreen() {
           hideRsvpCount: data.hideRsvpCount,
           visibility: data.visibility,
         });
-        // Persist the event chat toggle separately (it lives on chatChannels,
-        // not on the meeting). Fire the mutation only when the effective
-        // state changed. When no channel exists yet the effective state is
-        // "enabled" (default), so flipping to disabled triggers a
-        // materialize-and-patch via setEventChannelEnabled. Backend enforces
-        // permissions.
-        if (
-          eventChannel !== undefined &&
-          eventChatEnabled !== initialEventChatEnabled
-        ) {
-          try {
-            await setEventChannelEnabledMutation({
-              meetingId: data.meetingId as Id<"meetings">,
-              enabled: eventChatEnabled,
-            });
-          } catch (err) {
-            console.warn("Failed to update event chat toggle:", err);
-          }
-        }
         // Convex automatically updates queries
         router.back();
       } catch (error: any) {
@@ -792,11 +773,32 @@ export function CreateEventScreen() {
         const hasSeries = !!meeting?.seriesId;
         const isCommunityWide = !!meeting?.communityWideEventId;
 
+        // Event chat lives on chatChannels, not on the meeting. Flip it once
+        // up front for the meeting being edited so the state persists no
+        // matter which scope branch runs (single, series, or CWE-wide). The
+        // toggle is inherently per-meeting, so we never cascade it.
+        const persistEventChatToggle = async () => {
+          if (
+            eventChannel !== undefined &&
+            eventChatEnabled !== initialEventChatEnabled
+          ) {
+            try {
+              await setEventChannelEnabledMutation({
+                meetingId: meetingId as Id<"meetings">,
+                enabled: eventChatEnabled,
+              });
+            } catch (err) {
+              console.warn("Failed to update event chat toggle:", err);
+            }
+          }
+        };
+
         // Determine edit scope. Cross-cutting scopes on a community-wide
         // event route to `communityWideEvents.update`, which cascades to every
         // sibling. Single-meeting edits (and series-only) stay on
         // `meetings.update`. Matches the cancel flow split.
         const performUpdate = async (scope?: EditScope) => {
+          await persistEventChatToggle();
           if (
             isCommunityWide &&
             (scope === "this_date_all_groups" || scope === "all_in_series") &&
@@ -823,6 +825,7 @@ export function CreateEventScreen() {
                 // cascade across differing group addresses.
                 rsvpEnabled: data.rsvpEnabled,
                 rsvpOptions: data.rsvpOptions,
+                hideRsvpCount: data.hideRsvpCount,
                 visibility: data.visibility,
                 scope,
               });
@@ -891,6 +894,7 @@ export function CreateEventScreen() {
             meetingLink: data.meetingLink,
             note: data.note,
             coverImage: finalCoverImage,
+            hideRsvpCount: data.hideRsvpCount,
           });
           Alert.alert(
             "Series Created",
@@ -924,6 +928,7 @@ export function CreateEventScreen() {
             coverImage: finalCoverImage,
             rsvpEnabled: data.rsvpEnabled,
             rsvpOptions: data.rsvpOptions,
+            hideRsvpCount: data.hideRsvpCount,
             visibility: data.visibility,
           });
           Alert.alert(
@@ -953,6 +958,7 @@ export function CreateEventScreen() {
             coverImage: finalCoverImage,
             rsvpEnabled: data.rsvpEnabled,
             rsvpOptions: data.rsvpOptions,
+            hideRsvpCount: data.hideRsvpCount,
           });
           Alert.alert(
             "Events Created",

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -332,26 +332,25 @@ export function CreateEventScreen() {
     }
   }, [meeting, isEditMode, isCweAdminEdit, parentCweData]);
 
-  // Load event chat on/off state from the chat channel (edit mode only).
-  // Chat state lives on chatChannels, not the meeting, so we fetch and save it
-  // independently of the meeting update mutation. A `null` channel means no
-  // channel row exists yet — in that case the effective state is "enabled"
-  // (channels default to isEnabled: true on materialization).
-  const eventChannel = useConvexQuery(
-    api.functions.messaging.eventChat.getChannelByMeetingId,
+  // Load event chat on/off state for the edit form. Uses the editor-only
+  // query so leaders/admins who aren't RSVPed still see the real state. The
+  // user-facing `getChannelByMeetingId` returns null both when no channel
+  // exists AND when the caller lacks chat access — conflating those two
+  // would default the toggle to "enabled" for an editor viewing a disabled
+  // channel, and the no-op save path would silently skip the persist.
+  const eventChatState = useConvexQuery(
+    api.functions.messaging.eventChat.getChannelStateForEditor,
     isEditMode && meetingId && token
       ? { meetingId: meetingId as Id<"meetings">, token }
       : "skip"
   );
-  const initialEventChatEnabled = eventChannel
-    ? eventChannel.isEnabled !== false
-    : true; // null channel or still loading → default enabled
+  const initialEventChatEnabled = eventChatState?.isEnabled ?? true;
   useEffect(() => {
-    if (eventChannel !== undefined) {
+    if (eventChatState !== undefined && eventChatState !== null) {
       setEventChatEnabled(initialEventChatEnabled);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [eventChannel]);
+  }, [eventChatState]);
   const setEventChannelEnabledMutation = useAuthenticatedMutation(
     api.functions.messaging.eventChat.setEventChannelEnabled
   );
@@ -776,20 +775,20 @@ export function CreateEventScreen() {
         // Event chat lives on chatChannels, not on the meeting. Flip it once
         // up front for the meeting being edited so the state persists no
         // matter which scope branch runs (single, series, or CWE-wide). The
-        // toggle is inherently per-meeting, so we never cascade it.
+        // toggle is inherently per-meeting, so we never cascade it. Running
+        // BEFORE the meeting write means a failure here aborts the save and
+        // no other form changes land — that's intentional, since the
+        // alternative is a silent partial write where the user thinks the
+        // toggle saved but it didn't. The caller alerts on thrown errors.
         const persistEventChatToggle = async () => {
           if (
-            eventChannel !== undefined &&
+            eventChatState !== undefined &&
             eventChatEnabled !== initialEventChatEnabled
           ) {
-            try {
-              await setEventChannelEnabledMutation({
-                meetingId: meetingId as Id<"meetings">,
-                enabled: eventChatEnabled,
-              });
-            } catch (err) {
-              console.warn("Failed to update event chat toggle:", err);
-            }
+            await setEventChannelEnabledMutation({
+              meetingId: meetingId as Id<"meetings">,
+              enabled: eventChatEnabled,
+            });
           }
         };
 
@@ -798,7 +797,18 @@ export function CreateEventScreen() {
         // sibling. Single-meeting edits (and series-only) stay on
         // `meetings.update`. Matches the cancel flow split.
         const performUpdate = async (scope?: EditScope) => {
-          await persistEventChatToggle();
+          try {
+            await persistEventChatToggle();
+          } catch (err: any) {
+            Alert.alert(
+              "Error",
+              formatError(
+                err,
+                "Failed to update event chat. Other changes were not saved.",
+              ),
+            );
+            return;
+          }
           if (
             isCommunityWide &&
             (scope === "this_date_all_groups" || scope === "all_in_series") &&
@@ -1793,10 +1803,11 @@ export function CreateEventScreen() {
 
           {/* Event chat toggle — edit mode only. Hidden while the channel
               query is still loading so the switch doesn't flicker into the
-              wrong position and then snap. `setEventChannelEnabled`
-              materializes the channel on first flip, so a null channel here
-              is fine. */}
-          {isEditMode && eventChannel !== undefined && (
+              wrong position and then snap. A `null` result means the caller
+              isn't an editor (shouldn't happen on this screen, but guard
+              anyway). `setEventChannelEnabled` materializes the channel on
+              first flip, so an `exists: false` state is fine. */}
+          {isEditMode && !!eventChatState && (
             <View style={styles.section}>
               <Text style={[styles.sectionTitle, { color: colors.text }]}>Event Chat</Text>
               <View style={styles.toggleRow}>

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -61,6 +61,7 @@ interface CreateMeetingInput {
   posterId?: Id<"posters"> | null;
   rsvpEnabled?: boolean;
   rsvpOptions?: RsvpOption[];
+  hideRsvpCount?: boolean;
   visibility?: VisibilityLevel;
 }
 
@@ -153,6 +154,12 @@ export function CreateEventScreen() {
   const [rsvpEnabled, setRsvpEnabled] = useState(true);
   const [rsvpOptions, setRsvpOptions] =
     useState<RsvpOption[]>(DEFAULT_RSVP_OPTIONS);
+  // When true, RSVP count/list is hidden from non-leaders on the event page
+  // and in chat cards. Leaders still see the count with a "Leaders only" badge.
+  const [hideRsvpCount, setHideRsvpCount] = useState(false);
+  // Event chat lives on the chatChannels doc, not the meeting — loaded/saved
+  // separately from the meeting update mutation below.
+  const [eventChatEnabled, setEventChatEnabled] = useState(true);
   const [visibility, setVisibility] = useState<VisibilityLevel>("public");
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(hostingGroupId || null);
   const [isGroupDropdownOpen, setIsGroupDropdownOpen] = useState(false);
@@ -318,11 +325,36 @@ export function CreateEventScreen() {
       if (meeting.rsvpOptions && Array.isArray(meeting.rsvpOptions)) {
         setRsvpOptions(meeting.rsvpOptions as unknown as RsvpOption[]);
       }
+      setHideRsvpCount((meeting as any).hideRsvpCount === true);
       if (meeting.visibility) {
         setVisibility(meeting.visibility as VisibilityLevel);
       }
     }
   }, [meeting, isEditMode, isCweAdminEdit, parentCweData]);
+
+  // Load event chat on/off state from the chat channel (edit mode only).
+  // Chat state lives on chatChannels, not the meeting, so we fetch and save it
+  // independently of the meeting update mutation. A `null` channel means no
+  // channel row exists yet — in that case the effective state is "enabled"
+  // (channels default to isEnabled: true on materialization).
+  const eventChannel = useConvexQuery(
+    api.functions.messaging.eventChat.getChannelByMeetingId,
+    isEditMode && meetingId && token
+      ? { meetingId: meetingId as Id<"meetings">, token }
+      : "skip"
+  );
+  const initialEventChatEnabled = eventChannel
+    ? eventChannel.isEnabled !== false
+    : true; // null channel or still loading → default enabled
+  useEffect(() => {
+    if (eventChannel !== undefined) {
+      setEventChatEnabled(initialEventChatEnabled);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventChannel]);
+  const setEventChannelEnabledMutation = useAuthenticatedMutation(
+    api.functions.messaging.eventChat.setEventChannelEnabled
+  );
 
   // Debounced geocoding check for location field
   useEffect(() => {
@@ -390,7 +422,7 @@ export function CreateEventScreen() {
   // Wrapper for create mutation with state tracking
   // Note: useAuthenticatedMutation auto-injects the token
   const createMeeting = {
-    mutate: async (data: { groupId: string; scheduledAt: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; visibility?: VisibilityLevel }) => {
+    mutate: async (data: { groupId: string; scheduledAt: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; hideRsvpCount?: boolean; visibility?: VisibilityLevel }) => {
       setIsCreating(true);
       try {
         const newMeetingId = await createMeetingMutation({
@@ -409,6 +441,7 @@ export function CreateEventScreen() {
           posterId: data.posterId ?? undefined,
           rsvpEnabled: data.rsvpEnabled,
           rsvpOptions: data.rsvpOptions,
+          hideRsvpCount: data.hideRsvpCount,
           visibility: data.visibility,
         });
         // ADR-022 analytics: only fire for non-leader creators so the funnel
@@ -435,7 +468,7 @@ export function CreateEventScreen() {
   // Wrapper for update mutation with state tracking
   // Note: useAuthenticatedMutation auto-injects the token
   const updateMeeting = {
-    mutate: async (data: { meetingId: string; scheduledAt?: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; visibility?: VisibilityLevel; notifyGuests?: boolean }) => {
+    mutate: async (data: { meetingId: string; scheduledAt?: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; hideRsvpCount?: boolean; visibility?: VisibilityLevel; notifyGuests?: boolean }) => {
       setIsUpdating(true);
       try {
         await updateMeetingMutation({
@@ -451,8 +484,28 @@ export function CreateEventScreen() {
           posterId: data.posterId,
           rsvpEnabled: data.rsvpEnabled,
           rsvpOptions: data.rsvpOptions,
+          hideRsvpCount: data.hideRsvpCount,
           visibility: data.visibility,
         });
+        // Persist the event chat toggle separately (it lives on chatChannels,
+        // not on the meeting). Fire the mutation only when the effective
+        // state changed. When no channel exists yet the effective state is
+        // "enabled" (default), so flipping to disabled triggers a
+        // materialize-and-patch via setEventChannelEnabled. Backend enforces
+        // permissions.
+        if (
+          eventChannel !== undefined &&
+          eventChatEnabled !== initialEventChatEnabled
+        ) {
+          try {
+            await setEventChannelEnabledMutation({
+              meetingId: data.meetingId as Id<"meetings">,
+              enabled: eventChatEnabled,
+            });
+          } catch (err) {
+            console.warn("Failed to update event chat toggle:", err);
+          }
+        }
         // Convex automatically updates queries
         router.back();
       } catch (error: any) {
@@ -731,6 +784,7 @@ export function CreateEventScreen() {
         posterId: posterId,
         rsvpEnabled: rsvpEnabled,
         rsvpOptions: rsvpOptions.filter((opt) => opt.enabled),
+        hideRsvpCount: hideRsvpCount,
         visibility: visibility,
       };
 
@@ -1713,12 +1767,43 @@ export function CreateEventScreen() {
               <Switch value={rsvpEnabled} onValueChange={setRsvpEnabled} />
             </View>
             {rsvpEnabled && (
-              <RsvpOptionsEditor
-                options={rsvpOptions}
-                onChange={setRsvpOptions}
-              />
+              <>
+                <RsvpOptionsEditor
+                  options={rsvpOptions}
+                  onChange={setRsvpOptions}
+                />
+                <View style={styles.toggleRow}>
+                  <View style={{ flex: 1, paddingRight: 12 }}>
+                    <Text style={[styles.toggleLabel, { color: colors.text }]}>Hide RSVP count</Text>
+                    <Text style={[styles.toggleHint, { color: colors.textSecondary }]}>
+                      Attendees can RSVP but won't see totals. Only you and other leaders will.
+                    </Text>
+                  </View>
+                  <Switch value={hideRsvpCount} onValueChange={setHideRsvpCount} />
+                </View>
+              </>
             )}
           </View>
+
+          {/* Event chat toggle — edit mode only. Hidden while the channel
+              query is still loading so the switch doesn't flicker into the
+              wrong position and then snap. `setEventChannelEnabled`
+              materializes the channel on first flip, so a null channel here
+              is fine. */}
+          {isEditMode && eventChannel !== undefined && (
+            <View style={styles.section}>
+              <Text style={[styles.sectionTitle, { color: colors.text }]}>Event Chat</Text>
+              <View style={styles.toggleRow}>
+                <View style={{ flex: 1, paddingRight: 12 }}>
+                  <Text style={[styles.toggleLabel, { color: colors.text }]}>Enable event chat</Text>
+                  <Text style={[styles.toggleHint, { color: colors.textSecondary }]}>
+                    Only RSVP'd attendees can read or post. When off, no one can send messages.
+                  </Text>
+                </View>
+                <Switch value={eventChatEnabled} onValueChange={setEventChatEnabled} />
+              </View>
+            </View>
+          )}
 
           {/* Visibility */}
           <View style={styles.section}>

--- a/apps/mobile/features/leader-tools/components/__tests__/CreateEventScreen.pastDate.test.tsx
+++ b/apps/mobile/features/leader-tools/components/__tests__/CreateEventScreen.pastDate.test.tsx
@@ -159,6 +159,12 @@ jest.mock("@services/api/convex", () => ({
       posters: {
         search: "api.functions.posters.search",
       },
+      messaging: {
+        eventChat: {
+          getChannelByMeetingId: "api.functions.messaging.eventChat.getChannelByMeetingId",
+          setEventChannelEnabled: "api.functions.messaging.eventChat.setEventChannelEnabled",
+        },
+      },
     },
   },
   useQuery: (...args: any[]) => mockUseQuery(...args),

--- a/apps/mobile/features/profile/components/MyEventsScreen.tsx
+++ b/apps/mobile/features/profile/components/MyEventsScreen.tsx
@@ -60,6 +60,9 @@ function adaptSingleCard(card: any): CommunityEvent {
       totalGoing: card.rsvpSummary.totalGoing,
       topGoingGuests: card.rsvpSummary.topGoingGuests,
     },
+    hideRsvpCount: card.hideRsvpCount === true,
+    createdById: card.createdById ?? null,
+    viewerIsLeader: card.viewerIsLeader === true,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Relocate "Event chat" toggle** from the event detail page to the Edit Event form (edit mode only). The mutation materializes the channel on first flip, so hosts can pre-disable before anyone opens chat.
- **New `meetings.hideRsvpCount` flag.** When on, non-leaders see attendee avatars followed by an inline "and more" label — no numeric count, no progress bar, no "View all". Below a 5-attendee threshold the whole section hides so a sparse avatar stack can't leak the headcount.
- **Leaders still see the count** with a "Leaders only" pill badge on the detail page and chat event cards so they know attendees aren't seeing what they're seeing. Server computes `viewerIsLeader` on every event-returning query (`getByShortId`, `explore.communityEvents`, `events.listForEventsTab`, etc.).

Backend: `hideRsvpCount` added to `meetings` schema + `create`/`update`/`createSeriesEvents` mutations (cascaded on series-wide edits). Event queries now return `hideRsvpCount`, `createdById`, and `viewerIsLeader`. Event chat access (`canAccessEventChannel` + send-path `isEnabled` guard) is unchanged — only RSVP'd attendees can post, and disabling the toggle blocks new sends.

## Screenshots

**Leader view:** full count + "Leaders only" badge + "View all" button, standard +N overflow.
**Non-leader view:** avatars + muted "and more" label, no count or progress bar. Whole section hidden if attendee count is low.
**Edit form:** Hide RSVP count toggle lives in RSVP Options section (with helper text). Event Chat section below it in edit mode only.

## Test plan

- [x] Typecheck: backend + mobile clean on all touched files
- [x] Jest: full mobile suite (1030 passed) including past-date CreateEventScreen cases
- [x] Browser (Playwright, mobile viewport): edit form shows both new toggles and loads persisted state
- [x] Browser: event detail page no longer shows inline chat toggle
- [x] Browser: as primary admin, full count + "Leaders only" badge on detail page
- [x] Browser: as plain member, avatars + "and more" with no number / View all
- [x] Browser: toggling Event chat off via edit form sets `chatChannels.isEnabled = false` and records `disabledByUserId`; toggling back on re-enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)