### PR TITLE
fix(events): cap counts hosted events, not created events

### DIFF
--- a/apps/convex/__tests__/member-created-events.test.ts
+++ b/apps/convex/__tests__/member-created-events.test.ts
@@ -254,6 +254,60 @@ describe("meetings.create — member flow", () => {
   // "test began while previous transaction was still open". The cap
   // guarantee comes from the runtime invariant, not from a racy test.
 
+  test("non-leader can file event for someone else without hitting cap", async () => {
+    // Cap counts events the user is *hosting* (in hostUserIds), not events
+    // they merely created. A member who already hosts one future event can
+    // still file a separate event for someone else as long as they don't
+    // include themselves in the new event's hostUserIds.
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    // Member hosts their own future event (default hostUserIds = [creator]).
+    await t.mutation(api.functions.meetings.index.create, {
+      token: s.memberToken,
+      groupId: s.groupId,
+      scheduledAt: FUTURE(),
+      meetingType: 1,
+      locationMode: "tbd",
+    });
+
+    // Member files a second event with someone else as host — should succeed.
+    await t.mutation(api.functions.meetings.index.create, {
+      token: s.memberToken,
+      groupId: s.groupId,
+      scheduledAt: FUTURE() + 1000,
+      meetingType: 1,
+      locationMode: "tbd",
+      hostUserIds: [s.otherMemberId],
+    });
+  });
+
+  test("non-leader is capped when adding self as co-host on second event", async () => {
+    // The cap counts hostUserIds — if the new event includes the creator as
+    // a host alongside someone else, it still counts.
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(api.functions.meetings.index.create, {
+      token: s.memberToken,
+      groupId: s.groupId,
+      scheduledAt: FUTURE(),
+      meetingType: 1,
+      locationMode: "tbd",
+    });
+
+    await expect(
+      t.mutation(api.functions.meetings.index.create, {
+        token: s.memberToken,
+        groupId: s.groupId,
+        scheduledAt: FUTURE() + 1000,
+        meetingType: 1,
+        locationMode: "tbd",
+        hostUserIds: [s.memberId, s.otherMemberId],
+      })
+    ).rejects.toThrow(/upcoming event/i);
+  });
+
   test("leaders are unthrottled by the cap", async () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -14,7 +14,7 @@ import {
   canCreateInGroup,
   canEditMeeting,
   canEditSeriesWide,
-  countFutureEventsCreatedBy,
+  countFutureEventsHostedBy,
   NON_LEADER_FUTURE_EVENT_CAP,
 } from "../../lib/meetingPermissions";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
@@ -172,17 +172,24 @@ export const create = mutation({
       throw new Error("Only group leaders can add events to a series");
     }
 
-    // 1-future-event cap for non-leaders (ADR-022). Convex mutations are
-    // serialized per-document; a concurrent second create reads the just-inserted
-    // row and this check rejects it. Scoped to the target group's community —
-    // events in a different community don't count against this one.
-    if (!isLeader) {
+    // 1-future-event cap for non-leaders (ADR-022). Counts future events the
+    // creator is *hosting* (in `hostUserIds`), not events they merely created
+    // for someone else — matches "My Events" semantics so users see what's
+    // counting against them. Convex mutations are serialized per-document; a
+    // concurrent second create reads the just-inserted row and this check
+    // rejects it. Scoped to the target group's community — events in a
+    // different community don't count against this one.
+    //
+    // Note: the cap fires only when the creator is also in the new event's
+    // hostUserIds. Creating an event for someone else does not count against
+    // the creator's own hosting load.
+    if (!isLeader && hostUserIds.some((id) => id === createdById)) {
       // Look ahead to the target group so we know the community scope.
       const targetGroup = await ctx.db.get(args.groupId);
       if (!targetGroup?.communityId) {
         throw new Error("Group is not linked to a community");
       }
-      const futureCount = await countFutureEventsCreatedBy(
+      const futureCount = await countFutureEventsHostedBy(
         ctx,
         createdById,
         now(),
@@ -190,7 +197,7 @@ export const create = mutation({
       );
       if (futureCount >= NON_LEADER_FUTURE_EVENT_CAP) {
         throw new Error(
-          "You already have an upcoming event. Cancel or finish it before creating another."
+          "You're already hosting an upcoming event. Cancel or finish it before hosting another."
         );
       }
     }

--- a/apps/convex/functions/meetings/myEvents.ts
+++ b/apps/convex/functions/meetings/myEvents.ts
@@ -11,6 +11,7 @@ import { v } from "convex/values";
 import { query } from "../../_generated/server";
 import { Doc } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
+import { isMeetingHost } from "../../lib/meetingPermissions";
 import {
   buildBucket,
   buildEnrichment,
@@ -59,8 +60,14 @@ function splitByTime(
 }
 
 /**
- * Events this user created. Excludes cancelled. Split into upcoming and past
- * sections, both in the grouped-CWE shape.
+ * Events this user is hosting (in `hostUserIds`). Excludes cancelled. Split
+ * into upcoming and past sections, both in the grouped-CWE shape.
+ *
+ * Filters by `hostUserIds`, not `createdById`, so this matches "what events
+ * am I hosting" — events the user filed for someone else are excluded, and
+ * events the user was added to as a co-host (without creating them) are
+ * included. Aligned with the Events tab "My Events" carousel and the
+ * non-leader hosting cap on `meetings.create`.
  */
 export const myHostedEvents = query({
   args: {
@@ -75,13 +82,28 @@ export const myHostedEvents = query({
   ): Promise<{ upcoming: EventCard[]; past: EventCard[] }> => {
     const userId = await requireAuth(ctx, args.token);
 
-    const rows = await ctx.db
+    // No multi-value index on hostUserIds — scan by (communityId, scheduledAt)
+    // and filter host membership in memory. Two range queries (future, past)
+    // bound the work; past is only scanned when `includePast` is set.
+    const futureRows = await ctx.db
       .query("meetings")
-      .withIndex("by_createdBy", (q) => q.eq("createdById", userId))
+      .withIndex("by_community_scheduledAt", (q) =>
+        q.eq("communityId", args.communityId).gt("scheduledAt", args.now)
+      )
       .collect();
+    const pastRows = args.includePast
+      ? await ctx.db
+          .query("meetings")
+          .withIndex("by_community_scheduledAt", (q) =>
+            q
+              .eq("communityId", args.communityId)
+              .lte("scheduledAt", args.now)
+          )
+          .collect()
+      : [];
 
-    const live = rows.filter(
-      (m) => m.status !== "cancelled" && m.communityId === args.communityId
+    const live: Doc<"meetings">[] = [...futureRows, ...pastRows].filter(
+      (m) => m.status !== "cancelled" && isMeetingHost(m, userId)
     );
     const withGroupDocs = await withGroups(ctx, live);
     const { upcoming, past } = splitByTime(withGroupDocs, args.now);
@@ -134,7 +156,11 @@ export const myAttendedEvents = query({
     const meetings = (await Promise.all(meetingIds.map((id) => ctx.db.get(id))))
       .filter((m): m is Doc<"meetings"> => m !== null)
       .filter((m) => m.status !== "cancelled")
-      .filter((m) => m.createdById !== userId)
+      // Dedupe with myHostedEvents by host membership, not creator — matches
+      // the new "hosted = in hostUserIds" semantic so an event the user RSVPs
+      // to but doesn't host shows here even if they happened to file it for
+      // someone else.
+      .filter((m) => !isMeetingHost(m, userId))
       .filter((m) => m.communityId === args.communityId);
 
     const withGroupDocs = await withGroups(ctx, meetings);

--- a/apps/convex/lib/meetingPermissions.ts
+++ b/apps/convex/lib/meetingPermissions.ts
@@ -132,27 +132,36 @@ export async function canEditSeriesWide(
 }
 
 /**
- * Count a user's current "future events" for the non-leader cap.
- * Future event = status ∈ {scheduled, confirmed} AND scheduledAt > now.
- * Cancelled and completed don't count. Scoped to a community so a user
- * with hosted events in community A isn't throttled when creating in
- * community B. See ADR-022.
+ * Count a user's current "future events being hosted" for the non-leader cap.
+ * Future event = status ∈ {scheduled, confirmed} AND scheduledAt > now AND
+ * the user is in `hostUserIds`. Cancelled and completed don't count. Scoped
+ * to a community so a user hosting in community A isn't throttled when
+ * creating in community B. See ADR-022.
+ *
+ * Counts by `hostUserIds`, not `createdById`, so the cap matches what the
+ * user sees as "their" upcoming events (Events tab → "My Events" carousel,
+ * Profile → My Events Hosted). Creating an event for someone else doesn't
+ * count against your cap — only events you're actually hosting do.
  */
-export async function countFutureEventsCreatedBy(
+export async function countFutureEventsHostedBy(
   ctx: Ctx,
   userId: Id<"users">,
   nowMs: number,
   communityId: Id<"communities">
 ): Promise<number> {
+  // No multi-value index on hostUserIds, so we scan future meetings in the
+  // community via the (communityId, scheduledAt) compound index and filter
+  // host membership in memory. Bounded by future events in this community.
   const rows = await ctx.db
     .query("meetings")
-    .withIndex("by_createdBy", (q: any) => q.eq("createdById", userId))
+    .withIndex("by_community_scheduledAt", (q: any) =>
+      q.eq("communityId", communityId).gt("scheduledAt", nowMs)
+    )
     .collect();
   return rows.filter(
     (m: Doc<"meetings">) =>
-      m.communityId === communityId &&
       (m.status === "scheduled" || m.status === "confirmed") &&
-      m.scheduledAt > nowMs
+      isMeetingHost(m, userId)
   ).length;
 }
 

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -276,11 +276,17 @@ export function CreateEventScreen() {
   // Non-leader 1-future-event cap enforcement (client gate — the backend
   // enforces authoritatively). We only query when the user is actually at
   // risk of hitting the cap (non-leader, not editing) so leaders don't pay
-  // the query cost.
+  // the query cost. Cap counts events the user is hosting (not just creating)
+  // — matches the backend rule, so filing an event for someone else doesn't
+  // count against your own hosting load.
   const capGateEnabled = !isAdmin && !isEditMode && !isLeaderOfSelectedGroup;
   const { data: myHosted } = useMyHostedEvents({ enabled: capGateEnabled });
   const futureHostedCount = (myHosted?.upcoming?.length ?? 0) as number;
-  const capReached = capGateEnabled && futureHostedCount >= 1;
+  // Cap fires only when the new event will list the user as a host. If the
+  // user has chosen to delegate hosting (their id isn't in `hostUserIds`),
+  // they're not adding to their own hosting load and the cap shouldn't gate.
+  const userWillHost = !!user?.id && hostUserIds.some((id) => id === user.id);
+  const capReached = capGateEnabled && userWillHost && futureHostedCount >= 1;
 
   // Fetch existing meeting data if editing (using Convex)
   const meetingData = useConvexQuery(
@@ -1942,8 +1948,8 @@ export function CreateEventScreen() {
             >
               <Ionicons name="information-circle" size={20} color={colors.link} />
               <Text style={[styles.locationWarningText, { color: colors.textSecondary }]}>
-                You already have an upcoming event. Cancel or wait for it to
-                pass before creating another.
+                You're already hosting an upcoming event. Cancel or wait for
+                it to pass before hosting another.
               </Text>
             </View>
           )}


### PR DESCRIPTION
## Summary
- The non-leader 1-future-event cap counted by `createdById`, but "My Events" surfaces (Events tab carousel + Profile → My Events Hosted) count by `hostUserIds` since the host/creator decoupling (PR #340 / commit `c7fcf32`).
- Filing an event for someone else hit the cap even though the user wasn't actually hosting anything — the event didn't show up in their "My Events," but they were still blocked from creating another. Confusing.
- Switch the cap, `myHostedEvents`, and the `myAttendedEvents` dedupe filter to use `hostUserIds` so all three surfaces agree on what "hosted" means.
- Cap now also skips entirely when the new event delegates hosting (creator not in `hostUserIds`) — filing on someone else's behalf doesn't count against your own hosting load.
- Error copy updated: "You're already hosting an upcoming event…" (was "You already have an upcoming event…").

## Test plan
- [x] `pnpm test` in `apps/convex` — all 1375 tests pass (was 1373; added 2)
- [x] `pnpm test` in `apps/mobile` — all 1030 tests pass
- [x] New tests cover the two key paths:
  - non-leader can file an event for someone else (cap doesn't fire when creator isn't in the new `hostUserIds`)
  - non-leader is still capped when adding self as co-host on a second event
- [ ] Manual verify: log in as a member, host one future event, then create a second one with a different host picked → form submits without the banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)