### PR TITLE
feat(notifications): persistent inbox opt-in flow + admin enablement stats

### DIFF
--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -90,6 +90,7 @@ import type * as functions_messaging_typing from "../functions/messaging/typing.
 import type * as functions_migrations from "../functions/migrations.js";
 import type * as functions_migrations_migrateToCommunityPeople from "../functions/migrations/migrateToCommunityPeople.js";
 import type * as functions_notifications_actions from "../functions/notifications/actions.js";
+import type * as functions_notifications_dailyEnabledSnapshot from "../functions/notifications/dailyEnabledSnapshot.js";
 import type * as functions_notifications_debug from "../functions/notifications/debug.js";
 import type * as functions_notifications_index from "../functions/notifications/index.js";
 import type * as functions_notifications_internal from "../functions/notifications/internal.js";
@@ -262,6 +263,7 @@ declare const fullApi: ApiFromModules<{
   "functions/migrations": typeof functions_migrations;
   "functions/migrations/migrateToCommunityPeople": typeof functions_migrations_migrateToCommunityPeople;
   "functions/notifications/actions": typeof functions_notifications_actions;
+  "functions/notifications/dailyEnabledSnapshot": typeof functions_notifications_dailyEnabledSnapshot;
   "functions/notifications/debug": typeof functions_notifications_debug;
   "functions/notifications/index": typeof functions_notifications_index;
   "functions/notifications/internal": typeof functions_notifications_internal;

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -155,6 +155,7 @@ import type * as lib_memberSearch from "../lib/memberSearch.js";
 import type * as lib_membership from "../lib/membership.js";
 import type * as lib_notifications_definitions from "../lib/notifications/definitions.js";
 import type * as lib_notifications_emailTemplates from "../lib/notifications/emailTemplates.js";
+import type * as lib_notifications_enabledCounter from "../lib/notifications/enabledCounter.js";
 import type * as lib_notifications_index from "../lib/notifications/index.js";
 import type * as lib_notifications_registry from "../lib/notifications/registry.js";
 import type * as lib_notifications_send from "../lib/notifications/send.js";
@@ -328,6 +329,7 @@ declare const fullApi: ApiFromModules<{
   "lib/membership": typeof lib_membership;
   "lib/notifications/definitions": typeof lib_notifications_definitions;
   "lib/notifications/emailTemplates": typeof lib_notifications_emailTemplates;
+  "lib/notifications/enabledCounter": typeof lib_notifications_enabledCounter;
   "lib/notifications/index": typeof lib_notifications_index;
   "lib/notifications/registry": typeof lib_notifications_registry;
   "lib/notifications/send": typeof lib_notifications_send;

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -192,4 +192,19 @@ crons.hourly(
   internal.functions.messaging.directMessages.cleanupOldDmRateLimits
 );
 
+// =============================================================================
+// DAILY NOTIFICATION-ENABLED SNAPSHOT
+// =============================================================================
+// Runs daily at 00:05 UTC to snapshot the count of users with at least one
+// push token (per environment) into `dailyNotificationStats`. The superuser
+// admin dashboard reads "today (live) vs yesterday (snapshot)" from this
+// table, plus the live `pushTokens` count for today. Tokens are deleted on
+// disable, so historical counts cannot be reconstructed without snapshots.
+
+crons.daily(
+  "daily-notification-enabled-snapshot",
+  { hourUTC: 0, minuteUTC: 5 },
+  internal.functions.notifications.dailyEnabledSnapshot.run
+);
+
 export default crons;

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -195,15 +195,16 @@ crons.hourly(
 // =============================================================================
 // DAILY NOTIFICATION-ENABLED SNAPSHOT + COUNTER SELF-HEAL
 // =============================================================================
-// Runs daily at 00:05 UTC. Re-seeds `notificationEnabledCounter` from
-// pushTokens (idempotent, paginated — no transaction limits) so the running
-// tally self-heals from any drift, then writes the daily snapshot row. This
-// also means new deploys don't need a manual backfill — the counter
-// becomes accurate within 24h automatically.
+// Runs daily at 23:55 UTC — late in the UTC day so the snapshot captures
+// "end of today" under today's date label (avoids the off-by-one delta
+// distortion the earlier 00:05-of-next-day schedule had). Backfill re-seeds
+// `notificationEnabledCounter` from pushTokens (idempotent, paginated — no
+// transaction limits) for self-healing; if backfill fails the snapshot
+// still runs.
 
 crons.daily(
   "daily-notification-enabled-snapshot",
-  { hourUTC: 0, minuteUTC: 5 },
+  { hourUTC: 23, minuteUTC: 55 },
   internal.functions.notifications.dailyEnabledSnapshot.runDaily
 );
 

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -193,18 +193,18 @@ crons.hourly(
 );
 
 // =============================================================================
-// DAILY NOTIFICATION-ENABLED SNAPSHOT
+// DAILY NOTIFICATION-ENABLED SNAPSHOT + COUNTER SELF-HEAL
 // =============================================================================
-// Runs daily at 00:05 UTC to snapshot the count of users with at least one
-// push token (per environment) into `dailyNotificationStats`. The superuser
-// admin dashboard reads "today (live) vs yesterday (snapshot)" from this
-// table, plus the live `pushTokens` count for today. Tokens are deleted on
-// disable, so historical counts cannot be reconstructed without snapshots.
+// Runs daily at 00:05 UTC. Re-seeds `notificationEnabledCounter` from
+// pushTokens (idempotent, paginated — no transaction limits) so the running
+// tally self-heals from any drift, then writes the daily snapshot row. This
+// also means new deploys don't need a manual backfill — the counter
+// becomes accurate within 24h automatically.
 
 crons.daily(
   "daily-notification-enabled-snapshot",
   { hourUTC: 0, minuteUTC: 5 },
-  internal.functions.notifications.dailyEnabledSnapshot.run
+  internal.functions.notifications.dailyEnabledSnapshot.runDaily
 );
 
 export default crons;

--- a/apps/convex/functions/admin/stats.ts
+++ b/apps/convex/functions/admin/stats.ts
@@ -1595,15 +1595,28 @@ export const getDailyNotificationEnabledStats = query({
     // (the previous approach hit Convex transaction scan limits at scale).
     const today = await readEnabledCount(ctx, environment);
 
-    // Most recent snapshot for this environment (descending by date).
-    const lastSnapshot = await ctx.db
-      .query("dailyNotificationStats")
-      .withIndex("by_environment_date", (q) => q.eq("environment", environment))
-      .order("desc")
-      .first();
+    // Compare against the snapshot dated exactly yesterday in UTC. We can't
+    // just use "most recent snapshot" because:
+    //   - between 00:00–00:05 UTC the cron hasn't run yet, so the most recent
+    //     row is from two days ago — the UI would mislabel a 2-day delta as
+    //     "since yesterday"
+    //   - if a cron run is skipped (deploy pause, etc.) the same staleness
+    //     mislabeling happens
+    // If yesterday's snapshot is missing, return null so the UI shows the
+    // honest "Awaiting first daily snapshot" state instead of a wrong delta.
+    const DAY_MS_LOCAL = 24 * 60 * 60 * 1000;
+    const yesterdayDate = new Date(Date.now() - DAY_MS_LOCAL)
+      .toISOString()
+      .slice(0, 10);
 
-    const yesterday = lastSnapshot?.enabledCount ?? null;
-    const yesterdayDate = lastSnapshot?.date ?? null;
+    const yesterdaySnapshot = await ctx.db
+      .query("dailyNotificationStats")
+      .withIndex("by_environment_date", (q) =>
+        q.eq("environment", environment).eq("date", yesterdayDate),
+      )
+      .unique();
+
+    const yesterday = yesterdaySnapshot?.enabledCount ?? null;
 
     let delta: number | null = null;
     let percentChange: number | null = null;
@@ -1617,7 +1630,7 @@ export const getDailyNotificationEnabledStats = query({
     return {
       today,
       yesterday,
-      yesterdayDate,
+      yesterdayDate: yesterdaySnapshot?.date ?? null,
       delta,
       percentChange,
       environment,

--- a/apps/convex/functions/admin/stats.ts
+++ b/apps/convex/functions/admin/stats.ts
@@ -17,6 +17,7 @@ import { now, getMediaUrl } from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
 import { requireCommunityAdmin, checkCommunityAdmin } from "./auth";
 import { getCurrentEnvironment } from "../../lib/notifications/send";
+import { readEnabledCount } from "../../lib/notifications/enabledCounter";
 
 type SuperAdminRange = "7d" | "30d" | "90d" | "all";
 type SuperAdminGranularity = "day" | "month";
@@ -1589,15 +1590,10 @@ export const getDailyNotificationEnabledStats = query({
 
     const environment = getCurrentEnvironment();
 
-    // Live "today" count — distinct userIds with at least one push token in
-    // this environment. Mirrors the snapshot mutation's logic so today and
-    // yesterday are apples-to-apples.
-    const distinctUsers = new Set<string>();
-    for await (const row of ctx.db.query("pushTokens")) {
-      if (row.environment !== environment) continue;
-      distinctUsers.add(row.userId);
-    }
-    const today = distinctUsers.size;
+    // Live "today" count — read the running tally maintained by the token
+    // write paths in O(1) instead of scanning the full pushTokens table
+    // (the previous approach hit Convex transaction scan limits at scale).
+    const today = await readEnabledCount(ctx, environment);
 
     // Most recent snapshot for this environment (descending by date).
     const lastSnapshot = await ctx.db

--- a/apps/convex/functions/admin/stats.ts
+++ b/apps/convex/functions/admin/stats.ts
@@ -1595,42 +1595,36 @@ export const getDailyNotificationEnabledStats = query({
     // (the previous approach hit Convex transaction scan limits at scale).
     const today = await readEnabledCount(ctx, environment);
 
-    // Compare against the snapshot dated exactly yesterday in UTC. We can't
-    // just use "most recent snapshot" because:
-    //   - between 00:00–00:05 UTC the cron hasn't run yet, so the most recent
-    //     row is from two days ago — the UI would mislabel a 2-day delta as
-    //     "since yesterday"
-    //   - if a cron run is skipped (deploy pause, etc.) the same staleness
-    //     mislabeling happens
-    // If yesterday's snapshot is missing, return null so the UI shows the
-    // honest "Awaiting first daily snapshot" state instead of a wrong delta.
-    const DAY_MS_LOCAL = 24 * 60 * 60 * 1000;
-    const yesterdayDate = new Date(Date.now() - DAY_MS_LOCAL)
-      .toISOString()
-      .slice(0, 10);
-
-    const yesterdaySnapshot = await ctx.db
+    // Compare against the most recent dailyNotificationStats snapshot for
+    // this environment. We deliberately do NOT compute "yesterday's date"
+    // from `Date.now()` here — Convex queries don't rerun on wall-clock
+    // changes, only on tracked-data changes. A dashboard left open across
+    // UTC midnight would have read a stale yesterdayDate. By returning the
+    // snapshot's actual date, the UI labels the delta against the real
+    // snapshot date (e.g. "since 2026-04-29") and the query naturally
+    // reactivates when the daily cron writes a new snapshot.
+    const lastSnapshot = await ctx.db
       .query("dailyNotificationStats")
-      .withIndex("by_environment_date", (q) =>
-        q.eq("environment", environment).eq("date", yesterdayDate),
-      )
-      .unique();
+      .withIndex("by_environment_date", (q) => q.eq("environment", environment))
+      .order("desc")
+      .first();
 
-    const yesterday = yesterdaySnapshot?.enabledCount ?? null;
+    const previous = lastSnapshot?.enabledCount ?? null;
+    const previousDate = lastSnapshot?.date ?? null;
 
     let delta: number | null = null;
     let percentChange: number | null = null;
-    if (yesterday !== null) {
-      delta = today - yesterday;
-      if (yesterday > 0) {
-        percentChange = (delta / yesterday) * 100;
+    if (previous !== null) {
+      delta = today - previous;
+      if (previous > 0) {
+        percentChange = (delta / previous) * 100;
       }
     }
 
     return {
       today,
-      yesterday,
-      yesterdayDate: yesterdaySnapshot?.date ?? null,
+      previous,
+      previousDate,
       delta,
       percentChange,
       environment,

--- a/apps/convex/functions/admin/stats.ts
+++ b/apps/convex/functions/admin/stats.ts
@@ -16,6 +16,7 @@ import { Id, Doc } from "../../_generated/dataModel";
 import { now, getMediaUrl } from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
 import { requireCommunityAdmin, checkCommunityAdmin } from "./auth";
+import { getCurrentEnvironment } from "../../lib/notifications/send";
 
 type SuperAdminRange = "7d" | "30d" | "90d" | "all";
 type SuperAdminGranularity = "day" | "month";
@@ -1552,6 +1553,78 @@ export const getNotificationStats = query({
       byType: Object.entries(byType)
         .map(([type, stats]) => ({ type, ...stats }))
         .sort((a, b) => b.sent - a.sent),
+    };
+  },
+});
+
+/**
+ * Device-level notification opt-in counts for the superuser admin dashboard.
+ *
+ * Returns:
+ *   - `today`:        live count of distinct users with ≥1 push token in the
+ *                     current environment
+ *   - `yesterday`:    most recent dailyNotificationStats snapshot for this
+ *                     env (null if no snapshot has been taken yet — first day
+ *                     after deploy or before the cron has fired once)
+ *   - `delta`:        today - yesterday (null when yesterday is null)
+ *   - `percentChange`: (delta / yesterday) * 100 (null when yesterday is null
+ *                     or zero)
+ *
+ * "Enabled" matches the `notifications.preferences.preferences` query: token
+ * existence in `pushTokens` for the current environment, regardless of the
+ * `isActive` flag.
+ *
+ * Snapshots are written daily at 00:05 UTC by `dailyEnabledSnapshot.run`.
+ * Tokens are deleted on disable, so historical counts cannot be reconstructed
+ * without those snapshots.
+ */
+export const getDailyNotificationEnabledStats = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const user = await ctx.db.get(userId);
+    if (!user?.isStaff && !user?.isSuperuser) {
+      throw new Error("Togather internal access required");
+    }
+
+    const environment = getCurrentEnvironment();
+
+    // Live "today" count — distinct userIds with at least one push token in
+    // this environment. Mirrors the snapshot mutation's logic so today and
+    // yesterday are apples-to-apples.
+    const distinctUsers = new Set<string>();
+    for await (const row of ctx.db.query("pushTokens")) {
+      if (row.environment !== environment) continue;
+      distinctUsers.add(row.userId);
+    }
+    const today = distinctUsers.size;
+
+    // Most recent snapshot for this environment (descending by date).
+    const lastSnapshot = await ctx.db
+      .query("dailyNotificationStats")
+      .withIndex("by_environment_date", (q) => q.eq("environment", environment))
+      .order("desc")
+      .first();
+
+    const yesterday = lastSnapshot?.enabledCount ?? null;
+    const yesterdayDate = lastSnapshot?.date ?? null;
+
+    let delta: number | null = null;
+    let percentChange: number | null = null;
+    if (yesterday !== null) {
+      delta = today - yesterday;
+      if (yesterday > 0) {
+        percentChange = (delta / yesterday) * 100;
+      }
+    }
+
+    return {
+      today,
+      yesterday,
+      yesterdayDate,
+      delta,
+      percentChange,
+      environment,
     };
   },
 });

--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -29,6 +29,7 @@ import { requireAuth, getOptionalAuth } from "../lib/auth";
 import { isCommunityAdmin, ADMIN_ROLE_THRESHOLD } from "../lib/permissions";
 import { syncUserChannelMembershipsLogic } from "./sync/memberships";
 import { isActiveMembership, isActiveLeader, hasLeft } from "../lib/helpers";
+import { getUsersWithNotificationsDisabled } from "../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Member Queries
@@ -207,6 +208,8 @@ export const list = query({
       }
     });
 
+    const notifsDisabled = await getUsersWithNotificationsDisabled(ctx, userIds);
+
     // Map members to response with user details
     const membersWithUsers = paginatedMembers.map((member) => {
       const user = userMap.get(member.userId);
@@ -224,6 +227,7 @@ export const list = query({
               lastName: user.lastName || "",
               email: user.email || "",
               profileImage: getMediaUrl(user.profilePhoto),
+              notificationsDisabled: notifsDisabled.has(user._id),
             }
           : null,
       };
@@ -289,6 +293,7 @@ export const getMemberPreview = query({
     // Batch fetch users
     const userIds = previewMembers.map((m) => m.userId);
     const users = await Promise.all(userIds.map((id) => ctx.db.get(id)));
+    const notifsDisabled = await getUsersWithNotificationsDisabled(ctx, userIds);
 
     // Build response with limited public info only
     const membersPreview = previewMembers
@@ -301,6 +306,7 @@ export const getMemberPreview = query({
           lastName: user.lastName || "",
           profileImage: getMediaUrl(user.profilePhoto),
           role: member.role,
+          notificationsDisabled: notifsDisabled.has(user._id),
         };
       })
       .filter(Boolean);
@@ -367,6 +373,10 @@ export const getLeaderPreview = query({
 
     // Batch fetch users
     const users = await Promise.all(slice.map((m) => ctx.db.get(m.userId)));
+    const notifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      slice.map((m) => m.userId),
+    );
 
     const leadersPreview = slice
       .map((membership, i) => {
@@ -378,6 +388,7 @@ export const getLeaderPreview = query({
           lastName: user.lastName || "",
           profileImage: getMediaUrl(user.profilePhoto),
           role: membership.role,
+          notificationsDisabled: notifsDisabled.has(user._id),
         };
       })
       .filter(Boolean);

--- a/apps/convex/functions/groups/queries.ts
+++ b/apps/convex/functions/groups/queries.ts
@@ -12,6 +12,7 @@ import { paginationArgs } from "../../lib/validators";
 import { requireAuth, getOptionalAuth } from "../../lib/auth";
 import { isCommunityAdmin } from "../../lib/permissions";
 import { isLeaderRole } from "../../lib/helpers";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 /**
  * Get group by ID
@@ -260,8 +261,13 @@ export const getByShortId = query({
       return bLeader - aLeader;
     });
 
+    const previewSlice = sortedMembers.slice(0, 5);
+    const previewNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      previewSlice.map((gm) => gm.userId),
+    );
     const memberPreview = [];
-    for (const gm of sortedMembers.slice(0, 5)) {
+    for (const gm of previewSlice) {
       const user = await ctx.db.get(gm.userId);
       if (user) {
         memberPreview.push({
@@ -270,6 +276,7 @@ export const getByShortId = query({
           last_name: user.lastName || "",
           profile_photo: getMediaUrl(user.profilePhoto),
           isLeader: isLeaderRole(gm.role),
+          notificationsDisabled: previewNotifsDisabled.has(user._id),
         });
       }
     }

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -24,6 +24,7 @@ import { syncUserChannelMembershipsLogic } from "../sync/memberships";
 import { updateChannelMemberCount } from "./helpers";
 import { matchesSearchTerms, parseSearchTerms } from "../../lib/memberSearch";
 import { canAccessEventChannel } from "./eventChat";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Constants
@@ -814,6 +815,11 @@ export const getChannelMembers = query({
         })
       );
 
+      const pageNotifsDisabled = await getUsersWithNotificationsDisabled(
+        ctx,
+        page.map(({ member }) => member.userId),
+      );
+
       return {
         members: page.map(({ member, user }, idx) => ({
           id: member._id,
@@ -827,6 +833,7 @@ export const getChannelMembers = query({
           groupRole: pageGroupRoles[idx] ?? undefined,
           syncSource: member.syncSource,
           syncMetadata: member.syncMetadata,
+          notificationsDisabled: pageNotifsDisabled.has(member.userId),
         })),
         nextCursor,
         totalCount: matchedMembers.length,
@@ -877,9 +884,18 @@ export const getChannelMembers = query({
       })
     );
 
+    const browseNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      enrichedMembers.map((m) => m.userId),
+    );
+    const enrichedMembersWithNotifs = enrichedMembers.map((m) => ({
+      ...m,
+      notificationsDisabled: browseNotifsDisabled.has(m.userId),
+    }));
+
     // Return member data with pagination info
     return {
-      members: enrichedMembers,
+      members: enrichedMembersWithNotifs,
       nextCursor: hasMore ? JSON.stringify(result.continueCursor) : null,
       // Note: totalCount is expensive for large channels, use channel.memberCount instead
       totalCount: channel.memberCount || 0,
@@ -1362,6 +1378,21 @@ export const getInboxChannels = query({
       });
     }
 
+    // Look up notif-disabled status for every distinct lastMessageSenderId
+    // referenced by the inbox so each row can render the slashed-bell badge
+    // next to the sender's avatar/name.
+    const inboxSenderIds = Array.from(
+      new Set(
+        allChannels
+          .map((ch) => ch.lastMessageSenderId)
+          .filter((id): id is Id<"users"> => !!id),
+      ),
+    );
+    const inboxSenderNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      inboxSenderIds,
+    );
+
     // Build the result grouped by group
     const result: Array<{
       group: {
@@ -1382,6 +1413,7 @@ export const getInboxChannels = query({
         lastMessageAt: number | null;
         lastMessageSenderName: string | null;
         lastMessageSenderId: Id<"users"> | null;
+        lastMessageSenderNotificationsDisabled: boolean;
         unreadCount: number;
         isShared: boolean | undefined;
         isEnabled: boolean | undefined;
@@ -1494,6 +1526,9 @@ export const getInboxChannels = query({
           lastMessageAt: ch.lastMessageAt || null,
           lastMessageSenderName: ch.lastMessageSenderName || null,
           lastMessageSenderId: ch.lastMessageSenderId || null,
+          lastMessageSenderNotificationsDisabled: ch.lastMessageSenderId
+            ? inboxSenderNotifsDisabled.has(ch.lastMessageSenderId)
+            : false,
           unreadCount: unreadCounts.get(ch._id) || 0,
           isShared: ch.isShared || undefined,
           isEnabled: ch.isEnabled,

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -19,6 +19,7 @@ import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { checkRateLimit } from "../../lib/rateLimit";
 import { getDisplayName, getMediaUrl, normalizePhone } from "../../lib/utils";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Constants
@@ -1213,11 +1214,17 @@ export const searchUsersInSharedCommunities = query({
       return aName.localeCompare(bName);
     });
 
-    return candidates.slice(0, limit).map((c) => ({
+    const sliced = candidates.slice(0, limit);
+    const notifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      sliced.map((c) => c.user._id),
+    );
+    return sliced.map((c) => ({
       userId: c.user._id,
       displayName: getDisplayName(c.user.firstName, c.user.lastName),
       profilePhoto: getMediaUrl(c.user.profilePhoto) ?? null,
       sharedCommunityNames: communityName ? [communityName] : [],
+      notificationsDisabled: notifsDisabled.has(c.user._id),
     }));
   },
 });
@@ -1258,6 +1265,7 @@ export const getAdHocChannelMembers = query({
       userId: Id<"users">;
       displayName: string;
       profilePhoto: string | null;
+      notificationsDisabled: boolean;
     }>;
   } | null> => {
     const userId = await requireAuth(ctx, args.token);
@@ -1293,6 +1301,11 @@ export const getAdHocChannelMembers = query({
     const otherUsers = await Promise.all(
       others.map((m) => ctx.db.get(m.userId)),
     );
+    const otherIds = others.map((m) => m.userId);
+    const otherNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      otherIds,
+    );
     const otherMembers = others
       .map((m, i) => {
         const u = otherUsers[i];
@@ -1304,6 +1317,7 @@ export const getAdHocChannelMembers = query({
             m.displayName ||
             "Member",
           profilePhoto: getMediaUrl(u.profilePhoto ?? m.profilePhoto) ?? null,
+          notificationsDisabled: otherNotifsDisabled.has(m.userId),
         };
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
@@ -1341,10 +1355,13 @@ export const getDirectInbox = query({
         userId: Id<"users">;
         displayName: string;
         profilePhoto: string | null;
+        notificationsDisabled: boolean;
       }>;
       lastMessageAt: number | null;
       lastMessagePreview: string | null;
       lastMessageSenderName: string | null;
+      lastMessageSenderId: Id<"users"> | null;
+      lastMessageSenderNotificationsDisabled: boolean;
       unreadCount: number;
       isMuted: boolean;
     }> = [];
@@ -1385,12 +1402,24 @@ export const getDirectInbox = query({
         .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .collect();
+      const otherMemberIds = otherMemberRows
+        .filter((m) => m.userId !== userId)
+        .map((m) => m.userId);
+      const senderIdForRow = channel.lastMessageSenderId ?? null;
+      const idsToCheck = senderIdForRow
+        ? [...otherMemberIds, senderIdForRow]
+        : otherMemberIds;
+      const rowNotifsDisabled = await getUsersWithNotificationsDisabled(
+        ctx,
+        idsToCheck,
+      );
       const otherMembers = otherMemberRows
         .filter((m) => m.userId !== userId)
         .map((m) => ({
           userId: m.userId,
           displayName: m.displayName ?? "",
           profilePhoto: getMediaUrl(m.profilePhoto) ?? null,
+          notificationsDisabled: rowNotifsDisabled.has(m.userId),
         }));
 
       // Read state → unread count.
@@ -1411,6 +1440,10 @@ export const getDirectInbox = query({
         lastMessageAt: channel.lastMessageAt ?? null,
         lastMessagePreview: channel.lastMessagePreview ?? null,
         lastMessageSenderName: channel.lastMessageSenderName ?? null,
+        lastMessageSenderId: senderIdForRow,
+        lastMessageSenderNotificationsDisabled: senderIdForRow
+          ? rowNotifsDisabled.has(senderIdForRow)
+          : false,
         unreadCount,
         isMuted: row.isMuted,
       });

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -26,6 +26,26 @@ import {
 import { checkRateLimit } from "../../lib/rateLimit";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { canAccessEventChannel } from "./eventChat";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
+
+/**
+ * Decorate a list of message rows with `senderNotificationsDisabled` so chat
+ * surfaces can render the slashed-bell badge next to the sender's avatar.
+ * Batches one pushTokens lookup per distinct senderId.
+ */
+async function attachSenderNotifsDisabled(
+  ctx: QueryCtx,
+  messages: Doc<"chatMessages">[],
+): Promise<Array<Doc<"chatMessages"> & { senderNotificationsDisabled: boolean }>> {
+  const senderIds = messages
+    .map((m) => m.senderId)
+    .filter((id): id is Id<"users"> => !!id);
+  const disabled = await getUsersWithNotificationsDisabled(ctx, senderIds);
+  return messages.map((m) => ({
+    ...m,
+    senderNotificationsDisabled: m.senderId ? disabled.has(m.senderId) : false,
+  }));
+}
 
 /**
  * Same access check as `canAccessEventChannel` but keyed off a meeting doc
@@ -435,9 +455,10 @@ export const getMessages = query({
     // Reverse to chronological order (oldest first, newest at bottom)
     // This is the expected order for chat UIs
     const chronologicalMessages = [...pageMessages].reverse();
+    const decorated = await attachSenderNotifsDisabled(ctx, chronologicalMessages);
 
     return {
-      messages: chronologicalMessages,
+      messages: decorated,
       hasMore,
       cursor,
     };
@@ -493,9 +514,10 @@ export const getThreadReplies = query({
 
     const hasMore = replies.length === limit;
     const cursor = replies.length > 0 ? replies[replies.length - 1]._id : undefined;
+    const decorated = await attachSenderNotifsDisabled(ctx, replies);
 
     return {
-      messages: replies,
+      messages: decorated,
       hasMore,
       cursor,
     };

--- a/apps/convex/functions/messaging/reactions.ts
+++ b/apps/convex/functions/messaging/reactions.ts
@@ -9,6 +9,7 @@ import { query, mutation } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { canAccessEventChannel } from "./eventChat";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Queries
@@ -259,6 +260,10 @@ export const getReactionDetails = query({
       .collect();
 
     // Fetch user details for each reactor
+    const reactorNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      reactions.map((r) => r.userId),
+    );
     const users = await Promise.all(
       reactions.map(async (reaction) => {
         const user = await ctx.db.get(reaction.userId);
@@ -273,6 +278,7 @@ export const getReactionDetails = query({
           userId: reaction.userId,
           displayName,
           profilePhoto: user.profilePhoto ?? null,
+          notificationsDisabled: reactorNotifsDisabled.has(reaction.userId),
         };
       })
     );

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -132,6 +132,17 @@ export const setEnabledCounter = internalMutation({
   },
 });
 
+/** Return all environments that currently have a counter row. Used by
+ *  backfill to detect rows that need zeroing because their env had no
+ *  tokens this scan (full churn of users in that env since last backfill). */
+export const listCounterEnvironments = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("notificationEnabledCounter").collect();
+    return rows.map((r) => r.environment);
+  },
+});
+
 /**
  * One-time backfill action — pages through the entire `pushTokens` table,
  * tallies distinct userIds per environment, and writes the resulting counts
@@ -174,6 +185,20 @@ export const backfillEnabledCounter = internalAction({
       totalRows += result.page.length;
       if (result.isDone) break;
       cursor = result.continueCursor;
+    }
+
+    // Zero out any environment that has an existing counter row but no
+    // tokens in this scan — without this, `backfillEnabledCounter` would
+    // leave stale counts for envs whose users have all churned out, making
+    // the function silently non-idempotent and the dashboard permanently
+    // overstated for that env.
+    const knownEnvs: string[] = await ctx.runQuery(
+      internal.functions.notifications.dailyEnabledSnapshot.listCounterEnvironments,
+    );
+    for (const env of knownEnvs) {
+      if (!usersByEnv.has(env)) {
+        usersByEnv.set(env, new Set());
+      }
     }
 
     const summary: Array<{ environment: string; count: number }> = [];

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -75,12 +75,36 @@ export const run = internalMutation({
 });
 
 // ============================================================================
-// Backfill: one-time seeding of the running counter from existing pushTokens.
+// Daily orchestrator — wired into the cron.
 // ============================================================================
 //
-// The counter is maintained incrementally going forward, but the table
-// starts empty when this PR deploys. Run `backfillEnabledCounter` once after
-// deploy to seed it from the existing pushTokens rows. Paginated through an
+// Calls backfill (paginated re-seed of the counter from pushTokens, no
+// transaction limits since it's an action) and then the snapshot mutation.
+// This makes the counter self-healing — no manual post-deploy step required
+// before the dashboard is accurate, and any drift from the incremental
+// maintenance paths is corrected daily.
+
+export const runDaily = internalAction({
+  args: {},
+  // Explicit return-type annotation breaks the circular self-reference TS
+  // would otherwise hit when `internal.functions.notifications.dailyEnabledSnapshot.*`
+  // is read inside a function defined in that same module.
+  handler: async (ctx): Promise<{ date: string; environment: string; enabledCount: number }> => {
+    await ctx.runAction(
+      internal.functions.notifications.dailyEnabledSnapshot.backfillEnabledCounter,
+    );
+    return await ctx.runMutation(
+      internal.functions.notifications.dailyEnabledSnapshot.run,
+    );
+  },
+});
+
+// ============================================================================
+// Backfill: full re-seed of the running counter from pushTokens.
+// ============================================================================
+//
+// Originally documented as a one-time post-deploy step, now also called
+// daily by `runDaily` above so the counter self-heals. Paginated through an
 // action so it works regardless of token volume (no transaction-level scan
 // limits in actions calling internal queries).
 

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -1,0 +1,77 @@
+/**
+ * Daily snapshot of "users with notifications enabled at the device level".
+ *
+ * Why a snapshot instead of computing historically: push tokens are deleted
+ * when a user disables notifications, so any past moment's count isn't
+ * reconstructible from the current `pushTokens` table. We persist one row per
+ * UTC day per environment so the admin dashboard can show "today vs yesterday".
+ *
+ * Definition of "enabled": user has at least one row in `pushTokens` for the
+ * current environment. This matches `notifications.preferences.preferences`
+ * which derives `notificationsEnabled` from token existence (the `isActive`
+ * field is intentionally ignored — see comment in that query).
+ *
+ * Cron: runs at 00:05 UTC daily. The snapshot's `date` is the UTC day that
+ * just ended (e.g. firing at 00:05 UTC on 2026-04-30 writes a row dated
+ * 2026-04-29 representing the count as the day closed).
+ *
+ * Idempotent: re-running for the same date overwrites the row.
+ */
+
+import { internalMutation } from "../../_generated/server";
+import { getCurrentEnvironment } from "../../lib/notifications/send";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** "YYYY-MM-DD" for a given timestamp in UTC. */
+function toUtcDateString(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+export const run = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const environment = getCurrentEnvironment();
+    const nowMs = Date.now();
+    // Snapshot represents the day that just closed (e.g. fired at 00:05 UTC
+    // on 4/30 → this is the count for 4/29 EOD). Subtract a minute so we're
+    // squarely inside yesterday's UTC window even with cron timing slop.
+    const targetDate = toUtcDateString(nowMs - 60_000);
+
+    // Count distinct userIds with at least one push token in this env.
+    // We don't have a per-environment index without a userId prefix, so we
+    // page through `pushTokens` and tally a Set. Token volume scales with
+    // active users — fine for current scale (low six figures); revisit with
+    // a streaming aggregate if this gets slow.
+    const distinctUsers = new Set<string>();
+    for await (const row of ctx.db.query("pushTokens")) {
+      if (row.environment !== environment) continue;
+      distinctUsers.add(row.userId);
+    }
+    const enabledCount = distinctUsers.size;
+
+    // Idempotent upsert keyed by (environment, date).
+    const existing = await ctx.db
+      .query("dailyNotificationStats")
+      .withIndex("by_environment_date", (q) =>
+        q.eq("environment", environment).eq("date", targetDate),
+      )
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        enabledCount,
+        createdAt: nowMs,
+      });
+    } else {
+      await ctx.db.insert("dailyNotificationStats", {
+        date: targetDate,
+        environment,
+        enabledCount,
+        createdAt: nowMs,
+      });
+    }
+
+    return { date: targetDate, environment, enabledCount };
+  },
+});

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -9,9 +9,11 @@
  * Definition of "enabled": user has at least one row in `pushTokens` for the
  * current environment. Matches `notifications.preferences.preferences`.
  *
- * Cron: runs at 00:05 UTC daily. The snapshot's `date` is the UTC day that
- * just ended (e.g. firing at 00:05 UTC on 2026-04-30 writes a row dated
- * 2026-04-29 representing the count as the day closed).
+ * Cron: runs at 23:55 UTC daily — late in the UTC day so the counter we
+ * read aligns with the date label (the snapshot represents "end of day X"
+ * and is labelled X). The earlier 00:05-UTC-of-next-day approach backdated
+ * the row, so any token changes in the 0:00–0:05 sliver got attributed to
+ * the prior day and distorted the day-over-day delta.
  *
  * Idempotent: re-running for the same date overwrites the row.
  *
@@ -28,7 +30,6 @@ import { internal } from "../../_generated/api";
 import { getCurrentEnvironment } from "../../lib/notifications/send";
 import { readEnabledCount } from "../../lib/notifications/enabledCounter";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
 const BACKFILL_PAGE_SIZE = 1000;
 
 /** "YYYY-MM-DD" for a given timestamp in UTC. */
@@ -41,9 +42,12 @@ export const run = internalMutation({
   handler: async (ctx) => {
     const environment = getCurrentEnvironment();
     const nowMs = Date.now();
-    // Snapshot represents the UTC day that just closed (e.g. fired at 00:05
-    // UTC on 4/30 → this is the count for 4/29 EOD).
-    const targetDate = toUtcDateString(nowMs - DAY_MS);
+    // Snapshot date matches the UTC day the cron is running in — cron is
+    // scheduled at 23:55 UTC, so this records "end of today" under today's
+    // date. We deliberately don't backdate to "yesterday": that mismatched
+    // the counter (read at run time = today) against the row label and
+    // attributed any token changes near midnight to the wrong day.
+    const targetDate = toUtcDateString(nowMs);
 
     // O(1) read from the running tally maintained by the token write paths.
     const enabledCount = await readEnabledCount(ctx, environment);

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -90,9 +90,21 @@ export const runDaily = internalAction({
   // would otherwise hit when `internal.functions.notifications.dailyEnabledSnapshot.*`
   // is read inside a function defined in that same module.
   handler: async (ctx): Promise<{ date: string; environment: string; enabledCount: number }> => {
-    await ctx.runAction(
-      internal.functions.notifications.dailyEnabledSnapshot.backfillEnabledCounter,
-    );
+    // Backfill is best-effort. A transient action failure (timeout, memory
+    // pressure during the paginated scan) must NOT block the snapshot write
+    // — otherwise the admin trend would stall for that day. The counter
+    // itself self-heals on the next successful run; missing a snapshot row
+    // is the more visible failure mode, so the snapshot must always run.
+    try {
+      await ctx.runAction(
+        internal.functions.notifications.dailyEnabledSnapshot.backfillEnabledCounter,
+      );
+    } catch (error) {
+      console.error(
+        "[runDaily] backfillEnabledCounter failed; proceeding to snapshot anyway:",
+        error,
+      );
+    }
     return await ctx.runMutation(
       internal.functions.notifications.dailyEnabledSnapshot.run,
     );

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -33,10 +33,11 @@ export const run = internalMutation({
   handler: async (ctx) => {
     const environment = getCurrentEnvironment();
     const nowMs = Date.now();
-    // Snapshot represents the day that just closed (e.g. fired at 00:05 UTC
-    // on 4/30 → this is the count for 4/29 EOD). Subtract a minute so we're
-    // squarely inside yesterday's UTC window even with cron timing slop.
-    const targetDate = toUtcDateString(nowMs - 60_000);
+    // Snapshot represents the UTC day that just closed (e.g. fired at 00:05
+    // UTC on 4/30 → this is the count for 4/29 EOD). Subtract a full day —
+    // subtracting only a minute would still leave us inside the new UTC day
+    // and label the snapshot as today, breaking the "vs yesterday" comparison.
+    const targetDate = toUtcDateString(nowMs - DAY_MS);
 
     // Count distinct userIds with at least one push token in this env.
     // We don't have a per-environment index without a userId prefix, so we

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -1,27 +1,35 @@
 /**
  * Daily snapshot of "users with notifications enabled at the device level".
  *
- * Why a snapshot instead of computing historically: push tokens are deleted
- * when a user disables notifications, so any past moment's count isn't
- * reconstructible from the current `pushTokens` table. We persist one row per
- * UTC day per environment so the admin dashboard can show "today vs yesterday".
+ * Why a snapshot instead of computing historically: the live count comes
+ * from `notificationEnabledCounter` (a running tally maintained by the token
+ * write paths), but historical "yesterday" comparison needs a frozen value —
+ * so we write one row per UTC day per environment.
  *
  * Definition of "enabled": user has at least one row in `pushTokens` for the
- * current environment. This matches `notifications.preferences.preferences`
- * which derives `notificationsEnabled` from token existence (the `isActive`
- * field is intentionally ignored — see comment in that query).
+ * current environment. Matches `notifications.preferences.preferences`.
  *
  * Cron: runs at 00:05 UTC daily. The snapshot's `date` is the UTC day that
  * just ended (e.g. firing at 00:05 UTC on 2026-04-30 writes a row dated
  * 2026-04-29 representing the count as the day closed).
  *
  * Idempotent: re-running for the same date overwrites the row.
+ *
+ * Scale: O(1) — reads the running counter rather than scanning pushTokens.
  */
 
-import { internalMutation } from "../../_generated/server";
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "../../_generated/server";
+import { internal } from "../../_generated/api";
 import { getCurrentEnvironment } from "../../lib/notifications/send";
+import { readEnabledCount } from "../../lib/notifications/enabledCounter";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const BACKFILL_PAGE_SIZE = 1000;
 
 /** "YYYY-MM-DD" for a given timestamp in UTC. */
 function toUtcDateString(ts: number): string {
@@ -34,22 +42,11 @@ export const run = internalMutation({
     const environment = getCurrentEnvironment();
     const nowMs = Date.now();
     // Snapshot represents the UTC day that just closed (e.g. fired at 00:05
-    // UTC on 4/30 → this is the count for 4/29 EOD). Subtract a full day —
-    // subtracting only a minute would still leave us inside the new UTC day
-    // and label the snapshot as today, breaking the "vs yesterday" comparison.
+    // UTC on 4/30 → this is the count for 4/29 EOD).
     const targetDate = toUtcDateString(nowMs - DAY_MS);
 
-    // Count distinct userIds with at least one push token in this env.
-    // We don't have a per-environment index without a userId prefix, so we
-    // page through `pushTokens` and tally a Set. Token volume scales with
-    // active users — fine for current scale (low six figures); revisit with
-    // a streaming aggregate if this gets slow.
-    const distinctUsers = new Set<string>();
-    for await (const row of ctx.db.query("pushTokens")) {
-      if (row.environment !== environment) continue;
-      distinctUsers.add(row.userId);
-    }
-    const enabledCount = distinctUsers.size;
+    // O(1) read from the running tally maintained by the token write paths.
+    const enabledCount = await readEnabledCount(ctx, environment);
 
     // Idempotent upsert keyed by (environment, date).
     const existing = await ctx.db
@@ -74,5 +71,121 @@ export const run = internalMutation({
     }
 
     return { date: targetDate, environment, enabledCount };
+  },
+});
+
+// ============================================================================
+// Backfill: one-time seeding of the running counter from existing pushTokens.
+// ============================================================================
+//
+// The counter is maintained incrementally going forward, but the table
+// starts empty when this PR deploys. Run `backfillEnabledCounter` once after
+// deploy to seed it from the existing pushTokens rows. Paginated through an
+// action so it works regardless of token volume (no transaction-level scan
+// limits in actions calling internal queries).
+
+/** Page through pushTokens for backfill — returns one page + cursor. */
+export const pagePushTokensForBackfill = internalQuery({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    pageSize: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("pushTokens")
+      .paginate({ numItems: args.pageSize, cursor: args.cursor });
+    return {
+      page: result.page.map((r) => ({
+        userId: r.userId as string,
+        environment: r.environment ?? null,
+      })),
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+/** Overwrite the counter for `environment` with `count`. Used by backfill. */
+export const setEnabledCounter = internalMutation({
+  args: {
+    environment: v.string(),
+    count: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("notificationEnabledCounter")
+      .withIndex("by_environment", (q) => q.eq("environment", args.environment))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        count: args.count,
+        updatedAt: Date.now(),
+      });
+    } else {
+      await ctx.db.insert("notificationEnabledCounter", {
+        environment: args.environment,
+        count: args.count,
+        updatedAt: Date.now(),
+      });
+    }
+  },
+});
+
+/**
+ * One-time backfill action — pages through the entire `pushTokens` table,
+ * tallies distinct userIds per environment, and writes the resulting counts
+ * into `notificationEnabledCounter`. Run from the Convex dashboard once
+ * after deploy:
+ *
+ *   internal.functions.notifications.dailyEnabledSnapshot.backfillEnabledCounter()
+ *
+ * Idempotent — running it again overwrites with the freshly computed
+ * counts. Legacy tokens with `environment === undefined` are skipped (they
+ * aren't reachable by env-scoped reads anyway).
+ */
+export const backfillEnabledCounter = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const usersByEnv = new Map<string, Set<string>>();
+    let cursor: string | null = null;
+    let totalRows = 0;
+
+    while (true) {
+      const result: {
+        page: Array<{ userId: string; environment: string | null }>;
+        isDone: boolean;
+        continueCursor: string;
+      } = await ctx.runQuery(
+        internal.functions.notifications.dailyEnabledSnapshot.pagePushTokensForBackfill,
+        { cursor, pageSize: BACKFILL_PAGE_SIZE },
+      );
+
+      for (const row of result.page) {
+        if (!row.environment) continue; // skip legacy/unscoped tokens
+        let set = usersByEnv.get(row.environment);
+        if (!set) {
+          set = new Set();
+          usersByEnv.set(row.environment, set);
+        }
+        set.add(row.userId);
+      }
+
+      totalRows += result.page.length;
+      if (result.isDone) break;
+      cursor = result.continueCursor;
+    }
+
+    const summary: Array<{ environment: string; count: number }> = [];
+    for (const [environment, userSet] of usersByEnv) {
+      const count = userSet.size;
+      summary.push({ environment, count });
+      await ctx.runMutation(
+        internal.functions.notifications.dailyEnabledSnapshot.setEnabledCounter,
+        { environment, count },
+      );
+    }
+
+    return { totalRowsScanned: totalRows, environments: summary };
   },
 });

--- a/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
+++ b/apps/convex/functions/notifications/dailyEnabledSnapshot.ts
@@ -38,16 +38,21 @@ function toUtcDateString(ts: number): string {
 }
 
 export const run = internalMutation({
-  args: {},
-  handler: async (ctx) => {
+  args: {
+    // Optional override so `runDaily` can pin the snapshot date to the
+    // cron-fire time. If the paginated backfill before this mutation runs
+    // past midnight UTC, computing from `Date.now()` here would write the
+    // row under the wrong day and leave the intended day with no row.
+    // Defaults to today (UTC) when called directly from the dashboard.
+    targetDate: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
     const environment = getCurrentEnvironment();
     const nowMs = Date.now();
-    // Snapshot date matches the UTC day the cron is running in — cron is
-    // scheduled at 23:55 UTC, so this records "end of today" under today's
-    // date. We deliberately don't backdate to "yesterday": that mismatched
-    // the counter (read at run time = today) against the row label and
-    // attributed any token changes near midnight to the wrong day.
-    const targetDate = toUtcDateString(nowMs);
+    // Cron at 23:55 UTC labels the row as today, so the counter (read at
+    // run time, late in the UTC day) and the label both fall in the same
+    // UTC day.
+    const targetDate = args.targetDate ?? toUtcDateString(nowMs);
 
     // O(1) read from the running tally maintained by the token write paths.
     const enabledCount = await readEnabledCount(ctx, environment);
@@ -94,6 +99,13 @@ export const runDaily = internalAction({
   // would otherwise hit when `internal.functions.notifications.dailyEnabledSnapshot.*`
   // is read inside a function defined in that same module.
   handler: async (ctx): Promise<{ date: string; environment: string; enabledCount: number }> => {
+    // Pin the snapshot date to the cron-fire time, BEFORE backfill runs.
+    // Backfill is paginated and could take longer than the 5-minute
+    // 23:55→00:00 UTC window; without this pin, a slow backfill would
+    // cause the snapshot to be dated the next UTC day and leave the
+    // intended day with no row.
+    const targetDate = toUtcDateString(Date.now());
+
     // Backfill is best-effort. A transient action failure (timeout, memory
     // pressure during the paginated scan) must NOT block the snapshot write
     // — otherwise the admin trend would stall for that day. The counter
@@ -111,6 +123,7 @@ export const runDaily = internalAction({
     }
     return await ctx.runMutation(
       internal.functions.notifications.dailyEnabledSnapshot.run,
+      { targetDate },
     );
   },
 });

--- a/apps/convex/functions/notifications/preferences.ts
+++ b/apps/convex/functions/notifications/preferences.ts
@@ -346,6 +346,14 @@ export const updateChannelPreferences = mutation({
           await ctx.db.delete(tokenDoc._id);
         }
 
+        // Mirror updatePreferences: if the user had any tokens in this env,
+        // they transitioned from enabled → disabled. Decrement the counter
+        // exactly once. Without this the running tally drifts every time a
+        // user disables via the channel-prefs path.
+        if (tokens.length > 0) {
+          await adjustEnabledCounter(ctx, currentEnv, -1);
+        }
+
         console.log(
           `[updateChannelPreferences] Disabled push for user ${userId}: ` +
           `deleted ${tokens.length} token(s) in ${currentEnv}`

--- a/apps/convex/functions/notifications/preferences.ts
+++ b/apps/convex/functions/notifications/preferences.ts
@@ -10,6 +10,7 @@ import { query, mutation } from "../../_generated/server";
 import { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getCurrentEnvironment } from "../../lib/notifications/send";
+import { adjustEnabledCounter } from "../../lib/notifications/enabledCounter";
 
 // ============================================================================
 // Group Notification Settings
@@ -236,6 +237,12 @@ export const updatePreferences = mutation({
 
       for (const token of tokens) {
         await ctx.db.delete(token._id);
+      }
+
+      // If the user had at least one token in this env, they transitioned
+      // from enabled → disabled. Decrement the running tally exactly once.
+      if (tokens.length > 0) {
+        await adjustEnabledCounter(ctx, environment, -1);
       }
 
       console.log(

--- a/apps/convex/functions/notifications/tokens.ts
+++ b/apps/convex/functions/notifications/tokens.ts
@@ -11,6 +11,7 @@ import { now } from "../../lib/utils";
 import { platformValidator } from "../../lib/validators";
 import { requireAuth } from "../../lib/auth";
 import { getCurrentEnvironment } from "../../lib/notifications/send";
+import { adjustEnabledCounter } from "../../lib/notifications/enabledCounter";
 
 // ============================================================================
 // Public Mutations
@@ -62,6 +63,13 @@ export const registerToken = mutation({
       lastUsedAt: timestamp,
     });
 
+    // Maintain the enabled-count running tally: only increment when the user
+    // transitions from 0 → 1 token in this env. If they already had a token
+    // (re-register on relaunch), the count is unchanged.
+    if (existingTokens.length === 0) {
+      await adjustEnabledCounter(ctx, environment, 1);
+    }
+
     return {
       success: true,
       message: "Push token registered successfully",
@@ -83,10 +91,42 @@ export const unregisterToken = mutation({
       .withIndex("by_token", (q) => q.eq("token", args.token))
       .collect();
 
+    // Group the to-be-deleted tokens by (userId, environment) so we can
+    // decrement the enabled-count counter exactly once per (user, env) pair
+    // that loses its last token in that environment.
+    const affected: Array<{ userId: string; environment: string }> = [];
+    for (const tokenDoc of tokens) {
+      affected.push({
+        userId: tokenDoc.userId,
+        environment: tokenDoc.environment ?? "",
+      });
+    }
+
     let deletedCount = 0;
     for (const tokenDoc of tokens) {
       await ctx.db.delete(tokenDoc._id);
       deletedCount++;
+    }
+
+    // For each affected (user, env), check whether they still have any
+    // tokens left in that env after deletion. If not, that user transitions
+    // back to "disabled" → -1 on the counter. Skip rows with empty
+    // environment (legacy/unscoped tokens) — they're not in the counter.
+    const seen = new Set<string>();
+    for (const { userId, environment } of affected) {
+      if (!environment) continue;
+      const key = `${userId}|${environment}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const remaining = await ctx.db
+        .query("pushTokens")
+        .withIndex("by_user", (q) => q.eq("userId", userId as any))
+        .filter((q) => q.eq(q.field("environment"), environment))
+        .first();
+      if (!remaining) {
+        await adjustEnabledCounter(ctx, environment, -1);
+      }
     }
 
     return {

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -19,6 +19,10 @@ import { requireAuth, getOptionalAuth } from "../lib/auth";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ROLES, COMMUNITY_ADMIN_THRESHOLD } from "../lib/permissions";
 import { adjustEnabledCounter } from "../lib/notifications/enabledCounter";
+import {
+  getUsersWithNotificationsDisabled,
+  isUserNotificationsDisabled,
+} from "../lib/notifications/enabledStatus";
 
 /**
  * Get current user profile
@@ -44,22 +48,33 @@ type PublicUserFields = {
   firstName: string | undefined;
   lastName: string | undefined;
   profilePhoto: string | undefined;
+  /**
+   * True when the user has no push tokens for the current environment — UI
+   * surfaces render a "notifications disabled" badge so senders know not to
+   * expect immediate delivery. Truth source matches `pushTokens` (see
+   * `lib/notifications/enabledStatus.ts`).
+   */
+  notificationsDisabled: boolean;
 };
 
 /**
  * Extract only public fields from a user document
  */
-function extractPublicFields(user: {
-  _id: Id<"users">;
-  firstName?: string;
-  lastName?: string;
-  profilePhoto?: string;
-}): PublicUserFields {
+function extractPublicFields(
+  user: {
+    _id: Id<"users">;
+    firstName?: string;
+    lastName?: string;
+    profilePhoto?: string;
+  },
+  notificationsDisabled: boolean,
+): PublicUserFields {
   return {
     _id: user._id,
     firstName: user.firstName,
     lastName: user.lastName,
     profilePhoto: user.profilePhoto,
+    notificationsDisabled,
   };
 }
 
@@ -80,7 +95,8 @@ export const getById = query({
     }
 
     // Return only public fields to prevent PII exposure
-    return extractPublicFields(user);
+    const notificationsDisabled = await isUserNotificationsDisabled(ctx, user._id);
+    return extractPublicFields(user, notificationsDisabled);
   },
 });
 
@@ -153,11 +169,14 @@ export const getProfile = query({
       }
     }
 
+    const notificationsDisabled = await isUserNotificationsDisabled(ctx, user._id);
+
     return {
       _id: user._id,
       firstName: user.firstName,
       lastName: user.lastName,
       profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
+      notificationsDisabled,
       bio: user.bio ?? null,
       instagramHandle: user.instagramHandle ?? null,
       linkedinHandle: user.linkedinHandle ?? null,
@@ -536,11 +555,15 @@ export const getByIds = query({
     );
 
     // Filter out null users and deactivated users, return only public fields
-    return users
-      .filter((user): user is NonNullable<typeof user> =>
-        user !== null && user.isActive !== false
-      )
-      .map(extractPublicFields);
+    const livingUsers = users.filter(
+      (user): user is NonNullable<typeof user> =>
+        user !== null && user.isActive !== false,
+    );
+    const disabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      livingUsers.map((u) => u._id),
+    );
+    return livingUsers.map((u) => extractPublicFields(u, disabled.has(u._id)));
   },
 });
 
@@ -608,6 +631,8 @@ export const me = query({
       }
     }
 
+    const notificationsDisabled = await isUserNotificationsDisabled(ctx, userId);
+
     return {
       id: user._id,
       legacyId: user.legacyId,
@@ -616,6 +641,7 @@ export const me = query({
       email: user.email || "",
       isStaff: user.isStaff || false,
       isSuperuser: user.isSuperuser || false,
+      notificationsDisabled,
       phone: user.phone || null,
       phoneVerified: user.phoneVerified || false,
       profilePhoto: getMediaUrl(user.profilePhoto),

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -18,6 +18,7 @@ import { now, normalizePhone, getMediaUrl, buildSearchText } from "../lib/utils"
 import { requireAuth, getOptionalAuth } from "../lib/auth";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ROLES, COMMUNITY_ADMIN_THRESHOLD } from "../lib/permissions";
+import { adjustEnabledCounter } from "../lib/notifications/enabledCounter";
 
 /**
  * Get current user profile
@@ -845,7 +846,22 @@ export const deleteAccountInternal = internalMutation({
     // 4. Remove chat channel memberships
     await deleteByUserIndex("chatChannelMembers", "by_user");
 
-    // 5. Remove push tokens
+    // 5. Remove push tokens — decrement the per-environment enabled counter
+    //    once per env where this user had ≥1 token, BEFORE deletion (so we
+    //    can still see what envs they had tokens in).
+    {
+      const userTokens = await ctx.db
+        .query("pushTokens")
+        .withIndex("by_user", (q) => q.eq("userId", args.userId))
+        .collect();
+      const envs = new Set<string>();
+      for (const t of userTokens) {
+        if (t.environment) envs.add(t.environment);
+      }
+      for (const env of envs) {
+        await adjustEnabledCounter(ctx, env, -1);
+      }
+    }
     await deleteByUserIndex("pushTokens", "by_user");
 
     // 6. Remove notifications

--- a/apps/convex/lib/notifications/enabledCounter.ts
+++ b/apps/convex/lib/notifications/enabledCounter.ts
@@ -1,0 +1,63 @@
+/**
+ * Helpers for the `notificationEnabledCounter` running tally.
+ *
+ * The counter tracks distinct users with ≥1 push token, per environment, so
+ * the admin dashboard and daily snapshot can read in O(1) instead of
+ * scanning the full pushTokens table (which would hit Convex transaction
+ * scan limits at scale).
+ *
+ * Maintained by mutations on the token write paths:
+ *   - `tokens.registerToken`         → +1 when user transitions 0 → 1 token
+ *   - `tokens.unregisterToken`       → -1 when user's last token in env is deleted
+ *   - `preferences.updatePreferences` (disable) → -1 if user had ≥1 token
+ *   - `users.deleteUser` cascade     → -1 per env where user had ≥1 token
+ *
+ * Seeded by `dailyEnabledSnapshot.backfillEnabledCounter` on first deploy.
+ */
+
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+
+/**
+ * Atomically adjust the counter for `environment` by `delta` (typically +1
+ * or -1). Clamps to 0 — concurrent writes or replay errors should never
+ * produce a negative count.
+ */
+export async function adjustEnabledCounter(
+  ctx: MutationCtx,
+  environment: string,
+  delta: number,
+): Promise<void> {
+  if (delta === 0) return;
+
+  const existing = await ctx.db
+    .query("notificationEnabledCounter")
+    .withIndex("by_environment", (q) => q.eq("environment", environment))
+    .unique();
+
+  const next = Math.max(0, (existing?.count ?? 0) + delta);
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      count: next,
+      updatedAt: Date.now(),
+    });
+  } else if (delta > 0) {
+    await ctx.db.insert("notificationEnabledCounter", {
+      environment,
+      count: next,
+      updatedAt: Date.now(),
+    });
+  }
+  // If counter row doesn't exist and delta is negative, no-op (clamped to 0).
+}
+
+/** Read current count for an environment. Returns 0 if no row exists yet. */
+export async function readEnabledCount(
+  ctx: QueryCtx | MutationCtx,
+  environment: string,
+): Promise<number> {
+  const row = await ctx.db
+    .query("notificationEnabledCounter")
+    .withIndex("by_environment", (q) => q.eq("environment", environment))
+    .unique();
+  return row?.count ?? 0;
+}

--- a/apps/convex/lib/notifications/enabledStatus.ts
+++ b/apps/convex/lib/notifications/enabledStatus.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-user "is push enabled" lookups for client-facing UI.
+ *
+ * Truth table (matches `tokens.getActiveTokensForUser` and the running
+ * `notificationEnabledCounter`): a user has notifications enabled iff at
+ * least one row exists in `pushTokens` for `(userId, current environment)`.
+ *
+ * UI surfaces use the inverse — `notificationsDisabled: boolean` — because
+ * "disabled" is the state we render an indicator for.
+ */
+
+import type { QueryCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { getCurrentEnvironment } from "./send";
+
+/**
+ * Returns true when the user has no push tokens for the current environment.
+ */
+export async function isUserNotificationsDisabled(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const environment = getCurrentEnvironment();
+  const token = await ctx.db
+    .query("pushTokens")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .filter((q) => q.eq(q.field("environment"), environment))
+    .first();
+  return token === null;
+}
+
+/**
+ * Batched form for list/search queries — issues one parallel pushTokens
+ * lookup per unique user ID and returns the set of users with notifications
+ * disabled. Pass the resulting set to `notifsDisabledForUser(disabled, id)`.
+ */
+export async function getUsersWithNotificationsDisabled(
+  ctx: QueryCtx,
+  userIds: ReadonlyArray<Id<"users">>,
+): Promise<Set<Id<"users">>> {
+  if (userIds.length === 0) return new Set();
+  const environment = getCurrentEnvironment();
+  const unique = Array.from(new Set(userIds));
+  const tokens = await Promise.all(
+    unique.map((userId) =>
+      ctx.db
+        .query("pushTokens")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .filter((q) => q.eq(q.field("environment"), environment))
+        .first(),
+    ),
+  );
+  const disabled = new Set<Id<"users">>();
+  unique.forEach((userId, i) => {
+    if (tokens[i] === null) disabled.add(userId);
+  });
+  return disabled;
+}
+
+export function notifsDisabledForUser(
+  disabled: Set<Id<"users">>,
+  userId: Id<"users">,
+): boolean {
+  return disabled.has(userId);
+}

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -889,6 +889,22 @@ export default defineSchema({
     .index("by_environment_date", ["environment", "date"])
     .index("by_date", ["date"]),
 
+  // Running count of distinct users with ≥1 push token, scoped per
+  // environment. Maintained incrementally by mutations that insert/delete
+  // pushTokens rows (registerToken, unregisterToken, updatePreferences
+  // disable, user-delete cascade). Both the daily snapshot cron and the
+  // superuser dashboard query read this counter in O(1) instead of scanning
+  // the full pushTokens table — that scan would hit Convex transaction
+  // limits as token volume grows.
+  //
+  // One row per environment. Seeded by `backfillEnabledCounter`
+  // (paginated action) on first deploy.
+  notificationEnabledCounter: defineTable({
+    environment: v.string(),  // "production" | "staging"
+    count: v.number(),        // distinct userIds with ≥1 push token in this env
+    updatedAt: v.number(),
+  }).index("by_environment", ["environment"]),
+
   // =============================================================================
   // PUSH TOKENS
   // =============================================================================

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -869,6 +869,26 @@ export default defineSchema({
     lastProcessedHourMs: v.number(),
   }).index("by_key", ["key"]),
 
+  // Daily snapshot of distinct users with at least one active push token,
+  // scoped per environment. Populated by `dailyEnabledSnapshot.run` cron at
+  // 0:05 UTC. Drives the "notifications enabled — today vs yesterday" card on
+  // the superuser admin dashboard.
+  //
+  // We snapshot rather than compute historically because tokens are deleted
+  // on disable, so the row count at any past moment isn't reconstructible
+  // from the current `pushTokens` table.
+  //
+  // `date` is the UTC day this snapshot represents (e.g. "2026-04-29" for the
+  // run that fired at 00:05 UTC on 2026-04-30 covering the day that just ended).
+  dailyNotificationStats: defineTable({
+    date: v.string(),         // "YYYY-MM-DD" in UTC
+    environment: v.string(),  // "production" | "staging"
+    enabledCount: v.number(), // distinct userIds with ≥1 push token in this env
+    createdAt: v.number(),    // when the snapshot row was written
+  })
+    .index("by_environment_date", ["environment", "date"])
+    .index("by_date", ["date"]),
+
   // =============================================================================
   // PUSH TOKENS
   // =============================================================================

--- a/apps/mobile/components/ui/Avatar.tsx
+++ b/apps/mobile/components/ui/Avatar.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, ImageStyle, StyleProp } from 'react-native';
+import { StyleSheet, View, ImageStyle, StyleProp } from 'react-native';
 import { AppImage } from './AppImage';
+import { NotificationsDisabledBadge } from './NotificationsDisabledBadge';
 import { getMediaUrlWithTransform } from '@/utils/media';
 
 interface AvatarProps {
@@ -15,6 +16,19 @@ interface AvatarProps {
    *  color tied to the name. Pass a flat color (e.g. theme `border`) for
    *  contexts that want a neutral preview row. */
   placeholderBackgroundColor?: string;
+  /**
+   * When true, overlays a slashed-bell badge in the bottom-right corner to
+   * signal that this user has push notifications disabled (no push tokens
+   * for the current environment). Senders use this to set expectations
+   * before sending a message.
+   */
+  notificationsDisabled?: boolean;
+  /**
+   * Surface color the avatar sits on, passed through to the badge so its
+   * contrast border blends with the row/card background. Falls back to the
+   * theme `surface` when omitted.
+   */
+  notificationsBadgeRingColor?: string;
 }
 
 export function Avatar({
@@ -24,6 +38,8 @@ export function Avatar({
   style,
   disableOptimization = false,
   placeholderBackgroundColor,
+  notificationsDisabled,
+  notificationsBadgeRingColor,
 }: AvatarProps) {
   const safeSize = size && size > 0 ? size : 48;
 
@@ -39,7 +55,7 @@ export function Avatar({
     });
   }, [imageUrl, safeSize, disableOptimization]);
 
-  return (
+  const image = (
     <AppImage
       source={optimizedUrl}
       style={[
@@ -54,9 +70,27 @@ export function Avatar({
       }}
     />
   );
+
+  if (!notificationsDisabled) {
+    return image;
+  }
+
+  // Wrap so the badge can be absolutely positioned over the avatar's corner.
+  return (
+    <View style={[styles.wrapper, { width: safeSize, height: safeSize }]}>
+      {image}
+      <NotificationsDisabledBadge
+        avatarSize={safeSize}
+        ringColor={notificationsBadgeRingColor}
+      />
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
+  wrapper: {
+    position: 'relative',
+  },
   avatar: {
     justifyContent: 'center',
     alignItems: 'center',

--- a/apps/mobile/components/ui/NotificationsDisabledBadge.tsx
+++ b/apps/mobile/components/ui/NotificationsDisabledBadge.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View, ViewStyle, StyleProp } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/useTheme';
+
+interface NotificationsDisabledBadgeProps {
+  /**
+   * Diameter of the parent avatar in pixels. The badge scales relative to it
+   * so the slashed-bell stays legible on tiny stacked previews and on the
+   * large profile-header avatar.
+   */
+  avatarSize: number;
+  /**
+   * Optional style override — used to position the badge against a parent
+   * container.
+   */
+  style?: StyleProp<ViewStyle>;
+  /**
+   * Color used for the badge ring/contrast border. Defaults to
+   * `theme.surface`. Pass the actual surface the avatar sits on so the badge
+   * reads as an overlay rather than a free-floating dot.
+   */
+  ringColor?: string;
+}
+
+/**
+ * Slashed-bell badge overlaid on a user avatar to signal that the user has
+ * push notifications disabled. Renders nothing visual on its own — callsites
+ * mount it inside a `position: relative` parent (typically Avatar) so it sits
+ * over the bottom-right corner of the avatar.
+ *
+ * Sizing: badge diameter ~38% of the avatar (clamped to 14–24px). Icon takes
+ * ~62% of the badge so the slash is visible at small sizes.
+ */
+export function NotificationsDisabledBadge({
+  avatarSize,
+  style,
+  ringColor,
+}: NotificationsDisabledBadgeProps) {
+  const { colors } = useTheme();
+  const sizes = useMemo(() => {
+    const raw = Math.round(avatarSize * 0.42);
+    const badge = Math.max(11, Math.min(raw, 26));
+    const icon = Math.max(7, Math.round(badge * 0.65));
+    const border = badge >= 18 ? 1.5 : 1;
+    return { badge, icon, border };
+  }, [avatarSize]);
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[
+        styles.badge,
+        {
+          width: sizes.badge,
+          height: sizes.badge,
+          borderRadius: sizes.badge / 2,
+          backgroundColor: colors.textSecondary,
+          borderColor: ringColor ?? colors.surface,
+          borderWidth: sizes.border,
+        },
+        style,
+      ]}
+    >
+      <Ionicons
+        name="notifications-off"
+        size={sizes.icon}
+        color={colors.surface}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/features/admin/components/SuperAdminDashboardContent.tsx
+++ b/apps/mobile/features/admin/components/SuperAdminDashboardContent.tsx
@@ -71,6 +71,15 @@ export function SuperAdminDashboardContent() {
     token && isInternalUser ? { token, daysAgo, timeZone } : "skip"
   );
 
+  // Device-level "notifications enabled" — today (live count) vs yesterday
+  // (last daily snapshot from the dailyEnabledSnapshot cron). Not day-scoped
+  // so we don't pass `daysAgo` here; it's always "right now vs the most
+  // recent snapshot".
+  const notifEnabledStats = useQuery(
+    api.functions.admin.stats.getDailyNotificationEnabledStats,
+    token && isInternalUser ? { token } : "skip"
+  );
+
   const pendingProposals = useQuery(
     api.functions.ee.proposals.list,
     token && isInternalUser ? { token, status: "pending" } : "skip"
@@ -351,6 +360,51 @@ export function SuperAdminDashboardContent() {
         </>
       )}
 
+      {/* Device-level notification opt-in (today live vs yesterday snapshot).
+          Always shown to superusers — not gated on `notifStats.totals.sent` —
+          because we want to see opt-in trend even on quiet days. */}
+      {notifEnabledStats && (
+        <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+          <Text style={[styles.metricLabel, { color: colors.textSecondary }]}>
+            Notifications enabled (device level)
+          </Text>
+          <View style={styles.enabledRow}>
+            <Text style={[styles.enabledValue, { color: colors.text }]}>
+              {notifEnabledStats.today.toLocaleString()}
+            </Text>
+            <Text style={[styles.enabledUnit, { color: colors.textSecondary }]}>
+              {notifEnabledStats.today === 1 ? "user" : "users"}
+            </Text>
+          </View>
+          {notifEnabledStats.delta !== null && notifEnabledStats.yesterday !== null ? (
+            <Text
+              style={[
+                styles.enabledDelta,
+                {
+                  color:
+                    notifEnabledStats.delta > 0
+                      ? colors.success
+                      : notifEnabledStats.delta < 0
+                        ? colors.error
+                        : colors.textSecondary,
+                },
+              ]}
+            >
+              {notifEnabledStats.delta > 0 ? "↑" : notifEnabledStats.delta < 0 ? "↓" : "·"}{" "}
+              {Math.abs(notifEnabledStats.delta).toLocaleString()}
+              {notifEnabledStats.percentChange !== null
+                ? ` (${notifEnabledStats.percentChange > 0 ? "+" : ""}${notifEnabledStats.percentChange.toFixed(1)}%)`
+                : ""}
+              {" since yesterday"}
+            </Text>
+          ) : (
+            <Text style={[styles.enabledDelta, { color: colors.textTertiary }]}>
+              Awaiting first daily snapshot
+            </Text>
+          )}
+        </View>
+      )}
+
       {/* Notification Stats */}
       {notifStats && notifStats.totals.sent > 0 && (
         <>
@@ -543,6 +597,24 @@ const styles = StyleSheet.create({
   },
   notifTypeStats: {
     fontSize: 12,
+  },
+  enabledRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 6,
+    marginTop: 2,
+  },
+  enabledValue: {
+    fontSize: 28,
+    fontWeight: "800",
+  },
+  enabledUnit: {
+    fontSize: 14,
+  },
+  enabledDelta: {
+    fontSize: 13,
+    fontWeight: "500",
+    marginTop: 6,
   },
   proposalHeader: {
     flexDirection: "row",

--- a/apps/mobile/features/admin/components/SuperAdminDashboardContent.tsx
+++ b/apps/mobile/features/admin/components/SuperAdminDashboardContent.tsx
@@ -360,7 +360,7 @@ export function SuperAdminDashboardContent() {
         </>
       )}
 
-      {/* Device-level notification opt-in (today live vs yesterday snapshot).
+      {/* Device-level notification opt-in (today live vs most recent snapshot).
           Always shown to superusers — not gated on `notifStats.totals.sent` —
           because we want to see opt-in trend even on quiet days. */}
       {notifEnabledStats && (
@@ -376,7 +376,7 @@ export function SuperAdminDashboardContent() {
               {notifEnabledStats.today === 1 ? "user" : "users"}
             </Text>
           </View>
-          {notifEnabledStats.delta !== null && notifEnabledStats.yesterday !== null ? (
+          {notifEnabledStats.delta !== null && notifEnabledStats.previous !== null ? (
             <Text
               style={[
                 styles.enabledDelta,
@@ -395,7 +395,9 @@ export function SuperAdminDashboardContent() {
               {notifEnabledStats.percentChange !== null
                 ? ` (${notifEnabledStats.percentChange > 0 ? "+" : ""}${notifEnabledStats.percentChange.toFixed(1)}%)`
                 : ""}
-              {" since yesterday"}
+              {notifEnabledStats.previousDate
+                ? ` since ${formatDate(notifEnabledStats.previousDate)}`
+                : ""}
             </Text>
           ) : (
             <Text style={[styles.enabledDelta, { color: colors.textTertiary }]}>

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -577,6 +577,8 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
                       name={displayName}
                       imageUrl={m.profilePhoto}
                       size={40}
+                      notificationsDisabled={!!m.notificationsDisabled}
+                      notificationsBadgeRingColor={colors.surfaceSecondary}
                     />
                     <View style={styles.memberRowText}>
                       <Text

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -36,6 +36,7 @@ import { useInboxCache } from "../../../stores/inboxCache";
 import { Avatar } from "@components/ui/Avatar";
 import { useConvexFeatureFlag } from "@hooks/useConvexFeatureFlag";
 import { StackedMemberAvatars } from "./StackedMemberAvatars";
+import { EnableNotificationsBanner } from "@features/notifications/components/EnableNotificationsBanner";
 
 // Inbox event visibility is now driven server-side by
 // `INBOX_EVENT_HIDE_AFTER_MS` in apps/convex/functions/messaging/channels.ts
@@ -522,6 +523,7 @@ export function ChatInboxScreen({
       <Wrapper>
         <View style={[styles.container, { backgroundColor: colors.surface }]}>
           {renderHeader(true)}
+          <EnableNotificationsBanner />
           <ScrollView contentContainerStyle={styles.centeredScrollContent}>
             <Ionicons
               name="chatbubbles-outline"
@@ -543,6 +545,7 @@ export function ChatInboxScreen({
     <Wrapper>
       <View style={[styles.container, { backgroundColor: colors.surface }]}>
         {renderHeader(true)}
+        <EnableNotificationsBanner />
         <FlatList
           data={listItemsWithDm}
           renderItem={renderItem}

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -1024,10 +1024,13 @@ type DirectInboxRowData = {
     userId: Id<"users">;
     displayName: string;
     profilePhoto: string | null;
+    notificationsDisabled: boolean;
   }>;
   lastMessageAt: number | null;
   lastMessagePreview: string | null;
   lastMessageSenderName: string | null;
+  lastMessageSenderId: Id<"users"> | null;
+  lastMessageSenderNotificationsDisabled: boolean;
   unreadCount: number;
   isMuted: boolean;
 };
@@ -1100,6 +1103,8 @@ function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) 
           name={primaryAvatar?.displayName ?? headerName}
           imageUrl={primaryAvatar?.profilePhoto ?? undefined}
           size={56}
+          notificationsDisabled={primaryAvatar?.notificationsDisabled ?? false}
+          notificationsBadgeRingColor={colors.surface}
         />
       )}
       <View style={styles.dmRowContent}>

--- a/apps/mobile/features/chat/components/ChatInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInfoScreen.tsx
@@ -57,6 +57,7 @@ type SearchResult = {
   displayName: string;
   profilePhoto: string | null;
   sharedCommunityNames: string[];
+  notificationsDisabled: boolean;
 };
 
 type Member = {
@@ -65,6 +66,7 @@ type Member = {
   profilePhoto: string | null;
   isSelf: boolean;
   isInviter: boolean;
+  notificationsDisabled: boolean;
 };
 
 const SEARCH_DEBOUNCE_MS = 200;
@@ -133,6 +135,7 @@ export function ChatInfoScreen({ channelId }: Props) {
       profilePhoto: m.profilePhoto,
       isSelf: false,
       isInviter: m.userId === creatorId,
+      notificationsDisabled: m.notificationsDisabled,
     }));
     const self: Member = {
       userId: currentUserId,
@@ -140,6 +143,10 @@ export function ChatInfoScreen({ channelId }: Props) {
       profilePhoto: (user as { profile_photo?: string | null } | null)?.profile_photo ?? null,
       isSelf: true,
       isInviter: currentUserId === creatorId,
+      // The current viewer's own row in chat info doesn't need a "you don't
+      // have notifications" indicator — they already get the inbox banner
+      // and Settings warning. Always render as enabled here.
+      notificationsDisabled: false,
     };
     return [self, ...others];
   }, [inboxRow, currentUserId, creatorId, selfDisplayName, user]);
@@ -410,6 +417,8 @@ export function ChatInfoScreen({ channelId }: Props) {
                 name={m.displayName}
                 imageUrl={m.profilePhoto}
                 size={40}
+                notificationsDisabled={m.notificationsDisabled}
+                notificationsBadgeRingColor={colors.surfaceSecondary}
               />
               <View style={styles.memberRowText}>
                 <Text
@@ -774,6 +783,8 @@ function AddPeopleModal({
           name={item.displayName}
           imageUrl={item.profilePhoto}
           size={40}
+          notificationsDisabled={item.notificationsDisabled}
+          notificationsBadgeRingColor={colors.surface}
         />
         <View style={styles.searchRowText}>
           <Text style={[styles.searchRowName, { color: colors.text }]} numberOfLines={1}>

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -26,6 +26,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import type { Id } from '@services/api/convex';
 import { AppImage, ImageViewer } from '@components/ui';
+import { NotificationsDisabledBadge } from '@components/ui/NotificationsDisabledBadge';
 import { useReadReceipts } from '@features/chat/hooks/useReadReceipts';
 import { useReactions, type Reaction } from '@features/chat/hooks/useReactions';
 import { EventLinkCard } from './EventLinkCard';
@@ -67,6 +68,12 @@ interface MessageItemProps {
     isDeleted: boolean;
     senderName?: string;
     senderProfilePhoto?: string;
+    /**
+     * True when the sender has push notifications disabled (no token in
+     * the current environment). Drives the slashed-bell badge over the
+     * sender's avatar so readers know not to expect immediate read/response.
+     */
+    senderNotificationsDisabled?: boolean;
     mentionedUserIds?: Id<"users">[];
     threadReplyCount?: number;
     hideLinkPreview?: boolean;
@@ -952,6 +959,12 @@ function MessageItemInner({
                 backgroundColor: '#E5E5E5',
               }}
             />
+            {message.senderNotificationsDisabled ? (
+              <NotificationsDisabledBadge
+                avatarSize={24}
+                ringColor={themeColors.background}
+              />
+            ) : null}
           </Pressable>
         )}
 

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -342,6 +342,7 @@ export function MessageList({
             isDeleted: message.isDeleted,
             senderName: message.senderName,
             senderProfilePhoto: message.senderProfilePhoto,
+            senderNotificationsDisabled: message.senderNotificationsDisabled,
             mentionedUserIds: message.mentionedUserIds,
             threadReplyCount: message.threadReplyCount,
             hideLinkPreview: message.hideLinkPreview,

--- a/apps/mobile/features/chat/components/ThreadPage.tsx
+++ b/apps/mobile/features/chat/components/ThreadPage.tsx
@@ -277,6 +277,7 @@ export function ThreadPage({
                       isDeleted: item.data.isDeleted,
                       senderName: item.data.senderName,
                       senderProfilePhoto: item.data.senderProfilePhoto,
+                      senderNotificationsDisabled: item.data.senderNotificationsDisabled,
                     }}
                     currentUserId={currentUserId}
                     onLongPress={handleLongPressMessage}
@@ -315,6 +316,7 @@ export function ThreadPage({
                     isDeleted: item.data.isDeleted,
                     senderName: item.data.senderName,
                     senderProfilePhoto: item.data.senderProfilePhoto,
+                    senderNotificationsDisabled: item.data.senderNotificationsDisabled,
                   }}
                   currentUserId={currentUserId}
                   onLongPress={handleLongPressMessage}

--- a/apps/mobile/features/chat/context/ChatPrefetchContext.tsx
+++ b/apps/mobile/features/chat/context/ChatPrefetchContext.tsx
@@ -88,6 +88,9 @@ export interface PrefetchedMessage {
   threadReplyCount?: number;
   senderName?: string;
   senderProfilePhoto?: string;
+  /** Mirrors backend `senderNotificationsDisabled` so the slashed-bell badge
+   *  can render on prefetched messages too. */
+  senderNotificationsDisabled?: boolean;
   hideLinkPreview?: boolean;
 }
 
@@ -107,6 +110,7 @@ export interface PrefetchedThreadReply {
   senderId?: string;
   senderName?: string;
   senderProfilePhoto?: string;
+  senderNotificationsDisabled?: boolean;
   createdAt: number;
 }
 

--- a/apps/mobile/features/chat/hooks/usePrefetchChannel.ts
+++ b/apps/mobile/features/chat/hooks/usePrefetchChannel.ts
@@ -353,6 +353,7 @@ async function fetchThreadRepliesBatch(
           senderId: msg.senderId,
           senderName: msg.senderName,
           senderProfilePhoto: msg.senderProfilePhoto,
+          senderNotificationsDisabled: msg.senderNotificationsDisabled,
           createdAt: msg.createdAt,
         }));
         return { messageId: messageId.toString(), replies };

--- a/apps/mobile/features/chat/hooks/useThreadReplies.ts
+++ b/apps/mobile/features/chat/hooks/useThreadReplies.ts
@@ -22,6 +22,7 @@ interface ThreadReply {
   isDeleted: boolean;
   senderName?: string;
   senderProfilePhoto?: string;
+  senderNotificationsDisabled?: boolean;
   attachments?: Array<{
     type: string;
     url: string;
@@ -90,6 +91,7 @@ export function useThreadReplies(
       isDeleted: false,
       senderName: r.senderName,
       senderProfilePhoto: r.senderProfilePhoto,
+      senderNotificationsDisabled: r.senderNotificationsDisabled,
     }));
 
     return {

--- a/apps/mobile/features/notifications/components/EnableNotificationsBanner.tsx
+++ b/apps/mobile/features/notifications/components/EnableNotificationsBanner.tsx
@@ -1,0 +1,265 @@
+/**
+ * Persistent inbox CTA prompting users to enable push notifications.
+ *
+ * Visibility rules:
+ *  - Hidden on web, simulator, or while expo-notifications can't load
+ *  - Hidden while preferences are loading
+ *  - Hidden if push is fully working (OS-granted AND token registered server-side)
+ *  - Hidden if the user soft-dismissed it within the last 7 days
+ *
+ * Tapping "Turn on" delegates to `useEnableNotificationsFlow`, which routes
+ * to a soft-ask sheet, the OS prompt, or a Settings hand-off depending on
+ * the current permission state.
+ *
+ * Auto-recovery: when the app foregrounds and the OS now reports granted
+ * (e.g. user just flipped the toggle in iOS Settings) but our DB token is
+ * missing, we silently re-register the token. This closes the gap where a
+ * user comes back from Settings expecting things to "just work".
+ */
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AppState,
+  AppStateStatus,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Ionicons } from "@expo/vector-icons";
+import { api, useQuery, useStoredAuthToken } from "@services/api/convex";
+import { useAuth } from "@providers/AuthProvider";
+import {
+  useNotifications,
+  type PushPermissionStatus,
+} from "@providers/NotificationProvider";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useEnableNotificationsFlow } from "../hooks/useEnableNotificationsFlow";
+
+const SNOOZE_KEY_PREFIX = "enable_notifications_banner_snoozed_until:";
+const SNOOZE_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+function snoozeKey(userId: string | undefined): string | null {
+  if (!userId) return null;
+  return `${SNOOZE_KEY_PREFIX}${userId}`;
+}
+
+export function EnableNotificationsBanner() {
+  const { user } = useAuth();
+  const token = useStoredAuthToken();
+  const { primaryColor } = useCommunityTheme();
+  const { getPermissionStatus, enableNotifications } = useNotifications();
+  const { start, flowElements } = useEnableNotificationsFlow();
+
+  const userId = user?.id ? String(user.id) : undefined;
+
+  // Server-side notifications-enabled flag (true iff push token exists).
+  const preferences = useQuery(
+    api.functions.notifications.preferences.preferences,
+    token ? { token } : "skip",
+  );
+
+  const [osStatus, setOsStatus] = useState<PushPermissionStatus | null>(null);
+  const [snoozeChecked, setSnoozeChecked] = useState(false);
+  const [isSnoozed, setIsSnoozed] = useState(false);
+  // Track previous OS status across app-state changes so we can detect the
+  // "user just granted in Settings" transition and silently register the token.
+  const lastOsStatusRef = useRef<PushPermissionStatus | null>(null);
+
+  const refreshOsStatus = useCallback(async () => {
+    const status = await getPermissionStatus();
+    setOsStatus(status);
+
+    // Auto-recover: OS-granted now but token missing → register quietly.
+    const previous = lastOsStatusRef.current;
+    lastOsStatusRef.current = status;
+    if (
+      previous !== null &&
+      previous !== "granted" &&
+      status === "granted" &&
+      preferences?.notificationsEnabled === false
+    ) {
+      void enableNotifications();
+    }
+  }, [enableNotifications, getPermissionStatus, preferences?.notificationsEnabled]);
+
+  // Initial OS-status read.
+  useEffect(() => {
+    void refreshOsStatus();
+  }, [refreshOsStatus]);
+
+  // Re-read OS status when the app foregrounds (handles return-from-Settings).
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next: AppStateStatus) => {
+      if (next === "active") {
+        void refreshOsStatus();
+      }
+    });
+    return () => sub.remove();
+  }, [refreshOsStatus]);
+
+  // Read snooze flag from storage.
+  useEffect(() => {
+    let cancelled = false;
+    const key = snoozeKey(userId);
+    if (!key) {
+      setSnoozeChecked(true);
+      setIsSnoozed(false);
+      return;
+    }
+    AsyncStorage.getItem(key)
+      .then((raw) => {
+        if (cancelled) return;
+        const until = raw ? Number(raw) : 0;
+        setIsSnoozed(Number.isFinite(until) && until > Date.now());
+        setSnoozeChecked(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setIsSnoozed(false);
+        setSnoozeChecked(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const handleDismiss = useCallback(() => {
+    setIsSnoozed(true);
+    const key = snoozeKey(userId);
+    if (!key) return;
+    void AsyncStorage.setItem(key, String(Date.now() + SNOOZE_DURATION_MS));
+  }, [userId]);
+
+  const handleTurnOn = useCallback(async () => {
+    const result = await start();
+    // If user successfully enabled, the preferences query will reactively
+    // flip and the banner will hide on its own. If they cancelled or denied,
+    // the banner stays — that's the persistence the product needs.
+    if (result === "enabled") {
+      // Belt-and-suspenders: clear any stale snooze so the banner doesn't
+      // come back on the next session if the user re-disables.
+      const key = snoozeKey(userId);
+      if (key) {
+        void AsyncStorage.removeItem(key);
+      }
+    }
+  }, [start, userId]);
+
+  // Visibility gating. We render `flowElements` even when the banner is
+  // hidden so any in-flight sheet/toast can finish animating out.
+  const shouldShow = (() => {
+    if (Platform.OS === "web") return false;
+    if (osStatus === null) return false; // initial load
+    if (osStatus === "unsupported") return false; // simulator, missing module
+    if (preferences === undefined) return false; // query loading
+    if (!snoozeChecked) return false;
+    if (isSnoozed) return false;
+    // Banner shows if push isn't fully working: either OS not granted, or
+    // OS granted but no token in our DB (user previously toggled off).
+    const tokenRegistered = preferences.notificationsEnabled === true;
+    if (osStatus === "granted" && tokenRegistered) return false;
+    return true;
+  })();
+
+  if (!shouldShow) {
+    return flowElements;
+  }
+
+  return (
+    <>
+      <View style={[styles.container, { backgroundColor: primaryColor }]}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Turn on notifications"
+          onPress={handleTurnOn}
+          style={styles.content}
+        >
+          <View style={styles.iconWrap}>
+            <Ionicons name="notifications" size={20} color="#fff" />
+          </View>
+          <View style={styles.text}>
+            <Text style={styles.title}>Stay in the loop with your community</Text>
+            <Text style={styles.subtitle}>
+              Turn on notifications to hear from your groups. You can mute
+              individual groups or channels in Settings anytime.
+            </Text>
+          </View>
+          <View style={styles.cta}>
+            <Text style={styles.ctaText}>Turn on</Text>
+          </View>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss for 7 days"
+          onPress={handleDismiss}
+          style={styles.dismiss}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        >
+          <Ionicons name="close" size={16} color="rgba(255,255,255,0.85)" />
+        </Pressable>
+      </View>
+      {flowElements}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    paddingLeft: 16,
+    paddingRight: 8,
+    paddingVertical: 12,
+  },
+  content: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    ...(Platform.OS === "web" ? { cursor: "pointer" as any } : {}),
+  },
+  iconWrap: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: 12,
+  },
+  text: {
+    flex: 1,
+    marginRight: 8,
+  },
+  title: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "700",
+    lineHeight: 18,
+  },
+  subtitle: {
+    color: "rgba(255,255,255,0.88)",
+    fontSize: 12,
+    lineHeight: 16,
+    marginTop: 2,
+  },
+  cta: {
+    backgroundColor: "#fff",
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    marginRight: 4,
+  },
+  ctaText: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#000",
+  },
+  dismiss: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 8,
+    ...(Platform.OS === "web" ? { cursor: "pointer" as any } : {}),
+  },
+});

--- a/apps/mobile/features/notifications/components/NotificationOpenSettingsSheet.tsx
+++ b/apps/mobile/features/notifications/components/NotificationOpenSettingsSheet.tsx
@@ -1,0 +1,194 @@
+import React from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+
+interface NotificationOpenSettingsSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  onOpenSettings: () => void;
+}
+
+/**
+ * Coaching sheet for the OS-denied-permanent state. iOS only allows
+ * `requestPermissionsAsync()` once per install — after a denial, the OS
+ * silently no-ops every subsequent ask. The only way back is for the user to
+ * flip the app's permission in iOS Settings. Dropping users into Settings
+ * cold has a measurable abandon rate, so this sheet primes them with what to
+ * look for before the hand-off.
+ *
+ * Reused by:
+ *  - The inbox `EnableNotificationsBanner` CTA when status is denied-permanent
+ *  - The Settings master toggle when the user flips it on with OS perms off
+ */
+export function NotificationOpenSettingsSheet({
+  visible,
+  onClose,
+  onOpenSettings,
+}: NotificationOpenSettingsSheetProps) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+  const isWide = width >= 600;
+
+  // Platform-specific coaching:
+  //  - iOS: `Linking.openSettings()` lands on the app's settings page; user
+  //    taps Notifications row, then Allow Notifications.
+  //  - Android: `expo-intent-launcher` deep-links directly to the per-app
+  //    notification settings page; user just flips the switch.
+  const instructionLine =
+    Platform.OS === "ios"
+      ? "We'll open Settings — tap Notifications, then turn on Allow Notifications."
+      : "We'll take you to notification settings — turn on Allow Notifications.";
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: colors.surface,
+              paddingBottom: Math.max(insets.bottom + 16, 24),
+              maxWidth: isWide ? 480 : undefined,
+              alignSelf: isWide ? "center" : "stretch",
+              marginHorizontal: isWide ? 24 : 0,
+              marginBottom: isWide ? 24 : 0,
+              borderBottomLeftRadius: isWide ? 20 : 0,
+              borderBottomRightRadius: isWide ? 20 : 0,
+            },
+          ]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={styles.grabber} />
+
+          <View
+            style={[
+              styles.iconCircle,
+              { backgroundColor: primaryColor + "1A" },
+            ]}
+          >
+            <Ionicons name="settings-outline" size={30} color={primaryColor} />
+          </View>
+
+          <Text style={[styles.title, { color: colors.text }]}>
+            Notifications are off
+          </Text>
+          <Text style={[styles.body, { color: colors.textSecondary }]}>
+            {instructionLine} You can mute individual groups or channels in
+            Togather Settings anytime.
+          </Text>
+
+          <Pressable
+            accessibilityRole="button"
+            onPress={onOpenSettings}
+            style={[styles.primaryButton, { backgroundColor: primaryColor }]}
+          >
+            <Text style={styles.primaryButtonText}>Open Settings</Text>
+          </Pressable>
+
+          <Pressable
+            accessibilityRole="button"
+            onPress={onClose}
+            style={styles.secondaryButton}
+            hitSlop={8}
+          >
+            <Text style={[styles.secondaryButtonText, { color: colors.textSecondary }]}>
+              Cancel
+            </Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    alignItems: "center",
+    ...Platform.select({
+      web: {
+        boxShadow: "0px -4px 20px rgba(0,0,0,0.15)",
+      },
+      default: {
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: -4 },
+        shadowOpacity: 0.15,
+        shadowRadius: 20,
+        elevation: 12,
+      },
+    }),
+  },
+  grabber: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "rgba(0,0,0,0.15)",
+    marginBottom: 16,
+  },
+  iconCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 21,
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  primaryButton: {
+    width: "100%",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  primaryButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  secondaryButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  secondaryButtonText: {
+    fontSize: 15,
+    fontWeight: "500",
+  },
+});

--- a/apps/mobile/features/notifications/components/NotificationSoftAskSheet.tsx
+++ b/apps/mobile/features/notifications/components/NotificationSoftAskSheet.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+
+interface NotificationSoftAskSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Pre-permission explainer shown before the iOS one-shot OS prompt. The OS
+ * prompt is a single-use resource on iOS — once denied, recovery requires a
+ * trip to Settings. This sheet lets reflexive deniers back out via "Not now"
+ * without burning the prompt, and primes confirmers with the value prop +
+ * mute-anytime escape hatch.
+ */
+export function NotificationSoftAskSheet({
+  visible,
+  onClose,
+  onConfirm,
+}: NotificationSoftAskSheetProps) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+  const isWide = width >= 600;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: colors.surface,
+              paddingBottom: Math.max(insets.bottom + 16, 24),
+              maxWidth: isWide ? 480 : undefined,
+              alignSelf: isWide ? "center" : "stretch",
+              marginHorizontal: isWide ? 24 : 0,
+              marginBottom: isWide ? 24 : 0,
+              borderBottomLeftRadius: isWide ? 20 : 0,
+              borderBottomRightRadius: isWide ? 20 : 0,
+            },
+          ]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={styles.grabber} />
+
+          <View
+            style={[
+              styles.iconCircle,
+              { backgroundColor: primaryColor + "1A" },
+            ]}
+          >
+            <Ionicons name="notifications" size={32} color={primaryColor} />
+          </View>
+
+          <Text style={[styles.title, { color: colors.text }]}>
+            Stay in the loop with your community
+          </Text>
+          <Text style={[styles.body, { color: colors.textSecondary }]}>
+            Turn on notifications to hear from your groups and never miss a
+            message. You can mute individual groups or channels in Settings
+            anytime.
+          </Text>
+
+          <Pressable
+            accessibilityRole="button"
+            onPress={onConfirm}
+            style={[styles.primaryButton, { backgroundColor: primaryColor }]}
+          >
+            <Text style={styles.primaryButtonText}>Turn on notifications</Text>
+          </Pressable>
+
+          <Pressable
+            accessibilityRole="button"
+            onPress={onClose}
+            style={styles.secondaryButton}
+            hitSlop={8}
+          >
+            <Text style={[styles.secondaryButtonText, { color: colors.textSecondary }]}>
+              Not now
+            </Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    alignItems: "center",
+    ...Platform.select({
+      web: {
+        boxShadow: "0px -4px 20px rgba(0,0,0,0.15)",
+      },
+      default: {
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: -4 },
+        shadowOpacity: 0.15,
+        shadowRadius: 20,
+        elevation: 12,
+      },
+    }),
+  },
+  grabber: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "rgba(0,0,0,0.15)",
+    marginBottom: 16,
+  },
+  iconCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 21,
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  primaryButton: {
+    width: "100%",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  primaryButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  secondaryButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  secondaryButtonText: {
+    fontSize: 15,
+    fontWeight: "500",
+  },
+});

--- a/apps/mobile/features/notifications/hooks/useEnableNotificationsFlow.tsx
+++ b/apps/mobile/features/notifications/hooks/useEnableNotificationsFlow.tsx
@@ -3,8 +3,10 @@
  *
  * Two surfaces drive opt-in (the inbox banner and the Settings master toggle)
  * and both need identical behavior across all four permission states. This
- * hook owns the sheet visibility state, the success toast, and the routing
- * logic; the surfaces just call `start()` and render `<>{flowElements}</>`.
+ * hook owns the sheet visibility state, the success toast, the routing
+ * logic, AND the auto-recovery on app foreground after a Settings hand-off
+ * (so any consumer of the hook gets the recovery behavior, not just the
+ * banner).
  *
  * Routing:
  *  - granted (app-disabled in our DB) → register token + success toast
@@ -12,7 +14,8 @@
  *  - denied-permanent → show coaching sheet → on confirm, Linking.openSettings()
  *  - unsupported (web/sim) → no-op; the surfaces should already hide
  */
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { AppState, AppStateStatus } from "react-native";
 import { useNotifications } from "@providers/NotificationProvider";
 import { Toast } from "@components/ui/Toast";
 import { NotificationSoftAskSheet } from "../components/NotificationSoftAskSheet";
@@ -113,11 +116,45 @@ export function useEnableNotificationsFlow(): UseEnableNotificationsFlowReturn {
     resolveAndClear("cancelled");
   }, [resolveAndClear]);
 
+  // Track whether the user just handed off to OS Settings, so when they
+  // foreground the app again we know to re-attempt token registration.
+  // Without this, the Settings screen (which uses this hook but doesn't
+  // mount its own AppState listener) silently strands users who grant in
+  // iOS Settings: status flips to granted but nothing re-registers the
+  // token, so `notificationsEnabled` stays false until they manually toggle.
+  const handedOffToSettingsRef = useRef(false);
+
   const onOpenSettings = useCallback(() => {
     setOpenSettingsVisible(false);
+    handedOffToSettingsRef.current = true;
     void openNotificationSettings();
     resolveAndClear("denied-permanent");
   }, [resolveAndClear]);
+
+  // Re-check OS state when the app foregrounds. If permission flipped to
+  // granted (typical when the user just turned it on in Settings) and the
+  // user previously handed off via this flow, silently re-register the
+  // token + show the success toast so the opt-in completes without another
+  // tap. The check is gated on `handedOffToSettingsRef` to avoid running
+  // on every foreground for users who never opened Settings via this hook.
+  useEffect(() => {
+    const sub = AppState.addEventListener(
+      "change",
+      async (next: AppStateStatus) => {
+        if (next !== "active") return;
+        if (!handedOffToSettingsRef.current) return;
+        const status = await getPermissionStatus();
+        if (status === "granted") {
+          handedOffToSettingsRef.current = false;
+          const outcome = await enableNotifications();
+          if (outcome === "enabled") {
+            setToastVisible(true);
+          }
+        }
+      },
+    );
+    return () => sub.remove();
+  }, [enableNotifications, getPermissionStatus]);
 
   const onOpenSettingsClose = useCallback(() => {
     setOpenSettingsVisible(false);

--- a/apps/mobile/features/notifications/hooks/useEnableNotificationsFlow.tsx
+++ b/apps/mobile/features/notifications/hooks/useEnableNotificationsFlow.tsx
@@ -1,0 +1,151 @@
+/**
+ * Single source of truth for the push-notification opt-in flow.
+ *
+ * Two surfaces drive opt-in (the inbox banner and the Settings master toggle)
+ * and both need identical behavior across all four permission states. This
+ * hook owns the sheet visibility state, the success toast, and the routing
+ * logic; the surfaces just call `start()` and render `<>{flowElements}</>`.
+ *
+ * Routing:
+ *  - granted (app-disabled in our DB) → register token + success toast
+ *  - undetermined / denied-with-canAskAgain → show soft-ask sheet → on confirm, OS prompt
+ *  - denied-permanent → show coaching sheet → on confirm, Linking.openSettings()
+ *  - unsupported (web/sim) → no-op; the surfaces should already hide
+ */
+import React, { useCallback, useState } from "react";
+import { useNotifications } from "@providers/NotificationProvider";
+import { Toast } from "@components/ui/Toast";
+import { NotificationSoftAskSheet } from "../components/NotificationSoftAskSheet";
+import { NotificationOpenSettingsSheet } from "../components/NotificationOpenSettingsSheet";
+import { openNotificationSettings } from "../utils/openNotificationSettings";
+
+export type EnableFlowResult =
+  | "enabled"
+  | "denied"
+  | "denied-permanent"
+  | "unsupported"
+  | "cancelled";
+
+interface UseEnableNotificationsFlowReturn {
+  /** Kick off the flow. Resolves once the sheet (if any) is dismissed. */
+  start: () => Promise<EnableFlowResult>;
+  /** Render at the root of the consuming component to mount sheets + toast. */
+  flowElements: React.ReactElement;
+}
+
+const SUCCESS_TOAST_MESSAGE =
+  "Notifications on. Mute individual groups or channels in Settings → Notifications.";
+
+export function useEnableNotificationsFlow(): UseEnableNotificationsFlowReturn {
+  const { enableNotifications, getPermissionStatus } = useNotifications();
+
+  const [softAskVisible, setSoftAskVisible] = useState(false);
+  const [openSettingsVisible, setOpenSettingsVisible] = useState(false);
+  const [toastVisible, setToastVisible] = useState(false);
+
+  // Stash the resolver so a sheet's button can complete the start() promise.
+  const [pendingResolve, setPendingResolve] = useState<
+    ((value: EnableFlowResult) => void) | null
+  >(null);
+
+  const resolveAndClear = useCallback(
+    (value: EnableFlowResult) => {
+      pendingResolve?.(value);
+      setPendingResolve(null);
+    },
+    [pendingResolve],
+  );
+
+  const start = useCallback(async (): Promise<EnableFlowResult> => {
+    const status = await getPermissionStatus();
+
+    if (status === "unsupported") {
+      return "unsupported";
+    }
+
+    if (status === "granted") {
+      // OS already allows; user just needs a token registered (re-enables
+      // server-side `notificationsEnabled` since that's derived from token
+      // existence).
+      const outcome = await enableNotifications();
+      if (outcome === "enabled") {
+        setToastVisible(true);
+        return "enabled";
+      }
+      return outcome;
+    }
+
+    if (status === "denied-permanent") {
+      // iOS one-shot already burned. Hand off to Settings via coaching sheet.
+      return new Promise<EnableFlowResult>((resolve) => {
+        setPendingResolve(() => resolve);
+        setOpenSettingsVisible(true);
+      });
+    }
+
+    // undetermined or denied-with-canAskAgain — soft-ask first.
+    return new Promise<EnableFlowResult>((resolve) => {
+      setPendingResolve(() => resolve);
+      setSoftAskVisible(true);
+    });
+  }, [enableNotifications, getPermissionStatus]);
+
+  const onSoftAskConfirm = useCallback(async () => {
+    setSoftAskVisible(false);
+    const outcome = await enableNotifications();
+    if (outcome === "enabled") {
+      setToastVisible(true);
+      resolveAndClear("enabled");
+      return;
+    }
+    if (outcome === "denied-permanent") {
+      // User denied at the OS prompt. canAskAgain is now false on iOS — the
+      // banner will still be there, but for this turn we don't auto-open
+      // Settings (they just made an explicit choice). Just resolve.
+      resolveAndClear("denied-permanent");
+      return;
+    }
+    resolveAndClear(outcome);
+  }, [enableNotifications, resolveAndClear]);
+
+  const onSoftAskClose = useCallback(() => {
+    setSoftAskVisible(false);
+    resolveAndClear("cancelled");
+  }, [resolveAndClear]);
+
+  const onOpenSettings = useCallback(() => {
+    setOpenSettingsVisible(false);
+    void openNotificationSettings();
+    resolveAndClear("denied-permanent");
+  }, [resolveAndClear]);
+
+  const onOpenSettingsClose = useCallback(() => {
+    setOpenSettingsVisible(false);
+    resolveAndClear("cancelled");
+  }, [resolveAndClear]);
+
+  const flowElements = (
+    <>
+      <NotificationSoftAskSheet
+        visible={softAskVisible}
+        onClose={onSoftAskClose}
+        onConfirm={onSoftAskConfirm}
+      />
+      <NotificationOpenSettingsSheet
+        visible={openSettingsVisible}
+        onClose={onOpenSettingsClose}
+        onOpenSettings={onOpenSettings}
+      />
+      <Toast
+        visible={toastVisible}
+        message={SUCCESS_TOAST_MESSAGE}
+        type="success"
+        duration={5000}
+        position="top"
+        onClose={() => setToastVisible(false)}
+      />
+    </>
+  );
+
+  return { start, flowElements };
+}

--- a/apps/mobile/features/notifications/utils/openNotificationSettings.ts
+++ b/apps/mobile/features/notifications/utils/openNotificationSettings.ts
@@ -1,0 +1,44 @@
+/**
+ * Open the system notification settings for this app.
+ *
+ * Cross-platform best-effort:
+ *  - Android: deep-links directly to the per-app notification settings page
+ *    via `expo-intent-launcher` and `ACTION_APP_NOTIFICATION_SETTINGS`. Falls
+ *    back to `Linking.openSettings()` (which lands on app info — 1–2 extra
+ *    taps) if the intent fails.
+ *  - iOS: uses `Linking.openSettings()`, which opens the app's Settings page.
+ *    Notifications is typically the first row there, one tap away. We don't
+ *    use the unofficial `app-settings:notification` URL scheme — it's not
+ *    documented by Apple and has been a source of App Store rejections.
+ */
+import { Linking, Platform } from "react-native";
+import Constants from "expo-constants";
+import * as IntentLauncher from "expo-intent-launcher";
+
+export async function openNotificationSettings(): Promise<void> {
+  if (Platform.OS === "android") {
+    const bundleId = Constants.expoConfig?.android?.package;
+    if (bundleId) {
+      try {
+        await IntentLauncher.startActivityAsync(
+          "android.settings.APP_NOTIFICATION_SETTINGS",
+          {
+            extra: { "android.provider.extra.APP_PACKAGE": bundleId },
+          },
+        );
+        return;
+      } catch (error) {
+        console.warn(
+          "[openNotificationSettings] APP_NOTIFICATION_SETTINGS intent failed, falling back:",
+          error,
+        );
+      }
+    }
+    // Fallback: app info page.
+    await Linking.openSettings();
+    return;
+  }
+
+  // iOS (and any other platform): documented Apple-approved path.
+  await Linking.openSettings();
+}

--- a/apps/mobile/features/profile/components/UserProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/UserProfileHeader.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { AppImage } from '@components/ui';
 import { ImageViewer } from '@components/ui/ImageViewer';
+import { NotificationsDisabledBadge } from '@components/ui/NotificationsDisabledBadge';
 import { useTheme } from '@hooks/useTheme';
 
 import type { UserProfile } from '../hooks/useUserProfile';
@@ -41,16 +42,24 @@ export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
           if (profile.profilePhoto) setViewerVisible(true);
         }}
       >
-        <AppImage
-          source={profile.profilePhoto ?? undefined}
-          style={styles.avatar}
-          optimizedWidth={200}
-          placeholder={{
-            type: 'initials',
-            name: displayName,
-            backgroundColor: '#E5E5E5',
-          }}
-        />
+        <View style={styles.avatarWrapper}>
+          <AppImage
+            source={profile.profilePhoto ?? undefined}
+            style={styles.avatar}
+            optimizedWidth={200}
+            placeholder={{
+              type: 'initials',
+              name: displayName,
+              backgroundColor: '#E5E5E5',
+            }}
+          />
+          {profile.notificationsDisabled ? (
+            <NotificationsDisabledBadge
+              avatarSize={96}
+              ringColor={colors.surface}
+            />
+          ) : null}
+        </View>
       </TouchableOpacity>
       <Text style={[styles.name, { color: colors.text }]}>{displayName}</Text>
       {memberSinceLabel && (
@@ -85,11 +94,16 @@ const styles = StyleSheet.create({
     padding: 24,
     borderRadius: 12,
   },
+  avatarWrapper: {
+    position: 'relative',
+    width: 96,
+    height: 96,
+    marginBottom: 12,
+  },
   avatar: {
     width: 96,
     height: 96,
     borderRadius: 48,
-    marginBottom: 12,
   },
   name: {
     fontSize: 22,

--- a/apps/mobile/features/profile/components/UserProfileScreen.tsx
+++ b/apps/mobile/features/profile/components/UserProfileScreen.tsx
@@ -183,6 +183,33 @@ export function UserProfileScreen() {
       >
         <UserProfileHeader profile={profile} />
         <UserProfileBadges profile={profile} />
+        {profile.notificationsDisabled && !isSelf ? (
+          <View
+            style={[
+              styles.notifsDisabledNote,
+              {
+                backgroundColor: colors.surfaceSecondary,
+                borderColor: colors.border,
+              },
+            ]}
+          >
+            <Ionicons
+              name="notifications-off-outline"
+              size={16}
+              color={colors.textSecondary}
+              style={styles.notifsDisabledIcon}
+            />
+            <Text
+              style={[
+                styles.notifsDisabledText,
+                { color: colors.textSecondary },
+              ]}
+            >
+              This person has notifications disabled and may not see your
+              message right away.
+            </Text>
+          </View>
+        ) : null}
         {showMessageButton ? (
           <MessageButton
             onPress={handleMessagePress}
@@ -330,5 +357,22 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 15,
     fontWeight: '600',
+  },
+  notifsDisabledNote: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  notifsDisabledIcon: {
+    marginTop: 1,
+    marginRight: 8,
+  },
+  notifsDisabledText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
   },
 });

--- a/apps/mobile/features/profile/hooks/useUserProfile.ts
+++ b/apps/mobile/features/profile/hooks/useUserProfile.ts
@@ -19,6 +19,7 @@ export interface UserProfile {
   firstName?: string;
   lastName?: string;
   profilePhoto: string | null;
+  notificationsDisabled: boolean;
   bio: string | null;
   instagramHandle: string | null;
   linkedinHandle: string | null;

--- a/apps/mobile/features/settings/components/NotificationPreferencesSection.tsx
+++ b/apps/mobile/features/settings/components/NotificationPreferencesSection.tsx
@@ -14,14 +14,13 @@ import {
   ActivityIndicator,
   TouchableOpacity,
   Alert,
-  Platform,
 } from 'react-native';
-import Constants from 'expo-constants';
 import { useNotifications } from '@providers/NotificationProvider';
-import { useQuery, useAuthenticatedMutation, useMutation, api } from '@services/api/convex';
+import { useQuery, useAuthenticatedMutation, api } from '@services/api/convex';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useTheme } from '@hooks/useTheme';
 import { useAuth } from '@providers/AuthProvider';
+import { useEnableNotificationsFlow } from '@features/notifications/hooks/useEnableNotificationsFlow';
 import type { Id } from '@services/api/convex';
 
 type GroupNotificationToggleProps = {
@@ -91,7 +90,7 @@ const GroupNotificationToggle: React.FC<GroupNotificationToggleProps> = ({
 
 export const NotificationPreferencesSection: React.FC = () => {
   const { user, token } = useAuth();
-  const { isEnabled, requestPermissions, expoPushToken } = useNotifications();
+  const { isEnabled, expoPushToken } = useNotifications();
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
   const userId = user?.id as Id<"users"> | undefined;
@@ -107,19 +106,10 @@ export const NotificationPreferencesSection: React.FC = () => {
   // Update master toggle mutation
   const updatePreferences = useAuthenticatedMutation(api.functions.notifications.preferences.updatePreferences);
 
-  // Register token mutation (for enabling notifications)
-  const registerTokenMutation = useMutation(api.functions.notifications.tokens.registerToken);
-
-  const handleEnableNotifications = async (): Promise<boolean> => {
-    const granted = await requestPermissions();
-    if (!granted) {
-      Alert.alert(
-        'Permission Required',
-        'Please enable notifications in your device settings to receive updates.'
-      );
-    }
-    return granted;
-  };
+  // Shared opt-in flow — handles soft-ask, OS prompt, denied-permanent → Settings,
+  // and the post-grant success toast. Replaces the old custom Alert path which
+  // silently failed when OS perms were denied (no actual button to open Settings).
+  const enableFlow = useEnableNotificationsFlow();
 
   // Retry handler for error state
   const handleRetry = () => {
@@ -163,40 +153,27 @@ export const NotificationPreferencesSection: React.FC = () => {
   const handleToggleMaster = async (enabled: boolean) => {
     if (!userId || !token) return;
 
+    if (enabled) {
+      // Delegate to the shared opt-in flow. This:
+      //   - prompts the OS (or shows the soft-ask sheet first if undetermined)
+      //   - opens the coaching sheet → Settings hand-off when the OS has
+      //     already permanently denied (the bug the old Alert path silently
+      //     left users stuck on)
+      //   - registers the push token on grant, which flips
+      //     `preferences.notificationsEnabled` to true on its own (server
+      //     derives that flag from token existence)
+      //
+      // No "Saving..." indicator here — the sheet/OS prompt is the user's
+      // feedback. The query is reactive, and if the user cancelled or denied,
+      // the toggle naturally remains off.
+      void enableFlow.start();
+      return;
+    }
+
     setIsUpdating(true);
     try {
-      if (enabled) {
-        // When enabling, first check if we have permissions and token
-        if (!devicePermissionsGranted) {
-          // Request permissions - this will trigger NotificationProvider to register token
-          const granted = await handleEnableNotifications();
-          if (!granted) {
-            setIsUpdating(false);
-            return;
-          }
-        }
-
-        // If we already have a token, register it now
-        // Otherwise, NotificationProvider will handle registration after permissions are granted
-        if (expoPushToken) {
-          const platform = Platform.OS as 'ios' | 'android' | 'web';
-          const bundleId = platform === 'ios'
-            ? Constants.expoConfig?.ios?.bundleIdentifier
-            : Constants.expoConfig?.android?.package;
-
-          await registerTokenMutation({
-            authToken: token,
-            token: expoPushToken,
-            platform,
-            bundleId,
-          });
-        }
-        // If expoPushToken is null, NotificationProvider's useEffect will handle it
-        // after permissions are granted. The UI will update reactively via the preferences query.
-      } else {
-        // When disabling, delete the token via updatePreferences
-        await updatePreferences({ notificationsEnabled: false });
-      }
+      // When disabling, delete the token via updatePreferences
+      await updatePreferences({ notificationsEnabled: false });
     } catch (error) {
       Alert.alert('Error', 'Failed to update notification preference');
     } finally {
@@ -236,7 +213,9 @@ export const NotificationPreferencesSection: React.FC = () => {
           </Text>
           <TouchableOpacity
             style={[styles.enableButton, { backgroundColor: colors.warning }]}
-            onPress={handleEnableNotifications}
+            onPress={() => {
+              void enableFlow.start();
+            }}
           >
             <Text style={[styles.enableButtonText, { color: colors.textInverse }]}>Grant Permission</Text>
           </TouchableOpacity>
@@ -281,6 +260,8 @@ export const NotificationPreferencesSection: React.FC = () => {
           <Text style={[styles.savingText, { color: colors.textSecondary }]}>Saving...</Text>
         </View>
       )}
+
+      {enableFlow.flowElements}
     </View>
   );
 };

--- a/apps/mobile/providers/NotificationProvider.tsx
+++ b/apps/mobile/providers/NotificationProvider.tsx
@@ -82,7 +82,11 @@ type NotificationContextType = {
   unreadCount: number;
   /** Whether the notification system is ready */
   isReady: boolean;
-  /** Request notification permissions */
+  /**
+   * Request OS permission and (if granted) register the push token. Returns
+   * `true` only when both the OS prompt was granted AND the token was
+   * persisted to Convex.
+   */
   requestPermissions: () => Promise<boolean>;
   /**
    * Unified opt-in flow used by the inbox banner and the settings master toggle.
@@ -252,14 +256,20 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, []);
 
-  // Register push token with backend using Convex
-  const registerToken = useCallback(async () => {
-    if (!Notifications || !isAuthenticated || !user) return;
+  // Register push token with backend using Convex.
+  //
+  // Returns `true` only when the token was successfully persisted to Convex.
+  // Returns `false` for any failure (web/missing-prereqs/network/auth) so
+  // callers like `enableNotifications` don't show success UI when the
+  // backend write didn't actually happen — leaving notifications
+  // effectively disabled despite the user seeing a confirmation toast.
+  const registerToken = useCallback(async (): Promise<boolean> => {
+    if (!Notifications || !isAuthenticated || !user) return false;
 
     // Skip push notifications on web - requires VAPID key configuration
     if (Platform.OS === 'web') {
       console.log('Push notifications not supported on web (VAPID not configured)');
-      return;
+      return false;
     }
 
     try {
@@ -279,7 +289,7 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
       const storedUserId = await AsyncStorage.getItem("convex_user_id");
       if (!storedUserId) {
         console.warn('No stored user ID for push token registration');
-        return;
+        return false;
       }
 
       // Register with backend using Convex
@@ -291,7 +301,7 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
 
       if (!authToken) {
         console.warn('No auth token available for push token registration');
-        return;
+        return false;
       }
 
       await registerTokenMutation({
@@ -301,8 +311,10 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
         bundleId,
       });
       console.log('Push token registered with backend');
+      return true;
     } catch (error) {
       console.error('Failed to register push token:', error);
+      return false;
     }
   }, [isAuthenticated, user, authToken, registerTokenMutation]);
 
@@ -329,8 +341,13 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
 
       if (status === 'granted') {
         setIsEnabled(true);
-        await registerToken();
-        return 'enabled';
+        // Only return `enabled` when the backend write actually succeeded.
+        // `registerToken` returns false on any failure (network, auth,
+        // missing prereqs) so we don't tell the user notifications are on
+        // when the token never landed in Convex — without this, the
+        // success toast fires even though notifications stay broken.
+        const registered = await registerToken();
+        return registered ? 'enabled' : 'denied';
       }
 
       return canAskAgain ? 'denied' : 'denied-permanent';

--- a/apps/mobile/providers/NotificationProvider.tsx
+++ b/apps/mobile/providers/NotificationProvider.tsx
@@ -51,6 +51,28 @@ try {
 // Types
 // =========================================================================
 
+/**
+ * Coarse permission status used by the opt-in flow.
+ * - `granted`: OS allows push for this app
+ * - `undetermined`: OS hasn't been asked yet (or Android equivalent)
+ * - `denied`: OS-denied but `canAskAgain === true` (mostly Android)
+ * - `denied-permanent`: OS-denied and `canAskAgain === false` (iOS post-deny — only recovery is Settings)
+ * - `unsupported`: web, simulator, or expo-notifications unavailable
+ */
+export type PushPermissionStatus =
+  | 'granted'
+  | 'undetermined'
+  | 'denied'
+  | 'denied-permanent'
+  | 'unsupported';
+
+/** Outcome returned by `enableNotifications()`. */
+export type EnableNotificationsOutcome =
+  | 'enabled'
+  | 'denied'
+  | 'denied-permanent'
+  | 'unsupported';
+
 type NotificationContextType = {
   /** Expo push token for this device */
   expoPushToken: string | null;
@@ -62,6 +84,16 @@ type NotificationContextType = {
   isReady: boolean;
   /** Request notification permissions */
   requestPermissions: () => Promise<boolean>;
+  /**
+   * Unified opt-in flow used by the inbox banner and the settings master toggle.
+   * If the OS hasn't been asked, asks. If the OS already denied with no recourse,
+   * returns `denied-permanent` so the caller can open Settings. On grant, registers
+   * the push token (which also re-enables `notificationsEnabled` server-side since
+   * the flag is derived from token existence).
+   */
+  enableNotifications: () => Promise<EnableNotificationsOutcome>;
+  /** Read current OS permission state without prompting. */
+  getPermissionStatus: () => Promise<PushPermissionStatus>;
   /** Refresh unread count from server */
   refreshUnreadCount: () => Promise<void>;
   /** Handle notification received while app is open */
@@ -87,6 +119,8 @@ const NotificationContext = createContext<NotificationContextType>({
   unreadCount: 0,
   isReady: false,
   requestPermissions: async () => false,
+  enableNotifications: async () => 'unsupported',
+  getPermissionStatus: async () => 'unsupported',
   refreshUnreadCount: async () => {},
   lastNotification: null,
   handleNotificationTap: async () => {},
@@ -198,6 +232,26 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, []);
 
+  // Read current OS permission state without prompting. Used by the opt-in
+  // flow to decide whether to show a soft-ask sheet (undetermined), call
+  // through to the OS prompt, or jump straight to Settings (denied-permanent).
+  const getPermissionStatus = useCallback(async (): Promise<PushPermissionStatus> => {
+    if (!Notifications || !Device) return 'unsupported';
+    if (Platform.OS === 'web') return 'unsupported';
+    if (!Device.isDevice) return 'unsupported';
+
+    try {
+      const { status, canAskAgain } = await Notifications.getPermissionsAsync();
+      if (status === 'granted') return 'granted';
+      if (status === 'undetermined') return 'undetermined';
+      // status === 'denied' on iOS/Android
+      return canAskAgain ? 'denied' : 'denied-permanent';
+    } catch (error) {
+      console.error('getPermissionStatus failed:', error);
+      return 'unsupported';
+    }
+  }, []);
+
   // Register push token with backend using Convex
   const registerToken = useCallback(async () => {
     if (!Notifications || !isAuthenticated || !user) return;
@@ -251,6 +305,40 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
       console.error('Failed to register push token:', error);
     }
   }, [isAuthenticated, user, authToken, registerTokenMutation]);
+
+  // Unified opt-in flow. Asks the OS if it hasn't been asked, registers the
+  // push token on grant (which re-enables `notificationsEnabled` server-side
+  // since that flag is derived from token existence), and returns
+  // `denied-permanent` so callers can route the user to Settings when iOS has
+  // burned the one-shot prompt.
+  const enableNotifications = useCallback(async (): Promise<EnableNotificationsOutcome> => {
+    if (!Notifications || !Device) return 'unsupported';
+    if (Platform.OS === 'web') return 'unsupported';
+    if (!Device.isDevice) return 'unsupported';
+
+    try {
+      const current = await Notifications.getPermissionsAsync();
+      let status = current.status;
+      let canAskAgain = current.canAskAgain;
+
+      if (status !== 'granted' && canAskAgain) {
+        const result = await Notifications.requestPermissionsAsync();
+        status = result.status;
+        canAskAgain = result.canAskAgain;
+      }
+
+      if (status === 'granted') {
+        setIsEnabled(true);
+        await registerToken();
+        return 'enabled';
+      }
+
+      return canAskAgain ? 'denied' : 'denied-permanent';
+    } catch (error) {
+      console.error('enableNotifications failed:', error);
+      return 'denied';
+    }
+  }, [registerToken]);
 
   /**
    * Resolve a group ID for navigation.
@@ -662,6 +750,8 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
       unreadCount,
       isReady,
       requestPermissions,
+      enableNotifications,
+      getPermissionStatus,
       refreshUnreadCount,
       lastNotification,
       handleNotificationTap,
@@ -674,6 +764,8 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
       unreadCount,
       isReady,
       requestPermissions,
+      enableNotifications,
+      getPermissionStatus,
       refreshUnreadCount,
       lastNotification,
       handleNotificationTap,


### PR DESCRIPTION
## Summary

- **Persistent inbox banner** prompting users to enable push notifications. Brand-primary, two-line copy that defuses the noise objection by pointing at the existing per-group/channel mute UI. 7-day soft-snooze keyed by user ID — sticks around enough to recover drift, not enough to drive uninstalls.
- **Soft-ask bottom sheet** before the iOS one-shot OS prompt, so reflex deniers don't burn the prompt. Coaching sheet for the OS-denied-permanent state with a platform-specific Settings hand-off (Android: deep-links directly to notification settings via expo-intent-launcher; iOS: app settings page where Notifications is one tap away — Apple won't allow re-prompting after denial, so this is the only platform-supported recovery).
- **Settings master-toggle bug fix**: flipping the toggle ON when OS perms are denied no longer silently fails. Both the toggle and the warning-box "Grant Permission" button now route through the same shared flow.
- **Auto-recovery** when the user grants in OS Settings and returns to the app — token re-registers silently on foreground.
- **Superuser dashboard stats card**: "Notifications enabled — N users · ↑/↓Δ (±X.X%) since yesterday". Color-coded green/red/neutral. Today is live; yesterday comes from a daily 00:05 UTC cron snapshot into a new `dailyNotificationStats` table (push tokens are deleted on disable, so historical counts can't be reconstructed without snapshots).

## Test plan

- [ ] Inbox banner renders below the "Inbox" header for a user with no push token
- [ ] Banner is hidden on web, in the iOS Simulator (`Device.isDevice === false`), and once push is fully working
- [ ] Tapping "Turn on" with `undetermined` status shows the soft-ask sheet, then the OS prompt, then the success toast
- [ ] Tapping "Turn on" with `denied-permanent` status shows the coaching sheet, then opens Settings (Android lands directly on notification settings; iOS lands on the app's settings page)
- [ ] After granting in iOS Settings and returning, the token auto-registers and the banner disappears
- [ ] Dismiss x snoozes the banner for 7 days (re-appears after)
- [ ] Settings master toggle: flipping ON with OS denied opens the coaching sheet (no longer silently fails)
- [ ] Settings warning-box "Grant Permission" routes through the same flow
- [ ] Superuser admin dashboard: "Notifications enabled" card shows live count + "Awaiting first daily snapshot" until cron has fired once
- [ ] After the cron fires, the card shows the delta + percent vs yesterday with the right color

## Migrations

No data migration. Convex schema deploy adds the new `dailyNotificationStats` table; the daily 00:05 UTC cron starts populating it. Until the first cron tick, the stats card displays "Awaiting first daily snapshot".

🤖 Generated with [Claude Code](https://claude.com/claude-code)