### PR TITLE
feat(chat): foundation for ad-hoc DMs and group chats (backend, no UI)

### DIFF
--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Direct Message Tests
+ *
+ * Covers the new 1:1 DM and ad-hoc group-chat backend in
+ * `functions/messaging/directMessages.ts`, plus the `sendMessage` gating that
+ * applies while a recipient is still in `requestState: "pending"`, and the
+ * `blockUser` auto-decline branch in `functions/messaging/blocking.ts`.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import type { Id } from "../../_generated/dataModel";
+
+// Set up environment variables
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function uniquePhone(): string {
+  // Avoid collisions with other tests that use 555-555-XXXX style numbers.
+  const suffix = Math.floor(Math.random() * 100000)
+    .toString()
+    .padStart(5, "0");
+  return `+1444555${suffix}`;
+}
+
+async function createCommunity(
+  t: ReturnType<typeof convexTest>,
+  name: string,
+): Promise<Id<"communities">> {
+  return await t.run(async (ctx) => {
+    return await ctx.db.insert("communities", {
+      name,
+      subdomain: name.toLowerCase().replace(/\s+/g, "-"),
+      slug: name.toLowerCase().replace(/\s+/g, "-"),
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+async function createUserInCommunity(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  opts: { firstName: string; lastName?: string },
+): Promise<{ userId: Id<"users">; accessToken: string }> {
+  const userId = await t.run(async (ctx) => {
+    const uId = await ctx.db.insert("users", {
+      firstName: opts.firstName,
+      lastName: opts.lastName ?? "Tester",
+      phone: uniquePhone(),
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await ctx.db.insert("userCommunities", {
+      userId: uId,
+      communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return uId;
+  });
+
+  const { accessToken } = await generateTokens(userId);
+  return { userId, accessToken };
+}
+
+async function createUserInOtherCommunity(
+  t: ReturnType<typeof convexTest>,
+  opts: { firstName: string; lastName?: string },
+): Promise<{
+  userId: Id<"users">;
+  accessToken: string;
+  communityId: Id<"communities">;
+}> {
+  const communityId = await createCommunity(
+    t,
+    `Other-${Math.floor(Math.random() * 1_000_000)}`,
+  );
+  const { userId, accessToken } = await createUserInCommunity(t, communityId, opts);
+  return { userId, accessToken, communityId };
+}
+
+async function getMember(
+  t: ReturnType<typeof convexTest>,
+  channelId: Id<"chatChannels">,
+  userId: Id<"users">,
+) {
+  return await t.run(async (ctx) => {
+    return await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", channelId).eq("userId", userId),
+      )
+      .first();
+  });
+}
+
+// ============================================================================
+// createOrGetDirectChannel
+// ============================================================================
+
+describe("createOrGetDirectChannel", () => {
+  test("creates a DM between two users in the same community", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Shared Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const result = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    expect(result.isNew).toBe(true);
+    expect(result.channelId).toBeDefined();
+
+    const channel = await t.run(async (ctx) => ctx.db.get(result.channelId));
+    expect(channel?.channelType).toBe("dm");
+    expect(channel?.isAdHoc).toBe(true);
+    expect(channel?.communityId).toBe(communityId);
+    expect(channel?.dmPairKey).toBeDefined();
+    expect(typeof channel?.dmPairKey).toBe("string");
+    expect(channel?.dmPairKey!.length).toBeGreaterThan(0);
+
+    const aMember = await getMember(t, result.channelId, aId);
+    expect(aMember?.requestState).toBe("accepted");
+    expect(aMember?.role).toBe("admin");
+
+    const bMember = await getMember(t, result.channelId, bId);
+    expect(bMember?.requestState).toBe("pending");
+    expect(bMember?.invitedById).toBe(aId);
+  });
+
+  test("returns the existing channel on a second call (dedup)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Dedup Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const first = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+    const second = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    expect(first.isNew).toBe(true);
+    expect(second.isNew).toBe(false);
+    expect(second.channelId).toBe(first.channelId);
+  });
+
+  test("throws when the two users share no community", async () => {
+    const t = convexTest(schema, modules);
+    const community1 = await createCommunity(t, "Community One");
+    const { accessToken: aToken } = await createUserInCommunity(t, community1, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInOtherCommunity(t, {
+      firstName: "Bob",
+    });
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.directMessages.createOrGetDirectChannel,
+        { token: aToken, recipientUserId: bId },
+      ),
+    ).rejects.toThrow(/communities/i);
+  });
+});
+
+// ============================================================================
+// respondToChatRequest
+// ============================================================================
+
+describe("respondToChatRequest", () => {
+  test("accept flips state to accepted", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Accept Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: bToken, channelId, response: "accept" },
+    );
+
+    const bMember = await getMember(t, channelId, bId);
+    expect(bMember?.requestState).toBe("accepted");
+    expect(bMember?.requestRespondedAt).toBeDefined();
+    expect(typeof bMember?.requestRespondedAt).toBe("number");
+  });
+
+  test("decline marks declined and leftAt; sender unchanged", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Decline Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: bToken, channelId, response: "decline" },
+    );
+
+    const bMember = await getMember(t, channelId, bId);
+    expect(bMember?.requestState).toBe("declined");
+    expect(bMember?.leftAt).toBeDefined();
+
+    const aMember = await getMember(t, channelId, aId);
+    expect(aMember?.requestState).toBe("accepted");
+    expect(aMember?.leftAt).toBeUndefined();
+  });
+
+  test("block writes a chatUserBlocks row and a chatUserFlags row", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Block Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      {
+        token: bToken,
+        channelId,
+        response: "block",
+        reportReason: "spam",
+      },
+    );
+
+    const bMember = await getMember(t, channelId, bId);
+    expect(bMember?.requestState).toBe("declined");
+
+    const block = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatUserBlocks")
+        .withIndex("by_blocker_blocked", (q) =>
+          q.eq("blockerId", bId).eq("blockedId", aId),
+        )
+        .first(),
+    );
+    expect(block).not.toBeNull();
+    expect(block?.blockerId).toBe(bId);
+    expect(block?.blockedId).toBe(aId);
+
+    const flag = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatUserFlags")
+        .withIndex("by_user", (q) => q.eq("userId", aId))
+        .first(),
+    );
+    expect(flag).not.toBeNull();
+    expect(flag?.userId).toBe(aId);
+    expect(flag?.reportedById).toBe(bId);
+    expect(flag?.reason).toBe("spam");
+    expect(flag?.status).toBe("pending");
+  });
+});
+
+// ============================================================================
+// sendMessage gating on pending channels
+// ============================================================================
+
+describe("sendMessage gating on pending channels", () => {
+  test("rate limit: sender can only send 1 message to a pending recipient per 24h", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Rate Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    // First message succeeds.
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "hello",
+    });
+    await t.finishAllScheduledFunctions(() => {});
+
+    // Second send should be rate-limited.
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: aToken,
+        channelId,
+        content: "hello again",
+      }),
+    ).rejects.toThrow(/1 message|accept/i);
+  });
+
+  test("attachments are rejected while a recipient is pending", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Attach Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: aToken,
+        channelId,
+        content: "Picture for you",
+        attachments: [
+          {
+            type: "image",
+            url: "https://example.com/image.jpg",
+            name: "photo.jpg",
+            mimeType: "image/jpeg",
+          },
+        ],
+      }),
+    ).rejects.toThrow(/attachment/i);
+  });
+});
+
+// ============================================================================
+// listChatRequests
+// ============================================================================
+
+describe("listChatRequests", () => {
+  test("returns recipient's pending requests with metadata", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Inbox Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice", lastName: "Anderson" },
+    );
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "hi",
+    });
+    await t.finishAllScheduledFunctions(() => {});
+
+    const requests = await t.query(
+      api.functions.messaging.directMessages.listChatRequests,
+      { token: bToken },
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].channelId).toBe(channelId);
+    expect(requests[0].channelType).toBe("dm");
+    expect(requests[0].inviterUserId).toBe(aId);
+    expect(requests[0].firstMessagePreview).toBe("hi");
+    expect(requests[0].inviterDisplayName.toLowerCase()).toContain("alice");
+  });
+});
+
+// ============================================================================
+// blockUser auto-declines pending requests
+// ============================================================================
+
+describe("blockUser auto-declines pending requests", () => {
+  test("blocking the inviter silently declines a pending request", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "AutoDecline Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    await t.mutation(api.functions.messaging.blocking.blockUser, {
+      token: bToken,
+      blockedId: aId,
+    });
+
+    const bMember = await getMember(t, channelId, bId);
+    expect(bMember?.requestState).toBe("declined");
+    expect(bMember?.leftAt).toBeDefined();
+
+    const aMember = await getMember(t, channelId, aId);
+    expect(aMember?.requestState).toBe("accepted");
+    expect(aMember?.leftAt).toBeUndefined();
+  });
+});

--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -340,7 +340,7 @@ describe("sendMessage gating on pending channels", () => {
       channelId,
       content: "hello",
     });
-    await t.finishAllScheduledFunctions(() => {});
+    await t.finishInProgressScheduledFunctions();
 
     // Second send should be rate-limited.
     await expect(
@@ -350,6 +350,13 @@ describe("sendMessage gating on pending channels", () => {
         content: "hello again",
       }),
     ).rejects.toThrow(/1 message|accept/i);
+
+    // Drain again at end-of-test — `finishInProgressScheduledFunctions` only
+    // runs ONE round, but the notification chain (onMessageSent →
+    // sendMessageNotifications) schedules transitively. Without this, the
+    // tail-end of the chain leaks into the next test as a "test began while
+    // previous transaction was still open" error.
+    await t.finishInProgressScheduledFunctions();
   });
 
   test("attachments are rejected while a recipient is pending", async () => {
@@ -414,7 +421,7 @@ describe("listChatRequests", () => {
       channelId,
       content: "hi",
     });
-    await t.finishAllScheduledFunctions(() => {});
+    await t.finishInProgressScheduledFunctions();
 
     const requests = await t.query(
       api.functions.messaging.directMessages.listChatRequests,
@@ -427,6 +434,8 @@ describe("listChatRequests", () => {
     expect(requests[0].inviterUserId).toBe(aId);
     expect(requests[0].firstMessagePreview).toBe("hi");
     expect(requests[0].inviterDisplayName.toLowerCase()).toContain("alice");
+
+    await t.finishInProgressScheduledFunctions();
   });
 });
 
@@ -634,7 +643,7 @@ describe("getDirectInbox", () => {
       channelId: abChannelId,
       content: "hello",
     });
-    await t.finishAllScheduledFunctions(() => {});
+    await t.finishInProgressScheduledFunctions();
     await t.mutation(
       api.functions.messaging.directMessages.respondToChatRequest,
       { token: bToken, channelId: abChannelId, response: "accept" },
@@ -672,6 +681,8 @@ describe("getDirectInbox", () => {
       { token: cToken },
     );
     expect(cInbox).toHaveLength(0);
+
+    await t.finishInProgressScheduledFunctions();
   });
 });
 

--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -11,7 +11,7 @@ import { convexTest } from "convex-test";
 import { expect, test, describe } from "vitest";
 import schema from "../../schema";
 import { modules } from "../../test.setup";
-import { api } from "../../_generated/api";
+import { api, internal } from "../../_generated/api";
 import { generateTokens } from "../../lib/auth";
 import type { Id } from "../../_generated/dataModel";
 
@@ -466,5 +466,280 @@ describe("blockUser auto-declines pending requests", () => {
     const aMember = await getMember(t, channelId, aId);
     expect(aMember?.requestState).toBe("accepted");
     expect(aMember?.leftAt).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// createGroupChat
+// ============================================================================
+
+describe("createGroupChat", () => {
+  test("creates a group chat with multiple recipients in the same community", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Group Chat Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+    const { userId: cId } = await createUserInCommunity(t, communityId, {
+      firstName: "Carol",
+    });
+    const { userId: dId } = await createUserInCommunity(t, communityId, {
+      firstName: "Dan",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        recipientUserIds: [bId, cId, dId],
+        name: "Friends",
+      },
+    );
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.channelType).toBe("group_dm");
+    expect(channel?.isAdHoc).toBe(true);
+    expect(channel?.name).toBe("Friends");
+    expect(channel?.memberCount).toBe(4);
+    expect(channel?.dmPairKey).toBeUndefined();
+
+    const aMember = await getMember(t, channelId, aId);
+    expect(aMember?.requestState).toBe("accepted");
+    expect(aMember?.role).toBe("admin");
+
+    for (const rid of [bId, cId, dId]) {
+      const m = await getMember(t, channelId, rid);
+      expect(m?.requestState).toBe("pending");
+      expect(m?.role).toBe("member");
+      expect(m?.invitedById).toBe(aId);
+    }
+  });
+
+  test("rejects more than 19 recipients", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Big Group Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+
+    const recipientIds: Id<"users">[] = [];
+    for (let i = 0; i < 20; i++) {
+      const { userId } = await createUserInCommunity(t, communityId, {
+        firstName: `User${i}`,
+      });
+      recipientIds.push(userId);
+    }
+
+    await expect(
+      t.mutation(api.functions.messaging.directMessages.createGroupChat, {
+        token: aToken,
+        recipientUserIds: recipientIds,
+      }),
+    ).rejects.toThrow(/at most 19|too many/i);
+  });
+});
+
+// ============================================================================
+// searchUsersInSharedCommunities
+// ============================================================================
+
+describe("searchUsersInSharedCommunities", () => {
+  test("returns shared-community members and excludes blocked users", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Search Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+      lastName: "Brown",
+    });
+    const { userId: cId } = await createUserInCommunity(t, communityId, {
+      firstName: "Carol",
+      lastName: "Coleman",
+    });
+    const { userId: dId } = await createUserInOtherCommunity(t, {
+      firstName: "Daniel",
+      lastName: "Dawson",
+    });
+
+    // A blocks B.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatUserBlocks", {
+        blockerId: aId,
+        blockedId: bId,
+        createdAt: Date.now(),
+      });
+    });
+
+    const results = await t.query(
+      api.functions.messaging.directMessages.searchUsersInSharedCommunities,
+      { token: aToken, query: "" },
+    );
+
+    const ids = results.map((r) => r.userId);
+    expect(ids).toContain(cId);
+    expect(ids).not.toContain(bId);
+    expect(ids).not.toContain(dId);
+    expect(ids).not.toContain(aId);
+
+    const carolRow = results.find((r) => r.userId === cId);
+    expect(carolRow).toBeDefined();
+    expect(carolRow?.displayName).toBeDefined();
+    expect(carolRow?.displayName.length).toBeGreaterThan(0);
+    expect(Array.isArray(carolRow?.sharedCommunityNames)).toBe(true);
+    expect(carolRow?.sharedCommunityNames.length).toBeGreaterThan(0);
+    expect(carolRow?.sharedCommunityNames).toContain("Search Community");
+  });
+});
+
+// ============================================================================
+// getDirectInbox
+// ============================================================================
+
+describe("getDirectInbox", () => {
+  test("returns accepted ad-hoc channels with last-message metadata", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Inbox Direct Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice", lastName: "Anderson" },
+    );
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob", lastName: "Brown" },
+    );
+    const { userId: cId, accessToken: cToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Carol" },
+    );
+
+    // A creates DM with B, sends "hello", B accepts.
+    const { channelId: abChannelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId: abChannelId,
+      content: "hello",
+    });
+    await t.finishAllScheduledFunctions(() => {});
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: bToken, channelId: abChannelId, response: "accept" },
+    );
+
+    const inbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: aToken },
+    );
+
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].channelId).toBe(abChannelId);
+    expect(inbox[0].channelType).toBe("dm");
+    expect(inbox[0].lastMessagePreview).toBe("hello");
+    const aDoc = await t.run(async (ctx) => ctx.db.get(aId));
+    const expectedAName = `${aDoc?.firstName ?? ""} ${aDoc?.lastName ?? ""}`.trim();
+    expect(inbox[0].lastMessageSenderName).toBe(expectedAName);
+
+    const otherIds = inbox[0].otherMembers.map((m) => m.userId);
+    expect(otherIds).toEqual([bId]);
+    const bDoc = await t.run(async (ctx) => ctx.db.get(bId));
+    const expectedBName = `${bDoc?.firstName ?? ""} ${bDoc?.lastName ?? ""}`.trim();
+    expect(inbox[0].otherMembers[0].displayName).toBe(expectedBName);
+
+    // Now create a SECOND DM from A to C — C is still pending. Pending DMs
+    // should NOT appear in C's inbox (C is the pending recipient). Querying
+    // C's inbox should return zero accepted channels.
+    await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: cId },
+    );
+
+    const cInbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: cToken },
+    );
+    expect(cInbox).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// expireOldChatRequests cron
+// ============================================================================
+
+describe("expireOldChatRequests cron", () => {
+  test("marks pending requests older than 30 days as declined", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Expire Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+    const { userId: cId, accessToken: cToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Carol" },
+    );
+
+    // A creates DM with B → B is pending.
+    const { channelId: abChannelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, recipientUserId: bId },
+    );
+
+    const bMemberRowBefore = await getMember(t, abChannelId, bId);
+    expect(bMemberRowBefore?.requestState).toBe("pending");
+    const bMemberRowId = bMemberRowBefore!._id;
+
+    // Backdate B's pending row to 31 days old.
+    const thirtyOneDaysMs = 31 * 24 * 60 * 60 * 1000;
+    await t.run(async (ctx) => {
+      await ctx.db.patch(bMemberRowId, {
+        joinedAt: Date.now() - thirtyOneDaysMs,
+      });
+    });
+
+    // C creates a SECOND DM with B (recent — should NOT be expired). Note: we
+    // need a different inviter so the dmPairKey is different. C invites B.
+    const { channelId: cbChannelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: cToken, recipientUserId: bId },
+    );
+    const cbBMemberBefore = await getMember(t, cbChannelId, bId);
+    expect(cbBMemberBefore?.requestState).toBe("pending");
+
+    // Run the cron.
+    const beforeRun = Date.now();
+    await t.mutation(
+      internal.functions.messaging.directMessages.expireOldChatRequests,
+      {},
+    );
+    const afterRun = Date.now();
+
+    // Old pending row was expired.
+    const bMemberAfter = await getMember(t, abChannelId, bId);
+    expect(bMemberAfter?.requestState).toBe("declined");
+    expect(bMemberAfter?.leftAt).toBeDefined();
+    expect(bMemberAfter?.leftAt!).toBeGreaterThanOrEqual(beforeRun);
+    expect(bMemberAfter?.leftAt!).toBeLessThanOrEqual(afterRun);
+
+    // Recent pending row was NOT expired.
+    const cbBMemberAfter = await getMember(t, cbChannelId, bId);
+    expect(cbBMemberAfter?.requestState).toBe("pending");
+    expect(cbBMemberAfter?.leftAt).toBeUndefined();
   });
 });

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -74,6 +74,7 @@ import type * as functions_memberFollowups from "../functions/memberFollowups.js
 import type * as functions_messaging_blocking from "../functions/messaging/blocking.js";
 import type * as functions_messaging_channelInvites from "../functions/messaging/channelInvites.js";
 import type * as functions_messaging_channels from "../functions/messaging/channels.js";
+import type * as functions_messaging_directMessages from "../functions/messaging/directMessages.js";
 import type * as functions_messaging_eventChat from "../functions/messaging/eventChat.js";
 import type * as functions_messaging_events from "../functions/messaging/events.js";
 import type * as functions_messaging_flagging from "../functions/messaging/flagging.js";
@@ -244,6 +245,7 @@ declare const fullApi: ApiFromModules<{
   "functions/messaging/blocking": typeof functions_messaging_blocking;
   "functions/messaging/channelInvites": typeof functions_messaging_channelInvites;
   "functions/messaging/channels": typeof functions_messaging_channels;
+  "functions/messaging/directMessages": typeof functions_messaging_directMessages;
   "functions/messaging/eventChat": typeof functions_messaging_eventChat;
   "functions/messaging/events": typeof functions_messaging_events;
   "functions/messaging/flagging": typeof functions_messaging_flagging;

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -167,4 +167,29 @@ crons.daily(
   internal.functions.communityScoreComputation.dailyRefreshAllCommunityScores
 );
 
+// =============================================================================
+// CHAT REQUEST EXPIRY
+// =============================================================================
+// Runs daily at 8:00 UTC to expire pending DM/group_dm chat requests older than
+// 30 days. Marks them declined silently (the inviter is not notified).
+
+crons.daily(
+  "chat-request-expiry",
+  { hourUTC: 8, minuteUTC: 0 },
+  internal.functions.messaging.directMessages.expireOldChatRequests
+);
+
+// =============================================================================
+// DM RATE-LIMIT CLEANUP
+// =============================================================================
+// Runs hourly to delete `directMessageRateLimits` rows older than 24h. Old rows
+// have no further effect on the 1-msg-per-pending-pair-per-24h rule but would
+// otherwise accumulate forever.
+
+crons.hourly(
+  "dm-rate-limit-cleanup",
+  { minuteUTC: 40 },
+  internal.functions.messaging.directMessages.cleanupOldDmRateLimits
+);
+
 export default crons;

--- a/apps/convex/functions/cli/messaging.ts
+++ b/apps/convex/functions/cli/messaging.ts
@@ -67,6 +67,7 @@ export const getUserChannels = mutation({
     return channels
       .filter((c): c is NonNullable<typeof c> => {
         if (c === null || c.isArchived) return false;
+        if (!c.groupId) return false; // Skip ad-hoc channels (DM/group_dm)
         const role = roleByGroupId.get(c.groupId);
         const isLeader = isLeaderRole(role);
         if (
@@ -109,6 +110,10 @@ export const getMessages = mutation({
     if (!channel) {
       throw new Error("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new Error("This operation is only valid for group channels");
+    }
+    const groupId = channel.groupId;
 
     // Check channel membership
     const channelMembership = await ctx.db
@@ -122,7 +127,7 @@ export const getMessages = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();

--- a/apps/convex/functions/groups/mutations.ts
+++ b/apps/convex/functions/groups/mutations.ts
@@ -395,6 +395,7 @@ export const update = mutation({
           if (!channel.isShared) {
             continue;
           }
+          if (!channel.groupId) continue; // Skip ad-hoc channels (DM/group_dm)
 
           const sharedGroups = channel.sharedGroups ?? [];
           const entryIndex = sharedGroups.findIndex(

--- a/apps/convex/functions/messaging/blocking.ts
+++ b/apps/convex/functions/messaging/blocking.ts
@@ -116,12 +116,33 @@ export const blockUser = mutation({
       return;
     }
 
+    const now = Date.now();
     await ctx.db.insert("chatUserBlocks", {
       blockerId: userId,
       blockedId: args.blockedId,
-      createdAt: Date.now(),
+      createdAt: now,
       reason: args.reason,
     });
+
+    // Auto-decline any pending ad-hoc chat request between the blocker and the blocked.
+    // Only the blocker's own membership row is touched — the blocked user's view is
+    // unaffected (silent block). Without this, pending requests would linger in the
+    // blocker's inbox after they explicitly opted out of further contact.
+    const myMemberships = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_user_requestState", (q) =>
+        q.eq("userId", userId).eq("requestState", "pending"),
+      )
+      .collect();
+    for (const m of myMemberships) {
+      if (m.invitedById !== args.blockedId) continue;
+      if (m.leftAt !== undefined) continue;
+      await ctx.db.patch(m._id, {
+        requestState: "declined",
+        requestRespondedAt: now,
+        leftAt: now,
+      });
+    }
   },
 });
 

--- a/apps/convex/functions/messaging/channelInvites.ts
+++ b/apps/convex/functions/messaging/channelInvites.ts
@@ -17,7 +17,10 @@ import { generateShortId, getDisplayName, getMediaUrl } from "../../lib/utils";
  * Build the set of group IDs whose members are eligible to use a channel's invite link.
  * Includes the primary group and all accepted secondary groups for shared channels.
  */
-function getEligibleGroupIds(channel: { groupId: Id<"groups">; isShared?: boolean; sharedGroups?: Array<{ groupId: Id<"groups">; status: string }> }): Set<Id<"groups">> {
+function getEligibleGroupIds(channel: { groupId?: Id<"groups">; isShared?: boolean; sharedGroups?: Array<{ groupId: Id<"groups">; status: string }> }): Set<Id<"groups">> {
+  if (!channel.groupId) {
+    throw new Error("This operation is only valid for group channels");
+  }
   const ids = new Set<Id<"groups">>([channel.groupId]);
   if (channel.isShared) {
     for (const sg of channel.sharedGroups ?? []) {
@@ -52,6 +55,7 @@ export const getByShortId = query({
     if (!channel || !channel.inviteEnabled || channel.isArchived || !channelIsLeaderEnabled(channel)) {
       return null;
     }
+    if (!channel.groupId) return null; // Skip ad-hoc channels (DM/group_dm)
 
     // Get group info
     const group = await ctx.db.get(channel.groupId);
@@ -160,12 +164,14 @@ export const getInviteInfo = query({
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
     if (!channel) return null;
+    if (!channel.groupId) return null; // Skip ad-hoc channels (DM/group_dm)
+    const groupId = channel.groupId;
 
     // Verify user is a group leader
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -194,12 +200,14 @@ export const getPendingRequests = query({
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
     if (!channel) return [];
+    if (!channel.groupId) return []; // Skip ad-hoc channels (DM/group_dm)
+    const groupId = channel.groupId;
 
     // Verify user is a group leader
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -294,6 +302,8 @@ export const enableInviteLink = mutation({
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
     if (!channel) throw new ConvexError("Channel not found");
+    if (!channel.groupId) throw new ConvexError("This operation is only valid for group channels");
+    const groupId = channel.groupId;
 
     // Only custom channels
     if (channel.channelType !== "custom") {
@@ -306,7 +316,7 @@ export const enableInviteLink = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -338,11 +348,13 @@ export const disableInviteLink = mutation({
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
     if (!channel) throw new ConvexError("Channel not found");
+    if (!channel.groupId) throw new ConvexError("This operation is only valid for group channels");
+    const groupId = channel.groupId;
 
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -371,11 +383,13 @@ export const regenerateInviteLink = mutation({
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
     if (!channel) throw new ConvexError("Channel not found");
+    if (!channel.groupId) throw new ConvexError("This operation is only valid for group channels");
+    const groupId = channel.groupId;
 
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -408,6 +422,8 @@ export const updateJoinMode = mutation({
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
     if (!channel) throw new ConvexError("Channel not found");
+    if (!channel.groupId) throw new ConvexError("This operation is only valid for group channels");
+    const groupId = channel.groupId;
 
     if (channel.channelType !== "custom") {
       throw new ConvexError("Join mode can only be set on custom channels.");
@@ -416,7 +432,7 @@ export const updateJoinMode = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -458,6 +474,9 @@ export const joinViaInviteLink = mutation({
 
     if (!channel || !channel.inviteEnabled || channel.isArchived || !channelIsLeaderEnabled(channel)) {
       throw new ConvexError("This invite link is no longer valid.");
+    }
+    if (!channel.groupId) {
+      throw new ConvexError("This operation is only valid for group channels");
     }
 
     // Verify user is a member of any eligible group (primary + accepted shared groups)
@@ -650,12 +669,14 @@ export const approveJoinRequest = mutation({
 
     const channel = await ctx.db.get(request.channelId);
     if (!channel) throw new ConvexError("Channel not found.");
+    if (!channel.groupId) throw new ConvexError("This operation is only valid for group channels");
+    const groupId = channel.groupId;
 
     // Verify user is a group leader
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -758,11 +779,13 @@ export const declineJoinRequest = mutation({
 
     const channel = await ctx.db.get(request.channelId);
     if (!channel) throw new ConvexError("Channel not found.");
+    if (!channel.groupId) throw new ConvexError("This operation is only valid for group channels");
+    const groupId = channel.groupId;
 
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -804,11 +827,13 @@ export const bulkApproveRequests = mutation({
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
     if (!channel) throw new ConvexError("Channel not found");
+    if (!channel.groupId) throw new ConvexError("This operation is only valid for group channels");
+    const groupId = channel.groupId;
 
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId),
+        q.eq("groupId", groupId).eq("userId", userId),
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -228,6 +228,11 @@ export const getChannel = query({
       };
     }
 
+    if (!channel.groupId) {
+      return null; // Skip ad-hoc channels (DM/group_dm) - handled separately
+    }
+    const groupId = channel.groupId;
+
     // Check channel membership
     const membership = await ctx.db
       .query("chatChannelMembers")
@@ -241,7 +246,7 @@ export const getChannel = query({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -556,6 +561,7 @@ export const getUserChannels = query({
     return channels
       .filter((c): c is NonNullable<typeof c> => {
         if (c === null || c.isArchived) return false;
+        if (!c.groupId) return false; // Skip ad-hoc channels (DM/group_dm)
         const role = roleByGroupId.get(c.groupId);
         const isLeader = isLeaderRole(role);
         if (
@@ -596,6 +602,10 @@ export const getChannelMembers = query({
     if (!channel) {
       return { members: [], nextCursor: null, totalCount: 0 };
     }
+    if (!channel.groupId) {
+      return { members: [], nextCursor: null, totalCount: 0 }; // Skip ad-hoc channels (DM/group_dm)
+    }
+    const groupId = channel.groupId;
 
     // Check membership
     const membership = await ctx.db
@@ -613,7 +623,7 @@ export const getChannelMembers = query({
       const groupMembership = await ctx.db
         .query("groupMembers")
         .withIndex("by_group_user", (q) =>
-          q.eq("groupId", channel.groupId).eq("userId", userId)
+          q.eq("groupId", groupId).eq("userId", userId)
         )
         .filter((q) =>
           q.and(
@@ -626,7 +636,7 @@ export const getChannelMembers = query({
         )
         .first();
 
-      const group = await ctx.db.get(channel.groupId);
+      const group = await ctx.db.get(groupId);
       const isCommAdmin = group
         ? await isCommunityAdmin(ctx, group.communityId, userId)
         : false;
@@ -1189,8 +1199,10 @@ export const getInboxChannels = query({
     // owning group (and its group type) on demand and add it to validGroups
     // so the normal grouping step picks the channel up.
     for (const eventChannel of eventChannelsToInclude) {
-      const owningGroup = allGroups.find((g) => g && g._id === eventChannel.groupId)
-        ?? (await ctx.db.get(eventChannel.groupId));
+      if (!eventChannel.groupId) continue; // Skip ad-hoc channels (DM/group_dm)
+      const ecGroupId = eventChannel.groupId;
+      const owningGroup = allGroups.find((g) => g && g._id === ecGroupId)
+        ?? (await ctx.db.get(ecGroupId));
       if (!owningGroup || owningGroup.isArchived) continue;
       if (args.communityId && owningGroup.communityId !== args.communityId) continue;
 
@@ -1576,6 +1588,10 @@ export const updateChannel = mutation({
     if (!channel) {
       throw new Error("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new Error("This operation is only valid for group channels");
+    }
+    const groupId = channel.groupId;
 
     // Check if user is admin of channel or group leader
     const membership = await ctx.db
@@ -1589,7 +1605,7 @@ export const updateChannel = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -1635,12 +1651,16 @@ export const archiveChannel = mutation({
     if (!channel) {
       throw new Error("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new Error("This operation is only valid for group channels");
+    }
+    const groupId = channel.groupId;
 
     // Only group leaders/admins can archive
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -1686,6 +1706,10 @@ export const archiveCustomChannel = mutation({
     if (!channel) {
       throw new ConvexError({ code: "NOT_FOUND", message: "Channel not found" });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({ code: "INVALID_OPERATION", message: "This operation is only valid for group channels" });
+    }
+    const groupId = channel.groupId;
 
     // 3. If not custom channel, throw error
     if (!isCustomChannel(channel.channelType)) {
@@ -1709,7 +1733,7 @@ export const archiveCustomChannel = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -1775,6 +1799,10 @@ export const unarchiveCustomChannel = mutation({
     if (!channel) {
       throw new ConvexError({ code: "NOT_FOUND", message: "Channel not found" });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({ code: "INVALID_OPERATION", message: "This operation is only valid for group channels" });
+    }
+    const groupId = channel.groupId;
 
     if (!isCustomChannel(channel.channelType)) {
       throw new ConvexError({
@@ -1793,7 +1821,7 @@ export const unarchiveCustomChannel = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -1840,6 +1868,10 @@ export const setCustomChannelLeaderEnabled = mutation({
     if (!channel) {
       throw new ConvexError({ code: "NOT_FOUND", message: "Channel not found" });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({ code: "INVALID_OPERATION", message: "This operation is only valid for group channels" });
+    }
+    const groupId = channel.groupId;
 
     if (!isCustomChannel(channel.channelType)) {
       throw new ConvexError({
@@ -1848,7 +1880,7 @@ export const setCustomChannelLeaderEnabled = mutation({
       });
     }
 
-    const managingGroupId = args.managingGroupId ?? channel.groupId;
+    const managingGroupId = args.managingGroupId ?? groupId;
 
     const linkedResult = await handleLinkedGroupToggle(
       ctx,
@@ -1865,7 +1897,7 @@ export const setCustomChannelLeaderEnabled = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -1978,6 +2010,10 @@ export const archivePcoChannel = mutation({
     if (!channel) {
       throw new ConvexError({ code: "NOT_FOUND", message: "Channel not found" });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({ code: "INVALID_OPERATION", message: "This operation is only valid for group channels" });
+    }
+    const groupId = channel.groupId;
 
     // 3. Verify this is a PCO channel
     if (channel.channelType !== "pco_services") {
@@ -1991,7 +2027,7 @@ export const archivePcoChannel = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -2033,6 +2069,10 @@ export const togglePcoChannel = mutation({
     if (!channel) {
       throw new ConvexError({ code: "NOT_FOUND", message: "Channel not found" });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({ code: "INVALID_OPERATION", message: "This operation is only valid for group channels" });
+    }
+    const groupId = channel.groupId;
 
     if (channel.channelType !== "pco_services") {
       throw new ConvexError({
@@ -2041,7 +2081,7 @@ export const togglePcoChannel = mutation({
       });
     }
 
-    const managingGroupId = args.managingGroupId ?? channel.groupId;
+    const managingGroupId = args.managingGroupId ?? groupId;
 
     const linkedResult = await handleLinkedGroupToggle(
       ctx,
@@ -2058,7 +2098,7 @@ export const togglePcoChannel = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -2142,12 +2182,16 @@ export const addMember = mutation({
     if (!channel) {
       throw new Error("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new Error("This operation is only valid for group channels");
+    }
+    const groupId = channel.groupId;
 
     // Check if the user to be added is a group member
     const targetGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", args.userId)
+        q.eq("groupId", groupId).eq("userId", args.userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -2250,6 +2294,10 @@ export const updateMemberRole = mutation({
     if (!channel) {
       throw new Error("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new Error("This operation is only valid for group channels");
+    }
+    const groupId = channel.groupId;
 
     // Check if requester is admin
     const requesterMembership = await ctx.db
@@ -2263,7 +2311,7 @@ export const updateMemberRole = mutation({
     const requesterGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", requestingUserId)
+        q.eq("groupId", groupId).eq("userId", requestingUserId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -2751,6 +2799,10 @@ export const addChannelMembers = mutation({
     if (!channel) {
       throw new Error("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new Error("This operation is only valid for group channels");
+    }
+    const groupId = channel.groupId;
 
     if (!isCustomChannel(channel.channelType)) {
       throw new Error("You can only add members to custom channels.");
@@ -2776,7 +2828,7 @@ export const addChannelMembers = mutation({
     const callerGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", callerId)
+        q.eq("groupId", groupId).eq("userId", callerId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -2792,7 +2844,7 @@ export const addChannelMembers = mutation({
     const userDataMap = new Map<Id<"users">, { displayName: string; profilePhoto: string | undefined }>();
     const timestamp = Date.now();
     const isSharedChannel = channel.isShared === true;
-    const eligibleGroupIds = new Set<Id<"groups">>([channel.groupId]);
+    const eligibleGroupIds = new Set<Id<"groups">>([groupId]);
     const ineligibleUserDisplayNames: string[] = [];
 
     if (isSharedChannel) {
@@ -2842,7 +2894,7 @@ export const addChannelMembers = mutation({
         const existingGroupMembership = await ctx.db
           .query("groupMembers")
           .withIndex("by_group_user", (q) =>
-            q.eq("groupId", channel.groupId).eq("userId", userId)
+            q.eq("groupId", groupId).eq("userId", userId)
           )
           .first();
 
@@ -2861,7 +2913,7 @@ export const addChannelMembers = mutation({
           } else {
             // Create new group membership
             await ctx.db.insert("groupMembers", {
-              groupId: channel.groupId,
+              groupId,
               userId,
               role: "member",
               joinedAt: timestamp,
@@ -2873,14 +2925,14 @@ export const addChannelMembers = mutation({
               0,
               internal.functions.scheduledJobs.sendWelcomeMessage,
               {
-                groupId: channel.groupId,
+                groupId,
                 userId,
               }
             );
           }
 
           // Sync channel memberships for the newly added group member
-          await syncUserChannelMembershipsLogic(ctx, userId, channel.groupId);
+          await syncUserChannelMembershipsLogic(ctx, userId, groupId);
         }
       }
 
@@ -2978,6 +3030,13 @@ export const removeChannelMember = mutation({
         message: "Channel not found",
       });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({
+        code: "INVALID_CHANNEL_TYPE",
+        message: "This operation is only valid for group channels",
+      });
+    }
+    const groupId = channel.groupId;
 
     if (!isCustomChannel(channel.channelType)) {
       throw new ConvexError({
@@ -3002,7 +3061,7 @@ export const removeChannelMember = mutation({
     const callerGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", callerId)
+        q.eq("groupId", groupId).eq("userId", callerId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -3830,6 +3889,7 @@ export const syncUserChannelMemberships = internalMutation({
 
     // Sync each channel
     for (const channel of channels) {
+      if (!channel.groupId) continue; // Skip ad-hoc channels (DM/group_dm)
       const groupRole = groupRoleMap.get(channel.groupId);
       const isActiveGroupMember = groupRole !== undefined;
       const isLeaderOrAdmin = groupRole === "leader" || groupRole === "admin";
@@ -3961,6 +4021,13 @@ export const updateAutoChannelConfig = mutation({
         message: "Channel not found",
       });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({
+        code: "INVALID_OPERATION",
+        message: "This operation is only valid for group channels",
+      });
+    }
+    const groupId = channel.groupId;
 
     // 3. Verify channel is an auto channel (pco_services type)
     if (channel.channelType !== "pco_services") {
@@ -3974,7 +4041,7 @@ export const updateAutoChannelConfig = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -4104,6 +4171,13 @@ export const disableAutoChannel = mutation({
         message: "Channel not found",
       });
     }
+    if (!channel.groupId) {
+      throw new ConvexError({
+        code: "INVALID_OPERATION",
+        message: "This operation is only valid for group channels",
+      });
+    }
+    const groupId = channel.groupId;
 
     // 3. Verify channel is an auto channel
     if (channel.channelType !== "pco_services") {
@@ -4117,7 +4191,7 @@ export const disableAutoChannel = mutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -1,0 +1,724 @@
+/**
+ * Direct Message + Ad-Hoc Group Chat Functions
+ *
+ * Backend for 1:1 DMs and small ad-hoc group chats. Channels live in
+ * `chatChannels` alongside traditional group channels, distinguished by
+ * `isAdHoc: true` and `channelType: "dm" | "group_dm"`. They have a
+ * `communityId` (not `groupId`) since DMs are scoped to communities.
+ *
+ * Message Request flow: when user A creates a DM/group chat with user B,
+ * B's `chatChannelMembers` row starts in `requestState: "pending"`. B must
+ * Accept, Decline, or Block-and-Report before the chat is fully usable on
+ * B's side.
+ */
+
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "../../_generated/server";
+import type { QueryCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { checkRateLimit } from "../../lib/rateLimit";
+import { getDisplayName, getMediaUrl } from "../../lib/utils";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Max number of recipients in a `group_dm` (creator excluded). Total cap is 20. */
+const MAX_GROUP_DM_RECIPIENTS = 19;
+/** Cap on group chat name length. */
+const MAX_GROUP_NAME_LENGTH = 100;
+/** Cap on member-search result list length. */
+const DEFAULT_SEARCH_LIMIT = 30;
+const MAX_SEARCH_LIMIT = 50;
+/** Max new pending DM requests a user can initiate per 24h. */
+const NEW_REQUEST_LIMIT = 5;
+const NEW_REQUEST_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+/**
+ * Compute the deterministic dedup key for a 1:1 DM channel.
+ * Sorted lexicographically so that (a, b) and (b, a) produce the same key.
+ */
+function computeDmPairKey(a: Id<"users">, b: Id<"users">): string {
+  return [a, b].sort().join("::");
+}
+
+/**
+ * Returns true if either user has blocked the other (any direction).
+ * Use this before exposing the existence of either user to the other.
+ */
+async function isBlockedEitherDirection(
+  ctx: QueryCtx,
+  userIdA: Id<"users">,
+  userIdB: Id<"users">,
+): Promise<boolean> {
+  const aBlockedB = await ctx.db
+    .query("chatUserBlocks")
+    .withIndex("by_blocker_blocked", (q) =>
+      q.eq("blockerId", userIdA).eq("blockedId", userIdB),
+    )
+    .first();
+  if (aBlockedB) return true;
+
+  const bBlockedA = await ctx.db
+    .query("chatUserBlocks")
+    .withIndex("by_blocker_blocked", (q) =>
+      q.eq("blockerId", userIdB).eq("blockedId", userIdA),
+    )
+    .first();
+  return bBlockedA !== null;
+}
+
+/**
+ * Return the set of community IDs that both users are members of.
+ * Skips memberships with status === 3 (deactivated) — undefined status
+ * is treated as active for legacy rows.
+ */
+async function getSharedCommunityIds(
+  ctx: QueryCtx,
+  userIdA: Id<"users">,
+  userIdB: Id<"users">,
+): Promise<Id<"communities">[]> {
+  const [aMemberships, bMemberships] = await Promise.all([
+    ctx.db
+      .query("userCommunities")
+      .withIndex("by_user", (q) => q.eq("userId", userIdA))
+      .collect(),
+    ctx.db
+      .query("userCommunities")
+      .withIndex("by_user", (q) => q.eq("userId", userIdB))
+      .collect(),
+  ]);
+
+  const isActive = (status: number | undefined) => status !== 3;
+  const aSet = new Set(
+    aMemberships.filter((m) => isActive(m.status)).map((m) => m.communityId),
+  );
+  const shared: Id<"communities">[] = [];
+  for (const m of bMemberships) {
+    if (!isActive(m.status)) continue;
+    if (aSet.has(m.communityId)) shared.push(m.communityId);
+  }
+  return shared;
+}
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+/**
+ * Create a 1:1 DM channel between the caller and `recipientUserId`, or return
+ * the existing one. Returns `{ channelId, isNew }`. The recipient's membership
+ * row starts in `requestState: "pending"` until they accept.
+ *
+ * Rejects if:
+ *   - Caller is the recipient
+ *   - The two users share no community
+ *   - Either party has blocked the other
+ *   - Caller has already initiated 5 new pending DMs in the last 24h
+ */
+export const createOrGetDirectChannel = mutation({
+  args: {
+    token: v.string(),
+    recipientUserId: v.id("users"),
+  },
+  handler: async (ctx, args): Promise<{ channelId: Id<"chatChannels">; isNew: boolean }> => {
+    const senderId = await requireAuth(ctx, args.token);
+
+    if (senderId === args.recipientUserId) {
+      throw new Error("Cannot DM yourself");
+    }
+
+    const dmPairKey = computeDmPairKey(senderId, args.recipientUserId);
+
+    // Existing channel? Return it without rate-limit (already-known pair).
+    const existing = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_dmPairKey", (q) => q.eq("dmPairKey", dmPairKey))
+      .first();
+    if (existing) {
+      return { channelId: existing._id, isNew: false };
+    }
+
+    // Verify shared community.
+    const sharedCommunityIds = await getSharedCommunityIds(
+      ctx,
+      senderId,
+      args.recipientUserId,
+    );
+    if (sharedCommunityIds.length === 0) {
+      throw new Error("You can only message members of your communities");
+    }
+    const communityId = sharedCommunityIds[0]!;
+
+    // Verify neither party has blocked the other (generic error — don't leak who).
+    if (await isBlockedEitherDirection(ctx, senderId, args.recipientUserId)) {
+      throw new Error("Cannot start chat");
+    }
+
+    // Rate-limit new pending DM requests.
+    await checkRateLimit(
+      ctx,
+      `dm-init:${senderId}`,
+      NEW_REQUEST_LIMIT,
+      NEW_REQUEST_WINDOW_MS,
+    );
+
+    const recipient = await ctx.db.get(args.recipientUserId);
+    if (!recipient) {
+      throw new Error("Recipient not found");
+    }
+    const sender = await ctx.db.get(senderId);
+    if (!sender) {
+      throw new Error("Sender not found");
+    }
+
+    const now = Date.now();
+    const channelId = await ctx.db.insert("chatChannels", {
+      communityId,
+      isAdHoc: true,
+      dmPairKey,
+      channelType: "dm",
+      name: "",
+      createdById: senderId,
+      createdAt: now,
+      updatedAt: now,
+      isArchived: false,
+      memberCount: 2,
+    });
+
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: senderId,
+      role: "admin",
+      joinedAt: now,
+      isMuted: false,
+      requestState: "accepted",
+      displayName: getDisplayName(sender.firstName, sender.lastName),
+      profilePhoto: sender.profilePhoto,
+    });
+
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: args.recipientUserId,
+      role: "member",
+      joinedAt: now,
+      isMuted: false,
+      requestState: "pending",
+      invitedById: senderId,
+      displayName: getDisplayName(recipient.firstName, recipient.lastName),
+      profilePhoto: recipient.profilePhoto,
+    });
+
+    return { channelId, isNew: true };
+  },
+});
+
+/**
+ * Create an ad-hoc group chat with the caller plus 1-19 recipients (≤ 20 total).
+ * Returns `{ channelId }`. All recipients start in `requestState: "pending"`.
+ *
+ * Channel `communityId` is the community most-shared between the creator and
+ * recipients (mode of intersected memberships; ties broken arbitrarily).
+ *
+ * Group chats are NOT deduped — two calls with the same recipient set produce
+ * two distinct channels.
+ *
+ * Rejects if:
+ *   - Recipient list (after de-dupe) is empty or > 19
+ *   - Any recipient shares no community with the creator
+ *   - Any recipient is blocked-with or has blocked the creator
+ *   - Caller has already initiated 5 new pending requests in the last 24h
+ */
+export const createGroupChat = mutation({
+  args: {
+    token: v.string(),
+    recipientUserIds: v.array(v.id("users")),
+    name: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ channelId: Id<"chatChannels"> }> => {
+    const creatorId = await requireAuth(ctx, args.token);
+
+    // De-dupe and exclude creator.
+    const uniqueRecipients = Array.from(
+      new Set(args.recipientUserIds.filter((id) => id !== creatorId)),
+    );
+    if (uniqueRecipients.length === 0) {
+      throw new Error("Group chat requires at least one other recipient");
+    }
+    if (uniqueRecipients.length > MAX_GROUP_DM_RECIPIENTS) {
+      throw new Error(
+        `Group chat can include at most ${MAX_GROUP_DM_RECIPIENTS} other people`,
+      );
+    }
+
+    // For each recipient, get their shared communities with the creator and
+    // count community-IDs across the group. Recipients with no overlap fail
+    // the request entirely.
+    const sharedPerRecipient = await Promise.all(
+      uniqueRecipients.map((id) => getSharedCommunityIds(ctx, creatorId, id)),
+    );
+    const missingShared: Id<"users">[] = [];
+    const communityCounts = new Map<Id<"communities">, number>();
+    for (let i = 0; i < uniqueRecipients.length; i++) {
+      const shared = sharedPerRecipient[i]!;
+      if (shared.length === 0) {
+        missingShared.push(uniqueRecipients[i]!);
+        continue;
+      }
+      for (const cId of shared) {
+        communityCounts.set(cId, (communityCounts.get(cId) ?? 0) + 1);
+      }
+    }
+    if (missingShared.length > 0) {
+      throw new Error("You can only message members of your communities");
+    }
+
+    // Pick the most-shared community.
+    let communityId: Id<"communities"> | null = null;
+    let bestCount = 0;
+    for (const [cId, count] of communityCounts) {
+      if (count > bestCount) {
+        bestCount = count;
+        communityId = cId;
+      }
+    }
+    if (!communityId) {
+      throw new Error("You can only message members of your communities");
+    }
+
+    // Block-check every recipient. Generic message; do not enumerate.
+    const blockedChecks = await Promise.all(
+      uniqueRecipients.map((id) => isBlockedEitherDirection(ctx, creatorId, id)),
+    );
+    if (blockedChecks.some((b) => b)) {
+      throw new Error("Cannot include some users in this chat");
+    }
+
+    // Rate-limit new pending requests.
+    await checkRateLimit(
+      ctx,
+      `dm-init:${creatorId}`,
+      NEW_REQUEST_LIMIT,
+      NEW_REQUEST_WINDOW_MS,
+    );
+
+    const creator = await ctx.db.get(creatorId);
+    if (!creator) {
+      throw new Error("Sender not found");
+    }
+    const recipients = await Promise.all(
+      uniqueRecipients.map((id) => ctx.db.get(id)),
+    );
+
+    const now = Date.now();
+    const trimmedName = (args.name ?? "").trim().slice(0, MAX_GROUP_NAME_LENGTH);
+
+    const channelId = await ctx.db.insert("chatChannels", {
+      communityId,
+      isAdHoc: true,
+      channelType: "group_dm",
+      name: trimmedName,
+      createdById: creatorId,
+      createdAt: now,
+      updatedAt: now,
+      isArchived: false,
+      memberCount: 1 + uniqueRecipients.length,
+    });
+
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: creatorId,
+      role: "admin",
+      joinedAt: now,
+      isMuted: false,
+      requestState: "accepted",
+      displayName: getDisplayName(creator.firstName, creator.lastName),
+      profilePhoto: creator.profilePhoto,
+    });
+
+    for (let i = 0; i < uniqueRecipients.length; i++) {
+      const recipientId = uniqueRecipients[i]!;
+      const recipient = recipients[i];
+      if (!recipient) {
+        throw new Error("Recipient not found");
+      }
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: recipientId,
+        role: "member",
+        joinedAt: now,
+        isMuted: false,
+        requestState: "pending",
+        invitedById: creatorId,
+        displayName: getDisplayName(recipient.firstName, recipient.lastName),
+        profilePhoto: recipient.profilePhoto,
+      });
+    }
+
+    return { channelId };
+  },
+});
+
+/**
+ * Respond to a pending chat request as the recipient.
+ *
+ *   - "accept": flip requestState to "accepted"; chat is now fully usable for the responder
+ *   - "decline": mark declined and set leftAt so existing membership filters exclude them.
+ *     The inviter is NOT notified.
+ *   - "block": same as decline, plus inserts a `chatUserBlocks` row (idempotent) and a
+ *     `chatUserFlags` report so moderators can review the inviter.
+ *
+ * Throws if the row is not in pending state or the channel is not ad-hoc.
+ */
+export const respondToChatRequest = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    response: v.union(
+      v.literal("accept"),
+      v.literal("decline"),
+      v.literal("block"),
+    ),
+    reportReason: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const membership = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", args.channelId).eq("userId", userId),
+      )
+      .first();
+    if (!membership) {
+      throw new Error("Not a member of this channel");
+    }
+    if (membership.requestState !== "pending") {
+      throw new Error("This chat is not pending response");
+    }
+
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    if (!channel.isAdHoc) {
+      throw new ConvexError({
+        code: "INVALID_CHANNEL",
+        message: "Only ad-hoc chat requests can be responded to",
+      });
+    }
+
+    const now = Date.now();
+
+    if (args.response === "accept") {
+      await ctx.db.patch(membership._id, {
+        requestState: "accepted",
+        requestRespondedAt: now,
+      });
+      return { ok: true };
+    }
+
+    if (args.response === "decline") {
+      await ctx.db.patch(membership._id, {
+        requestState: "declined",
+        requestRespondedAt: now,
+        leftAt: now,
+      });
+      return { ok: true };
+    }
+
+    // response === "block"
+    const inviterId = membership.invitedById;
+    if (!inviterId) {
+      throw new Error("Cannot block: inviter unknown");
+    }
+
+    await ctx.db.patch(membership._id, {
+      requestState: "declined",
+      requestRespondedAt: now,
+      leftAt: now,
+    });
+
+    // Idempotent block insert.
+    const existingBlock = await ctx.db
+      .query("chatUserBlocks")
+      .withIndex("by_blocker_blocked", (q) =>
+        q.eq("blockerId", userId).eq("blockedId", inviterId),
+      )
+      .first();
+    if (!existingBlock) {
+      await ctx.db.insert("chatUserBlocks", {
+        blockerId: userId,
+        blockedId: inviterId,
+        createdAt: now,
+        reason: args.reportReason,
+      });
+    }
+
+    await ctx.db.insert("chatUserFlags", {
+      userId: inviterId,
+      reportedById: userId,
+      channelId: args.channelId,
+      reason: args.reportReason ?? "other",
+      status: "pending",
+      createdAt: now,
+    });
+
+    return { ok: true };
+  },
+});
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+/**
+ * List the caller's pending chat requests (DMs and group_dms where the caller's
+ * `requestState === "pending"`). Returns enough metadata to render an inbox row:
+ * inviter info, shared-community attribution, member count, and a first-message
+ * preview. Sorted most-recent-invite first. Returns an empty array when there
+ * are no pending requests — never throws on empty.
+ */
+export const listChatRequests = query({
+  args: {
+    token: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const pendingRows = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_user_requestState", (q) =>
+        q.eq("userId", userId).eq("requestState", "pending"),
+      )
+      .collect();
+
+    // Pre-fetch caller's communities for shared-community resolution.
+    const callerMemberships = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const callerCommunityIds = new Set(
+      callerMemberships
+        .filter((m) => m.status !== 3)
+        .map((m) => m.communityId),
+    );
+
+    const results: Array<{
+      channelId: Id<"chatChannels">;
+      channelType: "dm" | "group_dm";
+      channelName: string;
+      inviterUserId: Id<"users">;
+      inviterDisplayName: string;
+      inviterProfilePhoto: string | null;
+      sharedCommunityNames: string[];
+      memberCount: number;
+      firstMessagePreview: string | null;
+      firstMessageSenderName: string | null;
+      invitedAt: number;
+    }> = [];
+
+    for (const row of pendingRows) {
+      if (row.leftAt !== undefined) continue;
+      const channel = await ctx.db.get(row.channelId);
+      if (!channel || !channel.isAdHoc || channel.isArchived) continue;
+      if (!row.invitedById) continue;
+      const inviter = await ctx.db.get(row.invitedById);
+      if (!inviter) continue;
+
+      // Shared communities = (channel community ∪ inviter communities) ∩ caller communities.
+      const inviterMemberships = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_user", (q) => q.eq("userId", row.invitedById!))
+        .collect();
+      const inviterActive = inviterMemberships
+        .filter((m) => m.status !== 3)
+        .map((m) => m.communityId);
+      const sharedIds: Id<"communities">[] = [];
+      for (const cId of inviterActive) {
+        if (callerCommunityIds.has(cId)) sharedIds.push(cId);
+      }
+      // Always surface the channel's community first if it's shared with the caller.
+      if (channel.communityId && callerCommunityIds.has(channel.communityId)) {
+        sharedIds.sort((a, b) => {
+          if (a === channel.communityId) return -1;
+          if (b === channel.communityId) return 1;
+          return 0;
+        });
+      }
+      const sharedCommunityNames: string[] = [];
+      for (const cId of sharedIds.slice(0, 2)) {
+        const community = await ctx.db.get(cId);
+        if (community?.name) sharedCommunityNames.push(community.name);
+      }
+
+      // First non-deleted message preview.
+      const firstMessage = await ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel_createdAt", (q) =>
+          q.eq("channelId", channel._id),
+        )
+        .order("asc")
+        .filter((q) => q.eq(q.field("isDeleted"), false))
+        .first();
+
+      const channelType = channel.channelType as "dm" | "group_dm";
+      results.push({
+        channelId: channel._id,
+        channelType,
+        channelName: channel.name,
+        inviterUserId: inviter._id,
+        inviterDisplayName: getDisplayName(inviter.firstName, inviter.lastName),
+        inviterProfilePhoto: getMediaUrl(inviter.profilePhoto) ?? null,
+        sharedCommunityNames,
+        memberCount: channel.memberCount,
+        firstMessagePreview: firstMessage?.content ?? null,
+        firstMessageSenderName: firstMessage?.senderName ?? null,
+        invitedAt: row.joinedAt,
+      });
+    }
+
+    // Most recent invites first.
+    results.sort((a, b) => b.invitedAt - a.invitedAt);
+    return results;
+  },
+});
+
+/**
+ * Search users the caller could start a DM/group chat with: members of any
+ * community the caller belongs to. Filters out the caller, blocked users
+ * (either direction), and any explicitly excluded IDs. Empty `query` returns
+ * up to `limit` candidates from the caller's communities. Capped at 50.
+ */
+export const searchUsersInSharedCommunities = query({
+  args: {
+    token: v.string(),
+    query: v.string(),
+    excludeUserIds: v.optional(v.array(v.id("users"))),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+
+    const limit = Math.min(
+      Math.max(args.limit ?? DEFAULT_SEARCH_LIMIT, 1),
+      MAX_SEARCH_LIMIT,
+    );
+    const excludeIds = new Set<Id<"users">>(args.excludeUserIds ?? []);
+    excludeIds.add(callerId);
+    const trimmedQuery = args.query.trim().toLowerCase();
+
+    // Caller's communities.
+    const callerMemberships = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user", (q) => q.eq("userId", callerId))
+      .collect();
+    const callerCommunityIds = callerMemberships
+      .filter((m) => m.status !== 3)
+      .map((m) => m.communityId);
+    if (callerCommunityIds.length === 0) {
+      return [];
+    }
+
+    // Collect candidate user IDs and the community-IDs they share with the caller.
+    const sharedByUser = new Map<Id<"users">, Set<Id<"communities">>>();
+    for (const communityId of callerCommunityIds) {
+      const memberships = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .filter((q) => q.neq(q.field("status"), 3))
+        .take(2000);
+      for (const m of memberships) {
+        if (excludeIds.has(m.userId)) continue;
+        let set = sharedByUser.get(m.userId);
+        if (!set) {
+          set = new Set();
+          sharedByUser.set(m.userId, set);
+        }
+        set.add(communityId);
+      }
+    }
+
+    if (sharedByUser.size === 0) {
+      return [];
+    }
+
+    // Resolve user docs, filter by name match, and filter out blocks.
+    type Candidate = {
+      user: NonNullable<Awaited<ReturnType<typeof ctx.db.get<"users">>>>;
+      sharedCommunityIds: Id<"communities">[];
+      isFullNameMatch: boolean;
+    };
+    const candidates: Candidate[] = [];
+    for (const [candidateId, sharedSet] of sharedByUser) {
+      if (candidates.length >= limit * 4) break; // bound work; we'll filter & cap later
+      const user = await ctx.db.get(candidateId);
+      if (!user) continue;
+
+      const fullName = `${user.firstName ?? ""} ${user.lastName ?? ""}`
+        .trim()
+        .toLowerCase();
+      const searchText = (user.searchText ?? "").toLowerCase();
+
+      let isFullNameMatch = false;
+      if (trimmedQuery.length > 0) {
+        if (fullName.includes(trimmedQuery)) {
+          isFullNameMatch = true;
+        } else if (!searchText.includes(trimmedQuery)) {
+          continue;
+        }
+      }
+
+      if (await isBlockedEitherDirection(ctx, callerId, user._id)) {
+        continue;
+      }
+
+      candidates.push({
+        user,
+        sharedCommunityIds: Array.from(sharedSet),
+        isFullNameMatch,
+      });
+    }
+
+    // Sort: full-name matches first, then alphabetical by last/first.
+    candidates.sort((a, b) => {
+      if (a.isFullNameMatch !== b.isFullNameMatch) {
+        return a.isFullNameMatch ? -1 : 1;
+      }
+      const aName = `${a.user.lastName ?? ""} ${a.user.firstName ?? ""}`
+        .trim()
+        .toLowerCase();
+      const bName = `${b.user.lastName ?? ""} ${b.user.firstName ?? ""}`
+        .trim()
+        .toLowerCase();
+      return aName.localeCompare(bName);
+    });
+
+    const capped = candidates.slice(0, limit);
+
+    // Resolve shared community names.
+    const allCommunityIds = new Set<Id<"communities">>();
+    for (const c of capped) {
+      for (const cId of c.sharedCommunityIds) allCommunityIds.add(cId);
+    }
+    const communityNameById = new Map<Id<"communities">, string>();
+    for (const cId of allCommunityIds) {
+      const community = await ctx.db.get(cId);
+      if (community?.name) communityNameById.set(cId, community.name);
+    }
+
+    return capped.map((c) => ({
+      userId: c.user._id,
+      displayName: getDisplayName(c.user.firstName, c.user.lastName),
+      profilePhoto: getMediaUrl(c.user.profilePhoto) ?? null,
+      sharedCommunityNames: c.sharedCommunityIds
+        .map((cId) => communityNameById.get(cId))
+        .filter((n): n is string => Boolean(n)),
+    }));
+  },
+});

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -13,7 +13,7 @@
  */
 
 import { v, ConvexError } from "convex/values";
-import { query, mutation } from "../../_generated/server";
+import { query, mutation, internalMutation } from "../../_generated/server";
 import type { QueryCtx } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
@@ -720,5 +720,164 @@ export const searchUsersInSharedCommunities = query({
         .map((cId) => communityNameById.get(cId))
         .filter((n): n is string => Boolean(n)),
     }));
+  },
+});
+
+/**
+ * List the caller's accepted ad-hoc channels (DMs and group_dms). Powers the
+ * "Direct messages" section of the inbox. Does NOT include pending requests —
+ * those are surfaced separately by `listChatRequests`. Sorted most-recent
+ * activity first.
+ */
+export const getDirectInbox = query({
+  args: {
+    token: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const acceptedRows = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_user_requestState", (q) =>
+        q.eq("userId", userId).eq("requestState", "accepted"),
+      )
+      .collect();
+
+    const results: Array<{
+      channelId: Id<"chatChannels">;
+      channelType: "dm" | "group_dm";
+      channelName: string;
+      memberCount: number;
+      otherMembers: Array<{
+        userId: Id<"users">;
+        displayName: string;
+        profilePhoto: string | null;
+      }>;
+      lastMessageAt: number | null;
+      lastMessagePreview: string | null;
+      lastMessageSenderName: string | null;
+      unreadCount: number;
+      isMuted: boolean;
+    }> = [];
+
+    for (const row of acceptedRows) {
+      if (row.leftAt !== undefined) continue;
+      const channel = await ctx.db.get(row.channelId);
+      if (!channel || !channel.isAdHoc || channel.isArchived) continue;
+
+      const channelType = channel.channelType as "dm" | "group_dm";
+
+      // Other accepted/pending members for display (creator may still be
+      // surfacing the chat to a recipient who hasn't responded — that recipient
+      // shows in the member list with their pending state, but for inbox
+      // display we only need name+photo).
+      const otherMemberRows = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .collect();
+      const otherMembers = otherMemberRows
+        .filter((m) => m.userId !== userId)
+        .map((m) => ({
+          userId: m.userId,
+          displayName: m.displayName ?? "",
+          profilePhoto: getMediaUrl(m.profilePhoto) ?? null,
+        }));
+
+      // Read state → unread count.
+      const readState = await ctx.db
+        .query("chatReadState")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channel._id).eq("userId", userId),
+        )
+        .first();
+      const unreadCount = readState?.unreadCount ?? 0;
+
+      results.push({
+        channelId: channel._id,
+        channelType,
+        channelName: channel.name,
+        memberCount: channel.memberCount,
+        otherMembers,
+        lastMessageAt: channel.lastMessageAt ?? null,
+        lastMessagePreview: channel.lastMessagePreview ?? null,
+        lastMessageSenderName: channel.lastMessageSenderName ?? null,
+        unreadCount,
+        isMuted: row.isMuted,
+      });
+    }
+
+    results.sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0));
+    return results;
+  },
+});
+
+// ============================================================================
+// Cron handlers
+// ============================================================================
+
+/**
+ * Daily cron: expire pending chat requests older than 30 days.
+ *
+ * Sets `requestState: "declined"` and `leftAt: now` on stale `pending` rows so
+ * the recipient's inbox is cleaned up. The inviter is never notified (silent
+ * decline matches the on-demand decline behavior). Bounded by an explicit
+ * cutoff plus a `take()` cap so a backlog doesn't blow the per-mutation budget.
+ */
+export const expireOldChatRequests = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const PENDING_REQUEST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+    const MAX_PER_RUN = 500;
+    const cutoff = now - PENDING_REQUEST_TTL_MS;
+
+    const candidates = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_requestState_joinedAt", (q) =>
+        q.eq("requestState", "pending").lt("joinedAt", cutoff),
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .take(MAX_PER_RUN);
+
+    let expired = 0;
+    for (const row of candidates) {
+      await ctx.db.patch(row._id, {
+        requestState: "declined",
+        requestRespondedAt: now,
+        leftAt: now,
+      });
+      expired++;
+    }
+    return { expired };
+  },
+});
+
+/**
+ * Hourly cron: delete `directMessageRateLimits` rows older than 24h.
+ *
+ * Pending-pair rate-limit rows have a 24h window. Old rows have no further
+ * effect, but accumulating them would waste storage and slow scans. Bounded
+ * per-run for the same reasons as `expireOldChatRequests`.
+ */
+export const cleanupOldDmRateLimits = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const RATE_LIMIT_TTL_MS = 24 * 60 * 60 * 1000;
+    const MAX_PER_RUN = 1000;
+    const cutoff = now - RATE_LIMIT_TTL_MS;
+
+    const stale = await ctx.db
+      .query("directMessageRateLimits")
+      .withIndex("by_windowStartedAt", (q) => q.lt("windowStartedAt", cutoff))
+      .take(MAX_PER_RUN);
+
+    let deleted = 0;
+    for (const row of stale) {
+      await ctx.db.delete(row._id);
+      deleted++;
+    }
+    return { deleted };
   },
 });

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -212,9 +212,15 @@ export const onMessageSent = internalMutation({
           });
         }
       } else {
-        // Non-shared channel: original single-group path
+        // Non-shared channel: original single-group path. For ad-hoc DMs/group_dms,
+        // channel.groupId is undefined so we fall back to channel.communityId directly
+        // (the channel is the unit of routing here, not a group).
         const group = channel?.groupId ? await ctx.db.get(channel.groupId) : null;
-        const community = group?.communityId ? await ctx.db.get(group.communityId) : null;
+        const community = group?.communityId
+          ? await ctx.db.get(group.communityId)
+          : channel?.communityId
+            ? await ctx.db.get(channel.communityId)
+            : null;
 
         const mentionRecipients: Id<"users">[] = [];
         const regularRecipients: Id<"users">[] = [];
@@ -237,7 +243,7 @@ export const onMessageSent = internalMutation({
           messagePreview: preview,
           senderAvatarUrl,
           groupId: group?._id,
-          groupName: group?.name || 'Group Chat',
+          groupName: group?.name || channel?.name || 'Group Chat',
           communityId: community?._id,
           channelName: channel?.name,
           channelType: channel?.channelType || "main",

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -126,9 +126,10 @@ export const onMessageSent = internalMutation({
         (sg) => sg.status === "accepted"
       );
 
-      if (isSharedChannel && channel) {
+      if (isSharedChannel && channel && channel.groupId) {
         // Collect all group IDs: primary + accepted shared groups
-        const allGroupIds: Id<"groups">[] = [channel.groupId];
+        const channelGroupId = channel.groupId;
+        const allGroupIds: Id<"groups">[] = [channelGroupId];
         for (const sg of channel.sharedGroups || []) {
           if (sg.status === "accepted") {
             allGroupIds.push(sg.groupId);
@@ -167,7 +168,7 @@ export const onMessageSent = internalMutation({
           }
 
           // Fallback to primary group if membership lookup fails
-          const effectiveGroupId = memberGroupId || channel.groupId;
+          const effectiveGroupId = memberGroupId || channelGroupId;
           const key = effectiveGroupId;
 
           if (!groupBuckets.has(key)) {

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -615,6 +615,78 @@ export const sendMessage = mutation({
 
     const now = Date.now();
 
+    // Ad-hoc DM/group_dm gating: while ANY recipient is still in `requestState: "pending"`,
+    // restrict the sender to text-only, ≤1000 chars, and 1 message per 24h per pending pair.
+    // Sender themselves must be in `requestState: "accepted"` (declined/leftAt rows already
+    // bounced by the membership check above). `pendingOthers` is reused after insert to
+    // upsert the rate-limit rows.
+    let pendingOthersForRateLimit: Array<{ userId: Id<"users"> }> = [];
+    if (channel.isAdHoc) {
+      const senderMembership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", userId),
+        )
+        .first();
+      if (
+        !senderMembership ||
+        senderMembership.leftAt !== undefined ||
+        senderMembership.requestState !== "accepted"
+      ) {
+        throw new Error("Accept the request before replying");
+      }
+
+      const otherMembers = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .collect();
+      const pendingOthers = otherMembers.filter(
+        (m) => m.userId !== userId && m.requestState === "pending",
+      );
+
+      if (pendingOthers.length > 0) {
+        const PENDING_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+        const PENDING_MAX_TEXT_LENGTH = 1000;
+
+        if (args.attachments && args.attachments.length > 0) {
+          throw new Error(
+            "Cannot send attachments until the recipient accepts the request",
+          );
+        }
+        if (args.content.length > PENDING_MAX_TEXT_LENGTH) {
+          throw new Error(
+            `First message must be ${PENDING_MAX_TEXT_LENGTH} characters or fewer until accepted`,
+          );
+        }
+
+        for (const r of pendingOthers) {
+          const rl = await ctx.db
+            .query("directMessageRateLimits")
+            .withIndex("by_user_channel_recipient", (q) =>
+              q
+                .eq("userId", userId)
+                .eq("channelId", channelId)
+                .eq("recipientUserId", r.userId),
+            )
+            .first();
+          if (
+            rl &&
+            rl.windowStartedAt > now - PENDING_RATE_LIMIT_WINDOW_MS &&
+            rl.messageCount >= 1
+          ) {
+            throw new Error(
+              "You can send only 1 message until the recipient accepts the request",
+            );
+          }
+        }
+
+        pendingOthersForRateLimit = pendingOthers.map((r) => ({
+          userId: r.userId,
+        }));
+      }
+    }
+
     // Determine content type
     let contentType = "text";
     if (args.attachments && args.attachments.length > 0) {
@@ -663,6 +735,34 @@ export const sendMessage = mutation({
         await ctx.db.patch(args.parentMessageId, {
           threadReplyCount: (parentMessage.threadReplyCount || 0) + 1,
           lastActivityAt: now,
+        });
+      }
+    }
+
+    // Upsert rate-limit rows for each pending recipient. Done after a successful
+    // insert so a thrown rate-limit error doesn't leave stray counters behind.
+    for (const r of pendingOthersForRateLimit) {
+      const existingRl = await ctx.db
+        .query("directMessageRateLimits")
+        .withIndex("by_user_channel_recipient", (q) =>
+          q
+            .eq("userId", userId)
+            .eq("channelId", channelId)
+            .eq("recipientUserId", r.userId),
+        )
+        .first();
+      if (existingRl) {
+        await ctx.db.patch(existingRl._id, {
+          windowStartedAt: now,
+          messageCount: 1,
+        });
+      } else {
+        await ctx.db.insert("directMessageRateLimits", {
+          userId,
+          channelId,
+          recipientUserId: r.userId,
+          windowStartedAt: now,
+          messageCount: 1,
         });
       }
     }

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -226,6 +226,10 @@ export const getMessages = query({
         return { messages: [], hasMore: false, cursor: undefined };
       }
     } else {
+      if (!channel.groupId) {
+        throw new Error("This operation is only valid for group channels");
+      }
+      const channelGroupId = channel.groupId;
       // Check channel membership
       const channelMembership = await ctx.db
         .query("chatChannelMembers")
@@ -236,9 +240,9 @@ export const getMessages = query({
         .first();
 
       // Validate viewingGroupId is actually related to this channel
-      let contextGroupId = channel.groupId;
+      let contextGroupId: Id<"groups"> = channelGroupId;
       if (args.viewingGroupId) {
-        const isOwningGroup = args.viewingGroupId === channel.groupId;
+        const isOwningGroup = args.viewingGroupId === channelGroupId;
         const isAcceptedSharedGroup = channel.sharedGroups?.some(
           (sg) => sg.groupId === args.viewingGroupId && sg.status === "accepted"
         );
@@ -265,7 +269,7 @@ export const getMessages = query({
         ? await ctx.db
             .query("groupMembers")
             .withIndex("by_group_user", (q) =>
-              q.eq("groupId", channel.groupId).eq("userId", userId)
+              q.eq("groupId", channelGroupId).eq("userId", userId)
             )
             .filter((q) => q.eq(q.field("leftAt"), undefined))
             .first()
@@ -273,7 +277,7 @@ export const getMessages = query({
       const isOwningGroupLeader = isLeaderRole(owningGroupMembership?.role);
       // Also check linked group leadership when viewing from a linked group
       const isLinkedGroupLeader =
-        args.viewingGroupId && args.viewingGroupId !== channel.groupId
+        args.viewingGroupId && args.viewingGroupId !== channelGroupId
           ? isLeaderRole(groupMembership?.role)
           : false;
 
@@ -752,10 +756,11 @@ export const deleteMessage = mutation({
     let isCommunityAdminUser = false;
 
     if (channel?.groupId) {
+      const groupId = channel.groupId;
       const groupMembership = await ctx.db
         .query("groupMembers")
         .withIndex("by_group_user", (q) =>
-          q.eq("groupId", channel.groupId).eq("userId", userId)
+          q.eq("groupId", groupId).eq("userId", userId)
         )
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
@@ -763,7 +768,7 @@ export const deleteMessage = mutation({
       isGroupLeader = isLeaderRole(groupMembership?.role);
 
       // Community admins (ADMIN or PRIMARY_ADMIN) can delete any message in groups within their community
-      const group = await ctx.db.get(channel.groupId);
+      const group = await ctx.db.get(groupId);
       if (group?.communityId) {
         isCommunityAdminUser = await isCommunityAdmin(ctx, group.communityId, userId);
       }

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -225,10 +225,22 @@ export const getMessages = query({
       if (!(await canAccessEventChannel(ctx, userId, channel))) {
         return { messages: [], hasMore: false, cursor: undefined };
       }
-    } else {
-      if (!channel.groupId) {
-        throw new Error("This operation is only valid for group channels");
+    } else if (channel.isAdHoc || !channel.groupId) {
+      // Ad-hoc DM/group_dm — no group to gate on. Caller must have an active
+      // membership row (any requestState). Pending recipients can read the
+      // first message preview that's already in the channel; the chat-room
+      // banner gates replies until they accept, but they need to see the
+      // history to make that choice.
+      const adHocMembership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", args.channelId).eq("userId", userId),
+        )
+        .first();
+      if (!adHocMembership || adHocMembership.leftAt !== undefined) {
+        return { messages: [], hasMore: false, cursor: undefined };
       }
+    } else {
       const channelGroupId = channel.groupId;
       // Check channel membership
       const channelMembership = await ctx.db
@@ -641,6 +653,26 @@ export const sendMessage = mutation({
         .withIndex("by_channel", (q) => q.eq("channelId", channelId))
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .collect();
+
+      // Block enforcement on ad-hoc channels: if ANY active recipient has
+      // blocked the sender, the send is rejected. The message would otherwise
+      // be inserted (the existing notification path silences blocked users,
+      // but the message stays in the channel doc and stays visible to the
+      // blocker if they reopen the chat). A generic error keeps the block
+      // silent — the sender doesn't learn who blocked them.
+      for (const m of otherMembers) {
+        if (m.userId === userId) continue;
+        const block = await ctx.db
+          .query("chatUserBlocks")
+          .withIndex("by_blocker_blocked", (q) =>
+            q.eq("blockerId", m.userId).eq("blockedId", userId),
+          )
+          .first();
+        if (block) {
+          throw new Error("Cannot send message in this chat");
+        }
+      }
+
       const pendingOthers = otherMembers.filter(
         (m) => m.userId !== userId && m.requestState === "pending",
       );

--- a/apps/convex/functions/messaging/sharedChannels.ts
+++ b/apps/convex/functions/messaging/sharedChannels.ts
@@ -43,9 +43,13 @@ export const inviteGroupToChannel = mutation({
     if (!channel) {
       throw new ConvexError("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new ConvexError("This operation is only valid for group channels");
+    }
+    const channelGroupId = channel.groupId;
 
     // Cannot invite the channel's own group
-    if (args.groupId === channel.groupId) {
+    if (args.groupId === channelGroupId) {
       throw new ConvexError("Cannot invite the channel's own group");
     }
 
@@ -53,7 +57,7 @@ export const inviteGroupToChannel = mutation({
     const primaryGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", channelGroupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -70,7 +74,7 @@ export const inviteGroupToChannel = mutation({
 
     // Enforce same-community sharing boundaries.
     // Shared channels are scoped to groups within the same community.
-    const primaryGroup = await ctx.db.get(channel.groupId);
+    const primaryGroup = await ctx.db.get(channelGroupId);
     if (!primaryGroup) {
       throw new ConvexError("Primary group not found");
     }
@@ -112,7 +116,7 @@ export const inviteGroupToChannel = mutation({
       internal.functions.notifications.senders.notifySharedChannelInvite,
       {
         invitedGroupId: args.groupId,
-        primaryGroupId: channel.groupId,
+        primaryGroupId: channelGroupId,
         inviterId: userId,
         channelName: channel.name,
       }
@@ -224,12 +228,16 @@ export const removeGroupFromChannel = mutation({
     if (!channel) {
       throw new ConvexError("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new ConvexError("This operation is only valid for group channels");
+    }
+    const channelGroupId = channel.groupId;
 
     // Authorization: user must be a leader of either the primary group or the group being removed
     const primaryGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", channelGroupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -273,7 +281,7 @@ export const removeGroupFromChannel = mutation({
 
     // Determine the set of remaining group IDs (primary + other accepted secondary groups)
     const remainingGroupIds = new Set<string>();
-    remainingGroupIds.add(channel.groupId); // primary group always remains
+    remainingGroupIds.add(channelGroupId); // primary group always remains
     for (const sg of updatedSharedGroups) {
       if (sg.status === "accepted") {
         remainingGroupIds.add(sg.groupId);
@@ -455,6 +463,7 @@ export const listPendingInvitesForGroup = query({
     const results = [];
 
     for (const channel of sharedChannels) {
+      if (!channel.groupId) continue; // Skip ad-hoc channels (DM/group_dm)
       const sharedGroups = channel.sharedGroups ?? [];
       const pendingEntry = sharedGroups.find(
         (sg) => sg.groupId === args.groupId && sg.status === "pending"
@@ -528,6 +537,7 @@ export const listActiveSharedChannelsForGroup = query({
     const results = [];
 
     for (const channel of sharedChannels) {
+      if (!channel.groupId) continue; // Skip ad-hoc channels (DM/group_dm)
       const sharedGroups = channel.sharedGroups ?? [];
       const acceptedEntry = sharedGroups.find(
         (sg) => sg.groupId === args.groupId && sg.status === "accepted"
@@ -578,12 +588,16 @@ export const cancelChannelInvite = mutation({
     if (!channel) {
       throw new ConvexError("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new ConvexError("This operation is only valid for group channels");
+    }
+    const channelGroupId = channel.groupId;
 
     // Check that the user is a leader of the primary group
     const primaryGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", channelGroupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();

--- a/apps/convex/functions/pcoServices/actions.ts
+++ b/apps/convex/functions/pcoServices/actions.ts
@@ -216,9 +216,13 @@ export const verifyChannelAccess = internalMutation({
     if (!channel) {
       throw new Error("Channel not found");
     }
+    if (!channel.groupId) {
+      throw new Error("This operation is only valid for group channels");
+    }
+    const groupId = channel.groupId;
 
     // Get the group to find the community
-    const group = await ctx.db.get(channel.groupId);
+    const group = await ctx.db.get(groupId);
     if (!group) {
       throw new Error("Group not found");
     }
@@ -248,7 +252,7 @@ export const verifyChannelAccess = internalMutation({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();

--- a/apps/convex/functions/pcoServices/queries.ts
+++ b/apps/convex/functions/pcoServices/queries.ts
@@ -58,9 +58,13 @@ export const getAutoChannelConfigByChannel = query({
     if (!channel) {
       return null;
     }
+    if (!channel.groupId) {
+      return null; // Skip ad-hoc channels (DM/group_dm)
+    }
+    const groupId = channel.groupId;
 
     // Get the group to find the community
-    const group = await ctx.db.get(channel.groupId);
+    const group = await ctx.db.get(groupId);
     if (!group) {
       return null;
     }
@@ -82,7 +86,7 @@ export const getAutoChannelConfigByChannel = query({
     const groupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", userId)
+        q.eq("groupId", groupId).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();

--- a/apps/convex/functions/pcoServices/rotation.ts
+++ b/apps/convex/functions/pcoServices/rotation.ts
@@ -242,13 +242,17 @@ export const addChannelMember = internalMutation({
     if (!channel) {
       return { success: false, reason: "channel_not_found" };
     }
+    if (!channel.groupId) {
+      return { success: false, reason: "channel_not_found" }; // Skip ad-hoc channels (DM/group_dm)
+    }
+    const groupId = channel.groupId;
 
     // SAFEGUARD: Verify user is an active member of the primary group
     // or any accepted secondary group before adding to channel
     const primaryGroupMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId).eq("userId", args.userId)
+        q.eq("groupId", groupId).eq("userId", args.userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();

--- a/apps/convex/lib/helpers.ts
+++ b/apps/convex/lib/helpers.ts
@@ -168,7 +168,7 @@ export function channelIsLeaderEnabled(channel: { isEnabled?: boolean }): boolea
  */
 export function channelEffectiveEnabledForGroup(
   channel: {
-    groupId: Id<"groups">;
+    groupId?: Id<"groups">;
     isEnabled?: boolean;
     isShared?: boolean;
     sharedGroups?: Array<{

--- a/apps/convex/migrations/addChannelSlugs.ts
+++ b/apps/convex/migrations/addChannelSlugs.ts
@@ -19,6 +19,7 @@ export const addSlugsToExistingChannels = internalMutation({
 
     // Initialize with existing slugs from DB
     for (const channel of channels) {
+      if (!channel.groupId) continue; // Skip ad-hoc channels (DM/group_dm)
       if (channel.slug) {
         const groupSlugs = assignedSlugsPerGroup.get(channel.groupId) || new Set();
         groupSlugs.add(channel.slug);
@@ -27,6 +28,10 @@ export const addSlugsToExistingChannels = internalMutation({
     }
 
     for (const channel of channels) {
+      if (!channel.groupId) {
+        skippedCount++;
+        continue; // Skip ad-hoc channels (DM/group_dm)
+      }
       // Skip if already has slug
       if (channel.slug) {
         skippedCount++;

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1429,19 +1429,32 @@ export default defineSchema({
 
   /**
    * Chat Channels
-   * Represents a chat channel (group chat, leaders chat, or DM).
+   * Represents a chat channel (group chat, leaders chat, DM, or ad-hoc group chat).
    * Channel types:
    *   - "main" - Default channel for a group
    *   - "leaders" - Leaders-only channel
-   *   - "dm" - Direct message
+   *   - "dm" - 1:1 direct message (ad-hoc, not tied to a group)
+   *   - "group_dm" - Ad-hoc group chat (not tied to a group)
    *   - "custom" - Custom channel with manual membership
    *   - "pco_services" - Auto channel synced from PCO Services
+   *   - "event" - Event-tied channel scoped to a meeting
    *   - Future: "elvanto", "ccb", etc.
+   *
+   * Invariant: exactly one of `groupId` or `communityId` is set.
+   *   - groupId set: traditional group-channel ("main" | "leaders" | "custom" | "pco_services" | "event" | "reach_out")
+   *   - communityId set: ad-hoc channel ("dm" | "group_dm"), with `isAdHoc: true`
+   * Enforced in mutations, not at the DB level (Convex has no constraints).
    */
   chatChannels: defineTable({
-    groupId: v.id("groups"),
+    groupId: v.optional(v.id("groups")),
+    /** Set for ad-hoc channels (dm, group_dm) that are not bound to a group. */
+    communityId: v.optional(v.id("communities")),
+    /** Convenience flag: true for ad-hoc dm/group_dm channels. */
+    isAdHoc: v.optional(v.boolean()),
+    /** For 1:1 DMs: deterministic key for dedup, sorted "userIdA::userIdB". */
+    dmPairKey: v.optional(v.string()),
     slug: v.optional(v.string()), // URL-friendly, unique per group, immutable (optional for migration)
-    channelType: v.string(), // "main" | "leaders" | "dm" | "custom" | "pco_services" | "event"
+    channelType: v.string(), // "main" | "leaders" | "dm" | "group_dm" | "custom" | "pco_services" | "event" | "reach_out"
     name: v.string(),
     description: v.optional(v.string()),
     createdById: v.id("users"),
@@ -1491,7 +1504,9 @@ export default defineSchema({
     .index("by_archived", ["isArchived"])
     .index("by_isShared", ["isShared"])
     .index("by_inviteShortId", ["inviteShortId"])
-    .index("by_meetingId", ["meetingId"]),
+    .index("by_meetingId", ["meetingId"])
+    .index("by_dmPairKey", ["dmPairKey"])
+    .index("by_community_isAdHoc", ["communityId", "isAdHoc"]),
 
   /**
    * Chat Channel Members
@@ -1522,12 +1537,24 @@ export default defineSchema({
         serviceName: v.optional(v.string()), // e.g. "Sunday Service"
       }),
     ),
+    /**
+     * Per-user request state for ad-hoc channels (dm, group_dm).
+     *   - "pending": user was added but has not accepted; messages held from their view, no read-receipt/typing leakage
+     *   - "accepted": full access
+     *   - "declined": user rejected the chat; row treated as soft-deleted (creator not notified)
+     * Undefined for legacy/group-channel members → treated as "accepted".
+     */
+    requestState: v.optional(v.string()),
+    requestRespondedAt: v.optional(v.number()), // Unix timestamp ms; for analytics + 30d expiry
+    /** Who added this user to the channel (for ad-hoc invites). */
+    invitedById: v.optional(v.id("users")),
   })
     .index("by_channel", ["channelId"])
     .index("by_user", ["userId"])
     .index("by_channel_user", ["channelId", "userId"])
     .index("by_channel_syncSource", ["channelId", "syncSource"])
-    .index("by_role", ["role"]),
+    .index("by_role", ["role"])
+    .index("by_user_requestState", ["userId", "requestState"]),
 
   /**
    * Channel Join Requests
@@ -1730,6 +1757,27 @@ export default defineSchema({
     .index("by_channel", ["channelId"])
     .index("by_status", ["status"])
     .index("by_reviewedBy", ["reviewedById"]),
+
+  /**
+   * Direct Message Rate Limits
+   * Per-(sender, channel, recipient) counter for messages sent while a recipient is still
+   * in `pending` requestState. Enforces the 1-message-per-pending-pair-per-24h rule that
+   * prevents a single sender from spamming a not-yet-accepted DM/group_dm. Hourly cron
+   * cleans up rows older than 24h.
+   */
+  directMessageRateLimits: defineTable({
+    userId: v.id("users"), // sender
+    channelId: v.id("chatChannels"),
+    recipientUserId: v.id("users"),
+    windowStartedAt: v.number(), // Unix timestamp ms
+    messageCount: v.number(),
+  })
+    .index("by_user_channel_recipient", [
+      "userId",
+      "channelId",
+      "recipientUserId",
+    ])
+    .index("by_windowStartedAt", ["windowStartedAt"]),
 
   /**
    * Chat Push Notification Queue

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1554,7 +1554,9 @@ export default defineSchema({
     .index("by_channel_user", ["channelId", "userId"])
     .index("by_channel_syncSource", ["channelId", "syncSource"])
     .index("by_role", ["role"])
-    .index("by_user_requestState", ["userId", "requestState"]),
+    .index("by_user_requestState", ["userId", "requestState"])
+    // Cross-user index used by the daily cron to expire stale pending requests.
+    .index("by_requestState_joinedAt", ["requestState", "joinedAt"]),
 
   /**
    * Channel Join Requests


### PR DESCRIPTION
## Summary

PR 1 of 5 in a planned series introducing **direct messages and ad-hoc group chats** to Togather. This PR is backend-only — schema, mutations/queries, request-state wiring into existing chat, crons, and tests. **No UI in this PR**; the inbox surface, picker, and request banner ship in PRs 2–5.

The feature reuses the existing `chatChannels` infrastructure rather than building a parallel system. New ad-hoc channels live alongside group channels with `isAdHoc: true`, `channelType: "dm" | "group_dm"`, and a `communityId` instead of a `groupId`. Members go through a Signal-style **Message Request flow** (`requestState: "pending" | "accepted" | "declined"`) before the chat is fully usable on the recipient's side.

## Product decisions baked in

| Decision | Rationale |
|---|---|
| Even community co-members go through a Message Request | User chose Signal-grade safety for V1; no instant-DM tier yet |
| 1:1 + group chats ship together | Cohesive launch; group consent inherits the same per-member request flow |
| No phone-contacts integration | Deferred to V2; community-scoping is the trust gate for V1 |
| No cross-community DMs | Closes the stranger-spam vector entirely; no global user search |
| Pending requests **do** push (not silent) | Silent-request is a stranger-spam defense; we've closed that vector at the gate (community-only + 5-init/24h + 1-msg-per-pair-per-24h). For a community app, silent would mean legitimate first messages rot in an unchecked inbox. |

## Schema deltas

- `chatChannels`: `groupId` now optional; new `communityId`, `isAdHoc`, `dmPairKey`. Indexes `by_dmPairKey`, `by_community_isAdHoc`. Invariant: exactly one of `groupId` / `communityId` is set (enforced in mutations).
- `chatChannelMembers`: `requestState`, `requestRespondedAt`, `invitedById`. Indexes `by_user_requestState`, `by_requestState_joinedAt` (cron access pattern).
- New table `directMessageRateLimits` for the 1-msg-per-pending-pair-per-24h rule.

The schema change to `groupId` cascades through 11 existing files. Each call site that read `channel.groupId` got an explicit runtime guard (early throw or filter-out for ad-hoc rows) — the assumption that "this code path only handles group channels" is now documented in the code rather than hidden in the type.

## New backend functions (`apps/convex/functions/messaging/directMessages.ts`)

- `createOrGetDirectChannel` — 1:1 with `dmPairKey` dedup; verifies shared community; rate-limited (5 inits/24h)
- `createGroupChat` — multi-party (≤19 invitees); each must share a community with creator
- `respondToChatRequest` — accept / decline (silent) / block (writes \`chatUserBlocks\` + \`chatUserFlags\`)
- `listChatRequests` — pending requests for caller (sender profile, shared communities, first-message preview)
- `getDirectInbox` — accepted ad-hoc channels (kept separate from \`getInboxChannels\` rather than merging into the 4222-line file)
- `searchUsersInSharedCommunities` — picker-side user search across the caller's communities, with block-filter
- `expireOldChatRequests` — daily cron, flips 30-day-old pending → declined silently
- `cleanupOldDmRateLimits` — hourly cron, drops rate-limit rows past their 24h window

## Existing-code edits

- `messages.sendMessage`: rejects sends from `requestState !== "accepted"` members. While any other recipient is pending: blocks attachments, caps text at 1000 chars, enforces 1 message per pending pair per 24h via `directMessageRateLimits` (upserted only after a successful insert so a thrown validation can't leave a stray counter).
- `events.onMessageSent`: pulls `communityId` off the channel directly when there's no group (so push routing works for ad-hoc channels). The existing `channelType` in the payload lets the client distinguish dm/group_dm without a per-recipient routing change for V1.
- `blocking.blockUser`: auto-declines any pending request the blocker had from the blocked user. Blocked user's view is unchanged (silent block).

## Test plan

- [x] **15 unit tests** in `__tests__/messaging/directMessages.test.ts` covering: 1:1 happy path / dedup / no-shared-community rejection, group chat happy path / 19-recipient cap, accept / decline / block-and-report state transitions, sendMessage pending rate limit, attachment gate while pending, listChatRequests metadata, getDirectInbox accepted-only, searchUsersInSharedCommunities (shared-community + blocked exclusion), expireOldChatRequests cron flipping 31-day-old rows.
- [x] `npx tsc --noEmit` (apps/convex): 0 errors.
- [x] **382/382 messaging tests pass** — no regressions in existing chat suite (16 test files).
- [x] **69/69 schema-adjacent tests pass** (community-membership, security-admin-escalation, smoke, auth).
- [ ] Schema deploy verification — to be confirmed in CI / on push to a backend.
- [ ] Manual E2E once PR 2 (the inbox + picker UI) lands.

## Anti-patterns avoided (from research)

- No read receipts / typing leaked to sender pre-accept (Signal model).
- No "X has blocked you" notification — silent block.
- No global user search / "people nearby" — community-scoped only.
- No raw address-book upload (deferred + when added in V2 it'll be hash-only with iOS 18 partial-contacts support).

## Deviations from approved plan

- Did **not** modify the existing `getInboxChannels` (4222-line `channels.ts`) to merge ad-hoc channels into the group inbox — added a separate `getDirectInbox` query instead. Frontend will subscribe to both; Convex multi-subscriptions handle this without perf cost.
- Dropped the third planned cron (auto-flag users reported by 3+ people) — premature without the admin queue UI it would feed.

## Follow-up PRs (planned)

- **PR 2** — Inbox surface: "+" button, `StartChatScreen`, modify `ChatInboxScreen` to show requests header + Direct messages section.
- **PR 3** — Request flow UI: `ChatRequestsScreen`, accept/decline/block banner in `ConvexChatRoomScreen`, composer gating.
- **PR 4** — Group chat UI: multi-recipient picker, group naming.
- **PR 5** — Polish + flag enable: read-receipt suppression while pending, lock-screen copy, ramp the PostHog flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)