### PR TITLE
feat(chat): request flow UI for ad-hoc DMs (PR 3 of 5)

### DIFF
--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -251,7 +251,11 @@ export const getChannel = query({
       if (adHocMembership.invitedById) {
         const inviter = await ctx.db.get(adHocMembership.invitedById);
         if (inviter) {
-          inviterDisplayName = `${inviter.firstName ?? ""} ${inviter.lastName ?? ""}`.trim();
+          // Use the shared `getDisplayName` helper so unset firstName +
+          // lastName don't produce an empty string that would render as
+          // " would like to chat with you." in the request banner.
+          const resolved = getDisplayName(inviter.firstName, inviter.lastName);
+          inviterDisplayName = resolved.trim().length > 0 ? resolved : "Someone";
         }
       }
       return {

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -225,13 +225,16 @@ export const getChannel = query({
       return {
         ...channel,
         slug: getChannelSlug(channel),
+        myRequestState: undefined as string | undefined,
+        inviterDisplayName: undefined as string | undefined,
       };
     }
 
     // Ad-hoc channels (dm, group_dm) — caller must have a member row. The
     // request-state gate (showing the chat as accepted vs pending) is handled
-    // in the UI; this query just exposes the channel doc to anyone who's been
-    // added. Declined / left rows (leftAt set) lose access.
+    // in the UI; this query just exposes the channel doc + the caller's
+    // request state so the chat room knows whether to show the accept banner.
+    // Declined / left rows (leftAt set) lose access.
     if (channel.isAdHoc || !channel.groupId) {
       const adHocMembership = await ctx.db
         .query("chatChannelMembers")
@@ -242,9 +245,20 @@ export const getChannel = query({
       if (!adHocMembership || adHocMembership.leftAt !== undefined) {
         return null;
       }
+      // Resolve inviter info for the request banner — only relevant when the
+      // caller is still in `pending`; cheap enough to always include.
+      let inviterDisplayName: string | undefined;
+      if (adHocMembership.invitedById) {
+        const inviter = await ctx.db.get(adHocMembership.invitedById);
+        if (inviter) {
+          inviterDisplayName = `${inviter.firstName ?? ""} ${inviter.lastName ?? ""}`.trim();
+        }
+      }
       return {
         ...channel,
         slug: getChannelSlug(channel),
+        myRequestState: adHocMembership.requestState ?? "accepted",
+        inviterDisplayName,
       };
     }
     const groupId = channel.groupId;
@@ -299,6 +313,8 @@ export const getChannel = query({
     return {
       ...channel,
       slug: getChannelSlug(channel),
+      myRequestState: undefined as string | undefined,
+      inviterDisplayName: undefined as string | undefined,
     };
   },
 });

--- a/apps/mobile/app/inbox/_layout.tsx
+++ b/apps/mobile/app/inbox/_layout.tsx
@@ -63,6 +63,7 @@ export default function InboxLayout() {
             <Stack.Screen name="[chat_id]" options={{ animation: "none" }} />
             <Stack.Screen name="dm" options={{ animation: "none" }} />
             <Stack.Screen name="new" options={{ animation: "none" }} />
+            <Stack.Screen name="requests" options={{ animation: "none" }} />
           </Stack>
         </View>
       </View>
@@ -86,6 +87,8 @@ export default function InboxLayout() {
       <Stack.Screen name="dm" options={{ animation: "slide_from_right" }} />
       {/* New-chat picker - modal-style entry from the bottom */}
       <Stack.Screen name="new" options={{ animation: "slide_from_bottom" }} />
+      {/* Pending chat requests inbox */}
+      <Stack.Screen name="requests" options={{ animation: "slide_from_right" }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/inbox/requests.tsx
+++ b/apps/mobile/app/inbox/requests.tsx
@@ -113,11 +113,21 @@ export default function ChatRequestsScreen() {
       setPendingAction(null);
       // Replace, not push, so back from the chat goes to the inbox — not
       // back to the requests list (which will likely be empty/stale).
+      // For 1:1 DMs the chat header should show the inviter; for group_dms
+      // it should show the group's name + a generic group avatar so users
+      // recognize which thread they entered, not the inviter's identity.
+      const isGroup = row.channelType === "group_dm";
+      const headerName = isGroup
+        ? row.channelName.trim().length > 0
+          ? row.channelName
+          : `Group chat (${row.memberCount})`
+        : row.inviterDisplayName;
+      const headerImage = isGroup ? "" : row.inviterProfilePhoto ?? "";
       router.replace({
         pathname: `/inbox/dm/${row.channelId}` as any,
         params: {
-          groupName: row.inviterDisplayName,
-          imageUrl: row.inviterProfilePhoto ?? "",
+          groupName: headerName,
+          imageUrl: headerImage,
         },
       });
     } catch (e) {

--- a/apps/mobile/app/inbox/requests.tsx
+++ b/apps/mobile/app/inbox/requests.tsx
@@ -1,0 +1,638 @@
+/**
+ * Message Requests
+ *
+ * Route: /inbox/requests
+ *
+ * Signal-style inbox for incoming chat requests. A user lands here from a
+ * "You have N message requests" entry point on the chat inbox.
+ *
+ * Each row shows the inviter, the shared-community attribution, and a
+ * preview of the first message they sent. Tapping a row opens a bottom-sheet
+ * modal with three actions: Accept (opens the chat), Decline (silent — the
+ * sender is not notified), or Block & Report (writes `chatUserBlocks` +
+ * `chatUserFlags`). All three flow through `respondToChatRequest`.
+ */
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  Modal,
+  Alert,
+  Platform,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { Avatar } from "@components/ui/Avatar";
+import { useAuth } from "@providers/AuthProvider";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useTheme } from "@hooks/useTheme";
+import { useQuery, useMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+type ChatRequestRow = {
+  channelId: Id<"chatChannels">;
+  channelType: "dm" | "group_dm";
+  channelName: string;
+  inviterUserId: Id<"users">;
+  inviterDisplayName: string;
+  inviterProfilePhoto: string | null;
+  sharedCommunityNames: string[];
+  memberCount: number;
+  firstMessagePreview: string | null;
+  firstMessageSenderName: string | null;
+  invitedAt: number;
+};
+
+/**
+ * Format a millisecond timestamp as a compact relative label
+ * ("now", "5m", "3h", "2d", "3w"). No external dep.
+ */
+function formatRelativeShort(timestamp: number): string {
+  const diffSec = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (diffSec < 60) return "now";
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h`;
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d`;
+  return `${Math.floor(diffSec / 604800)}w`;
+}
+
+export default function ChatRequestsScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { token } = useAuth();
+  const { primaryColor } = useCommunityTheme();
+  const { colors } = useTheme();
+
+  const [selectedRequest, setSelectedRequest] = useState<ChatRequestRow | null>(
+    null
+  );
+  const [pendingAction, setPendingAction] = useState<
+    "accept" | "decline" | "block" | null
+  >(null);
+
+  const requests = useQuery(
+    api.functions.messaging.directMessages.listChatRequests,
+    token ? { token } : "skip"
+  );
+
+  const respondToChatRequest = useMutation(
+    api.functions.messaging.directMessages.respondToChatRequest
+  );
+
+  const isLoading = requests === undefined && token != null;
+
+  const handleClose = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/chat");
+    }
+  };
+
+  const closeSheet = () => {
+    if (pendingAction) return; // Block dismissal while a mutation is in flight.
+    setSelectedRequest(null);
+  };
+
+  const handleAccept = async () => {
+    if (!token || !selectedRequest || pendingAction) return;
+    setPendingAction("accept");
+    try {
+      await respondToChatRequest({
+        token,
+        channelId: selectedRequest.channelId,
+        response: "accept",
+      });
+      const row = selectedRequest;
+      setSelectedRequest(null);
+      setPendingAction(null);
+      // Replace, not push, so back from the chat goes to the inbox — not
+      // back to the requests list (which will likely be empty/stale).
+      router.replace({
+        pathname: `/inbox/dm/${row.channelId}` as any,
+        params: {
+          groupName: row.inviterDisplayName,
+          imageUrl: row.inviterProfilePhoto ?? "",
+        },
+      });
+    } catch (e) {
+      setPendingAction(null);
+      const message = e instanceof Error ? e.message : "Failed to accept";
+      Alert.alert("Couldn't accept", message);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!token || !selectedRequest || pendingAction) return;
+    setPendingAction("decline");
+    try {
+      await respondToChatRequest({
+        token,
+        channelId: selectedRequest.channelId,
+        response: "decline",
+      });
+      setSelectedRequest(null);
+      setPendingAction(null);
+    } catch (e) {
+      setPendingAction(null);
+      const message = e instanceof Error ? e.message : "Failed to decline";
+      Alert.alert("Couldn't decline", message);
+    }
+  };
+
+  const handleBlock = async () => {
+    if (!token || !selectedRequest || pendingAction) return;
+    setPendingAction("block");
+    try {
+      await respondToChatRequest({
+        token,
+        channelId: selectedRequest.channelId,
+        response: "block",
+        // V1 ships with a hard-coded reason; the picker is V2.
+        reportReason: "spam",
+      });
+      setSelectedRequest(null);
+      setPendingAction(null);
+      Alert.alert("Blocked", "They can't message you again.");
+    } catch (e) {
+      setPendingAction(null);
+      const message = e instanceof Error ? e.message : "Failed to block";
+      Alert.alert("Couldn't block", message);
+    }
+  };
+
+  const renderRow = ({ item }: { item: ChatRequestRow }) => {
+    const subtitle = item.sharedCommunityNames.slice(0, 2).join(" · ");
+    const preview = item.firstMessagePreview ?? "Started a chat";
+    return (
+      <TouchableOpacity
+        style={[styles.row, { borderBottomColor: colors.border }]}
+        onPress={() => setSelectedRequest(item)}
+        activeOpacity={0.7}
+      >
+        <Avatar
+          name={item.inviterDisplayName}
+          imageUrl={item.inviterProfilePhoto}
+          size={48}
+        />
+        <View style={styles.rowText}>
+          <View style={styles.rowTopLine}>
+            <Text
+              style={[styles.rowName, { color: colors.text }]}
+              numberOfLines={1}
+            >
+              {item.inviterDisplayName}
+            </Text>
+            <Text
+              style={[styles.rowTimestamp, { color: colors.textTertiary }]}
+            >
+              {formatRelativeShort(item.invitedAt)}
+            </Text>
+          </View>
+          {subtitle.length > 0 ? (
+            <Text
+              style={[styles.rowSubtitle, { color: colors.textSecondary }]}
+              numberOfLines={1}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+          <Text
+            style={[styles.rowPreview, { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            {preview}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderEmpty = () => {
+    if (isLoading) {
+      return (
+        <View style={styles.emptyContainer}>
+          <ActivityIndicator size="small" color={primaryColor} />
+        </View>
+      );
+    }
+    return (
+      <View style={styles.emptyContainer}>
+        <Ionicons
+          name="mail-open-outline"
+          size={56}
+          color={colors.textTertiary}
+        />
+        <Text style={[styles.emptyTitle, { color: colors.text }]}>
+          No message requests
+        </Text>
+        <Text
+          style={[styles.emptySubtitle, { color: colors.textSecondary }]}
+        >
+          When someone outside your existing chats messages you, you'll see
+          them here.
+        </Text>
+      </View>
+    );
+  };
+
+  return (
+    <View style={[styles.flex, { backgroundColor: colors.surface }]}>
+      {/* Header */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + 16,
+            borderBottomColor: colors.border,
+          },
+        ]}
+      >
+        <TouchableOpacity
+          onPress={handleClose}
+          style={styles.headerSide}
+          accessibilityLabel="Close"
+        >
+          <Ionicons name="chevron-back" size={26} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>
+          Message requests
+        </Text>
+        <View style={styles.headerSide} />
+      </View>
+
+      <FlatList
+        data={requests ?? []}
+        keyExtractor={(item) => item.channelId}
+        renderItem={renderRow}
+        ListEmptyComponent={renderEmpty}
+        contentContainerStyle={
+          (requests?.length ?? 0) === 0 ? styles.emptyListContent : undefined
+        }
+      />
+
+      <Modal
+        visible={selectedRequest !== null}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={closeSheet}
+      >
+        {selectedRequest ? (
+          <RequestSheetContent
+            request={selectedRequest}
+            primaryColor={primaryColor}
+            colors={colors}
+            pendingAction={pendingAction}
+            onClose={closeSheet}
+            onAccept={handleAccept}
+            onDecline={handleDecline}
+            onBlock={handleBlock}
+          />
+        ) : null}
+      </Modal>
+    </View>
+  );
+}
+
+function RequestSheetContent({
+  request,
+  primaryColor,
+  colors,
+  pendingAction,
+  onClose,
+  onAccept,
+  onDecline,
+  onBlock,
+}: {
+  request: ChatRequestRow;
+  primaryColor: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  pendingAction: "accept" | "decline" | "block" | null;
+  onClose: () => void;
+  onAccept: () => void;
+  onDecline: () => void;
+  onBlock: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const subtitle = request.sharedCommunityNames.slice(0, 2).join(" · ");
+  const isBusy = pendingAction !== null;
+
+  return (
+    <View
+      style={[
+        styles.sheetContainer,
+        { backgroundColor: colors.background },
+      ]}
+    >
+      {/* Sheet header */}
+      <View
+        style={[
+          styles.sheetHeader,
+          {
+            paddingTop: Platform.OS === "ios" ? 16 : insets.top + 12,
+            borderBottomColor: colors.border,
+          },
+        ]}
+      >
+        <TouchableOpacity
+          onPress={onClose}
+          style={styles.sheetClose}
+          disabled={isBusy}
+          accessibilityLabel="Close"
+        >
+          <Text
+            style={[
+              styles.sheetCloseText,
+              { color: isBusy ? colors.textTertiary : colors.textSecondary },
+            ]}
+          >
+            Close
+          </Text>
+        </TouchableOpacity>
+        <Text style={[styles.sheetTitle, { color: colors.text }]}>
+          Message request
+        </Text>
+        <View style={styles.sheetClose} />
+      </View>
+
+      <View style={styles.sheetBody}>
+        <View style={styles.sheetProfile}>
+          <Avatar
+            name={request.inviterDisplayName}
+            imageUrl={request.inviterProfilePhoto}
+            size={72}
+          />
+          <Text
+            style={[styles.sheetName, { color: colors.text }]}
+            numberOfLines={2}
+          >
+            {request.inviterDisplayName}
+          </Text>
+          {subtitle.length > 0 ? (
+            <Text
+              style={[
+                styles.sheetSubtitle,
+                { color: colors.textSecondary },
+              ]}
+              numberOfLines={2}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+
+        <View
+          style={[
+            styles.sheetMessage,
+            {
+              backgroundColor: colors.surfaceSecondary,
+              borderColor: colors.border,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.sheetMessageLabel,
+              { color: colors.textTertiary },
+            ]}
+          >
+            First message
+          </Text>
+          <Text style={[styles.sheetMessageText, { color: colors.text }]}>
+            {request.firstMessagePreview ?? "(No message yet)"}
+          </Text>
+        </View>
+      </View>
+
+      <View
+        style={[
+          styles.sheetActions,
+          { paddingBottom: insets.bottom + 16 },
+        ]}
+      >
+        <TouchableOpacity
+          style={[styles.actionButton, { backgroundColor: primaryColor }]}
+          onPress={onAccept}
+          disabled={isBusy}
+        >
+          {pendingAction === "accept" ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={[styles.actionButtonText, { color: "#fff" }]}>
+              Accept
+            </Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.actionButton,
+            styles.actionButtonNeutral,
+            {
+              borderColor: colors.border,
+              backgroundColor: colors.surfaceSecondary,
+            },
+          ]}
+          onPress={onDecline}
+          disabled={isBusy}
+        >
+          {pendingAction === "decline" ? (
+            <ActivityIndicator size="small" color={colors.text} />
+          ) : (
+            <Text style={[styles.actionButtonText, { color: colors.text }]}>
+              Decline
+            </Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.actionButton,
+            styles.actionButtonDestructive,
+            { borderColor: colors.destructive },
+          ]}
+          onPress={onBlock}
+          disabled={isBusy}
+        >
+          {pendingAction === "block" ? (
+            <ActivityIndicator size="small" color={colors.destructive} />
+          ) : (
+            <Text
+              style={[
+                styles.actionButtonText,
+                { color: colors.destructive },
+              ]}
+            >
+              Block & Report
+            </Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: 1,
+  },
+  headerSide: {
+    width: 40,
+    height: 32,
+    justifyContent: "center",
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: "500",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 12,
+  },
+  rowText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowTopLine: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  rowName: {
+    fontSize: 16,
+    fontWeight: "600",
+    flexShrink: 1,
+  },
+  rowTimestamp: {
+    fontSize: 12,
+  },
+  rowSubtitle: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  rowPreview: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  emptyContainer: {
+    flex: 1,
+    paddingHorizontal: 32,
+    paddingTop: 80,
+    alignItems: "center",
+    gap: 12,
+  },
+  emptyTitle: {
+    fontSize: 17,
+    fontWeight: "600",
+    marginTop: 8,
+    textAlign: "center",
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  emptyListContent: {
+    flexGrow: 1,
+  },
+
+  // Sheet
+  sheetContainer: {
+    flex: 1,
+  },
+  sheetHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: 1,
+  },
+  sheetClose: {
+    width: 60,
+  },
+  sheetCloseText: {
+    fontSize: 16,
+  },
+  sheetTitle: {
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  sheetBody: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    gap: 24,
+  },
+  sheetProfile: {
+    alignItems: "center",
+    gap: 8,
+  },
+  sheetName: {
+    fontSize: 22,
+    fontWeight: "700",
+    marginTop: 8,
+    textAlign: "center",
+  },
+  sheetSubtitle: {
+    fontSize: 14,
+    textAlign: "center",
+  },
+  sheetMessage: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    gap: 6,
+  },
+  sheetMessageLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  sheetMessageText: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  sheetActions: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    gap: 10,
+  },
+  actionButton: {
+    minHeight: 50,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+  },
+  actionButtonNeutral: {
+    borderWidth: 1,
+  },
+  actionButtonDestructive: {
+    backgroundColor: "transparent",
+    borderWidth: 1,
+  },
+  actionButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -154,6 +154,10 @@ export function ChatInboxScreen({
     api.functions.messaging.directMessages.getDirectInbox,
     token ? { token } : "skip",
   );
+  const chatRequests = useQuery(
+    api.functions.messaging.directMessages.listChatRequests,
+    token ? { token } : "skip",
+  );
 
   // Cache inbox data for offline use
   useEffect(() => {
@@ -172,11 +176,53 @@ export function ChatInboxScreen({
     | { kind: "group"; item: InboxGroup }
     | { kind: "event"; item: EventInboxRow }
     | { kind: "dm"; item: DirectInboxRow }
-    | { kind: "section"; key: string; title: string };
+    | { kind: "section"; key: string; title: string }
+    | { kind: "requests-link"; count: number };
 
-  // Render a single inbox row (group, event, dm, or a section header)
+  // Render a single inbox row (group, event, dm, section header, or
+  // requests-link). The requests-link is always a single tappable row that
+  // navigates to the dedicated requests inbox — keeping pending senders out
+  // of the active conversation list is the whole point of the Message
+  // Request flow, so we deliberately do NOT interleave them.
   const renderItem = useCallback(
     ({ item }: { item: InboxListItem }) => {
+      if (item.kind === "requests-link") {
+        return (
+          <Pressable
+            onPress={() => router.push("/inbox/requests" as any)}
+            style={styles.requestsLinkRow}
+            accessibilityRole="button"
+            accessibilityLabel={`${item.count} message request${item.count === 1 ? "" : "s"}`}
+          >
+            <View
+              style={[
+                styles.requestsLinkIcon,
+                { backgroundColor: primaryColor },
+              ]}
+            >
+              <Ionicons name="mail-unread-outline" size={20} color="#ffffff" />
+            </View>
+            <View style={styles.requestsLinkContent}>
+              <Text style={[styles.requestsLinkTitle, { color: colors.text }]}>
+                Message Requests
+              </Text>
+              <Text
+                style={[
+                  styles.requestsLinkSubtitle,
+                  { color: colors.textSecondary },
+                ]}
+              >
+                {item.count} pending
+              </Text>
+            </View>
+            <Ionicons
+              name="chevron-forward"
+              size={18}
+              color={colors.textSecondary}
+            />
+          </Pressable>
+        );
+      }
       if (item.kind === "section") {
         return (
           <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
@@ -215,11 +261,12 @@ export function ChatInboxScreen({
         />
       );
     },
-    [isGroupExpanded, toggleGroupExpanded, sidebarMode, activeGroupId, activeChannelSlug, primaryColor, colors]
+    [isGroupExpanded, toggleGroupExpanded, sidebarMode, activeGroupId, activeChannelSlug, primaryColor, colors, router]
   );
 
   // Key extractor for FlatList
   const keyExtractor = useCallback((item: InboxListItem) => {
+    if (item.kind === "requests-link") return "requests-link";
     if (item.kind === "section") return `section:${item.key}`;
     if (item.kind === "dm") return `dm:${item.item.channelId}`;
     return item.kind === "event"
@@ -366,18 +413,26 @@ export function ChatInboxScreen({
   }, [displayChannels]);
 
   // Prepend the Direct messages section when the user has any accepted DMs.
-  // Pending requests live in their own surface (PR 3) — not folded in here.
+  // Pending requests are surfaced as a single tappable header row above the
+  // section that routes to /inbox/requests; they're not interleaved into
+  // either DMs or groups so unaccepted senders can't sneak into the active
+  // chat list.
   const dmRows = directInbox ?? [];
+  const requestCount = chatRequests?.length ?? 0;
   const listItemsWithDm = useMemo<InboxListItem[]>(() => {
-    if (dmRows.length === 0) return listItems;
-    return [
-      { kind: "section", key: "dm-header", title: "Direct messages" },
-      ...dmRows.map(
-        (row) => ({ kind: "dm" as const, item: row }),
-      ),
-      ...listItems,
-    ];
-  }, [dmRows, listItems]);
+    const items: InboxListItem[] = [];
+    if (requestCount > 0) {
+      items.push({ kind: "requests-link", count: requestCount });
+    }
+    if (dmRows.length > 0) {
+      items.push({ kind: "section", key: "dm-header", title: "Direct messages" });
+      items.push(
+        ...dmRows.map((row) => ({ kind: "dm" as const, item: row })),
+      );
+    }
+    items.push(...listItems);
+    return items;
+  }, [requestCount, dmRows, listItems]);
   const hasInboxItems = listItemsWithDm.length > 0;
 
   // Show message when user has no community context
@@ -1040,6 +1095,31 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 8,
     paddingBottom: 6,
+  },
+  requestsLinkRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  requestsLinkIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  requestsLinkContent: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  requestsLinkTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  requestsLinkSubtitle: {
+    fontSize: 13,
+    marginTop: 2,
   },
   dmRow: {
     flexDirection: "row",

--- a/apps/mobile/features/chat/components/ChatRequestBanner.tsx
+++ b/apps/mobile/features/chat/components/ChatRequestBanner.tsx
@@ -1,0 +1,232 @@
+/**
+ * ChatRequestBanner
+ *
+ * Banner rendered above the message composer in `ConvexChatRoomScreen` when
+ * the current user's membership row in an ad-hoc channel has
+ * `requestState: "pending"`. Lets the recipient accept the request and start
+ * replying, decline silently, or block & report the inviter.
+ *
+ * Placement is the caller's responsibility — this component renders inline
+ * at full width and assumes it sits between the message list and the input.
+ */
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { useAuth } from "@providers/AuthProvider";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useTheme } from "@hooks/useTheme";
+import { useMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+export interface ChatRequestBannerProps {
+  channelId: Id<"chatChannels">;
+  inviterDisplayName: string;
+  /** Called after Accept succeeds — parent should refetch / re-render the chat room. */
+  onAccepted?: () => void;
+  /** Called after Decline / Block — parent should navigate away (back to inbox). */
+  onResolved?: () => void;
+}
+
+export function ChatRequestBanner({
+  channelId,
+  inviterDisplayName,
+  onAccepted,
+  onResolved,
+}: ChatRequestBannerProps) {
+  const { token } = useAuth();
+  const { primaryColor } = useCommunityTheme();
+  const { colors } = useTheme();
+
+  const [pendingAction, setPendingAction] = useState<
+    "accept" | "decline" | "block" | null
+  >(null);
+
+  const respondToChatRequest = useMutation(
+    api.functions.messaging.directMessages.respondToChatRequest
+  );
+
+  const isBusy = pendingAction !== null;
+
+  const handleAccept = async () => {
+    if (!token || isBusy) return;
+    setPendingAction("accept");
+    try {
+      await respondToChatRequest({
+        token,
+        channelId,
+        response: "accept",
+      });
+      setPendingAction(null);
+      onAccepted?.();
+    } catch (e) {
+      setPendingAction(null);
+      const message = e instanceof Error ? e.message : "Failed to accept";
+      Alert.alert("Couldn't accept", message);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!token || isBusy) return;
+    setPendingAction("decline");
+    try {
+      await respondToChatRequest({
+        token,
+        channelId,
+        response: "decline",
+      });
+      setPendingAction(null);
+      onResolved?.();
+    } catch (e) {
+      setPendingAction(null);
+      const message = e instanceof Error ? e.message : "Failed to decline";
+      Alert.alert("Couldn't decline", message);
+    }
+  };
+
+  const handleBlock = async () => {
+    if (!token || isBusy) return;
+    setPendingAction("block");
+    try {
+      await respondToChatRequest({
+        token,
+        channelId,
+        response: "block",
+        reportReason: "spam",
+      });
+      setPendingAction(null);
+      Alert.alert("Blocked", "They can't message you again.");
+      onResolved?.();
+    } catch (e) {
+      setPendingAction(null);
+      const message = e instanceof Error ? e.message : "Failed to block";
+      Alert.alert("Couldn't block", message);
+    }
+  };
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.surfaceSecondary,
+          borderTopColor: colors.border,
+          borderBottomColor: colors.border,
+        },
+      ]}
+    >
+      <Text style={[styles.title, { color: colors.text }]}>
+        {inviterDisplayName} would like to chat with you.
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+        Accept to reply with messages, photos, and reactions. Read receipts and
+        typing won't show until you accept.
+      </Text>
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[styles.button, { backgroundColor: primaryColor }]}
+          onPress={handleAccept}
+          disabled={isBusy}
+        >
+          {pendingAction === "accept" ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={[styles.buttonText, { color: "#fff" }]}>Accept</Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.button,
+            styles.buttonNeutral,
+            {
+              borderColor: colors.border,
+              backgroundColor: colors.surface,
+            },
+          ]}
+          onPress={handleDecline}
+          disabled={isBusy}
+        >
+          {pendingAction === "decline" ? (
+            <ActivityIndicator size="small" color={colors.text} />
+          ) : (
+            <Text style={[styles.buttonText, { color: colors.text }]}>
+              Decline
+            </Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.button,
+            styles.buttonDestructive,
+            { borderColor: colors.destructive },
+          ]}
+          onPress={handleBlock}
+          disabled={isBusy}
+        >
+          {pendingAction === "block" ? (
+            <ActivityIndicator size="small" color={colors.destructive} />
+          ) : (
+            <Text
+              style={[styles.buttonText, { color: colors.destructive }]}
+            >
+              Block & report
+            </Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 8,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  subtitle: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  actions: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginTop: 6,
+  },
+  button: {
+    flexGrow: 1,
+    flexBasis: 0,
+    minWidth: 100,
+    minHeight: 38,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 14,
+  },
+  buttonNeutral: {
+    borderWidth: 1,
+  },
+  buttonDestructive: {
+    backgroundColor: "transparent",
+    borderWidth: 1,
+  },
+  buttonText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -42,6 +42,7 @@ import { ChatMenuModal } from "./ChatMenuModal";
 import { ExternalChatModal } from "./ExternalChatModal";
 import { MessageList } from "./MessageList";
 import { MessageInput } from "./MessageInput";
+import { ChatRequestBanner } from "./ChatRequestBanner";
 import { TypingIndicator } from "./TypingIndicator";
 import { MessageActionsOverlay } from "./MessageActionsOverlay";
 import { ChannelMembersModal } from "@features/channels";
@@ -1032,8 +1033,18 @@ const ConvexChatRoomScreenInner: React.FC = () => {
             {/* Typing Indicator */}
             <TypingIndicator typingUsers={typingUsers} />
 
-            {/* Message Input */}
-            {canSendMessages ? (
+            {/* Message Input — or request banner if the caller is still
+                pending acceptance on an ad-hoc channel. The banner replaces the
+                composer entirely so the user can't bypass the gate; the
+                backend enforces the same rule (`sendMessage` rejects pending
+                senders) but UI-side gating is the better UX. */}
+            {channelData?.myRequestState === "pending" && activeChannelId ? (
+              <ChatRequestBanner
+                channelId={activeChannelId}
+                inviterDisplayName={channelData.inviterDisplayName ?? "Someone"}
+                onResolved={handleBack}
+              />
+            ) : canSendMessages ? (
               <MessageInput
                 channelId={activeChannelId ?? null}
                 replyToMessage={replyToMessageId ? { _id: replyToMessageId, content: "", senderName: "" } : null}


### PR DESCRIPTION
## Summary

PR 3 of 5. **Stacked on #345** which is stacked on #344. Review/merge in order.

This is the missing piece that turns the Message Request model from a backend invariant into something a recipient can actually act on — Accept / Decline / Block & Report.

## What ships

- **`/inbox/requests` (ChatRequestsScreen).** List of pending requests with inviter info + a one-line preview. Tap → a bottom sheet shows the full first message and three big buttons. Empty state for "no requests."
- **`ChatRequestBanner` mounted in `ConvexChatRoomScreen`.** When the caller's membership row is `requestState: "pending"`, the banner replaces the message composer — they can't reply until they accept, and the explanation copy makes the gate readable. Decline/block route back to the inbox.
- **"Message Requests (N pending)" row at the top of the inbox.** Tappable, routes to `/inbox/requests`. Deliberately not interleaved with active conversations — the whole point of the request model is to keep unaccepted senders out of the primary list.

## Backend touch

`getChannel` now returns `myRequestState` and `inviterDisplayName` for ad-hoc channels. Group + event branches return them as `undefined` so the Convex-generated TS union resolves cleanly (was breaking `channelData?.myRequestState` access until I made the shape consistent across branches). Backward compatible.

## Test plan

- [x] `npx tsc --noEmit` passes for both `apps/convex` and `apps/mobile` (no new errors).
- [x] **387/387 messaging tests pass** in `apps/convex` after the `getChannel` extension — no regressions.
- [x] Lint-staged + eslint clean on commit.
- [ ] **Manual smoke test (reviewer):** with seeded users A and B in the same community, A starts a DM with B and sends "hi". B logs in, sees "Message Requests (1 pending)" at the top of inbox, taps it, sees the request, taps Accept — channel opens with the message visible, B can reply. Repeat with Decline (channel disappears from B's view, sender not notified) and Block & Report (writes block + flag, banner dismisses). Confirm the chat room banner appears when navigating directly to a still-pending DM URL.

## What's NOT in this PR (later PRs)

- Group-chat creation (`group_dm` picker) → PR 4
- Read-receipt suppression while pending, lock-screen copy polish, full PostHog flag ramp → PR 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)