### PR TITLE
fix(events): render event cover images in natural aspect ratio

### DIFF
--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -15,6 +15,7 @@ import {
   Share,
   Switch,
   KeyboardAvoidingView,
+  Image,
 } from "react-native";
 import { useLocalSearchParams, useRouter, useSegments } from "expo-router";
 import { useQuery, useAuthenticatedMutation, api, Id } from "@services/api/convex";
@@ -62,6 +63,7 @@ function TextWithLinks({ text, style }: { text: string; style?: any }) {
 import { Ionicons } from "@expo/vector-icons";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppImage } from "@components/ui";
+import { getMediaUrl } from "@/utils/media";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useTheme } from "@hooks/useTheme";
 import {
@@ -176,6 +178,31 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   const eventData = event ?? (initialEventData as typeof event);
   const isLoading = event === undefined && !initialEventData;
   const error = event === null;
+
+  // Render the cover image in its natural aspect ratio so portrait/square
+  // posters aren't cropped. Default to 1:1 while loading; once Image.getSize
+  // resolves, switch to the real ratio.
+  const coverImagePath =
+    (eventData?.coverImage as string | null | undefined) ||
+    ((eventData as any)?.groupImage as string | null | undefined) ||
+    null;
+  const [coverAspectRatio, setCoverAspectRatio] = useState(1);
+  useEffect(() => {
+    if (!coverImagePath) return;
+    const url = getMediaUrl(coverImagePath);
+    if (!url || !(url.startsWith("http://") || url.startsWith("https://"))) return;
+    let cancelled = false;
+    Image.getSize(
+      url,
+      (w, h) => {
+        if (!cancelled && w > 0 && h > 0) setCoverAspectRatio(w / h);
+      },
+      () => {}
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [coverImagePath]);
 
   // Leader status using Convex
   const leaderStatus = useQuery(
@@ -736,7 +763,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
         {/* Cover Image - falls back to group image if no event cover */}
         <AppImage
           source={eventData.coverImage || eventData.groupImage}
-          style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary }]}
+          style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary, aspectRatio: coverAspectRatio }]}
           resizeMode="cover"
           placeholder={{
             type: 'icon',
@@ -1156,7 +1183,9 @@ const styles = StyleSheet.create({
   // Cover Image
   coverImage: {
     width: "100%",
-    aspectRatio: 16 / 9,
+    // Default 1:1 — overridden inline with the image's natural aspect ratio
+    // once Image.getSize resolves.
+    aspectRatio: 1,
   },
 
   // Content

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -188,6 +188,12 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
     null;
   const [coverAspectRatio, setCoverAspectRatio] = useState(1);
   useEffect(() => {
+    // Reset to the 1:1 fallback whenever the cover source changes so a new
+    // image is never laid out with the previous image's ratio while
+    // Image.getSize is in flight (or if it fails for the new URL). Without
+    // this, host edits or fallback switches (coverImage ↔ groupImage) can
+    // leave stale dimensions in place.
+    setCoverAspectRatio(1);
     if (!coverImagePath) return;
     const url = getMediaUrl(coverImagePath);
     if (!url || !(url.startsWith("http://") || url.startsWith("https://"))) return;

--- a/apps/mobile/features/chat/components/EventLinkCard.tsx
+++ b/apps/mobile/features/chat/components/EventLinkCard.tsx
@@ -5,11 +5,12 @@
  * Fetches live event data using the shortId.
  */
 import React, { useState, useRef, useEffect } from 'react';
-import { View, Text, TouchableOpacity, Pressable, StyleSheet, ActivityIndicator, Platform, Dimensions, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, Pressable, StyleSheet, ActivityIndicator, Platform, Dimensions, Alert, Image } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { format, parseISO, isPast } from 'date-fns';
 import { Avatar } from '@components/ui/Avatar';
 import { AppImage } from '@components/ui/AppImage';
+import { getMediaUrl } from '@/utils/media';
 import { useQuery, useMutation, api, useStoredAuthToken } from '@services/api/convex';
 import type { Id } from '@services/api/convex';
 import { useRouter } from 'expo-router';
@@ -120,9 +121,28 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
   // Submit RSVP mutation using Convex
   const submitRsvpMutation = useMutation(api.functions.meetingRsvps.submit);
 
-  // Note: We use a fixed 16:9 aspect ratio for the cover image to prevent layout shifts.
-  // Previously we calculated the actual image ratio, but this caused content to jump
-  // when the image loaded. Using a consistent aspect ratio is better UX.
+  // Render the cover image in its natural aspect ratio so portrait/square
+  // posters aren't cropped. Default to 1:1 while loading; once Image.getSize
+  // resolves, switch to the real ratio. The brief layout shift is preferable
+  // to permanently cropping the top/bottom of the artwork.
+  const coverImagePath = (eventData as { coverImage?: string | null } | null | undefined)?.coverImage ?? null;
+  const [coverAspectRatio, setCoverAspectRatio] = useState(1);
+  useEffect(() => {
+    if (!coverImagePath) return;
+    const url = getMediaUrl(coverImagePath);
+    if (!url || !(url.startsWith('http://') || url.startsWith('https://'))) return;
+    let cancelled = false;
+    Image.getSize(
+      url,
+      (w, h) => {
+        if (!cancelled && w > 0 && h > 0) setCoverAspectRatio(w / h);
+      },
+      () => {}
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [coverImagePath]);
 
   // Unified submit queue shared by BOTH the option-change handler and the
   // guest-stepper handler. Previously each handler had its own in-flight
@@ -414,7 +434,7 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
             >
               <AppImage
                 source={event.coverImage}
-                style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary }]}
+                style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary, aspectRatio: coverAspectRatio }]}
                 resizeMode="cover"
                 placeholder={{ type: 'icon', icon: 'calendar-outline', iconSize: 48, iconColor: colors.iconSecondary }}
               />
@@ -497,7 +517,7 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
           >
             <AppImage
               source={event.coverImage}
-              style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary }]}
+              style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary, aspectRatio: coverAspectRatio }]}
               resizeMode="cover"
               placeholder={{ type: 'icon', icon: 'calendar-outline', iconSize: 48, iconColor: colors.iconSecondary }}
             />
@@ -623,13 +643,16 @@ const styles = StyleSheet.create({
   },
   coverImage: {
     width: '100%',
-    aspectRatio: 16 / 9,
+    // Default 1:1 — overridden inline with the image's natural aspect ratio
+    // once Image.getSize resolves. Square is a good fallback because most
+    // event posters are square or portrait.
+    aspectRatio: 1,
     borderTopLeftRadius: 12,
     borderTopRightRadius: 12,
   },
   coverImagePlaceholder: {
     width: '100%',
-    aspectRatio: 16 / 9,
+    aspectRatio: 1,
     justifyContent: 'center',
     alignItems: 'center',
     borderTopLeftRadius: 12,
@@ -814,7 +837,7 @@ const styles = StyleSheet.create({
   // Skeleton loading styles
   skeletonCoverImage: {
     width: '100%',
-    aspectRatio: 16 / 9,
+    aspectRatio: 1,
     borderTopLeftRadius: 12,
     borderTopRightRadius: 12,
   },

--- a/apps/mobile/features/chat/components/EventLinkCard.tsx
+++ b/apps/mobile/features/chat/components/EventLinkCard.tsx
@@ -128,6 +128,10 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
   const coverImagePath = (eventData as { coverImage?: string | null } | null | undefined)?.coverImage ?? null;
   const [coverAspectRatio, setCoverAspectRatio] = useState(1);
   useEffect(() => {
+    // Reset to the 1:1 fallback whenever the cover source changes so a new
+    // image is never laid out with the previous image's ratio while
+    // Image.getSize is in flight (or if it fails for the new URL).
+    setCoverAspectRatio(1);
     if (!coverImagePath) return;
     const url = getMediaUrl(coverImagePath);
     if (!url || !(url.startsWith('http://') || url.startsWith('https://'))) return;


### PR DESCRIPTION
## Summary
- Event cover images on the chat link card (`EventLinkCard`) and event detail page (`EventPageClient`) were locked to 16:9 with `resizeMode="cover"`, which permanently chopped the top and bottom of square/portrait posters. Replace the static aspect ratio with one computed from the image's natural dimensions via `Image.getSize` — defaulting to 1:1 while the size resolves, then snapping to the real ratio.
- Matches how the same image renders in iMessage unfurl previews. The brief one-time layout shift on first paint is the trade-off (the original 16:9 was chosen to avoid that shift); cropping every portrait poster is worse UX.

## Test plan
- [x] Logged in as the seeded test user via Playwright on `localhost:8081`, opened a "Dinner Party" event detail page. Cover image source is **1600×1202** (ratio 1.331); rendered as **420×316** (ratio 1.329). Δ = 0.002 — image is no longer cropped.
- [x] `pnpm exec tsc --noEmit -p apps/mobile/tsconfig.json` shows no new errors in the changed files.
- [x] Pre-commit eslint passed.
- [ ] Verify on a portrait poster in iOS Simulator (Reviewer: please confirm the original "Joint LiC Dinner Party" Nigerian-food poster from the bug report renders fully on a real device.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)