### PR TITLE
feat(chat): polish + PostHog flag gate for DM rollout (PR 5 of 5)

### DIFF
--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as crons from "../crons.js";
 import type * as functions_admin_auth from "../functions/admin/auth.js";
 import type * as functions_admin_cleanup from "../functions/admin/cleanup.js";
 import type * as functions_admin_duplicates from "../functions/admin/duplicates.js";
+import type * as functions_admin_featureFlags from "../functions/admin/featureFlags.js";
 import type * as functions_admin_index from "../functions/admin/index.js";
 import type * as functions_admin_members from "../functions/admin/members.js";
 import type * as functions_admin_migrations from "../functions/admin/migrations.js";
@@ -188,6 +189,7 @@ declare const fullApi: ApiFromModules<{
   "functions/admin/auth": typeof functions_admin_auth;
   "functions/admin/cleanup": typeof functions_admin_cleanup;
   "functions/admin/duplicates": typeof functions_admin_duplicates;
+  "functions/admin/featureFlags": typeof functions_admin_featureFlags;
   "functions/admin/index": typeof functions_admin_index;
   "functions/admin/members": typeof functions_admin_members;
   "functions/admin/migrations": typeof functions_admin_migrations;

--- a/apps/convex/functions/admin/featureFlags.ts
+++ b/apps/convex/functions/admin/featureFlags.ts
@@ -1,0 +1,117 @@
+/**
+ * Feature Flags
+ *
+ * Database-backed global on/off switches for staged feature rollouts.
+ * Flipped by community primary admins via `/(user)/admin/features`.
+ *
+ * Design notes:
+ * - One boolean per key, applied to all users in the community. This is
+ *   deliberately simpler than PostHog targeting — Seyi found PostHog too
+ *   complex for the rollouts he actually does, so the operational model is
+ *   "set up the flag, ramp by flipping the switch."
+ * - When a flag's feature has fully ramped, the row and the gate sites are
+ *   removed together — there's no "flag retired" intermediate state.
+ * - Reads are an unauthenticated query so gates don't need to wait for the
+ *   user's session before deciding what to render. Writes require Primary
+ *   Admin via `requirePrimaryAdmin`.
+ */
+import { v } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import { requireAuth } from "../../lib/auth";
+import { requirePrimaryAdmin } from "../../lib/permissions";
+
+/**
+ * Get the current value of a single feature flag. Returns `false` if the row
+ * doesn't exist yet (default-off semantics).
+ */
+export const getFeatureFlag = query({
+  args: {
+    key: v.string(),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    const flag = await ctx.db
+      .query("featureFlags")
+      .withIndex("by_key", (q) => q.eq("key", args.key))
+      .first();
+    return flag?.enabled ?? false;
+  },
+});
+
+/**
+ * List all feature flags for the admin UI. Returns flags ordered by key.
+ * Auth-gated to primary admins only since the existence of a flag (and its
+ * description) can leak in-progress feature names.
+ */
+export const listFeatureFlags = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requirePrimaryAdmin(ctx, args.communityId, userId);
+
+    const flags = await ctx.db.query("featureFlags").collect();
+    return flags
+      .map((f) => ({
+        _id: f._id,
+        key: f.key,
+        enabled: f.enabled,
+        description: f.description ?? null,
+        updatedAt: f.updatedAt,
+        updatedById: f.updatedById ?? null,
+      }))
+      .sort((a, b) => a.key.localeCompare(b.key));
+  },
+});
+
+/**
+ * Set a feature flag's value. Creates the row if it doesn't exist yet,
+ * otherwise patches it. Authoring history is intentionally minimal —
+ * `updatedAt` + `updatedById` cover the "who flipped this and when"
+ * audit need without a separate event log table.
+ */
+export const setFeatureFlag = mutation({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    key: v.string(),
+    enabled: v.boolean(),
+    description: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const userId = await requireAuth(ctx, args.token);
+    await requirePrimaryAdmin(ctx, args.communityId, userId);
+
+    const trimmedKey = args.key.trim();
+    if (trimmedKey.length === 0) {
+      throw new Error("Feature flag key cannot be empty");
+    }
+
+    const existing = await ctx.db
+      .query("featureFlags")
+      .withIndex("by_key", (q) => q.eq("key", trimmedKey))
+      .first();
+
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        enabled: args.enabled,
+        ...(args.description !== undefined
+          ? { description: args.description }
+          : {}),
+        updatedAt: now,
+        updatedById: userId,
+      });
+    } else {
+      await ctx.db.insert("featureFlags", {
+        key: trimmedKey,
+        enabled: args.enabled,
+        description: args.description,
+        updatedAt: now,
+        updatedById: userId,
+      });
+    }
+    return { ok: true };
+  },
+});

--- a/apps/convex/functions/admin/index.ts
+++ b/apps/convex/functions/admin/index.ts
@@ -94,3 +94,10 @@ export {
 export {
   upsertGroupTypeFromLegacy,
 } from "./migrations";
+
+// Feature Flags - DB-backed global on/off switches for staged rollouts
+export {
+  getFeatureFlag,
+  listFeatureFlags,
+  setFeatureFlag,
+} from "./featureFlags";

--- a/apps/convex/functions/messaging/readState.ts
+++ b/apps/convex/functions/messaging/readState.ts
@@ -154,7 +154,11 @@ export const getMessageReadBy = query({
       throw new Error("Message does not belong to this channel");
     }
 
-    // Get all active members of the channel (excluding the sender)
+    // Get all active members of the channel (excluding the sender). Members
+    // whose `requestState` is still "pending" are excluded — read receipts
+    // shouldn't leak whether they've seen a message until they've accepted
+    // the chat (Signal-style protection). Legacy/group members have undefined
+    // `requestState` and are treated as accepted.
     const allMembers = await ctx.db
       .query("chatChannelMembers")
       .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
@@ -165,15 +169,22 @@ export const getMessageReadBy = query({
         )
       )
       .collect();
+    const acceptedMembers = allMembers.filter(
+      (m) => m.requestState !== "pending",
+    );
+    const acceptedMemberIds = new Set(acceptedMembers.map((m) => m.userId));
 
-    const totalMembers = allMembers.length;
+    const totalMembers = acceptedMembers.length;
 
-    // Get all read states for this channel
-    const allReadStates = await ctx.db
-      .query("chatReadState")
-      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
-      .filter((q) => q.neq(q.field("userId"), message.senderId))
-      .collect();
+    // Get all read states for this channel — only count those from accepted
+    // members so a pending recipient's read state doesn't leak.
+    const allReadStates = (
+      await ctx.db
+        .query("chatReadState")
+        .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+        .filter((q) => q.neq(q.field("userId"), message.senderId))
+        .collect()
+    ).filter((rs) => acceptedMemberIds.has(rs.userId));
 
     // Count users who have read this message
     // A user has read this message if:

--- a/apps/convex/functions/messaging/typing.ts
+++ b/apps/convex/functions/messaging/typing.ts
@@ -57,9 +57,33 @@ export const getTypingUsers = query({
       )
       .collect();
 
-    // Get user info for each typing user
+    if (indicators.length === 0) return [];
+
+    // Drop indicators from members whose `requestState` is still "pending" —
+    // typing should not leak to the channel until they've accepted the
+    // request (Signal-style protection). Legacy / group-channel members have
+    // undefined `requestState` and are treated as accepted.
     const userIds = indicators.map((i) => i.userId);
-    const users = await Promise.all(userIds.map((id) => ctx.db.get(id)));
+    const memberships = await Promise.all(
+      userIds.map((uid) =>
+        ctx.db
+          .query("chatChannelMembers")
+          .withIndex("by_channel_user", (q) =>
+            q.eq("channelId", args.channelId).eq("userId", uid),
+          )
+          .first(),
+      ),
+    );
+    const acceptedUserIds = new Set(
+      indicators
+        .filter((_, i) => memberships[i]?.requestState !== "pending")
+        .map((indicator) => indicator.userId),
+    );
+
+    // Get user info for each accepted typing user
+    const users = await Promise.all(
+      Array.from(acceptedUserIds).map((id) => ctx.db.get(id)),
+    );
 
     // Return transformed data with expected shape
     return users

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1802,6 +1802,26 @@ export default defineSchema({
     .index("by_message", ["messageId"]),
 
   // =============================================================================
+  // FEATURE FLAGS
+  // =============================================================================
+  // Global on/off switches for staged feature rollouts, flipped by primary
+  // admins from /(user)/admin/features. One row per flag key. The frontend
+  // gates render a brief loading state while the query hydrates, then either
+  // the feature or the disabled placeholder.
+  //
+  // Intentionally simple: single boolean for all users, no per-cohort
+  // targeting (we have PostHog for that and Seyi finds it too complex for
+  // these rollouts). When a feature flag has fully ramped to 100%, the row +
+  // the gate code are removed together.
+  featureFlags: defineTable({
+    key: v.string(), // canonical identifier, e.g. "direct-messages"
+    enabled: v.boolean(),
+    description: v.optional(v.string()),
+    updatedAt: v.number(), // Unix timestamp ms
+    updatedById: v.optional(v.id("users")),
+  }).index("by_key", ["key"]),
+
+  // =============================================================================
 
   // =============================================================================
   // SLACK SERVICE BOT THREADS

--- a/apps/mobile/app/(user)/admin/features/index.tsx
+++ b/apps/mobile/app/(user)/admin/features/index.tsx
@@ -1,0 +1,17 @@
+import { Stack } from "expo-router";
+import { FeatureFlagsContent } from "@features/admin";
+
+export default function FeatureFlagsRoute() {
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: "Feature Flags",
+          headerBackTitle: "Back",
+        }}
+      />
+      <FeatureFlagsContent />
+    </>
+  );
+}

--- a/apps/mobile/app/inbox/dm/[channelId]/index.tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/index.tsx
@@ -3,11 +3,21 @@
  *
  * Route: /inbox/dm/[channelId]
  *
- * Hosts the chat room for an ad-hoc 1:1 DM. The dynamic `[channelId]`
- * segment is the Convex `chatChannels` ID; ConvexChatRoomScreen reads it
- * from the route params (`params.channelId`) and resolves the active
- * channel from there.
+ * Hosts the chat room for an ad-hoc 1:1 or group DM. The dynamic
+ * `[channelId]` segment is the Convex `chatChannels` ID;
+ * `ConvexChatRoomScreen` reads it from the route params (`params.channelId`)
+ * and resolves the active channel from there.
+ *
+ * Behind the `direct-messages` PostHog flag — see `DmFeatureGate` for the
+ * placeholder shown when the flag is off.
  */
 import { ConvexChatRoomScreen } from "@features/chat/components/ConvexChatRoomScreen";
+import { DmFeatureGate } from "@features/chat/components/DmFeatureGate";
 
-export default ConvexChatRoomScreen;
+export default function DirectMessageChannelRoute() {
+  return (
+    <DmFeatureGate>
+      <ConvexChatRoomScreen />
+    </DmFeatureGate>
+  );
+}

--- a/apps/mobile/app/inbox/new.tsx
+++ b/apps/mobile/app/inbox/new.tsx
@@ -33,6 +33,7 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { useQuery, useMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { DmFeatureGate } from "@features/chat/components/DmFeatureGate";
 
 type SearchResult = {
   userId: Id<"users">;
@@ -45,7 +46,15 @@ const SEARCH_DEBOUNCE_MS = 200;
 const SEARCH_LIMIT = 30;
 const MAX_GROUP_RECIPIENTS = 19; // matches MAX_GROUP_DM_RECIPIENTS in directMessages.ts
 
-export default function StartChatScreen() {
+export default function StartChatScreenRoute() {
+  return (
+    <DmFeatureGate>
+      <StartChatScreen />
+    </DmFeatureGate>
+  );
+}
+
+function StartChatScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { token } = useAuth();

--- a/apps/mobile/app/inbox/requests.tsx
+++ b/apps/mobile/app/inbox/requests.tsx
@@ -33,6 +33,7 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { useQuery, useMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { DmFeatureGate } from "@features/chat/components/DmFeatureGate";
 
 type ChatRequestRow = {
   channelId: Id<"chatChannels">;
@@ -61,7 +62,15 @@ function formatRelativeShort(timestamp: number): string {
   return `${Math.floor(diffSec / 604800)}w`;
 }
 
-export default function ChatRequestsScreen() {
+export default function ChatRequestsRoute() {
+  return (
+    <DmFeatureGate>
+      <ChatRequestsScreen />
+    </DmFeatureGate>
+  );
+}
+
+function ChatRequestsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { token } = useAuth();

--- a/apps/mobile/features/admin/components/AdminDashboardScreen.tsx
+++ b/apps/mobile/features/admin/components/AdminDashboardScreen.tsx
@@ -97,6 +97,13 @@ export function AdminDashboardScreen() {
             <Text style={[styles.actionTitle, { color: colors.text }]}>Duplicate Accounts</Text>
             <Text style={[styles.actionSubtext, { color: colors.textSecondary }]}>Merge duplicate users</Text>
           </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.actionCard, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
+            onPress={() => router.push("/(user)/admin/features" as any)}
+          >
+            <Text style={[styles.actionTitle, { color: colors.text }]}>Feature Flags</Text>
+            <Text style={[styles.actionSubtext, { color: colors.textSecondary }]}>Toggle staged rollouts</Text>
+          </TouchableOpacity>
           <View style={[styles.actionCard, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
             <Text style={[styles.actionTitle, { color: colors.text }]}>Groups</Text>
             <Text style={[styles.actionSubtext, { color: colors.textSecondary }]}>Manage small groups</Text>

--- a/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
+++ b/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
@@ -1,0 +1,268 @@
+/**
+ * FeatureFlagsContent
+ *
+ * Primary-admin-only screen for flipping the global feature flags stored
+ * in the Convex `featureFlags` table. One row per flag, each with:
+ *   - the flag key + optional description
+ *   - a Switch that calls `setFeatureFlag` on change
+ *   - the last-updated timestamp
+ *
+ * Flags are created lazily — the first call to `setFeatureFlag(key, ...)`
+ * inserts the row. To show a flag here before it's been flipped for the
+ * first time, the `KNOWN_FLAGS` table below seeds the list with metadata
+ * so admins can see what flags exist even when they're still default-off.
+ */
+import React, { useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Switch,
+  RefreshControl,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAuth } from "@providers/AuthProvider";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useTheme } from "@hooks/useTheme";
+import { useQuery, useMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+/**
+ * Source-of-truth catalog of flags that exist in the codebase. Prevents the
+ * admin screen from showing a blank "no flags yet" state until someone flips
+ * something — and gives non-engineering admins a description of what each
+ * flag controls.
+ */
+const KNOWN_FLAGS: Array<{ key: string; description: string }> = [
+  {
+    key: "direct-messages",
+    description:
+      "1:1 direct messages and ad-hoc group chats. Enables the compose button on the inbox, the start-chat picker, and the request-flow inbox.",
+  },
+];
+
+type FlagRow = {
+  _id: Id<"featureFlags">;
+  key: string;
+  enabled: boolean;
+  description: string | null;
+  updatedAt: number;
+  updatedById: Id<"users"> | null;
+};
+
+function formatRelative(ts: number): string {
+  const diff = Date.now() - ts;
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+export function FeatureFlagsContent() {
+  const insets = useSafeAreaInsets();
+  const { token, community } = useAuth();
+  const { primaryColor } = useCommunityTheme();
+  const { colors } = useTheme();
+
+  const communityId = community?.id as Id<"communities"> | undefined;
+
+  const flags = useQuery(
+    api.functions.admin.featureFlags.listFeatureFlags,
+    token && communityId ? { token, communityId } : "skip",
+  ) as FlagRow[] | undefined;
+
+  const setFlag = useMutation(api.functions.admin.featureFlags.setFeatureFlag);
+
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+  // Merge backend rows with the KNOWN_FLAGS catalog so admins see flags that
+  // haven't been flipped yet.
+  const merged = useMemo(() => {
+    const byKey = new Map<string, FlagRow & { isSeed: boolean }>();
+    for (const known of KNOWN_FLAGS) {
+      byKey.set(known.key, {
+        _id: undefined as unknown as Id<"featureFlags">,
+        key: known.key,
+        enabled: false,
+        description: known.description,
+        updatedAt: 0,
+        updatedById: null,
+        isSeed: true,
+      });
+    }
+    if (flags) {
+      for (const f of flags) {
+        const known = KNOWN_FLAGS.find((k) => k.key === f.key);
+        byKey.set(f.key, {
+          ...f,
+          description: f.description ?? known?.description ?? null,
+          isSeed: false,
+        });
+      }
+    }
+    return Array.from(byKey.values()).sort((a, b) =>
+      a.key.localeCompare(b.key),
+    );
+  }, [flags]);
+
+  const onToggle = async (row: (typeof merged)[number], next: boolean) => {
+    if (!token || !communityId || pendingKey) return;
+    setPendingKey(row.key);
+    try {
+      await setFlag({
+        token,
+        communityId,
+        key: row.key,
+        enabled: next,
+        ...(row.description ? { description: row.description } : {}),
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to update flag";
+      Alert.alert("Couldn't update flag", message);
+    } finally {
+      setPendingKey(null);
+    }
+  };
+
+  if (!communityId) {
+    return (
+      <View
+        style={[
+          styles.container,
+          styles.centered,
+          { backgroundColor: colors.surface },
+        ]}
+      >
+        <Text style={[styles.empty, { color: colors.textSecondary }]}>
+          Select a community to manage feature flags.
+        </Text>
+      </View>
+    );
+  }
+
+  if (flags === undefined) {
+    return (
+      <View
+        style={[
+          styles.container,
+          styles.centered,
+          { backgroundColor: colors.surface },
+        ]}
+      >
+        <ActivityIndicator size="small" color={primaryColor} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.surface }]}
+      contentContainerStyle={[
+        styles.content,
+        { paddingBottom: insets.bottom + 24 },
+      ]}
+      refreshControl={
+        <RefreshControl refreshing={false} onRefresh={() => {}} tintColor={primaryColor} />
+      }
+    >
+      <Text style={[styles.intro, { color: colors.textSecondary }]}>
+        Toggle features on or off for everyone in this community. Changes take
+        effect immediately for any client with the chat tab open.
+      </Text>
+      {merged.map((row) => (
+        <View
+          key={row.key}
+          style={[styles.row, { borderColor: colors.border }]}
+        >
+          <View style={styles.rowMain}>
+            <Text style={[styles.key, { color: colors.text }]}>{row.key}</Text>
+            {row.description ? (
+              <Text
+                style={[styles.description, { color: colors.textSecondary }]}
+              >
+                {row.description}
+              </Text>
+            ) : null}
+            <Text
+              style={[styles.updatedAt, { color: colors.textSecondary }]}
+            >
+              {row.isSeed
+                ? "Never flipped"
+                : `Updated ${formatRelative(row.updatedAt)}`}
+            </Text>
+          </View>
+          <View style={styles.rowAction}>
+            {pendingKey === row.key ? (
+              <ActivityIndicator size="small" color={primaryColor} />
+            ) : (
+              <Switch
+                value={row.enabled}
+                onValueChange={(next) => onToggle(row, next)}
+                trackColor={{ false: colors.border, true: primaryColor }}
+                disabled={pendingKey !== null}
+              />
+            )}
+          </View>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
+  centered: {
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  empty: {
+    fontSize: 15,
+    textAlign: "center",
+  },
+  intro: {
+    fontSize: 14,
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 12,
+  },
+  rowMain: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowAction: {
+    width: 56,
+    alignItems: "flex-end",
+  },
+  key: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  description: {
+    fontSize: 13,
+    marginTop: 4,
+    lineHeight: 18,
+  },
+  updatedAt: {
+    fontSize: 11,
+    marginTop: 6,
+  },
+});

--- a/apps/mobile/features/admin/components/index.ts
+++ b/apps/mobile/features/admin/components/index.ts
@@ -4,6 +4,7 @@ export { AdminScreen } from "./AdminScreen";
 export { CommunityWideEventsScreen } from "./CommunityWideEventsScreen";
 export { DuplicateAccountsScreen } from "./DuplicateAccountsScreen";
 export { ExportBottomSheet } from "./ExportBottomSheet";
+export { FeatureFlagsContent } from "./FeatureFlagsContent";
 export { GroupAttendanceDetails } from "./GroupAttendanceDetails";
 export { GroupTypeEditModal } from "./GroupTypeEditModal";
 export { PendingRequestsContent } from "./PendingRequestsContent";

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -34,7 +34,7 @@ import { GroupedInboxItem } from "./GroupedInboxItem";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
 import { Avatar } from "@components/ui/Avatar";
-import { useFeatureFlag } from "@hooks/useFeatureFlag";
+import { useConvexFeatureFlag } from "@hooks/useConvexFeatureFlag";
 
 // Inbox event visibility is now driven server-side by
 // `INBOX_EVENT_HIDE_AFTER_MS` in apps/convex/functions/messaging/channels.ts
@@ -155,7 +155,7 @@ export function ChatInboxScreen({
   // The whole DM surface is behind a PostHog flag for staged rollout. When
   // the flag is off we skip the queries entirely (no spurious subscriptions
   // for users who don't have the feature) and hide every entry point below.
-  const dmsEnabled = useFeatureFlag("direct-messages");
+  const { enabled: dmsEnabled } = useConvexFeatureFlag("direct-messages");
   const directInbox = useQuery(
     api.functions.messaging.directMessages.getDirectInbox,
     token && dmsEnabled ? { token } : "skip",

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -34,6 +34,7 @@ import { GroupedInboxItem } from "./GroupedInboxItem";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
 import { Avatar } from "@components/ui/Avatar";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 
 // Inbox event visibility is now driven server-side by
 // `INBOX_EVENT_HIDE_AFTER_MS` in apps/convex/functions/messaging/channels.ts
@@ -150,13 +151,18 @@ export function ChatInboxScreen({
   // Direct-message inbox is a separate subscription so the existing
   // `getInboxChannels` query (and its 4222-line file) stays untouched. Convex
   // multi-subscription cost is negligible.
+  //
+  // The whole DM surface is behind a PostHog flag for staged rollout. When
+  // the flag is off we skip the queries entirely (no spurious subscriptions
+  // for users who don't have the feature) and hide every entry point below.
+  const dmsEnabled = useFeatureFlag("direct-messages");
   const directInbox = useQuery(
     api.functions.messaging.directMessages.getDirectInbox,
-    token ? { token } : "skip",
+    token && dmsEnabled ? { token } : "skip",
   );
   const chatRequests = useQuery(
     api.functions.messaging.directMessages.listChatRequests,
-    token ? { token } : "skip",
+    token && dmsEnabled ? { token } : "skip",
   );
 
   // Cache inbox data for offline use
@@ -280,11 +286,12 @@ export function ChatInboxScreen({
   // The same header is rendered above the list and the three empty/loading
   // states below; centralizing it here keeps the "+" button placement (and the
   // tap target that opens the new-chat picker) in one place. Hidden in the
-  // "no community" empty state since the picker has nothing to search.
+  // "no community" empty state since the picker has nothing to search, and
+  // hidden entirely when the DM feature flag is off.
   const renderHeader = (showCompose: boolean) => (
     <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
       <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
-      {showCompose && (
+      {showCompose && dmsEnabled && (
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Start a new chat"

--- a/apps/mobile/features/chat/components/DmFeatureGate.tsx
+++ b/apps/mobile/features/chat/components/DmFeatureGate.tsx
@@ -1,12 +1,13 @@
 /**
  * DmFeatureGate
  *
- * Wraps screens that exist only when the `direct-messages` PostHog flag is on.
- * Routes stay registered (so deep links don't 404) but the body shows a
+ * Wraps screens that exist only when the `direct-messages` feature flag is
+ * on. Routes stay registered (so deep links don't 404) but the body shows a
  * placeholder when the flag is off rather than rendering the feature.
  *
- * Renders a lightweight loading skeleton while the flag value is hydrating
- * from AsyncStorage / PostHog so we don't briefly flash the placeholder.
+ * The flag is a row in the Convex `featureFlags` table flipped from
+ * `/(user)/admin/features`. Renders a lightweight spinner while the query
+ * hydrates so rollout-cohort users don't see the disabled UI on cold start.
  */
 import React from "react";
 import {
@@ -21,14 +22,14 @@ import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
-import { useFeatureFlagState } from "@hooks/useFeatureFlag";
+import { useConvexFeatureFlag } from "@hooks/useConvexFeatureFlag";
 
 interface DmFeatureGateProps {
   children: React.ReactNode;
 }
 
 export function DmFeatureGate({ children }: DmFeatureGateProps) {
-  const { enabled, loaded } = useFeatureFlagState("direct-messages");
+  const { enabled, loaded } = useConvexFeatureFlag("direct-messages");
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();

--- a/apps/mobile/features/chat/components/DmFeatureGate.tsx
+++ b/apps/mobile/features/chat/components/DmFeatureGate.tsx
@@ -9,25 +9,51 @@
  * from AsyncStorage / PostHog so we don't briefly flash the placeholder.
  */
 import React from "react";
-import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
-import { useFeatureFlag } from "@hooks/useFeatureFlag";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useFeatureFlagState } from "@hooks/useFeatureFlag";
 
 interface DmFeatureGateProps {
   children: React.ReactNode;
 }
 
 export function DmFeatureGate({ children }: DmFeatureGateProps) {
-  const enabled = useFeatureFlag("direct-messages");
+  const { enabled, loaded } = useFeatureFlagState("direct-messages");
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
 
   if (enabled) {
     return <>{children}</>;
+  }
+
+  // Render a spinner — not the disabled placeholder — while the flag value
+  // is still hydrating from AsyncStorage / PostHog. Otherwise rollout-cohort
+  // users briefly see "Direct messages aren't available yet" on cold starts
+  // and could navigate away before the flag resolves to enabled.
+  if (!loaded) {
+    return (
+      <View
+        style={[
+          styles.container,
+          styles.loading,
+          { backgroundColor: colors.surface },
+        ]}
+      >
+        <ActivityIndicator size="small" color={primaryColor} />
+      </View>
+    );
   }
 
   const handleClose = () => {
@@ -79,6 +105,10 @@ export function DmFeatureGate({ children }: DmFeatureGateProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  loading: {
+    alignItems: "center",
+    justifyContent: "center",
   },
   header: {
     flexDirection: "row",

--- a/apps/mobile/features/chat/components/DmFeatureGate.tsx
+++ b/apps/mobile/features/chat/components/DmFeatureGate.tsx
@@ -1,0 +1,116 @@
+/**
+ * DmFeatureGate
+ *
+ * Wraps screens that exist only when the `direct-messages` PostHog flag is on.
+ * Routes stay registered (so deep links don't 404) but the body shows a
+ * placeholder when the flag is off rather than rendering the feature.
+ *
+ * Renders a lightweight loading skeleton while the flag value is hydrating
+ * from AsyncStorage / PostHog so we don't briefly flash the placeholder.
+ */
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
+
+interface DmFeatureGateProps {
+  children: React.ReactNode;
+}
+
+export function DmFeatureGate({ children }: DmFeatureGateProps) {
+  const enabled = useFeatureFlag("direct-messages");
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  if (enabled) {
+    return <>{children}</>;
+  }
+
+  const handleClose = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/chat");
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface }]}>
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + 16,
+            borderBottomColor: colors.border,
+          },
+        ]}
+      >
+        <TouchableOpacity
+          onPress={handleClose}
+          style={styles.headerSide}
+          accessibilityLabel="Close"
+        >
+          <Ionicons name="close" size={26} color={colors.text} />
+        </TouchableOpacity>
+        <View style={styles.headerSide} />
+      </View>
+      <View style={styles.body}>
+        <Ionicons
+          name="chatbubbles-outline"
+          size={56}
+          color={colors.iconSecondary}
+          style={styles.icon}
+        />
+        <Text style={[styles.title, { color: colors.text }]}>
+          Direct messages aren't available yet
+        </Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          Check back soon — we're rolling this out gradually.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: 1,
+  },
+  headerSide: {
+    width: 40,
+    height: 32,
+    justifyContent: "center",
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  icon: {
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "600",
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  subtitle: {
+    fontSize: 15,
+    textAlign: "center",
+    maxWidth: 320,
+  },
+});

--- a/apps/mobile/hooks/useConvexFeatureFlag.ts
+++ b/apps/mobile/hooks/useConvexFeatureFlag.ts
@@ -1,0 +1,28 @@
+/**
+ * useConvexFeatureFlag
+ *
+ * Reads a single feature flag from the Convex `featureFlags` table.
+ * Returns `{ enabled, loaded }` so callers can render a brief loading state
+ * (rather than flashing the disabled UI on rollout-cohort users) while the
+ * query hydrates.
+ *
+ * Use this for the new DB-backed flags flipped via `/(user)/admin/features`.
+ * The PostHog-backed `useFeatureFlag` in `./useFeatureFlag.ts` is still
+ * available for cases where per-cohort targeting is genuinely needed — but
+ * for staged on/off rollouts, prefer this one (Seyi finds PostHog too
+ * complex for those flows).
+ */
+import { useQuery, api } from "@services/api/convex";
+
+export function useConvexFeatureFlag(key: string): {
+  enabled: boolean;
+  loaded: boolean;
+} {
+  const value = useQuery(api.functions.admin.featureFlags.getFeatureFlag, {
+    key,
+  });
+  return {
+    enabled: value === true,
+    loaded: value !== undefined,
+  };
+}

--- a/apps/mobile/hooks/useFeatureFlag.ts
+++ b/apps/mobile/hooks/useFeatureFlag.ts
@@ -148,6 +148,55 @@ export function useFeatureFlag(flagKey: string): boolean {
 }
 
 /**
+ * Same as `useFeatureFlag` but distinguishes "feature is off" from "we don't
+ * yet know whether the feature is on" — the latter happens briefly on cold
+ * starts while AsyncStorage / PostHog are hydrating. Callers that want to
+ * render a loading state (rather than flashing the disabled UI on rollout
+ * users) should use this instead.
+ */
+export function useFeatureFlagState(flagKey: string): {
+  enabled: boolean;
+  loaded: boolean;
+} {
+  const posthog = usePostHog();
+  const [override, setOverride] = useState<boolean | undefined>(undefined);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    loadOverrides().then((overrides) => {
+      setOverride(overrides[flagKey]);
+      setLoaded(true);
+    });
+  }, [flagKey]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToOverrideChanges(() => {
+      loadOverrides().then((overrides) => {
+        setOverride(overrides[flagKey]);
+      });
+    });
+    return unsubscribe;
+  }, [flagKey]);
+
+  // Hydration order matches `useFeatureFlag`. We're "loaded" once both the
+  // local override has been read from AsyncStorage AND PostHog has produced
+  // a definitive value (or we hit a URL override, which is synchronous on
+  // web and bypasses both async sources).
+  const urlOverride = getUrlParamOverride(flagKey);
+  if (urlOverride !== undefined) {
+    return { enabled: urlOverride, loaded: true };
+  }
+  if (loaded && override !== undefined) {
+    return { enabled: override, loaded: true };
+  }
+  const posthogValue = posthog?.isFeatureEnabled(flagKey);
+  if (posthogValue !== undefined) {
+    return { enabled: posthogValue, loaded: true };
+  }
+  return { enabled: false, loaded: false };
+}
+
+/**
  * Get the variant value of a multivariate feature flag.
  *
  * @param flagKey - The feature flag key

--- a/apps/mobile/hooks/useFeatureFlag.ts
+++ b/apps/mobile/hooks/useFeatureFlag.ts
@@ -148,55 +148,6 @@ export function useFeatureFlag(flagKey: string): boolean {
 }
 
 /**
- * Same as `useFeatureFlag` but distinguishes "feature is off" from "we don't
- * yet know whether the feature is on" — the latter happens briefly on cold
- * starts while AsyncStorage / PostHog are hydrating. Callers that want to
- * render a loading state (rather than flashing the disabled UI on rollout
- * users) should use this instead.
- */
-export function useFeatureFlagState(flagKey: string): {
-  enabled: boolean;
-  loaded: boolean;
-} {
-  const posthog = usePostHog();
-  const [override, setOverride] = useState<boolean | undefined>(undefined);
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    loadOverrides().then((overrides) => {
-      setOverride(overrides[flagKey]);
-      setLoaded(true);
-    });
-  }, [flagKey]);
-
-  useEffect(() => {
-    const unsubscribe = subscribeToOverrideChanges(() => {
-      loadOverrides().then((overrides) => {
-        setOverride(overrides[flagKey]);
-      });
-    });
-    return unsubscribe;
-  }, [flagKey]);
-
-  // Hydration order matches `useFeatureFlag`. We're "loaded" once both the
-  // local override has been read from AsyncStorage AND PostHog has produced
-  // a definitive value (or we hit a URL override, which is synchronous on
-  // web and bypasses both async sources).
-  const urlOverride = getUrlParamOverride(flagKey);
-  if (urlOverride !== undefined) {
-    return { enabled: urlOverride, loaded: true };
-  }
-  if (loaded && override !== undefined) {
-    return { enabled: override, loaded: true };
-  }
-  const posthogValue = posthog?.isFeatureEnabled(flagKey);
-  if (posthogValue !== undefined) {
-    return { enabled: posthogValue, loaded: true };
-  }
-  return { enabled: false, loaded: false };
-}
-
-/**
  * Get the variant value of a multivariate feature flag.
  *
  * @param flagKey - The feature flag key


### PR DESCRIPTION
## Summary

PR 5 of 5 — the final PR. **Stacked on #347 → #346 → #345 → #344 (all merged).** Now targets `main`.

Two things ship: the rollout safety net (DB-backed feature flag + admin toggle UI) and the V1 privacy commitment (no read receipts / typing leakage from pending recipients).

## Why a DB-backed flag, not PostHog

Togather has PostHog wired up but operating it for these rollouts is more friction than they're worth — single boolean, flipped once, applied to everyone. New `featureFlags` table flipped from `/(user)/admin/features` keeps the operating model trivial: open the admin screen, hit a Switch.

## What ships

### Feature flag system
- New Convex `featureFlags` table (`key`, `enabled`, `description?`, `updatedAt`, `updatedById?`) indexed `by_key`.
- `admin/featureFlags.ts`:
  - `getFeatureFlag({ key })` — unauthenticated read so gate components don't have to wait for the session before deciding.
  - `listFeatureFlags({ token, communityId })` — admin-gated for the toggle screen.
  - `setFeatureFlag({ token, communityId, key, enabled, description? })` — `requirePrimaryAdmin`-gated upsert.
- `useConvexFeatureFlag(key)` hook returns `{ enabled, loaded }` so callers render a spinner while hydrating.
- `/(user)/admin/features` route + `FeatureFlagsContent` component: one row per flag with a Switch + description + "updated Xh ago". `KNOWN_FLAGS` catalog seeds the list with flags that exist in the codebase so admins see them even before first flip.
- `AdminDashboardScreen` gets a "Feature Flags" Quick Access tile.

### DM gates use the new flag
- `DmFeatureGate` (used by `/inbox/new`, `/inbox/requests`, `/inbox/dm/[channelId]`) reads from `useConvexFeatureFlag("direct-messages")`. Spinner during hydration → either children or "Direct messages aren't available yet" placeholder.
- `ChatInboxScreen` gates the compose button, the Direct messages section, and the Requests link on the same flag. Skips the `getDirectInbox` and `listChatRequests` queries when off.

### Read-receipt + typing suppression while pending
- `getMessageReadBy`: pending members are excluded from both the read-by count AND the `totalMembers` denominator.
- `getTypingUsers`: typing indicators from pending members are dropped before the user list returns. Composer-side gating from PR 3 is the primary protection; this is belt-and-suspenders.

## Test plan

- [x] `apps/convex` and `apps/mobile` typecheck clean (no new errors; 10 pre-existing untouched).
- [x] 387/387 messaging tests pass — no regressions from the read/typing filter additions.
- [x] Lint-staged + eslint clean on commit.
- [ ] **Reviewer manual smoke**:
  1. With the row absent or `enabled=false`, confirm the compose button is hidden, `/inbox/new` renders the placeholder, the inbox doesn't subscribe to DM data.
  2. As a primary admin, open `/(user)/admin/features`, toggle `direct-messages` on, watch the inbox light up immediately.
  3. With seeded users A→B pending, confirm B's read-state and typing don't appear on A's chat-room view until B accepts.

## How to roll out

1. Land PRs 1-5 in order (1-4 already merged).
2. Insert the row from the admin screen — toggle off — once #348 lands.
3. Toggle on for staff, validate the full flow, then ramp to all.
4. Once stable for ~30 days, delete the row from the table and remove the gate code (`DmFeatureGate`, `useConvexFeatureFlag` calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)