### PR TITLE
fix(chat): per-channel header query — fixes Sentry 'Maximum update depth' after DM send

### DIFF
--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -1176,6 +1176,92 @@ export const searchUsersInSharedCommunities = query({
  * community's threads. Pending requests are surfaced separately by
  * `listChatRequests`. Sorted most-recent activity first.
  */
+/**
+ * Tight per-channel query that returns just the metadata the chat-room
+ * header and chat-info screen need. Use this instead of `getDirectInbox`
+ * when you only care about ONE channel — `getDirectInbox` re-fires on every
+ * change to ANY of the caller's DM channels, which produces unnecessary
+ * re-renders (and was implicated in a "Maximum update depth exceeded"
+ * crash that fired right after sending a message in a DM).
+ *
+ * Returns null when the caller has no active membership in the channel,
+ * so the UI can render the loading / not-found state cleanly.
+ */
+export const getAdHocChannelMembers = query({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    channelType: "dm" | "group_dm";
+    channelName: string;
+    memberCount: number;
+    otherMembers: Array<{
+      userId: Id<"users">;
+      displayName: string;
+      profilePhoto: string | null;
+    }>;
+  } | null> => {
+    const userId = await requireAuth(ctx, args.token);
+    const channel = await ctx.db.get(args.channelId);
+    if (
+      !channel ||
+      !channel.isAdHoc ||
+      (channel.channelType !== "dm" && channel.channelType !== "group_dm")
+    ) {
+      return null;
+    }
+
+    const callerRow = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", args.channelId).eq("userId", userId),
+      )
+      .first();
+    if (!callerRow || callerRow.leftAt !== undefined) {
+      return null;
+    }
+
+    const memberRows = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+
+    const others = memberRows.filter((m) => m.userId !== userId);
+    // Resolve profilePhoto + displayName from each user doc — denormalized
+    // values on the member row may be stale when the user updates their
+    // profile, so prefer the live user record.
+    const otherUsers = await Promise.all(
+      others.map((m) => ctx.db.get(m.userId)),
+    );
+    const otherMembers = others
+      .map((m, i) => {
+        const u = otherUsers[i];
+        if (!u) return null;
+        return {
+          userId: m.userId,
+          displayName:
+            getDisplayName(u.firstName, u.lastName) ||
+            m.displayName ||
+            "Member",
+          profilePhoto: getMediaUrl(u.profilePhoto ?? m.profilePhoto) ?? null,
+        };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
+
+    return {
+      channelType: channel.channelType as "dm" | "group_dm",
+      channelName: channel.name ?? "",
+      memberCount: memberRows.length,
+      otherMembers,
+    };
+  },
+});
+
 export const getDirectInbox = query({
   args: {
     token: v.string(),

--- a/apps/mobile/features/chat/components/ChatInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInfoScreen.tsx
@@ -74,30 +74,38 @@ const MAX_TOTAL_MEMBERS = 20;
 export function ChatInfoScreen({ channelId }: Props) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { user, community } = useAuth();
+  const { user } = useAuth();
   const token = useStoredAuthToken();
   const { colors } = useTheme();
   const { primaryColor, accentLight } = useCommunityTheme();
-  const communityId = community?.id as Id<"communities"> | undefined;
 
   const channel = useQuery(
     api.functions.messaging.channels.getChannel,
     token ? { token, channelId } : "skip",
   );
-  // The inbox query is the simplest source of `otherMembers` for the
-  // current user's ad-hoc channels; it filters by request state already.
-  const directInbox = useQuery(
-    api.functions.messaging.directMessages.getDirectInbox,
-    token && communityId ? { token, communityId } : "skip",
+  // Tight per-channel query — replaces the previous `getDirectInbox`
+  // (community-wide) usage so this screen only re-renders when THIS
+  // channel's members change. Previously, opening the info sheet would
+  // refetch whenever any other DM channel's lastMessageAt updated.
+  const channelMembers = useQuery(
+    api.functions.messaging.directMessages.getAdHocChannelMembers,
+    token ? { token, channelId } : "skip",
   );
 
   const { rename, addMembers, removeMember, leave } =
     useAdHocChannelManagement(channelId);
 
+  // Adapt to the previous shape so the rest of this screen keeps working.
   const inboxRow = useMemo(() => {
-    if (!directInbox) return null;
-    return directInbox.find((row) => row.channelId === channelId) ?? null;
-  }, [directInbox, channelId]);
+    if (!channelMembers) return null;
+    return {
+      channelId,
+      channelType: channelMembers.channelType,
+      channelName: channelMembers.channelName,
+      memberCount: channelMembers.memberCount,
+      otherMembers: channelMembers.otherMembers,
+    };
+  }, [channelMembers, channelId]);
 
   const isGroupDm = channel?.channelType === "group_dm";
   const isAdHoc = channel?.isAdHoc === true;
@@ -291,7 +299,7 @@ export function ChatInfoScreen({ channelId }: Props) {
   );
 
   // -- Rendering --
-  if (channel === undefined || directInbox === undefined) {
+  if (channel === undefined || channelMembers === undefined) {
     return (
       <View
         style={[

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -92,9 +92,8 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const params = useLocalSearchParams() as ChatRoomParams;
   const router = useRouter();
   const pathname = usePathname();
-  const { user, community } = useAuth();
+  const { user } = useAuth();
   const token = useStoredAuthToken();
-  const adHocCommunityId = community?.id as Id<"communities"> | undefined;
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
 
@@ -910,30 +909,35 @@ const ConvexChatRoomScreenInner: React.FC = () => {
       ? (channelData.channelType as "dm" | "group_dm")
       : null;
 
-  // Ad-hoc channels need other-member metadata for the stacked-avatar header
-  // and the chat-info screen. `getDirectInbox` already returns this in the
-  // exact shape we need; reusing it avoids a second query path while the
-  // channel doc itself is being kept lean.
-  const directInboxForHeader = useQuery(
-    api.functions.messaging.directMessages.getDirectInbox,
-    isAdHocChannel && token && adHocCommunityId
-      ? { token, communityId: adHocCommunityId }
+  // Ad-hoc channels: fetch JUST the members for THIS channel. Previously we
+  // reused `getDirectInbox` (community-wide), which re-fired on every other
+  // DM channel's activity and was implicated in a "Maximum update depth
+  // exceeded" crash that fired right after sending a message in a DM —
+  // every send invalidated the inbox query, which produced a new array
+  // reference for `otherMembers` and cascaded re-renders through the
+  // header/avatars. The tight per-channel query only re-fires when this
+  // channel's member list actually changes.
+  const adHocChannelMembers = useQuery(
+    api.functions.messaging.directMessages.getAdHocChannelMembers,
+    isAdHocChannel && token && activeChannelId
+      ? { token, channelId: activeChannelId }
       : "skip",
   );
-  const adHocInboxRow = useMemo(() => {
-    if (!isAdHocChannel || !directInboxForHeader || !activeChannelId) return null;
-    return (
-      directInboxForHeader.find((row) => row.channelId === activeChannelId) ??
-      null
-    );
-  }, [isAdHocChannel, directInboxForHeader, activeChannelId]);
+  // Stabilise the member array reference: the query result is a fresh
+  // object on every Convex push, but if the underlying data hasn't changed,
+  // downstream consumers (StackedMemberAvatars, ChatRoomHeader) shouldn't
+  // see a new prop reference. Key on the userId+photo+name tuple.
+  const adHocOtherMembersKey = (adHocChannelMembers?.otherMembers ?? [])
+    .map((m) => `${m.userId}|${m.profilePhoto ?? ""}|${m.displayName}`)
+    .join("\n");
   const adHocOtherMembers = useMemo(
     () =>
-      (adHocInboxRow?.otherMembers ?? []).map((m) => ({
+      (adHocChannelMembers?.otherMembers ?? []).map((m) => ({
         name: m.displayName,
         imageUrl: m.profilePhoto,
       })),
-    [adHocInboxRow],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [adHocOtherMembersKey],
   );
 
   const handleOpenChatInfo = useCallback(() => {


### PR DESCRIPTION
## Summary

Fixes Sentry event \`eb6e1621af6e412e857343d29e10f533\` — \"Maximum update depth exceeded\" on staging build \`1.0.22+28\`, which fired ~700ms after sending a message in a DM (\`useSendMessage\` success → keyboard hides → crash).

## Root cause

Both \`ConvexChatRoomScreen\` and \`ChatInfoScreen\` reused \`getDirectInbox\` (a community-wide query) just to source \`otherMembers\` for the header of ONE channel. Every send invalidated the inbox query (channel's \`lastMessageAt\` updates), which produced:

- a fresh result array
- a fresh \`find()\` row object
- a fresh \`otherMembers\` array

That cascaded re-renders through \`StackedMemberAvatars\` and the chat header. Combined with the keyboard-hide layout pass, it tipped React past the update-depth ceiling.

## Fix

- New tight \`getAdHocChannelMembers({ channelId })\` query: returns only this channel's members + name + type. Re-fires only when this channel's member list actually changes.
- \`ConvexChatRoomScreen\` and \`ChatInfoScreen\` switched off \`getDirectInbox\`.
- Stabilised \`adHocOtherMembers\` reference in the chat room — memoised on a \`userId|photo|name\` string key so the prop reference stays stable when the underlying data hasn't changed.
- Cleaned up now-unused \`communityId\`/\`adHocCommunityId\` locals.

## Test plan

- [x] Convex \`tsc --noEmit\`: clean.
- [x] Mobile \`tsc --noEmit\`: zero new errors in changed files.
- [x] Convex unit: 33/33 pass in \`directMessages.test.ts\`.
- [x] Mobile Jest: 97/97 chat tests pass.
- [ ] Manual smoke on iOS: open DM → send a message → keyboard dismisses → no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)