### PR TITLE
fix(groups,chat): close access-control gaps + add admin-view disclaimers

### DIFF
--- a/apps/convex/__tests__/messaging/shared-channels-lifecycle.test.ts
+++ b/apps/convex/__tests__/messaging/shared-channels-lifecycle.test.ts
@@ -406,7 +406,8 @@ describe("Archive cascade — primary group archived", () => {
   test("archiving primary group archives all its owned channels", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.primaryLeaderId);
+    // Archive flips are community-admin-only (`groups.mutations.update`).
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
@@ -465,7 +466,7 @@ describe("Archive cascade — primary group archived", () => {
       }
     );
 
-    const { accessToken } = await generateTokens(ids.primaryLeaderId);
+    const { accessToken } = await generateTokens(ids.adminUserId);
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
       groupId: ids.primaryGroupId,
@@ -488,7 +489,7 @@ describe("Archive cascade — primary group archived", () => {
   test("archiving primary group soft-deletes all channel members", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.primaryLeaderId);
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
@@ -514,7 +515,7 @@ describe("Archive cascade — primary group archived", () => {
   test("archiving primary group sets archivedAt on the group itself", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.primaryLeaderId);
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
@@ -538,7 +539,7 @@ describe("Archive cascade — secondary group archived", () => {
   test("archiving secondary group A removes its entry from sharedGroups", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.secondaryLeaderAId);
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
@@ -562,7 +563,7 @@ describe("Archive cascade — secondary group archived", () => {
   test("archiving secondary group soft-deletes members exclusive to that group", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.secondaryLeaderAId);
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
@@ -655,7 +656,7 @@ describe("Archive cascade — secondary group archived", () => {
       }
     );
 
-    const { accessToken } = await generateTokens(ids.secondaryLeaderAId);
+    const { accessToken } = await generateTokens(ids.adminUserId);
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
       groupId: ids.secondaryGroupAId,
@@ -690,7 +691,7 @@ describe("Archive cascade — secondary group archived", () => {
   test("archiving secondary group keeps members who are also in primary group", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.secondaryLeaderAId);
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
@@ -721,7 +722,10 @@ describe("Archive cascade — secondary group archived", () => {
   test("archiving secondary group recomputes memberCount on shared channel", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.secondaryLeaderAId);
+    // Archive flips are gated to community admins (see
+    // `groups.mutations.update`) — use the seeded admin token, not the
+    // group leader's, to drive the cascade.
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,
@@ -748,23 +752,20 @@ describe("Archive cascade — secondary group archived", () => {
   test("archiving the last secondary group sets isShared to false", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
+    // Archive is community-admin-only — same admin token drives both
+    // archive calls.
+    const { accessToken: adminToken } = await generateTokens(ids.adminUserId);
 
     // Archive secondary group A first
-    const { accessToken: tokenA } = await generateTokens(
-      ids.secondaryLeaderAId
-    );
     await t.mutation(api.functions.groups.mutations.update, {
-      token: tokenA,
+      token: adminToken,
       groupId: ids.secondaryGroupAId,
       isArchived: true,
     });
 
     // Now archive secondary group B
-    const { accessToken: tokenB } = await generateTokens(
-      ids.secondaryLeaderBId
-    );
     await t.mutation(api.functions.groups.mutations.update, {
-      token: tokenB,
+      token: adminToken,
       groupId: ids.secondaryGroupBId,
       isArchived: true,
     });
@@ -780,7 +781,8 @@ describe("Archive cascade — secondary group archived", () => {
   test("shared channel stays alive when secondary group is archived", async () => {
     const t = convexTest(schema, modules);
     const ids = await seedSharedChannelData(t);
-    const { accessToken } = await generateTokens(ids.secondaryLeaderAId);
+    // Community-admin-only — see comment on the previous archive test.
+    const { accessToken } = await generateTokens(ids.adminUserId);
 
     await t.mutation(api.functions.groups.mutations.update, {
       token: accessToken,

--- a/apps/convex/functions/groups/mutations.ts
+++ b/apps/convex/functions/groups/mutations.ts
@@ -314,6 +314,24 @@ export const update = mutation({
       "edit this group"
     );
 
+    // Archive/unarchive cascades to channels and soft-deletes every active
+    // member — that's a community-wide operation, not a group-leader one.
+    // Tighten to community-admin-only so the backend matches the UI gate
+    // (which has always hidden the button from non-admins). Without this
+    // a group leader could call `update({ isArchived: true })` directly.
+    if (args.isArchived !== undefined) {
+      const isCommAdminForArchive = await isCommunityAdmin(
+        ctx,
+        currentGroup.communityId,
+        userId,
+      );
+      if (!isCommAdminForArchive) {
+        throw new Error(
+          "Only community admins can archive or unarchive groups",
+        );
+      }
+    }
+
     // Filter out undefined values
     const cleanedUpdates = Object.fromEntries(
       Object.entries(updates).filter(([, val]) => val !== undefined)

--- a/apps/mobile/app/(user)/dev/task-reminder-tester.tsx
+++ b/apps/mobile/app/(user)/dev/task-reminder-tester.tsx
@@ -63,9 +63,7 @@ export default function TaskReminderTesterPage() {
   // Filter to groups where user is a leader
   const leaderGroups = useMemo(() => {
     if (!groups) return [];
-    return groups.filter(
-      (g: any) => g.userRole === "leader" || g.userRole === "admin"
-    );
+    return groups.filter((g: any) => g.userRole === "leader");
   }, [groups]);
 
   // Get members of selected group

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/guests.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/guests.tsx
@@ -46,7 +46,7 @@ function GuestListPage() {
 
   const isLeader = React.useMemo(() => {
     if (!group) return false;
-    return group.userRole === "leader" || group.userRole === "admin";
+    return group.userRole === "leader";
   }, [group]);
 
   // Fetch meeting details using Convex

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/index.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/index.tsx
@@ -27,7 +27,7 @@ function EventDetailsPage() {
   // Check if current user is a leader based on userRole from Convex response
   const isLeader = React.useMemo(() => {
     if (!group) return false;
-    return group.userRole === "leader" || group.userRole === "admin";
+    return group.userRole === "leader";
   }, [group]);
 
   // Parse the event identifier

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/toolbar-settings.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/toolbar-settings.tsx
@@ -116,8 +116,8 @@ export default function ToolbarSettingsScreen() {
     }
   }, [group]);
 
-  // Check if user has access (leader/admin)
-  const canAccess = group?.userRole === "leader" || group?.userRole === "admin";
+  // Check if user has access (group leader)
+  const canAccess = group?.userRole === "leader";
 
   // Handle back navigation
   const handleBack = () => {

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
@@ -195,7 +195,7 @@ export default function ChannelMembersScreen() {
   const canManage = useMemo(() => {
     if (!channelData || !user) return false;
     const isOwner = channelData.role === "owner";
-    const isGroupLeader = channelData.userGroupRole === "leader" || channelData.userGroupRole === "admin";
+    const isGroupLeader = channelData.userGroupRole === "leader";
     return isOwner || isGroupLeader;
   }, [channelData, user]);
 
@@ -237,10 +237,8 @@ export default function ChannelMembersScreen() {
     // browse path is by channel-membership creation order — close enough
     // for pure visual grouping).
     const sortedMembers = [...(membersData?.members || [])].sort((a, b) => {
-      const aLeader =
-        a.groupRole === "leader" || a.groupRole === "admin" ? 0 : 1;
-      const bLeader =
-        b.groupRole === "leader" || b.groupRole === "admin" ? 0 : 1;
+      const aLeader = a.groupRole === "leader" ? 0 : 1;
+      const bLeader = b.groupRole === "leader" ? 0 : 1;
       return aLeader - bLeader;
     });
     const syncedItems: ListItem[] = sortedMembers.map((m) => ({
@@ -787,14 +785,34 @@ export default function ChannelMembersScreen() {
           (Leader Controls › PCO sync settings). Skipping the banner keeps
           this surface focused on member management. */}
 
-      {/* Members list (unified: synced members first, unsynced at bottom) */}
+      {/* Members list (unified: synced members first, unsynced at bottom).
+          For an announcement group viewed by a non-leader/admin, the
+          backend deliberately returns an empty roster (every community
+          member belongs to the announcement group, so exposing the full
+          list would be a directory leak). Without an explainer the
+          surface reads as "No Members" which is misleading — replace
+          with a restricted-view note. */}
       {unifiedList.length === 0 ? (
         <View style={styles.emptyContainer}>
           <Ionicons name="people-outline" size={64} color={colors.textTertiary} />
-          <Text style={[styles.emptyTitle, { color: colors.text }]}>No Members</Text>
-          <Text style={[styles.emptySubtitle, { color: colors.textSecondary }]}>
-            This channel has no members yet.
-          </Text>
+          {groupData?.isAnnouncementGroup && !canManage ? (
+            <>
+              <Text style={[styles.emptyTitle, { color: colors.text }]}>
+                Roster restricted
+              </Text>
+              <Text style={[styles.emptySubtitle, { color: colors.textSecondary }]}>
+                The full member list of an announcement group is visible
+                to leaders and community admins only.
+              </Text>
+            </>
+          ) : (
+            <>
+              <Text style={[styles.emptyTitle, { color: colors.text }]}>No Members</Text>
+              <Text style={[styles.emptySubtitle, { color: colors.textSecondary }]}>
+                This channel has no members yet.
+              </Text>
+            </>
+          )}
         </View>
       ) : (
         <FlatList

--- a/apps/mobile/components/ui/AdminViewNote.tsx
+++ b/apps/mobile/components/ui/AdminViewNote.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { View, Text, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+
+interface AdminViewNoteProps {
+  /** Disclaimer text. Keep short — one or two sentences, impersonal voice. */
+  text: string;
+  /**
+   * `card` (default): inset rounded note that sits in a section's flow.
+   * `banner`: full-bleed top banner with a hairline bottom border (use at
+   * the top of a screen below the header).
+   */
+  variant?: 'card' | 'banner';
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Small info note used to flag *asymmetric views* — when a community
+ * admin or group leader sees content that a regular member doesn't.
+ * Matches the existing pattern from `app/inbox/[groupId]/[channelSlug]/
+ * members.tsx` and the active-state hint card: outline info icon +
+ * `textSecondary` copy in a `surfaceSecondary` container.
+ *
+ * Voice convention (matches the codebase): impersonal, short, no period
+ * for one-liners; period when there's a second sentence. Examples:
+ *   - "Visible to community admins only"
+ *   - "Members don't see this address until they join."
+ */
+export function AdminViewNote({
+  text,
+  variant = 'card',
+  style,
+}: AdminViewNoteProps) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[
+        variant === 'card' ? styles.card : styles.banner,
+        {
+          backgroundColor: colors.surfaceSecondary,
+          borderColor: colors.border,
+        },
+        style,
+      ]}
+    >
+      <Ionicons
+        name="information-circle-outline"
+        size={16}
+        color={colors.textSecondary}
+        style={styles.icon}
+      />
+      <Text style={[styles.text, { color: colors.textSecondary }]}>
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  icon: {
+    marginTop: 1,
+    marginRight: 8,
+  },
+  text: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+});

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -41,6 +41,7 @@ import { useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Clipboard from "expo-clipboard";
 import { Avatar } from "@components/ui/Avatar";
+import { AdminViewNote } from "@components/ui/AdminViewNote";
 import { ConfirmModal } from "@components/ui/ConfirmModal";
 import { CustomModal } from "@components/ui/Modal";
 import { AutoChannelSettings } from "@features/channels";
@@ -209,10 +210,14 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   );
 
   const isLeader = useMemo(() => {
-    return (
-      channel?.userGroupRole === "leader" || channel?.userGroupRole === "admin"
-    );
+    return channel?.userGroupRole === "leader";
   }, [channel?.userGroupRole]);
+  // Backend `getChannelBySlug` allows leaders to open custom / PCO channels
+  // they're not members of (and the Leaders channel for any leader). When
+  // the viewer is on this screen *because* they're a leader and not because
+  // they're actually in the channel, surface that asymmetry.
+  const isMemberOfChannel = channel?.isMember === true;
+  const isViewingAsLeaderOnly = isLeader && !isMemberOfChannel;
 
   const channelType = (channel?.channelType ?? "custom") as ChannelType;
   const isMain = channelType === "main";
@@ -410,6 +415,16 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
         style={styles.scroll}
         contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 24 }]}
       >
+        {/* Asymmetric-view banner — only when the viewer is here because
+            they're a group leader and isn't actually a member of the
+            channel itself (custom / PCO disabled / Leaders for non-leader-channel-members). */}
+        {isViewingAsLeaderOnly && (
+          <AdminViewNote
+            variant="banner"
+            text="You can see this channel as a group leader. Members not in the channel don't see it."
+          />
+        )}
+
         {/* Hero */}
         <View style={styles.heroSection}>
           <View style={[styles.heroIconCircle, { backgroundColor: iconCfg.bg }]}>

--- a/apps/mobile/features/chat/components/ChatNavigation.tsx
+++ b/apps/mobile/features/chat/components/ChatNavigation.tsx
@@ -170,11 +170,11 @@ export const ChatToolbar = memo(function ChatToolbar({
   const token = useStoredAuthToken();
   const { colors: themeColors } = useTheme();
 
-  // Check if user is a leader/admin
-  const isLeaderOrAdmin = userRole === "leader" || userRole === "admin";
+  // Check if user is a group leader.
+  const isLeaderOrAdmin = userRole === "leader";
 
   // Fetch resources for this group
-  // Leaders/admins see ALL resources (to manage them), members see only visible ones
+  // Leaders see ALL resources (to manage them), members see only visible ones
   const allResources = useQuery(
     api.functions.groupResources.index.listByGroup,
     token && groupId && isLeaderOrAdmin

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -336,9 +336,7 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const isRoleLoading = groupDetails === undefined && groupData === undefined;
   const isUserLeader =
     groupDetails?.userRole === "leader" ||
-    groupDetails?.userRole === "admin" ||
     groupData?.userRole === "leader" ||
-    groupData?.userRole === "admin" ||
     // While loading, show leaders tab if navigating to leaders channel (avoids flash)
     (isRoleLoading && channelTypeParam === "leaders") ||
     false;

--- a/apps/mobile/features/chat/components/ThreadPage.tsx
+++ b/apps/mobile/features/chat/components/ThreadPage.tsx
@@ -71,9 +71,7 @@ export function ThreadPage({
   // leader/admin role concept — `useGroupDetails` is called with undefined
   // (skipped inside the hook) and `isUserLeader` stays false.
   const { data: groupDetails } = useGroupDetails(groupId);
-  const isUserLeader =
-    groupDetails?.user_role === "leader" ||
-    groupDetails?.user_role === "admin";
+  const isUserLeader = groupDetails?.user_role === "leader";
   // Community admins can delete any message in groups within their community
   const isCommunityAdmin = user?.is_admin === true;
 

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -68,7 +68,11 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
 
-  const isLeader = userRole === "leader" || userRole === "admin";
+  // The legacy `groupMembers.role === "admin"` enum is no longer assigned
+  // by the backend (only "member" / "leader" exist). The defensive `||
+  // "admin"` checks scattered through the app are dead — drop them as we
+  // touch each surface.
+  const isLeader = userRole === "leader";
 
   const pendingInvites = useQuery(
     api.functions.messaging.sharedChannels.listPendingInvitesForGroup,
@@ -236,7 +240,7 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
       name: channel.name,
       subtitle: enabled
         ? `${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""}`
-        : "Hidden from members",
+        : "Hidden — visible to leaders",
       enabled,
       onPress: () => navigateToChannelInfo(channel.slug),
       unreadCount: channel.unreadCount,

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -113,8 +113,7 @@ export function GroupDetailScreen() {
   }, [group, user?.id, userData?.group_memberships]);
 
   const isAdmin = user?.is_admin === true;
-  const isLeader =
-    group?.user_role === "leader" || group?.user_role === "admin";
+  const isLeader = group?.user_role === "leader";
   const canEditGroup = useMemo(() => {
     if (!group || !user?.id) return false;
     if (user.is_admin === true) return true;

--- a/apps/mobile/features/groups/components/GroupNonMemberView.tsx
+++ b/apps/mobile/features/groups/components/GroupNonMemberView.tsx
@@ -14,6 +14,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { Avatar } from "@components/ui";
+import { AdminViewNote } from "@components/ui/AdminViewNote";
 import { GroupHeader } from "./GroupHeader";
 import { MembersRow } from "./MembersRow";
 import { HighlightsGrid } from "./HighlightsGrid";
@@ -222,7 +223,9 @@ export function GroupNonMemberView({
         )}
 
         {/* LOCATION — admin-only. Address is sensitive for non-members so
-            the row stays gated. Matches the member view's DETAILS card. */}
+            the row stays gated. The disclaimer makes the asymmetry
+            explicit so admins know the field doesn't show to people
+            outside the group. Matches the member view's DETAILS card. */}
         {isAdmin && !!address && (
           <View style={sectionStyles.section}>
             <Text
@@ -263,6 +266,9 @@ export function GroupNonMemberView({
                   color={colors.textTertiary}
                 />
               </TouchableOpacity>
+            </View>
+            <View style={styles.adminNoteWrap}>
+              <AdminViewNote text="Address shown because you're a community admin. Members don't see it until they join." />
             </View>
           </View>
         )}
@@ -446,6 +452,11 @@ export function GroupNonMemberView({
                 </Container>
               );
             })()}
+            {isAdmin && (
+              <View style={styles.adminNoteWrap}>
+                <AdminViewNote text="Full roster shown because you're a community admin. Non-members see only public previews." />
+              </View>
+            )}
           </View>
         )}
 
@@ -521,6 +532,9 @@ const styles = StyleSheet.create({
   },
   spacer: {
     height: 20,
+  },
+  adminNoteWrap: {
+    marginTop: 8,
   },
   // Leaders horizontal scroll lives inside the section card.
   leadersScrollContent: {

--- a/apps/mobile/features/groups/components/GroupOptionsModal.tsx
+++ b/apps/mobile/features/groups/components/GroupOptionsModal.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "@providers/AuthProvider";
 import { Group } from "../types";
 import { DOMAIN_CONFIG } from "@togather/shared";
 import { useTheme } from "@hooks/useTheme";
+import { AdminViewNote } from "@components/ui/AdminViewNote";
 import * as Clipboard from "expo-clipboard";
 
 const { height: SCREEN_HEIGHT } = Dimensions.get("window");
@@ -135,23 +136,25 @@ export function GroupOptionsModal({
 
   // Check if current user is a leader or community admin
   // Community admins (user.is_admin === true) can edit any group in their community
-  const canEditGroup = useMemo(() => {
+  const isCommunityAdmin = user?.is_admin === true;
+  const isGroupLeader = useMemo(() => {
     if (!group || !user?.id) return false;
+    // Compare as strings since user.id is a Convex ID string.
+    return (
+      group.leaders?.some(
+        (leader) => String(leader.id) === String(user.id),
+      ) || false
+    );
+  }, [group, user?.id]);
+  const canEditGroup = isCommunityAdmin || isGroupLeader;
+  // True when the viewer can edit only because they're a community admin
+  // (not because they lead the group). Used to surface the asymmetric
+  // affordance to the user.
+  const isEditingAsAdminOnly = canEditGroup && isCommunityAdmin && !isGroupLeader;
 
-    // Check if user is a community admin
-    const isCommunityAdmin = user.is_admin === true;
-
-    // Check if user is a group leader
-    // Compare as strings since user.id is now a Convex ID string
-    const isGroupLeader = group.leaders?.some((leader) => String(leader.id) === String(user.id)) || false;
-
-    return isCommunityAdmin || isGroupLeader;
-  }, [group, user?.id, user?.is_admin]);
-
-  // Only community admins can archive groups
-  const canArchiveGroup = useMemo(() => {
-    return user?.is_admin === true;
-  }, [user?.is_admin]);
+  // Only community admins can archive groups (matches backend gate in
+  // `groups/mutations.update` — leaders are blocked by the API).
+  const canArchiveGroup = isCommunityAdmin;
 
   const handleArchiveGroup = () => {
     if (onArchiveGroup) {
@@ -193,27 +196,39 @@ export function GroupOptionsModal({
             )}
 
             {canEditGroup && (
-              <TouchableOpacity
-                style={[styles.optionButton, styles.editButton]}
-                onPress={handleEditGroup}
-                disabled={isLeaving || isArchiving}
-              >
-                <Text style={styles.editButtonText}>Edit Group</Text>
-              </TouchableOpacity>
+              <>
+                <TouchableOpacity
+                  style={[styles.optionButton, styles.editButton]}
+                  onPress={handleEditGroup}
+                  disabled={isLeaving || isArchiving}
+                >
+                  <Text style={styles.editButtonText}>Edit Group</Text>
+                </TouchableOpacity>
+                {isEditingAsAdminOnly && (
+                  <View style={styles.disclaimerWrap}>
+                    <AdminViewNote text="Editing this group as a community admin." />
+                  </View>
+                )}
+              </>
             )}
 
             {canArchiveGroup && !group?.is_announcement_group && (
-              <TouchableOpacity
-                style={[styles.optionButton, styles.archiveButton]}
-                onPress={handleArchiveGroup}
-                disabled={isLeaving || isArchiving}
-              >
-                {isArchiving ? (
-                  <ActivityIndicator color="#ffffff" size="small" />
-                ) : (
-                  <Text style={styles.archiveButtonText}>Archive Group</Text>
-                )}
-              </TouchableOpacity>
+              <>
+                <TouchableOpacity
+                  style={[styles.optionButton, styles.archiveButton]}
+                  onPress={handleArchiveGroup}
+                  disabled={isLeaving || isArchiving}
+                >
+                  {isArchiving ? (
+                    <ActivityIndicator color="#ffffff" size="small" />
+                  ) : (
+                    <Text style={styles.archiveButtonText}>Archive Group</Text>
+                  )}
+                </TouchableOpacity>
+                <View style={styles.disclaimerWrap}>
+                  <AdminViewNote text="Archiving cascades to all channels and members. Community admins only." />
+                </View>
+              </>
             )}
 
             {group?.is_announcement_group ? (
@@ -281,6 +296,11 @@ const styles = StyleSheet.create({
   },
   modalContent: {
     gap: 12,
+  },
+  disclaimerWrap: {
+    // Pulls the disclaimer up against the button it explains so the
+    // pairing reads as one row, not two stacked items.
+    marginTop: -4,
   },
   optionButton: {
     paddingVertical: 18,

--- a/apps/mobile/features/leader-tools/components/EventDetails.tsx
+++ b/apps/mobile/features/leader-tools/components/EventDetails.tsx
@@ -23,6 +23,7 @@ import { useQuery, useAuthenticatedMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { Avatar } from "@components/ui/Avatar";
 import { AppImage } from "@components/ui/AppImage";
+import { AdminViewNote } from "@components/ui/AdminViewNote";
 import { CommunityWideBadge } from "@components/ui/CommunityWideBadge";
 import { SeriesBadge } from "@components/ui/SeriesBadge";
 import { FloatingRsvpButtons } from "./FloatingRsvpButtons";
@@ -94,6 +95,17 @@ export function EventDetails({
     const hosts = ((meeting as any)?.hostUserIds as string[] | undefined) ?? [];
     return hosts.some((id) => String(id) === String(user.id));
   })();
+
+  // Community admins can manage events even when they aren't a leader of
+  // the hosting group — backend `canEditMeeting` (and `eventBlasts`) allow
+  // them. Treat them as having leader-level affordances here so they can
+  // actually act on what the API permits.
+  const isCommunityAdmin = user?.is_admin === true;
+  const canManageEvent = isLeader || isCreator || isCommunityAdmin;
+  // Show "you're seeing this as community admin" disclaimer only when the
+  // viewer is acting via admin role, not via being a leader/host of this
+  // group/event.
+  const isViewingAsAdminOnly = isCommunityAdmin && !isLeader && !isCreator;
 
   // Fetch RSVPs for the meeting (using Convex)
   const rsvpsRaw = useQuery(
@@ -370,7 +382,7 @@ export function EventDetails({
         >
           <Ionicons name="flag-outline" size={20} color={colors.text} />
         </TouchableOpacity>
-        {(isLeader || isCreator) && (
+        {canManageEvent && (
           <TouchableOpacity
             testID="edit-button"
             style={[styles.editButton, { backgroundColor: colors.surfaceSecondary }]}
@@ -393,6 +405,15 @@ export function EventDetails({
           </View>
         ) : (
           <>
+            {/* Admin-mode banner — only when the viewer's elevated access
+                comes from being a community admin (not from leading the
+                hosting group or hosting the event itself). */}
+            {isViewingAsAdminOnly && (
+              <View style={styles.adminNoteWrap}>
+                <AdminViewNote text="You're managing this event as a community admin." />
+              </View>
+            )}
+
             {/* Cover Image */}
             {displayCoverImage ? (
               <AppImage
@@ -587,8 +608,8 @@ export function EventDetails({
               </View>
             )}
 
-            {/* Leader-only toggle (creators always get notified; see sender). */}
-            {isLeader && rsvpEnabled && (
+            {/* Leader/admin-only toggle (creators always get notified; see sender). */}
+            {canManageEvent && rsvpEnabled && (
               <View style={[styles.detailCard, { backgroundColor: colors.surface }]}>
                 <View style={styles.detailRow}>
                   <Ionicons name="notifications-outline" size={20} color={colors.textSecondary} />
@@ -702,8 +723,11 @@ export function EventDetails({
             )}
 
             {/* Host actions: Message Attendees + Blast History. Available to
-                creators too (ADR-022) — backend enforces. */}
-            {(isLeader || isCreator) && (
+                creators too (ADR-022). Backend `canEditMeeting` also allows
+                community admins (`eventBlasts.ts` enforces), so the UI
+                opens to them as well — matched here so the affordance
+                isn't hidden from someone the API permits. */}
+            {canManageEvent && (
               <TouchableOpacity
                 style={[styles.messageAttendeesButton, { backgroundColor: colors.surface }]}
                 onPress={() => setShowBlastSheet(true)}
@@ -715,7 +739,7 @@ export function EventDetails({
               </TouchableOpacity>
             )}
 
-            {(isLeader || isCreator) && meetingId && (
+            {canManageEvent && meetingId && (
               <EventBlastHistory meetingId={meetingId} />
             )}
 
@@ -820,7 +844,7 @@ export function EventDetails({
       </Modal>
 
       {/* Event Blast Sheet */}
-      {isLeader && (
+      {canManageEvent && (
         <EventBlastSheet
           visible={showBlastSheet}
           meetingId={meetingId}
@@ -885,6 +909,9 @@ const styles = StyleSheet.create({
   contentContainer: {
     padding: 20,
     paddingBottom: 180, // Space for floating RSVP buttons
+  },
+  adminNoteWrap: {
+    marginBottom: 12,
   },
   sectionTitle: {
     fontSize: 12,

--- a/apps/mobile/features/leader-tools/components/EventDetails.tsx
+++ b/apps/mobile/features/leader-tools/components/EventDetails.tsx
@@ -608,8 +608,13 @@ export function EventDetails({
               </View>
             )}
 
-            {/* Leader/admin-only toggle (creators always get notified; see sender). */}
-            {canManageEvent && rsvpEnabled && (
+            {/* Leader-only toggle. Backend `toggleRsvpLeaderNotifications`
+                is strictly leader-only per ADR-022 — this controls whose
+                notifications fire (the group leaders'), so creators and
+                community admins shouldn't be able to silence them.
+                Creators always get notified via `notifyRsvpReceived` and
+                don't need a toggle here. */}
+            {isLeader && rsvpEnabled && (
               <View style={[styles.detailCard, { backgroundColor: colors.surface }]}>
                 <View style={styles.detailRow}>
                   <Ionicons name="notifications-outline" size={20} color={colors.textSecondary} />

--- a/apps/mobile/features/leader-tools/components/MembersScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/MembersScreen.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "@providers/AuthProvider";
 import { MemberSearch, CommunityMember } from "@components/ui";
 import { formatError } from "@/utils/error-handling";
 import { DragHandle } from "@components/ui/DragHandle";
+import { AdminViewNote } from "@components/ui/AdminViewNote";
 import { useTheme } from "@hooks/useTheme";
 
 export function MembersScreen() {
@@ -35,8 +36,13 @@ export function MembersScreen() {
 
   // Check if user is an admin or leader of this group
   const isAdmin = user?.is_admin === true;
-  const isGroupLeader = group?.userRole === 'leader' || group?.userRole === 'admin';
+  const isGroupLeader = group?.userRole === 'leader';
   const canManageMembers = isAdmin || isGroupLeader;
+  // True when the viewer is here only because they're a community admin
+  // (not a member or leader of this specific group). Surfacing this lets
+  // them know their access is asymmetric — regular leaders/members see
+  // the same screen but only when they're in the group.
+  const isManagingAsAdminOnly = isAdmin && !isGroupLeader;
 
   // State for showing/hiding the add member section
   const [showAddMember, setShowAddMember] = useState(false);
@@ -136,6 +142,15 @@ export function MembersScreen() {
           </TouchableOpacity>
         )}
       </View>
+
+      {/* Admin-mode banner — only when managing via community-admin role
+          rather than being a leader of this specific group. */}
+      {isManagingAsAdminOnly && (
+        <AdminViewNote
+          variant="banner"
+          text="You're managing this group's members as a community admin."
+        />
+      )}
 
       {/* Add Member Search (Admins and Leaders) */}
       {canManageMembers && showAddMember && (

--- a/apps/mobile/features/leader-tools/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/RunSheetScreen.tsx
@@ -469,7 +469,7 @@ export function RunSheetScreen({
 
   // Check if user can access settings (group leader/admin or community admin)
   const isAdmin = user?.is_admin === true;
-  const isGroupLeader = groupData?.userRole === "leader" || groupData?.userRole === "admin";
+  const isGroupLeader = groupData?.userRole === "leader";
   const canAccessSettings = isAdmin || isGroupLeader;
 
   // Extract available roles from notes

--- a/apps/mobile/features/leader-tools/hooks/useGroupLeaderTools.ts
+++ b/apps/mobile/features/leader-tools/hooks/useGroupLeaderTools.ts
@@ -176,7 +176,7 @@ export function useGroupLeaderTools(groupId: string) {
           groupName: userGroup.name || "",
           groupType: userGroup.groupTypeId || "",
           groupTypeSlug: userGroup.groupTypeSlug || "",
-          isLeader: (userGroup.userRole === 'leader' || userGroup.userRole === 'admin') ? "1" : "0",
+          isLeader: userGroup.userRole === 'leader' ? "1" : "0",
           leadersChannelId: userGroup.leadersChannelId || "",
         },
       });

--- a/apps/mobile/features/leader-tools/hooks/useLeaderGroups.ts
+++ b/apps/mobile/features/leader-tools/hooks/useLeaderGroups.ts
@@ -45,11 +45,13 @@ export function useLeaderGroups() {
   const isLoading = groupsData === undefined;
   const error = null; // Convex throws on error, handle with ErrorBoundary
 
-  // Backend returns role as string: "member", "leader", "admin"
+  // Backend assigns "member" or "leader" only — the legacy "admin" enum
+  // is no longer produced. Keep the MembershipRole.LEADER comparison for
+  // any callers that still pass the typed enum.
   const leaderGroups = useMemo(() => {
     return groups?.filter(
       (group: any) =>
-        group.role === "leader" || group.role === "admin" || group.role === MembershipRole.LEADER
+        group.role === "leader" || group.role === MembershipRole.LEADER
     ) || [];
   }, [groups]);
 

--- a/apps/mobile/features/tasks/components/TasksTabScreen.tsx
+++ b/apps/mobile/features/tasks/components/TasksTabScreen.tsx
@@ -239,9 +239,7 @@ export function TasksTabScreen() {
   ) as Array<{ _id: string; name: string; userRole?: string }> | undefined;
 
   const leaderGroups = useMemo(() => {
-    return (groups ?? []).filter(
-      (group) => group.userRole === "leader" || group.userRole === "admin",
-    );
+    return (groups ?? []).filter((group) => group.userRole === "leader");
   }, [groups]);
 
   const hasLeaderAccess = useAuthenticatedQuery(


### PR DESCRIPTION
## Summary

Audit-driven fix for the asymmetric-view problem you flagged: as a community admin you could see things regular members can't (group address, full member roster, leader tools), but the UI gave no signal that the view was elevated. Two real backend↔UI permission mismatches got rolled in too.

### A. Permission-mismatch fixes (real bugs)

1. **Event Blast button hidden from community admins.** `EventDetails.tsx` gated on `isLeader`, but `eventBlasts.ts` allows leaders + community admins. Admins couldn't send blasts the API permitted. Extend UI to `canManageEvent = isLeader || isCreator || user.is_admin`.
2. **Archive Group: backend permissive, UI restrictive.** UI gated on `user.is_admin === true`; backend used `requireGroupLeaderOrCommunityAdmin`, so a leader could call `update({ isArchived: true })` directly. Tightened the backend so `isArchived` flips require community admin specifically — archive cascades to all channels + members, that's a community-wide action. UI gate stays.

### B. Asymmetric-view disclaimers

New `<AdminViewNote />` primitive (`components/ui/AdminViewNote.tsx`) matching the existing info-note pattern (`members.tsx` PCO sync explainer + `active-state.tsx` Leaders-channel hint). Voice: impersonal, short — matches the codebase's convention.

Wired into:
- **`GroupNonMemberView` LOCATION row** — "Address shown because you're a community admin. Members don't see it until they join."
- **`GroupNonMemberView` MEMBERS card** — "Full roster shown because you're a community admin. Non-members see only public previews."
- **`GroupOptionsModal` Edit Group button** — "Editing this group as a community admin." (only when admin-not-leader)
- **`GroupOptionsModal` Archive Group button** — "Archiving cascades to all channels and members. Community admins only."
- **leader-tools `MembersScreen`** — banner: "You're managing this group's members as a community admin." (only when admin-not-leader)
- **`ChannelInfoScreen`** — banner: "You can see this channel as a group leader. Members not in the channel don't see it." (only when leader && !channel.isMember)
- **`EventDetails`** — banner: "You're managing this event as a community admin." (only when admin-not-leader-not-host)
- **Channel members empty state for announcement groups** — replaces the silent "0 members" with "Roster restricted — visible to leaders and community admins only" when a non-leader/admin lands on the screen.
- **`ChannelsSection`** disabled-channel subtitle: "Hidden from members" → "Hidden — visible to leaders".

### C. Stale `groupMembers.role === "admin"` cleanup

You called out that there's no group-admin role — the legacy enum value isn't produced by the backend anymore. Defensive `role === "admin"` checks were scattered across **15 files** as part of OR clauses; none reachable in production. Removed all of them so future readers don't infer a third group role exists.

### Verification

- **564 / 565 tests pass** across `features/groups`, `features/chat`, `features/leader-tools` (1 skipped, pre-existing).
- Mobile typecheck clean for changed files; the only remaining TS noise (`TasksTabScreen.helpers.test.ts`) is pre-existing on `origin/main`.

### Test plan

- [ ] As a community admin not in a group, navigate to that group's page. Address card shows the disclaimer. Members card (when full roster renders) shows the disclaimer.
- [ ] Open the group options modal as community-admin-not-leader → "Editing as a community admin." note appears under Edit Group.
- [ ] Archive Group note appears for any admin who sees the button.
- [ ] As a community admin not in a group, navigate to that group's leader-tools members screen → banner "You're managing this group's members as a community admin."
- [ ] As a leader, open a custom channel you aren't a member of → banner "You can see this channel as a group leader."
- [ ] As community admin not in the hosting group, open an event → "You're managing this event as a community admin." banner; Text Blast button is now visible (was previously hidden).
- [ ] As a regular community member, open the announcement group's main channel members screen → "Roster restricted — visible to leaders and community admins only" instead of "0 members".
- [ ] Try archive flow as a group leader (non-admin) — backend should reject with "Only community admins can archive or unarchive groups".
- [ ] All previously-merged PR #369 + #370 behaviors still work (member view layout + back button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)