### PR TITLE
fix(group): event chat unread, /events 404, bots gate, members count + access, leader badge, admin self-promote

### DIFF
--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -663,34 +663,41 @@ export const getChannelMembers = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
-    if (!membership) {
-      // If not a channel member, check elevated permissions:
-      // - group leaders/admins can view members of any channel in their group
-      // - community admins can manage/view members across all groups in community
-      const groupMembership = await ctx.db
-        .query("groupMembers")
-        .withIndex("by_group_user", (q) =>
-          q.eq("groupId", groupId).eq("userId", userId)
-        )
-        .filter((q) =>
-          q.and(
-            q.eq(q.field("leftAt"), undefined),
-            q.or(
-              q.eq(q.field("role"), "leader"),
-              q.eq(q.field("role"), "admin")
-            )
+    // Resolve elevated-permission state once. We need it both as the
+    // fallback when the caller isn't a channel member AND to gate the
+    // announcement-group full roster (every community member is auto-added
+    // to the announcement group's main channel, so plain channel
+    // membership isn't enough authorization for the directory dump).
+    const callerGroupMembership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", groupId).eq("userId", userId)
+      )
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("leftAt"), undefined),
+          q.or(
+            q.eq(q.field("role"), "leader"),
+            q.eq(q.field("role"), "admin")
           )
         )
-        .first();
+      )
+      .first();
+    const group = await ctx.db.get(groupId);
+    const isCommAdmin = group
+      ? await isCommunityAdmin(ctx, group.communityId, userId)
+      : false;
+    const isElevated = !!callerGroupMembership || isCommAdmin;
 
-      const group = await ctx.db.get(groupId);
-      const isCommAdmin = group
-        ? await isCommunityAdmin(ctx, group.communityId, userId)
-        : false;
+    if (!membership && !isElevated) {
+      return { members: [], nextCursor: null, totalCount: 0 };
+    }
 
-      if (!groupMembership && !isCommAdmin) {
-        return { members: [], nextCursor: null, totalCount: 0 };
-      }
+    // Announcement groups span the whole community; treating "channel
+    // member" as authorization there would expose the full directory to
+    // anyone in the community. Restrict the full roster to leaders/admins.
+    if (group?.isAnnouncementGroup && !isElevated) {
+      return { members: [], nextCursor: null, totalCount: 0 };
     }
 
     if (searchTerms.length > 0) {
@@ -770,8 +777,24 @@ export const getChannelMembers = query({
           ? String(cursorIndex + limit)
           : null;
 
+      // Resolve the group-level role for each visible member so the client
+      // can flag leaders/admins distinctly from channel "owner"/"member"
+      // (which is channel-scoped). One indexed lookup per row.
+      const pageGroupRoles = await Promise.all(
+        page.map(async ({ member }) => {
+          const gm = await ctx.db
+            .query("groupMembers")
+            .withIndex("by_group_user", (q) =>
+              q.eq("groupId", groupId).eq("userId", member.userId)
+            )
+            .filter((q) => q.eq(q.field("leftAt"), undefined))
+            .first();
+          return gm?.role ?? null;
+        })
+      );
+
       return {
-        members: page.map(({ member, user }) => ({
+        members: page.map(({ member, user }, idx) => ({
           id: member._id,
           userId: member.userId,
           displayName:
@@ -780,6 +803,7 @@ export const getChannelMembers = query({
             "Unknown",
           profilePhoto: member.profilePhoto || getMediaUrl(user.profilePhoto) || undefined,
           role: member.role,
+          groupRole: pageGroupRoles[idx] ?? undefined,
           syncSource: member.syncSource,
           syncMetadata: member.syncMetadata,
         })),
@@ -800,10 +824,21 @@ export const getChannelMembers = query({
     const hasMore = result.page.length > limit;
     const members = hasMore ? result.page.slice(0, limit) : result.page;
 
-    // Enrich member data with fresh user info (denormalized displayName may be stale/missing)
+    // Enrich member data with fresh user info (denormalized displayName may
+    // be stale/missing) and resolve each member's group-level role so the
+    // client can surface a "Leader" badge distinct from channel ownership.
     const enrichedMembers = await Promise.all(
       members.map(async (member) => {
-        const user = await ctx.db.get(member.userId);
+        const [user, groupMembership] = await Promise.all([
+          ctx.db.get(member.userId),
+          ctx.db
+            .query("groupMembers")
+            .withIndex("by_group_user", (q) =>
+              q.eq("groupId", groupId).eq("userId", member.userId)
+            )
+            .filter((q) => q.eq(q.field("leftAt"), undefined))
+            .first(),
+        ]);
         const freshDisplayName = user
           ? getDisplayName(user.firstName, user.lastName)
           : member.displayName;
@@ -814,6 +849,7 @@ export const getChannelMembers = query({
           displayName: freshDisplayName || member.displayName || "Unknown",
           profilePhoto: member.profilePhoto || (user ? getMediaUrl(user.profilePhoto) : undefined),
           role: member.role,
+          groupRole: groupMembership?.role ?? undefined,
           syncSource: member.syncSource,
           syncMetadata: member.syncMetadata,
         };

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -32,6 +32,7 @@ import {
 import { useTheme } from "@hooks/useTheme";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { ReactionsProvider } from "@/features/chat/context/ReactionsContext";
+import { useReadState } from "@/features/chat/hooks/useReadState";
 import { Ionicons } from "@expo/vector-icons";
 import { EventComment } from "./EventComment";
 import { EventCommentSheet } from "./EventCommentSheet";
@@ -154,6 +155,22 @@ export function EventActivity({
     () => messages.map((m: any) => m._id),
     [messages]
   );
+
+  // Clear the inbox unread badge for this event's channel when the user
+  // views it, and re-fire as new live messages arrive. EventActivity is the
+  // event page's chat surface, so without this the badge persists forever.
+  // Mirrors ConvexChatRoomScreen's auto-mount markAsRead.
+  const { markAsRead } = useReadState(channelId);
+  const latestMessageId = liveMessages.length
+    ? (liveMessages[liveMessages.length - 1]._id as Id<"chatMessages">)
+    : null;
+  React.useEffect(() => {
+    if (!channelId || !canAccess) return;
+    markAsRead(latestMessageId ?? undefined).catch(() => {
+      // Silently swallow — markAsRead also no-ops for ad-hoc channels with
+      // missing profile photo. We don't want a toast here.
+    });
+  }, [channelId, canAccess, latestMessageId, markAsRead]);
 
   const handleLoadOlder = useCallback(() => {
     if (isLoadingOlder || !olderCursor || !hasMoreOlder) return;

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
@@ -231,7 +231,19 @@ export default function ChannelMembersScreen() {
   // members. Avoids the prior split where requests, sync info, archive, and
   // join-mode all lived on this same surface.
   const unifiedList = useMemo((): ListItem[] => {
-    const syncedItems: ListItem[] = (membersData?.members || []).map((m) => ({
+    // Pin group leaders to the top so newcomers can immediately spot who to
+    // reach out to. Stable order preserved within each tier (the backend
+    // already returns leaders alphabetically inside the search path; the
+    // browse path is by channel-membership creation order — close enough
+    // for pure visual grouping).
+    const sortedMembers = [...(membersData?.members || [])].sort((a, b) => {
+      const aLeader =
+        a.groupRole === "leader" || a.groupRole === "admin" ? 0 : 1;
+      const bLeader =
+        b.groupRole === "leader" || b.groupRole === "admin" ? 0 : 1;
+      return aLeader - bLeader;
+    });
+    const syncedItems: ListItem[] = sortedMembers.map((m) => ({
       type: "synced" as const,
       data: m,
     }));
@@ -624,7 +636,13 @@ export default function ChannelMembersScreen() {
           canManage && isCustomChannel && (!isSharedChannel || isPrimaryGroup) && !(isOwner && isCurrentUser);
 
         return (
-          <View style={[styles.memberItem, { backgroundColor: colors.surface }]}>
+          <TouchableOpacity
+            activeOpacity={0.7}
+            onPress={() => router.push(`/profile/${member.userId}` as any)}
+            style={[styles.memberItem, { backgroundColor: colors.surface }]}
+            accessibilityRole="button"
+            accessibilityLabel={`Open ${member.displayName}'s profile`}
+          >
             <SyncedMemberRowContent
               member={member}
               primaryColor={primaryColor}
@@ -645,7 +663,7 @@ export default function ChannelMembersScreen() {
                 ) : undefined
               }
             />
-          </View>
+          </TouchableOpacity>
         );
       } else {
         const person = item.data;
@@ -665,7 +683,7 @@ export default function ChannelMembersScreen() {
         );
       }
     },
-    [canManage, isCustomChannel, isSharedChannel, isPrimaryGroup, user, removingMemberId, primaryColor, handleRemoveMember, colors, isDark, pendingRequests, handleBulkApprove, isBulkApproving, processingRequestId, handleApproveRequest, handleDeclineRequest]
+    [canManage, isCustomChannel, isSharedChannel, isPrimaryGroup, user, removingMemberId, primaryColor, handleRemoveMember, colors, isDark, pendingRequests, handleBulkApprove, isBulkApproving, processingRequestId, handleApproveRequest, handleDeclineRequest, router]
   );
 
   // Loading state

--- a/apps/mobile/components/ui/ChannelMemberRows.tsx
+++ b/apps/mobile/components/ui/ChannelMemberRows.tsx
@@ -49,6 +49,10 @@ export function SyncedMemberRowContent({
   const { colors, isDark } = useTheme();
   const isOwner = member.role === "owner";
   const isAdmin = member.role === "admin";
+  // Group-level leadership — separate from channel ownership. Surfaced as a
+  // "Leader" pill so members know who to reach out to about the group.
+  const isGroupLeader =
+    member.groupRole === "leader" || member.groupRole === "admin";
   const isPcoSynced = member.syncSource === "pco_services";
   const initials = getInitials(member.displayName);
 
@@ -74,17 +78,21 @@ export function SyncedMemberRowContent({
           {isCurrentUser && <Text style={[styles.youBadge, { color: colors.textTertiary }]}>(you)</Text>}
         </View>
 
-        {/* Role badges */}
-        {isOwner && (
+        {/* Role badges. Leader takes precedence — it's the most useful
+            signal to non-leaders ("who do I contact?"). */}
+        {isGroupLeader ? (
+          <View style={[styles.roleBadge, { backgroundColor: `${primaryColor}20` }]}>
+            <Text style={[styles.roleBadgeText, { color: primaryColor }]}>Leader</Text>
+          </View>
+        ) : isOwner ? (
           <View style={[styles.roleBadge, { backgroundColor: `${primaryColor}20` }]}>
             <Text style={[styles.roleBadgeText, { color: primaryColor }]}>Owner</Text>
           </View>
-        )}
-        {isAdmin && !isOwner && (
+        ) : isAdmin ? (
           <View style={[styles.roleBadge, { backgroundColor: `${primaryColor}20` }]}>
             <Text style={[styles.roleBadgeText, { color: primaryColor }]}>Admin</Text>
           </View>
-        )}
+        ) : null}
 
         {/* PCO sync metadata - team and position */}
         {isPcoSynced && member.syncMetadata && (

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -128,7 +128,14 @@ export function GroupDetailScreen() {
 
   const handleMembersPress = () => {
     if (!group?._id) return;
-    router.push(`/leader-tools/${group._id}/members`);
+    // Leaders/admins land on the full member-management surface (promote /
+    // demote / remove from group / add member). Regular members get the
+    // read-only roster on the general channel — same humans, no controls.
+    if (isLeader || isAdmin) {
+      router.push(`/leader-tools/${group._id}/members`);
+      return;
+    }
+    router.push(`/inbox/${group._id}/general/members` as any);
   };
 
   const handleLeaveGroup = () => {
@@ -405,7 +412,10 @@ export function GroupDetailScreen() {
           canEdit={canEditGroup}
         />
 
-        {/* MEMBERS — moved above channels */}
+        {/* MEMBERS — moved above channels. Announcement groups contain the
+            entire community, so exposing the full roster to a regular member
+            would be a directory leak. Leaders/admins still get the full
+            list there for moderation. */}
         {((group.members && group.members.length > 0) ||
           (group.leaders && group.leaders.length > 0) ||
           (group.members_count && group.members_count > 0)) && (
@@ -413,30 +423,39 @@ export function GroupDetailScreen() {
             <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
               MEMBERS{group.members_count ? ` · ${group.members_count}` : ""}
             </Text>
-            <TouchableOpacity
-              activeOpacity={0.7}
-              onPress={isLeader || isAdmin ? handleMembersPress : undefined}
-              disabled={!(isLeader || isAdmin)}
-              style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}
-            >
-              <MembersRow
-                members={group.members}
-                leaders={group.leaders}
-                totalCount={group.members_count ?? undefined}
-              />
-              {(isLeader || isAdmin) && (
-                <View style={[styles.viewAllRow, { borderTopColor: colors.border }]}>
-                  <Text style={[styles.viewAllText, { color: colors.text }]}>
-                    View all members
-                  </Text>
-                  <Ionicons
-                    name="chevron-forward"
-                    size={18}
-                    color={colors.textTertiary}
+            {(() => {
+              const isAnnouncementRoster =
+                !!group.is_announcement_group && !(isLeader || isAdmin);
+              const Container: React.ComponentType<any> = isAnnouncementRoster
+                ? View
+                : TouchableOpacity;
+              return (
+                <Container
+                  {...(isAnnouncementRoster
+                    ? {}
+                    : { activeOpacity: 0.7, onPress: handleMembersPress })}
+                  style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}
+                >
+                  <MembersRow
+                    members={group.members}
+                    leaders={group.leaders}
+                    totalCount={group.members_count ?? undefined}
                   />
-                </View>
-              )}
-            </TouchableOpacity>
+                  {!isAnnouncementRoster && (
+                    <View style={[styles.viewAllRow, { borderTopColor: colors.border }]}>
+                      <Text style={[styles.viewAllText, { color: colors.text }]}>
+                        View all members
+                      </Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={18}
+                        color={colors.textTertiary}
+                      />
+                    </View>
+                  )}
+                </Container>
+              );
+            })()}
           </View>
         )}
 
@@ -454,7 +473,7 @@ export function GroupDetailScreen() {
             only; renders the same bot cards + config modals BotsScreen
             renders. */}
         {group._id && (
-          <GroupBotsSection groupId={group._id} isLeader={isLeader || isAdmin} />
+          <GroupBotsSection groupId={group._id} isLeader={isLeader} />
         )}
 
         {/* Highlights */}

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -424,16 +424,25 @@ export function GroupDetailScreen() {
               MEMBERS{group.members_count ? ` · ${group.members_count}` : ""}
             </Text>
             {(() => {
+              // Tap disabled in two cases:
+              //  1. Announcement group + non-leader (directory leak).
+              //  2. Caller isn't an actual group member — `getChannelBySlug`
+              //     refuses non-members, so the destination would dead-end
+              //     in a permanent loading spinner. (Community super-admins
+              //     who aren't group members fall here too; that's fine,
+              //     they can use admin-tools surfaces instead.)
               const isAnnouncementRoster =
                 !!group.is_announcement_group && !(isLeader || isAdmin);
-              const Container: React.ComponentType<any> = isAnnouncementRoster
-                ? View
-                : TouchableOpacity;
+              const hasGroupMembership = !!group.user_role;
+              const tapEnabled = !isAnnouncementRoster && hasGroupMembership;
+              const Container: React.ComponentType<any> = tapEnabled
+                ? TouchableOpacity
+                : View;
               return (
                 <Container
-                  {...(isAnnouncementRoster
-                    ? {}
-                    : { activeOpacity: 0.7, onPress: handleMembersPress })}
+                  {...(tapEnabled
+                    ? { activeOpacity: 0.7, onPress: handleMembersPress }
+                    : {})}
                   style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}
                 >
                   <MembersRow
@@ -441,7 +450,7 @@ export function GroupDetailScreen() {
                     leaders={group.leaders}
                     totalCount={group.members_count ?? undefined}
                   />
-                  {!isAnnouncementRoster && (
+                  {tapEnabled && (
                     <View style={[styles.viewAllRow, { borderTopColor: colors.border }]}>
                       <Text style={[styles.viewAllText, { color: colors.text }]}>
                         View all members

--- a/apps/mobile/features/groups/components/UpcomingEventsSection.tsx
+++ b/apps/mobile/features/groups/components/UpcomingEventsSection.tsx
@@ -70,19 +70,28 @@ export function UpcomingEventsSection({ groupId }: Props) {
             : isTomorrow(date)
               ? `Tomorrow · ${format(date, "h:mm a")}`
               : format(date, "EEE, MMM d · h:mm a");
+          // Legacy meetings can lack `shortId`; pushing `/e/undefined` would
+          // dead-end. Disable the card in that case rather than navigating.
+          const canOpen = !!event.shortId;
           return (
             <Pressable
               key={event._id}
-              onPress={() =>
-                router.push(`/e/${event.shortId}?source=app` as any)
+              onPress={
+                canOpen
+                  ? () =>
+                      router.push(
+                        `/e/${event.shortId}?source=app` as any
+                      )
+                  : undefined
               }
+              disabled={!canOpen}
               style={({ pressed }) => [
                 styles.card,
                 {
                   backgroundColor: colors.surfaceSecondary,
                   borderColor: colors.border,
                 },
-                pressed && { opacity: 0.85 },
+                pressed && canOpen && { opacity: 0.85 },
               ]}
             >
               {event.coverImage ? (

--- a/apps/mobile/features/groups/components/UpcomingEventsSection.tsx
+++ b/apps/mobile/features/groups/components/UpcomingEventsSection.tsx
@@ -73,7 +73,9 @@ export function UpcomingEventsSection({ groupId }: Props) {
           return (
             <Pressable
               key={event._id}
-              onPress={() => router.push(`/events/${event._id}` as any)}
+              onPress={() =>
+                router.push(`/e/${event.shortId}?source=app` as any)
+              }
               style={({ pressed }) => [
                 styles.card,
                 {

--- a/apps/mobile/features/groups/hooks/useGroupDetails.ts
+++ b/apps/mobile/features/groups/hooks/useGroupDetails.ts
@@ -138,10 +138,17 @@ export function useGroupDetails(groupId: string | null | undefined) {
         default_meeting_link: effectiveGroup.defaultMeetingLink || null,
         preview: (effectiveGroup as any).preview || null,
         is_announcement_group: effectiveGroup.isAnnouncementGroup || false,
-        // Use actual members count if available, fallback to preview count for non-members
-        members_count: (effectiveMembers?.length || 0) + (effectiveLeaders?.length || 0) > 0
-          ? (effectiveMembers?.length || 0) + (effectiveLeaders?.length || 0)
-          : effectiveMemberPreview?.totalCount || 0,
+        // Prefer the general/main channel's memberCount — every active group
+        // member is also a main-channel member, so this is the authoritative
+        // count for "people in this group" and avoids undercounting when the
+        // members list is paginated. Falls back to list lengths for legacy
+        // payloads that don't carry memberCount, then to preview totalCount
+        // for the non-member path.
+        members_count:
+          (effectiveGroup as any).memberCount ??
+          ((effectiveMembers?.length || 0) + (effectiveLeaders?.length || 0) > 0
+            ? (effectiveMembers?.length || 0) + (effectiveLeaders?.length || 0)
+            : effectiveMemberPreview?.totalCount || 0),
         // Flatten member data to match GroupMember type expected by MembersRow
         members:
           effectiveMembers?.map((m: any) => ({

--- a/apps/mobile/features/leader-tools/components/Members.tsx
+++ b/apps/mobile/features/leader-tools/components/Members.tsx
@@ -465,8 +465,15 @@ function MemberActionsModal({
     memberRole === MembershipRole.LEADER ||
     memberRole === 2;
   const isCurrentUser = user?.id === member?.id;
-  // Show promote/demote if user can manage members AND we have group role data
-  const canPromoteDemote = canManageMembers && memberRole !== undefined;
+  // Global community admins can self-promote/demote in any group they're a
+  // member of — useful when an admin needs leader powers in a group they
+  // didn't create. The backend (`groupMembers.updateRole`) already permits
+  // this via its `isCommAdmin` short-circuit; this just unhides the UI.
+  const isGlobalAdmin = user?.is_admin === true;
+  // Show promote/demote if user can manage members AND we have group role
+  // data. Self-actions are normally hidden, but global admins can self-act.
+  const canPromoteDemote =
+    canManageMembers && memberRole !== undefined && (!isCurrentUser || isGlobalAdmin);
 
   // Visible to ANY caller — non-admin members can still view profiles.
   const handleViewProfile = () => {
@@ -511,7 +518,7 @@ function MemberActionsModal({
                 View profile
               </Text>
             </TouchableOpacity>
-            {canPromoteDemote && !isCurrentUser && (
+            {canPromoteDemote && (
               <>
                 {isLeader ? (
                   <TouchableOpacity

--- a/apps/mobile/utils/channel-members.ts
+++ b/apps/mobile/utils/channel-members.ts
@@ -8,7 +8,14 @@ export interface ChannelMember {
   userId: Id<"users">;
   displayName: string;
   profilePhoto?: string;
+  /** Channel-scoped role: "owner" or "member". */
   role: string;
+  /**
+   * Group-scoped role: "leader" | "admin" | "member" (or undefined if not a
+   * group member — possible for synced PCO rows). Distinct from `role` so
+   * UI can show channel ownership and group leadership independently.
+   */
+  groupRole?: string;
   syncSource?: string;
   syncMetadata?: {
     serviceTypeName?: string;


### PR DESCRIPTION
## Summary

Cleanup pass on the group page surfaces — five UX bugs reported in the simulator, one PR.

- **Event chat unread badge persisted** — `EventActivity` (the event page's chat surface) never wired up `markAsRead`, so opening an event from the inbox left the unread "1" forever. Now mirrors `ConvexChatRoomScreen`'s mount-and-watch pattern.
- **Upcoming Events 404** on web — `UpcomingEventsSection` linked to `/events/[id]`, which doesn't exist. Switched to `/e/[shortId]?source=app` to match every other event-card consumer.
- **Bots section visible to non-leaders** — `GroupDetailScreen` was passing `isLeader || isAdmin` (`isAdmin` is the *global* community-admin flag), so super-admins saw the Bots block in groups they don't lead. Gated to actual leaders only.
- **MEMBERS · N count was wrong** — count was `members.length + leaders.length` where `members` is paginated, so anything past the first page undercounted. Switched to the backend's `memberCount`, which the group response already derives from the main/general channel's denormalized counter.
- **Regular members couldn't see the full roster** — the members card was leader-tap-only with no chevron. Now non-leaders land on `/inbox/[id]/general/members` (the page already supports a read-only mode for them per its own header comment), with leaders pinned to the top via a new `groupRole` field on the channel-member payload, a "Leader" pill on those rows, and tap-to-profile across the list. Announcement groups stay restricted on both ends — frontend hides the tap, backend `getChannelMembers` refuses the full list to non-leader callers (defense in depth, since every community member is auto-added to the announcement group's main channel).
- **Global admins couldn't self-promote** — `MemberActionsModal` hid Promote/Demote on the current user's row, so a community admin in a group they didn't create had to ask another leader. Backend `groupMembers.updateRole` already permits this via its `isCommAdmin` short-circuit; only the UI gate needed adjusting.

Leaders/admins still go to `/leader-tools/[id]/members` from the group page (full management surface — promote/demote/add/remove). Non-leaders go to the channel members page. Same humans, role-appropriate chrome.

## Test plan

- [ ] Open a group you're a leader of → tap MEMBERS → leader-tools page loads with management actions intact (no regression).
- [ ] Open a group you're a regular member of (not announcement group) → tap MEMBERS → channel members page loads, leaders are at the top with a "Leader" pill, tap any row → opens that user's profile.
- [ ] Open the announcement group as a regular member → MEMBERS card shows preview avatars + count, no chevron, no tap response.
- [ ] As a global community admin in a group you're a "member" of → tap your own row in leader-tools/members → "Promote to Leader" appears; promoting works end-to-end.
- [ ] In the inbox, open an event chat with unread = 1 → unread clears immediately when EventActivity mounts. Send a new message from another account → unread updates and re-clears as soon as the page sees it live.
- [ ] On the group page, tap an UPCOMING EVENTS card on web (`togather.nyc/...`) → routes to `/e/[shortId]`, not `/events/[id]`. No 404.
- [ ] As a non-leader in a group with bots → no BOTS section appears.
- [ ] MEMBERS · N count matches the actual general-channel member count for groups with >1 page of members.
- [ ] Backend: a non-leader hitting `messaging.channels.getChannelMembers` for the announcement group's main channel gets `{ members: [], totalCount: 0 }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)