### PR TITLE
feat(chat): chat info, profile entry points, leaders preview, profile-photo gate

### DIFF
--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -49,7 +49,16 @@ async function createCommunity(
 async function createUserInCommunity(
   t: ReturnType<typeof convexTest>,
   communityId: Id<"communities">,
-  opts: { firstName: string; lastName?: string },
+  opts: {
+    firstName: string;
+    lastName?: string;
+    /**
+     * Override the default test profile photo. Pass `null` to omit the photo
+     * entirely (used by the profile-photo gate tests). When omitted, a
+     * non-empty placeholder photo is set so the photo gate is satisfied.
+     */
+    profilePhoto?: string | null;
+  },
 ): Promise<{ userId: Id<"users">; accessToken: string }> {
   const userId = await t.run(async (ctx) => {
     const uId = await ctx.db.insert("users", {
@@ -58,6 +67,10 @@ async function createUserInCommunity(
       phone: uniquePhone(),
       phoneVerified: true,
       activeCommunityId: communityId,
+      profilePhoto:
+        opts.profilePhoto === null
+          ? undefined
+          : (opts.profilePhoto ?? "https://example.com/avatar.png"),
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
@@ -76,7 +89,7 @@ async function createUserInCommunity(
 
 async function createUserInOtherCommunity(
   t: ReturnType<typeof convexTest>,
-  opts: { firstName: string; lastName?: string },
+  opts: { firstName: string; lastName?: string; profilePhoto?: string | null },
 ): Promise<{
   userId: Id<"users">;
   accessToken: string;
@@ -821,5 +834,448 @@ describe("expireOldChatRequests cron", () => {
     const cbBMemberAfter = await getMember(t, cbChannelId, bId);
     expect(cbBMemberAfter?.requestState).toBe("pending");
     expect(cbBMemberAfter?.leftAt).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Profile photo gate
+// ============================================================================
+
+describe("profile photo gate", () => {
+  test("createOrGetDirectChannel rejects when caller lacks profilePhoto", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Photo Caller Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+      profilePhoto: null,
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.directMessages.createOrGetDirectChannel,
+        { token: aToken, communityId, recipientUserId: bId },
+      ),
+    ).rejects.toThrow(/PROFILE_PHOTO_REQUIRED/);
+  });
+
+  test("createOrGetDirectChannel rejects when recipient lacks profilePhoto", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Photo Recipient Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+      profilePhoto: null,
+    });
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.directMessages.createOrGetDirectChannel,
+        { token: aToken, communityId, recipientUserId: bId },
+      ),
+    ).rejects.toThrow(/RECIPIENT_PROFILE_PHOTO_REQUIRED:/);
+  });
+
+  test("createOrGetDirectChannel succeeds when both have profilePhoto", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Photo OK Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const result = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+    expect(result.isNew).toBe(true);
+  });
+
+  test("respondToChatRequest accept rejects when caller lacks profilePhoto", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Accept Photo Community");
+    // Sender has a photo (so the request can be created), responder will get
+    // their photo cleared before accepting.
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+
+    // Clear B's profile photo so the accept-path gate fires.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(bId, { profilePhoto: undefined });
+    });
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.directMessages.respondToChatRequest,
+        { token: bToken, channelId, response: "accept" },
+      ),
+    ).rejects.toThrow(/PROFILE_PHOTO_REQUIRED/);
+  });
+});
+
+// ============================================================================
+// renameAdHocChannel
+// ============================================================================
+
+describe("renameAdHocChannel", () => {
+  test("works for an accepted member of a group_dm", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Rename Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+    const { userId: cId } = await createUserInCommunity(t, communityId, {
+      firstName: "Carol",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId, cId],
+        name: "Old name",
+      },
+    );
+
+    await t.mutation(
+      api.functions.messaging.directMessages.renameAdHocChannel,
+      { token: aToken, channelId, name: "New name" },
+    );
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.name).toBe("New name");
+  });
+
+  test("rejects rename for 1:1 dm channels", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Rename DM Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.directMessages.renameAdHocChannel,
+        { token: aToken, channelId, name: "Nope" },
+      ),
+    ).rejects.toThrow(/1:1|cannot be renamed/i);
+  });
+
+  test("rejects rename by a non-member", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Rename Outsider Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+    const { accessToken: outsiderToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Outsider" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId],
+        name: "Original",
+      },
+    );
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.directMessages.renameAdHocChannel,
+        { token: outsiderToken, channelId, name: "Hijacked" },
+      ),
+    ).rejects.toThrow(/not a member/i);
+  });
+
+  test("rejects blank rename for group_dm", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Rename Blank Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId],
+        name: "Original",
+      },
+    );
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.directMessages.renameAdHocChannel,
+        { token: aToken, channelId, name: "   " },
+      ),
+    ).rejects.toThrow(/blank/i);
+  });
+});
+
+// ============================================================================
+// addAdHocMembers
+// ============================================================================
+
+describe("addAdHocMembers", () => {
+  test("marks new members pending and respects the 20-member cap", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Add Members Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+
+    // Create initial group with 1 recipient (2 total members).
+    const { userId: b0Id } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob0",
+    });
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [b0Id],
+        name: "Cap test",
+      },
+    );
+
+    // Add 18 more — total becomes 20 (at cap).
+    const cappedIds: Id<"users">[] = [];
+    for (let i = 1; i <= 18; i++) {
+      const { userId } = await createUserInCommunity(t, communityId, {
+        firstName: `Bob${i}`,
+      });
+      cappedIds.push(userId);
+    }
+    const result = await t.mutation(
+      api.functions.messaging.directMessages.addAdHocMembers,
+      { token: aToken, channelId, userIds: cappedIds },
+    );
+    expect(result.added).toBe(18);
+    expect(result.skipped).toBe(0);
+
+    // Each new member should be pending and invitedById == aId.
+    for (const uId of cappedIds) {
+      const m = await getMember(t, channelId, uId);
+      expect(m?.requestState).toBe("pending");
+      expect(m?.invitedById).toBe(aId);
+    }
+
+    // Adding a 21st member must throw at the cap.
+    const { userId: extraId } = await createUserInCommunity(t, communityId, {
+      firstName: "Extra",
+    });
+    await expect(
+      t.mutation(api.functions.messaging.directMessages.addAdHocMembers, {
+        token: aToken,
+        channelId,
+        userIds: [extraId],
+      }),
+    ).rejects.toThrow(/at most 20|too many/i);
+  });
+
+  test("rejects adding a non-community-member", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Add Outsider Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+    const { userId: outsiderId } = await createUserInOtherCommunity(t, {
+      firstName: "Outsider",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId],
+        name: "Outsider test",
+      },
+    );
+
+    await expect(
+      t.mutation(api.functions.messaging.directMessages.addAdHocMembers, {
+        token: aToken,
+        channelId,
+        userIds: [outsiderId],
+      }),
+    ).rejects.toThrow(/community/i);
+  });
+
+  test("idempotent for users already in the channel", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Add Idempotent Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId],
+        name: "Idem test",
+      },
+    );
+
+    const result = await t.mutation(
+      api.functions.messaging.directMessages.addAdHocMembers,
+      { token: aToken, channelId, userIds: [bId] },
+    );
+    expect(result.added).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+});
+
+// ============================================================================
+// removeAdHocMember
+// ============================================================================
+
+describe("removeAdHocMember", () => {
+  test("self-remove always works", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Self Remove Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+    const { userId: cId } = await createUserInCommunity(t, communityId, {
+      firstName: "Carol",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId, cId],
+        name: "Self remove",
+      },
+    );
+
+    // B accepts so they're a real accepted member, then self-removes.
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: bToken, channelId, response: "accept" },
+    );
+
+    await t.mutation(
+      api.functions.messaging.directMessages.removeAdHocMember,
+      { token: bToken, channelId, userId: bId },
+    );
+
+    const bMember = await getMember(t, channelId, bId);
+    expect(bMember?.leftAt).toBeDefined();
+  });
+
+  test("non-creator cannot remove other members; creator can", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Remove Creator Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Alice" },
+    );
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+    const { userId: cId, accessToken: cToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Carol" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId, cId],
+        name: "Creator privilege",
+      },
+    );
+
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: bToken, channelId, response: "accept" },
+    );
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: cToken, channelId, response: "accept" },
+    );
+
+    // B (non-creator) tries to remove C.
+    await expect(
+      t.mutation(api.functions.messaging.directMessages.removeAdHocMember, {
+        token: bToken,
+        channelId,
+        userId: cId,
+      }),
+    ).rejects.toThrow(/creator|only/i);
+
+    // A (creator) removes C — succeeds.
+    await t.mutation(
+      api.functions.messaging.directMessages.removeAdHocMember,
+      { token: aToken, channelId, userId: cId },
+    );
+    const cMember = await getMember(t, channelId, cId);
+    expect(cMember?.leftAt).toBeDefined();
+    // Sanity: aId is the creator we asserted privileges for.
+    expect(aId).toBeDefined();
   });
 });

--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -1278,4 +1278,60 @@ describe("removeAdHocMember", () => {
     // Sanity: aId is the creator we asserted privileges for.
     expect(aId).toBeDefined();
   });
+
+  test("creator who has left cannot remove other members (stale-privilege guard)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Stale Privilege Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob" },
+    );
+    const { userId: cId, accessToken: cToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Carol" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId, cId],
+        name: "Stale privilege",
+      },
+    );
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: bToken, channelId, response: "accept" },
+    );
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: cToken, channelId, response: "accept" },
+    );
+
+    // Creator A leaves the channel.
+    await t.mutation(
+      api.functions.messaging.directMessages.leaveAdHocChannel,
+      { token: aToken, channelId },
+    );
+
+    // After leaving, A still holds the channelId but should not be able to
+    // remove other members from outside the chat.
+    await expect(
+      t.mutation(api.functions.messaging.directMessages.removeAdHocMember, {
+        token: aToken,
+        channelId,
+        userId: bId,
+      }),
+    ).rejects.toThrow(/active member/i);
+
+    // B is still active — sanity: their membership is intact.
+    const bMember = await getMember(t, channelId, bId);
+    expect(bMember?.leftAt).toBeUndefined();
+  });
 });

--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -312,6 +312,83 @@ export const getMemberPreview = query({
   },
 });
 
+/**
+ * Get a public preview of group leaders.
+ *
+ * Returns the active leaders (role === "leader") for a group, so non-members
+ * can see who to reach out to before joining. The standard `getLeaders` query
+ * is gated to members + community admins; this variant intentionally exposes
+ * leader name + avatar publicly so non-members can DM a leader before joining.
+ *
+ * Capped at `limit` (default 8) leaders. Sorted by joinedAt for stability.
+ */
+export const getLeaderPreview = query({
+  args: {
+    groupId: v.id("groups"),
+    limit: v.optional(v.number()), // How many leaders to show (default 8)
+  },
+  handler: async (ctx, args) => {
+    const previewLimit = args.limit ?? 8;
+
+    // Get group to verify it exists
+    const group = await ctx.db.get(args.groupId);
+    if (!group) {
+      return { leaders: [], totalCount: 0 };
+    }
+
+    // Fetch leader memberships only (filter at the DB layer where possible)
+    let leaderMemberships = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("leftAt"), undefined),
+          q.eq(q.field("role"), "leader")
+        )
+      )
+      .collect();
+
+    // Exclude any pending/declined join requests defensively (leftAt + role
+    // already filter most of the noise, but a row with role="leader" and
+    // requestStatus="pending" should not be exposed publicly).
+    leaderMemberships = leaderMemberships.filter(
+      (m) =>
+        !m.requestStatus ||
+        m.requestStatus === "accepted" ||
+        m.requestStatus === "approved"
+    );
+
+    const totalCount = leaderMemberships.length;
+
+    // Stable order: oldest leader first (matches member preview convention)
+    leaderMemberships.sort((a, b) => a.joinedAt - b.joinedAt);
+
+    const slice = leaderMemberships.slice(0, previewLimit);
+
+    // Batch fetch users
+    const users = await Promise.all(slice.map((m) => ctx.db.get(m.userId)));
+
+    const leadersPreview = slice
+      .map((membership, i) => {
+        const user = users[i];
+        if (!user) return null;
+        return {
+          id: user._id,
+          firstName: user.firstName || "",
+          lastName: user.lastName || "",
+          profileImage: getMediaUrl(user.profilePhoto),
+          role: membership.role,
+        };
+      })
+      .filter(Boolean);
+
+    return {
+      leaders: leadersPreview,
+      totalCount,
+    };
+  },
+});
+
 // ============================================================================
 // Member Mutations
 // ============================================================================

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -26,8 +26,12 @@ import { getDisplayName, getMediaUrl } from "../../lib/utils";
 
 /** Max number of recipients in a `group_dm` (creator excluded). Total cap is 20. */
 const MAX_GROUP_DM_RECIPIENTS = 19;
+/** Hard cap on total members in an ad-hoc group_dm (including creator). */
+const MAX_GROUP_DM_TOTAL = 20;
 /** Cap on group chat name length. */
 const MAX_GROUP_NAME_LENGTH = 100;
+/** Cap on rename length for ad-hoc group_dm channels (shorter than create cap to keep titles tight). */
+const MAX_GROUP_DM_RENAME_LENGTH = 60;
 /** Cap on member-search result list length. */
 const DEFAULT_SEARCH_LIMIT = 30;
 const MAX_SEARCH_LIMIT = 50;
@@ -83,6 +87,24 @@ async function isBlockedEitherDirection(
 }
 
 const isActiveMembership = (status: number | undefined) => status !== 3;
+
+/**
+ * Hard requirement: chats are restricted to people who have a profile photo.
+ *
+ * Throws `PROFILE_PHOTO_REQUIRED` if `userId` lacks one. Caller-side; if the
+ * gate needs to surface a specific recipient userId, the caller throws
+ * `RECIPIENT_PROFILE_PHOTO_REQUIRED:<userId>` instead so the frontend can
+ * format a per-user prompt.
+ */
+async function requireProfilePhoto(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+): Promise<void> {
+  const user = await ctx.db.get(userId);
+  if (!user?.profilePhoto || user.profilePhoto.trim() === "") {
+    throw new Error("PROFILE_PHOTO_REQUIRED");
+  }
+}
 
 /**
  * Return true iff `userId` is an active member of `communityId`.
@@ -165,6 +187,20 @@ export const createOrGetDirectChannel = mutation({
       throw new Error("Cannot start chat");
     }
 
+    // Profile photo gate: caller must have one; recipient must have one. We
+    // check after auth + community + block resolution so we never leak that a
+    // recipient exists when the caller couldn't message them anyway.
+    await requireProfilePhoto(ctx, senderId);
+    const recipientUser = await ctx.db.get(args.recipientUserId);
+    if (
+      !recipientUser?.profilePhoto ||
+      recipientUser.profilePhoto.trim() === ""
+    ) {
+      // Include the recipient userId so the frontend can format a per-user
+      // prompt (e.g. "Bob hasn't added a profile photo yet").
+      throw new Error(`RECIPIENT_PROFILE_PHOTO_REQUIRED:${args.recipientUserId}`);
+    }
+
     // Rate-limit new pending DM requests.
     await checkRateLimit(
       ctx,
@@ -173,10 +209,7 @@ export const createOrGetDirectChannel = mutation({
       NEW_REQUEST_WINDOW_MS,
     );
 
-    const recipient = await ctx.db.get(args.recipientUserId);
-    if (!recipient) {
-      throw new Error("Recipient not found");
-    }
+    const recipient = recipientUser;
     const sender = await ctx.db.get(senderId);
     if (!sender) {
       throw new Error("Sender not found");
@@ -286,6 +319,21 @@ export const createGroupChat = mutation({
       throw new Error("Cannot include some users in this chat");
     }
 
+    // Profile photo gate: creator AND every recipient must have one. Surface
+    // the first failing recipient userId so the frontend can pinpoint who.
+    await requireProfilePhoto(ctx, creatorId);
+    const recipientDocs = await Promise.all(
+      uniqueRecipients.map((id) => ctx.db.get(id)),
+    );
+    for (let i = 0; i < uniqueRecipients.length; i++) {
+      const u = recipientDocs[i];
+      if (!u?.profilePhoto || u.profilePhoto.trim() === "") {
+        throw new Error(
+          `RECIPIENT_PROFILE_PHOTO_REQUIRED:${uniqueRecipients[i]}`,
+        );
+      }
+    }
+
     // Rate-limit new pending requests.
     await checkRateLimit(
       ctx,
@@ -298,9 +346,7 @@ export const createGroupChat = mutation({
     if (!creator) {
       throw new Error("Sender not found");
     }
-    const recipients = await Promise.all(
-      uniqueRecipients.map((id) => ctx.db.get(id)),
-    );
+    const recipients = recipientDocs;
 
     const now = Date.now();
     const trimmedName = (args.name ?? "").trim().slice(0, MAX_GROUP_NAME_LENGTH);
@@ -403,6 +449,10 @@ export const respondToChatRequest = mutation({
     const now = Date.now();
 
     if (args.response === "accept") {
+      // Profile photo gate: accepting a chat is treated as opting in to the
+      // DM/group surface. Require the responder to have a profile photo so
+      // every accepted member of every ad-hoc channel has one.
+      await requireProfilePhoto(ctx, userId);
       await ctx.db.patch(membership._id, {
         requestState: "accepted",
         requestRespondedAt: now,
@@ -455,6 +505,349 @@ export const respondToChatRequest = mutation({
       status: "pending",
       createdAt: now,
     });
+
+    return { ok: true };
+  },
+});
+
+/**
+ * Rename an ad-hoc `group_dm` channel.
+ *
+ * Authorization: any accepted member can rename. 1:1 `dm` channels can NOT
+ * be renamed (their display name is auto-derived from the other member);
+ * a rename attempt on a `dm` is rejected. Trims whitespace and caps to
+ * `MAX_GROUP_DM_RENAME_LENGTH`. Rejects blank names for `group_dm`.
+ */
+export const renameAdHocChannel = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    name: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    if (!channel.isAdHoc) {
+      throw new Error("Only ad-hoc chats can be renamed");
+    }
+    // 1:1 DMs derive their display label from the other member; renaming
+    // would silently lie about who's on the other side.
+    if (channel.channelType === "dm") {
+      throw new Error("1:1 chats cannot be renamed");
+    }
+    if (channel.channelType !== "group_dm") {
+      throw new Error("Only group chats can be renamed");
+    }
+
+    const membership = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", args.channelId).eq("userId", userId),
+      )
+      .first();
+    if (
+      !membership ||
+      membership.leftAt !== undefined ||
+      membership.requestState !== "accepted"
+    ) {
+      throw new Error("Not a member of this channel");
+    }
+
+    const trimmed = args.name.trim().slice(0, MAX_GROUP_DM_RENAME_LENGTH);
+    if (trimmed.length === 0) {
+      throw new Error("Group chat name cannot be blank");
+    }
+
+    await ctx.db.patch(args.channelId, {
+      name: trimmed,
+      updatedAt: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+/**
+ * Add new members to an existing ad-hoc channel.
+ *
+ * Only accepted members may add. New members start in `requestState: "pending"`
+ * with `invitedById` = caller, mirroring `createGroupChat`. Existing members
+ * (active or pending) are skipped silently — the call is idempotent. Caps the
+ * total accepted+pending member count at `MAX_GROUP_DM_TOTAL` (20).
+ *
+ * Re-validates the per-community-member invariant for every new userId so
+ * that ad-hoc channels can't grow to include strangers from other communities.
+ * Profile-photo gate applies to each new invitee for parity with create.
+ */
+export const addAdHocMembers = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    userIds: v.array(v.id("users")),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ added: number; skipped: number }> => {
+    const callerId = await requireAuth(ctx, args.token);
+
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    if (!channel.isAdHoc) {
+      throw new Error("Only ad-hoc chats support adding members");
+    }
+    // Adding to a 1:1 DM would convert it to a group; require an explicit
+    // group_dm channel for that flow.
+    if (channel.channelType !== "group_dm") {
+      throw new Error("Only group chats support adding members");
+    }
+    if (!channel.communityId) {
+      throw new Error("Channel has no community context");
+    }
+
+    const callerMembership = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", args.channelId).eq("userId", callerId),
+      )
+      .first();
+    if (
+      !callerMembership ||
+      callerMembership.leftAt !== undefined ||
+      callerMembership.requestState !== "accepted"
+    ) {
+      throw new Error("Not a member of this channel");
+    }
+
+    // De-dupe + drop the caller (can't re-invite yourself).
+    const uniqueUserIds = Array.from(
+      new Set(args.userIds.filter((id) => id !== callerId)),
+    );
+    if (uniqueUserIds.length === 0) {
+      return { added: 0, skipped: 0 };
+    }
+
+    // Existing channel members (active rows). Used for idempotency + cap.
+    const existingMembers = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+    const existingUserIds = new Set(existingMembers.map((m) => m.userId));
+
+    let skipped = 0;
+    let added = 0;
+    const now = Date.now();
+
+    for (const newUserId of uniqueUserIds) {
+      if (existingUserIds.has(newUserId)) {
+        skipped++;
+        continue;
+      }
+
+      // Cap total members (existing + freshly added so far) at 20.
+      if (existingMembers.length + added + 1 > MAX_GROUP_DM_TOTAL) {
+        throw new Error(
+          `Group chat can include at most ${MAX_GROUP_DM_TOTAL} members`,
+        );
+      }
+
+      // Per-community-member invariant: every new addition must be an active
+      // member of the channel's community.
+      const inCommunity = await isCommunityMember(
+        ctx,
+        newUserId,
+        channel.communityId,
+      );
+      if (!inCommunity) {
+        throw new Error("You can only add members of this community");
+      }
+
+      // Block-check both directions.
+      if (await isBlockedEitherDirection(ctx, callerId, newUserId)) {
+        throw new Error("Cannot add some users to this chat");
+      }
+
+      const newUser = await ctx.db.get(newUserId);
+      if (!newUser) {
+        throw new Error("User not found");
+      }
+      // Profile photo gate.
+      if (!newUser.profilePhoto || newUser.profilePhoto.trim() === "") {
+        throw new Error(`RECIPIENT_PROFILE_PHOTO_REQUIRED:${newUserId}`);
+      }
+
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: args.channelId,
+        userId: newUserId,
+        role: "member",
+        joinedAt: now,
+        isMuted: false,
+        requestState: "pending",
+        invitedById: callerId,
+        displayName: getDisplayName(newUser.firstName, newUser.lastName),
+        profilePhoto: newUser.profilePhoto,
+      });
+      added++;
+    }
+
+    if (added > 0) {
+      await ctx.db.patch(args.channelId, {
+        memberCount: (channel.memberCount ?? existingMembers.length) + added,
+        updatedAt: now,
+      });
+    }
+
+    return { added, skipped };
+  },
+});
+
+/**
+ * Find the original inviter of an ad-hoc channel: the earliest accepted member
+ * by `joinedAt` who has no `invitedById` (i.e. the channel creator). Falls back
+ * to the channel's `createdById` when the row can't be found.
+ */
+async function getAdHocInviter(
+  ctx: QueryCtx,
+  channelId: Id<"chatChannels">,
+): Promise<Id<"users"> | null> {
+  const members = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .collect();
+  const accepted = members
+    .filter((m) => m.requestState === "accepted" && !m.invitedById)
+    .sort((a, b) => a.joinedAt - b.joinedAt);
+  if (accepted.length > 0) return accepted[0]!.userId;
+
+  const channel = await ctx.db.get(channelId);
+  return channel?.createdById ?? null;
+}
+
+/**
+ * Remove a member from an ad-hoc channel.
+ *
+ * Authorization:
+ *   - A user can always pass their own `userId` to leave.
+ *   - Otherwise, only the original inviter (channel creator) can remove others.
+ *
+ * Soft-deletes via `chatChannelMembers.leftAt` rather than deleting the row,
+ * matching the same pattern used by `respondToChatRequest` decline + the
+ * `expireOldChatRequests` cron.
+ */
+export const removeAdHocMember = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const callerId = await requireAuth(ctx, args.token);
+
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    if (!channel.isAdHoc) {
+      throw new Error("Only ad-hoc chats support removing members");
+    }
+
+    // Self-remove is always allowed; otherwise require inviter privileges.
+    const isSelf = args.userId === callerId;
+    if (!isSelf) {
+      const inviterId = await getAdHocInviter(ctx, args.channelId);
+      if (!inviterId || inviterId !== callerId) {
+        throw new Error("Only the chat creator can remove other members");
+      }
+    }
+
+    const target = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", args.channelId).eq("userId", args.userId),
+      )
+      .first();
+    if (!target || target.leftAt !== undefined) {
+      // Idempotent: already gone.
+      return { ok: true };
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(target._id, { leftAt: now });
+
+    // Decrement member count; cap at 0 to avoid negative due to drift.
+    const newCount = Math.max(0, (channel.memberCount ?? 1) - 1);
+    await ctx.db.patch(args.channelId, {
+      memberCount: newCount,
+      updatedAt: now,
+    });
+
+    return { ok: true };
+  },
+});
+
+/**
+ * Convenience wrapper: caller leaves the channel. If the caller is the last
+ * accepted member, the channel is archived (soft-closed) so it stops surfacing
+ * in anyone's inbox.
+ */
+export const leaveAdHocChannel = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+  },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const callerId = await requireAuth(ctx, args.token);
+
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    if (!channel.isAdHoc) {
+      throw new Error("Only ad-hoc chats support leaving");
+    }
+
+    const membership = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", args.channelId).eq("userId", callerId),
+      )
+      .first();
+    if (!membership || membership.leftAt !== undefined) {
+      // Idempotent: already gone.
+      return { ok: true };
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(membership._id, { leftAt: now });
+
+    const newCount = Math.max(0, (channel.memberCount ?? 1) - 1);
+    await ctx.db.patch(args.channelId, {
+      memberCount: newCount,
+      updatedAt: now,
+    });
+
+    // If the leaver was the last active accepted member, archive the channel.
+    const remainingAccepted = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+    const stillAccepted = remainingAccepted.filter(
+      (m) => m.requestState === "accepted",
+    );
+    if (stillAccepted.length === 0) {
+      await ctx.db.patch(args.channelId, {
+        isArchived: true,
+        archivedAt: now,
+      });
+    }
 
     return { ok: true };
   },

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -758,12 +758,28 @@ export const removeAdHocMember = mutation({
       throw new Error("Only ad-hoc chats support removing members");
     }
 
-    // Self-remove is always allowed; otherwise require inviter privileges.
+    // Self-remove is always allowed; otherwise require inviter privileges
+    // AND that the caller is still an active accepted member of the channel.
+    // Without the active-membership gate, a creator who has already left
+    // (leftAt set) could keep ejecting members from outside the chat.
     const isSelf = args.userId === callerId;
     if (!isSelf) {
       const inviterId = await getAdHocInviter(ctx, args.channelId);
       if (!inviterId || inviterId !== callerId) {
         throw new Error("Only the chat creator can remove other members");
+      }
+      const callerMembership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", args.channelId).eq("userId", callerId),
+        )
+        .first();
+      if (
+        !callerMembership ||
+        callerMembership.leftAt !== undefined ||
+        callerMembership.requestState !== "accepted"
+      ) {
+        throw new Error("Only an active member can remove other members");
       }
     }
 

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -6,7 +6,12 @@
  */
 
 import { v } from "convex/values";
-import { internalMutation, internalAction } from "../../_generated/server";
+import {
+  internalMutation,
+  internalAction,
+  internalQuery,
+} from "../../_generated/server";
+import type { ActionCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { getChannelSlug } from "../../lib/slugs";
@@ -211,6 +216,47 @@ export const onMessageSent = internalMutation({
             regularRecipients: bucket.regularRecipients,
           });
         }
+      } else if (channel?.isAdHoc) {
+        // Ad-hoc DM / group_dm channels have their own notification copy:
+        // no "Group Chat: <name>" subtitle, and pending requests get a
+        // "would like to chat:" prefix. Routed through a dedicated action so
+        // the standard formatter (which always includes "groupName: channel")
+        // doesn't run for these channels.
+        //
+        // We separate recipients into:
+        //   - "pending" recipients (their membership row is still pending) →
+        //     first-message-of-request copy
+        //   - "accepted" recipients → standard accepted-chat copy
+        // The split is done here (per-recipient) so we can render different
+        // bodies in a single fanout pass.
+        const pendingRecipients: Id<"users">[] = [];
+        const acceptedRecipients: Id<"users">[] = [];
+        for (const member of members) {
+          if (member.requestState === "pending") {
+            pendingRecipients.push(member.userId);
+          } else {
+            acceptedRecipients.push(member.userId);
+          }
+        }
+
+        console.log(
+          `[onMessageSent] Scheduling ad-hoc notifications: ${pendingRecipients.length} pending, ${acceptedRecipients.length} accepted`,
+        );
+
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.messaging.events.sendAdHocMessageNotifications,
+          {
+            channelId: args.channelId,
+            messageId: args.messageId,
+            senderName,
+            messagePreview: preview,
+            senderAvatarUrl,
+            communityId: channel.communityId,
+            pendingRecipients,
+            acceptedRecipients,
+          },
+        );
       } else {
         // Non-shared channel: original single-group path. For ad-hoc DMs/group_dms,
         // channel.groupId is undefined so we fall back to channel.communityId directly
@@ -354,6 +400,218 @@ export const sendMessageNotifications = internalAction({
     );
   },
 });
+
+/**
+ * Truncate a string to `max` chars, suffixing "…" if truncation occurred.
+ */
+function truncateForBody(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, Math.max(0, max - 1)) + "…";
+}
+
+/**
+ * Send push notifications for a new message in an ad-hoc DM / group_dm channel.
+ *
+ * Distinct from `sendMessageNotifications` because:
+ *   - Body never includes the legacy "Group Chat: General" subtitle that the
+ *     standard formatter always emits.
+ *   - "Pending" recipients (whose membership row is still pending) get a
+ *     "would like to chat:" prefix on the body.
+ *   - Group_dms render the channel name (or first 2 other-member names) into
+ *     the title so multi-person threads are distinguishable from 1:1 DMs.
+ *
+ * The push payload `data` carries `requestState` so the client can route the
+ * tap correctly (request inbox vs. accepted thread).
+ */
+export const sendAdHocMessageNotifications = internalAction({
+  args: {
+    channelId: v.id("chatChannels"),
+    messageId: v.id("chatMessages"),
+    senderName: v.string(),
+    messagePreview: v.string(),
+    senderAvatarUrl: v.optional(v.string()),
+    communityId: v.optional(v.id("communities")),
+    /** Members whose membership row is still in `requestState: "pending"`. */
+    pendingRecipients: v.array(v.id("users")),
+    /** Members whose membership row is `accepted` (or legacy/undefined). */
+    acceptedRecipients: v.array(v.id("users")),
+  },
+  handler: async (ctx, args) => {
+    console.log(
+      `[sendAdHocMessageNotifications] channelId=${args.channelId}, pending=${args.pendingRecipients.length}, accepted=${args.acceptedRecipients.length}`,
+    );
+
+    // Truncate the body's message excerpt. Match the previous fanout's
+    // ~120-char ceiling so iOS/Android push surfaces don't ellipsize twice.
+    const MAX_BODY_PREVIEW = 120;
+    const previewBody = truncateForBody(args.messagePreview, MAX_BODY_PREVIEW);
+
+    // Resolve channel + non-sender accepted member names so group_dms can
+    // render "<sender> in <channelName | first-two-others>" titles when
+    // there's no explicit channel name.
+    const channelInfo = await ctx.runQuery(
+      internal.functions.messaging.events.getAdHocChannelInfo,
+      { channelId: args.channelId },
+    );
+    const channelType: "dm" | "group_dm" =
+      (channelInfo?.channelType as "dm" | "group_dm") ?? "dm";
+    const channelName = channelInfo?.channelName ?? "";
+
+    // Build the accepted-recipient title once. For group_dms with no name we
+    // fall back to listing up to the first 2 other-member display names so
+    // the recipient sees who else is in the thread.
+    let acceptedTitle: string;
+    if (channelType === "group_dm") {
+      if (channelName.trim().length > 0) {
+        acceptedTitle = `${args.senderName} in ${channelName.trim()}`;
+      } else {
+        const others = (channelInfo?.otherDisplayNames ?? []).slice(0, 2);
+        acceptedTitle =
+          others.length > 0
+            ? `${args.senderName} in ${others.join(", ")}`
+            : args.senderName;
+      }
+    } else {
+      // 1:1 dm — title is just the sender name; body is the message text.
+      acceptedTitle = args.senderName;
+    }
+
+    const baseData = {
+      type: "new_message" as const,
+      channelId: args.channelId,
+      channelType,
+      channelName,
+      communityId: args.communityId,
+      senderAvatarUrl: args.senderAvatarUrl,
+      isAdHoc: true,
+      // Pre-computed deep link for ad-hoc threads. The client routes pending
+      // recipients to the requests inbox via `requestState` below.
+      url: `/inbox/dm/${args.channelId}`,
+    };
+
+    // Pending recipients: first-message-of-a-request copy.
+    if (args.pendingRecipients.length > 0) {
+      const pendingTitle = args.senderName;
+      const pendingBody = `would like to chat: ${previewBody}`;
+      for (const userId of args.pendingRecipients) {
+        await sendAdHocPushToUser(ctx, {
+          userId,
+          title: pendingTitle,
+          body: pendingBody,
+          data: { ...baseData, requestState: "pending" },
+          communityId: args.communityId,
+        });
+      }
+    }
+
+    // Accepted recipients: standard accepted-chat copy.
+    if (args.acceptedRecipients.length > 0) {
+      for (const userId of args.acceptedRecipients) {
+        await sendAdHocPushToUser(ctx, {
+          userId,
+          title: acceptedTitle,
+          body: previewBody,
+          data: { ...baseData, requestState: "accepted" },
+          communityId: args.communityId,
+        });
+      }
+    }
+  },
+});
+
+/**
+ * Internal query: minimal channel info needed by the ad-hoc push fanout.
+ * Returns `channelType`, the channel name, and up to a handful of accepted
+ * member display names for the title fallback.
+ */
+export const getAdHocChannelInfo = internalQuery({
+  args: { channelId: v.id("chatChannels") },
+  handler: async (ctx, args) => {
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) return null;
+
+    const members = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+
+    const otherDisplayNames = members
+      .map((m) => m.displayName ?? "")
+      .filter((n) => n.trim().length > 0);
+
+    return {
+      channelType: channel.channelType,
+      channelName: channel.name ?? "",
+      otherDisplayNames,
+    };
+  },
+});
+
+/**
+ * Send a single push to one user with custom title/body. Mirrors the
+ * essentials of `sendPushChannel` (token lookup → batch push → notification
+ * record) without invoking the standard formatter, which always emits the
+ * "groupName: channelLabel" subtitle that we want to suppress for ad-hoc
+ * channels.
+ */
+async function sendAdHocPushToUser(
+  ctx: ActionCtx,
+  args: {
+    userId: Id<"users">;
+    title: string;
+    body: string;
+    data: Record<string, unknown>;
+    communityId?: Id<"communities">;
+  },
+): Promise<void> {
+  const tokens = await ctx.runQuery(
+    internal.functions.notifications.tokens.getActiveTokensForUser,
+    { userId: args.userId },
+  );
+  if (tokens.length === 0) {
+    console.log(
+      `[sendAdHocMessageNotifications] No active push tokens for user ${args.userId} — skipping`,
+    );
+    return;
+  }
+
+  const trackingId = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  const notificationData = {
+    ...args.data,
+    trackingId,
+  };
+
+  const notifications = tokens.map((t: { token: string }) => ({
+    token: t.token,
+    title: args.title,
+    body: args.body,
+    data: notificationData,
+    imageUrl:
+      typeof args.data.senderAvatarUrl === "string"
+        ? args.data.senderAvatarUrl
+        : undefined,
+  }));
+
+  const result = await ctx.runAction(
+    internal.functions.notifications.internal.sendBatchPushNotifications,
+    { notifications },
+  );
+
+  await ctx.runMutation(
+    internal.functions.notifications.mutations.createNotification,
+    {
+      userId: args.userId,
+      communityId: args.communityId,
+      notificationType: "new_message",
+      title: args.title,
+      body: args.body,
+      data: notificationData,
+      status: result.success ? "sent" : "failed",
+      trackingId,
+    },
+  );
+}
 
 /**
  * Handle member added to channel.

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -16,6 +16,7 @@ import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { getChannelSlug } from "../../lib/slugs";
 import { notifyBatch } from "../../lib/notifications/send";
+import { chatRequestEmail } from "../../lib/notifications/emailTemplates";
 
 // ============================================================================
 // Constants
@@ -490,16 +491,40 @@ export const sendAdHocMessageNotifications = internalAction({
     };
 
     // Pending recipients: first-message-of-a-request copy.
+    // For each recipient, build a personalized email-fallback payload so that
+    // recipients without a live push token still hear about the request.
     if (args.pendingRecipients.length > 0) {
       const pendingTitle = args.senderName;
       const pendingBody = `would like to chat: ${previewBody}`;
+      const isGroupChat = channelType === "group_dm";
       for (const userId of args.pendingRecipients) {
+        const userInfo = await ctx.runQuery(
+          internal.functions.notifications.internal.getUserEmailInfo,
+          { userId },
+        );
+        const emailHtml = chatRequestEmail({
+          senderName: args.senderName,
+          isGroupChat,
+          channelName: isGroupChat ? channelName : undefined,
+          messagePreview: args.messagePreview,
+          firstName: userInfo?.firstName,
+        });
+        const emailSubject = isGroupChat
+          ? channelName.trim().length > 0
+            ? `${args.senderName} added you to ${channelName.trim()}`
+            : `${args.senderName} added you to a group chat`
+          : `${args.senderName} would like to chat`;
         await sendAdHocPushToUser(ctx, {
           userId,
           title: pendingTitle,
           body: pendingBody,
           data: { ...baseData, requestState: "pending" },
           communityId: args.communityId,
+          emailFallback: {
+            subject: emailSubject,
+            htmlBody: emailHtml,
+            notificationType: "chat_request",
+          },
         });
       }
     }
@@ -563,18 +588,22 @@ async function sendAdHocPushToUser(
     body: string;
     data: Record<string, unknown>;
     communityId?: Id<"communities">;
+    /**
+     * Optional email fallback fired when the recipient has no active push
+     * tokens, OR when the push send fails. Used for chat requests so a
+     * recipient who isn't reachable via push still hears about the request.
+     */
+    emailFallback?: {
+      subject: string;
+      htmlBody: string;
+      notificationType: string;
+    };
   },
 ): Promise<void> {
   const tokens = await ctx.runQuery(
     internal.functions.notifications.tokens.getActiveTokensForUser,
     { userId: args.userId },
   );
-  if (tokens.length === 0) {
-    console.log(
-      `[sendAdHocMessageNotifications] No active push tokens for user ${args.userId} — skipping`,
-    );
-    return;
-  }
 
   const trackingId = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
   const notificationData = {
@@ -582,21 +611,53 @@ async function sendAdHocPushToUser(
     trackingId,
   };
 
-  const notifications = tokens.map((t: { token: string }) => ({
-    token: t.token,
-    title: args.title,
-    body: args.body,
-    data: notificationData,
-    imageUrl:
-      typeof args.data.senderAvatarUrl === "string"
-        ? args.data.senderAvatarUrl
-        : undefined,
-  }));
+  let pushOk = false;
+  if (tokens.length > 0) {
+    const notifications = tokens.map((t: { token: string }) => ({
+      token: t.token,
+      title: args.title,
+      body: args.body,
+      data: notificationData,
+      imageUrl:
+        typeof args.data.senderAvatarUrl === "string"
+          ? args.data.senderAvatarUrl
+          : undefined,
+    }));
 
-  const result = await ctx.runAction(
-    internal.functions.notifications.internal.sendBatchPushNotifications,
-    { notifications },
-  );
+    const result = await ctx.runAction(
+      internal.functions.notifications.internal.sendBatchPushNotifications,
+      { notifications },
+    );
+    pushOk = result.success;
+  } else {
+    console.log(
+      `[sendAdHocMessageNotifications] No active push tokens for user ${args.userId}`,
+    );
+  }
+
+  // Cascade to email when push is unreachable (no tokens or send failed).
+  // Only requests get an email fallback — accepted-chat messages stay
+  // push-only so the inbox doesn't double-notify on every reply.
+  if (!pushOk && args.emailFallback) {
+    const userInfo = await ctx.runQuery(
+      internal.functions.notifications.internal.getUserEmailInfo,
+      { userId: args.userId },
+    );
+    if (userInfo?.email && userInfo.emailNotificationsEnabled) {
+      await ctx.runAction(
+        internal.functions.notifications.internal.sendEmailNotification,
+        {
+          to: userInfo.email,
+          subject: args.emailFallback.subject,
+          htmlBody: args.emailFallback.htmlBody,
+          notificationType: args.emailFallback.notificationType,
+        },
+      );
+      console.log(
+        `[sendAdHocMessageNotifications] Email fallback sent to ${userInfo.email} (push unreachable)`,
+      );
+    }
+  }
 
   await ctx.runMutation(
     internal.functions.notifications.mutations.createNotification,
@@ -607,7 +668,7 @@ async function sendAdHocPushToUser(
       title: args.title,
       body: args.body,
       data: notificationData,
-      status: result.success ? "sent" : "failed",
+      status: pushOk || args.emailFallback ? "sent" : "failed",
       trackingId,
     },
   );

--- a/apps/convex/lib/notifications/emailTemplates.ts
+++ b/apps/convex/lib/notifications/emailTemplates.ts
@@ -173,6 +173,44 @@ export function joinRequestApprovedEmail(data: { groupName: string }): string {
 }
 
 /**
+ * Chat request email — fired when a user receives a DM or group-chat request
+ * and has no active push tokens. Mirrors the in-app request banner copy.
+ */
+export function chatRequestEmail(data: {
+  senderName: string;
+  isGroupChat: boolean;
+  channelName?: string;
+  messagePreview: string;
+  firstName?: string;
+}): string {
+  const greeting = data.firstName
+    ? `Hi ${escapeHtml(data.firstName)},`
+    : "Hi there,";
+  const channelLine = data.isGroupChat
+    ? data.channelName && data.channelName.trim().length > 0
+      ? `added you to <strong>${escapeHtml(data.channelName)}</strong>`
+      : `added you to a group chat`
+    : `would like to chat with you`;
+  const content = `
+    <p style="${baseStyles.text}">${greeting}</p>
+    <h1 style="${baseStyles.heading}">${escapeHtml(data.senderName)} ${channelLine}</h1>
+    <div style="${baseStyles.messageBox}">
+      <p style="color: #1a1a1a; font-size: 15px; line-height: 24px; margin: 0;">
+        "${escapeHtml(data.messagePreview)}"
+      </p>
+    </div>
+    <p style="${baseStyles.text}">
+      Open Togather to accept the chat, reply, or block. Until you accept,
+      read receipts and typing indicators stay hidden.
+    </p>
+    <div style="${baseStyles.buttonContainer}">
+      <a href="${DOMAIN_CONFIG.appUrl}" style="${baseStyles.button}">Open Togather</a>
+    </div>
+  `;
+  return wrapInLayout(content);
+}
+
+/**
  * Mention notification email
  */
 export function mentionEmail(data: {

--- a/apps/mobile/app/inbox/dm/[channelId]/_layout.tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/_layout.tsx
@@ -17,6 +17,7 @@ export default function DmChannelLayout() {
       }}
     >
       <Stack.Screen name="index" options={{ animation: "none" }} />
+      <Stack.Screen name="info" options={{ animation: "slide_from_right" }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/inbox/dm/[channelId]/info.tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/info.tsx
@@ -1,0 +1,23 @@
+/**
+ * Direct Message Info Route
+ *
+ * Route: /inbox/dm/[channelId]/info
+ *
+ * Settings + member management surface for an ad-hoc DM/group_dm. Reached
+ * by tapping the chat-room header. Mounts `ChatInfoScreen`, which reads
+ * `channelId` from params.
+ */
+import { useLocalSearchParams } from "expo-router";
+import { ChatInfoScreen } from "@features/chat/components/ChatInfoScreen";
+import { DmFeatureGate } from "@features/chat/components/DmFeatureGate";
+import type { Id } from "@services/api/convex";
+
+export default function ChatInfoRoute() {
+  const { channelId } = useLocalSearchParams<{ channelId: string }>();
+  if (!channelId) return null;
+  return (
+    <DmFeatureGate>
+      <ChatInfoScreen channelId={channelId as Id<"chatChannels">} />
+    </DmFeatureGate>
+  );
+}

--- a/apps/mobile/app/inbox/new.tsx
+++ b/apps/mobile/app/inbox/new.tsx
@@ -38,6 +38,10 @@ import { useTheme } from "@hooks/useTheme";
 import { useQuery, useMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { DmFeatureGate } from "@features/chat/components/DmFeatureGate";
+import {
+  RequireProfilePhotoSheet,
+  classifyProfilePhotoError,
+} from "@features/chat/components/RequireProfilePhotoSheet";
 
 type SearchResult = {
   userId: Id<"users">;
@@ -75,7 +79,7 @@ if (
 function StartChatScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { token, community } = useAuth();
+  const { token, community, user } = useAuth();
   const { primaryColor, accentLight } = useCommunityTheme();
   const { colors, isDark } = useTheme();
   const communityId = community?.id as Id<"communities"> | undefined;
@@ -91,6 +95,15 @@ function StartChatScreen() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isFocused, setIsFocused] = useState(false);
+  const [photoSheetVisible, setPhotoSheetVisible] = useState(false);
+
+  // Local check; backend re-validates with PROFILE_PHOTO_REQUIRED. Treats an
+  // empty/whitespace string as "no photo" so legacy data with empty values
+  // doesn't slip through.
+  const hasOwnProfilePhoto = (() => {
+    const photo = user?.profile_photo;
+    return typeof photo === "string" && photo.trim().length > 0;
+  })();
 
   useEffect(() => {
     const handle = setTimeout(() => {
@@ -188,6 +201,13 @@ function StartChatScreen() {
   const handleSubmit = async () => {
     if (!token || !communityId || isSubmitting || selectedCount === 0) return;
     setErrorMessage(null);
+    // Local profile-photo gate. The backend re-validates with
+    // PROFILE_PHOTO_REQUIRED so the catch below still surfaces the sheet for
+    // edge cases (e.g. user object is stale).
+    if (!hasOwnProfilePhoto) {
+      setPhotoSheetVisible(true);
+      return;
+    }
     setIsSubmitting(true);
     try {
       if (selectedCount === 1) {
@@ -234,6 +254,19 @@ function StartChatScreen() {
         },
       });
     } catch (e) {
+      const photoError = classifyProfilePhotoError(e);
+      if (photoError === "self") {
+        setPhotoSheetVisible(true);
+        setIsSubmitting(false);
+        return;
+      }
+      if (photoError === "recipient") {
+        setErrorMessage(
+          "One of the people you selected hasn't added a profile photo yet. Ask them to add one first.",
+        );
+        setIsSubmitting(false);
+        return;
+      }
       const message = e instanceof Error ? e.message : "Something went wrong";
       setErrorMessage(message);
       setIsSubmitting(false);
@@ -516,6 +549,11 @@ function StartChatScreen() {
           </TouchableOpacity>
         </View>
       ) : null}
+
+      <RequireProfilePhotoSheet
+        visible={photoSheetVisible}
+        onClose={() => setPhotoSheetVisible(false)}
+      />
     </KeyboardAvoidingView>
   );
 }

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -35,6 +35,7 @@ import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
 import { Avatar } from "@components/ui/Avatar";
 import { useConvexFeatureFlag } from "@hooks/useConvexFeatureFlag";
+import { StackedMemberAvatars } from "./StackedMemberAvatars";
 
 // Inbox event visibility is now driven server-side by
 // `INBOX_EVENT_HIDE_AFTER_MS` in apps/convex/functions/messaging/channels.ts
@@ -1038,48 +1039,6 @@ interface DirectMessageRowProps {
   };
 }
 
-/**
- * iMessage-style stacked avatar pair for multi-member DMs. Two overlapping
- * circles inside a 56×56 bounding box so the row's vertical rhythm matches
- * the single-avatar 1:1 DM rows and the group rows from `GroupedInboxItem`.
- *
- *   - Back avatar: 40×40, top-left
- *   - Front avatar: 36×36, bottom-right, with a 2px ring in `surface` color
- *     so it visually separates from the back avatar (matches the inbox row
- *     background — same trick iMessage uses).
- */
-function StackedAvatars({
-  back,
-  front,
-  surfaceColor,
-}: {
-  back: { name: string; imageUrl: string | null };
-  front: { name: string; imageUrl: string | null };
-  surfaceColor: string;
-}) {
-  return (
-    <View style={styles.dmStackedAvatarContainer}>
-      <Avatar
-        name={back.name}
-        imageUrl={back.imageUrl ?? undefined}
-        size={40}
-        style={styles.dmStackedAvatarBack}
-      />
-      <View
-        style={[
-          styles.dmStackedAvatarFrontWrapper,
-          { backgroundColor: surfaceColor },
-        ]}
-      >
-        <Avatar
-          name={front.name}
-          imageUrl={front.imageUrl ?? undefined}
-          size={36}
-        />
-      </View>
-    </View>
-  );
-}
 
 function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) {
   const router = useRouter();
@@ -1101,8 +1060,8 @@ function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) 
           .filter(Boolean)
           .join(", ") || "Chat";
 
-  // Stack two avatars when this is a true multi-member group_dm with at least
-  // two visible others. iMessage doesn't try to fit three — neither do we.
+  // Stack avatars when this is a true multi-member group_dm with at least two
+  // visible others. The cluster scales 2/3/4+ — see `StackedMemberAvatars`.
   const useStackedAvatars = !isOneOnOne && row.otherMembers.length >= 2;
   const primaryAvatar = row.otherMembers[0];
 
@@ -1126,15 +1085,11 @@ function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) 
   return (
     <Pressable onPress={onPress} style={styles.dmRow}>
       {useStackedAvatars ? (
-        <StackedAvatars
-          back={{
-            name: row.otherMembers[0].displayName,
-            imageUrl: row.otherMembers[0].profilePhoto,
-          }}
-          front={{
-            name: row.otherMembers[1].displayName,
-            imageUrl: row.otherMembers[1].profilePhoto,
-          }}
+        <StackedMemberAvatars
+          members={row.otherMembers.map((m) => ({
+            name: m.displayName,
+            imageUrl: m.profilePhoto,
+          }))}
           surfaceColor={colors.surface}
         />
       ) : (
@@ -1229,33 +1184,6 @@ const styles = StyleSheet.create({
     flex: 1,
     marginLeft: 12,
     minWidth: 0,
-  },
-  // Stacked-avatar bounding box: 56×56 so multi-member DM rows have the same
-  // height + horizontal alignment as 1:1 DM rows and group rows. Absolute
-  // positioning inside; the back avatar anchors top-left and the front
-  // avatar bottom-right with a ~12pt overlap.
-  dmStackedAvatarContainer: {
-    width: 56,
-    height: 56,
-    position: "relative",
-  },
-  dmStackedAvatarBack: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-  },
-  // The front avatar wears a 2pt ring in the inbox row's surface color so the
-  // two circles read as separate at a glance. Wrapping the Avatar in a padded,
-  // rounded View is the cleanest way to draw that ring without poking at
-  // Avatar internals.
-  dmStackedAvatarFrontWrapper: {
-    position: "absolute",
-    bottom: 0,
-    right: 0,
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    padding: 2,
   },
   dmRowTopLine: {
     flexDirection: "row",

--- a/apps/mobile/features/chat/components/ChatInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInfoScreen.tsx
@@ -435,8 +435,11 @@ export function ChatInfoScreen({ channelId }: Props) {
           ))}
         </View>
 
-        {/* Add people */}
-        {remainingSlots > 0 ? (
+        {/* Add people — only group chats support adding members. The backend
+            rejects 1:1 DMs ("Only group chats support adding members"), so
+            hide the row entirely on `dm` channels rather than showing a
+            dead-end action. */}
+        {isGroupDm && remainingSlots > 0 ? (
           <Pressable
             onPress={() => setAddPeopleVisible(true)}
             style={({ pressed }) => [

--- a/apps/mobile/features/chat/components/ChatInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInfoScreen.tsx
@@ -1,0 +1,1072 @@
+/**
+ * Chat Info Screen
+ *
+ * Settings + member management surface for an ad-hoc DM/group_dm. Reached
+ * by tapping the chat-room header. Shows:
+ *
+ *   - Stacked-avatar hero with the chat name (rename inline if group_dm)
+ *   - Member rows with role + tap-to-act menu (View profile, Remove)
+ *   - "Add people" entry that opens an in-screen picker reusing
+ *     `searchUsersInSharedCommunities`
+ *   - "Leave chat" destructive action
+ *
+ * The screen sources its member list from `getDirectInbox`'s row for this
+ * channel — that endpoint already returns the member set the client is
+ * authorised to see (excludes blocked / left rows). We pair it with
+ * `getChannel` for canonical metadata (channelType, name, isAdHoc).
+ */
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  TouchableOpacity,
+  ActivityIndicator,
+  TextInput,
+  FlatList,
+  Alert,
+  ActionSheetIOS,
+  Platform,
+  ScrollView,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Avatar } from "@components/ui/Avatar";
+import { ConfirmModal } from "@components/ui/ConfirmModal";
+import { CustomModal } from "@components/ui/Modal";
+import { useAuth } from "@providers/AuthProvider";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import {
+  useQuery,
+  api,
+  useStoredAuthToken,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { StackedMemberAvatars } from "./StackedMemberAvatars";
+import { useAdHocChannelManagement } from "../hooks/useAdHocChannelManagement";
+
+type Props = {
+  channelId: Id<"chatChannels">;
+};
+
+type SearchResult = {
+  userId: Id<"users">;
+  displayName: string;
+  profilePhoto: string | null;
+  sharedCommunityNames: string[];
+};
+
+type Member = {
+  userId: Id<"users">;
+  displayName: string;
+  profilePhoto: string | null;
+  isSelf: boolean;
+  isInviter: boolean;
+};
+
+const SEARCH_DEBOUNCE_MS = 200;
+const SEARCH_LIMIT = 30;
+const MAX_TOTAL_MEMBERS = 20;
+
+export function ChatInfoScreen({ channelId }: Props) {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { user, community } = useAuth();
+  const token = useStoredAuthToken();
+  const { colors } = useTheme();
+  const { primaryColor, accentLight } = useCommunityTheme();
+  const communityId = community?.id as Id<"communities"> | undefined;
+
+  const channel = useQuery(
+    api.functions.messaging.channels.getChannel,
+    token ? { token, channelId } : "skip",
+  );
+  // The inbox query is the simplest source of `otherMembers` for the
+  // current user's ad-hoc channels; it filters by request state already.
+  const directInbox = useQuery(
+    api.functions.messaging.directMessages.getDirectInbox,
+    token && communityId ? { token, communityId } : "skip",
+  );
+
+  const { rename, addMembers, removeMember, leave } =
+    useAdHocChannelManagement(channelId);
+
+  const inboxRow = useMemo(() => {
+    if (!directInbox) return null;
+    return directInbox.find((row) => row.channelId === channelId) ?? null;
+  }, [directInbox, channelId]);
+
+  const isGroupDm = channel?.channelType === "group_dm";
+  const isAdHoc = channel?.isAdHoc === true;
+  // The creator is the closest proxy we have for "inviter" without a
+  // per-member field on this query path. Highlights the row in the UI;
+  // remove permissions follow the same rule (creator-only — backend
+  // enforces; see Agent A's `removeAdHocMember`).
+  const creatorId = (channel as { createdById?: Id<"users"> } | null)
+    ?.createdById;
+  const currentUserId = user?.id as Id<"users"> | undefined;
+  const isCreator = !!currentUserId && currentUserId === creatorId;
+
+  const selfDisplayName = useMemo(() => {
+    const first = user?.first_name ?? "";
+    const last = user?.last_name ?? "";
+    const joined = `${first} ${last}`.trim();
+    return joined.length > 0 ? joined : "You";
+  }, [user]);
+
+  const members: Member[] = useMemo(() => {
+    if (!inboxRow || !currentUserId) return [];
+    const others: Member[] = inboxRow.otherMembers.map((m) => ({
+      userId: m.userId,
+      displayName: m.displayName,
+      profilePhoto: m.profilePhoto,
+      isSelf: false,
+      isInviter: m.userId === creatorId,
+    }));
+    const self: Member = {
+      userId: currentUserId,
+      displayName: selfDisplayName,
+      profilePhoto: (user as { profile_photo?: string | null } | null)?.profile_photo ?? null,
+      isSelf: true,
+      isInviter: currentUserId === creatorId,
+    };
+    return [self, ...others];
+  }, [inboxRow, currentUserId, creatorId, selfDisplayName, user]);
+
+  const otherAvatars = useMemo(
+    () =>
+      (inboxRow?.otherMembers ?? []).map((m) => ({
+        name: m.displayName,
+        imageUrl: m.profilePhoto,
+      })),
+    [inboxRow],
+  );
+
+  const channelName = useMemo(() => {
+    if (!channel) return "";
+    if (channel.channelType === "dm") {
+      return inboxRow?.otherMembers[0]?.displayName ?? "Conversation";
+    }
+    if (channel.name && channel.name.trim().length > 0) return channel.name;
+    return (
+      (inboxRow?.otherMembers ?? [])
+        .slice(0, 3)
+        .map((m) => m.displayName.split(" ")[0])
+        .filter(Boolean)
+        .join(", ") || "Chat"
+    );
+  }, [channel, inboxRow]);
+
+  // ---- UI state ----
+  const [renameVisible, setRenameVisible] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const [renameSubmitting, setRenameSubmitting] = useState(false);
+  const [addPeopleVisible, setAddPeopleVisible] = useState(false);
+  const [pendingRemove, setPendingRemove] = useState<Member | null>(null);
+  const [leaveVisible, setLeaveVisible] = useState(false);
+  const [actionInFlight, setActionInFlight] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (renameVisible && channel?.name) {
+      setRenameValue(channel.name);
+    }
+  }, [renameVisible, channel?.name]);
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(`/inbox/dm/${channelId}` as any);
+    }
+  }, [router, channelId]);
+
+  const handleRenameSubmit = useCallback(async () => {
+    const trimmed = renameValue.trim();
+    if (!trimmed) {
+      setErrorMessage("Chat name can't be empty");
+      return;
+    }
+    setRenameSubmitting(true);
+    try {
+      await rename(trimmed);
+      setRenameVisible(false);
+      setErrorMessage(null);
+    } catch (e) {
+      setErrorMessage(e instanceof Error ? e.message : "Could not rename chat");
+    } finally {
+      setRenameSubmitting(false);
+    }
+  }, [renameValue, rename]);
+
+  const handleConfirmRemove = useCallback(async () => {
+    if (!pendingRemove) return;
+    setActionInFlight(true);
+    try {
+      await removeMember(pendingRemove.userId);
+      setPendingRemove(null);
+    } catch (e) {
+      Alert.alert(
+        "Couldn't remove",
+        e instanceof Error ? e.message : "Please try again.",
+      );
+    } finally {
+      setActionInFlight(false);
+    }
+  }, [pendingRemove, removeMember]);
+
+  const handleConfirmLeave = useCallback(async () => {
+    setActionInFlight(true);
+    try {
+      await leave();
+      setLeaveVisible(false);
+      // Pop back twice in spirit: out of /info AND out of /[channelId].
+      // `replace` to inbox keeps the stack clean.
+      router.replace("/(tabs)/chat");
+    } catch (e) {
+      Alert.alert(
+        "Couldn't leave",
+        e instanceof Error ? e.message : "Please try again.",
+      );
+    } finally {
+      setActionInFlight(false);
+    }
+  }, [leave, router]);
+
+  const openMemberMenu = useCallback(
+    (member: Member) => {
+      if (member.isSelf) return;
+      // Backend enforces "only creator can remove" — UI mirrors that gate
+      // so non-creators see only the read-only profile entry.
+      const canRemove = isCreator && !member.isSelf;
+      const options = canRemove
+        ? ["Cancel", "View profile", "Remove from chat"]
+        : ["Cancel", "View profile"];
+      const destructiveButtonIndex = canRemove ? 2 : undefined;
+
+      const handleSelection = (index: number) => {
+        if (index === 1) {
+          router.push(`/profile/${member.userId}` as any);
+          return;
+        }
+        if (canRemove && index === 2) {
+          setPendingRemove(member);
+        }
+      };
+
+      if (Platform.OS === "ios") {
+        ActionSheetIOS.showActionSheetWithOptions(
+          {
+            options,
+            cancelButtonIndex: 0,
+            destructiveButtonIndex,
+          },
+          handleSelection,
+        );
+      } else {
+        // Lightweight Android/web fallback. iMessage parity isn't critical
+        // here — non-iOS users get an Alert with the same options.
+        Alert.alert(member.displayName, undefined, [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "View profile",
+            onPress: () => handleSelection(1),
+          },
+          ...(canRemove
+            ? [
+                {
+                  text: "Remove from chat",
+                  style: "destructive" as const,
+                  onPress: () => handleSelection(2),
+                },
+              ]
+            : []),
+        ]);
+      }
+    },
+    [isCreator, router],
+  );
+
+  // -- Rendering --
+  if (channel === undefined || directInbox === undefined) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} />
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={primaryColor} />
+        </View>
+      </View>
+    );
+  }
+
+  if (!channel || !isAdHoc) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} />
+        <View style={styles.centered}>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+            This conversation is no longer available.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const memberCount = members.length;
+  const remainingSlots = Math.max(0, MAX_TOTAL_MEMBERS - memberCount);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      <Header onBack={handleBack} colors={colors} />
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Hero */}
+        <View style={styles.heroSection}>
+          <StackedMemberAvatars
+            members={otherAvatars.length > 0 ? otherAvatars : [{ name: channelName, imageUrl: null }]}
+            size={96}
+            surfaceColor={colors.surface}
+          />
+          <Pressable
+            onPress={() => {
+              if (isGroupDm) setRenameVisible(true);
+            }}
+            disabled={!isGroupDm}
+            style={({ pressed }) => [
+              styles.heroNameRow,
+              pressed && isGroupDm && { opacity: 0.7 },
+            ]}
+          >
+            <Text
+              style={[styles.heroName, { color: colors.text }]}
+              numberOfLines={2}
+            >
+              {channelName}
+            </Text>
+            {isGroupDm ? (
+              <Ionicons
+                name="pencil"
+                size={16}
+                color={colors.textSecondary}
+                style={styles.heroEditIcon}
+              />
+            ) : null}
+          </Pressable>
+          <Text style={[styles.heroSubtitle, { color: colors.textSecondary }]}>
+            {memberCount} {memberCount === 1 ? "person" : "people"}
+          </Text>
+        </View>
+
+        {/* Members */}
+        <SectionHeader colors={colors} label="Members" />
+        <View
+          style={[
+            styles.sectionGroup,
+            { backgroundColor: colors.surfaceSecondary },
+          ]}
+        >
+          {members.map((m, idx) => (
+            <Pressable
+              key={m.userId}
+              onPress={() => openMemberMenu(m)}
+              disabled={m.isSelf}
+              style={({ pressed }) => [
+                styles.memberRow,
+                idx > 0 && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
+                pressed && !m.isSelf && { backgroundColor: colors.selectedBackground },
+              ]}
+            >
+              <Avatar
+                name={m.displayName}
+                imageUrl={m.profilePhoto}
+                size={40}
+              />
+              <View style={styles.memberRowText}>
+                <Text
+                  style={[styles.memberRowName, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  {m.displayName}
+                  {m.isSelf ? (
+                    <Text style={{ color: colors.textSecondary }}> (you)</Text>
+                  ) : null}
+                </Text>
+                {m.isInviter ? (
+                  <Text
+                    style={[
+                      styles.memberRowSubtitle,
+                      { color: colors.textSecondary },
+                    ]}
+                  >
+                    Started this chat
+                  </Text>
+                ) : null}
+              </View>
+              {!m.isSelf ? (
+                <Ionicons
+                  name="chevron-forward"
+                  size={18}
+                  color={colors.textTertiary}
+                />
+              ) : null}
+            </Pressable>
+          ))}
+        </View>
+
+        {/* Add people */}
+        {remainingSlots > 0 ? (
+          <Pressable
+            onPress={() => setAddPeopleVisible(true)}
+            style={({ pressed }) => [
+              styles.actionRow,
+              { backgroundColor: pressed ? colors.selectedBackground : colors.surfaceSecondary },
+            ]}
+          >
+            <View style={[styles.actionIcon, { backgroundColor: accentLight }]}>
+              <Ionicons name="person-add" size={18} color={primaryColor} />
+            </View>
+            <Text style={[styles.actionLabel, { color: colors.text }]}>
+              Add people
+            </Text>
+          </Pressable>
+        ) : null}
+
+        {/* Channel actions */}
+        <SectionHeader colors={colors} label="Chat actions" />
+        <View
+          style={[
+            styles.sectionGroup,
+            { backgroundColor: colors.surfaceSecondary },
+          ]}
+        >
+          {isGroupDm ? (
+            <Pressable
+              onPress={() => setRenameVisible(true)}
+              style={({ pressed }) => [
+                styles.actionRowFlat,
+                pressed && { backgroundColor: colors.selectedBackground },
+              ]}
+            >
+              <Ionicons name="create-outline" size={20} color={colors.icon} />
+              <Text style={[styles.actionLabel, { color: colors.text }]}>
+                Rename chat
+              </Text>
+            </Pressable>
+          ) : null}
+          <Pressable
+            onPress={() => setLeaveVisible(true)}
+            style={({ pressed }) => [
+              styles.actionRowFlat,
+              isGroupDm && {
+                borderTopWidth: StyleSheet.hairlineWidth,
+                borderTopColor: colors.border,
+              },
+              pressed && { backgroundColor: colors.selectedBackground },
+            ]}
+          >
+            <Ionicons
+              name="exit-outline"
+              size={20}
+              color={colors.destructive}
+            />
+            <Text style={[styles.actionLabel, { color: colors.destructive }]}>
+              Leave chat
+            </Text>
+          </Pressable>
+        </View>
+
+        <View style={{ height: insets.bottom + 24 }} />
+      </ScrollView>
+
+      {/* Rename modal */}
+      <CustomModal
+        visible={renameVisible}
+        onClose={() => {
+          if (!renameSubmitting) {
+            setRenameVisible(false);
+            setErrorMessage(null);
+          }
+        }}
+        title="Rename chat"
+      >
+        <View>
+          <TextInput
+            value={renameValue}
+            onChangeText={setRenameValue}
+            placeholder="Chat name"
+            placeholderTextColor={colors.textSecondary}
+            maxLength={100}
+            autoFocus
+            style={[
+              styles.renameInput,
+              {
+                color: colors.text,
+                backgroundColor: colors.inputBackground,
+                borderColor: colors.inputBorder,
+              },
+            ]}
+          />
+          {errorMessage ? (
+            <Text style={[styles.errorText, { color: colors.destructive, marginTop: 8 }]}>
+              {errorMessage}
+            </Text>
+          ) : null}
+          <View style={styles.modalButtonRow}>
+            <TouchableOpacity
+              onPress={() => {
+                setRenameVisible(false);
+                setErrorMessage(null);
+              }}
+              disabled={renameSubmitting}
+              style={[
+                styles.modalButton,
+                { backgroundColor: colors.surfaceSecondary },
+              ]}
+            >
+              <Text style={[styles.modalButtonText, { color: colors.text }]}>
+                Cancel
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={handleRenameSubmit}
+              disabled={renameSubmitting}
+              style={[
+                styles.modalButton,
+                { backgroundColor: primaryColor },
+                renameSubmitting && { opacity: 0.6 },
+              ]}
+            >
+              {renameSubmitting ? (
+                <ActivityIndicator size="small" color="#ffffff" />
+              ) : (
+                <Text style={[styles.modalButtonText, { color: "#ffffff" }]}>
+                  Save
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </CustomModal>
+
+      {/* Add people modal */}
+      <AddPeopleModal
+        visible={addPeopleVisible}
+        onClose={() => setAddPeopleVisible(false)}
+        onSubmit={async (userIds) => {
+          await addMembers(userIds);
+        }}
+        excludeUserIds={members.map((m) => m.userId)}
+        remainingSlots={remainingSlots}
+      />
+
+      {/* Remove confirm */}
+      <ConfirmModal
+        visible={!!pendingRemove}
+        title="Remove from chat"
+        message={
+          pendingRemove
+            ? `Remove ${pendingRemove.displayName} from this chat? They won't see new messages.`
+            : ""
+        }
+        onConfirm={handleConfirmRemove}
+        onCancel={() => setPendingRemove(null)}
+        confirmText="Remove"
+        destructive
+        isLoading={actionInFlight}
+      />
+
+      {/* Leave confirm */}
+      <ConfirmModal
+        visible={leaveVisible}
+        title="Leave chat"
+        message="You won't see new messages and the chat will be removed from your inbox."
+        onConfirm={handleConfirmLeave}
+        onCancel={() => setLeaveVisible(false)}
+        confirmText="Leave"
+        destructive
+        isLoading={actionInFlight}
+      />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function Header({
+  onBack,
+  colors,
+}: {
+  onBack: () => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  return (
+    <View
+      style={[
+        styles.headerBar,
+        {
+          backgroundColor: colors.surface,
+          borderBottomColor: colors.border,
+        },
+      ]}
+    >
+      <TouchableOpacity onPress={onBack} style={styles.headerBackButton} hitSlop={12}>
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <Text style={[styles.headerTitle, { color: colors.text }]}>Chat info</Text>
+      <View style={styles.headerSpacer} />
+    </View>
+  );
+}
+
+function SectionHeader({
+  colors,
+  label,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  label: string;
+}) {
+  return (
+    <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+      {label.toUpperCase()}
+    </Text>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+type AddPeopleModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit: (userIds: Id<"users">[]) => Promise<void>;
+  excludeUserIds: Id<"users">[];
+  remainingSlots: number;
+};
+
+function AddPeopleModal({
+  visible,
+  onClose,
+  onSubmit,
+  excludeUserIds,
+  remainingSlots,
+}: AddPeopleModalProps) {
+  const { colors } = useTheme();
+  const { primaryColor, accentLight } = useCommunityTheme();
+  const { token, community } = useAuth();
+  const communityId = community?.id as Id<"communities"> | undefined;
+
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [selected, setSelected] = useState<Map<Id<"users">, SearchResult>>(
+    new Map(),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!visible) {
+      setQuery("");
+      setDebouncedQuery("");
+      setSelected(new Map());
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const trimmed = debouncedQuery.trim();
+  const hasQuery = trimmed.length > 0;
+
+  const results = useQuery(
+    api.functions.messaging.directMessages.searchUsersInSharedCommunities,
+    visible && token && communityId && hasQuery
+      ? {
+          token,
+          communityId,
+          query: debouncedQuery,
+          excludeUserIds,
+          limit: SEARCH_LIMIT,
+        }
+      : "skip",
+  );
+
+  const isLoading = visible && hasQuery && results === undefined && !!token;
+
+  const toggle = (item: SearchResult) => {
+    if (submitting) return;
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (next.has(item.userId)) {
+        next.delete(item.userId);
+      } else {
+        if (next.size >= remainingSlots) {
+          setError(`You can add up to ${remainingSlots} more here.`);
+          return prev;
+        }
+        next.set(item.userId, item);
+      }
+      setError(null);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (selected.size === 0 || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(Array.from(selected.keys()));
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not add people.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renderItem = ({ item }: { item: SearchResult }) => {
+    const isSelected = selected.has(item.userId);
+    return (
+      <TouchableOpacity
+        onPress={() => toggle(item)}
+        disabled={submitting}
+        style={[styles.searchRow, { borderBottomColor: colors.border }]}
+        activeOpacity={0.7}
+      >
+        <Avatar
+          name={item.displayName}
+          imageUrl={item.profilePhoto}
+          size={40}
+        />
+        <View style={styles.searchRowText}>
+          <Text style={[styles.searchRowName, { color: colors.text }]} numberOfLines={1}>
+            {item.displayName}
+          </Text>
+        </View>
+        <View
+          style={[
+            styles.checkmark,
+            {
+              borderColor: isSelected ? primaryColor : colors.border,
+              backgroundColor: isSelected ? primaryColor : "transparent",
+            },
+          ]}
+        >
+          {isSelected ? <Ionicons name="checkmark" size={14} color="#ffffff" /> : null}
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <CustomModal
+      visible={visible}
+      onClose={() => {
+        if (!submitting) onClose();
+      }}
+      title="Add people"
+      contentPadding="16px"
+    >
+      <View style={{ minHeight: 360 }}>
+        <TextInput
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Search by name…"
+          placeholderTextColor={colors.textSecondary}
+          autoCorrect={false}
+          autoCapitalize="none"
+          style={[
+            styles.renameInput,
+            {
+              color: colors.text,
+              backgroundColor: colors.inputBackground,
+              borderColor: colors.inputBorder,
+            },
+          ]}
+        />
+        {selected.size > 0 ? (
+          <View style={[styles.chipRow, { backgroundColor: accentLight }]}>
+            <Text style={[styles.chipRowText, { color: primaryColor }]}>
+              {selected.size} selected
+            </Text>
+          </View>
+        ) : null}
+        {error ? (
+          <Text style={[styles.errorText, { color: colors.destructive, marginTop: 8 }]}>
+            {error}
+          </Text>
+        ) : null}
+        <View style={{ height: 12 }} />
+        {isLoading ? (
+          <View style={styles.centered}>
+            <ActivityIndicator size="small" color={primaryColor} />
+          </View>
+        ) : !hasQuery ? (
+          <Text style={[styles.helper, { color: colors.textSecondary }]}>
+            Search for someone in your community to add them.
+          </Text>
+        ) : (results?.length ?? 0) === 0 ? (
+          <Text style={[styles.helper, { color: colors.textSecondary }]}>
+            No matches.
+          </Text>
+        ) : (
+          <FlatList
+            data={results ?? []}
+            keyExtractor={(item) => item.userId}
+            renderItem={renderItem}
+            keyboardShouldPersistTaps="handled"
+            style={{ maxHeight: 320 }}
+          />
+        )}
+        <View style={styles.modalButtonRow}>
+          <TouchableOpacity
+            onPress={onClose}
+            disabled={submitting}
+            style={[
+              styles.modalButton,
+              { backgroundColor: colors.surfaceSecondary },
+            ]}
+          >
+            <Text style={[styles.modalButtonText, { color: colors.text }]}>
+              Cancel
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleSubmit}
+            disabled={submitting || selected.size === 0}
+            style={[
+              styles.modalButton,
+              { backgroundColor: primaryColor },
+              (submitting || selected.size === 0) && { opacity: 0.5 },
+            ]}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color="#ffffff" />
+            ) : (
+              <Text style={[styles.modalButtonText, { color: "#ffffff" }]}>
+                Add
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </View>
+    </CustomModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  headerBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBackButton: {
+    padding: 4,
+    marginRight: 4,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  headerSpacer: {
+    width: 36,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 24,
+  },
+  centered: {
+    paddingVertical: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  errorText: {
+    fontSize: 14,
+    textAlign: "center",
+  },
+  heroSection: {
+    alignItems: "center",
+    paddingTop: 24,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+  },
+  heroNameRow: {
+    marginTop: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  heroName: {
+    fontSize: 22,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  heroEditIcon: {
+    marginTop: 4,
+  },
+  heroSubtitle: {
+    marginTop: 4,
+    fontSize: 13,
+  },
+  sectionHeader: {
+    fontSize: 11,
+    fontWeight: "600",
+    letterSpacing: 0.6,
+    marginTop: 24,
+    marginBottom: 8,
+    paddingHorizontal: 20,
+  },
+  sectionGroup: {
+    marginHorizontal: 12,
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  memberRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    minHeight: 56,
+    gap: 12,
+  },
+  memberRowText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  memberRowName: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  memberRowSubtitle: {
+    marginTop: 2,
+    fontSize: 12,
+  },
+  actionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginHorizontal: 12,
+    marginTop: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    minHeight: 48,
+  },
+  actionIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  actionRowFlat: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
+  },
+  actionLabel: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  renameInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+    minHeight: 44,
+  },
+  modalButtonRow: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 20,
+  },
+  modalButton: {
+    flex: 1,
+    minHeight: 48,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 12,
+  },
+  modalButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  searchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  searchRowText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  searchRowName: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  checkmark: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  chipRow: {
+    marginTop: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  chipRowText: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  helper: {
+    fontSize: 14,
+    paddingVertical: 24,
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/features/chat/components/ChatPrivacyCard.tsx
+++ b/apps/mobile/features/chat/components/ChatPrivacyCard.tsx
@@ -1,0 +1,64 @@
+/**
+ * Chat Privacy Card
+ *
+ * Subtle one-time notice rendered above the message list in ad-hoc DM
+ * channels. Sets expectations that messages aren't end-to-end encrypted
+ * and community admins can request access. Non-dismissible — appears
+ * once at the top of the conversation, not on every render.
+ */
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+
+export function ChatPrivacyCard() {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.surfaceSecondary,
+          borderColor: colors.border,
+        },
+      ]}
+      accessibilityRole="text"
+    >
+      <Ionicons
+        name="lock-closed-outline"
+        size={14}
+        color={colors.textSecondary}
+        style={styles.icon}
+      />
+      <Text style={[styles.text, { color: colors.textSecondary }]}>
+        Messages stay between people in this chat. They&apos;re not
+        end-to-end encrypted, and community admins can request access. Treat
+        this like a public conversation.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    marginHorizontal: 12,
+    marginTop: 8,
+    marginBottom: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  icon: {
+    marginTop: 1,
+  },
+  text: {
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 17,
+  },
+});

--- a/apps/mobile/features/chat/components/ChatRequestBanner.tsx
+++ b/apps/mobile/features/chat/components/ChatRequestBanner.tsx
@@ -23,6 +23,10 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { useMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import {
+  RequireProfilePhotoSheet,
+  classifyProfilePhotoError,
+} from "./RequireProfilePhotoSheet";
 
 export interface ChatRequestBannerProps {
   channelId: Id<"chatChannels">;
@@ -39,13 +43,23 @@ export function ChatRequestBanner({
   onAccepted,
   onResolved,
 }: ChatRequestBannerProps) {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
 
   const [pendingAction, setPendingAction] = useState<
     "accept" | "decline" | "block" | null
   >(null);
+  const [photoSheetVisible, setPhotoSheetVisible] = useState(false);
+
+  // Gate Accept on the responder having a profile photo. Recipients of a
+  // chat request are unbounded — they could be anyone with a community
+  // overlap — so we enforce the photo at the moment of acceptance rather
+  // than at chat creation. Backend re-validates server-side.
+  const hasOwnProfilePhoto = (() => {
+    const photo = user?.profile_photo;
+    return typeof photo === "string" && photo.trim().length > 0;
+  })();
 
   const respondToChatRequest = useMutation(
     api.functions.messaging.directMessages.respondToChatRequest
@@ -55,6 +69,12 @@ export function ChatRequestBanner({
 
   const handleAccept = async () => {
     if (!token || isBusy) return;
+    if (!hasOwnProfilePhoto) {
+      // Local check matches the backend's PROFILE_PHOTO_REQUIRED guard.
+      // The user uploads a photo, returns, and re-taps Accept.
+      setPhotoSheetVisible(true);
+      return;
+    }
     setPendingAction("accept");
     try {
       await respondToChatRequest({
@@ -66,6 +86,11 @@ export function ChatRequestBanner({
       onAccepted?.();
     } catch (e) {
       setPendingAction(null);
+      const photoError = classifyProfilePhotoError(e);
+      if (photoError === "self") {
+        setPhotoSheetVisible(true);
+        return;
+      }
       const message = e instanceof Error ? e.message : "Failed to accept";
       Alert.alert("Couldn't accept", message);
     }
@@ -110,6 +135,7 @@ export function ChatRequestBanner({
   };
 
   return (
+    <>
     <View
       style={[
         styles.container,
@@ -183,6 +209,11 @@ export function ChatRequestBanner({
         </TouchableOpacity>
       </View>
     </View>
+    <RequireProfilePhotoSheet
+      visible={photoSheetVisible}
+      onClose={() => setPhotoSheetVisible(false)}
+    />
+    </>
   );
 }
 

--- a/apps/mobile/features/chat/components/ChatRoomHeader.tsx
+++ b/apps/mobile/features/chat/components/ChatRoomHeader.tsx
@@ -1,0 +1,180 @@
+/**
+ * Chat Room Header (Ad-hoc DMs)
+ *
+ * Tappable header for `dm` / `group_dm` channels: stacked avatars + a
+ * member name list. Tapping it opens the chat-info screen. Used in place
+ * of the group-channel `<ChatHeader />` when `isAdHoc === true`.
+ *
+ * iMessage parity: the title line is the chat name (group_dm with name
+ * set), or the other person's full name (1:1), or a comma-list of first
+ * names (group_dm with no name). The subtitle reads "<N> people" so
+ * larger groups still feel scannable without trying to fit every name.
+ */
+import React, { memo, useMemo } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Pressable,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { Avatar } from "@components/ui/Avatar";
+import { useIsDesktopWeb } from "../../../hooks/useIsDesktopWeb";
+import { StackedMemberAvatars } from "./StackedMemberAvatars";
+
+type Member = {
+  name: string;
+  imageUrl: string | null;
+};
+
+type Props = {
+  channelType: "dm" | "group_dm";
+  /** Channel-level name (set on group_dm). Empty string when unset. */
+  channelName: string;
+  /** Other members (excludes the caller). */
+  otherMembers: Member[];
+  onBack: () => void;
+  onPressTitle: () => void;
+};
+
+export const ChatRoomHeader = memo(function ChatRoomHeader({
+  channelType,
+  channelName,
+  otherMembers,
+  onBack,
+  onPressTitle,
+}: Props) {
+  const { colors } = useTheme();
+  const isDesktopWeb = useIsDesktopWeb();
+  const isOneOnOne = channelType === "dm";
+
+  const titleLine = useMemo(() => {
+    if (isOneOnOne) {
+      return otherMembers[0]?.name ?? "Conversation";
+    }
+    if (channelName.trim().length > 0) return channelName;
+    const firstNames = otherMembers
+      .slice(0, 3)
+      .map((m) => m.name.split(" ")[0])
+      .filter(Boolean);
+    return firstNames.length > 0 ? firstNames.join(", ") : "Chat";
+  }, [isOneOnOne, otherMembers, channelName]);
+
+  const subtitleLine = useMemo(() => {
+    if (isOneOnOne) return null;
+    const total = otherMembers.length + 1;
+    return `${total} people`;
+  }, [isOneOnOne, otherMembers.length]);
+
+  return (
+    <View style={[styles.header, { backgroundColor: colors.surface }]}>
+      {!isDesktopWeb && (
+        <TouchableOpacity onPress={onBack} style={styles.backButton} hitSlop={8}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+      )}
+
+      {/*
+        On RN-web, function-style `style` props on Pressable do NOT apply,
+        so layout styles live on inner Views and pressed feedback on the
+        parent uses opacity via `style` (single object, not function).
+      */}
+      <Pressable
+        onPress={onPressTitle}
+        accessibilityRole="button"
+        accessibilityLabel="Open chat info"
+        style={({ pressed }) => [
+          styles.titleHit,
+          // RN-native picks up the pressed opacity here; web uses the
+          // inner View's `active:` Tailwind variants if you swap to
+          // NativeWind. We stick with this for parity with neighboring
+          // ChatHeader which also uses TouchableOpacity-style press.
+          pressed && Platform.OS !== "web" && { opacity: 0.7 },
+        ]}
+      >
+        <View style={styles.titleInner}>
+          {isOneOnOne ? (
+            <Avatar
+              name={otherMembers[0]?.name ?? titleLine}
+              imageUrl={otherMembers[0]?.imageUrl ?? undefined}
+              size={36}
+            />
+          ) : (
+            <StackedMemberAvatars
+              members={otherMembers.length > 0 ? otherMembers : [{ name: titleLine, imageUrl: null }]}
+              size={36}
+              surfaceColor={colors.surface}
+            />
+          )}
+
+          <View style={styles.titleTextWrap}>
+            <Text
+              style={[styles.titleText, { color: colors.text }]}
+              numberOfLines={1}
+            >
+              {titleLine}
+            </Text>
+            {subtitleLine ? (
+              <Text
+                style={[styles.subtitleText, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                {subtitleLine}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+      </Pressable>
+
+      <TouchableOpacity
+        onPress={onPressTitle}
+        style={styles.infoButton}
+        accessibilityLabel="Chat info"
+        hitSlop={8}
+      >
+        <Ionicons name="information-circle-outline" size={22} color={colors.text} />
+      </TouchableOpacity>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+  },
+  backButton: {
+    padding: 4,
+    marginRight: 4,
+  },
+  titleHit: {
+    flex: 1,
+    minHeight: 44,
+    justifyContent: "center",
+  },
+  titleInner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  titleTextWrap: {
+    flex: 1,
+    minWidth: 0,
+  },
+  titleText: {
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  subtitleText: {
+    fontSize: 12,
+    marginTop: 1,
+  },
+  infoButton: {
+    padding: 8,
+  },
+});

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -37,6 +37,8 @@ import { useQuery, api, useStoredAuthToken } from "@services/api/convex";
 
 // Local components
 import { ChatHeader, ChatHeaderPlaceholder } from "./ChatHeader";
+import { ChatRoomHeader } from "./ChatRoomHeader";
+import { ChatPrivacyCard } from "./ChatPrivacyCard";
 import { ChatNavigation, type ChannelTab } from "./ChatNavigation";
 import { ChatMenuModal } from "./ChatMenuModal";
 import { ExternalChatModal } from "./ExternalChatModal";
@@ -90,8 +92,9 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const params = useLocalSearchParams() as ChatRoomParams;
   const router = useRouter();
   const pathname = usePathname();
-  const { user } = useAuth();
+  const { user, community } = useAuth();
   const token = useStoredAuthToken();
+  const adHocCommunityId = community?.id as Id<"communities"> | undefined;
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
 
@@ -902,6 +905,42 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // toolbar falls back to URL params (`groupName`, `imageUrl`) for the
   // recipient's name + avatar.
   const isAdHocChannel = channelData?.isAdHoc === true;
+  const adHocChannelType =
+    isAdHocChannel && (channelData?.channelType === "dm" || channelData?.channelType === "group_dm")
+      ? (channelData.channelType as "dm" | "group_dm")
+      : null;
+
+  // Ad-hoc channels need other-member metadata for the stacked-avatar header
+  // and the chat-info screen. `getDirectInbox` already returns this in the
+  // exact shape we need; reusing it avoids a second query path while the
+  // channel doc itself is being kept lean.
+  const directInboxForHeader = useQuery(
+    api.functions.messaging.directMessages.getDirectInbox,
+    isAdHocChannel && token && adHocCommunityId
+      ? { token, communityId: adHocCommunityId }
+      : "skip",
+  );
+  const adHocInboxRow = useMemo(() => {
+    if (!isAdHocChannel || !directInboxForHeader || !activeChannelId) return null;
+    return (
+      directInboxForHeader.find((row) => row.channelId === activeChannelId) ??
+      null
+    );
+  }, [isAdHocChannel, directInboxForHeader, activeChannelId]);
+  const adHocOtherMembers = useMemo(
+    () =>
+      (adHocInboxRow?.otherMembers ?? []).map((m) => ({
+        name: m.displayName,
+        imageUrl: m.profilePhoto,
+      })),
+    [adHocInboxRow],
+  );
+
+  const handleOpenChatInfo = useCallback(() => {
+    if (!activeChannelId) return;
+    router.push(`/inbox/dm/${activeChannelId}/info` as any);
+  }, [router, activeChannelId]);
+
   const isEssentialDataReady =
     (resolvedGroupId || isAdHocChannel) && activeChannelId != null;
 
@@ -944,38 +983,53 @@ const ConvexChatRoomScreenInner: React.FC = () => {
       keyboardVerticalOffset={0}
     >
       <Pressable style={[styles.container, { backgroundColor: colors.surface }]} onPress={Platform.OS === 'web' ? undefined : dismissKeyboard}>
-        <ChatHeader
-          displayName={displayName}
-          displayType={displayType}
-          displayImage={displayImage}
-          groupTypeId={groupTypeId}
-          // Announcement groups auto-include everyone in the community, so
-          // surfacing a count next to them reads as noise ("9225 members" on
-          // every post) rather than signal. Hide for those only.
-          memberCount={
-            isAnnouncementGroup ? undefined : groupDetails?.memberCount
-          }
-          onBack={handleBack}
-          onMenuPress={() => setMenuVisible(true)}
-          onGroupPagePress={handleGoToGroupPage}
-          onMembersPress={handleGoToMembers}
-        />
-        <ChatNavigation
-          activeSlug={activeSlug}
-          channels={channelTabs}
-          showLeaderTools={showLeaderTools}
-          externalChatLink={externalChatLink}
-          onTabChange={handleTabChange}
-          onTabLongPress={handleTabLongPress}
-          onExternalChatPress={() => setExternalChatModalVisible(true)}
-          tools={(groupDetails as { leaderToolbarTools?: string[] } | undefined)?.leaderToolbarTools}
-          hasPcoChannels={hasPcoChannels ?? false}
-          toolVisibility={groupWithVisibility?.toolVisibility}
-          toolDisplayNames={groupWithVisibility?.toolDisplayNames}
-          userRole={userRole}
-          groupId={resolvedGroupId ?? undefined}
-          onToolPress={handleToolPress}
-        />
+        {isAdHocChannel && adHocChannelType ? (
+          <ChatRoomHeader
+            channelType={adHocChannelType}
+            channelName={(channelData as { name?: string } | null)?.name ?? ""}
+            otherMembers={adHocOtherMembers}
+            onBack={handleBack}
+            onPressTitle={handleOpenChatInfo}
+          />
+        ) : (
+          <ChatHeader
+            displayName={displayName}
+            displayType={displayType}
+            displayImage={displayImage}
+            groupTypeId={groupTypeId}
+            // Announcement groups auto-include everyone in the community, so
+            // surfacing a count next to them reads as noise ("9225 members" on
+            // every post) rather than signal. Hide for those only.
+            memberCount={
+              isAnnouncementGroup ? undefined : groupDetails?.memberCount
+            }
+            onBack={handleBack}
+            onMenuPress={() => setMenuVisible(true)}
+            onGroupPagePress={handleGoToGroupPage}
+            onMembersPress={handleGoToMembers}
+          />
+        )}
+        {/* ChatNavigation drives the channel-tab bar for group channels.
+            Ad-hoc DMs have no tabs — skip the row entirely so the message
+            list sits directly under the header. */}
+        {!isAdHocChannel && (
+          <ChatNavigation
+            activeSlug={activeSlug}
+            channels={channelTabs}
+            showLeaderTools={showLeaderTools}
+            externalChatLink={externalChatLink}
+            onTabChange={handleTabChange}
+            onTabLongPress={handleTabLongPress}
+            onExternalChatPress={() => setExternalChatModalVisible(true)}
+            tools={(groupDetails as { leaderToolbarTools?: string[] } | undefined)?.leaderToolbarTools}
+            hasPcoChannels={hasPcoChannels ?? false}
+            toolVisibility={groupWithVisibility?.toolVisibility}
+            toolDisplayNames={groupWithVisibility?.toolDisplayNames}
+            userRole={userRole}
+            groupId={resolvedGroupId ?? undefined}
+            onToolPress={handleToolPress}
+          />
+        )}
         <ChatMenuModal
           visible={menuVisible}
           hasGroup={hasGroup}
@@ -1004,6 +1058,12 @@ const ConvexChatRoomScreenInner: React.FC = () => {
           />
         ) : (
           <>
+            {/* Privacy notice for ad-hoc DM/group_dm threads. Sits above the
+                message list as a subtle reminder that ad-hoc chats aren't
+                end-to-end encrypted and admins can request access. Sticky
+                position above the list (not in the inverted FlatList) avoids
+                upending the chat scroll behavior. */}
+            {isAdHocChannel && <ChatPrivacyCard />}
             {/* Message List - handles its own loading state when channelId is null */}
             <View style={styles.chatContainer}>
               <MessageList

--- a/apps/mobile/features/chat/components/RequireProfilePhotoSheet.tsx
+++ b/apps/mobile/features/chat/components/RequireProfilePhotoSheet.tsx
@@ -1,0 +1,218 @@
+/**
+ * RequireProfilePhotoSheet
+ *
+ * Modal shown when the current user tries to start or accept a chat without a
+ * profile photo. Togather requires profile photos for chat so members can
+ * recognize each other. The "Add photo" CTA routes to the existing edit-profile
+ * screen at `/(user)/edit-profile` (which embeds an ImagePicker in
+ * `EditProfileForm`); the user returns and re-taps the original action after
+ * uploading.
+ *
+ * Used by:
+ *   - Creator path: `app/inbox/new.tsx` (Start chat / Create chat)
+ *   - Recipient path: `ChatRequestBanner.tsx` (Accept)
+ *
+ * Backend enforces this defense-in-depth via `PROFILE_PHOTO_REQUIRED` thrown
+ * from chat-creation/accept mutations — callers should wrap mutations in
+ * try/catch and re-show this sheet on that error string.
+ */
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal as RNModal,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+
+interface RequireProfilePhotoSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  /**
+   * Optional override of the destination route. Defaults to the project's
+   * existing edit-profile screen, which already embeds an `ImagePicker`.
+   */
+  uploadRoute?: string;
+}
+
+export function RequireProfilePhotoSheet({
+  visible,
+  onClose,
+  uploadRoute = "/(user)/edit-profile",
+}: RequireProfilePhotoSheetProps) {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const handleAddPhoto = () => {
+    onClose();
+    // Tiny delay so the modal dismiss animation doesn't conflict with the
+    // route push on iOS (otherwise the push can sometimes get swallowed).
+    setTimeout(() => {
+      router.push(uploadRoute as any);
+    }, 50);
+  };
+
+  return (
+    <RNModal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback onPress={onClose}>
+          <View
+            style={[styles.backdrop, { backgroundColor: colors.overlay }]}
+          />
+        </TouchableWithoutFeedback>
+        <View
+          style={[
+            styles.sheet,
+            { backgroundColor: colors.surface },
+            Platform.select({
+              web: { boxShadow: "0px 4px 20px rgba(0, 0, 0, 0.15)" },
+              default: {
+                shadowColor: "#000",
+                shadowOffset: { width: 0, height: 4 },
+                shadowOpacity: 0.15,
+                shadowRadius: 20,
+                elevation: 5,
+              },
+            }),
+          ]}
+          accessibilityRole="alert"
+        >
+          <View
+            style={[
+              styles.iconCircle,
+              { backgroundColor: primaryColor + "1A" },
+            ]}
+          >
+            <Ionicons name="camera-outline" size={28} color={primaryColor} />
+          </View>
+
+          <Text style={[styles.title, { color: colors.text }]}>
+            Add a profile photo to chat
+          </Text>
+          <Text style={[styles.body, { color: colors.textSecondary }]}>
+            Togather requires a profile photo to start or accept chats. This
+            helps members recognize each other.
+          </Text>
+
+          <TouchableOpacity
+            style={[styles.primaryButton, { backgroundColor: primaryColor }]}
+            onPress={handleAddPhoto}
+            accessibilityRole="button"
+            accessibilityLabel="Add photo"
+          >
+            <Text style={styles.primaryButtonText}>Add photo</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Maybe later"
+          >
+            <Text
+              style={[
+                styles.secondaryButtonText,
+                { color: colors.textSecondary },
+              ]}
+            >
+              Maybe later
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </RNModal>
+  );
+}
+
+/**
+ * Detect the backend's profile-photo error strings so callers can re-surface
+ * the sheet (or a toast for the recipient case) when a mutation fails.
+ *
+ * Returns:
+ *   - "self": current user is missing a photo → show the sheet
+ *   - "recipient": one of the selected recipients is missing one → toast
+ *   - null: not a profile-photo error
+ */
+export function classifyProfilePhotoError(
+  error: unknown,
+): "self" | "recipient" | null {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (message.includes("RECIPIENT_PROFILE_PHOTO_REQUIRED")) return "recipient";
+  if (message.includes("PROFILE_PHOTO_REQUIRED")) return "self";
+  return null;
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  sheet: {
+    width: "100%",
+    maxWidth: 380,
+    borderRadius: 18,
+    padding: 24,
+    alignItems: "center",
+  },
+  iconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: "center",
+    marginBottom: 20,
+  },
+  primaryButton: {
+    width: "100%",
+    minHeight: 48,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+  },
+  primaryButtonText: {
+    color: "#fff",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  secondaryButton: {
+    width: "100%",
+    minHeight: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 8,
+  },
+  secondaryButtonText: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+});

--- a/apps/mobile/features/chat/components/StackedMemberAvatars.tsx
+++ b/apps/mobile/features/chat/components/StackedMemberAvatars.tsx
@@ -1,0 +1,190 @@
+import React from "react";
+import { View, StyleSheet, Text } from "react-native";
+import { Avatar } from "@components/ui/Avatar";
+
+type StackMember = {
+  name: string;
+  imageUrl: string | null;
+};
+
+type Props = {
+  members: StackMember[];
+  totalCount?: number;
+  surfaceColor: string;
+  /** Overall bounding-box edge in pt. Default 56 (inbox row). */
+  size?: number;
+};
+
+export function StackedMemberAvatars({
+  members,
+  totalCount,
+  surfaceColor,
+  size = 56,
+}: Props) {
+  const visible = members.slice(0, 4);
+  const total = totalCount ?? members.length;
+
+  if (visible.length === 0) {
+    return <View style={{ width: size, height: size }} />;
+  }
+
+  if (visible.length === 1) {
+    const m = visible[0]!;
+    return (
+      <View style={{ width: size, height: size }}>
+        <Avatar name={m.name} imageUrl={m.imageUrl ?? undefined} size={size} />
+      </View>
+    );
+  }
+
+  // Sizes are proportional to the bounding box so the cluster scales for
+  // header (36), inbox (56), and info-hero (96) callers without re-tuning.
+  const back2 = Math.round(size * 0.71);
+  const front2 = Math.round(size * 0.64);
+  const front2Wrap = front2 + 4;
+  const a3 = Math.round(size * 0.57);
+  const a3Wrap = a3 + 4;
+  const a4 = Math.round(size * 0.54);
+  const a4Wrap = a4 + 4;
+  const overflowFont = Math.max(10, Math.round(size * 0.22));
+
+  if (visible.length === 2) {
+    return (
+      <View style={[styles.box, { width: size, height: size }]}>
+        <Avatar
+          name={visible[0]!.name}
+          imageUrl={visible[0]!.imageUrl ?? undefined}
+          size={back2}
+          style={styles.topLeft}
+        />
+        <View
+          style={[
+            styles.bottomRight,
+            {
+              width: front2Wrap,
+              height: front2Wrap,
+              borderRadius: front2Wrap / 2,
+              backgroundColor: surfaceColor,
+              padding: 2,
+            },
+          ]}
+        >
+          <Avatar
+            name={visible[1]!.name}
+            imageUrl={visible[1]!.imageUrl ?? undefined}
+            size={front2}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  if (visible.length === 3) {
+    const ring = (positionStyle: any, m: StackMember) => (
+      <View
+        style={[
+          styles.absolute,
+          positionStyle,
+          {
+            width: a3Wrap,
+            height: a3Wrap,
+            borderRadius: a3Wrap / 2,
+            backgroundColor: surfaceColor,
+            padding: 2,
+          },
+        ]}
+      >
+        <Avatar name={m.name} imageUrl={m.imageUrl ?? undefined} size={a3} />
+      </View>
+    );
+    const bottomCenterStyle = {
+      bottom: 0,
+      left: Math.round((size - a3Wrap) / 2),
+    };
+    return (
+      <View style={[styles.box, { width: size, height: size }]}>
+        {ring(styles.topLeft, visible[0]!)}
+        {ring(styles.topRight, visible[1]!)}
+        {ring(bottomCenterStyle, visible[2]!)}
+      </View>
+    );
+  }
+
+  // 4+ members: quad cluster. If there are more members than fit, render the
+  // first three avatars and use the 4th slot for a "+N" badge.
+  const overflow = total - 3;
+  const showOverflow = total > 4;
+  const ring4 = (positionStyle: any, m: StackMember) => (
+    <View
+      style={[
+        styles.absolute,
+        positionStyle,
+        {
+          width: a4Wrap,
+          height: a4Wrap,
+          borderRadius: a4Wrap / 2,
+          backgroundColor: surfaceColor,
+          padding: 2,
+        },
+      ]}
+    >
+      <Avatar name={m.name} imageUrl={m.imageUrl ?? undefined} size={a4} />
+    </View>
+  );
+  return (
+    <View style={[styles.box, { width: size, height: size }]}>
+      {ring4(styles.topLeft, visible[0]!)}
+      {ring4(styles.topRight, visible[1]!)}
+      {ring4(styles.bottomLeft, visible[2]!)}
+      {showOverflow ? (
+        <View
+          style={[
+            styles.absolute,
+            styles.bottomRight,
+            {
+              width: a4Wrap,
+              height: a4Wrap,
+              borderRadius: a4Wrap / 2,
+              backgroundColor: surfaceColor,
+              padding: 2,
+            },
+          ]}
+        >
+          <View
+            style={[
+              styles.overflowInner,
+              { width: a4, height: a4, borderRadius: a4 / 2 },
+            ]}
+          >
+            <Text
+              style={[styles.overflowText, { fontSize: overflowFont }]}
+              numberOfLines={1}
+            >
+              +{overflow}
+            </Text>
+          </View>
+        </View>
+      ) : (
+        ring4(styles.bottomRight, visible[3]!)
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: { position: "relative" },
+  absolute: { position: "absolute" },
+  topLeft: { position: "absolute", top: 0, left: 0 },
+  topRight: { position: "absolute", top: 0, right: 0 },
+  bottomLeft: { position: "absolute", bottom: 0, left: 0 },
+  bottomRight: { position: "absolute", bottom: 0, right: 0 },
+  overflowInner: {
+    backgroundColor: "rgba(0,0,0,0.55)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  overflowText: {
+    color: "#fff",
+    fontWeight: "700",
+  },
+});

--- a/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
@@ -52,6 +52,9 @@ jest.mock('@services/api/convex', () => ({
           listGroupChannels: 'api.functions.messaging.channels.listGroupChannels',
           hasAutoChannels: 'api.functions.messaging.channels.hasAutoChannels',
         },
+        directMessages: {
+          getDirectInbox: 'api.functions.messaging.directMessages.getDirectInbox',
+        },
         readState: {
           getUnreadCounts: 'api.functions.messaging.readState.getUnreadCounts',
         },

--- a/apps/mobile/features/chat/hooks/useAdHocChannelManagement.ts
+++ b/apps/mobile/features/chat/hooks/useAdHocChannelManagement.ts
@@ -1,0 +1,79 @@
+/**
+ * useAdHocChannelManagement
+ *
+ * Thin wrapper around the ad-hoc DM management mutations Agent A is
+ * landing in `apps/convex/functions/messaging/directMessages.ts`:
+ *
+ *   - renameAdHocChannel({ token, channelId, name })
+ *   - addAdHocMembers({ token, channelId, userIds })
+ *   - removeAdHocMember({ token, channelId, userId })
+ *   - leaveAdHocChannel({ token, channelId })
+ *
+ * Returns auto-bound async functions; the caller supplies arguments and
+ * the hook injects the auth token. Each function rejects when the token
+ * is missing — the chat-info UI gates user-facing actions on
+ * `currentUserId` upstream so this should not happen in practice.
+ *
+ * NOTE: Until Agent A's mutations land, the `api.functions.messaging.
+ * directMessages.<name>` accessors are typed as `any` via a runtime
+ * indexing pattern. TypeScript will start type-checking these calls
+ * once the mutation specs appear in `_generated/api.d.ts`.
+ */
+import { useCallback } from "react";
+import {
+  useMutation,
+  api,
+  useStoredAuthToken,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+// Indexed access avoids hard-coded "may not exist on type" errors while the
+// backend mutations are being landed in parallel.
+const directMessages = (
+  api.functions.messaging.directMessages as unknown as Record<string, any>
+);
+
+export function useAdHocChannelManagement(channelId: Id<"chatChannels"> | null) {
+  const token = useStoredAuthToken();
+
+  const renameMutation = useMutation(directMessages.renameAdHocChannel);
+  const addMembersMutation = useMutation(directMessages.addAdHocMembers);
+  const removeMemberMutation = useMutation(directMessages.removeAdHocMember);
+  const leaveMutation = useMutation(directMessages.leaveAdHocChannel);
+
+  const requireReady = useCallback(() => {
+    if (!token) throw new Error("Not authenticated");
+    if (!channelId) throw new Error("Channel not loaded");
+  }, [token, channelId]);
+
+  const rename = useCallback(
+    async (name: string) => {
+      requireReady();
+      return renameMutation({ token, channelId, name });
+    },
+    [renameMutation, token, channelId, requireReady],
+  );
+
+  const addMembers = useCallback(
+    async (userIds: Id<"users">[]) => {
+      requireReady();
+      return addMembersMutation({ token, channelId, userIds });
+    },
+    [addMembersMutation, token, channelId, requireReady],
+  );
+
+  const removeMember = useCallback(
+    async (userId: Id<"users">) => {
+      requireReady();
+      return removeMemberMutation({ token, channelId, userId });
+    },
+    [removeMemberMutation, token, channelId, requireReady],
+  );
+
+  const leave = useCallback(async () => {
+    requireReady();
+    return leaveMutation({ token, channelId });
+  }, [leaveMutation, token, channelId, requireReady]);
+
+  return { rename, addMembers, removeMember, leave };
+}

--- a/apps/mobile/features/chat/hooks/useStartDirectMessage.ts
+++ b/apps/mobile/features/chat/hooks/useStartDirectMessage.ts
@@ -1,0 +1,112 @@
+/**
+ * useStartDirectMessage
+ *
+ * Wraps `createOrGetDirectChannel` for entry points outside the dedicated
+ * "/inbox/new" picker (e.g. the Message button on someone else's profile).
+ * Centralizes the navigation + error-classification logic so individual call
+ * sites don't each re-implement the PROFILE_PHOTO_REQUIRED /
+ * RECIPIENT_PROFILE_PHOTO_REQUIRED / NO_SHARED_COMMUNITY handling.
+ *
+ * The caller is expected to have already gated rendering on a community
+ * context — `messageUser` requires a `communityId` and short-circuits with
+ * "no_context" when one isn't provided.
+ */
+import { useCallback, useState } from "react";
+import { useRouter } from "expo-router";
+import { useMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useAuth } from "@providers/AuthProvider";
+import { ToastManager } from "@components/ui/Toast";
+import { classifyProfilePhotoError } from "@features/chat/components/RequireProfilePhotoSheet";
+
+export type StartDmOutcome =
+  | { kind: "success"; channelId: Id<"chatChannels"> }
+  | { kind: "needs_self_photo" }
+  | { kind: "needs_recipient_photo" }
+  | { kind: "no_shared_community" }
+  | { kind: "no_context" }
+  | { kind: "error"; message: string };
+
+interface MessageUserInput {
+  otherUserId: Id<"users">;
+  /** First name of the other user — used in recipient-photo toast copy. */
+  firstName?: string | null;
+  /** Display name of the other user — used to seed the chat header on navigate. */
+  displayName?: string | null;
+  /** Profile photo of the other user — used to seed the chat header on navigate. */
+  profilePhoto?: string | null;
+}
+
+export function useStartDirectMessage() {
+  const router = useRouter();
+  const { token, community } = useAuth();
+  const communityId = community?.id as Id<"communities"> | undefined;
+
+  const createOrGetDirectChannel = useMutation(
+    api.functions.messaging.directMessages.createOrGetDirectChannel,
+  );
+
+  const [isStarting, setIsStarting] = useState(false);
+
+  const messageUser = useCallback(
+    async ({
+      otherUserId,
+      firstName,
+      displayName,
+      profilePhoto,
+    }: MessageUserInput): Promise<StartDmOutcome> => {
+      if (!token || !communityId) {
+        return { kind: "no_context" };
+      }
+      setIsStarting(true);
+      try {
+        const { channelId } = await createOrGetDirectChannel({
+          token,
+          communityId,
+          recipientUserId: otherUserId,
+        });
+        router.push({
+          pathname: `/inbox/dm/${channelId}` as any,
+          params: {
+            groupName: displayName ?? "",
+            imageUrl: profilePhoto ?? "",
+          },
+        });
+        return { kind: "success", channelId };
+      } catch (e) {
+        const photoError = classifyProfilePhotoError(e);
+        if (photoError === "self") {
+          return { kind: "needs_self_photo" };
+        }
+        if (photoError === "recipient") {
+          const name = (firstName ?? "").trim();
+          ToastManager.error(
+            name.length > 0
+              ? `${name} hasn't added a profile photo yet.`
+              : "They haven't added a profile photo yet.",
+          );
+          return { kind: "needs_recipient_photo" };
+        }
+        const message = e instanceof Error ? e.message : String(e ?? "");
+        if (message.includes("NO_SHARED_COMMUNITY")) {
+          ToastManager.error(
+            "You can only message people in your community.",
+          );
+          return { kind: "no_shared_community" };
+        }
+        ToastManager.error("Couldn't start chat. Try again.");
+        return { kind: "error", message };
+      } finally {
+        setIsStarting(false);
+      }
+    },
+    [token, communityId, createOrGetDirectChannel, router],
+  );
+
+  return {
+    messageUser,
+    isStarting,
+    /** True when the hook has the context needed to attempt a DM. */
+    canMessage: Boolean(token && communityId),
+  };
+}

--- a/apps/mobile/features/groups/components/GroupNonMemberView.tsx
+++ b/apps/mobile/features/groups/components/GroupNonMemberView.tsx
@@ -3,6 +3,8 @@ import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert } from "rea
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { Avatar } from "@components/ui";
 import { GroupHeader } from "./GroupHeader";
 import { MembersRow } from "./MembersRow";
 import { HighlightsGrid } from "./HighlightsGrid";
@@ -32,7 +34,27 @@ export function GroupNonMemberView({
   const { user } = useAuth();
   const router = useRouter();
   const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
   const [showOptionsModal, setShowOptionsModal] = useState(false);
+
+  // Leaders are intentionally exposed to non-members so they can reach out
+  // before joining. Provided publicly by groupMembers.getLeaderPreview.
+  const leaderPreview =
+    ((group as any).leader_preview as
+      | Array<{
+          id: string;
+          first_name: string;
+          last_name: string;
+          profile_photo?: string;
+        }>
+      | undefined) ?? [];
+
+  const handleLeaderPress = (userId: string) => {
+    if (!userId) return;
+    // Use the canonical profile route pattern shared across the app
+    // (see chat/MessageItem, EventComment, ChatInfoScreen, etc.)
+    router.push(`/profile/${userId}` as any);
+  };
 
   // Check if user is a community admin - admins should see the menu even if not a member
   const isAdmin = user?.is_admin === true;
@@ -96,6 +118,63 @@ export function GroupNonMemberView({
         {/* Map Section - Only shown to admins for non-members
             SECURITY: Location data should not be shown to non-members */}
         {isAdmin && <GroupMapSection group={group} />}
+
+        {/* Leaders Section — exposed to non-members so they can DM a leader
+            before joining the group. Tap a leader card to open their profile,
+            where the Message button initiates a DM. */}
+        {leaderPreview.length > 0 && (
+          <View style={[styles.leadersContainer, { backgroundColor: colors.surfaceSecondary }]}>
+            <Text style={[styles.leadersTitle, { color: colors.text }]}>LEADERS</Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.leadersScrollContent}
+            >
+              {leaderPreview.map((leader) => {
+                const fullName = `${leader.first_name || ""} ${leader.last_name || ""}`.trim();
+                const displayName =
+                  leader.first_name ||
+                  fullName ||
+                  "Leader";
+                return (
+                  <TouchableOpacity
+                    key={leader.id}
+                    onPress={() => handleLeaderPress(leader.id)}
+                    activeOpacity={0.7}
+                    accessibilityRole="button"
+                    accessibilityLabel={`View ${displayName}'s profile`}
+                    style={styles.leaderCardTouchable}
+                  >
+                    {/* Layout styles live on this inner View so they apply on
+                        React Native Web (Pressable/Touchable function-style
+                        is silently ignored on web). */}
+                    <View style={styles.leaderCard}>
+                      <View style={[styles.leaderAvatarWrapper, { borderColor: primaryColor }]}>
+                        <Avatar
+                          name={fullName || displayName}
+                          imageUrl={leader.profile_photo}
+                          size={56}
+                        />
+                        <View
+                          style={[
+                            styles.leaderBadge,
+                            { backgroundColor: primaryColor, borderColor: colors.surfaceSecondary },
+                          ]}
+                        />
+                      </View>
+                      <Text
+                        style={[styles.leaderName, { color: colors.text }]}
+                        numberOfLines={1}
+                      >
+                        {displayName}
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+                );
+              })}
+            </ScrollView>
+          </View>
+        )}
 
         {/* Members Section */}
         {/* Admins can see full member list and navigate to members page */}
@@ -304,6 +383,56 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 16,
     marginTop: -8,
+  },
+  // Leaders section (non-members can tap a leader to message them)
+  leadersContainer: {
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+  },
+  leadersTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 12,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  leadersScrollContent: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  leaderCardTouchable: {
+    // 44pt+ tap target enforced via inner padding/sizing below
+  },
+  leaderCard: {
+    alignItems: "center",
+    width: 72,
+    paddingVertical: 4,
+    paddingHorizontal: 4,
+    minHeight: 88,
+  },
+  leaderAvatarWrapper: {
+    position: "relative",
+    borderRadius: 32,
+    borderWidth: 3,
+    padding: 2,
+    marginBottom: 6,
+  },
+  leaderBadge: {
+    position: "absolute",
+    top: -2,
+    right: -2,
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 2,
+    zIndex: 1,
+  },
+  leaderName: {
+    fontSize: 13,
+    fontWeight: "500",
+    textAlign: "center",
+    maxWidth: 72,
   },
 });
 

--- a/apps/mobile/features/groups/hooks/useGroupDetails.ts
+++ b/apps/mobile/features/groups/hooks/useGroupDetails.ts
@@ -62,25 +62,40 @@ export function useGroupDetails(groupId: string | null | undefined) {
     enabled && convexGroupId ? { groupId: convexGroupId, limit: 5 } : "skip"
   );
 
+  // Fetch leader preview (public data — intentionally exposed to non-members
+  // so they can DM a leader before joining the group). Capped at 8.
+  const leaderPreview = useQuery(
+    api.functions.groupMembers.getLeaderPreview,
+    enabled && convexGroupId ? { groupId: convexGroupId, limit: 8 } : "skip"
+  );
+
   // Fetch group type details if we have the group
   const groupTypeId = group?.groupTypeId;
   // Note: Group type info is included in the group query via groupTypeName, groupTypeSlug
 
   // Cache live data when all queries resolve
   useEffect(() => {
-    if (group && members !== undefined && leaders !== undefined && memberPreview !== undefined && groupId) {
+    if (
+      group &&
+      members !== undefined &&
+      leaders !== undefined &&
+      memberPreview !== undefined &&
+      leaderPreview !== undefined &&
+      groupId
+    ) {
       setFullGroupData(groupId, {
         details: group,
         members: members,
         leaders: leaders,
         memberPreview: memberPreview,
+        leaderPreview: leaderPreview,
       });
     }
-  }, [group, members, leaders, memberPreview, groupId, setFullGroupData]);
+  }, [group, members, leaders, memberPreview, leaderPreview, groupId, setFullGroupData]);
 
   // Determine loading state
   const isLoading =
-    enabled && (group === undefined || membersResponse === undefined || leaders === undefined || memberPreview === undefined);
+    enabled && (group === undefined || membersResponse === undefined || leaders === undefined || memberPreview === undefined || leaderPreview === undefined);
 
   // Check cache for stale-while-revalidate
   const cached = isLoading && groupId ? getFullGroupData(groupId) : null;
@@ -91,6 +106,7 @@ export function useGroupDetails(groupId: string | null | undefined) {
   const effectiveMembers = members ?? cached?.members;
   const effectiveLeaders = leaders ?? cached?.leaders;
   const effectiveMemberPreview = memberPreview ?? cached?.memberPreview;
+  const effectiveLeaderPreview = leaderPreview ?? cached?.leaderPreview;
 
   // Transform to snake_case format for compatibility with existing components
   // Note: Using `as any` casts where needed for Convex ID types to match legacy number types
@@ -173,6 +189,16 @@ export function useGroupDetails(groupId: string | null | undefined) {
           profile_photo: m.profileImage || undefined,
           role: m.role || "member",
         })) || [],
+        // Leader preview — intentionally exposed to non-members so they can
+        // DM a leader before joining the group. Capped at 8 by the backend.
+        leader_preview: effectiveLeaderPreview?.leaders?.map((l: any) => ({
+          id: l.id || "",
+          first_name: l.firstName || "",
+          last_name: l.lastName || "",
+          profile_photo: l.profileImage || undefined,
+          role: l.role || "leader",
+        })) || [],
+        leader_preview_total_count: effectiveLeaderPreview?.totalCount || 0,
       }
     : undefined;
 

--- a/apps/mobile/features/leader-tools/components/Members.tsx
+++ b/apps/mobile/features/leader-tools/components/Members.tsx
@@ -10,6 +10,7 @@ import {
   Modal,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
 import { SearchBar } from "@components/ui/SearchBar";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
@@ -452,6 +453,7 @@ function MemberActionsModal({
 }: MemberActionsModalProps) {
   const { colors } = useTheme();
   const { user } = useAuth();
+  const router = useRouter();
 
   if (!member || !visible) {
     return null;
@@ -465,6 +467,15 @@ function MemberActionsModal({
   const isCurrentUser = user?.id === member?.id;
   // Show promote/demote if user can manage members AND we have group role data
   const canPromoteDemote = canManageMembers && memberRole !== undefined;
+
+  // Visible to ANY caller — non-admin members can still view profiles.
+  const handleViewProfile = () => {
+    const userId = member?.id ?? member?._id ?? member?.user?.id;
+    onClose();
+    if (userId) {
+      router.push(`/profile/${userId}` as any);
+    }
+  };
 
   return (
     <Modal
@@ -490,6 +501,16 @@ function MemberActionsModal({
           </View>
 
           <View style={styles.modalActions}>
+            {/* View profile is always available — non-admins included. */}
+            <TouchableOpacity
+              style={[styles.modalActionButton, { borderBottomColor: colors.border }]}
+              onPress={handleViewProfile}
+            >
+              <Ionicons name="person-circle-outline" size={20} color={colors.text} />
+              <Text style={[styles.modalActionText, { color: colors.text }]}>
+                View profile
+              </Text>
+            </TouchableOpacity>
             {canPromoteDemote && !isCurrentUser && (
               <>
                 {isLeader ? (

--- a/apps/mobile/features/profile/components/UserProfileScreen.tsx
+++ b/apps/mobile/features/profile/components/UserProfileScreen.tsx
@@ -6,7 +6,7 @@
  * Route: /profile/[userId]
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -14,6 +14,7 @@ import {
   ScrollView,
   ActivityIndicator,
   TouchableOpacity,
+  Pressable,
   Platform,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -22,7 +23,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useAuth } from '@providers/AuthProvider';
 import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useConvexFeatureFlag } from '@hooks/useConvexFeatureFlag';
 import type { Id } from '@services/api/convex';
+import { useStartDirectMessage } from '@features/chat/hooks/useStartDirectMessage';
+import { RequireProfilePhotoSheet } from '@features/chat/components/RequireProfilePhotoSheet';
 
 import { useUserProfile } from '../hooks/useUserProfile';
 import { UserProfileHeader } from './UserProfileHeader';
@@ -56,6 +61,35 @@ export function UserProfileScreen() {
     // the dedicated self profile screen already owns that view.
     skipViewerScopedQueries: isSelf,
   });
+
+  // DM entry point. Hidden behind the `direct-messages` feature flag; while
+  // the flag is hydrating we render nothing so the button doesn't flicker in.
+  const { enabled: dmsEnabled, loaded: dmsFlagLoaded } =
+    useConvexFeatureFlag('direct-messages');
+  const { messageUser, isStarting, canMessage } = useStartDirectMessage();
+  const [photoSheetVisible, setPhotoSheetVisible] = useState(false);
+
+  const showMessageButton =
+    dmsFlagLoaded &&
+    dmsEnabled &&
+    !isSelf &&
+    !!profile &&
+    canMessage;
+
+  const handleMessagePress = async () => {
+    if (!profile || !userId) return;
+    const displayName =
+      [profile.firstName, profile.lastName].filter(Boolean).join(' ').trim();
+    const outcome = await messageUser({
+      otherUserId: userId,
+      firstName: profile.firstName ?? null,
+      displayName: displayName.length > 0 ? displayName : null,
+      profilePhoto: profile.profilePhoto ?? null,
+    });
+    if (outcome.kind === 'needs_self_photo') {
+      setPhotoSheetVisible(true);
+    }
+  };
 
   const headerBar = (
     <View
@@ -149,6 +183,12 @@ export function UserProfileScreen() {
       >
         <UserProfileHeader profile={profile} />
         <UserProfileBadges profile={profile} />
+        {showMessageButton ? (
+          <MessageButton
+            onPress={handleMessagePress}
+            disabled={isStarting}
+          />
+        ) : null}
         <UserProfileBio bio={profile.bio} />
         <UserProfileSocials
           instagramHandle={profile.instagramHandle}
@@ -166,7 +206,45 @@ export function UserProfileScreen() {
           <UserProfileUpcomingEvents events={upcomingEvents ?? []} />
         )}
       </ScrollView>
+      <RequireProfilePhotoSheet
+        visible={photoSheetVisible}
+        onClose={() => setPhotoSheetVisible(false)}
+      />
     </View>
+  );
+}
+
+interface MessageButtonProps {
+  onPress: () => void;
+  disabled?: boolean;
+}
+
+function MessageButton({ onPress, disabled }: MessageButtonProps) {
+  const { primaryColor } = useCommunityTheme();
+  // Web RN ignores layout styles passed via Pressable's function-style prop —
+  // keep all layout on the inner View and only use the function form to dim
+  // the press state on native.
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel="Message"
+      style={({ pressed }) => ({
+        opacity: disabled ? 0.6 : pressed ? 0.85 : 1,
+      })}
+    >
+      <View style={[styles.messageButton, { backgroundColor: primaryColor }]}>
+        {disabled ? (
+          <ActivityIndicator size="small" color="#fff" />
+        ) : (
+          <>
+            <Ionicons name="chatbubble-outline" size={18} color="#fff" />
+            <Text style={styles.messageButtonText}>Message</Text>
+          </>
+        )}
+      </View>
+    </Pressable>
   );
 }
 
@@ -237,5 +315,20 @@ const styles = StyleSheet.create({
   missingText: {
     fontSize: 14,
     textAlign: 'center',
+  },
+  messageButton: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    gap: 8,
+  },
+  messageButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
   },
 });

--- a/apps/mobile/stores/groupCache.ts
+++ b/apps/mobile/stores/groupCache.ts
@@ -23,6 +23,7 @@ interface CachedGroup {
   members?: any[]; // From groupMembers.list (group detail page only)
   leaders?: any[]; // From getLeaders (group detail page only)
   memberPreview?: any; // From getMemberPreview (group detail page only)
+  leaderPreview?: any; // From getLeaderPreview (public — used by non-members)
   timestamp: number;
 }
 
@@ -36,6 +37,7 @@ interface GroupCacheState {
       members?: any[];
       leaders?: any[];
       memberPreview?: any;
+      leaderPreview?: any;
     }
   ) => void;
   getGroupDetails: (groupId: string) => any | null;
@@ -85,6 +87,7 @@ export const useGroupCache = create<GroupCacheState>()(
               members: data.members,
               leaders: data.leaders,
               memberPreview: data.memberPreview,
+              leaderPreview: data.leaderPreview,
               timestamp: Date.now(),
             },
           });


### PR DESCRIPTION
## Summary

Big polish pass on the DM/group-chat surface that landed in PRs 346–351, plus new entry points to start a DM from outside the inbox.

### Chat-room polish
- **Tappable header** replaces the bare "Chat" title — stacked-avatar cluster + member name list + info icon, all routing to a new chat-info screen.
- **Privacy card** above the message list reminds members the chat is not end-to-end encrypted and admins can request access.

### Chat info screen (`/inbox/dm/<channelId>/info`)
- Stacked-avatar hero, member rows with **View profile** / **Remove from chat** actions.
- **Add people** sheet (reuses search picker), **Rename** (group_dm only, `dm` rejects), **Leave chat**.
- Backed by four new mutations in `directMessages.ts`:
  - `renameAdHocChannel`, `addAdHocMembers` (capped at 20), `removeAdHocMember`, `leaveAdHocChannel`.

### New entry points to DMs
- **Profile screen** — Message CTA opens or creates a DM with the viewed user, scoped to the active community. Hidden behind the `direct-messages` flag.
- **Group members list** — action sheet adds **View profile** as the first item, so non-admins also have a meaningful action.
- **Group detail page** — non-members now see a horizontally scrolling **LEADERS** section (max 8) so they can tap a leader and message them before joining. New public `groupMembers.getLeaderPreview` query.

### Profile-photo hard requirement
- Backend throws `PROFILE_PHOTO_REQUIRED` (caller) / `RECIPIENT_PROFILE_PHOTO_REQUIRED:<userId>` (recipient) at `createOrGetDirectChannel`, `createGroupChat`, and `respondToChatRequest` accept-path.
- Frontend shows `RequireProfilePhotoSheet` that routes to `/(user)/edit-profile`.
- Catches both the local check (current user state) and the backend echo for stale-state edges.

### Push notification fix
- Ad-hoc channels no longer carry the bogus "Group Chat: General" subtitle.
- Pending request: title=`<sender>`, body=`would like to chat: <preview>`.
- Accepted group_dm: title=`<sender> in <channelName | first-two-others>`.
- Accepted 1:1 dm: title=`<sender>`, body=`<preview>`.

### Stacked-avatar component
- Generalized to 1 / 2 / 3 / 4+ tiers with a `+N` overflow badge.
- Parameterized `size` so the same component drives the inbox row (56pt), chat-room header (36pt), and info-screen hero (96pt).
- Single source of truth at `features/chat/components/StackedMemberAvatars.tsx`.

## Test plan

- [x] Convex unit tests: 1404/1404 pass (29/29 in `directMessages.test.ts` — 13 new).
- [x] Convex `npx tsc --noEmit`: clean.
- [x] Mobile `npx tsc --noEmit`: zero new errors in any modified/created file.
- [x] Mobile Jest suite: 1024 pass / 9 skipped (after `directMessages.getDirectInbox` mock added to LeaderChatNavigation test).
- [ ] Playwright walkthrough — running locally now: start chat → header opens info → add/remove member → rename → leave; profile Message button → starts DM; group leaders section visible to non-members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)