### PR TITLE
feat(group,chat): DM-sleek group page + dedicated channel info screen

### DIFF
--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -332,19 +332,31 @@ export const getChannelBySlug = query({
     token: v.string(),
     groupId: v.id("groups"),
     slug: v.string(),
+    /**
+     * Include channels that are leader-disabled or archived. The channel info
+     * screen (`/info` route) sets this so a leader can land on a disabled
+     * Leaders / Reach Out channel and re-enable it from the Active state row.
+     * For Leaders / Reach Out / main, `isArchived` is the legacy-disable flag
+     * (NOT a tombstone) — without this flag the row is silently filtered out
+     * and the screen shows "no longer available." Defaults to false.
+     */
+    includeArchived: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     // 1. Authenticate user
     const userId = await requireAuth(ctx, args.token);
 
-    // 2. Query by_group_slug index for the channel (exclude archived channels)
-    const channel = await ctx.db
+    const archiveFilter = args.includeArchived === true;
+
+    // 2. Query by_group_slug index for the channel
+    const channelQuery = ctx.db
       .query("chatChannels")
       .withIndex("by_group_slug", (q) =>
         q.eq("groupId", args.groupId).eq("slug", args.slug)
-      )
-      .filter((q) => q.eq(q.field("isArchived"), false))
-      .first();
+      );
+    const channel = archiveFilter
+      ? await channelQuery.first()
+      : await channelQuery.filter((q) => q.eq(q.field("isArchived"), false)).first();
 
     // Also try matching by channelType for backwards compatibility
     // (e.g., "general" might be stored as slug, but "main" is channelType)
@@ -357,15 +369,14 @@ export const getChannelBySlug = query({
       };
       const channelType = slugToType[args.slug];
       if (channelType) {
-        // Filter out archived channels in the query to avoid returning archived
-        // channels when multiple channels of the same type exist
-        resolvedChannel = await ctx.db
+        const typeQuery = ctx.db
           .query("chatChannels")
           .withIndex("by_group_type", (q) =>
             q.eq("groupId", args.groupId).eq("channelType", channelType)
-          )
-          .filter((q) => q.eq(q.field("isArchived"), false))
-          .first();
+          );
+        resolvedChannel = archiveFilter
+          ? await typeQuery.first()
+          : await typeQuery.filter((q) => q.eq(q.field("isArchived"), false)).first();
       }
     }
 

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/__tests__/members.test.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/__tests__/members.test.tsx
@@ -313,14 +313,20 @@ describe("ChannelMembersScreen", () => {
       expect(removeIcons.length).toBe(2);
     });
 
-    it("shows archive button for custom channel owner", () => {
-      const { getByText } = render(<ChannelMembersScreen />);
-      expect(getByText("Archive Channel")).toBeTruthy();
+    // Archive button moved to the channel info screen (Leader Controls).
+    // The /members surface is now focused on member management only.
+    it("does NOT show archive button for custom channel owner", () => {
+      const { queryByText } = render(<ChannelMembersScreen />);
+      expect(queryByText("Archive Channel")).toBeNull();
     });
 
-    it("renders bottom actions container when actions are available", () => {
-      const { getByTestId } = render(<ChannelMembersScreen />);
+    it("renders bottom actions container with Share with Groups for owner", () => {
+      // Archive button moved off this surface; the bottom actions
+      // container is still rendered for primary-group leaders because
+      // "Share with Groups" lives there.
+      const { getByTestId, getByText } = render(<ChannelMembersScreen />);
       expect(getByTestId("bottom-actions")).toBeTruthy();
+      expect(getByText("Share with Groups")).toBeTruthy();
     });
   });
 
@@ -469,96 +475,9 @@ describe("ChannelMembersScreen", () => {
     });
   });
 
-  describe("Archive Channel", () => {
-    it("shows confirmation dialog when archiving", () => {
-      const { getByText } = render(<ChannelMembersScreen />);
-      const archiveButton = getByText("Archive Channel");
-
-      act(() => {
-        fireEvent.press(archiveButton.parent!);
-      });
-
-      expect(Alert.alert).toHaveBeenCalledWith(
-        "Archive Channel",
-        expect.stringContaining("Test Channel"),
-        expect.any(Array)
-      );
-    });
-
-    it("calls archiveChannelMutation after confirmation", async () => {
-      mockArchiveChannelMutation.mockResolvedValueOnce(undefined);
-
-      const { getByText } = render(<ChannelMembersScreen />);
-      const archiveButton = getByText("Archive Channel");
-
-      act(() => {
-        fireEvent.press(archiveButton.parent!);
-      });
-
-      const alertCalls = (Alert.alert as jest.Mock).mock.calls;
-      const alertButtons = alertCalls[0][2];
-      const confirmButton = alertButtons.find((b: any) => b.text === "Archive");
-
-      await act(async () => {
-        await confirmButton.onPress();
-      });
-
-      expect(mockArchiveChannelMutation).toHaveBeenCalledWith({
-        token: "mock-token",
-        channelId: "channel-1",
-      });
-    });
-
-    it("shows success alert and navigates after archiving", async () => {
-      mockArchiveChannelMutation.mockResolvedValueOnce(undefined);
-
-      const { getByText } = render(<ChannelMembersScreen />);
-      const archiveButton = getByText("Archive Channel");
-
-      act(() => {
-        fireEvent.press(archiveButton.parent!);
-      });
-
-      const alertCalls = (Alert.alert as jest.Mock).mock.calls;
-      const confirmButton = alertCalls[0][2].find((b: any) => b.text === "Archive");
-
-      await act(async () => {
-        await confirmButton.onPress();
-      });
-
-      await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith(
-          "Channel Archived",
-          "The channel has been archived.",
-          expect.any(Array)
-        );
-      });
-    });
-
-    it("shows error alert on archive failure", async () => {
-      mockArchiveChannelMutation.mockRejectedValueOnce(
-        new Error("Archive failed")
-      );
-
-      const { getByText } = render(<ChannelMembersScreen />);
-      const archiveButton = getByText("Archive Channel");
-
-      act(() => {
-        fireEvent.press(archiveButton.parent!);
-      });
-
-      const alertCalls = (Alert.alert as jest.Mock).mock.calls;
-      const confirmButton = alertCalls[0][2].find((b: any) => b.text === "Archive");
-
-      await act(async () => {
-        await confirmButton.onPress();
-      });
-
-      await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith("Error", "Archive failed");
-      });
-    });
-  });
+  // Archive Channel surface moved to the channel info screen
+  // (ChannelInfoScreen.tsx → Leader Controls › Archive channel). Tests
+  // for that flow now live alongside the info screen, not here.
 
   describe("Add Members Modal", () => {
     it("opens add member modal when add button is pressed", () => {

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/_layout.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/_layout.tsx
@@ -4,8 +4,11 @@ import { Stack } from "expo-router";
  * Layout for channel-specific routes
  *
  * Provides stack navigation for:
- * - /inbox/[groupId]/[channelSlug] - Channel chat (index)
- * - /inbox/[groupId]/[channelSlug]/members - Channel member management
+ * - /inbox/[groupId]/[channelSlug]                       - Channel chat (index)
+ * - /inbox/[groupId]/[channelSlug]/members               - Channel member management
+ * - /inbox/[groupId]/[channelSlug]/info                  - Channel info (DM-style)
+ * - /inbox/[groupId]/[channelSlug]/info/active-state     - Active/Disabled picker
+ * - /inbox/[groupId]/[channelSlug]/info/join-mode        - Open / Approval-required picker
  */
 export default function ChannelLayout() {
   return (
@@ -18,6 +21,16 @@ export default function ChannelLayout() {
       <Stack.Screen name="index" options={{ animation: "none" }} />
       {/* Members management - slide animation */}
       <Stack.Screen name="members" options={{ animation: "slide_from_right" }} />
+      {/* Channel info - slide animation */}
+      <Stack.Screen name="info/index" options={{ animation: "slide_from_right" }} />
+      <Stack.Screen
+        name="info/active-state"
+        options={{ animation: "slide_from_right" }}
+      />
+      <Stack.Screen
+        name="info/join-mode"
+        options={{ animation: "slide_from_right" }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
@@ -1,0 +1,448 @@
+/**
+ * Active state picker for a channel.
+ *
+ * Route: /inbox/[groupId]/[channelSlug]/info/active-state
+ *
+ * Explicit Active / Disabled choice with consequence text under each
+ * option — NOT a single-tap toggle. Wires to whichever toggle mutation
+ * exists per channel type:
+ *   - "leaders":      toggleLeadersChannel
+ *   - "reach_out":    toggleReachOutChannel
+ *   - "custom":       setCustomChannelLeaderEnabled
+ *   - "pco_services": togglePcoChannel
+ *   - "main":         toggleMainChannel  (the General row in the group
+ *                     page CHANNELS card always navigates to chat, so
+ *                     this path isn't currently reachable from the UI,
+ *                     but is wired for completeness)
+ *
+ * Reach Out: when the Leaders channel is disabled at the group level,
+ * the "Active" option is itself disabled and we surface a hint at the
+ * top so the user knows what to fix first.
+ */
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  Alert,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useAuth } from "@providers/AuthProvider";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import {
+  useQuery,
+  api,
+  useAuthenticatedMutation,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+export default function ChannelActiveStateRoute() {
+  const { groupId, channelSlug } = useLocalSearchParams<{
+    groupId: string;
+    channelSlug: string;
+  }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { token } = useAuth();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const channel = useQuery(
+    api.functions.messaging.channels.getChannelBySlug,
+    // includeArchived: this picker is the place a leader re-enables a
+    // disabled channel — must work even when `isArchived` is true (the
+    // legacy-disable state for Leaders/Reach Out/main).
+    token && groupId && channelSlug
+      ? {
+          token,
+          groupId: groupId as Id<"groups">,
+          slug: channelSlug,
+          includeArchived: true,
+        }
+      : "skip",
+  );
+
+  const groupChannels = useQuery(
+    api.functions.messaging.channels.listGroupChannels,
+    token && groupId
+      ? { token, groupId: groupId as Id<"groups">, includeArchived: true }
+      : "skip",
+  );
+
+  const toggleLeadersChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.toggleLeadersChannel,
+  );
+  const toggleReachOutChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.toggleReachOutChannel,
+  );
+  const toggleMainChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.toggleMainChannel,
+  );
+  const togglePcoChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.togglePcoChannel,
+  );
+  const setCustomChannelLeaderEnabledMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.setCustomChannelLeaderEnabled,
+  );
+
+  const [submitting, setSubmitting] = useState(false);
+
+  const channelType = channel?.channelType;
+  const currentEnabled = useMemo(() => {
+    if (!channel) return false;
+    return !channel.isArchived && (channel as any).isEnabled !== false;
+  }, [channel]);
+
+  const leadersChannel = groupChannels?.find(
+    (c: any) => c.channelType === "leaders",
+  );
+  const leadersEnabled =
+    !!leadersChannel && !leadersChannel.isArchived && leadersChannel.isEnabled !== false;
+
+  const isReachOutAndLeadersOff = channelType === "reach_out" && !leadersEnabled;
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(`/inbox/${groupId}/${channelSlug}/info` as any);
+    }
+  }, [router, groupId, channelSlug]);
+
+  const setActive = useCallback(
+    async (next: boolean) => {
+      if (!channel || !channelType || !groupId) return;
+      if (next === currentEnabled) {
+        // Already in this state.
+        return;
+      }
+      setSubmitting(true);
+      try {
+        if (channelType === "leaders") {
+          await toggleLeadersChannelMutation({
+            groupId: groupId as Id<"groups">,
+            enabled: next,
+          });
+        } else if (channelType === "reach_out") {
+          await toggleReachOutChannelMutation({
+            groupId: groupId as Id<"groups">,
+            enabled: next,
+          });
+        } else if (channelType === "main") {
+          await toggleMainChannelMutation({
+            groupId: groupId as Id<"groups">,
+            enabled: next,
+          });
+        } else if (channelType === "pco_services") {
+          await togglePcoChannelMutation({
+            channelId: channel._id,
+            enabled: next,
+            managingGroupId: groupId as Id<"groups">,
+          });
+        } else {
+          // custom
+          await setCustomChannelLeaderEnabledMutation({
+            channelId: channel._id,
+            enabled: next,
+            managingGroupId: groupId as Id<"groups">,
+          });
+        }
+        if (router.canGoBack()) {
+          router.back();
+        }
+      } catch (e: any) {
+        Alert.alert("Error", e?.message || "Failed to update channel");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      channel,
+      channelType,
+      groupId,
+      currentEnabled,
+      toggleLeadersChannelMutation,
+      toggleReachOutChannelMutation,
+      toggleMainChannelMutation,
+      togglePcoChannelMutation,
+      setCustomChannelLeaderEnabledMutation,
+      router,
+    ],
+  );
+
+  if (channel === undefined) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} />
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={primaryColor} />
+        </View>
+      </View>
+    );
+  }
+
+  if (!channel) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} />
+        <View style={styles.centered}>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+            This channel is no longer available.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      <Header onBack={handleBack} colors={colors} />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        {isReachOutAndLeadersOff && (
+          <View
+            style={[
+              styles.hintCard,
+              { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+            ]}
+          >
+            <Ionicons name="information-circle" size={18} color={colors.textSecondary} />
+            <Text style={[styles.hintText, { color: colors.textSecondary }]}>
+              Requires Leaders channel to be active
+            </Text>
+          </View>
+        )}
+
+        <Option
+          colors={colors}
+          primaryColor={primaryColor}
+          selected={currentEnabled}
+          disabled={submitting || isReachOutAndLeadersOff}
+          label="Active"
+          consequence={consequenceFor(channelType ?? "", true)}
+          onPress={() => setActive(true)}
+        />
+        <Option
+          colors={colors}
+          primaryColor={primaryColor}
+          selected={!currentEnabled}
+          disabled={submitting}
+          label="Disabled"
+          consequence={consequenceFor(channelType ?? "", false)}
+          onPress={() => setActive(false)}
+        />
+
+        {submitting && (
+          <View style={styles.submittingRow}>
+            <ActivityIndicator size="small" color={primaryColor} />
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+function consequenceFor(channelType: string, active: boolean): string {
+  if (channelType === "leaders") {
+    return active
+      ? "Leaders channel is visible to leaders and admins of this group."
+      : "Leaders channel is hidden. Reach Out also requires this to be active.";
+  }
+  if (channelType === "reach_out") {
+    return active
+      ? "Reach Out is available to leaders for one-on-one outreach."
+      : "Reach Out is hidden. Leaders won't see it in their tabs.";
+  }
+  if (channelType === "main") {
+    return active
+      ? "General is visible to all members."
+      : "General is hidden. Members will not be able to use it until you turn it back on.";
+  }
+  if (channelType === "pco_services") {
+    return active
+      ? "PCO synced channel is visible to its members."
+      : "PCO synced channel is hidden. Memberships are kept in case you re-enable it later.";
+  }
+  // custom
+  return active
+    ? "Custom channel is visible to its members."
+    : "Channel is hidden from members. No one is removed.";
+}
+
+function Option({
+  colors,
+  primaryColor,
+  selected,
+  disabled,
+  label,
+  consequence,
+  onPress,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  selected: boolean;
+  disabled: boolean;
+  label: string;
+  consequence: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={disabled ? undefined : onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.optionCard,
+        {
+          backgroundColor: pressed ? colors.selectedBackground : colors.surfaceSecondary,
+          borderColor: selected ? primaryColor : "transparent",
+          opacity: disabled && !selected ? 0.5 : 1,
+        },
+      ]}
+    >
+      <View style={styles.optionRow}>
+        <View
+          style={[
+            styles.radio,
+            {
+              borderColor: selected ? primaryColor : colors.border,
+            },
+          ]}
+        >
+          {selected && (
+            <View style={[styles.radioInner, { backgroundColor: primaryColor }]} />
+          )}
+        </View>
+        <Text style={[styles.optionLabel, { color: colors.text }]}>{label}</Text>
+      </View>
+      <Text style={[styles.optionConsequence, { color: colors.textSecondary }]}>
+        {consequence}
+      </Text>
+    </Pressable>
+  );
+}
+
+function Header({
+  onBack,
+  colors,
+}: {
+  onBack: () => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  return (
+    <View
+      style={[
+        styles.headerBar,
+        {
+          backgroundColor: colors.surface,
+          borderBottomColor: colors.border,
+        },
+      ]}
+    >
+      <TouchableOpacity onPress={onBack} style={styles.headerBackButton} hitSlop={12}>
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <Text style={[styles.headerTitle, { color: colors.text }]}>Active state</Text>
+      <View style={styles.headerSpacer} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scrollContent: { paddingVertical: 24, paddingHorizontal: 12, gap: 12 },
+  centered: {
+    paddingVertical: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  errorText: {
+    fontSize: 14,
+    textAlign: "center",
+  },
+  headerBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBackButton: {
+    padding: 4,
+    marginRight: 4,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  headerSpacer: { width: 36 },
+  hintCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  hintText: { fontSize: 13, flex: 1 },
+  optionCard: {
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 2,
+  },
+  optionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  radio: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  radioInner: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  optionLabel: {
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  optionConsequence: {
+    marginTop: 8,
+    marginLeft: 34,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  submittingRow: {
+    alignItems: "center",
+    paddingTop: 16,
+  },
+});

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/index.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/index.tsx
@@ -1,0 +1,30 @@
+/**
+ * Channel Info Route
+ *
+ * Route: /inbox/[groupId]/[channelSlug]/info
+ *
+ * Mounts `ChannelInfoScreen` for non-General channels. For General
+ * (channelType === "main") the group page IS the channel info, so we
+ * redirect there on mount.
+ *
+ * The "general" slug always maps to channelType "main", so the redirect
+ * fires synchronously without a flash of the info screen.
+ */
+import { Redirect, useLocalSearchParams } from "expo-router";
+import { ChannelInfoScreen } from "@features/chat/components/ChannelInfoScreen";
+
+export default function ChannelInfoRoute() {
+  const { groupId, channelSlug } = useLocalSearchParams<{
+    groupId: string;
+    channelSlug: string;
+  }>();
+
+  if (!groupId || !channelSlug) return null;
+
+  // General -> the group page IS the info surface for the main channel.
+  if (channelSlug === "general") {
+    return <Redirect href={`/groups/${groupId}` as any} />;
+  }
+
+  return <ChannelInfoScreen groupId={groupId} channelSlug={channelSlug} />;
+}

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/join-mode.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/join-mode.tsx
@@ -1,0 +1,305 @@
+/**
+ * Join mode picker for a custom channel.
+ *
+ * Route: /inbox/[groupId]/[channelSlug]/info/join-mode
+ *
+ * Explicit Open / Approval-required choice with consequence text. Replaces
+ * the swap-icon toggle that used to live next to the invite-link banner on
+ * the /members screen — leaders now reach this from a dedicated row in the
+ * channel info Leader Controls card.
+ *
+ * Custom channels only: leaders/reach_out/main don't have an invite link,
+ * and PCO channels are sync-driven. Backend will reject other types via
+ * `updateJoinMode` even if we forget to gate at the UI.
+ */
+import React, { useCallback, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  Alert,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useAuth } from "@providers/AuthProvider";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import {
+  useQuery,
+  api,
+  useAuthenticatedMutation,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+type JoinMode = "open" | "approval_required";
+
+export default function ChannelJoinModeRoute() {
+  const { groupId, channelSlug } = useLocalSearchParams<{
+    groupId: string;
+    channelSlug: string;
+  }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { token } = useAuth();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const channel = useQuery(
+    api.functions.messaging.channels.getChannelBySlug,
+    token && groupId && channelSlug
+      ? {
+          token,
+          groupId: groupId as Id<"groups">,
+          slug: channelSlug,
+          includeArchived: true,
+        }
+      : "skip",
+  );
+
+  const inviteInfo = useQuery(
+    api.functions.messaging.channelInvites.getInviteInfo,
+    token && channel?._id ? { token, channelId: channel._id } : "skip",
+  );
+
+  const updateJoinModeMutation = useAuthenticatedMutation(
+    api.functions.messaging.channelInvites.updateJoinMode,
+  );
+
+  const [submitting, setSubmitting] = useState<JoinMode | null>(null);
+
+  const currentMode: JoinMode =
+    (inviteInfo?.joinMode as JoinMode | undefined) ?? "open";
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(`/inbox/${groupId}/${channelSlug}/info` as any);
+    }
+  }, [router, groupId, channelSlug]);
+
+  const handleSelect = useCallback(
+    async (mode: JoinMode) => {
+      if (!channel?._id) return;
+      if (mode === currentMode) {
+        handleBack();
+        return;
+      }
+      setSubmitting(mode);
+      try {
+        await updateJoinModeMutation({
+          channelId: channel._id,
+          joinMode: mode,
+        });
+        handleBack();
+      } catch (e: any) {
+        Alert.alert("Could not update", e?.message ?? "Try again.");
+      } finally {
+        setSubmitting(null);
+      }
+    },
+    [channel?._id, currentMode, updateJoinModeMutation, handleBack],
+  );
+
+  if (channel === undefined) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} title="Join mode" />
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={primaryColor} />
+        </View>
+      </View>
+    );
+  }
+
+  if (!channel) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} title="Join mode" />
+        <View style={styles.centered}>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+            This channel is no longer available.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const channelName = channel.name?.trim() || "Channel";
+
+  const options: {
+    mode: JoinMode;
+    title: string;
+    description: string;
+  }[] = [
+    {
+      mode: "open",
+      title: "Open",
+      description:
+        "Any channel-eligible member can add others. Invite links grant instant access.",
+    },
+    {
+      mode: "approval_required",
+      title: "Approval required",
+      description:
+        "Adds and invite-link clicks create requests. Leaders approve before someone joins.",
+    },
+  ];
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      <Header onBack={handleBack} colors={colors} title="Join mode" />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={[styles.helper, { color: colors.textSecondary }]}>
+          Choose how new members join #{channelName}.
+        </Text>
+        <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
+          {options.map((opt, idx) => {
+            const selected = currentMode === opt.mode;
+            const inFlight = submitting === opt.mode;
+            return (
+              <Pressable
+                key={opt.mode}
+                onPress={() => handleSelect(opt.mode)}
+                disabled={!!submitting}
+                style={({ pressed }) => [
+                  styles.option,
+                  idx > 0 && {
+                    borderTopWidth: StyleSheet.hairlineWidth,
+                    borderTopColor: colors.border,
+                  },
+                  pressed && { backgroundColor: colors.selectedBackground },
+                ]}
+              >
+                <View style={styles.optionText}>
+                  <Text style={[styles.optionTitle, { color: colors.text }]}>
+                    {opt.title}
+                  </Text>
+                  <Text
+                    style={[styles.optionDescription, { color: colors.textSecondary }]}
+                  >
+                    {opt.description}
+                  </Text>
+                </View>
+                {inFlight ? (
+                  <ActivityIndicator size="small" color={primaryColor} />
+                ) : selected ? (
+                  <View
+                    style={[
+                      styles.checkCircle,
+                      { backgroundColor: primaryColor },
+                    ]}
+                  >
+                    <Ionicons name="checkmark" size={16} color="#fff" />
+                  </View>
+                ) : (
+                  <View
+                    style={[
+                      styles.uncheckCircle,
+                      { borderColor: colors.border },
+                    ]}
+                  />
+                )}
+              </Pressable>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+function Header({
+  onBack,
+  colors,
+  title,
+}: {
+  onBack: () => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+  title: string;
+}) {
+  return (
+    <View
+      style={[
+        styles.headerBar,
+        {
+          backgroundColor: colors.surface,
+          borderBottomColor: colors.border,
+        },
+      ]}
+    >
+      <TouchableOpacity onPress={onBack} style={styles.headerBackButton} hitSlop={12}>
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <Text style={[styles.headerTitle, { color: colors.text }]}>{title}</Text>
+      <View style={styles.headerSpacer} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scrollContent: { padding: 16, gap: 16 },
+  centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  errorText: { fontSize: 14 },
+  headerBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBackButton: { padding: 4 },
+  headerTitle: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  headerSpacer: { width: 36 },
+  helper: { fontSize: 13, lineHeight: 18 },
+  card: { borderRadius: 12, overflow: "hidden" },
+  option: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  optionText: { flex: 1, gap: 4 },
+  optionTitle: { fontSize: 16, fontWeight: "600" },
+  optionDescription: { fontSize: 13, lineHeight: 18 },
+  checkCircle: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  uncheckCircle: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 1.5,
+  },
+});

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
@@ -226,41 +226,21 @@ export default function ChannelMembersScreen() {
     return autoChannelConfig.lastSyncResults.unmatchedPeople;
   }, [autoChannelConfig]);
 
-  // Create unified list with pending requests first, then synced members, then unsynced at bottom
+  // Member list. Pending join requests now live on the channel info screen
+  // (Leader Controls › REQUESTS), so this list is just synced + unsynced
+  // members. Avoids the prior split where requests, sync info, archive, and
+  // join-mode all lived on this same surface.
   const unifiedList = useMemo((): ListItem[] => {
-    const items: ListItem[] = [];
-
-    // Add pending requests section (leaders only, when there are pending requests)
-    if (canManage && pendingRequests && pendingRequests.length > 0) {
-      items.push({ type: "pending-header" as const });
-      for (const req of pendingRequests) {
-        items.push({
-          type: "pending-request" as const,
-          data: {
-            _id: req._id,
-            userId: req.userId,
-            displayName: req.displayName,
-            profilePhoto: req.profilePhoto,
-            requestedAt: req.requestedAt,
-          },
-        });
-      }
-    }
-
-    // Add synced members
     const syncedItems: ListItem[] = (membersData?.members || []).map((m) => ({
       type: "synced" as const,
       data: m,
     }));
-
-    // Add unsynced people
     const unsyncedItems: ListItem[] = unsyncedPeople.map((p) => ({
       type: "unsynced" as const,
       data: p,
     }));
-
-    return [...items, ...syncedItems, ...unsyncedItems];
-  }, [canManage, pendingRequests, membersData?.members, unsyncedPeople]);
+    return [...syncedItems, ...unsyncedItems];
+  }, [membersData?.members, unsyncedPeople]);
 
   // Total member count including unsynced
   const totalMemberCount = useMemo(() => {
@@ -269,10 +249,13 @@ export default function ChannelMembersScreen() {
     return syncedCount + unsyncedCount;
   }, [membersData?.totalCount, unsyncedPeople.length]);
 
+  // Archive lives on the channel info screen (Leader Controls › Archive
+  // channel) — keep this surface focused on member management. Leaving the
+  // shared-channel "leave" exit for secondary group leaders here since
+  // that's a per-membership action distinct from archive.
   const showLeaveSharedChannelAction = isSecondaryGroup && canManage;
-  const showArchiveChannelAction =
-    canManage && isPrimaryGroup && (isCustomChannel || isPcoAutoChannel);
-  const hasBottomActions = showLeaveSharedChannelAction || showArchiveChannelAction || canShare;
+  const showArchiveChannelAction = false;
+  const hasBottomActions = showLeaveSharedChannelAction || canShare;
 
   const handleBack = () => {
     if (router.canGoBack()) {
@@ -767,32 +750,10 @@ export default function ChannelMembersScreen() {
         </View>
       )}
 
-      {/* Join mode info (custom channels, leaders only) */}
-      {canManage && isCustomChannel && inviteInfo && (
-        <View style={[styles.sharedBanner, {
-          backgroundColor: isDark ? 'rgba(0,188,212,0.1)' : '#E0F7FA',
-          borderBottomColor: isDark ? 'rgba(0,188,212,0.2)' : '#B2EBF2',
-        }]}>
-          <Ionicons name="link" size={16} color="#00BCD4" />
-          <View style={styles.sharedBannerContent}>
-            <Text style={[styles.sharedBannerTitle, { color: isDark ? '#80DEEA' : '#006064' }]}>
-              Invite Link {inviteInfo.inviteEnabled ? "Active" : "Disabled"}
-            </Text>
-            <Text style={[styles.sharedBannerText, { color: colors.textSecondary }]}>
-              Join mode: {(inviteInfo.joinMode || "open") === "open" ? "Open" : "Approval Required"}
-            </Text>
-          </View>
-          <TouchableOpacity
-            onPress={() => {
-              const currentMode = inviteInfo.joinMode || "open";
-              const newMode = currentMode === "open" ? "approval_required" : "open";
-              handleUpdateJoinMode(newMode);
-            }}
-          >
-            <Ionicons name="swap-horizontal" size={20} color="#00BCD4" />
-          </TouchableOpacity>
-        </View>
-      )}
+      {/* Join mode and pending join requests live on the channel info
+          screen now — this page is focused on member management only.
+          See `apps/mobile/features/chat/components/ChannelInfoScreen.tsx`
+          (Leader Controls › Join mode + REQUESTS section). */}
 
       {/* Member count */}
       <View style={[styles.memberCount, { backgroundColor: colors.surfaceSecondary }]}>
@@ -804,25 +765,9 @@ export default function ChannelMembersScreen() {
         </Text>
       </View>
 
-      {/* Auto channel info banner */}
-      {isPcoAutoChannel && (!isSharedChannel || isPrimaryGroup) && (
-        <TouchableOpacity
-          style={[styles.autoChannelBanner, {
-            backgroundColor: isDark ? 'rgba(33,150,243,0.1)' : '#F0F7FF',
-            borderBottomColor: colors.border,
-          }]}
-          onPress={() => setShowAutoChannelSettings(true)}
-        >
-          <Ionicons name="sync" size={16} color={primaryColor} />
-          <View style={styles.autoChannelBannerContent}>
-            <Text style={[styles.autoChannelBannerTitle, { color: colors.text }]}>PCO Auto Channel</Text>
-            <Text style={[styles.autoChannelBannerText, { color: colors.textSecondary }]}>
-              Members are automatically synced from Planning Center Services
-            </Text>
-          </View>
-          <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
-        </TouchableOpacity>
-      )}
+      {/* PCO sync info / settings live on the channel info screen now
+          (Leader Controls › PCO sync settings). Skipping the banner keeps
+          this surface focused on member management. */}
 
       {/* Members list (unified: synced members first, unsynced at bottom) */}
       {unifiedList.length === 0 ? (

--- a/apps/mobile/components/ui/Avatar.tsx
+++ b/apps/mobile/components/ui/Avatar.tsx
@@ -11,6 +11,10 @@ interface AvatarProps {
   style?: StyleProp<ImageStyle>;
   /** Disable image optimization (for debugging) */
   disableOptimization?: boolean;
+  /** Background color for the initials placeholder. Defaults to a hashed
+   *  color tied to the name. Pass a flat color (e.g. theme `border`) for
+   *  contexts that want a neutral preview row. */
+  placeholderBackgroundColor?: string;
 }
 
 export function Avatar({
@@ -19,6 +23,7 @@ export function Avatar({
   size = 48,
   style,
   disableOptimization = false,
+  placeholderBackgroundColor,
 }: AvatarProps) {
   const safeSize = size && size > 0 ? size : 48;
 
@@ -45,6 +50,7 @@ export function Avatar({
       placeholder={{
         type: 'initials',
         name: name,
+        ...(placeholderBackgroundColor ? { backgroundColor: placeholderBackgroundColor } : {}),
       }}
     />
   );

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -149,6 +149,9 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   const leaveChannelMutation = useAuthenticatedMutation(
     api.functions.messaging.channels.leaveChannel,
   );
+  const archiveCustomChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.archiveCustomChannel,
+  );
   const enableInviteLinkMutation = useAuthenticatedMutation(
     api.functions.messaging.channelInvites.enableInviteLink,
   );
@@ -158,6 +161,8 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   const [renameSubmitting, setRenameSubmitting] = useState(false);
   const [renameError, setRenameError] = useState<string | null>(null);
   const [leaveVisible, setLeaveVisible] = useState(false);
+  const [archiveVisible, setArchiveVisible] = useState(false);
+  const [archiving, setArchiving] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [pcoSettingsVisible, setPcoSettingsVisible] = useState(false);
   const [requestInFlight, setRequestInFlight] = useState<string | null>(null);
@@ -297,6 +302,20 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
       setLeaving(false);
     }
   }, [channel?._id, leaveChannelMutation, groupId, router]);
+
+  const handleArchiveChannel = useCallback(async () => {
+    if (!channel?._id) return;
+    setArchiving(true);
+    try {
+      await archiveCustomChannelMutation({ channelId: channel._id });
+      setArchiveVisible(false);
+      router.replace(`/groups/${groupId}` as any);
+    } catch (e: any) {
+      Alert.alert("Couldn't archive", e?.message || "Please try again.");
+    } finally {
+      setArchiving(false);
+    }
+  }, [channel?._id, archiveCustomChannelMutation, groupId, router]);
 
   const handleRename = useCallback(async () => {
     const trimmed = renameValue.trim();
@@ -448,7 +467,9 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
             <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
               {pendingRequests!.map((req: any, idx: number) => {
                 const inFlight = requestInFlight === (req._id as string);
-                const requesterName = req.userName || req.user?.displayName || "Someone";
+                // Backend `getPendingRequests` returns these fields directly
+                // on each enriched row — see channelInvites.ts.
+                const requesterName = req.displayName || "Someone";
                 return (
                   <View
                     key={req._id}
@@ -462,7 +483,7 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
                   >
                     <Avatar
                       name={requesterName}
-                      imageUrl={req.userPhoto || req.user?.profilePhoto}
+                      imageUrl={req.profilePhoto}
                       size={40}
                     />
                     <View style={styles.requestText}>
@@ -805,7 +826,7 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
                   Active state; archive is a stronger op). */}
               {isCustom && (
                 <Pressable
-                  onPress={handleManageMembers}
+                  onPress={() => setArchiveVisible(true)}
                   style={({ pressed }) => [
                     styles.actionRowFlat,
                     {
@@ -942,6 +963,17 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
         confirmText="Leave"
         destructive
         isLoading={leaving}
+      />
+
+      <ConfirmModal
+        visible={archiveVisible}
+        title="Archive channel"
+        message={`Archive #${channelDisplayName}? This removes all members and hides the channel. This action cannot be undone.`}
+        onConfirm={handleArchiveChannel}
+        onCancel={() => setArchiveVisible(false)}
+        confirmText="Archive"
+        destructive
+        isLoading={archiving}
       />
 
       {/* PCO Sync Settings — full-screen modal mounting the existing

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -1,0 +1,1232 @@
+/**
+ * ChannelInfoScreen
+ *
+ * Mirror of `ChatInfoScreen` (the DM info surface) but for group channels
+ * — Leaders, Reach Out, PCO synced, and custom channels. Reached via the
+ * (i) icon in the chat header on non-General channels and via the
+ * CHANNELS card on the group page.
+ *
+ * General (channelType === "main") does NOT mount this screen — the
+ * group page IS the channel info for General. The route shim
+ * `/inbox/[groupId]/[channelSlug]/info/index.tsx` redirects in that
+ * case.
+ *
+ * Layout (DM-sleek):
+ *   - "Channel info" centered title + back chevron
+ *   - Centered hero (channel icon + #name + "N members" + share pill if shared)
+ *   - "Open chat" CTA card
+ *   - MEMBERS card
+ *   - "Add people" standalone card (leaders only — manage screen)
+ *   - CHANNEL ACTIONS (Share invite link, Leave channel)
+ *   - LEADER CONTROLS (Active state, Rename, Share with groups, Archive)
+ */
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  Alert,
+  Share,
+  ActionSheetIOS,
+  Platform,
+  TextInput,
+  Modal,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import * as Clipboard from "expo-clipboard";
+import { Avatar } from "@components/ui/Avatar";
+import { ConfirmModal } from "@components/ui/ConfirmModal";
+import { CustomModal } from "@components/ui/Modal";
+import { AutoChannelSettings } from "@features/channels";
+import { useAuth } from "@providers/AuthProvider";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import {
+  useQuery,
+  api,
+  useAuthenticatedMutation,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { DOMAIN_CONFIG } from "@togather/shared";
+
+type Props = {
+  groupId: string;
+  channelSlug: string;
+};
+
+type ChannelType = "main" | "leaders" | "reach_out" | "pco_services" | "custom";
+
+type ChannelIconConfig = {
+  icon: React.ComponentProps<typeof Ionicons>["name"];
+  color: string;
+  bg: string;
+  defaultName: string;
+};
+
+function getChannelIconConfig(
+  channelType: string,
+  brand: string,
+): ChannelIconConfig {
+  switch (channelType) {
+    case "main":
+      return { icon: "chatbubbles", color: brand, bg: brand + "15", defaultName: "General" };
+    case "leaders":
+      return { icon: "star", color: "#FFA500", bg: "#FFA50015", defaultName: "Leaders" };
+    case "reach_out":
+      return { icon: "hand-left", color: "#8E44AD", bg: "#8E44AD15", defaultName: "Reach Out" };
+    case "pco_services":
+      return { icon: "sync", color: "#2196F3", bg: "#2196F315", defaultName: "PCO Channel" };
+    default:
+      return { icon: "chatbubble", color: "#00BCD4", bg: "#00BCD415", defaultName: "Channel" };
+  }
+}
+
+export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { token, user } = useAuth();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const channel = useQuery(
+    api.functions.messaging.channels.getChannelBySlug,
+    // includeArchived: leaders may land here on a disabled Leaders/Reach Out
+    // channel (where `isArchived` doubles as the legacy-disable flag) so they
+    // can re-enable from Active state. Without this, the row is filtered out
+    // and the screen shows "no longer available."
+    token
+      ? { token, groupId: groupId as Id<"groups">, slug: channelSlug, includeArchived: true }
+      : "skip",
+  );
+
+  const channelMembers = useQuery(
+    api.functions.messaging.channels.getChannelMembers,
+    token && channel
+      ? { token, channelId: channel._id, limit: 50 }
+      : "skip",
+  );
+
+  // Group data — needed to pass communityId into AutoChannelSettings for
+  // PCO synced channels.
+  const groupData = useQuery(
+    api.functions.groups.index.getById,
+    token ? { token, groupId: groupId as Id<"groups"> } : "skip",
+  );
+
+  // Invite info — exposes joinMode for the Leader Controls "Join mode" row.
+  // Leader-only on the backend; query returns null for non-leaders.
+  const inviteInfo = useQuery(
+    api.functions.messaging.channelInvites.getInviteInfo,
+    token && channel?._id ? { token, channelId: channel._id } : "skip",
+  );
+
+  // Pending join requests (custom channels, leader-only) — surfaced as a
+  // dedicated REQUESTS card on this screen so leaders don't have to dig
+  // into /members to approve.
+  const pendingRequests = useQuery(
+    api.functions.messaging.channelInvites.getPendingRequests,
+    token && channel?._id && channel.channelType === "custom"
+      ? { token, channelId: channel._id }
+      : "skip",
+  );
+
+  const approveRequestMutation = useAuthenticatedMutation(
+    api.functions.messaging.channelInvites.approveJoinRequest,
+  );
+  const declineRequestMutation = useAuthenticatedMutation(
+    api.functions.messaging.channelInvites.declineJoinRequest,
+  );
+
+  const updateChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.updateChannel,
+  );
+  const leaveChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.leaveChannel,
+  );
+  const enableInviteLinkMutation = useAuthenticatedMutation(
+    api.functions.messaging.channelInvites.enableInviteLink,
+  );
+
+  const [renameVisible, setRenameVisible] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const [renameSubmitting, setRenameSubmitting] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [leaveVisible, setLeaveVisible] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+  const [pcoSettingsVisible, setPcoSettingsVisible] = useState(false);
+  const [requestInFlight, setRequestInFlight] = useState<string | null>(null);
+
+  const handleJoinMode = useCallback(() => {
+    router.push(`/inbox/${groupId}/${channelSlug}/info/join-mode` as any);
+  }, [router, groupId, channelSlug]);
+
+  const handleApproveRequest = useCallback(
+    async (requestId: Id<"channelJoinRequests">) => {
+      setRequestInFlight(requestId as string);
+      try {
+        await approveRequestMutation({ requestId });
+      } catch (e: any) {
+        Alert.alert("Could not approve", e?.message ?? "Try again.");
+      } finally {
+        setRequestInFlight(null);
+      }
+    },
+    [approveRequestMutation],
+  );
+
+  const handleDeclineRequest = useCallback(
+    async (requestId: Id<"channelJoinRequests">) => {
+      Alert.alert("Decline request?", "The user will not be added to the channel.", [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Decline",
+          style: "destructive",
+          onPress: async () => {
+            setRequestInFlight(requestId as string);
+            try {
+              await declineRequestMutation({ requestId });
+            } catch (e: any) {
+              Alert.alert("Could not decline", e?.message ?? "Try again.");
+            } finally {
+              setRequestInFlight(null);
+            }
+          },
+        },
+      ]);
+    },
+    [declineRequestMutation],
+  );
+
+  const isLeader = useMemo(() => {
+    return (
+      channel?.userGroupRole === "leader" || channel?.userGroupRole === "admin"
+    );
+  }, [channel?.userGroupRole]);
+
+  const channelType = (channel?.channelType ?? "custom") as ChannelType;
+  const isMain = channelType === "main";
+  const isCustom = channelType === "custom";
+  const isLeadersChannel = channelType === "leaders";
+  const isReachOut = channelType === "reach_out";
+  const isPco = channelType === "pco_services";
+
+  const iconCfg = getChannelIconConfig(channelType, primaryColor);
+  const channelDisplayName = channel?.name?.trim() || iconCfg.defaultName;
+
+  const sharedGroupCount = useMemo(() => {
+    if (!channel?.sharedGroups) return 0;
+    return channel.sharedGroups.filter((sg: any) => sg.status === "accepted").length;
+  }, [channel?.sharedGroups]);
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(`/groups/${groupId}` as any);
+    }
+  }, [router, groupId]);
+
+  const handleOpenChat = useCallback(() => {
+    router.push(`/inbox/${groupId}/${channelSlug}` as any);
+  }, [router, groupId, channelSlug]);
+
+  const handleManageMembers = useCallback(() => {
+    router.push(`/inbox/${groupId}/${channelSlug}/members` as any);
+  }, [router, groupId, channelSlug]);
+
+  const handleActiveState = useCallback(() => {
+    router.push(`/inbox/${groupId}/${channelSlug}/info/active-state` as any);
+  }, [router, groupId, channelSlug]);
+
+  const handleShareInvite = useCallback(async () => {
+    if (!isCustom) {
+      Alert.alert(
+        "Not available",
+        "Invite links are only available for custom channels.",
+      );
+      return;
+    }
+    if (!channel?._id) return;
+    try {
+      const result = await enableInviteLinkMutation({ channelId: channel._id });
+      const url = DOMAIN_CONFIG.channelInviteUrl(result.shortId);
+      if (Platform.OS === "ios") {
+        ActionSheetIOS.showActionSheetWithOptions(
+          {
+            options: ["Cancel", "Copy Link", "Share Link"],
+            cancelButtonIndex: 0,
+          },
+          async (buttonIndex) => {
+            if (buttonIndex === 1) {
+              await Clipboard.setStringAsync(url);
+              Alert.alert("Copied!", "Invite link copied to clipboard.");
+            } else if (buttonIndex === 2) {
+              Share.share({
+                url,
+                message: `Join #${channelDisplayName}: ${url}`,
+              });
+            }
+          },
+        );
+      } else {
+        await Share.share({
+          message: `Join #${channelDisplayName}: ${url}`,
+        });
+      }
+    } catch (e: any) {
+      Alert.alert("Error", e?.message || "Failed to share channel");
+    }
+  }, [enableInviteLinkMutation, channel?._id, isCustom, channelDisplayName]);
+
+  const handleLeaveChannel = useCallback(async () => {
+    if (!channel?._id) return;
+    setLeaving(true);
+    try {
+      await leaveChannelMutation({ channelId: channel._id });
+      setLeaveVisible(false);
+      router.replace(`/groups/${groupId}` as any);
+    } catch (e: any) {
+      Alert.alert("Couldn't leave", e?.message || "Please try again.");
+    } finally {
+      setLeaving(false);
+    }
+  }, [channel?._id, leaveChannelMutation, groupId, router]);
+
+  const handleRename = useCallback(async () => {
+    const trimmed = renameValue.trim();
+    if (!trimmed) {
+      setRenameError("Channel name can't be empty");
+      return;
+    }
+    if (!channel?._id) return;
+    setRenameSubmitting(true);
+    try {
+      await updateChannelMutation({
+        channelId: channel._id,
+        name: trimmed,
+      });
+      setRenameVisible(false);
+      setRenameError(null);
+    } catch (e: any) {
+      setRenameError(e?.message || "Could not rename channel");
+    } finally {
+      setRenameSubmitting(false);
+    }
+  }, [renameValue, channel?._id, updateChannelMutation]);
+
+  if (channel === undefined) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} />
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={primaryColor} />
+        </View>
+      </View>
+    );
+  }
+
+  if (!channel) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} />
+        <View style={styles.centered}>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+            This channel is no longer available.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  // Main channel never reaches the rendered body — the route shim
+  // redirects to the group page. This is a defensive fallback.
+  if (isMain) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        <Header onBack={handleBack} colors={colors} />
+        <View style={styles.centered}>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+            The General channel uses the group page for info.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const memberRows = channelMembers?.members ?? [];
+  const totalMemberCount = channelMembers?.totalCount ?? channel.memberCount ?? 0;
+  const ownerId = (channel as { createdById?: Id<"users"> }).createdById;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      <Header onBack={handleBack} colors={colors} />
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 24 }]}
+      >
+        {/* Hero */}
+        <View style={styles.heroSection}>
+          <View style={[styles.heroIconCircle, { backgroundColor: iconCfg.bg }]}>
+            <Ionicons name={iconCfg.icon} size={48} color={iconCfg.color} />
+          </View>
+          <Text style={[styles.heroName, { color: colors.text }]} numberOfLines={2}>
+            {isCustom || isPco ? `#${channelDisplayName}` : channelDisplayName}
+          </Text>
+          <Text style={[styles.heroSubtitle, { color: colors.textSecondary }]}>
+            {totalMemberCount} {totalMemberCount === 1 ? "member" : "members"}
+          </Text>
+          {sharedGroupCount > 0 && (
+            <View
+              style={[
+                styles.sharedPill,
+                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+            >
+              <Ionicons name="link" size={12} color={colors.textSecondary} />
+              <Text style={[styles.sharedPillText, { color: colors.textSecondary }]}>
+                Shared with {sharedGroupCount} group{sharedGroupCount === 1 ? "" : "s"}
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {/* Open chat */}
+        <Pressable
+          onPress={handleOpenChat}
+          style={({ pressed }) => [
+            styles.actionCard,
+            {
+              backgroundColor: pressed ? colors.selectedBackground : colors.surfaceSecondary,
+            },
+          ]}
+        >
+          <View style={[styles.actionIcon, { backgroundColor: iconCfg.bg }]}>
+            <Ionicons name="chatbubbles" size={18} color={iconCfg.color} />
+          </View>
+          <Text style={[styles.actionLabel, { color: colors.text }]}>
+            Open chat
+          </Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+        </Pressable>
+
+        {/* Pending join requests — leader-only, custom channels with
+            approval-required mode. Shown above Members so leaders see
+            pending work first. */}
+        {isLeader && (pendingRequests?.length ?? 0) > 0 && (
+          <>
+            <SectionHeader
+              colors={colors}
+              label={`Requests · ${pendingRequests!.length}`}
+            />
+            <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
+              {pendingRequests!.map((req: any, idx: number) => {
+                const inFlight = requestInFlight === (req._id as string);
+                const requesterName = req.userName || req.user?.displayName || "Someone";
+                return (
+                  <View
+                    key={req._id}
+                    style={[
+                      styles.requestRow,
+                      idx > 0 && {
+                        borderTopWidth: StyleSheet.hairlineWidth,
+                        borderTopColor: colors.border,
+                      },
+                    ]}
+                  >
+                    <Avatar
+                      name={requesterName}
+                      imageUrl={req.userPhoto || req.user?.profilePhoto}
+                      size={40}
+                    />
+                    <View style={styles.requestText}>
+                      <Text
+                        style={[styles.requestName, { color: colors.text }]}
+                        numberOfLines={1}
+                      >
+                        {requesterName}
+                      </Text>
+                      <Text
+                        style={[styles.requestSubtitle, { color: colors.textSecondary }]}
+                        numberOfLines={1}
+                      >
+                        Wants to join
+                      </Text>
+                    </View>
+                    <View style={styles.requestActions}>
+                      <Pressable
+                        onPress={() => handleDeclineRequest(req._id)}
+                        disabled={inFlight}
+                        style={({ pressed }) => [
+                          styles.requestActionBtn,
+                          {
+                            backgroundColor: pressed
+                              ? colors.selectedBackground
+                              : colors.surface,
+                            opacity: inFlight ? 0.5 : 1,
+                          },
+                        ]}
+                      >
+                        <Text
+                          style={[styles.requestActionLabel, { color: colors.destructive }]}
+                        >
+                          Decline
+                        </Text>
+                      </Pressable>
+                      <Pressable
+                        onPress={() => handleApproveRequest(req._id)}
+                        disabled={inFlight}
+                        style={({ pressed }) => [
+                          styles.requestActionBtn,
+                          {
+                            backgroundColor: pressed
+                              ? primaryColor + "CC"
+                              : primaryColor,
+                            opacity: inFlight ? 0.6 : 1,
+                          },
+                        ]}
+                      >
+                        {inFlight ? (
+                          <ActivityIndicator size="small" color="#fff" />
+                        ) : (
+                          <Text
+                            style={[styles.requestActionLabel, { color: "#fff" }]}
+                          >
+                            Approve
+                          </Text>
+                        )}
+                      </Pressable>
+                    </View>
+                  </View>
+                );
+              })}
+            </View>
+          </>
+        )}
+
+        {/* Members */}
+        {memberRows.length > 0 && (
+          <>
+            <SectionHeader colors={colors} label="Members" />
+            <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
+              {memberRows.map((m: any, idx: number) => {
+                const displayName = m.displayName || "Member";
+                const isOwner = !!ownerId && m.userId === ownerId;
+                const isSelf = m.userId === user?.id;
+                return (
+                  <Pressable
+                    key={m.id}
+                    onPress={() => router.push(`/profile/${m.userId}` as any)}
+                    style={({ pressed }) => [
+                      styles.memberRow,
+                      idx > 0 && {
+                        borderTopWidth: StyleSheet.hairlineWidth,
+                        borderTopColor: colors.border,
+                      },
+                      pressed && { backgroundColor: colors.selectedBackground },
+                    ]}
+                  >
+                    <Avatar
+                      name={displayName}
+                      imageUrl={m.profilePhoto}
+                      size={40}
+                    />
+                    <View style={styles.memberRowText}>
+                      <Text
+                        style={[styles.memberRowName, { color: colors.text }]}
+                        numberOfLines={1}
+                      >
+                        {displayName}
+                        {isSelf ? (
+                          <Text style={{ color: colors.textSecondary }}> (you)</Text>
+                        ) : null}
+                      </Text>
+                      {isOwner && (
+                        <Text
+                          style={[styles.memberRowSubtitle, { color: colors.textSecondary }]}
+                        >
+                          OWNER
+                        </Text>
+                      )}
+                    </View>
+                    <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+                  </Pressable>
+                );
+              })}
+            </View>
+            {totalMemberCount > memberRows.length && (
+              <Pressable
+                onPress={handleManageMembers}
+                style={({ pressed }) => [
+                  styles.viewAllButton,
+                  pressed && { opacity: 0.7 },
+                ]}
+              >
+                <Text style={[styles.viewAllText, { color: primaryColor }]}>
+                  View all {totalMemberCount} members
+                </Text>
+              </Pressable>
+            )}
+          </>
+        )}
+
+        {/* Add people — for now this routes to the existing manage-members
+            sub-route. TODO: fold the in-screen picker (mirror of DM
+            ChatInfoScreen.AddPeopleModal) inline once we have a
+            channel-scoped search query. */}
+        {isLeader && (
+          <Pressable
+            onPress={handleManageMembers}
+            style={({ pressed }) => [
+              styles.actionCard,
+              {
+                backgroundColor: pressed ? colors.selectedBackground : colors.surfaceSecondary,
+              },
+            ]}
+          >
+            <View style={[styles.actionIcon, { backgroundColor: primaryColor + "15" }]}>
+              <Ionicons name="person-add" size={18} color={primaryColor} />
+            </View>
+            <Text style={[styles.actionLabel, { color: colors.text }]}>
+              Add people
+            </Text>
+          </Pressable>
+        )}
+
+        {/* CHANNEL ACTIONS */}
+        <SectionHeader colors={colors} label="Channel actions" />
+        <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
+          {isLeader && isCustom && (
+            <Pressable
+              onPress={handleShareInvite}
+              style={({ pressed }) => [
+                styles.actionRowFlat,
+                pressed && { backgroundColor: colors.selectedBackground },
+              ]}
+            >
+              <Ionicons name="share-outline" size={20} color={colors.icon} />
+              <Text style={[styles.actionLabel, { color: colors.text }]}>
+                Share invite link
+              </Text>
+            </Pressable>
+          )}
+          <Pressable
+            onPress={() => setLeaveVisible(true)}
+            style={({ pressed }) => [
+              styles.actionRowFlat,
+              isLeader && isCustom && {
+                borderTopWidth: StyleSheet.hairlineWidth,
+                borderTopColor: colors.border,
+              },
+              pressed && { backgroundColor: colors.selectedBackground },
+            ]}
+          >
+            <Ionicons name="exit-outline" size={20} color={colors.destructive} />
+            <Text style={[styles.actionLabel, { color: colors.destructive }]}>
+              Leave channel
+            </Text>
+          </Pressable>
+        </View>
+
+        {/* LEADER CONTROLS */}
+        {isLeader && (
+          <>
+            <SectionHeader colors={colors} label="Leader controls" />
+            <View
+              style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}
+            >
+              {/* Active state — common to leaders/reach_out/custom/pco */}
+              <Pressable
+                onPress={handleActiveState}
+                style={({ pressed }) => [
+                  styles.actionRowFlat,
+                  pressed && { backgroundColor: colors.selectedBackground },
+                ]}
+              >
+                <Ionicons name="toggle-outline" size={20} color={colors.icon} />
+                <Text style={[styles.actionLabel, { color: colors.text }]}>
+                  Active state
+                </Text>
+                <Ionicons
+                  name="chevron-forward"
+                  size={18}
+                  color={colors.textTertiary}
+                  style={{ marginLeft: "auto" }}
+                />
+              </Pressable>
+
+              {/* Join mode — custom channels only. Routes to an explicit
+                  picker (Open / Approval required) so leaders don't have to
+                  dive into Share with groups → swap-icon to change it. */}
+              {isCustom && (
+                <Pressable
+                  onPress={handleJoinMode}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons name="key-outline" size={20} color={colors.icon} />
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>
+                    Join mode
+                  </Text>
+                  <Text
+                    style={[
+                      styles.actionRowValue,
+                      { color: colors.textSecondary },
+                    ]}
+                  >
+                    {(inviteInfo?.joinMode ?? "open") === "open"
+                      ? "Open"
+                      : "Approval required"}
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                  />
+                </Pressable>
+              )}
+
+              {/* PCO Sync Settings — open the existing AutoChannelSettings
+                  modal. Only meaningful for PCO synced channels. */}
+              {isPco && (
+                <Pressable
+                  onPress={() => setPcoSettingsVisible(true)}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons name="sync-outline" size={20} color={colors.icon} />
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>
+                    PCO sync settings
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                    style={{ marginLeft: "auto" }}
+                  />
+                </Pressable>
+              )}
+
+              {/* Rename — custom channels only (backend gates the rest). */}
+              {isCustom && (
+                <Pressable
+                  onPress={() => {
+                    setRenameValue(channelDisplayName);
+                    setRenameError(null);
+                    setRenameVisible(true);
+                  }}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons name="create-outline" size={20} color={colors.icon} />
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>
+                    Rename
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                    style={{ marginLeft: "auto" }}
+                  />
+                </Pressable>
+              )}
+
+              {/* Share with groups — custom + pco_services */}
+              {(isCustom || isPco) && (
+                <Pressable
+                  onPress={handleManageMembers}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons name="people-outline" size={20} color={colors.icon} />
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>
+                    Share with groups
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                    style={{ marginLeft: "auto" }}
+                  />
+                </Pressable>
+              )}
+
+              {/* Archive — custom only (Leaders/Reach Out are toggled via
+                  Active state; archive is a stronger op). */}
+              {isCustom && (
+                <Pressable
+                  onPress={handleManageMembers}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons
+                    name="archive-outline"
+                    size={20}
+                    color={colors.destructive}
+                  />
+                  <Text
+                    style={[styles.actionLabel, { color: colors.destructive }]}
+                  >
+                    Archive channel
+                  </Text>
+                </Pressable>
+              )}
+
+              {/* Reach Out hint — surface the dependency on Leaders. */}
+              {isReachOut && (
+                <View
+                  style={[
+                    styles.helperRow,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                  ]}
+                >
+                  <Text style={[styles.helperText, { color: colors.textSecondary }]}>
+                    Reach Out requires the Leaders channel to be active.
+                  </Text>
+                </View>
+              )}
+
+              {/* Leaders channel hint */}
+              {isLeadersChannel && (
+                <View
+                  style={[
+                    styles.helperRow,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                  ]}
+                >
+                  <Text style={[styles.helperText, { color: colors.textSecondary }]}>
+                    Leaders channel is private to group leaders and admins.
+                  </Text>
+                </View>
+              )}
+            </View>
+          </>
+        )}
+      </ScrollView>
+
+      {/* Rename modal */}
+      <CustomModal
+        visible={renameVisible}
+        onClose={() => {
+          if (!renameSubmitting) {
+            setRenameVisible(false);
+            setRenameError(null);
+          }
+        }}
+        title="Rename channel"
+      >
+        <View>
+          <TextInput
+            value={renameValue}
+            onChangeText={setRenameValue}
+            placeholder="Channel name"
+            placeholderTextColor={colors.textSecondary}
+            maxLength={100}
+            autoFocus
+            style={[
+              styles.renameInput,
+              {
+                color: colors.text,
+                backgroundColor: colors.inputBackground,
+                borderColor: colors.inputBorder,
+              },
+            ]}
+          />
+          {renameError ? (
+            <Text style={[styles.errorText, { color: colors.destructive, marginTop: 8 }]}>
+              {renameError}
+            </Text>
+          ) : null}
+          <View style={styles.modalButtonRow}>
+            <TouchableOpacity
+              onPress={() => {
+                setRenameVisible(false);
+                setRenameError(null);
+              }}
+              disabled={renameSubmitting}
+              style={[styles.modalButton, { backgroundColor: colors.surfaceSecondary }]}
+            >
+              <Text style={[styles.modalButtonText, { color: colors.text }]}>
+                Cancel
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={handleRename}
+              disabled={renameSubmitting}
+              style={[
+                styles.modalButton,
+                { backgroundColor: primaryColor },
+                renameSubmitting && { opacity: 0.6 },
+              ]}
+            >
+              {renameSubmitting ? (
+                <ActivityIndicator size="small" color="#ffffff" />
+              ) : (
+                <Text style={[styles.modalButtonText, { color: "#ffffff" }]}>
+                  Save
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </CustomModal>
+
+      <ConfirmModal
+        visible={leaveVisible}
+        title="Leave channel"
+        message="You won't see new messages and the channel will be removed from your inbox."
+        onConfirm={handleLeaveChannel}
+        onCancel={() => setLeaveVisible(false)}
+        confirmText="Leave"
+        destructive
+        isLoading={leaving}
+      />
+
+      {/* PCO Sync Settings — full-screen modal mounting the existing
+          AutoChannelSettings UI for PCO synced channels. */}
+      <Modal
+        visible={pcoSettingsVisible}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setPcoSettingsVisible(false)}
+      >
+        {channel && groupData?.communityId && (
+          <AutoChannelSettings
+            channelId={channel._id}
+            groupId={groupId as Id<"groups">}
+            communityId={groupData.communityId}
+            canEdit={isLeader}
+            onClose={() => setPcoSettingsVisible(false)}
+          />
+        )}
+      </Modal>
+    </View>
+  );
+}
+
+function Header({
+  onBack,
+  colors,
+}: {
+  onBack: () => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  return (
+    <View
+      style={[
+        styles.headerBar,
+        {
+          backgroundColor: colors.surface,
+          borderBottomColor: colors.border,
+        },
+      ]}
+    >
+      <TouchableOpacity onPress={onBack} style={styles.headerBackButton} hitSlop={12}>
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <Text style={[styles.headerTitle, { color: colors.text }]}>Channel info</Text>
+      <View style={styles.headerSpacer} />
+    </View>
+  );
+}
+
+function SectionHeader({
+  colors,
+  label,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  label: string;
+}) {
+  return (
+    <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+      {label.toUpperCase()}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  headerBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBackButton: {
+    padding: 4,
+    marginRight: 4,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  headerSpacer: {
+    width: 36,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 24,
+  },
+  centered: {
+    paddingVertical: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  errorText: {
+    fontSize: 14,
+    textAlign: "center",
+  },
+  heroSection: {
+    alignItems: "center",
+    paddingTop: 24,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+  },
+  heroIconCircle: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  heroName: {
+    marginTop: 16,
+    fontSize: 22,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  heroSubtitle: {
+    marginTop: 4,
+    fontSize: 13,
+  },
+  sharedPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  sharedPillText: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  sectionHeader: {
+    fontSize: 11,
+    fontWeight: "600",
+    letterSpacing: 0.6,
+    marginTop: 24,
+    marginBottom: 8,
+    paddingHorizontal: 20,
+  },
+  sectionGroup: {
+    marginHorizontal: 12,
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  memberRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    minHeight: 56,
+    gap: 12,
+  },
+  memberRowText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  memberRowName: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  memberRowSubtitle: {
+    marginTop: 2,
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+  viewAllButton: {
+    alignItems: "center",
+    paddingVertical: 10,
+    marginHorizontal: 12,
+  },
+  viewAllText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  actionCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginHorizontal: 12,
+    marginTop: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    minHeight: 48,
+  },
+  actionIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  actionRowFlat: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
+  },
+  actionLabel: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  actionRowValue: {
+    fontSize: 14,
+    fontWeight: "500",
+    marginLeft: "auto",
+    marginRight: 4,
+  },
+  requestRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  requestText: {
+    flex: 1,
+    flexDirection: "column",
+    gap: 2,
+  },
+  requestName: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  requestSubtitle: {
+    fontSize: 12,
+  },
+  requestActions: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  requestActionBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+    minWidth: 72,
+    alignItems: "center",
+  },
+  requestActionLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  helperRow: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  helperText: {
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  renameInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+    minHeight: 44,
+  },
+  modalButtonRow: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 20,
+  },
+  modalButton: {
+    flex: 1,
+    minHeight: 48,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 12,
+  },
+  modalButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/features/chat/components/ChatHeader.tsx
+++ b/apps/mobile/features/chat/components/ChatHeader.tsx
@@ -12,7 +12,6 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { AppImage } from "@components/ui";
 import { useTheme } from "@hooks/useTheme";
-import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { getGroupTypeColorScheme } from "../../../constants/groupTypes";
 import { useIsDesktopWeb } from "../../../hooks/useIsDesktopWeb";
 
@@ -21,12 +20,17 @@ type ChatHeaderProps = {
   displayType: string;
   displayImage: string;
   groupTypeId: number;
-  /** When provided, renders a tappable "N members" link under the group name. */
+  /** Member count rendered next to the group-type badge. */
   memberCount?: number;
   onBack: () => void;
-  onMenuPress: () => void;
+  /**
+   * Tap handler for the (i) info icon in the top-right. For General chats
+   * this should route to the group page; for non-General channels it
+   * should route to the per-channel info screen.
+   */
+  onInfoPress: () => void;
+  /** Tap handler for the entire identity block (avatar + name + meta). */
   onGroupPagePress: () => void;
-  onMembersPress?: () => void;
 };
 
 export const ChatHeader = memo(function ChatHeader({
@@ -36,12 +40,10 @@ export const ChatHeader = memo(function ChatHeader({
   groupTypeId,
   memberCount,
   onBack,
-  onMenuPress,
+  onInfoPress,
   onGroupPagePress,
-  onMembersPress,
 }: ChatHeaderProps) {
   const { colors: themeColors } = useTheme();
-  const { primaryColor } = useCommunityTheme();
   const scheme = getGroupTypeColorScheme(groupTypeId);
   const badgeColors = { bg: scheme.bg, text: scheme.color };
   const isDesktopWeb = useIsDesktopWeb();
@@ -54,8 +56,17 @@ export const ChatHeader = memo(function ChatHeader({
         </TouchableOpacity>
       )}
 
-      {/* Group Image - clickable to go to group page */}
-      <TouchableOpacity onPress={onGroupPagePress}>
+      {/* Whole identity block — avatar + name + badge + member count — is
+          one tap target that routes to the group page. Mirrors the DM
+          chat-header pattern where tapping anywhere in the title row goes
+          to the chat info. The dedicated `onMembersPress` link is gone;
+          members are reachable from the group page. */}
+      <TouchableOpacity
+        onPress={onGroupPagePress}
+        style={styles.identityBlock}
+        accessibilityRole="button"
+        accessibilityLabel={`${displayName} — open group page`}
+      >
         <AppImage
           source={displayImage}
           style={styles.groupImage}
@@ -66,41 +77,34 @@ export const ChatHeader = memo(function ChatHeader({
             backgroundColor: '#E5E5E5',
           }}
         />
-      </TouchableOpacity>
-
-      {/* Group Info */}
-      <View style={styles.headerInfo}>
-        <Text style={[styles.groupName, { color: themeColors.text }]} numberOfLines={1}>
-          {displayName}
-        </Text>
-        <View style={styles.headerMetaRow}>
-          {displayType && (
-            <View style={[styles.headerBadge, { backgroundColor: badgeColors.bg }]}>
-              <Text style={[styles.headerBadgeText, { color: badgeColors.text }]}>
-                {displayType}
-              </Text>
-            </View>
-          )}
-          {typeof memberCount === "number" && memberCount > 0 && (
-            <TouchableOpacity
-              onPress={onMembersPress}
-              disabled={!onMembersPress}
-              hitSlop={6}
-              style={styles.memberCountButton}
-            >
+        <View style={styles.headerInfo}>
+          <Text style={[styles.groupName, { color: themeColors.text }]} numberOfLines={1}>
+            {displayName}
+          </Text>
+          <View style={styles.headerMetaRow}>
+            {!!displayType && (
+              <View style={[styles.headerBadge, { backgroundColor: badgeColors.bg }]}>
+                <Text style={[styles.headerBadgeText, { color: badgeColors.text }]}>
+                  {displayType}
+                </Text>
+              </View>
+            )}
+            {typeof memberCount === "number" && memberCount > 0 && (
               <Text
-                style={[styles.memberCountText, { color: primaryColor }]}
+                style={[styles.memberCountText, { color: themeColors.textSecondary }]}
               >
                 {memberCount} {memberCount === 1 ? "member" : "members"}
               </Text>
-            </TouchableOpacity>
-          )}
+            )}
+          </View>
         </View>
-      </View>
+      </TouchableOpacity>
 
-      {/* Menu Button */}
-      <TouchableOpacity onPress={onMenuPress} style={styles.menuButton}>
-        <Ionicons name="ellipsis-vertical" size={20} color={themeColors.text} />
+      {/* Info Button — replaces the legacy 3-dot menu. Routes via the
+          parent's onInfoPress to either the group page (General) or the
+          per-channel info screen. */}
+      <TouchableOpacity onPress={onInfoPress} style={styles.menuButton} accessibilityLabel="Channel info">
+        <Ionicons name="information-circle-outline" size={26} color={themeColors.text} />
       </TouchableOpacity>
     </View>
   );
@@ -146,6 +150,11 @@ const styles = StyleSheet.create({
     padding: 4,
     marginRight: 4,
   },
+  identityBlock: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+  },
   groupImage: {
     width: 40,
     height: 40,
@@ -175,12 +184,9 @@ const styles = StyleSheet.create({
     fontSize: 10,
     fontWeight: "600",
   },
-  memberCountButton: {
-    // Hit-target is tight to the text. Tappability signalled by brand color.
-  },
   memberCountText: {
     fontSize: 12,
-    fontWeight: "600",
+    fontWeight: "500",
   },
   menuButton: {
     padding: 8,

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -685,6 +685,31 @@ const ConvexChatRoomScreenInner: React.FC = () => {
     }
   }, [router, getGroupIdForNavigation]);
 
+  /**
+   * Handler for the (i) icon in the chat header (replaced the old 3-dot
+   * menu opener). Routes:
+   *   - General (channelType === "main"): → /groups/{id}  (group page IS
+   *     the channel info for General)
+   *   - Other channels: → /inbox/{groupId}/{slug}/info
+   *
+   * `ChatMenuModal` stays mounted because other components rely on its
+   * handlers; we just stopped opening it from the (i).
+   */
+  const handleOpenChannelInfo = useCallback(() => {
+    const id = getGroupIdForNavigation();
+    if (!id) return;
+    // Determine channel type from the active tab. Fall back to "main" if
+    // we can't resolve — the General -> group page route is the safest
+    // default.
+    const activeTab = channelTabs.find((t) => t.slug === activeSlug);
+    const isMain = !activeTab || activeTab.channelType === "main";
+    if (isMain) {
+      router.push(`/groups/${id}`);
+    } else {
+      router.push(`/inbox/${id}/${activeSlug}/info` as any);
+    }
+  }, [router, getGroupIdForNavigation, channelTabs, activeSlug]);
+
   const handleShareGroup = useCallback(() => {
     setMenuVisible(false);
     runAfterChatMenuDismiss(() => {
@@ -1014,9 +1039,8 @@ const ConvexChatRoomScreenInner: React.FC = () => {
               isAnnouncementGroup ? undefined : groupDetails?.memberCount
             }
             onBack={handleBack}
-            onMenuPress={() => setMenuVisible(true)}
+            onInfoPress={handleOpenChannelInfo}
             onGroupPagePress={handleGoToGroupPage}
-            onMembersPress={handleGoToMembers}
           />
         )}
         {/* ChatNavigation drives the channel-tab bar for group channels.

--- a/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
@@ -425,8 +425,11 @@ describe('ChatNavigation - Full Component', () => {
     expect(getByText('Attendance')).toBeTruthy();
     expect(getByText('People')).toBeTruthy();
     expect(queryByText('Tasks')).toBeNull();
-    expect(getByText('Events')).toBeTruthy();
-    expect(getByText('Bots')).toBeTruthy();
+    // Events and Bots chips were retired from the toolbar — those
+    // sections live on the group page (UpcomingEventsSection,
+    // GroupBotsSection).
+    expect(queryByText('Events')).toBeNull();
+    expect(queryByText('Bots')).toBeNull();
   });
 
   it('should hide leader toolbar when showLeaderTools is false', () => {

--- a/apps/mobile/features/chat/constants/__tests__/toolbarTools.test.ts
+++ b/apps/mobile/features/chat/constants/__tests__/toolbarTools.test.ts
@@ -11,6 +11,13 @@ describe("toolbar tools", () => {
 
   test("hides tasks from default tools until enabled", () => {
     expect(DEFAULT_TOOLS).not.toContain("tasks");
-    expect(DEFAULT_TOOLS).toEqual(["attendance", "followup", "events", "bots"]);
+    expect(DEFAULT_TOOLS).toEqual(["attendance", "followup"]);
+  });
+
+  test("retires the bots and events chips — both live on the group page now", () => {
+    expect(DEFAULT_TOOLS).not.toContain("bots");
+    expect(DEFAULT_TOOLS).not.toContain("events");
+    expect(TOOLBAR_TOOLS as Record<string, unknown>).not.toHaveProperty("bots");
+    expect(TOOLBAR_TOOLS as Record<string, unknown>).not.toHaveProperty("events");
   });
 });

--- a/apps/mobile/features/chat/constants/toolbarTools.ts
+++ b/apps/mobile/features/chat/constants/toolbarTools.ts
@@ -29,8 +29,11 @@ export const TOOLBAR_TOOLS = {
     icon: "checkmark-done-outline",
     label: "Tasks",
   },
-  events: { id: "events", icon: "calendar-outline", label: "Events" },
-  bots: { id: "bots", icon: "hardware-chip-outline", label: "Bots" },
+  // NOTE: "events" and "bots" were retired from the toolbar — they live
+  // as sections on the group page (UpcomingEventsSection,
+  // GroupBotsSection). Existing groups whose `leaderToolbarTools` still
+  // references these IDs are filtered out at the consumer (ChatNavigation
+  // skips IDs not in this record).
   sync: {
     id: "sync",
     icon: "sync-outline",
@@ -62,7 +65,7 @@ export const ALL_TOOL_IDS = Object.keys(TOOLBAR_TOOLS) as ToolId[];
  * - "tasks" is NOT included by default - group leaders must explicitly enable it.
  * - "sync" is NOT included by default - must be explicitly enabled.
  */
-export const DEFAULT_TOOLS = ["attendance", "followup", "events", "bots"];
+export const DEFAULT_TOOLS = ["attendance", "followup"];
 
 /**
  * Resource tool ID helpers.

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -1,44 +1,40 @@
 /**
- * ChannelsSection Component
+ * ChannelsSection (clean, DM-style)
  *
- * Displays all channels for a group with management options.
- * Part of the Group Detail screen.
+ * Single CHANNELS card on the group page. Each row is icon + name +
+ * subtitle + chevron — no toggles, no trailing icon clusters. Per-channel
+ * configuration (active/disabled state, share-with-groups, archive,
+ * leave) lives on the per-channel info screen at
+ * `/inbox/[groupId]/[channelSlug]/info`.
  *
- * Features:
- * - Shows "Auto Channels" section (General and Leaders channels)
- * - Shows "Custom Channels" section with user's custom channels
- * - Leaders can toggle any channel on/off (General, Leaders, Reach Out, PCO, custom)
- * - Leaders can manage custom channel members
- * - Leaders can create new custom channels
- * - Users can leave custom channels
- * - Pin indicators for pinned channels
+ * Order:
+ *   1. CHANNELS card (general → leaders → reach_out → pco → custom)
+ *   2. Solid "Create Channel" affordance (leaders only)
+ *   3. SHARED CHANNEL INVITATIONS card (leaders only, when present)
+ *
+ * Navigation:
+ *   - General (channelType === "main"): → /inbox/{groupId}/{slug} (chat)
+ *   - Everything else: → /inbox/{groupId}/{slug}/info
+ *
+ * The Pin Channels / Toolbar Settings buttons that used to float at the
+ * bottom of this section now live in GROUP ACTIONS on
+ * GroupDetailScreen.
  */
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
-  Alert,
-  Switch,
   ActivityIndicator,
-  Share,
-  ActionSheetIOS,
-  Platform,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import {
-  useAuthenticatedMutation,
-  useQuery,
-  api,
-} from "@services/api/convex";
+import { useQuery, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
-import { DOMAIN_CONFIG } from "@togather/shared";
-import * as Clipboard from "expo-clipboard";
 import { useGroupChannels } from "../hooks/useGroupChannels";
 import { useRespondToChannelInvite } from "../hooks/useRespondToChannelInvite";
 import { ChannelJoinRequestsBanner } from "./ChannelJoinRequestsBanner";
@@ -71,15 +67,9 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
   const { token } = useAuth();
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
-  const [togglingLeaders, setTogglingLeaders] = useState(false);
-  const [togglingReachOut, setTogglingReachOut] = useState(false);
-  const [togglingChannelId, setTogglingChannelId] = useState<string | null>(null);
-  const [leavingChannelId, setLeavingChannelId] = useState<string | null>(null);
 
-  // Determine if user is a leader
   const isLeader = userRole === "leader" || userRole === "admin";
 
-  // Query pending shared channel invites for this group (leaders only)
   const pendingInvites = useQuery(
     api.functions.messaging.sharedChannels.listPendingInvitesForGroup,
     token && isLeader ? { token, groupId: groupId as Id<"groups"> } : "skip"
@@ -88,571 +78,293 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
   const { respondingTo, handleRespond: handleRespondToInvite } =
     useRespondToChannelInvite({ token, groupId });
 
-  // Fetch channels for this group (with offline cache support)
-  const { channels: rawChannels } = useGroupChannels(groupId, { includeArchived: isLeader });
+  const { channels: rawChannels } = useGroupChannels(groupId, {
+    includeArchived: isLeader,
+  });
 
-  // Defense in depth: never show leader-disabled channels to non-leaders (group page)
   const channels = useMemo(() => {
     if (rawChannels === undefined) return undefined;
     if (isLeader) return rawChannels;
     return rawChannels.filter((c: Channel) => c.isEnabled !== false);
   }, [rawChannels, isLeader]);
 
-  // Mutations
-  const leaveChannelMutation = useAuthenticatedMutation(
-    api.functions.messaging.channels.leaveChannel
-  );
-  const toggleLeadersChannelMutation = useAuthenticatedMutation(
-    api.functions.messaging.channels.toggleLeadersChannel
-  );
-  const toggleReachOutChannelMutation = useAuthenticatedMutation(
-    api.functions.messaging.channels.toggleReachOutChannel
-  );
-  const toggleMainChannelMutation = useAuthenticatedMutation(
-    api.functions.messaging.channels.toggleMainChannel
-  );
-  const togglePcoChannelMutation = useAuthenticatedMutation(
-    api.functions.messaging.channels.togglePcoChannel
-  );
-  const setCustomChannelLeaderEnabledMutation = useAuthenticatedMutation(
-    api.functions.messaging.channels.setCustomChannelLeaderEnabled
-  );
-  const enableInviteLinkMutation = useAuthenticatedMutation(
-    api.functions.messaging.channelInvites.enableInviteLink
-  );
-
-  // Filter channels by type
   const mainChannel = channels?.find((c: Channel) => c.channelType === "main");
   const leadersChannel = channels?.find((c: Channel) => c.channelType === "leaders");
+  const reachOutChannel = channels?.find((c: Channel) => c.channelType === "reach_out");
   const pcoSyncedChannels = channels?.filter((c: Channel) => c.channelType === "pco_services") ?? [];
   const customChannels = channels?.filter((c: Channel) => c.channelType === "custom") ?? [];
 
-  // Check if leaders channel is enabled (exists and not archived)
-  const leadersChannelEnabled = leadersChannel && !leadersChannel.isArchived;
+  const leadersEnabled = !!leadersChannel && !leadersChannel.isArchived;
+  const mainEnabled = !!mainChannel && !mainChannel.isArchived;
+  const reachOutEnabled = !!reachOutChannel && !reachOutChannel.isArchived;
 
-  const mainChannelEnabled = mainChannel ? !mainChannel.isArchived : false;
-
-  // Check if reach out channel exists and is enabled
-  const reachOutChannel = channels?.find((c: Channel) => c.channelType === "reach_out");
-  const reachOutEnabled = reachOutChannel ? !reachOutChannel.isArchived : false;
-
-  // Navigate to channel chat
-  const handleChannelPress = useCallback(
-    (channel: Channel) => {
-      router.push(`/inbox/${groupId}/${channel.slug}`);
-    },
+  const navigateToChannelChat = useCallback(
+    (slug: string) => router.push(`/inbox/${groupId}/${slug}` as any),
     [router, groupId]
   );
 
-  // Leave a custom channel
-  const handleLeaveChannel = useCallback(
-    (channel: Channel) => {
-      Alert.alert(
-        "Leave Channel",
-        `Are you sure you want to leave "${channel.name}"?`,
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Leave",
-            style: "destructive",
-            onPress: async () => {
-              setLeavingChannelId(channel._id);
-              try {
-                await leaveChannelMutation({ channelId: channel._id });
-              } catch (error: any) {
-                Alert.alert(
-                  "Error",
-                  error?.message || "Failed to leave channel"
-                );
-              } finally {
-                setLeavingChannelId(null);
-              }
-            },
-          },
-        ]
-      );
-    },
-    [leaveChannelMutation]
-  );
-
-  // Navigate to manage members screen
-  const handleManageMembers = useCallback(
-    (channel: Channel) => {
-      router.push(`/inbox/${groupId}/${channel.slug}/members`);
-    },
+  const navigateToChannelInfo = useCallback(
+    (slug: string) => router.push(`/inbox/${groupId}/${slug}/info` as any),
     [router, groupId]
   );
 
-  // Toggle leaders channel on/off
-  const handleToggleLeadersChannel = useCallback(
-    async (enabled: boolean) => {
-      setTogglingLeaders(true);
-      try {
-        await toggleLeadersChannelMutation({
-          groupId: groupId as Id<"groups">,
-          enabled,
-        });
-      } catch (error: any) {
-        Alert.alert(
-          "Error",
-          error?.message || "Failed to toggle leaders channel"
-        );
-      } finally {
-        setTogglingLeaders(false);
-      }
-    },
-    [toggleLeadersChannelMutation, groupId]
-  );
-
-  // Toggle reach out channel on/off
-  const handleToggleReachOutChannel = useCallback(async (enabled: boolean) => {
-    setTogglingReachOut(true);
-    try {
-      await toggleReachOutChannelMutation({ groupId: groupId as Id<"groups">, enabled });
-    } catch (error: any) {
-      Alert.alert("Error", error?.message || "Failed to toggle reach out channel");
-    } finally {
-      setTogglingReachOut(false);
-    }
-  }, [toggleReachOutChannelMutation, groupId]);
-
-  const handleToggleMainChannel = useCallback(
-    async (enabled: boolean) => {
-      if (!enabled) {
-        Alert.alert(
-          "Disable General channel?",
-          "Members will not be able to use General until you turn it back on.",
-          [
-            { text: "Cancel", style: "cancel" },
-            {
-              text: "Disable",
-              style: "destructive",
-              onPress: async () => {
-                setTogglingChannelId("main");
-                try {
-                  await toggleMainChannelMutation({
-                    groupId: groupId as Id<"groups">,
-                    enabled: false,
-                  });
-                } catch (error: any) {
-                  Alert.alert(
-                    "Error",
-                    error?.message || "Failed to update General channel"
-                  );
-                } finally {
-                  setTogglingChannelId(null);
-                }
-              },
-            },
-          ]
-        );
-        return;
-      }
-      setTogglingChannelId("main");
-      try {
-        await toggleMainChannelMutation({
-          groupId: groupId as Id<"groups">,
-          enabled: true,
-        });
-      } catch (error: any) {
-        Alert.alert("Error", error?.message || "Failed to update General channel");
-      } finally {
-        setTogglingChannelId(null);
-      }
-    },
-    [toggleMainChannelMutation, groupId]
-  );
-
-  const handleTogglePcoChannel = useCallback(
-    async (channel: Channel, enabled: boolean) => {
-      setTogglingChannelId(channel._id);
-      try {
-        await togglePcoChannelMutation({
-          channelId: channel._id,
-          enabled,
-          managingGroupId: groupId as Id<"groups">,
-        });
-      } catch (error: any) {
-        Alert.alert("Error", error?.message || "Failed to update channel");
-      } finally {
-        setTogglingChannelId(null);
-      }
-    },
-    [togglePcoChannelMutation, groupId]
-  );
-
-  const handleToggleCustomChannel = useCallback(
-    async (channel: Channel, enabled: boolean) => {
-      if (!enabled) {
-        Alert.alert(
-          "Hide channel from members?",
-          `Members will not see "${channel.name}" until you turn it back on. No one is removed from the channel.`,
-          [
-            { text: "Cancel", style: "cancel" },
-            {
-              text: "Hide",
-              style: "destructive",
-              onPress: async () => {
-                setTogglingChannelId(channel._id);
-                try {
-                  await setCustomChannelLeaderEnabledMutation({
-                    channelId: channel._id,
-                    enabled: false,
-                    managingGroupId: groupId as Id<"groups">,
-                  });
-                } catch (error: any) {
-                  Alert.alert("Error", error?.message || "Failed to update channel");
-                } finally {
-                  setTogglingChannelId(null);
-                }
-              },
-            },
-          ]
-        );
-        return;
-      }
-      setTogglingChannelId(channel._id);
-      try {
-        await setCustomChannelLeaderEnabledMutation({
-          channelId: channel._id,
-          enabled: true,
-          managingGroupId: groupId as Id<"groups">,
-        });
-      } catch (error: any) {
-        Alert.alert("Error", error?.message || "Failed to enable channel");
-      } finally {
-        setTogglingChannelId(null);
-      }
-    },
-    [setCustomChannelLeaderEnabledMutation, groupId]
-  );
-
-  // Navigate to create channel screen
   const handleCreateChannel = useCallback(() => {
-    router.push(`/inbox/${groupId}/create`);
+    router.push(`/inbox/${groupId}/create` as any);
   }, [router, groupId]);
 
-  // Share channel invite link
-  const handleShareChannel = useCallback(async (channel: Channel) => {
-    try {
-      const result = await enableInviteLinkMutation({
-        channelId: channel._id,
-      });
-      const url = DOMAIN_CONFIG.channelInviteUrl(result.shortId);
-
-      if (Platform.OS === "ios") {
-        ActionSheetIOS.showActionSheetWithOptions(
-          {
-            options: ["Cancel", "Copy Link", "Share Link"],
-            cancelButtonIndex: 0,
-          },
-          async (buttonIndex) => {
-            if (buttonIndex === 1) {
-              await Clipboard.setStringAsync(url);
-              Alert.alert("Copied!", "Invite link copied to clipboard.");
-            } else if (buttonIndex === 2) {
-              Share.share({ url, message: `Join #${channel.name}: ${url}` });
-            }
-          }
-        );
-      } else {
-        Share.share({ message: `Join #${channel.name}: ${url}` });
-      }
-    } catch (error: any) {
-      Alert.alert("Error", error?.message || "Failed to share channel");
-    }
-  }, [enableInviteLinkMutation]);
-
-  // Navigate to pin channels screen (dedicated route)
-  const handlePinChannels = useCallback(() => {
-    router.push(`/(user)/leader-tools/${groupId}/pin-channels`);
-  }, [router, groupId]);
-
-  // Navigate to toolbar settings screen
-  const handleToolbarSettings = useCallback(() => {
-    router.push(`/(user)/leader-tools/${groupId}/toolbar-settings`);
-  }, [router, groupId]);
-
-  // Loading state
   if (channels === undefined) {
     return (
-      <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
-        <Text style={[styles.header, { color: colors.text }]}>CHANNELS</Text>
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="small" color={primaryColor} />
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <Text style={[styles.header, { color: colors.textSecondary }]}>CHANNELS</Text>
+        <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="small" color={primaryColor} />
+          </View>
         </View>
       </View>
     );
   }
 
-  // No channels case (shouldn't happen normally)
   if (channels.length === 0) {
     return null;
   }
 
+  // Build the row list in canonical order so renderers don't have to think
+  // about dividers — we draw a hairline between rows by index.
+  type Row = {
+    key: string;
+    icon: React.ComponentProps<typeof Ionicons>["name"];
+    iconColor: string;
+    iconBg: string;
+    name: string;
+    subtitle: string;
+    enabled: boolean;
+    /** Omit for placeholder rows (e.g. Leaders/Reach Out shown to a leader
+     *  before the channel record exists). When set, the row is tappable —
+     *  even if `enabled === false`, since "tap a disabled channel to
+     *  re-enable" is the primary recovery path. */
+    onPress?: () => void;
+    unreadCount?: number;
+    pinned?: boolean;
+  };
+
+  const rows: Row[] = [];
+
+  if (mainChannel) {
+    rows.push({
+      key: mainChannel._id,
+      icon: "chatbubbles",
+      iconColor: primaryColor,
+      iconBg: primaryColor + "15",
+      name: "General",
+      subtitle: mainEnabled ? "All members" : "Disabled",
+      enabled: mainEnabled,
+      // General opens the chat directly. The group page IS its info screen.
+      onPress: () => navigateToChannelChat(mainChannel.slug),
+      unreadCount: mainChannel.unreadCount,
+      pinned: mainChannel.isPinned,
+    });
+  }
+
+  if (leadersChannel || isLeader) {
+    rows.push({
+      key: leadersChannel?._id ?? "leaders-placeholder",
+      icon: "star",
+      iconColor: "#FFA500",
+      iconBg: "#FFA50015",
+      name: "Leaders",
+      subtitle: leadersChannel
+        ? leadersEnabled
+          ? `${leadersChannel.memberCount} leader${leadersChannel.memberCount !== 1 ? "s" : ""}`
+          : "Disabled"
+        : "Disabled",
+      enabled: !!leadersChannel && leadersEnabled,
+      onPress: leadersChannel
+        ? () => navigateToChannelInfo(leadersChannel.slug)
+        : undefined,
+      unreadCount: leadersChannel?.unreadCount,
+      pinned: leadersChannel?.isPinned,
+    });
+  }
+
+  if (isLeader) {
+    rows.push({
+      key: reachOutChannel?._id ?? "reach-out-placeholder",
+      icon: "hand-left",
+      iconColor: "#8E44AD",
+      iconBg: "#8E44AD15",
+      name: "Reach Out",
+      subtitle: !leadersEnabled
+        ? "Requires Leaders channel"
+        : reachOutChannel && reachOutEnabled
+          ? `${reachOutChannel.memberCount} member${reachOutChannel.memberCount !== 1 ? "s" : ""}`
+          : "Disabled",
+      enabled: !!reachOutChannel && reachOutEnabled && leadersEnabled,
+      onPress: reachOutChannel
+        ? () => navigateToChannelInfo(reachOutChannel.slug)
+        : undefined,
+      unreadCount: reachOutChannel?.unreadCount,
+      pinned: reachOutChannel?.isPinned,
+    });
+  }
+
+  pcoSyncedChannels.forEach((channel: Channel) => {
+    const enabled = channel.isEnabled && !channel.isArchived;
+    rows.push({
+      key: channel._id,
+      icon: "sync",
+      iconColor: "#2196F3",
+      iconBg: "#2196F315",
+      name: channel.name,
+      subtitle: enabled
+        ? `${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""} · PCO Synced`
+        : "Disabled",
+      enabled,
+      onPress: () => navigateToChannelInfo(channel.slug),
+      unreadCount: channel.unreadCount,
+      pinned: channel.isPinned,
+    });
+  });
+
+  customChannels.forEach((channel: Channel) => {
+    const enabled = channel.isEnabled && !channel.isArchived;
+    rows.push({
+      key: channel._id,
+      icon: "chatbubble",
+      iconColor: "#00BCD4",
+      iconBg: "#00BCD415",
+      name: channel.name,
+      subtitle: enabled
+        ? `${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""}`
+        : "Hidden from members",
+      enabled,
+      onPress: () => navigateToChannelInfo(channel.slug),
+      unreadCount: channel.unreadCount,
+      pinned: channel.isPinned,
+    });
+  });
+
   return (
-    <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
-      {/* AUTO CHANNELS Section */}
-      <Text style={[styles.header, { color: colors.text }]}>AUTO CHANNELS</Text>
-      <View style={[styles.channelList, { backgroundColor: colors.surface }]}>
-        {/* General Channel */}
-        {mainChannel && (
-          <View style={[styles.channelRow, { borderBottomColor: colors.border }]}>
-            <TouchableOpacity
-              style={styles.channelContent}
-              onPress={() =>
-                mainChannelEnabled ? handleChannelPress(mainChannel) : undefined
-              }
-              activeOpacity={mainChannelEnabled ? 0.7 : 1}
-              disabled={!mainChannelEnabled}
-            >
-              <View style={[styles.channelIcon, { backgroundColor: primaryColor + "15" }]}>
-                <Ionicons name="chatbubbles" size={20} color={primaryColor} />
-              </View>
-              <View style={styles.channelInfo}>
-                <Text
-                  style={[
-                    styles.channelName,
-                    { color: colors.text },
-                    !mainChannelEnabled && { color: colors.textTertiary },
-                  ]}
-                >
-                  General
-                </Text>
-                <Text style={[styles.channelSubtitle, { color: colors.textSecondary }]}>
-                  {mainChannelEnabled ? "All members" : "Disabled"}
-                </Text>
-              </View>
-              {mainChannelEnabled && mainChannel.unreadCount > 0 && (
-                <View style={[styles.unreadBadge, { backgroundColor: primaryColor }]}>
-                  <Text style={styles.unreadText}>
-                    {mainChannel.unreadCount > 99 ? "99+" : mainChannel.unreadCount}
-                  </Text>
-                </View>
-              )}
-            </TouchableOpacity>
-            {isLeader ? (
-              <View style={styles.toggleContainer}>
-                {togglingChannelId === "main" ? (
-                  <ActivityIndicator size="small" color={primaryColor} />
-                ) : (
-                  <Switch
-                    testID="channel-toggle-general"
-                    value={mainChannelEnabled}
-                    onValueChange={handleToggleMainChannel}
-                    trackColor={{ false: colors.border, true: primaryColor + "80" }}
-                    thumbColor={mainChannelEnabled ? primaryColor : colors.surfaceSecondary}
-                  />
-                )}
-              </View>
-            ) : (
-              mainChannelEnabled && (
-                <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
-              )
-            )}
-          </View>
-        )}
-
-        {/* Leaders Channel */}
-        {(leadersChannel || isLeader) && (
-          <View style={[styles.channelRow, { borderBottomColor: colors.border }]}>
-            <TouchableOpacity
-              style={styles.channelContent}
-              onPress={() => leadersChannel && leadersChannelEnabled && handleChannelPress(leadersChannel)}
-              activeOpacity={leadersChannelEnabled ? 0.7 : 1}
-              disabled={!leadersChannelEnabled}
-            >
-              <View style={[styles.channelIcon, { backgroundColor: "#FFA50015" }]}>
-                <Ionicons name="star" size={20} color="#FFA500" />
-              </View>
-              <View style={styles.channelInfo}>
-                <Text style={[styles.channelName, { color: colors.text }, !leadersChannelEnabled && { color: colors.textTertiary }]}>
-                  Leaders
-                </Text>
-                <Text style={[styles.channelSubtitle, { color: colors.textSecondary }]}>
-                  {leadersChannel
-                    ? `${leadersChannel.memberCount} leader${leadersChannel.memberCount !== 1 ? "s" : ""}`
-                    : "Disabled"}
-                </Text>
-                {leadersChannel && leadersChannelEnabled && (
-                  <Text style={[styles.channelNote, { color: colors.textTertiary }]}>
-                    You're here because you're a leader
-                  </Text>
-                )}
-              </View>
-              {leadersChannel && leadersChannelEnabled && leadersChannel.unreadCount > 0 && (
-                <View style={[styles.unreadBadge, { backgroundColor: "#FFA500" }]}>
-                  <Text style={styles.unreadText}>
-                    {leadersChannel.unreadCount > 99 ? "99+" : leadersChannel.unreadCount}
-                  </Text>
-                </View>
-              )}
-            </TouchableOpacity>
-            {isLeader && (
-              <View style={styles.toggleContainer}>
-                {togglingLeaders ? (
-                  <ActivityIndicator size="small" color={primaryColor} />
-                ) : (
-                  <Switch
-                    testID="channel-toggle-leaders"
-                    value={leadersChannelEnabled}
-                    onValueChange={handleToggleLeadersChannel}
-                    trackColor={{ false: colors.border, true: primaryColor + "80" }}
-                    thumbColor={leadersChannelEnabled ? primaryColor : colors.surfaceSecondary}
-                  />
-                )}
-              </View>
-            )}
-            {!isLeader && leadersChannelEnabled && (
-              <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
-            )}
-          </View>
-        )}
-
-        {/* Reach Out Channel */}
-        {isLeader && (
-          <View style={[styles.channelRow, { borderBottomColor: colors.border }]}>
-            <View style={styles.channelContent}>
-              <View style={[styles.channelIcon, { backgroundColor: "#8E44AD15" }]}>
-                <Ionicons name="hand-left" size={20} color="#8E44AD" />
-              </View>
-              <View style={styles.channelInfo}>
-                <Text style={[styles.channelName, { color: colors.text }, (!reachOutEnabled || !leadersChannelEnabled) && { color: colors.textTertiary }]}>
-                  Reach Out
-                </Text>
-                <Text style={[styles.channelSubtitle, { color: colors.textSecondary }]}>
-                  {!leadersChannelEnabled
-                    ? "Requires Leaders channel"
-                    : reachOutChannel
-                      ? `${reachOutChannel.memberCount} member(s)`
-                      : "Disabled"}
-                </Text>
-              </View>
-            </View>
-            <View style={styles.toggleContainer}>
-              {togglingReachOut ? (
-                <ActivityIndicator size="small" color={primaryColor} />
-              ) : (
-                <Switch
-                  testID="channel-toggle-reach-out"
-                  value={reachOutEnabled}
-                  onValueChange={handleToggleReachOutChannel}
-                  trackColor={{ false: colors.border, true: primaryColor + "80" }}
-                  thumbColor={reachOutEnabled ? primaryColor : colors.surfaceSecondary}
-                  disabled={!leadersChannelEnabled}
-                />
-              )}
-            </View>
-          </View>
-        )}
-
-        {/* PCO Synced Channels */}
-        {pcoSyncedChannels.map((channel: Channel) => {
-          const pcoEnabled = channel.isEnabled && !channel.isArchived;
-          const canTogglePco = isLeader;
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text style={[styles.header, { color: colors.textSecondary }]}>CHANNELS</Text>
+      <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
+        {rows.map((row, idx) => {
+          const isFirst = idx === 0;
+          const dimmed = !row.enabled;
+          // Disabled channels stay tappable so a leader can re-enable from
+          // the info screen's Active state. Placeholder rows with no
+          // onPress fall through to disabled.
+          const tappable = !!row.onPress;
           return (
-            <View key={channel._id} style={[styles.channelRow, { borderBottomColor: colors.border }]}>
-              <TouchableOpacity
-                style={styles.channelContent}
-                onPress={() =>
-                  pcoEnabled && channel.isMember
-                    ? handleChannelPress(channel)
-                    : pcoEnabled
-                      ? handleManageMembers(channel)
-                      : undefined
-                }
-                activeOpacity={pcoEnabled ? 0.7 : 1}
-                disabled={!pcoEnabled}
-              >
-                <View style={[styles.channelIcon, { backgroundColor: "#2196F315" }]}>
-                  <Ionicons name="sync" size={20} color="#2196F3" />
-                </View>
-                <View style={styles.channelInfo}>
-                  <View style={styles.channelNameRow}>
-                    <Text
-                      style={[
-                        styles.channelName,
-                        { color: colors.text },
-                        (!channel.isMember || !pcoEnabled) && { color: colors.textTertiary },
-                      ]}
-                    >
-                      {channel.name}
-                    </Text>
-                    {channel.isPinned && (
-                      <Ionicons name="pin" size={14} color={colors.iconSecondary} style={styles.pinIcon} />
-                    )}
-                  </View>
-                  <Text style={[styles.channelSubtitle, { color: colors.textSecondary }]}>
-                    {pcoEnabled
-                      ? `${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""} · PCO Synced`
-                      : "Disabled"}
+            <TouchableOpacity
+              key={row.key}
+              activeOpacity={0.7}
+              onPress={row.onPress}
+              disabled={!tappable}
+              style={[
+                styles.row,
+                !isFirst && {
+                  borderTopWidth: StyleSheet.hairlineWidth,
+                  borderTopColor: colors.border,
+                },
+              ]}
+            >
+              <View style={[styles.iconContainer, { backgroundColor: row.iconBg }]}>
+                <Ionicons name={row.icon} size={20} color={row.iconColor} />
+              </View>
+              <View style={styles.rowInfo}>
+                <View style={styles.rowNameLine}>
+                  <Text
+                    style={[
+                      styles.rowName,
+                      { color: dimmed ? colors.textTertiary : colors.text },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {row.name}
                   </Text>
-                  {!channel.isMember && isLeader && pcoEnabled && (
-                    <Text style={[styles.channelNote, { color: colors.textTertiary }]}>
-                      You're not in this channel
-                    </Text>
-                  )}
-                </View>
-                {pcoEnabled && channel.isMember && channel.unreadCount > 0 && (
-                  <View style={[styles.unreadBadge, { backgroundColor: "#2196F3" }]}>
-                    <Text style={styles.unreadText}>
-                      {channel.unreadCount > 99 ? "99+" : channel.unreadCount}
-                    </Text>
-                  </View>
-                )}
-              </TouchableOpacity>
-              {canTogglePco && (
-                <View style={styles.toggleContainer}>
-                  {togglingChannelId === channel._id ? (
-                    <ActivityIndicator size="small" color={primaryColor} />
-                  ) : (
-                    <Switch
-                      testID={`channel-toggle-pco-${channel.slug}`}
-                      value={pcoEnabled}
-                      onValueChange={(on) => handleTogglePcoChannel(channel, on)}
-                      trackColor={{ false: colors.border, true: primaryColor + "80" }}
-                      thumbColor={pcoEnabled ? primaryColor : colors.surfaceSecondary}
+                  {row.pinned && (
+                    <Ionicons
+                      name="pin"
+                      size={13}
+                      color={colors.iconSecondary}
+                      style={styles.pinIcon}
                     />
                   )}
                 </View>
-              )}
-              {isLeader && (
-                <TouchableOpacity
-                  style={[styles.actionButton, { backgroundColor: colors.surfaceSecondary }]}
-                  onPress={() => handleManageMembers(channel)}
-                  activeOpacity={0.7}
+                <Text
+                  style={[styles.rowSubtitle, { color: colors.textSecondary }]}
+                  numberOfLines={1}
                 >
-                  <Ionicons name="settings-outline" size={18} color={colors.icon} />
-                </TouchableOpacity>
+                  {row.subtitle}
+                </Text>
+              </View>
+              {row.enabled && row.unreadCount && row.unreadCount > 0 ? (
+                <View style={[styles.unreadBadge, { backgroundColor: row.iconColor }]}>
+                  <Text style={styles.unreadText}>
+                    {row.unreadCount > 99 ? "99+" : row.unreadCount}
+                  </Text>
+                </View>
+              ) : null}
+              {tappable && (
+                <Ionicons
+                  name="chevron-forward"
+                  size={18}
+                  color={colors.textTertiary}
+                />
               )}
-              {!isLeader && channel.isMember && (
-                <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
-              )}
-            </View>
+            </TouchableOpacity>
           );
         })}
       </View>
 
-      {/* PENDING SHARED CHANNEL INVITATIONS Section */}
+      {/* Solid Create Channel affordance — matches the DM "Add people"
+          card. Replaces the dashed-border button. */}
+      {isLeader && (
+        <TouchableOpacity
+          style={[styles.createCard, { backgroundColor: colors.surfaceSecondary }]}
+          onPress={handleCreateChannel}
+          activeOpacity={0.7}
+        >
+          <View style={[styles.createIcon, { backgroundColor: primaryColor + "15" }]}>
+            <Ionicons name="add" size={20} color={primaryColor} />
+          </View>
+          <Text style={[styles.createLabel, { color: colors.text }]}>
+            Create Channel
+          </Text>
+        </TouchableOpacity>
+      )}
+
       {isLeader && pendingInvites && pendingInvites.length > 0 && (
         <>
-          <Text style={[styles.header, styles.customHeader, { color: colors.text }]}>SHARED CHANNEL INVITATIONS</Text>
-          <View style={[styles.channelList, { backgroundColor: colors.surface }]}>
-            {pendingInvites.map((invite) => (
-              <View key={invite.channelId} style={[styles.channelRow, { borderBottomColor: colors.border }]}>
-                <View style={styles.channelContent}>
-                  <View style={[styles.channelIcon, { backgroundColor: "#8B5CF615" }]}>
-                    <Ionicons name="link" size={20} color="#8B5CF6" />
-                  </View>
-                  <View style={styles.channelInfo}>
-                    <Text style={[styles.channelName, { color: colors.text }]}>#{invite.channelName}</Text>
-                    <Text style={[styles.channelSubtitle, { color: colors.textSecondary }]}>
-                      From {invite.primaryGroupName}
-                    </Text>
-                    <Text style={[styles.channelNote, { color: colors.textTertiary }]}>
-                      Invited by {invite.invitedByName}
-                    </Text>
-                  </View>
+          <Text style={[styles.header, styles.subSectionHeader, { color: colors.textSecondary }]}>
+            SHARED CHANNEL INVITATIONS
+          </Text>
+          <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
+            {pendingInvites.map((invite, idx) => (
+              <View
+                key={invite.channelId}
+                style={[
+                  styles.row,
+                  idx > 0 && {
+                    borderTopWidth: StyleSheet.hairlineWidth,
+                    borderTopColor: colors.border,
+                  },
+                ]}
+              >
+                <View style={[styles.iconContainer, { backgroundColor: "#8B5CF615" }]}>
+                  <Ionicons name="link" size={20} color="#8B5CF6" />
+                </View>
+                <View style={styles.rowInfo}>
+                  <Text style={[styles.rowName, { color: colors.text }]}>
+                    #{invite.channelName}
+                  </Text>
+                  <Text style={[styles.rowSubtitle, { color: colors.textSecondary }]}>
+                    From {invite.primaryGroupName}
+                  </Text>
+                  <Text style={[styles.rowNote, { color: colors.textTertiary }]}>
+                    Invited by {invite.invitedByName}
+                  </Text>
                 </View>
                 <View style={styles.inviteActions}>
                   <TouchableOpacity
@@ -684,234 +396,70 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
         </>
       )}
 
-      {/* CUSTOM CHANNELS Section */}
-      {(customChannels.length > 0 || isLeader) && (
-        <>
-          <Text style={[styles.header, styles.customHeader, { color: colors.text }]}>CUSTOM CHANNELS</Text>
-          {isLeader && <ChannelJoinRequestsBanner groupId={groupId} />}
-          <View style={[styles.channelList, { backgroundColor: colors.surface }]}>
-            {customChannels.map((channel: Channel) => {
-              const customEnabled = channel.isEnabled && !channel.isArchived;
-              const canToggleCustom = isLeader;
-              return (
-                <View key={channel._id} style={[styles.channelRow, { borderBottomColor: colors.border }]}>
-                  <TouchableOpacity
-                    style={styles.channelContent}
-                    onPress={() =>
-                      customEnabled && channel.isMember
-                        ? handleChannelPress(channel)
-                        : customEnabled
-                          ? handleManageMembers(channel)
-                          : undefined
-                    }
-                    activeOpacity={customEnabled ? 0.7 : 1}
-                    disabled={!customEnabled}
-                  >
-                    <View style={[styles.channelIcon, { backgroundColor: "#00BCD415" }]}>
-                      <Ionicons name="chatbubble" size={20} color="#00BCD4" />
-                    </View>
-                    <View style={styles.channelInfo}>
-                      <View style={styles.channelNameRow}>
-                        <Text
-                          style={[
-                            styles.channelName,
-                            { color: colors.text },
-                            (!channel.isMember || !customEnabled) && { color: colors.textTertiary },
-                          ]}
-                        >
-                          {channel.name}
-                        </Text>
-                        {channel.isPinned && (
-                          <Ionicons name="pin" size={14} color={colors.iconSecondary} style={styles.pinIcon} />
-                        )}
-                      </View>
-                      <Text style={[styles.channelSubtitle, { color: colors.textSecondary }]}>
-                        {customEnabled
-                          ? `${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""}`
-                          : "Hidden from members"}
-                      </Text>
-                      {!channel.isMember && isLeader && customEnabled && (
-                        <Text style={[styles.channelNote, { color: colors.textTertiary }]}>
-                          You're not in this channel
-                        </Text>
-                      )}
-                    </View>
-                    {customEnabled && channel.isMember && channel.unreadCount > 0 && (
-                      <View style={[styles.unreadBadge, { backgroundColor: "#00BCD4" }]}>
-                        <Text style={styles.unreadText}>
-                          {channel.unreadCount > 99 ? "99+" : channel.unreadCount}
-                        </Text>
-                      </View>
-                    )}
-                  </TouchableOpacity>
-                  {canToggleCustom && (
-                    <View style={styles.toggleContainer}>
-                      {togglingChannelId === channel._id ? (
-                        <ActivityIndicator size="small" color={primaryColor} />
-                      ) : (
-                        <Switch
-                          testID={`channel-toggle-custom-${channel.slug}`}
-                          value={customEnabled}
-                          onValueChange={(on) => handleToggleCustomChannel(channel, on)}
-                          trackColor={{ false: colors.border, true: primaryColor + "80" }}
-                          thumbColor={customEnabled ? primaryColor : colors.surfaceSecondary}
-                        />
-                      )}
-                    </View>
-                  )}
-                  <View style={styles.actionButtons}>
-                    {isLeader && customEnabled && (
-                      <TouchableOpacity
-                        style={[styles.actionButton, { backgroundColor: colors.surfaceSecondary }]}
-                        onPress={() => handleManageMembers(channel)}
-                        activeOpacity={0.7}
-                      >
-                        <Ionicons name="people-outline" size={18} color={colors.icon} />
-                      </TouchableOpacity>
-                    )}
-                    {isLeader && customEnabled && (
-                      <TouchableOpacity
-                        style={[styles.actionButton, { backgroundColor: colors.surfaceSecondary }]}
-                        onPress={() => handleShareChannel(channel)}
-                        activeOpacity={0.7}
-                      >
-                        <Ionicons name="share-outline" size={18} color={colors.icon} />
-                      </TouchableOpacity>
-                    )}
-                    {channel.isMember && customEnabled && (
-                      <TouchableOpacity
-                        style={[styles.actionButton, { backgroundColor: colors.surfaceSecondary }]}
-                        onPress={() => handleLeaveChannel(channel)}
-                        activeOpacity={0.7}
-                        disabled={leavingChannelId === channel._id}
-                      >
-                        {leavingChannelId === channel._id ? (
-                          <ActivityIndicator size="small" color={colors.destructive} />
-                        ) : (
-                          <Ionicons name="exit-outline" size={18} color={colors.destructive} />
-                        )}
-                      </TouchableOpacity>
-                    )}
-                  </View>
-                </View>
-              );
-            })}
-
-            {/* Empty state for custom channels */}
-            {customChannels.length === 0 && isLeader && (
-              <View style={styles.emptyState}>
-                <Text style={[styles.emptyStateText, { color: colors.textTertiary }]}>
-                  No custom channels yet
-                </Text>
-              </View>
-            )}
-          </View>
-
-          {/* Create Channel Button (Leaders only) */}
-          {isLeader && (
-            <TouchableOpacity
-              style={[styles.createButton, { borderColor: primaryColor, backgroundColor: colors.surface }]}
-              onPress={handleCreateChannel}
-              activeOpacity={0.7}
-            >
-              <Ionicons name="add" size={20} color={primaryColor} />
-              <Text style={[styles.createButtonText, { color: primaryColor }]}>
-                Create Channel
-              </Text>
-            </TouchableOpacity>
-          )}
-
-          {/* Pin Channels Button (Leaders only) */}
-          {isLeader && (
-            <TouchableOpacity
-              style={styles.pinChannelsButton}
-              onPress={handlePinChannels}
-              activeOpacity={0.7}
-            >
-              <Ionicons name="pin-outline" size={18} color={colors.icon} />
-              <Text style={[styles.pinChannelsButtonText, { color: colors.icon }]}>Pin Channels</Text>
-            </TouchableOpacity>
-          )}
-
-          {/* Toolbar Settings Button (Leaders only) */}
-          {isLeader && (
-            <TouchableOpacity
-              style={styles.pinChannelsButton}
-              onPress={handleToolbarSettings}
-              activeOpacity={0.7}
-            >
-              <Ionicons name="options-outline" size={18} color={colors.icon} />
-              <Text style={[styles.pinChannelsButtonText, { color: colors.icon }]}>Toolbar Settings</Text>
-            </TouchableOpacity>
-          )}
-        </>
-      )}
+      {isLeader && <ChannelJoinRequestsBanner groupId={groupId} />}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
+    paddingHorizontal: 12,
+    paddingTop: 16,
+    paddingBottom: 8,
   },
   header: {
-    fontSize: 14,
+    fontSize: 11,
     fontWeight: "600",
-    marginBottom: 12,
-    letterSpacing: 0.5,
+    letterSpacing: 0.6,
+    marginBottom: 8,
+    paddingHorizontal: 8,
   },
-  customHeader: {
-    marginTop: 20,
+  subSectionHeader: {
+    marginTop: 24,
   },
-  loadingContainer: {
-    paddingVertical: 20,
-    alignItems: "center",
-  },
-  channelList: {
+  card: {
     borderRadius: 12,
     overflow: "hidden",
   },
-  channelRow: {
+  loadingContainer: {
+    paddingVertical: 24,
+    alignItems: "center",
+  },
+  row: {
     flexDirection: "row",
     alignItems: "center",
     paddingHorizontal: 12,
     paddingVertical: 12,
-    borderBottomWidth: StyleSheet.hairlineWidth,
+    minHeight: 56,
+    gap: 12,
   },
-  channelContent: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  channelIcon: {
+  iconContainer: {
     width: 40,
     height: 40,
     borderRadius: 20,
     justifyContent: "center",
     alignItems: "center",
-    marginRight: 12,
   },
-  channelInfo: {
+  rowInfo: {
     flex: 1,
+    minWidth: 0,
   },
-  channelNameRow: {
+  rowNameLine: {
     flexDirection: "row",
     alignItems: "center",
   },
-  channelName: {
+  rowName: {
     fontSize: 16,
     fontWeight: "600",
-    marginBottom: 2,
   },
   pinIcon: {
     marginLeft: 6,
-    marginBottom: 2,
   },
-  channelSubtitle: {
+  rowSubtitle: {
+    marginTop: 2,
     fontSize: 13,
   },
-  channelNote: {
+  rowNote: {
     fontSize: 11,
     fontStyle: "italic",
     marginTop: 2,
@@ -923,63 +471,32 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 6,
-    marginRight: 8,
+    marginRight: 4,
   },
   unreadText: {
     fontSize: 11,
     fontWeight: "700",
     color: "#fff",
   },
-  toggleContainer: {
-    marginLeft: 8,
-    width: 51, // Standard Switch width
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  actionButtons: {
+  createCard: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
-  },
-  actionButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  emptyState: {
-    paddingVertical: 16,
-    alignItems: "center",
-  },
-  emptyStateText: {
-    fontSize: 14,
-  },
-  createButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    marginTop: 12,
+    gap: 12,
+    marginTop: 8,
+    paddingHorizontal: 12,
     paddingVertical: 12,
     borderRadius: 12,
-    borderWidth: 2,
-    borderStyle: "dashed",
+    minHeight: 48,
   },
-  createButtonText: {
-    fontSize: 16,
-    fontWeight: "600",
-    marginLeft: 8,
-  },
-  pinChannelsButton: {
-    flexDirection: "row",
+  createIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
     alignItems: "center",
     justifyContent: "center",
-    marginTop: 12,
-    paddingVertical: 10,
-    gap: 6,
   },
-  pinChannelsButtonText: {
-    fontSize: 14,
+  createLabel: {
+    fontSize: 16,
     fontWeight: "500",
   },
   inviteActions: {

--- a/apps/mobile/features/groups/components/EditGroupScreen.tsx
+++ b/apps/mobile/features/groups/components/EditGroupScreen.tsx
@@ -26,6 +26,7 @@ import { useRouter, useLocalSearchParams } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@providers/AuthProvider";
+import { useTheme } from "@hooks/useTheme";
 import { uploadAsync, FileSystemUploadType } from "expo-file-system/legacy";
 import {
   FormInput,
@@ -121,6 +122,7 @@ export function EditGroupScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { user } = useAuth();
+  const { colors } = useTheme();
   const { group_id } = useLocalSearchParams<{ group_id: string }>();
 
   const { data: group, isLoading } = useGroupDetails(group_id);
@@ -402,7 +404,7 @@ export function EditGroupScreen() {
   if (isLoading) {
     return (
       <>
-        <View style={[styles.container, { paddingTop: insets.top }]}>
+        <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
           <View style={styles.header}>
             <SkeletonCard style={{ height: 44 }} />
           </View>
@@ -422,19 +424,24 @@ export function EditGroupScreen() {
   if (!canEditGroup) {
     return (
       <>
-        <View style={[styles.container, { paddingTop: insets.top }]}>
-          <View style={styles.header}>
+        <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+          <View
+            style={[
+              styles.header,
+              { backgroundColor: colors.surface, borderBottomColor: colors.border },
+            ]}
+          >
             <TouchableOpacity
               onPress={() => router.back()}
               style={styles.backButton}
             >
-              <Ionicons name="arrow-back" size={24} color="#000" />
+              <Ionicons name="arrow-back" size={24} color={colors.text} />
             </TouchableOpacity>
-            <Text style={styles.headerTitle}>Edit Group</Text>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>Edit Group</Text>
             <View style={styles.headerRight} />
           </View>
           <View style={styles.centerContainer}>
-            <Text style={styles.errorText}>
+            <Text style={[styles.errorText, { color: colors.destructive }]}>
               You must be a group leader or community admin to edit this group.
             </Text>
           </View>
@@ -446,18 +453,25 @@ export function EditGroupScreen() {
   return (
     <>
       <KeyboardAvoidingView
-        style={[styles.container, { paddingTop: insets.top }]}
+        style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
         {/* Header */}
-        <View style={styles.header}>
+        <View
+          style={[
+            styles.header,
+            { backgroundColor: colors.surface, borderBottomColor: colors.border },
+          ]}
+        >
           <TouchableOpacity
             onPress={() => router.back()}
             style={styles.backButton}
           >
-            <Ionicons name="arrow-back" size={24} color="#000" />
+            <Ionicons name="arrow-back" size={24} color={colors.text} />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>Edit Group</Text>
+          <Text style={[styles.headerTitle, { color: colors.text }]}>
+            Edit Group
+          </Text>
           <View style={styles.headerRight} />
         </View>
 
@@ -468,12 +482,12 @@ export function EditGroupScreen() {
           keyboardShouldPersistTaps="handled"
         >
           {/* Basic Information Section */}
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Basic Information</Text>
+          <View style={[styles.section, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Basic Information</Text>
 
             {/* Group Picture Upload */}
             <View style={styles.imagePickerContainer}>
-              <Text style={styles.imagePickerLabel}>Group Picture</Text>
+              <Text style={[styles.imagePickerLabel, { color: colors.text }]}>Group Picture</Text>
               <ImagePicker
                 onImageSelected={handleImageSelected}
                 onImageRemoved={handleImageRemoved}
@@ -523,8 +537,8 @@ export function EditGroupScreen() {
           </View>
 
           {/* Location Section */}
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Location</Text>
+          <View style={[styles.section, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Location</Text>
 
             <FormInput
               name="address_line1"
@@ -573,9 +587,14 @@ export function EditGroupScreen() {
 
             {/* Geocoding warning */}
             {hasAddressWithoutZip && (
-              <View style={styles.locationWarning}>
-                <Ionicons name="warning" size={20} color="#F59E0B" />
-                <Text style={styles.locationWarningText}>
+              <View
+                style={[
+                  styles.locationWarning,
+                  { backgroundColor: colors.warning + "1F" },
+                ]}
+              >
+                <Ionicons name="warning" size={20} color={colors.warning} />
+                <Text style={[styles.locationWarningText, { color: colors.warning }]}>
                   Add a valid ZIP code so this group appears on the map
                 </Text>
               </View>
@@ -583,8 +602,8 @@ export function EditGroupScreen() {
           </View>
 
           {/* Meeting Schedule Section */}
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Meeting Schedule</Text>
+          <View style={[styles.section, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Meeting Schedule</Text>
 
             <Controller
               name="default_day"
@@ -720,9 +739,9 @@ export function EditGroupScreen() {
           </View>
 
           {/* External Chat Section */}
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>External Chat</Text>
-            <Text style={styles.sectionDescription}>
+          <View style={[styles.section, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>External Chat</Text>
+            <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
               If your group also communicates on another platform like WhatsApp, Slack, Telegram, or Discord, add the invite link here. Members will see a "Join" button in the chat to join your external group.
             </Text>
 
@@ -740,12 +759,12 @@ export function EditGroupScreen() {
 
           {/* Visibility Section — community admins only */}
           {isCommunityAdmin && (
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Visibility</Text>
+            <View style={[styles.section, { backgroundColor: colors.surface }]}>
+              <Text style={[styles.sectionTitle, { color: colors.text }]}>Visibility</Text>
               <View style={styles.toggleRow}>
                 <View style={styles.toggleTextWrap}>
-                  <Text style={styles.toggleLabel}>Hide from discovery</Text>
-                  <Text style={styles.toggleDescription}>
+                  <Text style={[styles.toggleLabel, { color: colors.text }]}>Hide from discovery</Text>
+                  <Text style={[styles.toggleDescription, { color: colors.textSecondary }]}>
                     When on, this group won't appear on the map, near-me page,
                     or community group browse. People with a direct share link
                     can still view and request to join.

--- a/apps/mobile/features/groups/components/GroupBotsSection.tsx
+++ b/apps/mobile/features/groups/components/GroupBotsSection.tsx
@@ -1,0 +1,261 @@
+/**
+ * GroupBotsSection
+ *
+ * Inline bots list on the group page. Replaces the "Bots" toolbar chip in
+ * the chat navigation. Renders a compact card per bot with a Switch toggle
+ * and a Configure affordance for bots that have config UI. Mounts the same
+ * config modals BotsScreen does so behavior is identical.
+ *
+ * Hidden for non-leaders. Hidden if the bots query returns no entries.
+ */
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Switch,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import {
+  useQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { BotConfigModal } from "@features/leader-tools/components/BotConfigModal";
+import { TaskReminderConfigModal } from "@features/leader-tools/components/TaskReminderConfigModal";
+import { CommunicationBotConfigModal } from "@features/leader-tools/components/CommunicationBotConfigModal";
+
+interface Props {
+  groupId: string;
+  isLeader: boolean;
+}
+
+type Bot = {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  triggerType: string;
+  enabled: boolean;
+  hasConfig?: boolean;
+  customConfigUI?: boolean;
+};
+
+export function GroupBotsSection({ groupId, isLeader }: Props) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const [selectedBot, setSelectedBot] = useState<Bot | null>(null);
+  const [configModalVisible, setConfigModalVisible] = useState(false);
+  const [taskReminderModalVisible, setTaskReminderModalVisible] = useState(false);
+  const [communicationBotModalVisible, setCommunicationBotModalVisible] =
+    useState(false);
+
+  const botsData = useQuery(
+    api.functions.groupBots.listForGroup,
+    isLeader && groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+  );
+
+  const communicationBotConfig = useQuery(
+    api.functions.groupBots.getConfig,
+    isLeader && groupId
+      ? { groupId: groupId as Id<"groups">, botId: "communication" }
+      : "skip",
+  );
+
+  const toggleBot = useAuthenticatedMutation(api.functions.groupBots.toggle);
+  const updateConfig = useAuthenticatedMutation(
+    api.functions.groupBots.updateConfig,
+  );
+
+  if (!isLeader) return null;
+  if (!botsData || botsData.length === 0) return null;
+
+  const bots = botsData as Bot[];
+
+  const handleOpenConfig = (bot: Bot) => {
+    setSelectedBot(bot);
+    if (bot.id === "task-reminder") {
+      setTaskReminderModalVisible(true);
+    } else if (bot.id === "communication") {
+      setCommunicationBotModalVisible(true);
+    } else {
+      setConfigModalVisible(true);
+    }
+  };
+
+  const handleCloseConfig = () => {
+    setConfigModalVisible(false);
+    setTaskReminderModalVisible(false);
+    setCommunicationBotModalVisible(false);
+    setSelectedBot(null);
+  };
+
+  const handleToggle = async (bot: Bot, value: boolean) => {
+    try {
+      await toggleBot({
+        groupId: groupId as Id<"groups">,
+        botId: bot.id,
+        enabled: value,
+      });
+    } catch (e) {
+      // Convex auto-rolls back; nothing to do here. BotConfigModal owns
+      // alerts for richer flows.
+    }
+  };
+
+  const handleSaveCommunicationBotConfig = async (config: {
+    messages: Array<{
+      id: string;
+      message: string;
+      schedule: { dayOfWeek: number; hour: number; minute: number };
+      targetChannelSlug: string;
+      enabled: boolean;
+    }>;
+  }) => {
+    await updateConfig({
+      groupId: groupId as Id<"groups">,
+      botId: "communication",
+      config,
+    });
+  };
+
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.header, { color: colors.textSecondary }]}>BOTS</Text>
+      <View
+        style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}
+      >
+        {bots.map((bot, idx) => (
+          <View
+            key={bot.id}
+            style={[
+              styles.row,
+              idx > 0 && {
+                borderTopWidth: StyleSheet.hairlineWidth,
+                borderTopColor: colors.border,
+              },
+            ]}
+          >
+            <Text style={styles.botIcon}>{bot.icon}</Text>
+            <View style={styles.botInfo}>
+              <Text style={[styles.botName, { color: colors.text }]} numberOfLines={1}>
+                {bot.name}
+              </Text>
+              <Text
+                style={[styles.botDescription, { color: colors.textSecondary }]}
+                numberOfLines={2}
+              >
+                {bot.description}
+              </Text>
+              {(bot.hasConfig || bot.customConfigUI) && (
+                <Pressable
+                  onPress={() => handleOpenConfig(bot)}
+                  hitSlop={6}
+                  style={styles.configButton}
+                >
+                  <Ionicons
+                    name="settings-outline"
+                    size={14}
+                    color={primaryColor}
+                  />
+                  <Text style={[styles.configLabel, { color: primaryColor }]}>
+                    Configure
+                  </Text>
+                </Pressable>
+              )}
+            </View>
+            <Switch
+              value={bot.enabled}
+              onValueChange={(value) => handleToggle(bot, value)}
+              trackColor={{ false: colors.border, true: primaryColor }}
+              thumbColor={bot.enabled ? primaryColor : "#f4f3f4"}
+            />
+          </View>
+        ))}
+      </View>
+
+      {selectedBot &&
+        selectedBot.id !== "task-reminder" &&
+        selectedBot.id !== "communication" && (
+          <BotConfigModal
+            visible={configModalVisible}
+            onClose={handleCloseConfig}
+            groupId={groupId}
+            botId={selectedBot.id}
+            botName={selectedBot.name}
+            botIcon={selectedBot.icon}
+          />
+        )}
+
+      <TaskReminderConfigModal
+        visible={taskReminderModalVisible}
+        onClose={handleCloseConfig}
+        groupId={groupId}
+      />
+
+      <CommunicationBotConfigModal
+        visible={communicationBotModalVisible}
+        onClose={handleCloseConfig}
+        groupId={groupId as Id<"groups">}
+        initialConfig={communicationBotConfig?.config as any}
+        onSave={handleSaveCommunicationBotConfig}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: 24,
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  header: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+  },
+  card: {
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  botIcon: {
+    fontSize: 24,
+    lineHeight: 28,
+    marginTop: 2,
+  },
+  botInfo: {
+    flex: 1,
+    gap: 4,
+  },
+  botName: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  botDescription: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  configButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginTop: 4,
+  },
+  configLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -8,10 +8,16 @@ import {
   Alert,
   RefreshControl,
   Modal,
+  Linking,
+  Platform,
+  Share,
+  ActionSheetIOS,
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import * as Clipboard from "expo-clipboard";
+import { DOMAIN_CONFIG } from "@togather/shared";
 import { useTheme } from "@hooks/useTheme";
 import { GroupDetailSkeleton } from "./GroupDetailSkeleton";
 import { useAuth } from "@providers/AuthProvider";
@@ -26,18 +32,22 @@ import { useMyPendingJoinRequests } from "../hooks/useMyPendingJoinRequests";
 import { PendingRequestLimitModal } from "./PendingRequestLimitModal";
 import { isGroupMember } from "../utils";
 import { useUserData } from "@features/profile/hooks/useUserData";
-import { RSVPModal } from "./RSVPModal";
 import { GroupHeader } from "./GroupHeader";
 import { GroupOptionsModal } from "./GroupOptionsModal";
 import { NextEventSection } from "./NextEventSection";
 import { MembersRow } from "./MembersRow";
 import { HighlightsGrid } from "./HighlightsGrid";
-import { GroupMapSection } from "./GroupMapSection";
 import { GroupNonMemberView } from "./GroupNonMemberView";
 import { ChannelsSection } from "./ChannelsSection";
+import { UpcomingEventsSection } from "./UpcomingEventsSection";
+import { GroupBotsSection } from "./GroupBotsSection";
 import { Group } from "../types";
 import { ImageViewerManager } from "@/providers/ImageViewerProvider";
-import { getExternalChatInfo, openExternalChatLink } from "@features/chat/utils/externalChat";
+import { formatCadence } from "../utils";
+import {
+  getExternalChatInfo,
+  openExternalChatLink,
+} from "@features/chat/utils/externalChat";
 
 export function GroupDetailScreen() {
   const params = useLocalSearchParams<{ group_id: string }>();
@@ -46,84 +56,76 @@ export function GroupDetailScreen() {
   const { user } = useAuth();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const [showRSVPModal, setShowRSVPModal] = useState(false);
   const [showOptionsModal, setShowOptionsModal] = useState(false);
   const [showJoinSuccessModal, setShowJoinSuccessModal] = useState(false);
   const [showPendingLimitModal, setShowPendingLimitModal] = useState(false);
 
-  // Pending join request cap (frontend stopgap — backend allows unlimited).
-  // When the user already has 2 pending requests in the active community we
-  // surface a friction modal instead of submitting another request.
-  // We also track loading: until the query has resolved, isAtLimit is false
-  // by default (empty list), which would let an at-cap user slip through.
-  // The Join button is disabled and handleJoinGroup returns early until the
-  // count is known.
   const {
     isAtLimit: isAtPendingLimit,
     isLoading: isPendingLimitLoading,
   } = useMyPendingJoinRequests();
 
-  const { data: group, isLoading, error, refetch, isRefetching } = useGroupDetails(group_id);
+  const {
+    data: group,
+    isLoading,
+    error,
+    refetch,
+    isRefetching,
+  } = useGroupDetails(group_id);
   const { data: userData } = useUserData(!!user);
 
-  // Use Convex _id for navigation, fallback to group_id for legacy
   const groupIdentifier = group?._id || group_id;
 
-  // Mutations for group actions
   const leaveGroupMutation = useLeaveGroup();
   const joinGroupMutation = useJoinGroup(groupIdentifier);
   const withdrawMutation = useWithdrawJoinRequest(groupIdentifier);
   const archiveGroupMutation = useArchiveGroup(groupIdentifier);
 
-  // Handle pull-to-refresh - must be before any early returns to satisfy Rules of Hooks
   const handleRefresh = useCallback(() => {
     refetch();
   }, [refetch]);
 
-  // Check if current user is a member of the group
-  // Use the API's user_request_status field as the source of truth
-  // 'accepted' means the user is a member, 'pending' means waiting for approval, null/'declined' means not a member
   const isMember = useMemo(() => {
     if (!group || !user?.id) {
       return false;
     }
-
-    // Primary check: user_request_status from API (most reliable)
     if (group.user_request_status === "accepted") {
       return true;
     }
-
-    // Secondary check: user_role indicates membership (includes leaders and admins)
     if (group.user_role && group.user_role !== null) {
       return true;
     }
-
-    // Fallback check: user in group.members array
     const memberCheck = isGroupMember(group, user.id);
     if (memberCheck) {
       return true;
     }
-
-    // Final fallback: user's group_memberships contains this group
     if (
       userData?.group_memberships &&
       Array.isArray(userData.group_memberships)
     ) {
       const hasMembership = userData.group_memberships.some(
-        (membership: any) => membership.group?._id === group._id
+        (membership: any) => membership.group?._id === group._id,
       );
       if (hasMembership) {
         return true;
       }
     }
-
     return false;
   }, [group, user?.id, userData?.group_memberships]);
 
-  // Check if user is a community admin
   const isAdmin = user?.is_admin === true;
+  const isLeader =
+    group?.user_role === "leader" || group?.user_role === "admin";
+  const canEditGroup = useMemo(() => {
+    if (!group || !user?.id) return false;
+    if (user.is_admin === true) return true;
+    return (
+      group.leaders?.some((leader) => String(leader.id) === String(user.id)) ||
+      false
+    );
+  }, [group, user?.id, user?.is_admin]);
+  const canArchiveGroup = isAdmin && !group?.is_announcement_group;
 
-  // Navigate to members page - use Convex _id for navigation
   const handleMembersPress = () => {
     if (!group?._id) return;
     router.push(`/leader-tools/${group._id}/members`);
@@ -146,12 +148,15 @@ export function GroupDetailScreen() {
           style: "destructive",
           onPress: () => {
             if (user?.id) {
-              leaveGroupMutation.mutate({ groupId: groupIdentifier, userId: String(user.id) });
+              leaveGroupMutation.mutate({
+                groupId: groupIdentifier,
+                userId: String(user.id),
+              });
             }
             setShowOptionsModal(false);
           },
         },
-      ]
+      ],
     );
   };
 
@@ -160,35 +165,19 @@ export function GroupDetailScreen() {
       Alert.alert("Error", "Please log in to join a group.");
       return;
     }
-
     if (!group?._id && !group?.id) {
       Alert.alert("Error", "Group information is missing. Please try again.");
       return;
     }
-
-    // Frontend stopgap: if the user already has the maximum number of pending
-    // join requests in this community, show the limit modal instead of
-    // submitting another request. The cap exists to keep leaders from getting
-    // overwhelmed with requests from people who join 3+ groups and ghost.
-    //
-    // Defensive guard: if the pending-requests query hasn't resolved yet,
-    // refuse the submission. Without this an at-cap user could slip through
-    // during the loading window (isAtLimit defaults to false on empty data).
-    // The Join button is also disabled below while loading, but we double
-    // gate here in case anything else triggers handleJoinGroup.
-    if (isPendingLimitLoading) {
-      return;
-    }
+    if (isPendingLimitLoading) return;
     if (isAtPendingLimit) {
       setShowPendingLimitModal(true);
       return;
     }
-
     try {
       await joinGroupMutation.mutateAsync();
       setShowJoinSuccessModal(true);
     } catch (error) {
-      // Error alert is already handled in the hook
       console.error("Join group error:", error);
     }
   };
@@ -198,18 +187,13 @@ export function GroupDetailScreen() {
       "Withdraw Request",
       "Are you sure you want to withdraw your join request?",
       [
-        {
-          text: "Cancel",
-          style: "cancel",
-        },
+        { text: "Cancel", style: "cancel" },
         {
           text: "Withdraw",
           style: "destructive",
-          onPress: () => {
-            withdrawMutation.mutate();
-          },
+          onPress: () => withdrawMutation.mutate(),
         },
-      ]
+      ],
     );
   };
 
@@ -220,11 +204,7 @@ export function GroupDetailScreen() {
         group?.title || group?.name || "this group"
       }"? This will hide the group from all members. This action can be undone by a community admin.`,
       [
-        {
-          text: "Cancel",
-          style: "cancel",
-          onPress: () => setShowOptionsModal(false),
-        },
+        { text: "Cancel", style: "cancel" },
         {
           text: "Archive",
           style: "destructive",
@@ -232,43 +212,80 @@ export function GroupDetailScreen() {
             await archiveGroupMutation.mutate();
           },
         },
-      ]
+      ],
     );
   };
 
+  const handleEditGroup = () => {
+    if (!group?._id) return;
+    router.push(`/groups/${group._id}/edit`);
+  };
+
+  const handleShareGroup = async () => {
+    if (!group?.shortId) {
+      Alert.alert("Cannot Share", "This group doesn't have a shareable link yet.");
+      return;
+    }
+    const groupUrl = DOMAIN_CONFIG.groupShareUrl(group.shortId);
+    const groupName = group.name || group.title || "Group";
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          options: ["Cancel", "Copy Link", "Share"],
+          cancelButtonIndex: 0,
+        },
+        async (buttonIndex) => {
+          if (buttonIndex === 1) {
+            await Clipboard.setStringAsync(groupUrl);
+            Alert.alert("Link Copied", "Group link has been copied to clipboard.");
+          } else if (buttonIndex === 2) {
+            await Share.share({
+              message: `${groupName}\n${groupUrl}`,
+              url: groupUrl,
+            });
+          }
+        },
+      );
+    } else {
+      await Share.share({ message: `${groupName}\n${groupUrl}` });
+    }
+  };
+
+  const handlePinChannels = () => {
+    if (!group?._id) return;
+    router.push(`/(user)/leader-tools/${group._id}/pin-channels`);
+  };
+
+  const handleToolbarSettings = () => {
+    if (!group?._id) return;
+    router.push(`/(user)/leader-tools/${group._id}/toolbar-settings`);
+  };
+
   if (isLoading) {
-    return (
-      <>
-        <GroupDetailSkeleton />
-      </>
-    );
+    return <GroupDetailSkeleton />;
   }
 
   if (error || !group) {
     return (
-      <>
-        <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
-          <Text style={[styles.errorText, { color: colors.error }]}>Group not found</Text>
-          <TouchableOpacity
-            style={[styles.button, { backgroundColor: colors.link }]}
-            onPress={() => {
-              if (router.canGoBack()) {
-                router.back();
-              } else {
-                router.replace("/groups");
-              }
-            }}
-          >
-            <Text style={[styles.buttonText, { color: colors.textInverse }]}>Go Back</Text>
-          </TouchableOpacity>
-        </View>
-      </>
+      <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <Text style={[styles.errorText, { color: colors.error }]}>Group not found</Text>
+        <TouchableOpacity
+          style={[styles.button, { backgroundColor: colors.link }]}
+          onPress={() => {
+            if (router.canGoBack()) {
+              router.back();
+            } else {
+              router.replace("/groups");
+            }
+          }}
+        >
+          <Text style={[styles.buttonText, { color: colors.textInverse }]}>Go Back</Text>
+        </TouchableOpacity>
+      </View>
     );
   }
 
-  // Show non-member view if user is not a member.
-  // Non-member admins should also see this view so they can join the group,
-  // but the GroupNonMemberView provides admin-specific features (menu, member list access).
   if (!isMember) {
     return (
       <>
@@ -279,9 +296,6 @@ export function GroupDetailScreen() {
           isJoining={joinGroupMutation.isPending || isPendingLimitLoading}
           isWithdrawing={withdrawMutation.isPending}
         />
-
-        {/* Pending request limit modal — fires when the user is already at
-            the cap and tries to request to join another group. */}
         <PendingRequestLimitModal
           visible={showPendingLimitModal}
           onDismiss={() => setShowPendingLimitModal(false)}
@@ -290,8 +304,6 @@ export function GroupDetailScreen() {
             router.push("/(tabs)/profile");
           }}
         />
-
-        {/* Join Success Modal */}
         <Modal
           visible={showJoinSuccessModal}
           transparent
@@ -331,31 +343,51 @@ export function GroupDetailScreen() {
     );
   }
 
-  // Debug: Log group data to help diagnose missing sections
-  if (__DEV__) {
-    console.log("GroupDetailScreen - Group data:", {
-      _id: group._id,
-      hasDate: !!(group as any).date,
-      hasNextMeetingDate: !!(group as any).next_meeting_date,
-      hasSchedule: !!(group as any).group_schedule_details,
-      membersCount: group.members?.length || 0,
-      leadersCount: group.leaders?.length || 0,
-      members_count: group.members_count,
-      highlightsCount: group.highlights?.length || 0,
-      hasHighlights: !!group.highlights,
-      // Membership detection fields
-      user_request_status: group.user_request_status,
-      user_role: group.user_role,
-      isMember: isMember,
-    });
-  }
+  const cadence = formatCadence(group);
+  const address =
+    group.full_address ||
+    (group.address_line1 || group.city || group.state || group.zip_code
+      ? [
+          group.address_line1,
+          group.address_line2,
+          [group.city, group.state].filter(Boolean).join(", "),
+          group.zip_code,
+        ]
+          .filter(Boolean)
+          .join(", ")
+      : null) ||
+    group.location ||
+    null;
 
-  // Show member view
+  const handleAddressPress = async () => {
+    if (!address) return;
+    const encoded = encodeURIComponent(address);
+    const url =
+      Platform.OS === "ios"
+        ? `maps://maps.apple.com/?q=${encoded}`
+        : `https://www.google.com/maps/search/?api=1&query=${encoded}`;
+    try {
+      const canOpen = await Linking.canOpenURL(url);
+      if (canOpen) {
+        await Linking.openURL(url);
+      } else {
+        await Linking.openURL(
+          `https://www.google.com/maps/search/?api=1&query=${encoded}`,
+        );
+      }
+    } catch (err) {
+      console.error("Error opening maps:", err);
+    }
+  };
+
+  const showDetailsCard = !!cadence || !!address;
+  const externalChatLink = (group as any).externalChatLink as string | undefined;
+
   return (
     <>
       <ScrollView
         style={[styles.scrollView, { backgroundColor: colors.background }]}
-        contentContainerStyle={{ paddingTop: insets.top }}
+        contentContainerStyle={{ paddingTop: insets.top, paddingBottom: 24 }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
@@ -365,126 +397,67 @@ export function GroupDetailScreen() {
           />
         }
       >
-        {/* Header with image, name, and cadence */}
+        {/* Centered hero (DM-style). The (i) icon is gone — you're
+            already on the info surface; share lives in the top right. */}
         <GroupHeader
           group={group}
-          onMenuPress={() => setShowOptionsModal(true)}
-          showMenu={true}
+          onSharePress={group.shortId ? handleShareGroup : undefined}
+          canEdit={canEditGroup}
         />
 
-        {/* Description */}
-        <View style={[styles.descriptionContainer, { backgroundColor: colors.surfaceSecondary }]}>
-          <Text style={[styles.description, { color: colors.textSecondary }]}>
-            {group.description || "No description available."}
-          </Text>
-        </View>
-
-        {/* Chat Section - Link to group chat */}
-        {(group as any).main_channel_id && (
-          <View style={[styles.chatSection, { backgroundColor: colors.surfaceSecondary }]}>
+        {/* MEMBERS — moved above channels */}
+        {((group.members && group.members.length > 0) ||
+          (group.leaders && group.leaders.length > 0) ||
+          (group.members_count && group.members_count > 0)) && (
+          <View style={styles.section}>
+            <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+              MEMBERS{group.members_count ? ` · ${group.members_count}` : ""}
+            </Text>
             <TouchableOpacity
-              style={[styles.chatCard, { backgroundColor: colors.surface }]}
-              onPress={() => {
-                const mainChannelId = (group as any).main_channel_id;
-                const leadersChannelId = (group as any).leaders_channel_id;
-                router.push({
-                  pathname: `/inbox/${mainChannelId}`,
-                  params: {
-                    groupId: group._id,
-                    groupName: group.title || group.name || "",
-                    groupType: group.group_type_name || "",
-                    groupTypeSlug: (group as any).group_type_slug || "",
-                    groupTypeId: String(group.group_type || 3),
-                    imageUrl: group.preview || "",
-                    isLeader: (group.user_role === "leader" || group.user_role === "admin") ? "1" : "0",
-                    leadersChannelId: leadersChannelId || "",
-                    isAnnouncementGroup: (group as any).is_announcement_group ? "1" : "0",
-                    externalChatLink: (group as any).externalChatLink || "",
-                  },
-                });
-              }}
               activeOpacity={0.7}
+              onPress={isLeader || isAdmin ? handleMembersPress : undefined}
+              disabled={!(isLeader || isAdmin)}
+              style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}
             >
-              <View style={[styles.chatIconContainer, { backgroundColor: colors.link + "15" }]}>
-                <Ionicons name="chatbubbles" size={24} color={colors.link} />
-              </View>
-              <View style={styles.chatInfo}>
-                <Text style={[styles.chatTitle, { color: colors.text }]}>Group Chat</Text>
-                <Text style={[styles.chatSubtitle, { color: colors.textSecondary }]}>Message your group members</Text>
-              </View>
-              <Ionicons name="chevron-forward" size={20} color={colors.link} />
+              <MembersRow
+                members={group.members}
+                leaders={group.leaders}
+                totalCount={group.members_count ?? undefined}
+              />
+              {(isLeader || isAdmin) && (
+                <View style={[styles.viewAllRow, { borderTopColor: colors.border }]}>
+                  <Text style={[styles.viewAllText, { color: colors.text }]}>
+                    View all members
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                  />
+                </View>
+              )}
             </TouchableOpacity>
           </View>
         )}
 
-        {/* External Chat Section */}
-        {(group as any).externalChatLink && (() => {
-          const externalChatInfo = getExternalChatInfo((group as any).externalChatLink);
-          return (
-            <View style={[styles.externalChatSection, { backgroundColor: colors.surfaceSecondary }]}>
-              <Text style={[styles.sectionTitle, { color: colors.text }]}>EXTERNAL CHAT</Text>
-              <TouchableOpacity
-                style={[styles.externalChatCard, { backgroundColor: colors.surface }]}
-                onPress={() => openExternalChatLink((group as any).externalChatLink)}
-                activeOpacity={0.7}
-              >
-                <View style={[styles.externalChatIconContainer, { backgroundColor: externalChatInfo.color + "15" }]}>
-                  <Ionicons
-                    name={externalChatInfo.iconName as any}
-                    size={24}
-                    color={externalChatInfo.color}
-                  />
-                </View>
-                <View style={styles.externalChatInfo}>
-                  <Text style={[styles.externalChatTitle, { color: colors.text }]}>
-                    Join on {externalChatInfo.name}
-                  </Text>
-                  <Text style={[styles.externalChatSubtitle, { color: colors.textSecondary }]}>
-                    This group also chats on {externalChatInfo.name}
-                  </Text>
-                </View>
-                <Ionicons name="open-outline" size={20} color={externalChatInfo.color} />
-              </TouchableOpacity>
-            </View>
-          );
-        })()}
+        {/* UPCOMING EVENTS — horizontal scroll, sits between Members and
+            Channels per product design. Hidden when there are no upcoming
+            events. */}
+        {group._id && <UpcomingEventsSection groupId={group._id} />}
 
-        {/* Channels Section - Shows all channels with management options */}
+        {/* CHANNELS */}
         {group._id && (
-          <ChannelsSection
-            groupId={group._id}
-            userRole={group.user_role}
-          />
+          <ChannelsSection groupId={group._id} userRole={group.user_role} />
         )}
 
-        {/* Map Section */}
-        <GroupMapSection group={group} />
+        {/* BOTS — replaces the legacy "Bots" toolbar chip in chat. Leader
+            only; renders the same bot cards + config modals BotsScreen
+            renders. */}
+        {group._id && (
+          <GroupBotsSection groupId={group._id} isLeader={isLeader || isAdmin} />
+        )}
 
-        {/* Next Event - Always show if group has date info */}
-        <NextEventSection group={group} currentRSVP={null} />
-
-        {/* Members - Show if members or leaders exist, or if members_count > 0 */}
-        {/* Clickable for admins/leaders to navigate to members page */}
-        {/* Note: Non-members are handled by GroupNonMemberView (early return above) */}
-        {(group.members && group.members.length > 0) ||
-        (group.leaders && group.leaders.length > 0) ||
-        (group.members_count && group.members_count > 0) ? (
-          isAdmin ||
-          group.user_role === "leader" ||
-          group.user_role === "admin" ? (
-            <TouchableOpacity onPress={handleMembersPress} activeOpacity={0.7}>
-              <MembersRow members={group.members} leaders={group.leaders} />
-              <View style={[styles.viewMembersHint, { backgroundColor: colors.surfaceSecondary }]}>
-                <Text style={[styles.viewMembersText, { color: colors.link }]}>View all members</Text>
-                <Ionicons name="chevron-forward" size={16} color={colors.link} />
-              </View>
-            </TouchableOpacity>
-          ) : (
-            <MembersRow members={group.members} leaders={group.leaders} />
-          )
-        ) : null}
-
-        {/* Highlights - Show if highlights exist */}
+        {/* Highlights */}
         {group.highlights && group.highlights.length > 0 && (
           <HighlightsGrid
             highlights={group.highlights as any}
@@ -492,18 +465,181 @@ export function GroupDetailScreen() {
               const imageUrls = (group.highlights as any)
                 .map((h: any) => h.image_url)
                 .filter(Boolean);
-
               const index = (group.highlights as any).findIndex(
-                (h: any) => h.id === clickedHighlight.id
+                (h: any) => h.id === clickedHighlight.id,
               );
-
               ImageViewerManager.show(imageUrls, Math.max(0, index));
             }}
           />
         )}
+
+        {/* Next event */}
+        <NextEventSection group={group} currentRSVP={null} />
+
+        {/* External chat */}
+        {!!externalChatLink &&
+          (() => {
+            const externalChatInfo = getExternalChatInfo(externalChatLink);
+            return (
+              <View style={styles.section}>
+                <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+                  EXTERNAL CHAT
+                </Text>
+                <TouchableOpacity
+                  style={[styles.card, styles.externalRow, { backgroundColor: colors.surfaceSecondary }]}
+                  onPress={() => openExternalChatLink(externalChatLink)}
+                  activeOpacity={0.7}
+                >
+                  <View
+                    style={[
+                      styles.externalIcon,
+                      { backgroundColor: externalChatInfo.color + "15" },
+                    ]}
+                  >
+                    <Ionicons
+                      name={externalChatInfo.iconName as any}
+                      size={20}
+                      color={externalChatInfo.color}
+                    />
+                  </View>
+                  <View style={styles.externalInfo}>
+                    <Text style={[styles.externalTitle, { color: colors.text }]}>
+                      Join on {externalChatInfo.name}
+                    </Text>
+                    <Text
+                      style={[styles.externalSubtitle, { color: colors.textSecondary }]}
+                    >
+                      This group also chats on {externalChatInfo.name}
+                    </Text>
+                  </View>
+                  <Ionicons name="open-outline" size={18} color={externalChatInfo.color} />
+                </TouchableOpacity>
+              </View>
+            );
+          })()}
+
+        {/* DETAILS — schedule + address */}
+        {showDetailsCard && (
+          <View style={styles.section}>
+            <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+              DETAILS
+            </Text>
+            <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
+              {!!cadence && (
+                <View style={styles.detailRow}>
+                  <Ionicons name="calendar-outline" size={20} color={colors.icon} />
+                  <Text style={[styles.detailText, { color: colors.text }]}>{cadence}</Text>
+                </View>
+              )}
+              {!!address && (
+                <TouchableOpacity
+                  onPress={handleAddressPress}
+                  activeOpacity={0.7}
+                  style={[
+                    styles.detailRow,
+                    cadence && {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                  ]}
+                >
+                  <Ionicons name="location-outline" size={20} color={colors.icon} />
+                  <Text
+                    style={[styles.detailText, { color: colors.text }]}
+                    numberOfLines={2}
+                  >
+                    {address}
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                  />
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        )}
+
+        {/* GROUP ACTIONS */}
+        <View style={styles.section}>
+          <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+            GROUP ACTIONS
+          </Text>
+          <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
+            {isLeader && (
+              <ActionRow
+                icon="pin-outline"
+                label="Pin Channels"
+                onPress={handlePinChannels}
+                color={colors.text}
+                iconColor={colors.icon}
+                topBorder={false}
+                borderColor={colors.border}
+              />
+            )}
+            {isLeader && (
+              <ActionRow
+                icon="options-outline"
+                label="Toolbar Settings"
+                onPress={handleToolbarSettings}
+                color={colors.text}
+                iconColor={colors.icon}
+                topBorder
+                borderColor={colors.border}
+              />
+            )}
+            {group.shortId && (
+              <ActionRow
+                icon="share-outline"
+                label="Share Group"
+                onPress={handleShareGroup}
+                color={colors.text}
+                iconColor={colors.icon}
+                topBorder={isLeader}
+                borderColor={colors.border}
+              />
+            )}
+            {canEditGroup && (
+              <ActionRow
+                icon="create-outline"
+                label="Edit Group"
+                onPress={handleEditGroup}
+                color={colors.text}
+                iconColor={colors.icon}
+                topBorder
+                borderColor={colors.border}
+              />
+            )}
+            {canArchiveGroup && (
+              <ActionRow
+                icon="archive-outline"
+                label="Archive Group"
+                onPress={handleArchiveGroup}
+                color={colors.text}
+                iconColor={colors.icon}
+                topBorder
+                borderColor={colors.border}
+              />
+            )}
+            {!group.is_announcement_group && (
+              <ActionRow
+                icon="exit-outline"
+                label="Leave Group"
+                onPress={handleLeaveGroup}
+                color={colors.destructive}
+                iconColor={colors.destructive}
+                topBorder
+                borderColor={colors.border}
+              />
+            )}
+          </View>
+        </View>
       </ScrollView>
 
-      {/* Options Modal */}
+      {/* Kept mounted for any external openers; the (i) on the hero no
+          longer opens it. Migrating fully out of GroupOptionsModal would
+          touch the non-member flow too — out of scope for this redesign. */}
       <GroupOptionsModal
         visible={showOptionsModal}
         group={group}
@@ -514,6 +650,38 @@ export function GroupDetailScreen() {
         isArchiving={archiveGroupMutation.isPending}
       />
     </>
+  );
+}
+
+function ActionRow({
+  icon,
+  label,
+  onPress,
+  color,
+  iconColor,
+  topBorder,
+  borderColor,
+}: {
+  icon: React.ComponentProps<typeof Ionicons>["name"];
+  label: string;
+  onPress: () => void;
+  color: string;
+  iconColor: string;
+  topBorder: boolean;
+  borderColor: string;
+}) {
+  return (
+    <TouchableOpacity
+      activeOpacity={0.7}
+      onPress={onPress}
+      style={[
+        styles.actionRow,
+        topBorder && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: borderColor },
+      ]}
+    >
+      <Ionicons name={icon} size={20} color={iconColor} />
+      <Text style={[styles.actionLabel, { color }]}>{label}</Text>
+    </TouchableOpacity>
   );
 }
 
@@ -541,105 +709,84 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
   },
-  descriptionContainer: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    marginTop: 0,
+  section: {
+    paddingHorizontal: 12,
+    paddingTop: 16,
+    paddingBottom: 8,
   },
-  description: {
-    fontSize: 16,
-    lineHeight: 24,
+  sectionHeader: {
+    fontSize: 11,
+    fontWeight: "600",
+    letterSpacing: 0.6,
+    marginBottom: 8,
+    paddingHorizontal: 8,
   },
-  viewMembersHint: {
+  card: {
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  viewAllRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
-    paddingVertical: 8,
-    marginTop: -8,
-    paddingBottom: 16,
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
   },
-  viewMembersText: {
-    fontSize: 14,
+  viewAllText: {
+    fontSize: 15,
     fontWeight: "500",
-    marginRight: 4,
   },
-  // External Chat Section styles
-  externalChatSection: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-  },
-  sectionTitle: {
-    fontSize: 14,
-    fontWeight: "600",
-    letterSpacing: 0.5,
-    marginBottom: 12,
-  },
-  externalChatCard: {
+  detailRow: {
     flexDirection: "row",
     alignItems: "center",
-    borderRadius: 12,
-    padding: 12,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 1,
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
   },
-  externalChatIconContainer: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    justifyContent: "center",
+  detailText: {
+    flex: 1,
+    fontSize: 15,
+  },
+  actionRow: {
+    flexDirection: "row",
     alignItems: "center",
-    marginRight: 12,
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
   },
-  externalChatInfo: {
+  actionLabel: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  externalRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    minHeight: 56,
+  },
+  externalIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  externalInfo: {
     flex: 1,
   },
-  externalChatTitle: {
+  externalTitle: {
     fontSize: 16,
     fontWeight: "600",
     marginBottom: 2,
   },
-  externalChatSubtitle: {
+  externalSubtitle: {
     fontSize: 13,
   },
-  // Chat Section styles
-  chatSection: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-  },
-  chatCard: {
-    flexDirection: "row",
-    alignItems: "center",
-    borderRadius: 12,
-    padding: 12,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 1,
-  },
-  chatIconContainer: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 12,
-  },
-  chatInfo: {
-    flex: 1,
-  },
-  chatTitle: {
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 2,
-  },
-  chatSubtitle: {
-    fontSize: 13,
-  },
-  // Join Success Modal styles
   modalOverlay: {
     flex: 1,
     justifyContent: "center",

--- a/apps/mobile/features/groups/components/GroupHeader.tsx
+++ b/apps/mobile/features/groups/components/GroupHeader.tsx
@@ -1,36 +1,48 @@
+/**
+ * GroupHeader (sleek, DM-style hero)
+ *
+ * Centered presentation on white:
+ *   - back chevron top-left
+ *   - share icon top-right (no info icon — you're already on the info)
+ *   - circular group avatar (~120px), tappable to view full-size
+ *   - centered group name with optional pencil-edit icon for leaders/admins
+ *   - centered cadence subtitle
+ *   - optional centered description (rendered when non-empty)
+ *
+ * Match-list with `apps/mobile/features/chat/components/ChatInfoScreen.tsx`
+ * to keep DM/info parity. The full-bleed grey hero with a left-aligned
+ * title was retired in favour of this layout.
+ */
 import React from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  Platform,
-  Dimensions,
-} from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { Group } from "../types";
 import { formatCadence } from "../utils";
-import { AppImageBackground } from "@components/ui/AppImageBackground";
+import { Avatar } from "@components/ui";
 import { useTheme } from "@hooks/useTheme";
-
-const { width: SCREEN_WIDTH } = Dimensions.get("window");
-const HEADER_HEIGHT = SCREEN_WIDTH * 0.6; // 60% of screen width for aspect ratio
+import { ImageViewerManager } from "@/providers/ImageViewerProvider";
 
 interface GroupHeaderProps {
   group: Group;
-  onMenuPress?: () => void;
-  showMenu?: boolean;
+  /** Tap handler for the share icon. Hidden when not provided. */
+  onSharePress?: () => void;
+  /** When true, the user can edit this group; renders a pencil next to the title. */
+  canEdit?: boolean;
 }
 
-export function GroupHeader({ group, onMenuPress, showMenu = true }: GroupHeaderProps) {
+export function GroupHeader({
+  group,
+  onSharePress,
+  canEdit = false,
+}: GroupHeaderProps) {
   const router = useRouter();
   const { colors } = useTheme();
-  const previewUrl = group.preview || group.image_url;
-  const hasImage = !!previewUrl;
-  // Ensure group name always has a value
+  const previewUrl = group.preview || group.image_url || null;
   const groupName = group?.title || group?.name || "Group";
   const cadence = formatCadence(group);
+  const description = group.description?.trim() || "";
+  const hasDescription = description.length > 0;
 
   const handleBack = () => {
     if (router.canGoBack()) {
@@ -40,80 +52,88 @@ export function GroupHeader({ group, onMenuPress, showMenu = true }: GroupHeader
     }
   };
 
-  const iconColor = hasImage ? "#ffffff" : colors.text;
-  const textColor = hasImage ? "#ffffff" : colors.text;
+  const handleEdit = () => {
+    if (!group?._id) return;
+    router.push(`/groups/${group._id}/edit`);
+  };
 
-  const content = (
-    <View style={styles.contentContainer}>
-      {/* Top bar with back button and menu */}
+  const handleAvatarPress = () => {
+    if (!previewUrl) return;
+    ImageViewerManager.show([previewUrl], 0);
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface }]}>
       <View style={styles.topBar}>
         <TouchableOpacity
-          style={styles.backButton}
+          style={styles.iconButton}
           onPress={handleBack}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityLabel="Back"
         >
-          <Ionicons name="arrow-back" size={24} color={iconColor} />
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
         </TouchableOpacity>
-        <View style={styles.topBarSpacer} />
-        {showMenu && onMenuPress && (
+        <View style={styles.spacer} />
+        {!!onSharePress && (
           <TouchableOpacity
-            style={styles.menuButton}
-            onPress={onMenuPress}
+            style={styles.iconButton}
+            onPress={onSharePress}
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityLabel="Share group"
           >
-            <Ionicons name="ellipsis-vertical" size={24} color={iconColor} />
+            <Ionicons
+              name="share-outline"
+              size={24}
+              color={colors.text}
+            />
           </TouchableOpacity>
         )}
       </View>
 
-      {/* Group name and cadence */}
-      <View style={styles.textContainer}>
-        <Text 
-          style={[
-            styles.groupName, 
-            { color: textColor },
-            !hasImage && styles.groupNameNoImage
-          ]} 
-          numberOfLines={2}
+      <View style={styles.heroContent}>
+        <Pressable
+          onPress={handleAvatarPress}
+          disabled={!previewUrl}
+          style={({ pressed }) => [pressed && previewUrl && { opacity: 0.85 }]}
+          accessibilityRole={previewUrl ? "button" : undefined}
+          accessibilityLabel={previewUrl ? "View group photo" : undefined}
         >
-          {groupName}
-        </Text>
-        {cadence && (
-          <Text 
-            style={[
-              styles.cadence, 
-              { color: textColor },
-              !hasImage && styles.cadenceNoImage
-            ]} 
-            numberOfLines={1}
-          >
+          <Avatar name={groupName} imageUrl={previewUrl} size={120} />
+        </Pressable>
+        <Pressable
+          onPress={canEdit ? handleEdit : undefined}
+          disabled={!canEdit}
+          style={({ pressed }) => [
+            styles.titleRow,
+            pressed && canEdit && { opacity: 0.7 },
+          ]}
+        >
+          <Text style={[styles.groupName, { color: colors.text }]} numberOfLines={2}>
+            {groupName}
+          </Text>
+          {canEdit && (
+            <Ionicons
+              name="pencil"
+              size={16}
+              color={colors.textSecondary}
+              style={styles.pencilIcon}
+            />
+          )}
+        </Pressable>
+        {cadence ? (
+          <Text style={[styles.cadence, { color: colors.textSecondary }]} numberOfLines={1}>
             {cadence}
           </Text>
-        )}
+        ) : null}
+        {hasDescription ? (
+          <Text
+            style={[styles.description, { color: colors.textSecondary }]}
+            numberOfLines={3}
+          >
+            {description}
+          </Text>
+        ) : null}
       </View>
-    </View>
-  );
-
-  return (
-    <View style={styles.container}>
-      {hasImage ? (
-        <AppImageBackground
-          source={previewUrl}
-          style={styles.imageBackground}
-          imageStyle={styles.imageStyle}
-          optimizedWidth={800}
-        >
-          <View style={styles.gradientOverlay}>
-            {content}
-          </View>
-        </AppImageBackground>
-      ) : (
-        <View style={[styles.placeholderContainer, { backgroundColor: colors.border }]}>
-          <View style={styles.gradient}>
-            {content}
-          </View>
-        </View>
-      )}
     </View>
   );
 }
@@ -121,82 +141,49 @@ export function GroupHeader({ group, onMenuPress, showMenu = true }: GroupHeader
 const styles = StyleSheet.create({
   container: {
     width: "100%",
-    height: HEADER_HEIGHT,
-  },
-  imageBackground: {
-    width: "100%",
-    height: "100%",
-  },
-  imageStyle: {
-    resizeMode: "cover",
-  },
-  placeholderContainer: {
-    width: "100%",
-    height: "100%",
-    backgroundColor: "#E0E0E0", // Placeholder gradient - stays as design constant
-  },
-  gradient: {
-    flex: 1,
-    justifyContent: "space-between",
-    paddingTop: Platform.OS === "ios" ? 50 : 20,
-    paddingBottom: 20,
-    paddingHorizontal: 16,
-  },
-  gradientOverlay: {
-    flex: 1,
-    justifyContent: "space-between",
-    paddingTop: Platform.OS === "ios" ? 50 : 20,
-    paddingBottom: 20,
-    paddingHorizontal: 16,
-    backgroundColor: "rgba(0, 0, 0, 0.4)",
-  },
-  contentContainer: {
-    flex: 1,
-    justifyContent: "space-between",
+    paddingBottom: 24,
   },
   topBar: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
+    paddingHorizontal: 8,
+    paddingVertical: 8,
   },
-  backButton: {
-    padding: 8,
+  iconButton: {
+    padding: 4,
   },
-  topBarSpacer: {
+  spacer: {
     flex: 1,
   },
-  menuButton: {
-    padding: 8,
+  heroContent: {
+    alignItems: "center",
+    paddingHorizontal: 24,
+    paddingTop: 8,
   },
-  textContainer: {
-    paddingBottom: 8,
+  titleRow: {
+    marginTop: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
   },
   groupName: {
-    fontSize: 28,
+    fontSize: 24,
     fontWeight: "700",
-    color: "#ffffff",
-    marginBottom: 8,
-    textShadowColor: "rgba(0, 0, 0, 0.3)",
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 3,
+    textAlign: "center",
   },
-  groupNameNoImage: {
-    textShadowColor: "transparent",
-    textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 0,
+  pencilIcon: {
+    marginTop: 4,
   },
   cadence: {
-    fontSize: 16,
+    marginTop: 4,
+    fontSize: 14,
     fontWeight: "500",
-    color: "#ffffff",
-    textShadowColor: "rgba(0, 0, 0, 0.3)",
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 3,
+    textAlign: "center",
   },
-  cadenceNoImage: {
-    textShadowColor: "transparent",
-    textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 0,
+  description: {
+    marginTop: 8,
+    fontSize: 13,
+    lineHeight: 18,
+    textAlign: "center",
   },
 });
-

--- a/apps/mobile/features/groups/components/GroupNonMemberView.tsx
+++ b/apps/mobile/features/groups/components/GroupNonMemberView.tsx
@@ -100,12 +100,13 @@ export function GroupNonMemberView({
         showsVerticalScrollIndicator={false}
         contentContainerStyle={styles.scrollContent}
       >
-        {/* Header with image, name, and cadence */}
-        {/* Show 3-dots menu for everyone (Share Group) and admins (Edit, Archive, etc.) */}
+        {/* Header with image, name, and cadence. Tapping the share icon
+            opens the GroupOptionsModal which non-members rely on for
+            "Share Group" + admin "Edit/Archive". The (i) icon was retired
+            — you're already on the info surface. */}
         <GroupHeader
           group={group}
-          showMenu={true}
-          onMenuPress={() => setShowOptionsModal(true)}
+          onSharePress={() => setShowOptionsModal(true)}
         />
 
         {/* Description */}

--- a/apps/mobile/features/groups/components/MembersRow.tsx
+++ b/apps/mobile/features/groups/components/MembersRow.tsx
@@ -2,31 +2,35 @@ import React, { useMemo } from "react";
 import { View, Text, StyleSheet, ScrollView } from "react-native";
 import { Avatar } from "@components/ui";
 import { GroupMember } from "../types";
-import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useTheme } from "@hooks/useTheme";
 
 interface MembersRowProps {
   members?: GroupMember[];
   leaders?: GroupMember[];
   maxVisible?: number;
-  totalCount?: number; // Optional total count for preview mode (when we only have partial data)
+  totalCount?: number;
 }
 
+/**
+ * Horizontal avatar preview for the MEMBERS card on the group page.
+ * Initials avatars now use neutral gray (theme-aware) — the previous
+ * red/green community-tinted leader rings have been retired in favour of
+ * the cleaner DM-info aesthetic. Leaders are still surfaced via a
+ * subtle dark dot in the corner.
+ */
 export function MembersRow({
   members = [],
   leaders = [],
   maxVisible = 10,
   totalCount,
 }: MembersRowProps) {
-  const { primaryColor } = useCommunityTheme();
+  const { colors } = useTheme();
 
-  // Merge leaders and members, ensuring leaders appear first and aren't duplicated
   const mergedMembers = useMemo(() => {
     const leaderIds = new Set(leaders.map((leader) => leader.id));
-    // Filter out members who are also leaders to avoid duplicates
     const nonLeaderMembers = members.filter(
-      (member) => !leaderIds.has(member.id)
+      (member) => !leaderIds.has(member.id),
     );
-    // Leaders first, then regular members
     return [...leaders, ...nonLeaderMembers];
   }, [members, leaders]);
 
@@ -36,13 +40,11 @@ export function MembersRow({
 
   const leaderIds = new Set(leaders.map((leader) => leader.id));
   const visibleMembers = mergedMembers.slice(0, maxVisible);
-  // Use provided totalCount if available (for preview mode), otherwise calculate from array
   const actualTotal = totalCount ?? mergedMembers.length;
   const remainingCount = actualTotal - Math.min(maxVisible, mergedMembers.length);
 
   return (
     <View style={styles.container}>
-      <Text style={styles.header}>MEMBERS</Text>
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
@@ -51,34 +53,37 @@ export function MembersRow({
         {visibleMembers.map((member, index) => {
           const isLeader = leaderIds.has(member.id);
           return (
-            <View
-              key={member.id || index}
-              style={styles.avatarContainer}
-            >
-              {isLeader ? (
-                <View style={[styles.leaderWrapper, { borderColor: primaryColor }]}>
-                  <Avatar
-                    name={`${member.first_name || ""} ${member.last_name || ""}`.trim()}
-                    imageUrl={member.profile_photo}
-                    size={56}
-                  />
-                  <View style={[styles.leaderBadge, { backgroundColor: primaryColor }]} />
-                </View>
-              ) : (
-                <Avatar
-                  name={`${member.first_name || ""} ${member.last_name || ""}`.trim()}
-                  imageUrl={member.profile_photo}
-                  size={56}
+            <View key={member.id || index} style={styles.avatarContainer}>
+              <Avatar
+                name={`${member.first_name || ""} ${member.last_name || ""}`.trim()}
+                imageUrl={member.profile_photo}
+                size={48}
+                placeholderBackgroundColor={colors.border}
+              />
+              {isLeader && (
+                <View
+                  style={[
+                    styles.leaderBadge,
+                    {
+                      backgroundColor: colors.text,
+                      borderColor: colors.surfaceSecondary,
+                    },
+                  ]}
                 />
               )}
             </View>
           );
         })}
         {remainingCount > 0 && (
-          <View style={styles.countContainer}>
-            <View style={styles.countCircle}>
-              <Text style={styles.countText}>+{remainingCount}</Text>
-            </View>
+          <View
+            style={[
+              styles.countCircle,
+              { backgroundColor: colors.border },
+            ]}
+          >
+            <Text style={[styles.countText, { color: colors.textSecondary }]}>
+              +{remainingCount}
+            </Text>
           </View>
         )}
       </ScrollView>
@@ -88,64 +93,35 @@ export function MembersRow({
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: "#F5F5F5",
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    marginTop: 0,
-  },
-  header: {
-    fontSize: 14,
-    fontWeight: "600",
-    color: "#333",
-    marginBottom: 12,
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
   },
   scrollContent: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
+    gap: 8,
   },
   avatarContainer: {
-    marginRight: 0,
     position: "relative",
-  },
-  leaderWrapper: {
-    position: "relative",
-    borderRadius: 30,
-    borderWidth: 3,
-    // borderColor set dynamically via style prop
-    padding: 2,
   },
   leaderBadge: {
     position: "absolute",
     top: -2,
     right: -2,
-    width: 16,
-    height: 16,
-    borderRadius: 8,
-    // backgroundColor set dynamically via style prop
+    width: 12,
+    height: 12,
+    borderRadius: 6,
     borderWidth: 2,
-    borderColor: "#FFFFFF",
-    zIndex: 1,
-  },
-  countContainer: {
-    marginLeft: 4,
-    justifyContent: "center",
-    alignItems: "center",
   },
   countCircle: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: "#E0E0E0",
+    width: 48,
+    height: 48,
+    borderRadius: 24,
     justifyContent: "center",
     alignItems: "center",
   },
   countText: {
-    fontSize: 14,
+    fontSize: 13,
     fontWeight: "600",
-    color: "#666",
   },
 });
-

--- a/apps/mobile/features/groups/components/UpcomingEventsSection.tsx
+++ b/apps/mobile/features/groups/components/UpcomingEventsSection.tsx
@@ -1,0 +1,171 @@
+/**
+ * UpcomingEventsSection
+ *
+ * Horizontal scroll list of upcoming events for a group on the group page.
+ * Sits between MEMBERS and CHANNELS. Mirrors the card aesthetic of
+ * EventsList.tsx (leader-tools) but stripped down to "future events only,
+ * tap to open the event."
+ *
+ * Hidden when there are no upcoming events so we don't render an empty band.
+ */
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { format, isToday, isTomorrow } from "date-fns";
+import { useQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useTheme } from "@hooks/useTheme";
+import { AppImage } from "@components/ui";
+
+interface Props {
+  groupId: string;
+}
+
+export function UpcomingEventsSection({ groupId }: Props) {
+  const router = useRouter();
+  const { colors } = useTheme();
+
+  const meetingsData = useQuery(
+    api.functions.meetings.index.listByGroup,
+    groupId
+      ? {
+          groupId: groupId as Id<"groups">,
+          includeCompleted: false,
+          includeCancelled: false,
+        }
+      : "skip",
+  );
+
+  if (meetingsData === undefined) return null;
+
+  const now = Date.now();
+  const upcoming = (meetingsData ?? [])
+    .filter((m: any) => typeof m.scheduledAt === "number" && m.scheduledAt >= now)
+    .sort((a: any, b: any) => a.scheduledAt - b.scheduledAt)
+    .slice(0, 12);
+
+  if (upcoming.length === 0) return null;
+
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.header, { color: colors.textSecondary }]}>
+        UPCOMING EVENTS
+      </Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+      >
+        {upcoming.map((event: any) => {
+          const date = new Date(event.scheduledAt);
+          const dateLabel = isToday(date)
+            ? `Today · ${format(date, "h:mm a")}`
+            : isTomorrow(date)
+              ? `Tomorrow · ${format(date, "h:mm a")}`
+              : format(date, "EEE, MMM d · h:mm a");
+          return (
+            <Pressable
+              key={event._id}
+              onPress={() => router.push(`/events/${event._id}` as any)}
+              style={({ pressed }) => [
+                styles.card,
+                {
+                  backgroundColor: colors.surfaceSecondary,
+                  borderColor: colors.border,
+                },
+                pressed && { opacity: 0.85 },
+              ]}
+            >
+              {event.coverImage ? (
+                <AppImage
+                  source={event.coverImage}
+                  style={styles.cardImage}
+                  optimizedWidth={400}
+                />
+              ) : (
+                <View
+                  style={[
+                    styles.cardImagePlaceholder,
+                    { backgroundColor: colors.border },
+                  ]}
+                >
+                  <Ionicons
+                    name="calendar-outline"
+                    size={28}
+                    color={colors.textTertiary}
+                  />
+                </View>
+              )}
+              <View style={styles.cardBody}>
+                <Text
+                  style={[styles.cardTitle, { color: colors.text }]}
+                  numberOfLines={2}
+                >
+                  {event.title || "Event"}
+                </Text>
+                <Text
+                  style={[styles.cardDate, { color: colors.textSecondary }]}
+                  numberOfLines={1}
+                >
+                  {dateLabel}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: 24,
+    gap: 8,
+  },
+  header: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+    paddingHorizontal: 16,
+  },
+  scrollContent: {
+    paddingHorizontal: 12,
+    gap: 12,
+  },
+  card: {
+    width: 200,
+    borderRadius: 12,
+    overflow: "hidden",
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  cardImage: {
+    width: "100%",
+    height: 110,
+  },
+  cardImagePlaceholder: {
+    width: "100%",
+    height: 110,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cardBody: {
+    padding: 12,
+    gap: 4,
+  },
+  cardTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    lineHeight: 18,
+  },
+  cardDate: {
+    fontSize: 12,
+  },
+});

--- a/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
@@ -1,41 +1,50 @@
 /**
- * Tests for ChannelsSection Component
+ * Tests for the redesigned ChannelsSection.
  *
- * Component: ChannelsSection
- * Location: /features/groups/components/ChannelsSection.tsx
+ * The single CHANNELS card replaced the AUTO/CUSTOM split. Each row is
+ * navigation-only — no toggles, no trailing icon clusters. Per-channel
+ * configuration moved to /inbox/[groupId]/[channelSlug]/info, so tap
+ * targets here just route there.
  *
- * Tests the channels display on the group detail page including:
- * - Auto channels section (General, Leaders)
- * - Custom channels section
- * - Leader toggle for leaders channel
- * - Create channel button for leaders
- * - Leave channel functionality
- * - Unread badges
- * - Navigation
+ * Removed (covered by the new info screen tests once they exist):
+ *   - Leaders Channel Toggle
+ *   - Manage members button
+ *   - Leave Channel from row
+ *   - "AUTO CHANNELS" / "CUSTOM CHANNELS" headers
  */
 import React from "react";
-import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { render, fireEvent, act } from "@testing-library/react-native";
 import { Alert } from "react-native";
 
-// Mock Alert
 jest.spyOn(Alert, "alert");
 
-// Mock router
 const mockPush = jest.fn();
 jest.mock("expo-router", () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
-// Mock useCommunityTheme
 jest.mock("@hooks/useCommunityTheme", () => ({
-  useCommunityTheme: () => ({
-    primaryColor: "#007AFF",
+  useCommunityTheme: () => ({ primaryColor: "#007AFF" }),
+}));
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#fff",
+      surface: "#fff",
+      surfaceSecondary: "#f5f5f5",
+      text: "#000",
+      textSecondary: "#666",
+      textTertiary: "#999",
+      border: "#e5e5e5",
+      iconSecondary: "#666",
+      destructive: "#FF3B30",
+      textInverse: "#fff",
+    },
+    isDark: false,
   }),
 }));
 
-// Mock channel data
 const mockMainChannel = {
   _id: "channel-main",
   slug: "general",
@@ -89,35 +98,38 @@ const mockCustomChannels = [
   },
 ];
 
-// Mock Convex hooks
 let mockChannelsData: any[] | undefined = undefined;
-const mockLeaveChannelMutation = jest.fn();
-const mockToggleLeadersChannelMutation = jest.fn();
 
 jest.mock("@providers/AuthProvider", () => ({
   useAuth: () => ({ token: "test-token", user: { id: "test-user" }, community: null }),
 }));
 
+// Mock the useGroupChannels hook directly — that's the source of truth
+// the component reads from, and this avoids us having to model the
+// authenticated-query plumbing inside this test.
+jest.mock("../../hooks/useGroupChannels", () => ({
+  useGroupChannels: () => ({
+    channels: mockChannelsData,
+    isLoading: mockChannelsData === undefined,
+    isStale: false,
+  }),
+}));
+
+jest.mock("../../hooks/useRespondToChannelInvite", () => ({
+  useRespondToChannelInvite: () => ({
+    respondingTo: null,
+    handleRespond: jest.fn(),
+  }),
+}));
+
 jest.mock("@services/api/convex", () => ({
-  useAuthenticatedQuery: () => mockChannelsData,
-  useAuthenticatedMutation: (fn: any) => {
-    if (fn === "leaveChannel") return mockLeaveChannelMutation;
-    if (fn === "toggleLeadersChannel") return mockToggleLeadersChannelMutation;
-    return jest.fn();
-  },
-  useQuery: () => undefined,
+  useAuthenticatedMutation: () => jest.fn(),
+  useQuery: () => undefined, // pendingInvites
   useMutation: () => jest.fn(),
   api: {
     functions: {
       messaging: {
-        channels: {
-          listGroupChannels: "listGroupChannels",
-          leaveChannel: "leaveChannel",
-          toggleLeadersChannel: "toggleLeadersChannel",
-          toggleMainChannel: "toggleMainChannel",
-          togglePcoChannel: "togglePcoChannel",
-          setCustomChannelLeaderEnabled: "setCustomChannelLeaderEnabled",
-        },
+        channels: { listGroupChannels: "listGroupChannels" },
         channelInvites: {
           enableInviteLink: "enableInviteLink",
           getPendingRequestCountByGroup: "getPendingRequestCountByGroup",
@@ -131,10 +143,15 @@ jest.mock("@services/api/convex", () => ({
   },
 }));
 
-// Import component AFTER mocks
+// Mock the join-requests banner so we don't have to set up its query
+// dependencies for these tests.
+jest.mock("../ChannelJoinRequestsBanner", () => ({
+  ChannelJoinRequestsBanner: () => null,
+}));
+
 import { ChannelsSection } from "../ChannelsSection";
 
-describe("ChannelsSection", () => {
+describe("ChannelsSection (redesigned)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockChannelsData = [
@@ -144,7 +161,7 @@ describe("ChannelsSection", () => {
     ];
   });
 
-  describe("Loading State", () => {
+  describe("Loading state", () => {
     it("shows loading indicator when channels are undefined", () => {
       mockChannelsData = undefined;
 
@@ -153,11 +170,10 @@ describe("ChannelsSection", () => {
       );
 
       expect(getByText("CHANNELS")).toBeTruthy();
-      // ActivityIndicator should be present
     });
   });
 
-  describe("Empty State", () => {
+  describe("Empty state", () => {
     it("returns null when no channels exist", () => {
       mockChannelsData = [];
 
@@ -169,16 +185,18 @@ describe("ChannelsSection", () => {
     });
   });
 
-  describe("Auto Channels Section", () => {
-    it("renders AUTO CHANNELS header", () => {
-      const { getByText } = render(
+  describe("Single CHANNELS section", () => {
+    it("renders one CHANNELS header (no AUTO/CUSTOM split)", () => {
+      const { getByText, queryByText } = render(
         <ChannelsSection groupId="test-group" userRole="member" />
       );
 
-      expect(getByText("AUTO CHANNELS")).toBeTruthy();
+      expect(getByText("CHANNELS")).toBeTruthy();
+      expect(queryByText("AUTO CHANNELS")).toBeNull();
+      expect(queryByText("CUSTOM CHANNELS")).toBeNull();
     });
 
-    it("renders General channel for all users", () => {
+    it("renders General row with 'All members' subtitle", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="member" />
       );
@@ -187,7 +205,7 @@ describe("ChannelsSection", () => {
       expect(getByText("All members")).toBeTruthy();
     });
 
-    it("renders Leaders channel for leaders", () => {
+    it("renders Leaders row for leaders", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="leader" />
       );
@@ -196,80 +214,97 @@ describe("ChannelsSection", () => {
       expect(getByText("5 leaders")).toBeTruthy();
     });
 
-    it("shows leader note for leaders channel", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      expect(getByText("You're here because you're a leader")).toBeTruthy();
-    });
-
-    it("shows singular leader count correctly", () => {
-      mockChannelsData = [
-        mockMainChannel,
-        { ...mockLeadersChannel, memberCount: 1 },
-      ];
-
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      expect(getByText("1 leader")).toBeTruthy();
-    });
-  });
-
-  describe("Custom Channels Section", () => {
-    it("renders CUSTOM CHANNELS header", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      expect(getByText("CUSTOM CHANNELS")).toBeTruthy();
-    });
-
-    it("renders custom channel names", () => {
+    it("renders custom channel names and member counts", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="member" />
       );
 
       expect(getByText("Directors")).toBeTruthy();
       expect(getByText("Volunteers")).toBeTruthy();
-    });
-
-    it("renders member counts for custom channels", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
       expect(getByText("8 members")).toBeTruthy();
       expect(getByText("15 members")).toBeTruthy();
     });
+  });
 
-    it("shows singular member count correctly", () => {
-      mockChannelsData = [
-        mockMainChannel,
-        { ...mockCustomChannels[0], memberCount: 1 },
-      ];
+  describe("No toggles, no trailing icon clusters", () => {
+    it("does not render any channel toggle switches for leaders", () => {
+      const { queryByTestId } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
 
+      expect(queryByTestId("channel-toggle-general")).toBeNull();
+      expect(queryByTestId("channel-toggle-leaders")).toBeNull();
+      expect(queryByTestId("channel-toggle-reach-out")).toBeNull();
+    });
+
+    it("does not render leave (exit) icons on custom channel rows", () => {
+      const { queryAllByText } = render(
+        <ChannelsSection groupId="test-group" userRole="member" />
+      );
+
+      expect(queryAllByText("exit-outline")).toHaveLength(0);
+    });
+
+    it("does not render manage-members (people-outline) icons", () => {
+      const { queryAllByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(queryAllByText("people-outline")).toHaveLength(0);
+    });
+  });
+
+  describe("Navigation", () => {
+    it("navigates to General chat (not info) on tap", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="member" />
       );
 
-      expect(getByText("1 member")).toBeTruthy();
+      act(() => {
+        fireEvent.press(getByText("General").parent!.parent!.parent!);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/general");
     });
 
-    it("shows empty state for leaders with no custom channels", () => {
-      mockChannelsData = [mockMainChannel, mockLeadersChannel];
-
+    it("navigates to Leaders /info on tap", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="leader" />
       );
 
-      expect(getByText("No custom channels yet")).toBeTruthy();
+      act(() => {
+        fireEvent.press(getByText("Leaders").parent!.parent!.parent!);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/leaders/info");
+    });
+
+    it("navigates to custom channel /info on tap", () => {
+      const { getByText } = render(
+        <ChannelsSection groupId="test-group" userRole="member" />
+      );
+
+      act(() => {
+        fireEvent.press(getByText("Directors").parent!.parent!.parent!);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/directors/info");
+    });
+
+    it("navigates to create channel screen", () => {
+      const { getByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      act(() => {
+        fireEvent.press(getByText("Create Channel").parent!);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/create");
     });
   });
 
-  describe("Unread Badges", () => {
+  describe("Unread badges", () => {
     it("displays unread badge on Leaders channel", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="leader" />
@@ -296,7 +331,6 @@ describe("ChannelsSection", () => {
         <ChannelsSection groupId="test-group" userRole="leader" />
       );
 
-      // Should not have any numeric badges
       expect(queryByText("0")).toBeNull();
     });
 
@@ -311,125 +345,8 @@ describe("ChannelsSection", () => {
     });
   });
 
-  describe("Leaders Channel Toggle", () => {
-    it("shows toggle switches for leaders (General + Leaders)", () => {
-      const { getByTestId } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      expect(getByTestId("channel-toggle-general")).toBeTruthy();
-      expect(getByTestId("channel-toggle-leaders")).toBeTruthy();
-    });
-
-    it("leaders channel toggle is on when channel is enabled", () => {
-      const { getByTestId } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const leadersSwitch = getByTestId("channel-toggle-leaders");
-      expect(leadersSwitch.props.value).toBe(true);
-    });
-
-    it("leaders channel toggle is off when channel is archived", () => {
-      mockChannelsData = [
-        mockMainChannel,
-        { ...mockLeadersChannel, isArchived: true },
-      ];
-
-      const { getByTestId } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const leadersSwitch = getByTestId("channel-toggle-leaders");
-      expect(leadersSwitch.props.value).toBe(false);
-    });
-
-    it("calls toggleLeadersChannel mutation when leaders toggle is used", async () => {
-      mockToggleLeadersChannelMutation.mockResolvedValueOnce(undefined);
-
-      const { getByTestId } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const toggle = getByTestId("channel-toggle-leaders");
-
-      await act(async () => {
-        fireEvent(toggle, "valueChange", false);
-      });
-
-      await waitFor(() => {
-        expect(mockToggleLeadersChannelMutation).toHaveBeenCalledWith({
-          groupId: "test-group",
-          enabled: false,
-        });
-      });
-    });
-
-    it("shows error alert on leaders toggle failure", async () => {
-      mockToggleLeadersChannelMutation.mockRejectedValueOnce(
-        new Error("Toggle failed")
-      );
-
-      const { getByTestId } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const toggle = getByTestId("channel-toggle-leaders");
-
-      await act(async () => {
-        fireEvent(toggle, "valueChange", false);
-      });
-
-      await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith("Error", "Toggle failed");
-      });
-    });
-
-    it("hides channel toggles for non-leaders", () => {
-      const { queryByTestId } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      expect(queryByTestId("channel-toggle-general")).toBeNull();
-      expect(queryByTestId("channel-toggle-leaders")).toBeNull();
-    });
-
-    it("shows disabled state for leaders channel name when archived", () => {
-      mockChannelsData = [
-        mockMainChannel,
-        { ...mockLeadersChannel, isArchived: true },
-      ];
-
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const leadersText = getByText("Leaders");
-      // Check that the disabled style is applied (color: #999999)
-      expect(leadersText.props.style).toContainEqual({ color: "#999999" });
-    });
-  });
-
-  describe("Leader-Only Features", () => {
-    it("shows manage members button for leaders on custom channels", () => {
-      const { getAllByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      // people-outline icons for manage members
-      const manageIcons = getAllByText("people-outline");
-      expect(manageIcons.length).toBe(mockCustomChannels.length);
-    });
-
-    it("hides manage members button for non-leaders", () => {
-      const { queryByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      expect(queryByText("people-outline")).toBeNull();
-    });
-
-    it("shows create channel button for leaders", () => {
+  describe("Leader-only affordances", () => {
+    it("shows Create Channel for leaders", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="leader" />
       );
@@ -437,250 +354,12 @@ describe("ChannelsSection", () => {
       expect(getByText("Create Channel")).toBeTruthy();
     });
 
-    it("hides create channel button for non-leaders", () => {
+    it("hides Create Channel for non-leaders", () => {
       const { queryByText } = render(
         <ChannelsSection groupId="test-group" userRole="member" />
       );
 
       expect(queryByText("Create Channel")).toBeNull();
-    });
-
-    it("shows create button for admins", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="admin" />
-      );
-
-      expect(getByText("Create Channel")).toBeTruthy();
-    });
-  });
-
-  describe("Leave Channel", () => {
-    it("shows leave button for custom channels", () => {
-      const { getAllByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      // exit-outline icons for leave
-      const leaveIcons = getAllByText("exit-outline");
-      expect(leaveIcons.length).toBe(mockCustomChannels.length);
-    });
-
-    it("shows confirmation dialog when leaving channel", () => {
-      const { getAllByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      const leaveIcons = getAllByText("exit-outline");
-
-      act(() => {
-        fireEvent.press(leaveIcons[0].parent!.parent!);
-      });
-
-      expect(Alert.alert).toHaveBeenCalledWith(
-        "Leave Channel",
-        expect.stringContaining("Directors"),
-        expect.any(Array)
-      );
-    });
-
-    it("calls leaveChannel mutation after confirmation", async () => {
-      mockLeaveChannelMutation.mockResolvedValueOnce(undefined);
-
-      const { getAllByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      const leaveIcons = getAllByText("exit-outline");
-
-      act(() => {
-        fireEvent.press(leaveIcons[0].parent!.parent!);
-      });
-
-      const alertCalls = (Alert.alert as jest.Mock).mock.calls;
-      const alertButtons = alertCalls[0][2];
-      const leaveButton = alertButtons.find((b: any) => b.text === "Leave");
-
-      await act(async () => {
-        await leaveButton.onPress();
-      });
-
-      expect(mockLeaveChannelMutation).toHaveBeenCalledWith({
-        channelId: "channel-custom-1",
-      });
-    });
-
-    it("shows error alert on leave failure", async () => {
-      mockLeaveChannelMutation.mockRejectedValueOnce(
-        new Error("Failed to leave channel")
-      );
-
-      const { getAllByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      const leaveIcons = getAllByText("exit-outline");
-
-      act(() => {
-        fireEvent.press(leaveIcons[0].parent!.parent!);
-      });
-
-      const alertCalls = (Alert.alert as jest.Mock).mock.calls;
-      const leaveButton = alertCalls[0][2].find((b: any) => b.text === "Leave");
-
-      await act(async () => {
-        await leaveButton.onPress();
-      });
-
-      await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith(
-          "Error",
-          "Failed to leave channel"
-        );
-      });
-    });
-  });
-
-  describe("Navigation", () => {
-    it("navigates to General channel on tap", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      const generalChannel = getByText("General");
-
-      act(() => {
-        fireEvent.press(generalChannel.parent!.parent!);
-      });
-
-      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/general");
-    });
-
-    it("navigates to Leaders channel on tap", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const leadersChannel = getByText("Leaders");
-
-      act(() => {
-        fireEvent.press(leadersChannel.parent!.parent!);
-      });
-
-      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/leaders");
-    });
-
-    it("navigates to custom channel on tap", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      const directorsChannel = getByText("Directors");
-
-      act(() => {
-        fireEvent.press(directorsChannel.parent!.parent!);
-      });
-
-      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/directors");
-    });
-
-    it("navigates to create channel screen", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const createButton = getByText("Create Channel");
-
-      act(() => {
-        fireEvent.press(createButton.parent!);
-      });
-
-      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/create");
-    });
-
-    it("navigates to manage members for custom channel", () => {
-      const { getAllByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const manageIcons = getAllByText("people-outline");
-
-      act(() => {
-        fireEvent.press(manageIcons[0].parent!.parent!);
-      });
-
-      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/directors/members");
-    });
-
-    it("does not navigate to disabled Leaders channel", () => {
-      mockChannelsData = [
-        mockMainChannel,
-        { ...mockLeadersChannel, isArchived: true },
-      ];
-
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      const leadersChannel = getByText("Leaders");
-
-      act(() => {
-        fireEvent.press(leadersChannel.parent!.parent!);
-      });
-
-      // Should not navigate when disabled
-      expect(mockPush).not.toHaveBeenCalledWith(
-        expect.stringContaining("leaders")
-      );
-    });
-  });
-
-  describe("Channel Icons", () => {
-    it("renders chatbubbles icon for General channel", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      expect(getByText("chatbubbles")).toBeTruthy();
-    });
-
-    it("renders star icon for Leaders channel", () => {
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      expect(getByText("star")).toBeTruthy();
-    });
-
-    it("renders chatbubble icon for custom channels", () => {
-      const { getAllByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      // chatbubble (singular) for custom channels
-      const chatIcons = getAllByText("chatbubble");
-      expect(chatIcons.length).toBe(mockCustomChannels.length);
-    });
-  });
-
-  describe("Visibility Rules", () => {
-    it("hides custom channels section for non-leaders with no custom channels", () => {
-      mockChannelsData = [mockMainChannel];
-
-      const { queryByText } = render(
-        <ChannelsSection groupId="test-group" userRole="member" />
-      );
-
-      expect(queryByText("CUSTOM CHANNELS")).toBeNull();
-    });
-
-    it("shows custom channels section for leaders even with no custom channels", () => {
-      mockChannelsData = [mockMainChannel, mockLeadersChannel];
-
-      const { getByText } = render(
-        <ChannelsSection groupId="test-group" userRole="leader" />
-      );
-
-      expect(getByText("CUSTOM CHANNELS")).toBeTruthy();
     });
 
     it("shows Leaders row for leaders even when channel does not exist yet", () => {

--- a/apps/mobile/features/groups/components/__tests__/GroupDetailScreen.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/GroupDetailScreen.test.tsx
@@ -175,10 +175,14 @@ jest.mock("@/providers/ImageViewerProvider", () => ({
 jest.mock("../GroupHeader", () => {
   const { View, Text, Pressable } = require("react-native");
   return {
-    GroupHeader: ({ group, onMenuPress }: any) => (
+    GroupHeader: ({ group, onSharePress }: any) => (
       <View testID="group-header">
         <Text testID="group-header-title">{group?.title || group?.name}</Text>
-        <Pressable testID="menu-button" onPress={onMenuPress}><Text>Menu</Text></Pressable>
+        {onSharePress && (
+          <Pressable testID="share-button" onPress={onSharePress}>
+            <Text>Share</Text>
+          </Pressable>
+        )}
       </View>
     ),
   };
@@ -338,7 +342,9 @@ describe("GroupDetailScreen", () => {
     render(<GroupDetailScreen />, { wrapper: createWrapper() });
 
     expect(screen.queryByTestId("non-member-view")).toBeNull();
-    expect(screen.getByText("Test description")).toBeTruthy();
+    // Description is now rendered inside GroupHeader (centered, under
+    // schedule). The mock surfaces the title via testID instead.
+    expect(screen.getByTestId("group-header-title")).toBeTruthy();
   });
 
   it("calls join group mutation when join button is pressed", async () => {
@@ -671,7 +677,9 @@ describe("GroupDetailScreen", () => {
       // Member (even if admin) should NOT see non-member view
       expect(screen.queryByTestId("non-member-view")).toBeNull();
       // Should see the member view content instead
-      expect(screen.getByText("Test description")).toBeTruthy();
+      // Description is now rendered inside GroupHeader (centered, under
+    // schedule). The mock surfaces the title via testID instead.
+    expect(screen.getByTestId("group-header-title")).toBeTruthy();
     });
   });
 });

--- a/apps/mobile/features/groups/components/__tests__/MembersRow.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/MembersRow.test.tsx
@@ -15,6 +15,21 @@ jest.mock("@components/ui", () => {
   };
 });
 
+// Mock useTheme — MembersRow now uses theme tokens for the leader badge
+// and the +N overflow circle. The header "MEMBERS" label moved out to the
+// section header rendered by GroupDetailScreen, so these tests focus on
+// avatar layout only.
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      text: "#1a1a1a",
+      textSecondary: "#666666",
+      border: "#e5e5e5",
+      surfaceSecondary: "#f5f5f5",
+    },
+  }),
+}));
+
 const createQueryClient = () =>
   new QueryClient({
     defaultOptions: {
@@ -44,14 +59,12 @@ describe("MembersRow", () => {
   it("renders members when provided", () => {
     renderWithProvider(<MembersRow members={mockMembers} />);
 
-    expect(screen.getByText("MEMBERS")).toBeTruthy();
     expect(screen.getAllByTestId("avatar").length).toBe(3);
   });
 
   it("renders leaders when provided", () => {
     renderWithProvider(<MembersRow leaders={mockLeaders} />);
 
-    expect(screen.getByText("MEMBERS")).toBeTruthy();
     expect(screen.getAllByTestId("avatar").length).toBe(2);
   });
 
@@ -79,8 +92,8 @@ describe("MembersRow", () => {
   });
 
   it("does not render when no members or leaders", () => {
-    renderWithProvider(<MembersRow members={[]} leaders={[]} />);
-    expect(screen.queryByText("MEMBERS")).toBeNull();
+    const { toJSON } = renderWithProvider(<MembersRow members={[]} leaders={[]} />);
+    expect(toJSON()).toBeNull();
   });
 
   it("shows remaining count when members exceed maxVisible", () => {
@@ -96,11 +109,11 @@ describe("MembersRow", () => {
   });
 
   it("handles undefined members and leaders gracefully", () => {
-    renderWithProvider(<MembersRow />);
-    expect(screen.queryByText("MEMBERS")).toBeNull();
+    let result = renderWithProvider(<MembersRow />);
+    expect(result.toJSON()).toBeNull();
 
-    renderWithProvider(<MembersRow members={undefined} leaders={undefined} />);
-    expect(screen.queryByText("MEMBERS")).toBeNull();
+    result = renderWithProvider(<MembersRow members={undefined} leaders={undefined} />);
+    expect(result.toJSON()).toBeNull();
   });
 
   it("handles members with missing names", () => {
@@ -116,4 +129,3 @@ describe("MembersRow", () => {
     expect(avatars.length).toBe(3);
   });
 });
-


### PR DESCRIPTION
## Summary

- Group page redesigned to match the DM/group-DM info aesthetic — centered avatar, MEMBERS above CHANNELS, single CHANNELS card with chevron-only rows, DETAILS + GROUP ACTIONS, share icon in the hero, avatar tap opens full-size, no redundant `(i)`.
- New per-channel info screen at `/inbox/[groupId]/[channelSlug]/info` with Open chat CTA, Members, Add people, Channel Actions, Leader Controls (Active state, Join mode picker, PCO sync settings, Rename, Share with groups, Archive). General redirects to the group page.
- Surfacing previously-buried things: Join mode is a Leader Controls row with explicit Open / Approval picker; pending join requests show inline above MEMBERS with approve/decline; PCO sync settings open the existing `AutoChannelSettings` modal directly from Leader Controls; disabled channels stay tappable so a leader can re-enable from Active state (`getChannelBySlug` accepts `includeArchived`).
- New on the group page: **UPCOMING EVENTS** horizontal scroll between Members and Channels, **BOTS** section listing the four bots inline. **Bots** and **Events** chips retired from the chat toolbar (`TOOLBAR_TOOLS` no longer exposes them; consumers filter unknown ids so groups with stale `leaderToolbarTools` stay safe).
- Chat header is one tappable identity block (avatar + name + badge + member count) routing to the group page — DM pattern.
- `EditGroupScreen` now respects dark mode via `useTheme` overrides on every JSX style.
- `/members.tsx` stripped of duplicates: Join mode banner, inline pending requests, PCO auto-channel banner, and Archive button all moved to the info screen. Members surface is now focused on member management.

## Test plan

- [ ] Group page (member): hero centered, share icon top-right, no `(i)`, tap avatar opens full-size, MEMBERS row above CHANNELS, UPCOMING EVENTS horizontal scroll, CHANNELS rows clean (chevron only), DETAILS + GROUP ACTIONS at bottom
- [ ] Group page (leader): BOTS section visible with all four bots; Configure opens correct modal
- [ ] Tap any non-General channel row → channel info screen loads; tap General → goes straight to chat
- [ ] Channel info — Leader Controls Join mode picker: Open / Approval required save and round-trip
- [ ] Channel info — pending join requests render with approve/decline; approve removes from list
- [ ] Channel info — PCO channels show "PCO sync settings" row that opens AutoChannelSettings modal
- [ ] Disabled Leaders or Reach Out channel: tap from group page → info screen loads → Active state row enables it
- [ ] Chat header: tap anywhere in identity block (incl. member count) → group page; tap `(i)` → channel info (or group page for General)
- [ ] Edit Group page in dark mode: dark surfaces, light text, warning banner readable
- [ ] Toolbar: no Bots or Events chips; Attendance + People (and others if enabled) still render
- [ ] `/members` page: no Join mode banner, no inline join requests, no auto-channel banner, no Archive button
- [ ] Light mode regression: hero/cards/text contrast OK
- [ ] Convex dev backend with seeded data: `pnpm test` passes (1003 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)