### PR TITLE
fix(groups): make group-page back button reachable on safe-area devices

### DIFF
--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -15,7 +15,6 @@ import {
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Clipboard from "expo-clipboard";
 import { DOMAIN_CONFIG } from "@togather/shared";
 import { useTheme } from "@hooks/useTheme";
@@ -55,7 +54,6 @@ export function GroupDetailScreen() {
   const group_id = params.group_id;
   const router = useRouter();
   const { user } = useAuth();
-  const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const [showOptionsModal, setShowOptionsModal] = useState(false);
   const [showJoinSuccessModal, setShowJoinSuccessModal] = useState(false);
@@ -395,7 +393,8 @@ export function GroupDetailScreen() {
     <>
       <ScrollView
         style={[styles.scrollView, { backgroundColor: colors.background }]}
-        contentContainerStyle={{ paddingTop: insets.top, paddingBottom: 24 }}
+        // GroupHeader owns its own safe-area top inset; only need bottom padding here.
+        contentContainerStyle={{ paddingBottom: 24 }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl

--- a/apps/mobile/features/groups/components/GroupHeader.tsx
+++ b/apps/mobile/features/groups/components/GroupHeader.tsx
@@ -17,6 +17,7 @@ import React from "react";
 import { View, Text, StyleSheet, TouchableOpacity, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Group } from "../types";
 import { formatCadence } from "../utils";
 import { Avatar } from "@components/ui";
@@ -38,6 +39,13 @@ export function GroupHeader({
 }: GroupHeaderProps) {
   const router = useRouter();
   const { colors } = useTheme();
+  // The screen this header sits on hides the native nav header
+  // (root `_layout.tsx` sets `headerShown: false`), so the back chevron is
+  // ours and has to clear the device safe area itself. Reading insets
+  // here keeps any consumer of `GroupHeader` (member view + non-member
+  // view) safe-area-correct without each one remembering to wrap the
+  // surrounding scroll view.
+  const insets = useSafeAreaInsets();
   const previewUrl = group.preview || group.image_url || null;
   const groupName = group?.title || group?.name || "Group";
   const cadence = formatCadence(group);
@@ -64,11 +72,11 @@ export function GroupHeader({
 
   return (
     <View style={[styles.container, { backgroundColor: colors.surface }]}>
-      <View style={styles.topBar}>
+      <View style={[styles.topBar, { paddingTop: insets.top + 8 }]}>
         <TouchableOpacity
           style={styles.iconButton}
           onPress={handleBack}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           accessibilityLabel="Back"
         >
           <Ionicons name="chevron-back" size={28} color={colors.text} />
@@ -78,7 +86,7 @@ export function GroupHeader({
           <TouchableOpacity
             style={styles.iconButton}
             onPress={onSharePress}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
             accessibilityLabel="Share group"
           >
             <Ionicons
@@ -150,7 +158,11 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   iconButton: {
-    padding: 4,
+    // ≥44pt tap target so back/share clear the iOS HIG minimum.
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: "center",
+    justifyContent: "center",
   },
   spacer: {
     flex: 1,


### PR DESCRIPTION
## Summary

Following up on #369 — the back chevron rendered by \`GroupHeader\` sat directly under the iOS dynamic island / status bar with only 8px of vertical padding, making the tap target unreachable on Face ID devices. The member view (\`GroupDetailScreen\`) compensated with \`paddingTop: insets.top\` on its ScrollView, but the non-member view (\`GroupNonMemberView\`) didn't — so the back button stayed permanently squeezed against the top edge for non-members.

### Fix

Move the safe-area top padding into \`GroupHeader\` itself — the component that owns the back/share row — so every consumer is correct without each ScrollView having to remember the inset. The root \`_layout.tsx\` hides the native nav header globally (\`headerShown: false\`), so this is a single source of truth for the page's top spacing.

Also:
- Bump back/share buttons to **44pt minimum touch targets** (iOS HIG)
- Widen \`hitSlop\` from 10 → 12px on each side
- \`GroupDetailScreen\` drops its now-redundant \`paddingTop: insets.top\` + unused \`useSafeAreaInsets\` import

### Verification

- 22/22 group component tests pass (\`GroupNonMemberView.test.tsx\` + \`GroupDetailScreen.test.tsx\`)
- Test fixture mocks \`useSafeAreaInsets\` to return zeros, so the new \`insets.top + 8\` collapses to the previous 8px in tests — no fixture changes needed
- Mobile typecheck clean for the changed files

### Test plan

- [ ] On iPhone with dynamic island, navigate to a group detail page (member view) — back chevron is comfortably below the dynamic island, easily tappable
- [ ] Same for a non-member group page — back chevron now clears the safe area (was previously crammed under the status bar; see screenshot in the original report)
- [ ] Back chevron tap target is ≥ 44pt
- [ ] Share icon tap target is ≥ 44pt
- [ ] Member view's content (Members card, Channels, etc.) starts at the right vertical position — no double-padding regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)