### PR TITLE
fix(chat): photo-gated DM accept shows CTA, not Server Error

### DIFF
--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -131,7 +131,9 @@ const isActiveMembership = (status: number | undefined) => status !== 3;
 /**
  * Hard requirement: chats are restricted to people who have a profile photo.
  *
- * Throws `PROFILE_PHOTO_REQUIRED` if `userId` lacks one. Caller-side; if the
+ * Throws `ConvexError("PROFILE_PHOTO_REQUIRED")` if `userId` lacks one — using
+ * `ConvexError` so the message reaches the client in production (Convex
+ * sanitizes `new Error(...)` messages to "Server Error"). Caller-side; if the
  * gate needs to surface a specific recipient userId, the caller throws
  * `RECIPIENT_PROFILE_PHOTO_REQUIRED:<userId>` instead so the frontend can
  * format a per-user prompt.
@@ -142,7 +144,7 @@ async function requireProfilePhoto(
 ): Promise<void> {
   const user = await ctx.db.get(userId);
   if (!user?.profilePhoto || user.profilePhoto.trim() === "") {
-    throw new Error("PROFILE_PHOTO_REQUIRED");
+    throw new ConvexError("PROFILE_PHOTO_REQUIRED");
   }
 }
 
@@ -492,15 +494,15 @@ export const respondToChatRequest = mutation({
       )
       .first();
     if (!membership) {
-      throw new Error("Not a member of this channel");
+      throw new ConvexError("Not a member of this channel");
     }
     if (membership.requestState !== "pending") {
-      throw new Error("This chat is not pending response");
+      throw new ConvexError("This chat is not pending response");
     }
 
     const channel = await ctx.db.get(args.channelId);
     if (!channel) {
-      throw new Error("Channel not found");
+      throw new ConvexError("Channel not found");
     }
     if (!channel.isAdHoc) {
       throw new ConvexError({
@@ -535,7 +537,7 @@ export const respondToChatRequest = mutation({
     // response === "block"
     const inviterId = membership.invitedById;
     if (!inviterId) {
-      throw new Error("Cannot block: inviter unknown");
+      throw new ConvexError("Cannot block: inviter unknown");
     }
 
     await ctx.db.patch(membership._id, {

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -4,7 +4,7 @@
  * Send, edit, delete, and list messages with pagination.
  */
 
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation, internalMutation } from "../../_generated/server";
 import type { QueryCtx, MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
@@ -658,7 +658,7 @@ export const sendMessage = mutation({
         !sender?.profilePhoto ||
         sender.profilePhoto.trim() === ""
       ) {
-        throw new Error("PROFILE_PHOTO_REQUIRED");
+        throw new ConvexError("PROFILE_PHOTO_REQUIRED");
       }
 
       const otherMembers = await ctx.db

--- a/apps/mobile/app/inbox/requests.tsx
+++ b/apps/mobile/app/inbox/requests.tsx
@@ -73,9 +73,15 @@ export default function ChatRequestsRoute() {
 function ChatRequestsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { token, community } = useAuth();
+  const { token, community, user } = useAuth();
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
+
+  // Profile-photo gate mirrors the chat-room composer (`ConvexChatRoomScreen`).
+  // Backend `respondToChatRequest` enforces it on accept; surfacing a clear
+  // CTA here avoids a useless "Server Error" alert when the user lacks a photo.
+  const needsProfilePhoto =
+    !user?.profile_photo || user.profile_photo.trim() === "";
 
   const communityId = community?.id as Id<"communities"> | undefined;
 
@@ -309,8 +315,13 @@ function ChatRequestsScreen() {
             primaryColor={primaryColor}
             colors={colors}
             pendingAction={pendingAction}
+            needsProfilePhoto={needsProfilePhoto}
             onClose={closeSheet}
             onAccept={handleAccept}
+            onAddPhoto={() => {
+              setSelectedRequest(null);
+              router.push("/(user)/edit-profile" as any);
+            }}
             onDecline={handleDecline}
             onBlock={handleBlock}
           />
@@ -325,8 +336,10 @@ function RequestSheetContent({
   primaryColor,
   colors,
   pendingAction,
+  needsProfilePhoto,
   onClose,
   onAccept,
+  onAddPhoto,
   onDecline,
   onBlock,
 }: {
@@ -334,8 +347,10 @@ function RequestSheetContent({
   primaryColor: string;
   colors: ReturnType<typeof useTheme>["colors"];
   pendingAction: "accept" | "decline" | "block" | null;
+  needsProfilePhoto: boolean;
   onClose: () => void;
   onAccept: () => void;
+  onAddPhoto: () => void;
   onDecline: () => void;
   onBlock: () => void;
 }) {
@@ -436,19 +451,41 @@ function RequestSheetContent({
           { paddingBottom: insets.bottom + 16 },
         ]}
       >
-        <TouchableOpacity
-          style={[styles.actionButton, { backgroundColor: primaryColor }]}
-          onPress={onAccept}
-          disabled={isBusy}
-        >
-          {pendingAction === "accept" ? (
-            <ActivityIndicator size="small" color="#fff" />
-          ) : (
-            <Text style={[styles.actionButtonText, { color: "#fff" }]}>
-              Accept
+        {needsProfilePhoto ? (
+          <>
+            <Text
+              style={[
+                styles.gateHelpText,
+                { color: colors.textSecondary },
+              ]}
+            >
+              Add a profile photo to accept this chat.
             </Text>
-          )}
-        </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: primaryColor }]}
+              onPress={onAddPhoto}
+              disabled={isBusy}
+            >
+              <Text style={[styles.actionButtonText, { color: "#fff" }]}>
+                Add photo
+              </Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <TouchableOpacity
+            style={[styles.actionButton, { backgroundColor: primaryColor }]}
+            onPress={onAccept}
+            disabled={isBusy}
+          >
+            {pendingAction === "accept" ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text style={[styles.actionButtonText, { color: "#fff" }]}>
+                Accept
+              </Text>
+            )}
+          </TouchableOpacity>
+        )}
 
         <TouchableOpacity
           style={[
@@ -655,5 +692,10 @@ const styles = StyleSheet.create({
   actionButtonText: {
     fontSize: 16,
     fontWeight: "600",
+  },
+  gateHelpText: {
+    fontSize: 14,
+    textAlign: "center",
+    marginBottom: 4,
   },
 });


### PR DESCRIPTION
## Summary
- /inbox/requests Accept currently throws `PROFILE_PHOTO_REQUIRED` from `requireProfilePhoto`, which Convex sanitizes to "Server Error" in production. Recipients without a profile photo see a raw, unactionable alert ([screenshot context: prod incident, group_dm `nd77ey2s393s4fhbyhm56vj72x85qgth`, both pending recipients had no photo]).
- Mirror the chat-room composer's gate (`ConvexChatRoomScreen.tsx:1107-1141`): when the responder has no `profile_photo`, replace Accept with an "Add a profile photo to accept this chat" CTA that routes to `/(user)/edit-profile`. Decline and Block stay enabled.
- Defense-in-depth: convert the user-actionable `new Error(...)` throws in `requireProfilePhoto`, `respondToChatRequest`, and the ad-hoc-channel `sendMessage` photo gate to `ConvexError`, so if the gate is ever hit (race, stale client, other path) the client sees the message instead of "Server Error". Existing `classifyProfilePhotoError` regex keeps working — `e.message` still includes the data string.

## Test plan
- [x] Convex `pnpm exec vitest run __tests__/messaging` — 405/405 pass
- [x] `directMessages.test.ts` — 33/33 pass (existing `rejects.toThrow(/PROFILE_PHOTO_REQUIRED/)` matchers still match against `ConvexError`)
- [x] Mobile `tsc --noEmit` — no new errors in `apps/mobile/app/inbox/requests.tsx` (pre-existing errors elsewhere on main are unaffected)
- [ ] Manual: as a user with no profile photo, open `/inbox/requests`, tap a request → see "Add photo" CTA, not Accept. Tapping it routes to `/(user)/edit-profile` and dismisses the sheet.
- [ ] Manual: as a user with a photo, the modal still shows Accept and the existing flow works.
- [ ] Manual: Decline + Block & Report still work without a photo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)