### PR TITLE
feat(notifications): slashed-bell badge for users with push disabled

### DIFF
--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -29,6 +29,7 @@ import { requireAuth, getOptionalAuth } from "../lib/auth";
 import { isCommunityAdmin, ADMIN_ROLE_THRESHOLD } from "../lib/permissions";
 import { syncUserChannelMembershipsLogic } from "./sync/memberships";
 import { isActiveMembership, isActiveLeader, hasLeft } from "../lib/helpers";
+import { getUsersWithNotificationsDisabled } from "../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Member Queries
@@ -207,6 +208,8 @@ export const list = query({
       }
     });
 
+    const notifsDisabled = await getUsersWithNotificationsDisabled(ctx, userIds);
+
     // Map members to response with user details
     const membersWithUsers = paginatedMembers.map((member) => {
       const user = userMap.get(member.userId);
@@ -224,6 +227,7 @@ export const list = query({
               lastName: user.lastName || "",
               email: user.email || "",
               profileImage: getMediaUrl(user.profilePhoto),
+              notificationsDisabled: notifsDisabled.has(user._id),
             }
           : null,
       };
@@ -289,6 +293,7 @@ export const getMemberPreview = query({
     // Batch fetch users
     const userIds = previewMembers.map((m) => m.userId);
     const users = await Promise.all(userIds.map((id) => ctx.db.get(id)));
+    const notifsDisabled = await getUsersWithNotificationsDisabled(ctx, userIds);
 
     // Build response with limited public info only
     const membersPreview = previewMembers
@@ -301,6 +306,7 @@ export const getMemberPreview = query({
           lastName: user.lastName || "",
           profileImage: getMediaUrl(user.profilePhoto),
           role: member.role,
+          notificationsDisabled: notifsDisabled.has(user._id),
         };
       })
       .filter(Boolean);
@@ -367,6 +373,10 @@ export const getLeaderPreview = query({
 
     // Batch fetch users
     const users = await Promise.all(slice.map((m) => ctx.db.get(m.userId)));
+    const notifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      slice.map((m) => m.userId),
+    );
 
     const leadersPreview = slice
       .map((membership, i) => {
@@ -378,6 +388,7 @@ export const getLeaderPreview = query({
           lastName: user.lastName || "",
           profileImage: getMediaUrl(user.profilePhoto),
           role: membership.role,
+          notificationsDisabled: notifsDisabled.has(user._id),
         };
       })
       .filter(Boolean);

--- a/apps/convex/functions/groups/queries.ts
+++ b/apps/convex/functions/groups/queries.ts
@@ -12,6 +12,7 @@ import { paginationArgs } from "../../lib/validators";
 import { requireAuth, getOptionalAuth } from "../../lib/auth";
 import { isCommunityAdmin } from "../../lib/permissions";
 import { isLeaderRole } from "../../lib/helpers";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 /**
  * Get group by ID
@@ -260,8 +261,13 @@ export const getByShortId = query({
       return bLeader - aLeader;
     });
 
+    const previewSlice = sortedMembers.slice(0, 5);
+    const previewNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      previewSlice.map((gm) => gm.userId),
+    );
     const memberPreview = [];
-    for (const gm of sortedMembers.slice(0, 5)) {
+    for (const gm of previewSlice) {
       const user = await ctx.db.get(gm.userId);
       if (user) {
         memberPreview.push({
@@ -270,6 +276,7 @@ export const getByShortId = query({
           last_name: user.lastName || "",
           profile_photo: getMediaUrl(user.profilePhoto),
           isLeader: isLeaderRole(gm.role),
+          notificationsDisabled: previewNotifsDisabled.has(user._id),
         });
       }
     }

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -24,6 +24,7 @@ import { syncUserChannelMembershipsLogic } from "../sync/memberships";
 import { updateChannelMemberCount } from "./helpers";
 import { matchesSearchTerms, parseSearchTerms } from "../../lib/memberSearch";
 import { canAccessEventChannel } from "./eventChat";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Constants
@@ -814,6 +815,11 @@ export const getChannelMembers = query({
         })
       );
 
+      const pageNotifsDisabled = await getUsersWithNotificationsDisabled(
+        ctx,
+        page.map(({ member }) => member.userId),
+      );
+
       return {
         members: page.map(({ member, user }, idx) => ({
           id: member._id,
@@ -827,6 +833,7 @@ export const getChannelMembers = query({
           groupRole: pageGroupRoles[idx] ?? undefined,
           syncSource: member.syncSource,
           syncMetadata: member.syncMetadata,
+          notificationsDisabled: pageNotifsDisabled.has(member.userId),
         })),
         nextCursor,
         totalCount: matchedMembers.length,
@@ -877,9 +884,18 @@ export const getChannelMembers = query({
       })
     );
 
+    const browseNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      enrichedMembers.map((m) => m.userId),
+    );
+    const enrichedMembersWithNotifs = enrichedMembers.map((m) => ({
+      ...m,
+      notificationsDisabled: browseNotifsDisabled.has(m.userId),
+    }));
+
     // Return member data with pagination info
     return {
-      members: enrichedMembers,
+      members: enrichedMembersWithNotifs,
       nextCursor: hasMore ? JSON.stringify(result.continueCursor) : null,
       // Note: totalCount is expensive for large channels, use channel.memberCount instead
       totalCount: channel.memberCount || 0,
@@ -1362,6 +1378,21 @@ export const getInboxChannels = query({
       });
     }
 
+    // Look up notif-disabled status for every distinct lastMessageSenderId
+    // referenced by the inbox so each row can render the slashed-bell badge
+    // next to the sender's avatar/name.
+    const inboxSenderIds = Array.from(
+      new Set(
+        allChannels
+          .map((ch) => ch.lastMessageSenderId)
+          .filter((id): id is Id<"users"> => !!id),
+      ),
+    );
+    const inboxSenderNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      inboxSenderIds,
+    );
+
     // Build the result grouped by group
     const result: Array<{
       group: {
@@ -1382,6 +1413,7 @@ export const getInboxChannels = query({
         lastMessageAt: number | null;
         lastMessageSenderName: string | null;
         lastMessageSenderId: Id<"users"> | null;
+        lastMessageSenderNotificationsDisabled: boolean;
         unreadCount: number;
         isShared: boolean | undefined;
         isEnabled: boolean | undefined;
@@ -1494,6 +1526,9 @@ export const getInboxChannels = query({
           lastMessageAt: ch.lastMessageAt || null,
           lastMessageSenderName: ch.lastMessageSenderName || null,
           lastMessageSenderId: ch.lastMessageSenderId || null,
+          lastMessageSenderNotificationsDisabled: ch.lastMessageSenderId
+            ? inboxSenderNotifsDisabled.has(ch.lastMessageSenderId)
+            : false,
           unreadCount: unreadCounts.get(ch._id) || 0,
           isShared: ch.isShared || undefined,
           isEnabled: ch.isEnabled,

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -19,6 +19,7 @@ import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { checkRateLimit } from "../../lib/rateLimit";
 import { getDisplayName, getMediaUrl, normalizePhone } from "../../lib/utils";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Constants
@@ -1213,11 +1214,17 @@ export const searchUsersInSharedCommunities = query({
       return aName.localeCompare(bName);
     });
 
-    return candidates.slice(0, limit).map((c) => ({
+    const sliced = candidates.slice(0, limit);
+    const notifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      sliced.map((c) => c.user._id),
+    );
+    return sliced.map((c) => ({
       userId: c.user._id,
       displayName: getDisplayName(c.user.firstName, c.user.lastName),
       profilePhoto: getMediaUrl(c.user.profilePhoto) ?? null,
       sharedCommunityNames: communityName ? [communityName] : [],
+      notificationsDisabled: notifsDisabled.has(c.user._id),
     }));
   },
 });
@@ -1258,6 +1265,7 @@ export const getAdHocChannelMembers = query({
       userId: Id<"users">;
       displayName: string;
       profilePhoto: string | null;
+      notificationsDisabled: boolean;
     }>;
   } | null> => {
     const userId = await requireAuth(ctx, args.token);
@@ -1293,6 +1301,11 @@ export const getAdHocChannelMembers = query({
     const otherUsers = await Promise.all(
       others.map((m) => ctx.db.get(m.userId)),
     );
+    const otherIds = others.map((m) => m.userId);
+    const otherNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      otherIds,
+    );
     const otherMembers = others
       .map((m, i) => {
         const u = otherUsers[i];
@@ -1304,6 +1317,7 @@ export const getAdHocChannelMembers = query({
             m.displayName ||
             "Member",
           profilePhoto: getMediaUrl(u.profilePhoto ?? m.profilePhoto) ?? null,
+          notificationsDisabled: otherNotifsDisabled.has(m.userId),
         };
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
@@ -1341,10 +1355,13 @@ export const getDirectInbox = query({
         userId: Id<"users">;
         displayName: string;
         profilePhoto: string | null;
+        notificationsDisabled: boolean;
       }>;
       lastMessageAt: number | null;
       lastMessagePreview: string | null;
       lastMessageSenderName: string | null;
+      lastMessageSenderId: Id<"users"> | null;
+      lastMessageSenderNotificationsDisabled: boolean;
       unreadCount: number;
       isMuted: boolean;
     }> = [];
@@ -1385,12 +1402,24 @@ export const getDirectInbox = query({
         .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .collect();
+      const otherMemberIds = otherMemberRows
+        .filter((m) => m.userId !== userId)
+        .map((m) => m.userId);
+      const senderIdForRow = channel.lastMessageSenderId ?? null;
+      const idsToCheck = senderIdForRow
+        ? [...otherMemberIds, senderIdForRow]
+        : otherMemberIds;
+      const rowNotifsDisabled = await getUsersWithNotificationsDisabled(
+        ctx,
+        idsToCheck,
+      );
       const otherMembers = otherMemberRows
         .filter((m) => m.userId !== userId)
         .map((m) => ({
           userId: m.userId,
           displayName: m.displayName ?? "",
           profilePhoto: getMediaUrl(m.profilePhoto) ?? null,
+          notificationsDisabled: rowNotifsDisabled.has(m.userId),
         }));
 
       // Read state → unread count.
@@ -1411,6 +1440,10 @@ export const getDirectInbox = query({
         lastMessageAt: channel.lastMessageAt ?? null,
         lastMessagePreview: channel.lastMessagePreview ?? null,
         lastMessageSenderName: channel.lastMessageSenderName ?? null,
+        lastMessageSenderId: senderIdForRow,
+        lastMessageSenderNotificationsDisabled: senderIdForRow
+          ? rowNotifsDisabled.has(senderIdForRow)
+          : false,
         unreadCount,
         isMuted: row.isMuted,
       });

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -26,6 +26,26 @@ import {
 import { checkRateLimit } from "../../lib/rateLimit";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { canAccessEventChannel } from "./eventChat";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
+
+/**
+ * Decorate a list of message rows with `senderNotificationsDisabled` so chat
+ * surfaces can render the slashed-bell badge next to the sender's avatar.
+ * Batches one pushTokens lookup per distinct senderId.
+ */
+async function attachSenderNotifsDisabled(
+  ctx: QueryCtx,
+  messages: Doc<"chatMessages">[],
+): Promise<Array<Doc<"chatMessages"> & { senderNotificationsDisabled: boolean }>> {
+  const senderIds = messages
+    .map((m) => m.senderId)
+    .filter((id): id is Id<"users"> => !!id);
+  const disabled = await getUsersWithNotificationsDisabled(ctx, senderIds);
+  return messages.map((m) => ({
+    ...m,
+    senderNotificationsDisabled: m.senderId ? disabled.has(m.senderId) : false,
+  }));
+}
 
 /**
  * Same access check as `canAccessEventChannel` but keyed off a meeting doc
@@ -435,9 +455,10 @@ export const getMessages = query({
     // Reverse to chronological order (oldest first, newest at bottom)
     // This is the expected order for chat UIs
     const chronologicalMessages = [...pageMessages].reverse();
+    const decorated = await attachSenderNotifsDisabled(ctx, chronologicalMessages);
 
     return {
-      messages: chronologicalMessages,
+      messages: decorated,
       hasMore,
       cursor,
     };
@@ -493,9 +514,10 @@ export const getThreadReplies = query({
 
     const hasMore = replies.length === limit;
     const cursor = replies.length > 0 ? replies[replies.length - 1]._id : undefined;
+    const decorated = await attachSenderNotifsDisabled(ctx, replies);
 
     return {
-      messages: replies,
+      messages: decorated,
       hasMore,
       cursor,
     };

--- a/apps/convex/functions/messaging/reactions.ts
+++ b/apps/convex/functions/messaging/reactions.ts
@@ -9,6 +9,7 @@ import { query, mutation } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { canAccessEventChannel } from "./eventChat";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 // ============================================================================
 // Queries
@@ -259,6 +260,10 @@ export const getReactionDetails = query({
       .collect();
 
     // Fetch user details for each reactor
+    const reactorNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      reactions.map((r) => r.userId),
+    );
     const users = await Promise.all(
       reactions.map(async (reaction) => {
         const user = await ctx.db.get(reaction.userId);
@@ -273,6 +278,7 @@ export const getReactionDetails = query({
           userId: reaction.userId,
           displayName,
           profilePhoto: user.profilePhoto ?? null,
+          notificationsDisabled: reactorNotifsDisabled.has(reaction.userId),
         };
       })
     );

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -19,6 +19,10 @@ import { requireAuth, getOptionalAuth } from "../lib/auth";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ROLES, COMMUNITY_ADMIN_THRESHOLD } from "../lib/permissions";
 import { adjustEnabledCounter } from "../lib/notifications/enabledCounter";
+import {
+  getUsersWithNotificationsDisabled,
+  isUserNotificationsDisabled,
+} from "../lib/notifications/enabledStatus";
 
 /**
  * Get current user profile
@@ -44,22 +48,33 @@ type PublicUserFields = {
   firstName: string | undefined;
   lastName: string | undefined;
   profilePhoto: string | undefined;
+  /**
+   * True when the user has no push tokens for the current environment — UI
+   * surfaces render a "notifications disabled" badge so senders know not to
+   * expect immediate delivery. Truth source matches `pushTokens` (see
+   * `lib/notifications/enabledStatus.ts`).
+   */
+  notificationsDisabled: boolean;
 };
 
 /**
  * Extract only public fields from a user document
  */
-function extractPublicFields(user: {
-  _id: Id<"users">;
-  firstName?: string;
-  lastName?: string;
-  profilePhoto?: string;
-}): PublicUserFields {
+function extractPublicFields(
+  user: {
+    _id: Id<"users">;
+    firstName?: string;
+    lastName?: string;
+    profilePhoto?: string;
+  },
+  notificationsDisabled: boolean,
+): PublicUserFields {
   return {
     _id: user._id,
     firstName: user.firstName,
     lastName: user.lastName,
     profilePhoto: user.profilePhoto,
+    notificationsDisabled,
   };
 }
 
@@ -80,7 +95,8 @@ export const getById = query({
     }
 
     // Return only public fields to prevent PII exposure
-    return extractPublicFields(user);
+    const notificationsDisabled = await isUserNotificationsDisabled(ctx, user._id);
+    return extractPublicFields(user, notificationsDisabled);
   },
 });
 
@@ -153,11 +169,14 @@ export const getProfile = query({
       }
     }
 
+    const notificationsDisabled = await isUserNotificationsDisabled(ctx, user._id);
+
     return {
       _id: user._id,
       firstName: user.firstName,
       lastName: user.lastName,
       profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
+      notificationsDisabled,
       bio: user.bio ?? null,
       instagramHandle: user.instagramHandle ?? null,
       linkedinHandle: user.linkedinHandle ?? null,
@@ -536,11 +555,15 @@ export const getByIds = query({
     );
 
     // Filter out null users and deactivated users, return only public fields
-    return users
-      .filter((user): user is NonNullable<typeof user> =>
-        user !== null && user.isActive !== false
-      )
-      .map(extractPublicFields);
+    const livingUsers = users.filter(
+      (user): user is NonNullable<typeof user> =>
+        user !== null && user.isActive !== false,
+    );
+    const disabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      livingUsers.map((u) => u._id),
+    );
+    return livingUsers.map((u) => extractPublicFields(u, disabled.has(u._id)));
   },
 });
 
@@ -608,6 +631,8 @@ export const me = query({
       }
     }
 
+    const notificationsDisabled = await isUserNotificationsDisabled(ctx, userId);
+
     return {
       id: user._id,
       legacyId: user.legacyId,
@@ -616,6 +641,7 @@ export const me = query({
       email: user.email || "",
       isStaff: user.isStaff || false,
       isSuperuser: user.isSuperuser || false,
+      notificationsDisabled,
       phone: user.phone || null,
       phoneVerified: user.phoneVerified || false,
       profilePhoto: getMediaUrl(user.profilePhoto),

--- a/apps/convex/lib/notifications/enabledStatus.ts
+++ b/apps/convex/lib/notifications/enabledStatus.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-user "is push enabled" lookups for client-facing UI.
+ *
+ * Truth table (matches `tokens.getActiveTokensForUser` and the running
+ * `notificationEnabledCounter`): a user has notifications enabled iff at
+ * least one row exists in `pushTokens` for `(userId, current environment)`.
+ *
+ * UI surfaces use the inverse — `notificationsDisabled: boolean` — because
+ * "disabled" is the state we render an indicator for.
+ */
+
+import type { QueryCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { getCurrentEnvironment } from "./send";
+
+/**
+ * Returns true when the user has no push tokens for the current environment.
+ */
+export async function isUserNotificationsDisabled(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const environment = getCurrentEnvironment();
+  const token = await ctx.db
+    .query("pushTokens")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .filter((q) => q.eq(q.field("environment"), environment))
+    .first();
+  return token === null;
+}
+
+/**
+ * Batched form for list/search queries — issues one parallel pushTokens
+ * lookup per unique user ID and returns the set of users with notifications
+ * disabled. Pass the resulting set to `notifsDisabledForUser(disabled, id)`.
+ */
+export async function getUsersWithNotificationsDisabled(
+  ctx: QueryCtx,
+  userIds: ReadonlyArray<Id<"users">>,
+): Promise<Set<Id<"users">>> {
+  if (userIds.length === 0) return new Set();
+  const environment = getCurrentEnvironment();
+  const unique = Array.from(new Set(userIds));
+  const tokens = await Promise.all(
+    unique.map((userId) =>
+      ctx.db
+        .query("pushTokens")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .filter((q) => q.eq(q.field("environment"), environment))
+        .first(),
+    ),
+  );
+  const disabled = new Set<Id<"users">>();
+  unique.forEach((userId, i) => {
+    if (tokens[i] === null) disabled.add(userId);
+  });
+  return disabled;
+}
+
+export function notifsDisabledForUser(
+  disabled: Set<Id<"users">>,
+  userId: Id<"users">,
+): boolean {
+  return disabled.has(userId);
+}

--- a/apps/mobile/components/ui/Avatar.tsx
+++ b/apps/mobile/components/ui/Avatar.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, ImageStyle, StyleProp } from 'react-native';
+import { StyleSheet, View, ImageStyle, StyleProp } from 'react-native';
 import { AppImage } from './AppImage';
+import { NotificationsDisabledBadge } from './NotificationsDisabledBadge';
 import { getMediaUrlWithTransform } from '@/utils/media';
 
 interface AvatarProps {
@@ -15,6 +16,19 @@ interface AvatarProps {
    *  color tied to the name. Pass a flat color (e.g. theme `border`) for
    *  contexts that want a neutral preview row. */
   placeholderBackgroundColor?: string;
+  /**
+   * When true, overlays a slashed-bell badge in the bottom-right corner to
+   * signal that this user has push notifications disabled (no push tokens
+   * for the current environment). Senders use this to set expectations
+   * before sending a message.
+   */
+  notificationsDisabled?: boolean;
+  /**
+   * Surface color the avatar sits on, passed through to the badge so its
+   * contrast border blends with the row/card background. Falls back to the
+   * theme `surface` when omitted.
+   */
+  notificationsBadgeRingColor?: string;
 }
 
 export function Avatar({
@@ -24,6 +38,8 @@ export function Avatar({
   style,
   disableOptimization = false,
   placeholderBackgroundColor,
+  notificationsDisabled,
+  notificationsBadgeRingColor,
 }: AvatarProps) {
   const safeSize = size && size > 0 ? size : 48;
 
@@ -39,7 +55,7 @@ export function Avatar({
     });
   }, [imageUrl, safeSize, disableOptimization]);
 
-  return (
+  const image = (
     <AppImage
       source={optimizedUrl}
       style={[
@@ -54,9 +70,27 @@ export function Avatar({
       }}
     />
   );
+
+  if (!notificationsDisabled) {
+    return image;
+  }
+
+  // Wrap so the badge can be absolutely positioned over the avatar's corner.
+  return (
+    <View style={[styles.wrapper, { width: safeSize, height: safeSize }]}>
+      {image}
+      <NotificationsDisabledBadge
+        avatarSize={safeSize}
+        ringColor={notificationsBadgeRingColor}
+      />
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
+  wrapper: {
+    position: 'relative',
+  },
   avatar: {
     justifyContent: 'center',
     alignItems: 'center',

--- a/apps/mobile/components/ui/NotificationsDisabledBadge.tsx
+++ b/apps/mobile/components/ui/NotificationsDisabledBadge.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View, ViewStyle, StyleProp } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/useTheme';
+
+interface NotificationsDisabledBadgeProps {
+  /**
+   * Diameter of the parent avatar in pixels. The badge scales relative to it
+   * so the slashed-bell stays legible on tiny stacked previews and on the
+   * large profile-header avatar.
+   */
+  avatarSize: number;
+  /**
+   * Optional style override — used to position the badge against a parent
+   * container.
+   */
+  style?: StyleProp<ViewStyle>;
+  /**
+   * Color used for the badge ring/contrast border. Defaults to
+   * `theme.surface`. Pass the actual surface the avatar sits on so the badge
+   * reads as an overlay rather than a free-floating dot.
+   */
+  ringColor?: string;
+}
+
+/**
+ * Slashed-bell badge overlaid on a user avatar to signal that the user has
+ * push notifications disabled. Renders nothing visual on its own — callsites
+ * mount it inside a `position: relative` parent (typically Avatar) so it sits
+ * over the bottom-right corner of the avatar.
+ *
+ * Sizing: badge diameter ~38% of the avatar (clamped to 14–24px). Icon takes
+ * ~62% of the badge so the slash is visible at small sizes.
+ */
+export function NotificationsDisabledBadge({
+  avatarSize,
+  style,
+  ringColor,
+}: NotificationsDisabledBadgeProps) {
+  const { colors } = useTheme();
+  const sizes = useMemo(() => {
+    const raw = Math.round(avatarSize * 0.42);
+    const badge = Math.max(11, Math.min(raw, 26));
+    const icon = Math.max(7, Math.round(badge * 0.65));
+    const border = badge >= 18 ? 1.5 : 1;
+    return { badge, icon, border };
+  }, [avatarSize]);
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[
+        styles.badge,
+        {
+          width: sizes.badge,
+          height: sizes.badge,
+          borderRadius: sizes.badge / 2,
+          backgroundColor: colors.textSecondary,
+          borderColor: ringColor ?? colors.surface,
+          borderWidth: sizes.border,
+        },
+        style,
+      ]}
+    >
+      <Ionicons
+        name="notifications-off"
+        size={sizes.icon}
+        color={colors.surface}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -577,6 +577,8 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
                       name={displayName}
                       imageUrl={m.profilePhoto}
                       size={40}
+                      notificationsDisabled={!!m.notificationsDisabled}
+                      notificationsBadgeRingColor={colors.surfaceSecondary}
                     />
                     <View style={styles.memberRowText}>
                       <Text

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -1024,10 +1024,13 @@ type DirectInboxRowData = {
     userId: Id<"users">;
     displayName: string;
     profilePhoto: string | null;
+    notificationsDisabled: boolean;
   }>;
   lastMessageAt: number | null;
   lastMessagePreview: string | null;
   lastMessageSenderName: string | null;
+  lastMessageSenderId: Id<"users"> | null;
+  lastMessageSenderNotificationsDisabled: boolean;
   unreadCount: number;
   isMuted: boolean;
 };
@@ -1100,6 +1103,8 @@ function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) 
           name={primaryAvatar?.displayName ?? headerName}
           imageUrl={primaryAvatar?.profilePhoto ?? undefined}
           size={56}
+          notificationsDisabled={primaryAvatar?.notificationsDisabled ?? false}
+          notificationsBadgeRingColor={colors.surface}
         />
       )}
       <View style={styles.dmRowContent}>

--- a/apps/mobile/features/chat/components/ChatInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInfoScreen.tsx
@@ -57,6 +57,7 @@ type SearchResult = {
   displayName: string;
   profilePhoto: string | null;
   sharedCommunityNames: string[];
+  notificationsDisabled: boolean;
 };
 
 type Member = {
@@ -65,6 +66,7 @@ type Member = {
   profilePhoto: string | null;
   isSelf: boolean;
   isInviter: boolean;
+  notificationsDisabled: boolean;
 };
 
 const SEARCH_DEBOUNCE_MS = 200;
@@ -133,6 +135,7 @@ export function ChatInfoScreen({ channelId }: Props) {
       profilePhoto: m.profilePhoto,
       isSelf: false,
       isInviter: m.userId === creatorId,
+      notificationsDisabled: m.notificationsDisabled,
     }));
     const self: Member = {
       userId: currentUserId,
@@ -140,6 +143,10 @@ export function ChatInfoScreen({ channelId }: Props) {
       profilePhoto: (user as { profile_photo?: string | null } | null)?.profile_photo ?? null,
       isSelf: true,
       isInviter: currentUserId === creatorId,
+      // The current viewer's own row in chat info doesn't need a "you don't
+      // have notifications" indicator — they already get the inbox banner
+      // and Settings warning. Always render as enabled here.
+      notificationsDisabled: false,
     };
     return [self, ...others];
   }, [inboxRow, currentUserId, creatorId, selfDisplayName, user]);
@@ -410,6 +417,8 @@ export function ChatInfoScreen({ channelId }: Props) {
                 name={m.displayName}
                 imageUrl={m.profilePhoto}
                 size={40}
+                notificationsDisabled={m.notificationsDisabled}
+                notificationsBadgeRingColor={colors.surfaceSecondary}
               />
               <View style={styles.memberRowText}>
                 <Text
@@ -774,6 +783,8 @@ function AddPeopleModal({
           name={item.displayName}
           imageUrl={item.profilePhoto}
           size={40}
+          notificationsDisabled={item.notificationsDisabled}
+          notificationsBadgeRingColor={colors.surface}
         />
         <View style={styles.searchRowText}>
           <Text style={[styles.searchRowName, { color: colors.text }]} numberOfLines={1}>

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -26,6 +26,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import type { Id } from '@services/api/convex';
 import { AppImage, ImageViewer } from '@components/ui';
+import { NotificationsDisabledBadge } from '@components/ui/NotificationsDisabledBadge';
 import { useReadReceipts } from '@features/chat/hooks/useReadReceipts';
 import { useReactions, type Reaction } from '@features/chat/hooks/useReactions';
 import { EventLinkCard } from './EventLinkCard';
@@ -67,6 +68,12 @@ interface MessageItemProps {
     isDeleted: boolean;
     senderName?: string;
     senderProfilePhoto?: string;
+    /**
+     * True when the sender has push notifications disabled (no token in
+     * the current environment). Drives the slashed-bell badge over the
+     * sender's avatar so readers know not to expect immediate read/response.
+     */
+    senderNotificationsDisabled?: boolean;
     mentionedUserIds?: Id<"users">[];
     threadReplyCount?: number;
     hideLinkPreview?: boolean;
@@ -952,6 +959,12 @@ function MessageItemInner({
                 backgroundColor: '#E5E5E5',
               }}
             />
+            {message.senderNotificationsDisabled ? (
+              <NotificationsDisabledBadge
+                avatarSize={24}
+                ringColor={themeColors.background}
+              />
+            ) : null}
           </Pressable>
         )}
 

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -342,6 +342,7 @@ export function MessageList({
             isDeleted: message.isDeleted,
             senderName: message.senderName,
             senderProfilePhoto: message.senderProfilePhoto,
+            senderNotificationsDisabled: message.senderNotificationsDisabled,
             mentionedUserIds: message.mentionedUserIds,
             threadReplyCount: message.threadReplyCount,
             hideLinkPreview: message.hideLinkPreview,

--- a/apps/mobile/features/chat/components/ThreadPage.tsx
+++ b/apps/mobile/features/chat/components/ThreadPage.tsx
@@ -277,6 +277,7 @@ export function ThreadPage({
                       isDeleted: item.data.isDeleted,
                       senderName: item.data.senderName,
                       senderProfilePhoto: item.data.senderProfilePhoto,
+                      senderNotificationsDisabled: item.data.senderNotificationsDisabled,
                     }}
                     currentUserId={currentUserId}
                     onLongPress={handleLongPressMessage}
@@ -315,6 +316,7 @@ export function ThreadPage({
                     isDeleted: item.data.isDeleted,
                     senderName: item.data.senderName,
                     senderProfilePhoto: item.data.senderProfilePhoto,
+                    senderNotificationsDisabled: item.data.senderNotificationsDisabled,
                   }}
                   currentUserId={currentUserId}
                   onLongPress={handleLongPressMessage}

--- a/apps/mobile/features/chat/context/ChatPrefetchContext.tsx
+++ b/apps/mobile/features/chat/context/ChatPrefetchContext.tsx
@@ -88,6 +88,9 @@ export interface PrefetchedMessage {
   threadReplyCount?: number;
   senderName?: string;
   senderProfilePhoto?: string;
+  /** Mirrors backend `senderNotificationsDisabled` so the slashed-bell badge
+   *  can render on prefetched messages too. */
+  senderNotificationsDisabled?: boolean;
   hideLinkPreview?: boolean;
 }
 
@@ -107,6 +110,7 @@ export interface PrefetchedThreadReply {
   senderId?: string;
   senderName?: string;
   senderProfilePhoto?: string;
+  senderNotificationsDisabled?: boolean;
   createdAt: number;
 }
 

--- a/apps/mobile/features/chat/hooks/usePrefetchChannel.ts
+++ b/apps/mobile/features/chat/hooks/usePrefetchChannel.ts
@@ -353,6 +353,7 @@ async function fetchThreadRepliesBatch(
           senderId: msg.senderId,
           senderName: msg.senderName,
           senderProfilePhoto: msg.senderProfilePhoto,
+          senderNotificationsDisabled: msg.senderNotificationsDisabled,
           createdAt: msg.createdAt,
         }));
         return { messageId: messageId.toString(), replies };

--- a/apps/mobile/features/chat/hooks/useThreadReplies.ts
+++ b/apps/mobile/features/chat/hooks/useThreadReplies.ts
@@ -91,6 +91,7 @@ export function useThreadReplies(
       isDeleted: false,
       senderName: r.senderName,
       senderProfilePhoto: r.senderProfilePhoto,
+      senderNotificationsDisabled: r.senderNotificationsDisabled,
     }));
 
     return {

--- a/apps/mobile/features/chat/hooks/useThreadReplies.ts
+++ b/apps/mobile/features/chat/hooks/useThreadReplies.ts
@@ -22,6 +22,7 @@ interface ThreadReply {
   isDeleted: boolean;
   senderName?: string;
   senderProfilePhoto?: string;
+  senderNotificationsDisabled?: boolean;
   attachments?: Array<{
     type: string;
     url: string;

--- a/apps/mobile/features/profile/components/UserProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/UserProfileHeader.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { AppImage } from '@components/ui';
 import { ImageViewer } from '@components/ui/ImageViewer';
+import { NotificationsDisabledBadge } from '@components/ui/NotificationsDisabledBadge';
 import { useTheme } from '@hooks/useTheme';
 
 import type { UserProfile } from '../hooks/useUserProfile';
@@ -41,16 +42,24 @@ export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
           if (profile.profilePhoto) setViewerVisible(true);
         }}
       >
-        <AppImage
-          source={profile.profilePhoto ?? undefined}
-          style={styles.avatar}
-          optimizedWidth={200}
-          placeholder={{
-            type: 'initials',
-            name: displayName,
-            backgroundColor: '#E5E5E5',
-          }}
-        />
+        <View style={styles.avatarWrapper}>
+          <AppImage
+            source={profile.profilePhoto ?? undefined}
+            style={styles.avatar}
+            optimizedWidth={200}
+            placeholder={{
+              type: 'initials',
+              name: displayName,
+              backgroundColor: '#E5E5E5',
+            }}
+          />
+          {profile.notificationsDisabled ? (
+            <NotificationsDisabledBadge
+              avatarSize={96}
+              ringColor={colors.surface}
+            />
+          ) : null}
+        </View>
       </TouchableOpacity>
       <Text style={[styles.name, { color: colors.text }]}>{displayName}</Text>
       {memberSinceLabel && (
@@ -85,11 +94,16 @@ const styles = StyleSheet.create({
     padding: 24,
     borderRadius: 12,
   },
+  avatarWrapper: {
+    position: 'relative',
+    width: 96,
+    height: 96,
+    marginBottom: 12,
+  },
   avatar: {
     width: 96,
     height: 96,
     borderRadius: 48,
-    marginBottom: 12,
   },
   name: {
     fontSize: 22,

--- a/apps/mobile/features/profile/components/UserProfileScreen.tsx
+++ b/apps/mobile/features/profile/components/UserProfileScreen.tsx
@@ -183,6 +183,33 @@ export function UserProfileScreen() {
       >
         <UserProfileHeader profile={profile} />
         <UserProfileBadges profile={profile} />
+        {profile.notificationsDisabled && !isSelf ? (
+          <View
+            style={[
+              styles.notifsDisabledNote,
+              {
+                backgroundColor: colors.surfaceSecondary,
+                borderColor: colors.border,
+              },
+            ]}
+          >
+            <Ionicons
+              name="notifications-off-outline"
+              size={16}
+              color={colors.textSecondary}
+              style={styles.notifsDisabledIcon}
+            />
+            <Text
+              style={[
+                styles.notifsDisabledText,
+                { color: colors.textSecondary },
+              ]}
+            >
+              This person has notifications disabled and may not see your
+              message right away.
+            </Text>
+          </View>
+        ) : null}
         {showMessageButton ? (
           <MessageButton
             onPress={handleMessagePress}
@@ -330,5 +357,22 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 15,
     fontWeight: '600',
+  },
+  notifsDisabledNote: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  notifsDisabledIcon: {
+    marginTop: 1,
+    marginRight: 8,
+  },
+  notifsDisabledText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
   },
 });

--- a/apps/mobile/features/profile/hooks/useUserProfile.ts
+++ b/apps/mobile/features/profile/hooks/useUserProfile.ts
@@ -19,6 +19,7 @@ export interface UserProfile {
   firstName?: string;
   lastName?: string;
   profilePhoto: string | null;
+  notificationsDisabled: boolean;
   bio: string | null;
   instagramHandle: string | null;
   linkedinHandle: string | null;


### PR DESCRIPTION
## Summary

Senders deserve to know when the person they're messaging has push notifications turned off. This PR surfaces that state next to a user's avatar everywhere they appear in the app — a slashed-bell badge on chat list rows, message bubbles, member lists, profile screens — plus a one-line note on the profile that says *"This person has notifications disabled and may not see your message right away."*

The truth signal is identical to the inbox opt-in banner introduced in #367: a row in `pushTokens` for the current environment ⇒ enabled. So whatever further iteration #367 picks up on the opt-in side, this badge stays in sync automatically.

## What's wired

- **Backend** — `lib/notifications/enabledStatus.ts` exposes a batched `getUsersWithNotificationsDisabled(userIds)` that does one parallel `pushTokens` lookup per distinct user. Embedded `notificationsDisabled: boolean` (and `senderNotificationsDisabled` for messages, `lastMessageSenderNotificationsDisabled` for inbox rows) on:
  - `users.getById` / `getByIds` / `getProfile` / `me`
  - `groupMembers.list` / `getMemberPreview` / `getLeaderPreview`
  - `groups.queries.getByShortId` (memberPreview)
  - `messaging.channels.getChannelMembers` (search + browse) / `getInboxChannels`
  - `messaging.directMessages.getAdHocChannelMembers` / `searchUsersInSharedCommunities` / `getDirectInbox`
  - `messaging.messages.getMessages` / `getThreadReplies`
  - `messaging.reactions.getReactionDetails`
- **Mobile** — new `<NotificationsDisabledBadge />` (Ionicons `notifications-off`, scaled relative to the parent avatar, themed border that blends with the surface), opt-in `notificationsDisabled` prop on the shared `<Avatar>`. Wired into:
  - Chat inbox 1:1 DM row primary avatar
  - Message bubble sender avatar in group/channel chats
  - Chat info & channel info member rows
  - User profile header (96px) + an explanation banner above the Message button (hidden on the viewer's own profile — they get the inbox opt-in banner instead)

## Why option 2 (embed) over option 1 (separate query)

Picked at planning time: every screen that already loads users gets the flag for free with no extra round-trip; the per-query cost is one batched `pushTokens` lookup with `Promise.all`. Costs grow with already-paginated list sizes, not with screen count.

## Not included

The user-list pickers further from the screenshots (mention autocomplete, channel-members browse, RSVP guests, admin People tab, attendance lists) — the helper + Avatar prop are in place; wiring them is mechanical follow-up. Happy to extend in this PR if reviewers prefer a single landing.

## Test plan

- [ ] Open a 1:1 DM with a user who has no push token; the inbox row shows the slashed-bell badge over the recipient's avatar
- [ ] In a group channel, a message from a sender with notifications off shows the badge over their avatar in the bubble
- [ ] Tap the chat header to open Chat Info; rows for members with notifications off show the badge
- [ ] Open the same user's profile — large avatar shows the badge, and the note "This person has notifications disabled and may not see your message right away." appears above the Message button
- [ ] Your own profile does NOT show the note (you already get the inbox opt-in banner)
- [ ] Toggling notifications off via Settings clears push tokens → indicators flip in real time across surfaces
- [ ] Re-enabling notifications (registers a token) makes the indicators disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)