### PR TITLE
fix(chat): drop 1-message-per-24h cap on pending DMs

### DIFF
--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -408,7 +408,13 @@ describe("respondToChatRequest", () => {
 // ============================================================================
 
 describe("sendMessage gating on pending channels", () => {
-  test("rate limit: sender can only send 1 message to a pending recipient per 24h", async () => {
+  test("inviter can send multiple messages while a recipient is still pending", async () => {
+    // Regression: a 1-message-per-24h cap used to fire here as a stranger-spam
+    // defense, but ad-hoc channels are scoped to shared community membership
+    // (recipient and sender aren't strangers) and the cap surfaced as an
+    // unactionable "failed" error on legitimate follow-ups before acceptance.
+    // Multiple sends are now allowed; only the per-message length cap and the
+    // attachments restriction remain active until acceptance.
     const t = convexTest(schema, modules);
     const communityId = await createCommunity(t, "Rate Community");
     const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
@@ -431,14 +437,31 @@ describe("sendMessage gating on pending channels", () => {
     });
     await t.finishInProgressScheduledFunctions();
 
-    // Second send should be rate-limited.
-    await expect(
-      t.mutation(api.functions.messaging.messages.sendMessage, {
-        token: aToken,
-        channelId,
-        content: "hello again",
-      }),
-    ).rejects.toThrow(/1 message|accept/i);
+    // Subsequent messages also succeed while Bob is still pending.
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "hello again",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "and once more",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    // Verify all three landed in the channel.
+    const stored = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect(),
+    );
+    expect(stored.map((m) => m.content).sort()).toEqual(
+      ["and once more", "hello", "hello again"].sort(),
+    );
 
     // Drain again at end-of-test — `finishInProgressScheduledFunctions` only
     // runs ONE round, but the notification chain (onMessageSent →

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -627,12 +627,17 @@ export const sendMessage = mutation({
 
     const now = Date.now();
 
-    // Ad-hoc DM/group_dm gating: while ANY recipient is still in `requestState: "pending"`,
-    // restrict the sender to text-only, ≤1000 chars, and 1 message per 24h per pending pair.
-    // Sender themselves must be in `requestState: "accepted"` (declined/leftAt rows already
-    // bounced by the membership check above). `pendingOthers` is reused after insert to
-    // upsert the rate-limit rows.
-    let pendingOthersForRateLimit: Array<{ userId: Id<"users"> }> = [];
+    // Ad-hoc DM/group_dm gating: while ANY recipient is still in
+    // `requestState: "pending"`, restrict the sender to text-only and
+    // ≤1000 chars per message. Sender themselves must be in
+    // `requestState: "accepted"` (declined/leftAt rows already bounced by
+    // the membership check above).
+    //
+    // Historically there was also a 1-message-per-24h cap per pending pair,
+    // intended as a stranger-spam defense. It was removed because ad-hoc
+    // channels are already scoped to shared community membership — the
+    // recipient and sender aren't strangers — and the cap surfaced as a
+    // confusing "failed" error on legitimate follow-ups before acceptance.
     if (channel.isAdHoc) {
       const senderMembership = await ctx.db
         .query("chatChannelMembers")
@@ -645,7 +650,7 @@ export const sendMessage = mutation({
         senderMembership.leftAt !== undefined ||
         senderMembership.requestState !== "accepted"
       ) {
-        throw new Error("Accept the request before replying");
+        throw new ConvexError("Accept the request before replying");
       }
 
       // Profile photo is a hard requirement on every send to an ad-hoc
@@ -682,53 +687,27 @@ export const sendMessage = mutation({
           )
           .first();
         if (block) {
-          throw new Error("Cannot send message in this chat");
+          throw new ConvexError("Cannot send message in this chat");
         }
       }
 
-      const pendingOthers = otherMembers.filter(
+      const hasPendingOthers = otherMembers.some(
         (m) => m.userId !== userId && m.requestState === "pending",
       );
 
-      if (pendingOthers.length > 0) {
-        const PENDING_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+      if (hasPendingOthers) {
         const PENDING_MAX_TEXT_LENGTH = 1000;
 
         if (args.attachments && args.attachments.length > 0) {
-          throw new Error(
+          throw new ConvexError(
             "Cannot send attachments until the recipient accepts the request",
           );
         }
         if (args.content.length > PENDING_MAX_TEXT_LENGTH) {
-          throw new Error(
-            `First message must be ${PENDING_MAX_TEXT_LENGTH} characters or fewer until accepted`,
+          throw new ConvexError(
+            `Messages must be ${PENDING_MAX_TEXT_LENGTH} characters or fewer until the recipient accepts`,
           );
         }
-
-        for (const r of pendingOthers) {
-          const rl = await ctx.db
-            .query("directMessageRateLimits")
-            .withIndex("by_user_channel_recipient", (q) =>
-              q
-                .eq("userId", userId)
-                .eq("channelId", channelId)
-                .eq("recipientUserId", r.userId),
-            )
-            .first();
-          if (
-            rl &&
-            rl.windowStartedAt > now - PENDING_RATE_LIMIT_WINDOW_MS &&
-            rl.messageCount >= 1
-          ) {
-            throw new Error(
-              "You can send only 1 message until the recipient accepts the request",
-            );
-          }
-        }
-
-        pendingOthersForRateLimit = pendingOthers.map((r) => ({
-          userId: r.userId,
-        }));
       }
     }
 
@@ -780,34 +759,6 @@ export const sendMessage = mutation({
         await ctx.db.patch(args.parentMessageId, {
           threadReplyCount: (parentMessage.threadReplyCount || 0) + 1,
           lastActivityAt: now,
-        });
-      }
-    }
-
-    // Upsert rate-limit rows for each pending recipient. Done after a successful
-    // insert so a thrown rate-limit error doesn't leave stray counters behind.
-    for (const r of pendingOthersForRateLimit) {
-      const existingRl = await ctx.db
-        .query("directMessageRateLimits")
-        .withIndex("by_user_channel_recipient", (q) =>
-          q
-            .eq("userId", userId)
-            .eq("channelId", channelId)
-            .eq("recipientUserId", r.userId),
-        )
-        .first();
-      if (existingRl) {
-        await ctx.db.patch(existingRl._id, {
-          windowStartedAt: now,
-          messageCount: 1,
-        });
-      } else {
-        await ctx.db.insert("directMessageRateLimits", {
-          userId,
-          channelId,
-          recipientUserId: r.userId,
-          windowStartedAt: now,
-          messageCount: 1,
         });
       }
     }


### PR DESCRIPTION
## Summary
Ad-hoc DM/group_dm `sendMessage` enforced a 1-message-per-pending-pair-per-24h cap as stranger-spam defense. Users hit it on their second message before the recipient had time to accept, and the throw was `new Error(...)` so Convex sanitized it to "Server Error" / "failed" with no signal that the cap was the problem.

Drop the cap entirely. Ad-hoc channels are already scoped to shared community membership — sender and recipient aren't strangers — so the original concern doesn't really apply. Also stop writing to \`directMessageRateLimits\` (table left in schema as orphan; follow-up cleanup PR can drop it once we confirm no other readers).

Defense-in-depth kept while a recipient is still pending:
- Attachments still rejected.
- Per-message text length still capped at 1000 chars.
- All these throws (plus "Accept the request before replying" and the block-recipient throw) now use \`ConvexError\` so the actual message reaches the client.

## Test plan
- [x] \`__tests__/messaging/directMessages.test.ts\`: replaced the rate-limit test with a positive "inviter can send multiple messages while pending" test — 33/33 pass.
- [x] Full messaging suite: 405/405 pass.
- [x] Convex \`tsc --noEmit\` clean.
- [ ] Manual: in a fresh DM, send first message → succeeds; send second message immediately → also succeeds (was "failed" before).
- [ ] Manual: try to attach an image while recipient still pending → clear "Cannot send attachments…" error reaches the UI (was sanitized).
- [ ] Manual: type >1000 chars while pending → clear length error reaches the UI.

## Follow-up
The \`directMessageRateLimits\` table is now unused. Leaving in schema for one release to be safe; can be dropped in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)