### PR TITLE
feat(chat): DM inbox surface + start-chat picker (PR 2 of 5)

### DIFF
--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -228,8 +228,24 @@ export const getChannel = query({
       };
     }
 
-    if (!channel.groupId) {
-      return null; // Skip ad-hoc channels (DM/group_dm) - handled separately
+    // Ad-hoc channels (dm, group_dm) — caller must have a member row. The
+    // request-state gate (showing the chat as accepted vs pending) is handled
+    // in the UI; this query just exposes the channel doc to anyone who's been
+    // added. Declined / left rows (leftAt set) lose access.
+    if (channel.isAdHoc || !channel.groupId) {
+      const adHocMembership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", args.channelId).eq("userId", userId),
+        )
+        .first();
+      if (!adHocMembership || adHocMembership.leftAt !== undefined) {
+        return null;
+      }
+      return {
+        ...channel,
+        slug: getChannelSlug(channel),
+      };
     }
     const groupId = channel.groupId;
 

--- a/apps/mobile/app/inbox/[chat_id]/index.tsx
+++ b/apps/mobile/app/inbox/[chat_id]/index.tsx
@@ -103,6 +103,17 @@ export default function LegacyChatIdRoute() {
       return;
     }
 
+    // Ad-hoc DM/group_dm channels have no `groupId` — redirect to the
+    // dedicated `/inbox/dm/{channelId}` route instead. Without this branch,
+    // legacy `/inbox/{channelId}` deep links to ad-hoc channels (notifications,
+    // saved bookmarks) render the loading spinner forever because none of the
+    // group-channel branches above match.
+    if (channelData && (channelData as { isAdHoc?: boolean }).isAdHoc) {
+      hasRedirected.current = true;
+      router.replace(`/inbox/dm/${channelData._id}` as any);
+      return;
+    }
+
     // If groupIdParam is provided but chat_id is a Convex channel ID,
     // we need to wait for channelData to determine the correct channel type.
     // Only redirect immediately if we can't get channel type from query.

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
@@ -926,7 +926,7 @@ export default function ChannelMembersScreen() {
         presentationStyle="pageSheet"
         onRequestClose={() => setShowShareModal(false)}
       >
-        {channelData && (
+        {channelData && channelData.groupId && (
           <ShareWithGroupModal
             channelId={channelData._id}
             channelName={channelData.name}

--- a/apps/mobile/app/inbox/_layout.tsx
+++ b/apps/mobile/app/inbox/_layout.tsx
@@ -61,6 +61,8 @@ export default function InboxLayout() {
             <Stack.Screen name="index" options={{ animation: "none" }} />
             <Stack.Screen name="[groupId]" options={{ animation: "none" }} />
             <Stack.Screen name="[chat_id]" options={{ animation: "none" }} />
+            <Stack.Screen name="dm" options={{ animation: "none" }} />
+            <Stack.Screen name="new" options={{ animation: "none" }} />
           </Stack>
         </View>
       </View>
@@ -80,6 +82,10 @@ export default function InboxLayout() {
       <Stack.Screen name="[groupId]" options={{ animation: "slide_from_right" }} />
       {/* Direct messages - slide in from right */}
       <Stack.Screen name="[chat_id]" options={{ animation: "slide_from_right" }} />
+      {/* Ad-hoc direct messages (1:1 + group_dm) */}
+      <Stack.Screen name="dm" options={{ animation: "slide_from_right" }} />
+      {/* New-chat picker - modal-style entry from the bottom */}
+      <Stack.Screen name="new" options={{ animation: "slide_from_bottom" }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/inbox/dm/[channelId]/_layout.tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/_layout.tsx
@@ -1,0 +1,22 @@
+import { Stack } from "expo-router";
+
+/**
+ * Layout for an individual direct-message channel
+ *
+ * Mirrors the legacy `[chat_id]` layout: a single-screen Stack so the
+ * parent `dm/_layout.tsx` declaration `<Stack.Screen name="[channelId]" />`
+ * resolves to a nested navigator rather than flattening to
+ * "[channelId]/index" (which can mis-match screen names and trigger
+ * navigator re-render loops).
+ */
+export default function DmChannelLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen name="index" options={{ animation: "none" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/inbox/dm/[channelId]/index.tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * Direct Message Channel Route
+ *
+ * Route: /inbox/dm/[channelId]
+ *
+ * Hosts the chat room for an ad-hoc 1:1 DM. The dynamic `[channelId]`
+ * segment is the Convex `chatChannels` ID; ConvexChatRoomScreen reads it
+ * from the route params (`params.channelId`) and resolves the active
+ * channel from there.
+ */
+import { ConvexChatRoomScreen } from "@features/chat/components/ConvexChatRoomScreen";
+
+export default ConvexChatRoomScreen;

--- a/apps/mobile/app/inbox/dm/_layout.tsx
+++ b/apps/mobile/app/inbox/dm/_layout.tsx
@@ -1,0 +1,21 @@
+import { Stack } from "expo-router";
+
+/**
+ * Layout for direct-message routes
+ *
+ * Required so Expo Router resolves the `dm/[channelId]` directory as a nested
+ * navigator with screen name "dm", matching the declaration in the parent
+ * inbox/_layout.tsx. Without it the route flattens and the parent's
+ * `<Stack.Screen name="dm" />` registration becomes a name mismatch.
+ */
+export default function DmLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen name="[channelId]" options={{ animation: "none" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/inbox/new.tsx
+++ b/apps/mobile/app/inbox/new.tsx
@@ -1,0 +1,322 @@
+/**
+ * Start a new direct message
+ *
+ * Route: /inbox/new
+ *
+ * Lets the caller search across the people in their communities and start
+ * (or open) a 1:1 DM with one of them. On selection we call
+ * `createOrGetDirectChannel` and navigate to the resulting channel.
+ *
+ * Group chats (`group_dm`) are out of scope here — they ship in a later PR.
+ */
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { Avatar } from "@components/ui/Avatar";
+import { useAuth } from "@providers/AuthProvider";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useTheme } from "@hooks/useTheme";
+import { useQuery, useMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+type SearchResult = {
+  userId: Id<"users">;
+  displayName: string;
+  profilePhoto: string | null;
+  sharedCommunityNames: string[];
+};
+
+const SEARCH_DEBOUNCE_MS = 200;
+const SEARCH_LIMIT = 30;
+
+export default function StartChatScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { token } = useAuth();
+  const { primaryColor } = useCommunityTheme();
+  const { colors } = useTheme();
+
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [pendingUserId, setPendingUserId] = useState<Id<"users"> | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isFocused, setIsFocused] = useState(false);
+
+  // Debounce the search query so we don't refetch on every keystroke.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const results = useQuery(
+    api.functions.messaging.directMessages.searchUsersInSharedCommunities,
+    token
+      ? { token, query: debouncedQuery, limit: SEARCH_LIMIT }
+      : "skip"
+  );
+
+  const createOrGetDirectChannel = useMutation(
+    api.functions.messaging.directMessages.createOrGetDirectChannel
+  );
+
+  const trimmedQuery = debouncedQuery.trim();
+  const hasQuery = trimmedQuery.length > 0;
+  const isLoadingResults = results === undefined && token != null;
+
+  const handleClose = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/chat");
+    }
+  };
+
+  const handleSelectUser = async (row: SearchResult) => {
+    if (!token || pendingUserId) return;
+    setErrorMessage(null);
+    setPendingUserId(row.userId);
+    try {
+      const { channelId } = await createOrGetDirectChannel({
+        token,
+        recipientUserId: row.userId,
+      });
+      // Pass recipient name + photo as URL params so the chat header has
+      // something to show before the channel doc loads — `ConvexChatRoomScreen`
+      // reads `groupName` / `imageUrl` directly off `useLocalSearchParams`.
+      router.replace({
+        pathname: `/inbox/dm/${channelId}` as any,
+        params: {
+          groupName: row.displayName,
+          imageUrl: row.profilePhoto ?? "",
+        },
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Something went wrong";
+      setErrorMessage(message);
+      setPendingUserId(null);
+    }
+  };
+
+  const renderItem = ({ item }: { item: SearchResult }) => {
+    const isPending = pendingUserId === item.userId;
+    const isAnyPending = pendingUserId !== null;
+    const subtitle = item.sharedCommunityNames.slice(0, 2).join(" • ");
+    return (
+      <TouchableOpacity
+        style={[
+          styles.row,
+          { borderBottomColor: colors.border },
+          isAnyPending && !isPending && styles.rowDimmed,
+        ]}
+        onPress={() => handleSelectUser(item)}
+        disabled={isAnyPending}
+        activeOpacity={0.7}
+      >
+        <Avatar
+          name={item.displayName}
+          imageUrl={item.profilePhoto}
+          size={48}
+        />
+        <View style={styles.rowText}>
+          <Text style={[styles.rowName, { color: colors.text }]} numberOfLines={1}>
+            {item.displayName}
+          </Text>
+          {subtitle.length > 0 ? (
+            <Text
+              style={[styles.rowSubtitle, { color: colors.textSecondary }]}
+              numberOfLines={1}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+        {isPending ? (
+          <ActivityIndicator size="small" color={primaryColor} />
+        ) : null}
+      </TouchableOpacity>
+    );
+  };
+
+  const emptyState = useMemo(() => {
+    if (isLoadingResults) {
+      return (
+        <View style={styles.emptyContainer}>
+          <ActivityIndicator size="small" color={primaryColor} />
+        </View>
+      );
+    }
+    if (!hasQuery && (results?.length ?? 0) === 0) {
+      return (
+        <View style={styles.emptyContainer}>
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            Type to find someone in your communities.
+          </Text>
+        </View>
+      );
+    }
+    if (hasQuery && (results?.length ?? 0) === 0) {
+      return (
+        <View style={styles.emptyContainer}>
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            No matches in your communities.
+          </Text>
+        </View>
+      );
+    }
+    return null;
+  }, [hasQuery, isLoadingResults, results, colors.textSecondary, primaryColor]);
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.flex, { backgroundColor: colors.surface }]}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      {/* Header */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + 16,
+            borderBottomColor: colors.border,
+          },
+        ]}
+      >
+        <TouchableOpacity
+          onPress={handleClose}
+          style={styles.headerSide}
+          accessibilityLabel="Close"
+        >
+          <Ionicons name="close" size={26} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>New chat</Text>
+        <View style={styles.headerSide} />
+      </View>
+
+      {/* Search input */}
+      <View style={styles.searchContainer}>
+        <TextInput
+          value={query}
+          onChangeText={setQuery}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          placeholder="Search by name…"
+          placeholderTextColor={colors.textSecondary}
+          autoCorrect={false}
+          autoCapitalize="none"
+          style={[
+            styles.searchInput,
+            {
+              color: colors.text,
+              backgroundColor: colors.surfaceSecondary,
+              borderColor: isFocused ? primaryColor : colors.border,
+            },
+          ]}
+        />
+        {errorMessage ? (
+          <Text style={[styles.errorText, { color: colors.error }]}>
+            {errorMessage}
+          </Text>
+        ) : null}
+      </View>
+
+      {/* Results */}
+      <FlatList
+        data={results ?? []}
+        keyExtractor={(item) => item.userId}
+        renderItem={renderItem}
+        keyboardShouldPersistTaps="handled"
+        ListEmptyComponent={emptyState}
+        contentContainerStyle={
+          (results?.length ?? 0) === 0 ? styles.emptyListContent : undefined
+        }
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: 1,
+  },
+  headerSide: {
+    width: 40,
+    height: 32,
+    justifyContent: "center",
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: "500",
+  },
+  searchContainer: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  searchInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  errorText: {
+    marginTop: 8,
+    fontSize: 13,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 12,
+  },
+  rowDimmed: {
+    opacity: 0.5,
+  },
+  rowText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowName: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  rowSubtitle: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  emptyContainer: {
+    paddingHorizontal: 24,
+    paddingTop: 40,
+    alignItems: "center",
+  },
+  emptyText: {
+    fontSize: 14,
+    textAlign: "center",
+  },
+  emptyListContent: {
+    flexGrow: 1,
+  },
+});

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -33,6 +33,7 @@ import { useTheme } from "@hooks/useTheme";
 import { GroupedInboxItem } from "./GroupedInboxItem";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
+import { Avatar } from "@components/ui/Avatar";
 
 // Inbox event visibility is now driven server-side by
 // `INBOX_EVENT_HIDE_AFTER_MS` in apps/convex/functions/messaging/channels.ts
@@ -146,6 +147,14 @@ export function ChatInboxScreen({
     inboxQueryArgs
   );
 
+  // Direct-message inbox is a separate subscription so the existing
+  // `getInboxChannels` query (and its 4222-line file) stays untouched. Convex
+  // multi-subscription cost is negligible.
+  const directInbox = useQuery(
+    api.functions.messaging.directMessages.getDirectInbox,
+    token ? { token } : "skip",
+  );
+
   // Cache inbox data for offline use
   useEffect(() => {
     if (inboxChannels && inboxChannels.length > 0 && communityId) {
@@ -153,17 +162,37 @@ export function ChatInboxScreen({
     }
   }, [inboxChannels, communityId, setInboxChannels]);
 
-  // Inbox list entries are either a grouped item (group + its channels) or a
-  // standalone event row. They're interleaved so activity, not type, drives
-  // recency — a group with a fresh message sits above an event with a
-  // week-old one (and vice versa). Announcement group stays pinned on top.
+  // Inbox list entries are a grouped item (group + its channels), an event row,
+  // a direct-message row, or a section divider. Groups + events interleave by
+  // recency; direct messages sit in their own section at the top so the user
+  // can scan them at a glance (the iMessage layout). Announcement group stays
+  // pinned on top of the groups+events block.
+  type DirectInboxRow = NonNullable<typeof directInbox>[number];
   type InboxListItem =
     | { kind: "group"; item: InboxGroup }
-    | { kind: "event"; item: EventInboxRow };
+    | { kind: "event"; item: EventInboxRow }
+    | { kind: "dm"; item: DirectInboxRow }
+    | { kind: "section"; key: string; title: string };
 
-  // Render a single inbox row (group or event)
+  // Render a single inbox row (group, event, dm, or a section header)
   const renderItem = useCallback(
     ({ item }: { item: InboxListItem }) => {
+      if (item.kind === "section") {
+        return (
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+            {item.title}
+          </Text>
+        );
+      }
+      if (item.kind === "dm") {
+        return (
+          <DirectMessageRow
+            row={item.item}
+            primaryColor={primaryColor}
+            colors={colors}
+          />
+        );
+      }
       if (item.kind === "event") {
         return (
           <EventInboxRowItem
@@ -186,11 +215,13 @@ export function ChatInboxScreen({
         />
       );
     },
-    [isGroupExpanded, toggleGroupExpanded, sidebarMode, activeGroupId, activeChannelSlug]
+    [isGroupExpanded, toggleGroupExpanded, sidebarMode, activeGroupId, activeChannelSlug, primaryColor, colors]
   );
 
   // Key extractor for FlatList
   const keyExtractor = useCallback((item: InboxListItem) => {
+    if (item.kind === "section") return `section:${item.key}`;
+    if (item.kind === "dm") return `dm:${item.item.channelId}`;
     return item.kind === "event"
       ? `event:${item.item.channel._id}`
       : `group:${item.item.group._id}`;
@@ -198,6 +229,31 @@ export function ChatInboxScreen({
 
   const Wrapper = React.Fragment;
   const headerPaddingTop = sidebarMode ? 16 : insets.top + 16;
+
+  // The same header is rendered above the list and the three empty/loading
+  // states below; centralizing it here keeps the "+" button placement (and the
+  // tap target that opens the new-chat picker) in one place. Hidden in the
+  // "no community" empty state since the picker has nothing to search.
+  const renderHeader = (showCompose: boolean) => (
+    <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
+      <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+      {showCompose && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Start a new chat"
+          onPress={() => router.push("/inbox/new" as any)}
+          style={styles.headerActionButton}
+          hitSlop={12}
+        >
+          <Ionicons
+            name="create-outline"
+            size={24}
+            color={colors.text}
+          />
+        </Pressable>
+      )}
+    </View>
+  );
 
   // Auto-select first conversation when in sidebar mode and no conversation is active
   useEffect(() => {
@@ -248,8 +304,11 @@ export function ChatInboxScreen({
   const listItems = useMemo<InboxListItem[]>(() => {
     if (!displayChannels) return [];
 
-    const groupItems: InboxListItem[] = [];
-    const eventItems: InboxListItem[] = [];
+    type GroupOrEventItem =
+      | { kind: "group"; item: InboxGroup }
+      | { kind: "event"; item: EventInboxRow };
+    const groupItems: GroupOrEventItem[] = [];
+    const eventItems: GroupOrEventItem[] = [];
 
     for (const g of displayChannels) {
       const nonEventChannels: InboxChannel[] = [];
@@ -275,7 +334,7 @@ export function ChatInboxScreen({
       }
     }
 
-    const effectiveTime = (entry: InboxListItem): number => {
+    const effectiveTime = (entry: GroupOrEventItem): number => {
       if (entry.kind === "event") {
         return (
           entry.item.channel.lastMessageAt ??
@@ -305,16 +364,28 @@ export function ChatInboxScreen({
 
     return combined;
   }, [displayChannels]);
-  const hasInboxItems = listItems.length > 0;
+
+  // Prepend the Direct messages section when the user has any accepted DMs.
+  // Pending requests live in their own surface (PR 3) — not folded in here.
+  const dmRows = directInbox ?? [];
+  const listItemsWithDm = useMemo<InboxListItem[]>(() => {
+    if (dmRows.length === 0) return listItems;
+    return [
+      { kind: "section", key: "dm-header", title: "Direct messages" },
+      ...dmRows.map(
+        (row) => ({ kind: "dm" as const, item: row }),
+      ),
+      ...listItems,
+    ];
+  }, [dmRows, listItems]);
+  const hasInboxItems = listItemsWithDm.length > 0;
 
   // Show message when user has no community context
   if (!hasCommunity) {
     return (
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
-          <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
-          </View>
+          {renderHeader(false)}
           <View style={styles.centered}>
             <Ionicons
               name="chatbubbles-outline"
@@ -338,9 +409,7 @@ export function ChatInboxScreen({
     return (
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
-          <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
-          </View>
+          {renderHeader(true)}
           <View style={styles.centered}>
             <ActivityIndicator size="large" color={primaryColor} />
             <Text style={[styles.loadingText, { color: colors.textSecondary }]}>Loading your chats...</Text>
@@ -354,9 +423,7 @@ export function ChatInboxScreen({
     return (
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
-          <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
-          </View>
+          {renderHeader(true)}
           <ScrollView contentContainerStyle={styles.centeredScrollContent}>
             <Ionicons
               name="chatbubbles-outline"
@@ -377,11 +444,9 @@ export function ChatInboxScreen({
   return (
     <Wrapper>
       <View style={[styles.container, { backgroundColor: colors.surface }]}>
-        <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-          <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
-        </View>
+        {renderHeader(true)}
         <FlatList
-          data={listItems}
+          data={listItemsWithDm}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           contentContainerStyle={styles.listContainer}
@@ -845,6 +910,107 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
   );
 }
 
+// ============================================================================
+// Direct Messages section
+// ============================================================================
+
+type DirectInboxRowData = {
+  channelId: Id<"chatChannels">;
+  channelType: "dm" | "group_dm";
+  channelName: string;
+  memberCount: number;
+  otherMembers: Array<{
+    userId: Id<"users">;
+    displayName: string;
+    profilePhoto: string | null;
+  }>;
+  lastMessageAt: number | null;
+  lastMessagePreview: string | null;
+  lastMessageSenderName: string | null;
+  unreadCount: number;
+  isMuted: boolean;
+};
+
+interface DirectMessageRowProps {
+  row: DirectInboxRowData;
+  primaryColor: string;
+  colors: {
+    text: string;
+    textSecondary: string;
+  };
+}
+
+function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) {
+  const router = useRouter();
+
+  // Display name: for 1:1, the other member; for group_dm, the channel name
+  // (or a comma-separated member list as a fallback when no name is set —
+  // group_dm with empty name renders client-side from the member list).
+  const isOneOnOne = row.channelType === "dm";
+  const headerName = isOneOnOne
+    ? row.otherMembers[0]?.displayName ?? "Conversation"
+    : row.channelName.trim().length > 0
+      ? row.channelName
+      : row.otherMembers
+          .slice(0, 3)
+          .map((m) => m.displayName.split(" ")[0])
+          .filter(Boolean)
+          .join(", ") || "Group chat";
+
+  // Avatar: for 1:1, the other person; for group_dm, the first member.
+  const avatarSource = row.otherMembers[0];
+
+  // Compose preview line. Mute icon takes precedence when muted.
+  const preview = row.lastMessagePreview ?? "No messages yet";
+  const previewWithSender =
+    isOneOnOne || !row.lastMessageSenderName
+      ? preview
+      : `${row.lastMessageSenderName.split(" ")[0]}: ${preview}`;
+
+  const onPress = () => {
+    router.push({
+      pathname: `/inbox/dm/${row.channelId}` as any,
+      params: {
+        groupName: headerName,
+        imageUrl: avatarSource?.profilePhoto ?? "",
+      },
+    });
+  };
+
+  return (
+    <Pressable onPress={onPress} style={styles.dmRow}>
+      <Avatar
+        name={avatarSource?.displayName ?? headerName}
+        imageUrl={avatarSource?.profilePhoto ?? undefined}
+        size={48}
+      />
+      <View style={styles.dmRowContent}>
+        <View style={styles.dmRowTopLine}>
+          <Text
+            numberOfLines={1}
+            style={[styles.dmRowName, { color: colors.text }]}
+          >
+            {headerName}
+          </Text>
+          {row.unreadCount > 0 && (
+            <View style={[styles.dmUnreadBadge, { backgroundColor: primaryColor }]}>
+              <Text style={styles.dmUnreadBadgeText}>
+                {row.unreadCount > 99 ? "99+" : row.unreadCount}
+              </Text>
+            </View>
+          )}
+        </View>
+        <Text
+          numberOfLines={1}
+          style={[styles.dmRowPreview, { color: colors.textSecondary }]}
+        >
+          {previewWithSender}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -852,10 +1018,71 @@ const styles = StyleSheet.create({
   header: {
     paddingHorizontal: 16,
     paddingBottom: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   headerTitle: {
     fontSize: 28,
     fontWeight: "bold",
+  },
+  headerActionButton: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 6,
+  },
+  dmRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  dmRowContent: {
+    flex: 1,
+    marginLeft: 12,
+    minWidth: 0,
+  },
+  dmRowTopLine: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  dmRowName: {
+    fontSize: 16,
+    fontWeight: "600",
+    flexShrink: 1,
+  },
+  dmRowTimestamp: {
+    fontSize: 12,
+    marginLeft: 8,
+  },
+  dmRowPreview: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  dmUnreadBadge: {
+    minWidth: 20,
+    height: 20,
+    borderRadius: 10,
+    paddingHorizontal: 6,
+    marginLeft: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dmUnreadBadgeText: {
+    color: "#ffffff",
+    fontSize: 11,
+    fontWeight: "700",
   },
   centered: {
     flex: 1,

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -893,7 +893,16 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // Don't render the full UI until essential data is ready. Without this gate,
   // the toolbar and message list flash empty then populate, causing visible jitter.
   // The inbox flow resolves quickly (prefetch + params), notifications may take longer.
-  const isEssentialDataReady = resolvedGroupId && activeChannelId != null;
+  //
+  // Ad-hoc DM/group_dm channels have no `groupId` — once the channel doc has
+  // loaded and confirmed `isAdHoc`, the group-shaped data we'd normally wait
+  // on (group details, channel-tab list, leaders/main IDs) doesn't apply, so
+  // we let the screen render as soon as `activeChannelId` resolves. The
+  // toolbar falls back to URL params (`groupName`, `imageUrl`) for the
+  // recipient's name + avatar.
+  const isAdHocChannel = channelData?.isAdHoc === true;
+  const isEssentialDataReady =
+    (resolvedGroupId || isAdHocChannel) && activeChannelId != null;
 
   // Loading state: show placeholder while essential data resolves
   if (!isEssentialDataReady) {
@@ -1095,7 +1104,7 @@ const ConvexChatRoomScreenInner: React.FC = () => {
           onClose={() => setMembersModalChannel(null)}
           channelId={membersModalChannel?.channelId}
           channelName={membersModalChannel?.name ?? ""}
-          groupId={resolvedGroupId}
+          groupId={resolvedGroupId ?? undefined}
           channelSlug={membersModalChannel?.slug}
         />
 


### PR DESCRIPTION
## Summary

PR 2 of 5. **Stacked on #344** — review/merge that first.

User-facing surface for the DM feature scaffolded in PR 1. Ships **1:1 DMs only**; the group-chat picker is deferred to PR 4, the request-flow UI (accept/decline banner, requests inbox) to PR 3.

## What ships

- **Compose button on the inbox header.** Tapping it opens `/inbox/new`.
- **`/inbox/new` (StartChatScreen)** — debounced search input across the caller's shared communities. Each row shows avatar + name + the community attribution. Tapping a row creates (or fetches) the 1:1 DM channel and replaces the route to `/inbox/dm/{channelId}`. Errors from the backend (no shared community / blocked / rate-limit) are surfaced inline.
- **`/inbox/dm/[channelId]`** — new route hosting the existing `ConvexChatRoomScreen`. Reuses the message list, composer, reactions, etc. instead of forking. Recipient's name and avatar are passed as URL params so the chat header has something to show before the channel doc loads.
- **"Direct messages" section in the inbox** — accepted ad-hoc channels appear above groups + events, populated by the new `getDirectInbox` query. Pending requests stay surfaced separately via `listChatRequests` in PR 3.

## Backend touches

Two minimal corrections to PR 1's wiring:

- `getChannel` was returning `null` for ad-hoc channels (the null-check sweep was overcautious for the new schema). Replaced with an explicit ad-hoc branch that does its own membership check and returns the channel.
- `ConvexChatRoomScreen`'s `isEssentialDataReady` gate required `resolvedGroupId`, which is null for ad-hoc DMs. Now passes through when the channel doc has loaded with `isAdHoc: true`.

## Test plan

- [x] `npx tsc --noEmit` passes for both `apps/convex` and `apps/mobile` (no new errors; 10 pre-existing Node-typings + theme errors untouched).
- [x] **387/387 messaging tests pass** in `apps/convex` (no regressions from the `getChannel` change).
- [x] Lint-staged + eslint clean on commit.
- [ ] **Browser smoke-test by reviewer**: from the seeded test user (`+12025550123`, OTP `000000`), tap the compose button, search, pick another community member, verify the chat opens with the recipient's name in the header and a message can be sent. Confirm the DM appears in the sender's inbox under "Direct messages". (I have not run a Playwright pass; recommending the reviewer or follow-up CI run does this since this PR's ergonomics are best judged interactively.)

## Known V1 limitations (addressed in later PRs)

- The receiver's accept/decline banner is not yet rendered in `ConvexChatRoomScreen` — comes in PR 3. Today, the recipient gets the push notification (per the V1 trust model) but landing in the chat shows the message normally without the request gate UI.
- The "N requests" header row above the inbox list is also PR 3.
- Group-chat creation (`group_dm`) is PR 4.
- The chat-room toolbar for an ad-hoc DM uses URL params for the title — this works for fresh-from-picker entries but a refresh will fall back to the channel name (empty for 1:1). Polish in PR 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)