### PR TITLE
fix(chat): clearer error on Accept (Sentry — Server Error masking)

### DIFF
--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -490,13 +490,26 @@ export const respondToChatRequest = mutation({
     // "Server Error" (which `throw new Error` produces in production mode).
     // See Sentry — recipients tapping Accept were getting an opaque "Server
     // Error" alert with no signal that they needed to re-authenticate.
+    //
+    // Catch is NARROWED to actual auth failures only. `requireAuth` performs
+    // DB lookups internally; a transient DB/runtime error from those would
+    // otherwise be misdiagnosed as a session-expiry issue, masking real
+    // server faults during incidents. Only the documented auth-failure
+    // messages get the friendly rewrite; everything else re-throws.
     let userId: Id<"users">;
     try {
       userId = await requireAuth(ctx, args.token);
-    } catch {
-      throw new ConvexError(
-        "Your sign-in has expired. Pull down to refresh, then try again.",
-      );
+    } catch (err) {
+      // Only the explicit "Not authenticated" message — every other failure
+      // (DB hiccup, runtime error inside requireAuth's internal lookups)
+      // re-throws so prod incidents aren't misdiagnosed as auth issues.
+      const message = err instanceof Error ? err.message : "";
+      if (message === "Not authenticated") {
+        throw new ConvexError(
+          "Your sign-in has expired. Pull down to refresh, then try again.",
+        );
+      }
+      throw err;
     }
 
     const membership = await ctx.db

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -485,7 +485,19 @@ export const respondToChatRequest = mutation({
     reportReason: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ ok: true }> => {
-    const userId = await requireAuth(ctx, args.token);
+    // Wrap requireAuth so a stale/invalidated token surfaces as a user-
+    // actionable message instead of getting masked as the generic Convex
+    // "Server Error" (which `throw new Error` produces in production mode).
+    // See Sentry — recipients tapping Accept were getting an opaque "Server
+    // Error" alert with no signal that they needed to re-authenticate.
+    let userId: Id<"users">;
+    try {
+      userId = await requireAuth(ctx, args.token);
+    } catch {
+      throw new ConvexError(
+        "Your sign-in has expired. Pull down to refresh, then try again.",
+      );
+    }
 
     const membership = await ctx.db
       .query("chatChannelMembers")
@@ -496,8 +508,20 @@ export const respondToChatRequest = mutation({
     if (!membership) {
       throw new ConvexError("Not a member of this channel");
     }
+    // Accept on an already-accepted membership is idempotent — the user
+    // probably double-tapped or got a stale UI; quietly succeed instead of
+    // throwing a confusing "not pending" error.
+    if (
+      args.response === "accept" &&
+      membership.requestState === "accepted" &&
+      membership.leftAt === undefined
+    ) {
+      return { ok: true };
+    }
     if (membership.requestState !== "pending") {
-      throw new ConvexError("This chat is not pending response");
+      throw new ConvexError(
+        "This chat is no longer waiting for a response.",
+      );
     }
 
     const channel = await ctx.db.get(args.channelId);


### PR DESCRIPTION
> Replaces #361 — that PR accidentally committed 27 unrelated files. Please close #361. This is the clean one-file version.

## Summary

A recipient tapping **Accept** on a chat request was getting an opaque \"[CONVEX M(...directMessages:respondToChatRequest)] [Request ID: ec9b7b6dcf7bc863] Server Error\" alert (screenshot in the bug report).

## Root cause

\`requireAuth\` throws \`new Error(\"Not authenticated\")\` for an expired/revoked token. Convex hides plain-Error messages as \"Server Error\" in prod (only \`ConvexError\` messages surface). The recipient's auth token most likely expired between page load (\`listChatRequests\` succeeded) and the Accept tap.

## Changes

- Wrap \`requireAuth\` in \`respondToChatRequest\` to re-throw as \`ConvexError\`:
  > Your sign-in has expired. Pull down to refresh, then try again.
- Make Accept idempotent — if the caller's membership is already \`accepted\` and not left, return \`{ ok: true }\` instead of throwing \"not pending response\". Covers double-taps / stale UI.

## Test plan

- [x] Convex \`tsc --noEmit\`: clean.
- [x] Convex unit: 33/33 pass in \`directMessages.test.ts\`.
- [ ] Prod smoke: recipient with expired token taps Accept → sees \"Your sign-in has expired\" instead of \"Server Error\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)