### PR TITLE
fix(admin): feature flags are superuser-only, not primary admin

### DIFF
--- a/apps/convex/functions/admin/featureFlags.ts
+++ b/apps/convex/functions/admin/featureFlags.ts
@@ -1,24 +1,41 @@
 /**
  * Feature Flags
  *
- * Database-backed global on/off switches for staged feature rollouts.
- * Flipped by community primary admins via `/(user)/admin/features`.
+ * Database-backed APP-WIDE on/off switches for staged feature rollouts.
+ * Flipped by Togather superusers via `/(user)/admin/features`.
  *
  * Design notes:
- * - One boolean per key, applied to all users in the community. This is
- *   deliberately simpler than PostHog targeting — Seyi found PostHog too
+ * - Flags are GLOBAL — one row per key, applied to every user across every
+ *   community. Community primary admins are NOT permitted to flip them,
+ *   only Togather staff/superusers, since these gate platform features
+ *   that aren't community-scoped.
+ * - Deliberately simpler than PostHog targeting — Seyi found PostHog too
  *   complex for the rollouts he actually does, so the operational model is
  *   "set up the flag, ramp by flipping the switch."
  * - When a flag's feature has fully ramped, the row and the gate sites are
  *   removed together — there's no "flag retired" intermediate state.
  * - Reads are an unauthenticated query so gates don't need to wait for the
- *   user's session before deciding what to render. Writes require Primary
- *   Admin via `requirePrimaryAdmin`.
+ *   user's session before deciding what to render.
  */
 import { v } from "convex/values";
 import { mutation, query } from "../../_generated/server";
 import { requireAuth } from "../../lib/auth";
-import { requirePrimaryAdmin } from "../../lib/permissions";
+
+/**
+ * Throw unless the caller is a Togather superuser or staff member.
+ * Inline with the rest of the codebase (proposals.ts, posters.ts) — no
+ * dedicated helper because the check is small and only used in a few
+ * platform-level admin endpoints.
+ */
+async function requireSuperuser(
+  ctx: { db: { get: (id: any) => Promise<any> } },
+  userId: any,
+): Promise<void> {
+  const user = await ctx.db.get(userId);
+  if (!user?.isStaff && !user?.isSuperuser) {
+    throw new Error("Superuser access required");
+  }
+}
 
 /**
  * Get the current value of a single feature flag. Returns `false` if the row
@@ -39,17 +56,18 @@ export const getFeatureFlag = query({
 
 /**
  * List all feature flags for the admin UI. Returns flags ordered by key.
- * Auth-gated to primary admins only since the existence of a flag (and its
- * description) can leak in-progress feature names.
+ * Auth-gated to superusers only — the existence of a flag (and its
+ * description) can leak in-progress feature names, and these are
+ * platform-level switches that community admins shouldn't be able to
+ * see or flip.
  */
 export const listFeatureFlags = query({
   args: {
     token: v.string(),
-    communityId: v.id("communities"),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
-    await requirePrimaryAdmin(ctx, args.communityId, userId);
+    await requireSuperuser(ctx, userId);
 
     const flags = await ctx.db.query("featureFlags").collect();
     return flags
@@ -69,19 +87,19 @@ export const listFeatureFlags = query({
  * Set a feature flag's value. Creates the row if it doesn't exist yet,
  * otherwise patches it. Authoring history is intentionally minimal —
  * `updatedAt` + `updatedById` cover the "who flipped this and when"
- * audit need without a separate event log table.
+ * audit need without a separate event log table. Superuser only —
+ * see `listFeatureFlags`.
  */
 export const setFeatureFlag = mutation({
   args: {
     token: v.string(),
-    communityId: v.id("communities"),
     key: v.string(),
     enabled: v.boolean(),
     description: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ ok: true }> => {
     const userId = await requireAuth(ctx, args.token);
-    await requirePrimaryAdmin(ctx, args.communityId, userId);
+    await requireSuperuser(ctx, userId);
 
     const trimmedKey = args.key.trim();
     if (trimmedKey.length === 0) {

--- a/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
+++ b/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
@@ -1,16 +1,21 @@
 /**
  * FeatureFlagsContent
  *
- * Primary-admin-only screen for flipping the global feature flags stored
+ * Superuser-only screen for flipping the APP-WIDE feature flags stored
  * in the Convex `featureFlags` table. One row per flag, each with:
  *   - the flag key + optional description
  *   - a Switch that calls `setFeatureFlag` on change
  *   - the last-updated timestamp
  *
+ * Flags are global, not community-scoped — community primary admins
+ * cannot see or flip them. The route is gated on `user.is_superuser ||
+ * user.is_staff`; non-superusers see a permission-denied state.
+ *
  * Flags are created lazily — the first call to `setFeatureFlag(key, ...)`
  * inserts the row. To show a flag here before it's been flipped for the
  * first time, the `KNOWN_FLAGS` table below seeds the list with metadata
- * so admins can see what flags exist even when they're still default-off.
+ * so superusers can see what flags exist even when they're still
+ * default-off.
  */
 import React, { useMemo, useState } from "react";
 import {
@@ -67,23 +72,23 @@ function formatRelative(ts: number): string {
 
 export function FeatureFlagsContent() {
   const insets = useSafeAreaInsets();
-  const { token, community } = useAuth();
+  const { token, user } = useAuth();
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
 
-  const communityId = community?.id as Id<"communities"> | undefined;
+  const isSuperuser = user?.is_superuser === true || user?.is_staff === true;
 
   const flags = useQuery(
     api.functions.admin.featureFlags.listFeatureFlags,
-    token && communityId ? { token, communityId } : "skip",
+    token && isSuperuser ? { token } : "skip",
   ) as FlagRow[] | undefined;
 
   const setFlag = useMutation(api.functions.admin.featureFlags.setFeatureFlag);
 
   const [pendingKey, setPendingKey] = useState<string | null>(null);
 
-  // Merge backend rows with the KNOWN_FLAGS catalog so admins see flags that
-  // haven't been flipped yet.
+  // Merge backend rows with the KNOWN_FLAGS catalog so superusers see flags
+  // that haven't been flipped yet.
   const merged = useMemo(() => {
     const byKey = new Map<string, FlagRow & { isSeed: boolean }>();
     for (const known of KNOWN_FLAGS) {
@@ -113,12 +118,11 @@ export function FeatureFlagsContent() {
   }, [flags]);
 
   const onToggle = async (row: (typeof merged)[number], next: boolean) => {
-    if (!token || !communityId || pendingKey) return;
+    if (!token || !isSuperuser || pendingKey) return;
     setPendingKey(row.key);
     try {
       await setFlag({
         token,
-        communityId,
         key: row.key,
         enabled: next,
         ...(row.description ? { description: row.description } : {}),
@@ -131,7 +135,7 @@ export function FeatureFlagsContent() {
     }
   };
 
-  if (!communityId) {
+  if (!isSuperuser) {
     return (
       <View
         style={[
@@ -141,7 +145,7 @@ export function FeatureFlagsContent() {
         ]}
       >
         <Text style={[styles.empty, { color: colors.textSecondary }]}>
-          Select a community to manage feature flags.
+          Feature flags are managed by Togather staff. You don't have access.
         </Text>
       </View>
     );
@@ -173,8 +177,8 @@ export function FeatureFlagsContent() {
       }
     >
       <Text style={[styles.intro, { color: colors.textSecondary }]}>
-        Toggle features on or off for everyone in this community. Changes take
-        effect immediately for any client with the chat tab open.
+        App-wide feature flags. Changes take effect immediately for every
+        user across every community.
       </Text>
       {merged.map((row) => (
         <View


### PR DESCRIPTION
## Summary

Fixes Sentry event \`03b1de3336684b3c9a2711197dd85b3c\` and the underlying authorization model. Feature flags are app-wide platform switches, not community-scoped — community primary admins were never the right gate.

## Why

- The flags are GLOBAL (one row per key, applied to all users across all communities). The UI was gated on \`requirePrimaryAdmin\`, which (a) rejected role-3 admins of any community, (b) only worked for primary admins of the active community, and (c) leaked flag descriptions to community admins who shouldn't see in-progress feature names.
- For Seyi specifically: he's role 3 (admin) of FOUNT and Demo Community, role 4 (primary admin) only of MD Run Club + MN Painters. Visiting \`/admin/features\` from FOUNT in prod hit \`requirePrimaryAdmin\` → \`Primary Admin role required\` → Convex \"Server Error\" → Sentry.

## Changes

**Backend** (\`apps/convex/functions/admin/featureFlags.ts\`):
- \`listFeatureFlags\` and \`setFeatureFlag\` drop the \`communityId\` arg.
- Both gate via a small inline \`requireSuperuser\` (matches the \`isStaff || isSuperuser\` pattern already used in \`proposals.ts\` and \`posters.ts\`).
- Removed the \`requirePrimaryAdmin\` import.

**Frontend** (\`apps/mobile/features/admin/components/FeatureFlagsContent.tsx\`):
- Drop \`communityId\` from query/mutation calls.
- Non-superusers see a \"managed by Togather staff\" empty state instead of triggering the Convex auth error.
- Intro copy: \"App-wide feature flags. Changes take effect immediately for every user across every community.\"

## Test plan

- [x] Convex \`npx tsc --noEmit\`: clean.
- [x] Mobile \`npx tsc --noEmit\`: zero errors in changed files.
- [x] Convex unit: 1408/1408 pass.
- [ ] Prod smoke: visit \`/admin/features\` as Seyi → flags load (regardless of active community); toggle \`direct-messages\` → chat goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)