### PR TITLE
fix(inbox): guard /inbox/[groupId] from reserved route names

### DIFF
--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/index.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/index.tsx
@@ -12,7 +12,27 @@
  * - "general" - Maps to the main channel (channelType: "main")
  * - "leaders" - Maps to the leaders channel (channelType: "leaders")
  * - Custom slugs - Custom channels created by group leaders
+ *
+ * Reserved-name guard: if `groupId` is one of the sibling literal route
+ * names (`new`, `requests`, `dm`), the dynamic resolver landed on this
+ * file spuriously. Redirect away before mounting `ConvexChatRoomScreen`
+ * so it doesn't fire `listGroupChannels({ groupId: "new" })` and crash
+ * Convex's `v.id("groups")` validator. See `[groupId]/index.tsx` for
+ * the same guard at the parent level.
  */
+import { Redirect, useLocalSearchParams } from "expo-router";
 import { ConvexChatRoomScreen } from "@features/chat/components/ConvexChatRoomScreen";
 
-export default ConvexChatRoomScreen;
+const RESERVED_INBOX_ROUTES: ReadonlySet<string> = new Set([
+  "new",
+  "requests",
+  "dm",
+]);
+
+export default function ChannelSlugRoute() {
+  const { groupId } = useLocalSearchParams<{ groupId: string }>();
+  if (groupId && RESERVED_INBOX_ROUTES.has(groupId)) {
+    return <Redirect href={`/inbox/${groupId}` as any} />;
+  }
+  return <ConvexChatRoomScreen />;
+}

--- a/apps/mobile/app/inbox/[groupId]/index.tsx
+++ b/apps/mobile/app/inbox/[groupId]/index.tsx
@@ -3,11 +3,30 @@
  *
  * Redirects from /inbox/[groupId] to /inbox/[groupId]/general
  * This ensures a consistent URL structure for chat navigation.
+ *
+ * Reserved-name guard: if `groupId` matches a sibling literal route
+ * (`new`, `requests`, `dm`), expo-router has resolved this dynamic file
+ * spuriously — redirect to that literal route instead of building a
+ * nonsense URL like `/inbox/new/general`. Without this guard the
+ * downstream `[channelSlug]` screen mounts `ConvexChatRoomScreen` with
+ * `groupId="new"`, which fails Convex's `v.id("groups")` validator on
+ * `listGroupChannels` ("ArgumentValidationError: Value does not match
+ * validator. Path: .groupId Value: \"new\"").
  */
 import { useLocalSearchParams, Redirect } from "expo-router";
 
+const RESERVED_INBOX_ROUTES: ReadonlySet<string> = new Set([
+  "new",
+  "requests",
+  "dm",
+]);
+
 export default function GroupChatIndexRoute() {
   const { groupId } = useLocalSearchParams<{ groupId: string }>();
+
+  if (groupId && RESERVED_INBOX_ROUTES.has(groupId)) {
+    return <Redirect href={`/inbox/${groupId}` as any} />;
+  }
 
   // Redirect to general tab by default
   return <Redirect href={`/inbox/${groupId}/general`} />;


### PR DESCRIPTION
## Summary

Tapping the compose icon on the inbox crashed with:

```
[CONVEX Q(functions/messaging/channels:listGroupChannels)] Server Error
ArgumentValidationError: Value does not match validator.
Path: .groupId
Value: "new"
Validator: v.id("groups")
```

## Why

expo-router's dynamic `[groupId]/` route resolved `/inbox/new` to itself instead of the literal sibling `new.tsx`. The dynamic `index.tsx` redirected to `/inbox/new/general`, mounting `ConvexChatRoomScreen` with `groupId="new"`. That screen fires `useQuery(listGroupChannels, { groupId })` which fails Convex's `v.id("groups")` validator on the server.

This was reproducible after the DM-feature merge — the new sibling routes (`new`, `requests`, `dm`) collide with the dynamic param at the same level.

## Fix

Both `[groupId]/index.tsx` and `[groupId]/[channelSlug]/index.tsx` now short-circuit when `groupId` is one of the sibling literal route names (`new`, `requests`, `dm`) and `<Redirect>` to the literal URL. The literal route renders via expo-router's file-system match, and `ConvexChatRoomScreen` is never mounted with a non-Id string.

Belt-and-suspenders even when expo-router picks the right file on first paint — desktop split-pane navigation can briefly remount the dynamic Stack screen with stale URL params during transitions.

## Test plan

- [x] `apps/mobile` typecheck clean
- [x] Lint-staged + eslint clean
- [x] No backend touches
- [ ] **Manual smoke** on staging: tap compose → no console error, lands on the picker.

@codex please review this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)