### PR TITLE
feat(chat): group chat creation in start-chat picker (PR 4 of 5)

### DIFF
--- a/apps/mobile/app/inbox/new.tsx
+++ b/apps/mobile/app/inbox/new.tsx
@@ -1,13 +1,15 @@
 /**
- * Start a new direct message
+ * Start a new direct message or group chat
  *
  * Route: /inbox/new
  *
- * Lets the caller search across the people in their communities and start
- * (or open) a 1:1 DM with one of them. On selection we call
- * `createOrGetDirectChannel` and navigate to the resulting channel.
+ * Multi-select picker over the caller's shared communities. One recipient
+ * selected → 1:1 DM via `createOrGetDirectChannel`. 2+ recipients selected
+ * → `group_dm` via `createGroupChat`, with an optional name input. Both
+ * flows navigate to `/inbox/dm/{channelId}`.
  *
- * Group chats (`group_dm`) are out of scope here — they ship in a later PR.
+ * iMessage-style UX: tap to toggle selection, chips at the top show who's
+ * selected, the bottom CTA reflects the current count.
  */
 import React, { useEffect, useMemo, useState } from "react";
 import {
@@ -20,6 +22,7 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  ScrollView,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -40,6 +43,7 @@ type SearchResult = {
 
 const SEARCH_DEBOUNCE_MS = 200;
 const SEARCH_LIMIT = 30;
+const MAX_GROUP_RECIPIENTS = 19; // matches MAX_GROUP_DM_RECIPIENTS in directMessages.ts
 
 export default function StartChatScreen() {
   const router = useRouter();
@@ -50,11 +54,16 @@ export default function StartChatScreen() {
 
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
-  const [pendingUserId, setPendingUserId] = useState<Id<"users"> | null>(null);
+  // Selected recipients keyed by userId. Map (not Set) so we keep
+  // `displayName` + `profilePhoto` for the chip row without re-querying.
+  const [selected, setSelected] = useState<Map<Id<"users">, SearchResult>>(
+    new Map(),
+  );
+  const [groupName, setGroupName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isFocused, setIsFocused] = useState(false);
 
-  // Debounce the search query so we don't refetch on every keystroke.
   useEffect(() => {
     const handle = setTimeout(() => {
       setDebouncedQuery(query);
@@ -62,20 +71,38 @@ export default function StartChatScreen() {
     return () => clearTimeout(handle);
   }, [query]);
 
+  // Excluding already-selected ids from the search result keeps the list
+  // tidy when someone has a long pick list — they can scroll for more
+  // candidates instead of seeing the same names re-appear.
+  const excludeUserIds = useMemo(
+    () => Array.from(selected.keys()),
+    [selected],
+  );
+
   const results = useQuery(
     api.functions.messaging.directMessages.searchUsersInSharedCommunities,
     token
-      ? { token, query: debouncedQuery, limit: SEARCH_LIMIT }
-      : "skip"
+      ? {
+          token,
+          query: debouncedQuery,
+          excludeUserIds,
+          limit: SEARCH_LIMIT,
+        }
+      : "skip",
   );
 
   const createOrGetDirectChannel = useMutation(
-    api.functions.messaging.directMessages.createOrGetDirectChannel
+    api.functions.messaging.directMessages.createOrGetDirectChannel,
+  );
+  const createGroupChat = useMutation(
+    api.functions.messaging.directMessages.createGroupChat,
   );
 
   const trimmedQuery = debouncedQuery.trim();
   const hasQuery = trimmedQuery.length > 0;
   const isLoadingResults = results === undefined && token != null;
+  const selectedCount = selected.size;
+  const isGroupMode = selectedCount >= 2;
 
   const handleClose = () => {
     if (router.canGoBack()) {
@@ -85,45 +112,101 @@ export default function StartChatScreen() {
     }
   };
 
-  const handleSelectUser = async (row: SearchResult) => {
-    if (!token || pendingUserId) return;
+  const toggleSelect = (row: SearchResult) => {
+    if (isSubmitting) return;
     setErrorMessage(null);
-    setPendingUserId(row.userId);
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (next.has(row.userId)) {
+        next.delete(row.userId);
+      } else {
+        if (next.size >= MAX_GROUP_RECIPIENTS) {
+          setErrorMessage(
+            `You can include up to ${MAX_GROUP_RECIPIENTS} other people in a group chat.`,
+          );
+          return prev;
+        }
+        next.set(row.userId, row);
+      }
+      return next;
+    });
+  };
+
+  const removeSelected = (userId: Id<"users">) => {
+    if (isSubmitting) return;
+    setErrorMessage(null);
+    setSelected((prev) => {
+      const next = new Map(prev);
+      next.delete(userId);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!token || isSubmitting || selectedCount === 0) return;
+    setErrorMessage(null);
+    setIsSubmitting(true);
     try {
-      const { channelId } = await createOrGetDirectChannel({
+      if (selectedCount === 1) {
+        const only = Array.from(selected.values())[0]!;
+        const { channelId } = await createOrGetDirectChannel({
+          token,
+          recipientUserId: only.userId,
+        });
+        router.replace({
+          pathname: `/inbox/dm/${channelId}` as any,
+          params: {
+            groupName: only.displayName,
+            imageUrl: only.profilePhoto ?? "",
+          },
+        });
+        return;
+      }
+
+      const recipientUserIds = Array.from(selected.keys());
+      const trimmedName = groupName.trim();
+      const { channelId } = await createGroupChat({
         token,
-        recipientUserId: row.userId,
+        recipientUserIds,
+        ...(trimmedName.length > 0 ? { name: trimmedName } : {}),
       });
-      // Pass recipient name + photo as URL params so the chat header has
-      // something to show before the channel doc loads — `ConvexChatRoomScreen`
-      // reads `groupName` / `imageUrl` directly off `useLocalSearchParams`.
+      // For group_dm the chat header reads from `groupName`. Fall back to
+      // a comma-separated first-names line so unnamed groups are recognizable
+      // from the header even before the channel doc loads.
+      const headerName =
+        trimmedName.length > 0
+          ? trimmedName
+          : Array.from(selected.values())
+              .slice(0, 3)
+              .map((u) => u.displayName.split(" ")[0])
+              .filter(Boolean)
+              .join(", ") || "Group chat";
       router.replace({
         pathname: `/inbox/dm/${channelId}` as any,
         params: {
-          groupName: row.displayName,
-          imageUrl: row.profilePhoto ?? "",
+          groupName: headerName,
+          imageUrl: "",
         },
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : "Something went wrong";
       setErrorMessage(message);
-      setPendingUserId(null);
+      setIsSubmitting(false);
     }
   };
 
   const renderItem = ({ item }: { item: SearchResult }) => {
-    const isPending = pendingUserId === item.userId;
-    const isAnyPending = pendingUserId !== null;
+    const isSelected = selected.has(item.userId);
     const subtitle = item.sharedCommunityNames.slice(0, 2).join(" • ");
     return (
       <TouchableOpacity
         style={[
           styles.row,
           { borderBottomColor: colors.border },
-          isAnyPending && !isPending && styles.rowDimmed,
+          isSubmitting && styles.rowDimmed,
         ]}
-        onPress={() => handleSelectUser(item)}
-        disabled={isAnyPending}
+        onPress={() => toggleSelect(item)}
+        disabled={isSubmitting}
         activeOpacity={0.7}
       >
         <Avatar
@@ -132,7 +215,10 @@ export default function StartChatScreen() {
           size={48}
         />
         <View style={styles.rowText}>
-          <Text style={[styles.rowName, { color: colors.text }]} numberOfLines={1}>
+          <Text
+            style={[styles.rowName, { color: colors.text }]}
+            numberOfLines={1}
+          >
             {item.displayName}
           </Text>
           {subtitle.length > 0 ? (
@@ -144,9 +230,19 @@ export default function StartChatScreen() {
             </Text>
           ) : null}
         </View>
-        {isPending ? (
-          <ActivityIndicator size="small" color={primaryColor} />
-        ) : null}
+        <View
+          style={[
+            styles.checkmark,
+            {
+              borderColor: isSelected ? primaryColor : colors.border,
+              backgroundColor: isSelected ? primaryColor : "transparent",
+            },
+          ]}
+        >
+          {isSelected ? (
+            <Ionicons name="checkmark" size={16} color="#ffffff" />
+          ) : null}
+        </View>
       </TouchableOpacity>
     );
   };
@@ -180,6 +276,13 @@ export default function StartChatScreen() {
     return null;
   }, [hasQuery, isLoadingResults, results, colors.textSecondary, primaryColor]);
 
+  const ctaLabel =
+    selectedCount === 0
+      ? "Select someone"
+      : selectedCount === 1
+        ? "Start chat"
+        : "Create group";
+
   return (
     <KeyboardAvoidingView
       style={[styles.flex, { backgroundColor: colors.surface }]}
@@ -202,9 +305,79 @@ export default function StartChatScreen() {
         >
           <Ionicons name="close" size={26} color={colors.text} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text }]}>New chat</Text>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>
+          {isGroupMode ? "New group chat" : "New chat"}
+        </Text>
         <View style={styles.headerSide} />
       </View>
+
+      {/* Selected chips */}
+      {selectedCount > 0 ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.chipsRow}
+          contentContainerStyle={styles.chipsContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          {Array.from(selected.values()).map((row) => (
+            <View
+              key={row.userId}
+              style={[
+                styles.chip,
+                {
+                  backgroundColor: colors.surfaceSecondary,
+                  borderColor: colors.border,
+                },
+              ]}
+            >
+              <Avatar
+                name={row.displayName}
+                imageUrl={row.profilePhoto}
+                size={20}
+              />
+              <Text
+                style={[styles.chipText, { color: colors.text }]}
+                numberOfLines={1}
+              >
+                {row.displayName.split(" ")[0]}
+              </Text>
+              <TouchableOpacity
+                onPress={() => removeSelected(row.userId)}
+                accessibilityLabel={`Remove ${row.displayName}`}
+                hitSlop={8}
+              >
+                <Ionicons
+                  name="close-circle"
+                  size={16}
+                  color={colors.textSecondary}
+                />
+              </TouchableOpacity>
+            </View>
+          ))}
+        </ScrollView>
+      ) : null}
+
+      {/* Optional group name (only when 2+ selected) */}
+      {isGroupMode ? (
+        <View style={styles.searchContainer}>
+          <TextInput
+            value={groupName}
+            onChangeText={setGroupName}
+            placeholder="Group name (optional)"
+            placeholderTextColor={colors.textSecondary}
+            maxLength={100}
+            style={[
+              styles.searchInput,
+              {
+                color: colors.text,
+                backgroundColor: colors.surfaceSecondary,
+                borderColor: colors.border,
+              },
+            ]}
+          />
+        </View>
+      ) : null}
 
       {/* Search input */}
       <View style={styles.searchContainer}>
@@ -244,6 +417,37 @@ export default function StartChatScreen() {
           (results?.length ?? 0) === 0 ? styles.emptyListContent : undefined
         }
       />
+
+      {/* CTA */}
+      {selectedCount > 0 ? (
+        <View
+          style={[
+            styles.ctaBar,
+            {
+              backgroundColor: colors.surface,
+              borderTopColor: colors.border,
+              paddingBottom: insets.bottom + 12,
+            },
+          ]}
+        >
+          <TouchableOpacity
+            onPress={handleSubmit}
+            disabled={isSubmitting}
+            style={[
+              styles.ctaButton,
+              { backgroundColor: primaryColor },
+              isSubmitting && styles.rowDimmed,
+            ]}
+            accessibilityRole="button"
+          >
+            {isSubmitting ? (
+              <ActivityIndicator size="small" color="#ffffff" />
+            ) : (
+              <Text style={styles.ctaButtonText}>{ctaLabel}</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      ) : null}
     </KeyboardAvoidingView>
   );
 }
@@ -269,9 +473,34 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: "500",
   },
+  chipsRow: {
+    maxHeight: 48,
+    flexGrow: 0,
+  },
+  chipsContent: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 8,
+    alignItems: "center",
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingLeft: 4,
+    paddingRight: 8,
+    paddingVertical: 4,
+    borderRadius: 16,
+    borderWidth: 1,
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: "500",
+    maxWidth: 120,
+  },
   searchContainer: {
     paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingVertical: 8,
   },
   searchInput: {
     borderWidth: 1,
@@ -307,6 +536,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 2,
   },
+  checkmark: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   emptyContainer: {
     paddingHorizontal: 24,
     paddingTop: 40,
@@ -318,5 +555,21 @@ const styles = StyleSheet.create({
   },
   emptyListContent: {
     flexGrow: 1,
+  },
+  ctaBar: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    borderTopWidth: 1,
+  },
+  ctaButton: {
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ctaButtonText: {
+    color: "#ffffff",
+    fontSize: 16,
+    fontWeight: "600",
   },
 });


### PR DESCRIPTION
## Summary

PR 4 of 5. **Stacked on #346 → #345 → #344.** Review/merge in order.

Extends the `/inbox/new` picker from 1:1-only to multi-select, wiring the picker into `createGroupChat` (already in place from PR 1) for `group_dm` channels.

## What ships

- Tap a row to toggle selection; chips appear at the top with one-tap removal.
- One recipient → "Start chat" CTA → 1:1 DM via `createOrGetDirectChannel` (unchanged behavior).
- Two-plus recipients → "Create group" CTA → `group_dm` via `createGroupChat`. Optional name input (capped at 100 chars to match server validation) appears above the search input when 2+ are selected.
- Cap of 19 invitees (matches `MAX_GROUP_DM_RECIPIENTS` on the backend); inline error if the user tries to add a 20th.
- Selected ids are excluded from the search query so the result list scrolls forward instead of repeating names already chosen.

## Test plan

- [x] Both packages typecheck clean (no new errors; 10 pre-existing untouched).
- [x] 15/15 directMessages backend tests still pass — no production-code changes in this PR.
- [x] Lint-staged + eslint clean on commit.
- [ ] **Manual smoke test (reviewer):** with seeded users A, B, C in same community: A taps "+", picks B and C, optionally names the group, taps "Create group" → lands in chat, sends a message. B and C see "Message Requests (1 pending)" → tap → see the group request from A → Accept → message visible, can reply. Decline by C while B has accepted: A and B see the chat continue normally; C is removed silently.

## What's NOT in this PR

- Group_dm-specific toolbar polish (member list, group avatar grid) → PR 5.
- Read-receipt suppression while pending → PR 5.
- PostHog flag ramp + lock-screen copy → PR 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)