### PR TITLE
fix(chat): DMs get the same thread reply UX as group channels

### DIFF
--- a/apps/mobile/app/inbox/dm/[channelId]/_layout.tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/_layout.tsx
@@ -18,6 +18,7 @@ export default function DmChannelLayout() {
     >
       <Stack.Screen name="index" options={{ animation: "none" }} />
       <Stack.Screen name="info" options={{ animation: "slide_from_right" }} />
+      <Stack.Screen name="thread" options={{ animation: "slide_from_right" }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/inbox/dm/[channelId]/thread/[messageId].tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/thread/[messageId].tsx
@@ -1,0 +1,34 @@
+/**
+ * DM Thread Page Route
+ *
+ * Route: /inbox/dm/[channelId]/thread/[messageId]
+ *
+ * Mirrors `/inbox/[groupId]/thread/[messageId]` for ad-hoc DMs and group_dms,
+ * which have a `communityId` instead of a `groupId`. Renders the same
+ * `ThreadPage` component in DM mode (no leader/admin role concept; back-nav
+ * returns to the DM channel).
+ */
+import { useLocalSearchParams } from "expo-router";
+import type { Id } from "@services/api/convex";
+import { ThreadPage } from "@features/chat/components/ThreadPage";
+
+type DmThreadRouteParams = {
+  channelId: string;
+  messageId: string;
+};
+
+export default function DmThreadRoute() {
+  const params = useLocalSearchParams<DmThreadRouteParams>();
+  const { channelId, messageId } = params;
+
+  if (!channelId || !messageId) {
+    return null;
+  }
+
+  return (
+    <ThreadPage
+      messageId={messageId as Id<"chatMessages">}
+      dmChannelId={channelId as Id<"chatChannels">}
+    />
+  );
+}

--- a/apps/mobile/app/inbox/dm/[channelId]/thread/_layout.tsx
+++ b/apps/mobile/app/inbox/dm/[channelId]/thread/_layout.tsx
@@ -1,0 +1,22 @@
+import { Stack } from "expo-router";
+
+/**
+ * Layout for DM thread routes
+ *
+ * Mirrors `apps/mobile/app/inbox/[groupId]/thread/_layout.tsx`. Required so
+ * Expo Router resolves the directory as a nested navigator with screen name
+ * "thread", matching the parent `[channelId]/_layout.tsx` declaration.
+ * Without it the route flattens to "thread/[messageId]" and can trigger
+ * navigator re-render loops.
+ */
+export default function DmThreadLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen name="[messageId]" options={{ animation: "none" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -56,6 +56,7 @@ import { useConvexChannelFromGroup } from "../hooks/useConvexChannelFromGroup";
 import { useReadState } from "../hooks/useReadState";
 import { useTypingIndicators } from "../hooks/useTypingIndicators";
 import { useSendMessage } from "../hooks/useConvexSendMessage";
+import { useParentMessage } from "../hooks/useParentMessage";
 import { BlockedUsersProvider, useBlockedUsersContext } from "../context/BlockedUsersContext";
 import { useMutation, useAction } from "@services/api/convex";
 import { useGroupCache } from "@/stores/groupCache";
@@ -399,6 +400,11 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const [selectedMessageSenderPhoto, setSelectedMessageSenderPhoto] = useState<string | undefined>();
   const [selectedMessageAttachments, setSelectedMessageAttachments] = useState<Array<{ type: string; url: string }> | undefined>();
   const [replyToMessageId, setReplyToMessageId] = useState<Id<"chatMessages"> | null>(null);
+
+  // Load the parent message when a reply is in progress so the composer can
+  // show a real "Replying to <name>: <preview>" banner instead of the empty
+  // placeholder it used to render.
+  const { message: replyParentMessage } = useParentMessage(replyToMessageId);
 
   // Sync modal state
   const [syncModalVisible, setSyncModalVisible] = useState(false);
@@ -1148,7 +1154,15 @@ const ConvexChatRoomScreenInner: React.FC = () => {
             ) : canSendMessages ? (
               <MessageInput
                 channelId={activeChannelId ?? null}
-                replyToMessage={replyToMessageId ? { _id: replyToMessageId, content: "", senderName: "" } : null}
+                replyToMessage={
+                  replyToMessageId
+                    ? {
+                        _id: replyToMessageId,
+                        content: replyParentMessage?.content ?? "",
+                        senderName: replyParentMessage?.senderName ?? "",
+                      }
+                    : null
+                }
                 onCancelReply={handleCancelReply}
                 externalSendMessage={sendMessage}
                 externalIsSending={isSending}

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -786,7 +786,9 @@ function MessageItemInner({
   };
 
 
-  // Handle thread press - navigate to thread page
+  // Handle thread press — navigate to thread page. Group channels and DMs
+  // have parallel routes (`/inbox/[groupId]/thread/...` vs
+  // `/inbox/dm/[channelId]/thread/...`); pick by which context we're in.
   const handleThreadPress = useCallback(() => {
     if (groupId) {
       router.push({
@@ -795,8 +797,12 @@ function MessageItemInner({
           channelName: channelName || 'general',
         },
       });
+    } else {
+      router.push({
+        pathname: `/inbox/dm/${message.channelId}/thread/${message._id}` as any,
+      });
     }
-  }, [router, groupId, message._id, channelName]);
+  }, [router, groupId, message._id, message.channelId, channelName]);
 
   // Render reach-out request card (embedded in normal message layout)
   const renderReachOutCard = () => {
@@ -825,7 +831,7 @@ function MessageItemInner({
         parentMessageId={message._id}
         channelId={message.channelId}
         replyCount={replyCount}
-        onPress={groupId ? handleThreadPress : undefined}
+        onPress={handleThreadPress}
       />
     );
   };

--- a/apps/mobile/features/chat/components/ThreadPage.tsx
+++ b/apps/mobile/features/chat/components/ThreadPage.tsx
@@ -37,13 +37,25 @@ import { MessageActionsOverlay } from "./MessageActionsOverlay";
 
 interface ThreadPageProps {
   messageId: Id<"chatMessages">;
-  groupId: Id<"groups">;
+  /**
+   * Group context for group-channel threads. Mutually exclusive with
+   * `dmChannelId` — exactly one is required. When set, the page uses
+   * group leader/admin checks and routes back-nav to the group channel.
+   */
+  groupId?: Id<"groups">;
+  /**
+   * Ad-hoc channel context for DM/group_dm threads. Set when threading
+   * inside a `/inbox/dm/[channelId]` flow. There's no leader/admin role
+   * concept for DMs; back-nav returns to the DM channel.
+   */
+  dmChannelId?: Id<"chatChannels">;
   channelName?: string;
 }
 
 export function ThreadPage({
   messageId,
   groupId,
+  dmChannelId,
   channelName,
 }: ThreadPageProps) {
   const insets = useSafeAreaInsets();
@@ -55,7 +67,9 @@ export function ThreadPage({
   const currentUserId = user?.id as Id<"users"> | undefined;
   const flashListRef = useRef<FlashListRef<any>>(null);
 
-  // Fetch group details to determine if user is a leader
+  // Fetch group details to determine if user is a leader. DMs have no
+  // leader/admin role concept — `useGroupDetails` is called with undefined
+  // (skipped inside the hook) and `isUserLeader` stays false.
   const { data: groupDetails } = useGroupDetails(groupId);
   const isUserLeader =
     groupDetails?.user_role === "leader" ||
@@ -98,10 +112,19 @@ export function ThreadPage({
   const handleBack = useCallback(() => {
     if (router.canGoBack()) {
       router.back();
-    } else {
-      router.replace(`/inbox/${groupId}/general`);
+      return;
     }
-  }, [router, groupId]);
+    // Fallback when there's no back stack (deep-link / restored state).
+    // Group threads return to the group's general channel; DM threads
+    // return to the DM channel surface.
+    if (groupId) {
+      router.replace(`/inbox/${groupId}/general`);
+    } else if (dmChannelId) {
+      router.replace(`/inbox/dm/${dmChannelId}` as any);
+    } else {
+      router.replace("/(tabs)/chat");
+    }
+  }, [router, groupId, dmChannelId]);
 
   // Message action handlers
   const handleLongPressMessage = useCallback((


### PR DESCRIPTION
## Summary
Replies in DMs were broken three ways. Group-channel parity:

- **Empty reply preview**: `ConvexChatRoomScreen.tsx` passed a hardcoded `{ _id, content: "", senderName: "" }` to `MessageInput`, so the "Replying to …" banner rendered with no name and no quoted text. Now loads the parent via `useParentMessage(replyToMessageId)` and passes real values.
- **Replies vanished**: `getMessages` filters out any message with a `parentMessageId` — they only render inside a thread page. DMs had no thread page, so replies were unreachable.
- **Thread nav was groupId-gated**: `MessageItem.handleThreadPress` only ran `if (groupId)` and `<ThreadReplies onPress={...} />` was wired to `undefined` for DMs. The "1 reply" indicator was non-tappable.

Fix:
- Add `/inbox/dm/[channelId]/thread/[messageId]` (mirrors the group route).
- Generalize `ThreadPage` to accept either `groupId` or `dmChannelId` — DMs skip the leader/admin check (no role concept) and back-nav returns to `/inbox/dm/<channelId>`.
- `MessageItem.handleThreadPress` picks the route by context (group vs DM) instead of refusing to navigate.

## Test plan
- [x] Mobile `tsc --noEmit` — no new errors in changed files (only pre-existing errors elsewhere remain)
- [ ] Manual: in a DM, long-press a message → Reply → composer shows "Replying to <name>: <preview>" (was blank)
- [ ] Manual: send the reply → it disappears from the main DM list (expected — thread reply), parent shows "1 reply"
- [ ] Manual: tap "1 reply" on the parent → navigates to `/inbox/dm/<channelId>/thread/<messageId>` and shows the parent + replies
- [ ] Manual: send another reply from the thread page → appears inline; back arrow returns to the DM
- [ ] Manual: same flow in a group channel → unchanged behavior, still routes to `/inbox/<groupId>/thread/<messageId>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)