### PR TITLE
fix(ui): apply percent-string Modal width on native

### DIFF
--- a/apps/mobile/components/ui/Modal.tsx
+++ b/apps/mobile/components/ui/Modal.tsx
@@ -85,17 +85,21 @@ export function CustomModal({
             style={[
               styles.modalContent,
               { backgroundColor: colors.surface },
-              Platform.OS === "web"
-                ? {
-                    width: width as any,
-                    ...(fixedHeight ? { height: fixedHeight as any } : {}),
-                  }
-                : {
-                    width: typeof width === "number" ? width : undefined,
-                    ...(fixedHeight && typeof fixedHeight === "number"
-                      ? { height: fixedHeight }
-                      : {}),
-                  },
+              // React Native accepts both numeric and percent-string widths
+              // (e.g. "90%"). The previous native branch used a `typeof
+              // === "number"` guard and silently dropped string widths to
+              // `undefined`, which collapsed the modal to its intrinsic
+              // content width and produced a narrow column on iOS — visible
+              // in the Add People / Rename Chat sheets that take the default
+              // "90%" width. Pass the width through directly on every
+              // platform; cast for TS because RN's style types disallow
+              // percent strings even though the runtime supports them.
+              {
+                width: width as any,
+                ...(fixedHeight !== undefined
+                  ? { height: fixedHeight as any }
+                  : {}),
+              },
               Platform.select({
                 web: {
                   boxShadow: "0px 4px 20px rgba(0, 0, 0, 0.15)",


### PR DESCRIPTION
## Summary

Fixes the Add People sheet rendering as a narrow vertical strip on iOS (screenshot in the bug report).

`CustomModal`'s native branch had:
\`\`\`ts
width: typeof width === \"number\" ? width : undefined
\`\`\`

The default \`width=\"90%\"\` is a string, so the type guard silently dropped it on iOS. Without an explicit width, \`modalContent\` had no width style and the centered container shrank to intrinsic content width. Modals with narrow content (the new Add People sheet — avatar + name + checkbox row) collapsed to a thin vertical column with single-char button text wrapping (\"Can/cel\"). Modals with wide content (DeleteAccount, LeaveCommunity, etc.) masked the bug because their buttons were already wide enough.

React Native accepts percent-string widths (e.g. \`\"90%\"\`) at runtime even though the type doesn't allow them. Now passes the width through directly on every platform with an \`as any\` cast (the same cast the web branch already used).

## Test plan

- [x] \`tsc --noEmit\`: clean.
- [x] ESLint: zero new warnings (two pre-existing \`any\` warnings already on the changed lines).
- [ ] iOS smoke: open chat info → Add people → modal renders at ~90% width like the Rename Chat modal already did on web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)