### PR TITLE
feat(notifications): extend slashed-bell badge to admin + leader-tools surfaces

### DIFF
--- a/apps/convex/functions/admin/members.ts
+++ b/apps/convex/functions/admin/members.ts
@@ -146,20 +146,9 @@ export const searchCommunityMembers = query({
       profilePhoto: string | null;
       isAdmin: boolean;
       role: number;
-      notificationsDisabled: boolean;
       communityLastLogin: number;
       appLastLogin: number;
     }> = [];
-
-    // Batched notif-disabled lookup so each row can show the slashed-bell.
-    const candidateUserIds = allResults
-      .map((u, i) => ({ user: u, membership: memberships[i] }))
-      .filter(({ membership }) => membership && membership.status !== 3)
-      .map(({ user }) => user._id);
-    const notifsDisabled = await getUsersWithNotificationsDisabled(
-      ctx,
-      candidateUserIds,
-    );
 
     for (let i = 0; i < allResults.length; i++) {
       const user = allResults[i];
@@ -177,7 +166,6 @@ export const searchCommunityMembers = query({
         profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
         isAdmin: (membership.roles ?? 0) >= ADMIN_ROLE_THRESHOLD,
         role: membership.roles ?? COMMUNITY_ROLES.MEMBER,
-        notificationsDisabled: notifsDisabled.has(user._id),
         communityLastLogin: membership.lastLogin ?? 0,
         appLastLogin: user.lastLogin ?? 0,
       });
@@ -193,8 +181,22 @@ export const searchCommunityMembers = query({
       return b.appLastLogin - a.appLastLogin;
     });
 
-    // Take only the requested limit and remove sort fields from response
-    const limitedMatches = matches.slice(0, limit).map(({ communityLastLogin, appLastLogin, ...rest }) => rest);
+    // Slice to the response limit BEFORE looking up notif-disabled status —
+    // pushTokens reads should scale with the number of rows we're actually
+    // returning, not with how many candidates the search index pulled
+    // back (up to 500). For broad queries this avoids hundreds of extra
+    // reads per keystroke (codex review #372).
+    const sliced = matches.slice(0, limit);
+    const sliceNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      sliced.map((m) => m.id),
+    );
+    const limitedMatches = sliced.map(
+      ({ communityLastLogin, appLastLogin, ...rest }) => ({
+        ...rest,
+        notificationsDisabled: sliceNotifsDisabled.has(rest.id),
+      }),
+    );
 
     return {
       members: limitedMatches,

--- a/apps/convex/functions/admin/members.ts
+++ b/apps/convex/functions/admin/members.ts
@@ -13,6 +13,7 @@ import { query, mutation } from "../../_generated/server";
 import { now, normalizePhone, getMediaUrl } from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
 import { searchCommunityMembersPaginated } from "../../lib/memberSearch";
+import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 import { syncAnnouncementGroupMembership } from "../sync/memberships";
 import {
   requireCommunityAdmin,
@@ -145,9 +146,20 @@ export const searchCommunityMembers = query({
       profilePhoto: string | null;
       isAdmin: boolean;
       role: number;
+      notificationsDisabled: boolean;
       communityLastLogin: number;
       appLastLogin: number;
     }> = [];
+
+    // Batched notif-disabled lookup so each row can show the slashed-bell.
+    const candidateUserIds = allResults
+      .map((u, i) => ({ user: u, membership: memberships[i] }))
+      .filter(({ membership }) => membership && membership.status !== 3)
+      .map(({ user }) => user._id);
+    const notifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      candidateUserIds,
+    );
 
     for (let i = 0; i < allResults.length; i++) {
       const user = allResults[i];
@@ -165,6 +177,7 @@ export const searchCommunityMembers = query({
         profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
         isAdmin: (membership.roles ?? 0) >= ADMIN_ROLE_THRESHOLD,
         role: membership.roles ?? COMMUNITY_ROLES.MEMBER,
+        notificationsDisabled: notifsDisabled.has(user._id),
         communityLastLogin: membership.lastLogin ?? 0,
         appLastLogin: user.lastLogin ?? 0,
       });
@@ -284,6 +297,10 @@ export const getCommunityMemberById = query({
     const attendedCount = communityAttendances.filter((a) => a.status === 1).length;
     const attendanceRate = totalAttendance > 0 ? (attendedCount / totalAttendance) * 100 : 0;
 
+    const notifsDisabled = await getUsersWithNotificationsDisabled(ctx, [
+      user._id,
+    ]);
+
     return {
       id: user._id,
       firstName: user.firstName || "",
@@ -292,6 +309,7 @@ export const getCommunityMemberById = query({
       phone: user.phone || null,
       phoneVerified: user.phoneVerified || false,
       profilePhoto: getMediaUrl(user.profilePhoto),
+      notificationsDisabled: notifsDisabled.has(user._id),
       dateOfBirth: user.dateOfBirth || null,
       lastLogin: communityMembership.lastLogin || null,
       communityMembership: {

--- a/apps/convex/lib/memberSearch.ts
+++ b/apps/convex/lib/memberSearch.ts
@@ -14,6 +14,7 @@ import type { QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { getMediaUrl, normalizePhone } from "./utils";
 import { COMMUNITY_ADMIN_THRESHOLD, PRIMARY_ADMIN_ROLE } from "./permissions";
+import { getUsersWithNotificationsDisabled } from "./notifications/enabledStatus";
 
 /**
  * Base member result returned by search
@@ -26,6 +27,13 @@ export interface MemberSearchResult {
   phone: string | null;
   profilePhoto: string | null;
   isAdmin: boolean;
+  /**
+   * True when the user has no push tokens for the current environment —
+   * UI surfaces overlay a slashed-bell badge on the avatar so admins know
+   * the person won't get an immediate push for any action they take.
+   * Truth source: `pushTokens` (see `lib/notifications/enabledStatus.ts`).
+   */
+  notificationsDisabled: boolean;
 }
 
 /**
@@ -314,9 +322,28 @@ export async function searchCommunityMembersInternal(
   );
   const memberships = await Promise.all(membershipPromises);
 
+  // Pre-compute the candidate set so we can batch the notif-disabled
+  // lookup once for the whole result. The loop below filters again with
+  // the limit, but the extra IDs collected here are negligible.
+  const candidateUserIds: Id<"users">[] = [];
+  const usersArray = Array.from(allMatchingUsers.values());
+  for (let i = 0; i < usersArray.length; i++) {
+    const user = usersArray[i];
+    const membership = memberships[i];
+    if (!membership) continue;
+    if (excludeIds.has(user._id)) continue;
+    if (excludedGroupUserIds?.has(user._id)) continue;
+    if (targetUserIds && !targetUserIds.has(user._id)) continue;
+    candidateUserIds.push(user._id);
+    if (candidateUserIds.length >= limit) break;
+  }
+  const notifsDisabled = await getUsersWithNotificationsDisabled(
+    ctx,
+    candidateUserIds,
+  );
+
   // Build results for users who are community members
   const results: (MemberSearchResult | AdminMemberSearchResult)[] = [];
-  const usersArray = Array.from(allMatchingUsers.values());
 
   for (let i = 0; i < usersArray.length; i++) {
     if (results.length >= limit) break;
@@ -346,6 +373,7 @@ export async function searchCommunityMembersInternal(
       phone: user.phone || null,
       profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
       isAdmin,
+      notificationsDisabled: notifsDisabled.has(user._id),
     };
 
     if (includeAdminFields) {
@@ -419,6 +447,13 @@ export async function searchCommunityMembersPaginated(
       users.filter((u): u is NonNullable<typeof u> => u !== null).map((u) => [u._id, u])
     );
 
+    // Look up notif-disabled status for the page in one batched call so
+    // each row can render the slashed-bell badge.
+    const pageNotifsDisabled = await getUsersWithNotificationsDisabled(
+      ctx,
+      pageMemberships.map((m) => m.userId),
+    );
+
     // Build results - NO group counts (shown in detail view only for speed)
     const results: AdminMemberSearchResult[] = [];
     for (const membership of pageMemberships) {
@@ -438,6 +473,7 @@ export async function searchCommunityMembersPaginated(
         role: membership.roles ?? 0,
         lastLogin: membership.lastLogin || null,
         groupsCount: 0, // Not fetched in list view for performance - see detail view
+        notificationsDisabled: pageNotifsDisabled.has(user._id),
       });
     }
 
@@ -533,6 +569,13 @@ export async function searchCommunityMembersPaginated(
   // Apply pagination
   const paginatedMembers = matchingMembers.slice(skip, skip + pageSize);
 
+  // Look up notif-disabled status for the page in one batched call so
+  // each row can render the slashed-bell badge.
+  const filteredNotifsDisabled = await getUsersWithNotificationsDisabled(
+    ctx,
+    paginatedMembers.map(({ user }) => user._id),
+  );
+
   // Build results - NO group counts for performance (shown in detail view)
   const results: AdminMemberSearchResult[] = paginatedMembers.map(({ user, membership }) => {
     const isAdmin = (membership.roles ?? 0) >= COMMUNITY_ADMIN_THRESHOLD;
@@ -548,6 +591,7 @@ export async function searchCommunityMembersPaginated(
       role: membership.roles ?? 0,
       lastLogin: membership.lastLogin || null,
       groupsCount: 0, // Not fetched in list view for performance - see detail view
+      notificationsDisabled: filteredNotifsDisabled.has(user._id),
     };
   });
 

--- a/apps/mobile/components/ui/ChannelMemberRows.tsx
+++ b/apps/mobile/components/ui/ChannelMemberRows.tsx
@@ -10,6 +10,7 @@ import React, { ReactNode } from "react";
 import { View, Text, StyleSheet, Image } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
+import { NotificationsDisabledBadge } from "@components/ui/NotificationsDisabledBadge";
 import type { ChannelMember, UnsyncedPerson } from "@/utils/channel-members";
 import { getDebugReasonText } from "@/utils/channel-members";
 
@@ -58,7 +59,9 @@ export function SyncedMemberRowContent({
 
   return (
     <>
-      {/* Avatar */}
+      {/* Avatar — wrapped in a relatively-positioned container so the
+          notifications-disabled badge can overlay the bottom-right corner
+          (same pattern used by `<Avatar>` in `components/ui/Avatar.tsx`). */}
       <View style={styles.memberAvatar}>
         {member.profilePhoto ? (
           <Image source={{ uri: member.profilePhoto }} style={styles.avatarImage} />
@@ -67,6 +70,9 @@ export function SyncedMemberRowContent({
             <Text style={[styles.avatarInitials, { color: colors.textInverse }]}>{initials}</Text>
           </View>
         )}
+        {member.notificationsDisabled ? (
+          <NotificationsDisabledBadge avatarSize={44} />
+        ) : null}
       </View>
 
       {/* Name and badges */}
@@ -192,19 +198,23 @@ export function UnsyncedPersonRowContent({
 
 const styles = StyleSheet.create({
   memberAvatar: {
+    // No overflow:hidden on the wrapper so the notifications-disabled
+    // badge can peek past the bottom-right corner. The inner Image /
+    // placeholder owns the circular crop.
     width: 44,
     height: 44,
-    borderRadius: 22,
-    overflow: "hidden",
     marginRight: 12,
+    position: "relative",
   },
   avatarImage: {
     width: "100%",
     height: "100%",
+    borderRadius: 22,
   },
   avatarPlaceholder: {
     width: "100%",
     height: "100%",
+    borderRadius: 22,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/apps/mobile/components/ui/MemberSearch.tsx
+++ b/apps/mobile/components/ui/MemberSearch.tsx
@@ -39,6 +39,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { useMemberSearch, UseMemberSearchOptions, parseSearchTerms } from "@hooks/useMemberSearch";
+import { NotificationsDisabledBadge } from "@components/ui/NotificationsDisabledBadge";
 import type { CommunityMember } from "@/types/community";
 
 // Re-export types for convenience
@@ -144,6 +145,9 @@ function DefaultMemberItem({
             <Text style={[styles.avatarText, { color: colors.textInverse }]}>{initials}</Text>
           </View>
         )}
+        {member.notifications_disabled ? (
+          <NotificationsDisabledBadge avatarSize={48} />
+        ) : null}
       </View>
       <View style={styles.memberInfo}>
         <Text style={[styles.memberName, { color: colors.text }]} numberOfLines={1}>
@@ -543,19 +547,23 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   avatar: {
+    // Wrapper drops overflow:hidden so the slashed-bell badge can peek
+    // past the bottom-right corner; inner image/placeholder owns the
+    // circular crop.
     width: 44,
     height: 44,
-    borderRadius: 22,
     marginRight: 12,
-    overflow: "hidden",
+    position: "relative",
   },
   avatarImage: {
     width: "100%",
     height: "100%",
+    borderRadius: 22,
   },
   avatarPlaceholder: {
     width: "100%",
     height: "100%",
+    borderRadius: 22,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/apps/mobile/features/admin/components/PeopleContent.tsx
+++ b/apps/mobile/features/admin/components/PeopleContent.tsx
@@ -25,6 +25,7 @@ import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
+import { NotificationsDisabledBadge } from "@components/ui/NotificationsDisabledBadge";
 
 // Type for transformed community member (snake_case for compatibility)
 interface CommunityMember {
@@ -36,6 +37,7 @@ interface CommunityMember {
   profile_photo: string | null;
   is_admin: boolean;
   is_primary_admin: boolean;
+  notifications_disabled: boolean;
 }
 
 const PAGE_SIZE = 50;
@@ -111,6 +113,7 @@ export function PeopleContent() {
       profile_photo: m.profilePhoto,
       is_admin: m.isAdmin,
       is_primary_admin: false,
+      notifications_disabled: !!m.notificationsDisabled,
     }));
   }, [searchData?.members]);
 
@@ -129,6 +132,7 @@ export function PeopleContent() {
       profile_photo: m.profilePhoto,
       is_admin: m.isAdmin,
       is_primary_admin: m.isPrimaryAdmin,
+      notifications_disabled: !!m.notificationsDisabled,
     }));
   }, []);
 
@@ -420,6 +424,9 @@ function MemberCard({ member, onPress }: MemberCardProps) {
             <Text style={styles.avatarInitials}>{initials}</Text>
           </View>
         )}
+        {member.notifications_disabled ? (
+          <NotificationsDisabledBadge avatarSize={48} />
+        ) : null}
       </View>
       <View style={styles.memberInfo}>
         <View style={styles.memberNameRow}>
@@ -585,18 +592,22 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   memberAvatar: {
+    // overflow:hidden moved off the wrapper so the notifications-disabled
+    // badge can peek past the bottom-right corner — same pattern as the
+    // shared `<Avatar>` primitive.
     width: 56,
     height: 56,
-    borderRadius: 28,
-    overflow: "hidden",
+    position: "relative",
   },
   avatarImage: {
     width: "100%",
     height: "100%",
+    borderRadius: 28,
   },
   avatarPlaceholder: {
     width: "100%",
     height: "100%",
+    borderRadius: 28,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/apps/mobile/features/admin/components/PersonDetailScreen.tsx
+++ b/apps/mobile/features/admin/components/PersonDetailScreen.tsx
@@ -32,6 +32,7 @@ import { useAuth } from "@/providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { formatError } from "@/utils/error-handling";
+import { NotificationsDisabledBadge } from "@components/ui/NotificationsDisabledBadge";
 
 // Role constants (matching backend)
 const COMMUNITY_ROLES = {
@@ -84,6 +85,7 @@ export function PersonDetailScreen() {
         email: rawMember.email,
         phone: rawMember.phone,
         profile_photo: rawMember.profilePhoto,
+        notifications_disabled: !!(rawMember as any).notificationsDisabled,
         last_login: rawMember.lastLogin,
         created_at: rawMember.communityMembership?.joinedAt,
         is_admin: rawMember.communityMembership?.isAdmin ?? false,
@@ -388,6 +390,9 @@ export function PersonDetailScreen() {
                   <Text style={styles.avatarInitials}>{initials}</Text>
                 </View>
               )}
+              {member.notifications_disabled ? (
+                <NotificationsDisabledBadge avatarSize={80} />
+              ) : null}
             </View>
             <View style={styles.profileInfo}>
               <View style={styles.nameRow}>
@@ -793,18 +798,22 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   profileAvatar: {
+    // Wrapper drops overflow:hidden so the notifications-disabled badge
+    // can peek past the bottom-right corner. Inner image/placeholder
+    // owns the circular crop.
     width: 80,
     height: 80,
-    borderRadius: 40,
-    overflow: "hidden",
+    position: "relative",
   },
   avatarImage: {
     width: "100%",
     height: "100%",
+    borderRadius: 40,
   },
   avatarPlaceholder: {
     width: "100%",
     height: "100%",
+    borderRadius: 40,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -29,6 +29,7 @@ import { useSendMessage } from '../hooks/useConvexSendMessage';
 import { useConnectionStatus } from '@providers/ConnectionProvider';
 import { useTypingIndicators } from '../hooks/useTypingIndicators';
 import { useChannelMembers } from '../hooks/useChannelMembers';
+import { NotificationsDisabledBadge } from '@components/ui/NotificationsDisabledBadge';
 import { useLinkPreview } from '../hooks/useLinkPreview';
 import { LinkPreviewCard } from './LinkPreviewCard';
 import { FilePreview } from './FilePreview';
@@ -78,6 +79,7 @@ interface ChannelMember {
   userId: Id<"users">;
   displayName: string;
   profilePhoto?: string;
+  notificationsDisabled?: boolean;
 }
 
 interface MentionMatch {
@@ -906,18 +908,23 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
                 style={[styles.autocompleteItem, { borderBottomColor: themeColors.borderLight }]}
                 onPress={() => insertMention(item)}
               >
-                {item.profilePhoto ? (
-                  <Image
-                    source={{ uri: item.profilePhoto }}
-                    style={styles.autocompleteAvatar}
-                  />
-                ) : (
-                  <View style={[styles.autocompleteAvatar, styles.autocompleteAvatarPlaceholder]}>
-                    <Text style={styles.autocompleteAvatarText}>
-                      {item.displayName.charAt(0).toUpperCase()}
-                    </Text>
-                  </View>
-                )}
+                <View style={styles.autocompleteAvatarWrap}>
+                  {item.profilePhoto ? (
+                    <Image
+                      source={{ uri: item.profilePhoto }}
+                      style={styles.autocompleteAvatar}
+                    />
+                  ) : (
+                    <View style={[styles.autocompleteAvatar, styles.autocompleteAvatarPlaceholder]}>
+                      <Text style={styles.autocompleteAvatarText}>
+                        {item.displayName.charAt(0).toUpperCase()}
+                      </Text>
+                    </View>
+                  )}
+                  {item.notificationsDisabled ? (
+                    <NotificationsDisabledBadge avatarSize={32} />
+                  ) : null}
+                </View>
                 <Text style={[styles.autocompleteName, { color: themeColors.text }]}>{item.displayName}</Text>
               </Pressable>
             )}
@@ -1168,11 +1175,16 @@ const styles = StyleSheet.create({
     padding: 12,
     borderBottomWidth: 1,
   },
+  autocompleteAvatarWrap: {
+    width: 32,
+    height: 32,
+    marginRight: 12,
+    position: 'relative',
+  },
   autocompleteAvatar: {
     width: 32,
     height: 32,
     borderRadius: 16,
-    marginRight: 12,
   },
   autocompleteAvatarPlaceholder: {
     backgroundColor: '#007AFF',

--- a/apps/mobile/features/chat/components/StackedMemberAvatars.tsx
+++ b/apps/mobile/features/chat/components/StackedMemberAvatars.tsx
@@ -5,6 +5,8 @@ import { Avatar } from "@components/ui/Avatar";
 type StackMember = {
   name: string;
   imageUrl: string | null;
+  /** When true, the slashed-bell badge overlays this avatar in the stack. */
+  notificationsDisabled?: boolean;
 };
 
 type Props = {
@@ -32,7 +34,13 @@ export function StackedMemberAvatars({
     const m = visible[0]!;
     return (
       <View style={{ width: size, height: size }}>
-        <Avatar name={m.name} imageUrl={m.imageUrl ?? undefined} size={size} />
+        <Avatar
+          name={m.name}
+          imageUrl={m.imageUrl ?? undefined}
+          size={size}
+          notificationsDisabled={m.notificationsDisabled}
+          notificationsBadgeRingColor={surfaceColor}
+        />
       </View>
     );
   }

--- a/apps/mobile/features/chat/hooks/useChannelMembers.ts
+++ b/apps/mobile/features/chat/hooks/useChannelMembers.ts
@@ -12,6 +12,11 @@ interface ChannelMember {
   displayName: string;
   profilePhoto?: string;
   role: string;
+  /**
+   * Mirrors backend `getChannelMembers` so the @mention autocomplete and
+   * any other consumer can render the slashed-bell badge.
+   */
+  notificationsDisabled?: boolean;
 }
 
 interface UseChannelMembersResult {

--- a/apps/mobile/features/groups/components/MembersRow.tsx
+++ b/apps/mobile/features/groups/components/MembersRow.tsx
@@ -59,6 +59,8 @@ export function MembersRow({
                 imageUrl={member.profile_photo}
                 size={48}
                 placeholderBackgroundColor={colors.border}
+                notificationsDisabled={member.notificationsDisabled}
+                notificationsBadgeRingColor={colors.surfaceSecondary}
               />
               {isLeader && (
                 <View

--- a/apps/mobile/features/groups/hooks/useGroupDetails.ts
+++ b/apps/mobile/features/groups/hooks/useGroupDetails.ts
@@ -157,6 +157,7 @@ export function useGroupDetails(groupId: string | null | undefined) {
             last_name: m.user?.lastName || "",
             email: m.user?.email || "",
             profile_photo: m.user?.profileImage || undefined,
+            notificationsDisabled: !!m.user?.notificationsDisabled,
           })) || [],
         leaders:
           effectiveLeaders?.map((l: any) => ({
@@ -165,6 +166,7 @@ export function useGroupDetails(groupId: string | null | undefined) {
             last_name: l.lastName || "",
             email: l.email || "",
             profile_photo: l.profilePhoto || undefined,
+            notificationsDisabled: !!l.notificationsDisabled,
           })) || [],
         highlights: [], // Not yet available in Convex
       }
@@ -195,6 +197,7 @@ export function useGroupDetails(groupId: string | null | undefined) {
           last_name: m.lastName || "",
           profile_photo: m.profileImage || undefined,
           role: m.role || "member",
+          notificationsDisabled: !!m.notificationsDisabled,
         })) || [],
         // Leader preview — intentionally exposed to non-members so they can
         // DM a leader before joining the group. Capped at 8 by the backend.
@@ -204,6 +207,7 @@ export function useGroupDetails(groupId: string | null | undefined) {
           last_name: l.lastName || "",
           profile_photo: l.profileImage || undefined,
           role: l.role || "leader",
+          notificationsDisabled: !!l.notificationsDisabled,
         })) || [],
         leader_preview_total_count: effectiveLeaderPreview?.totalCount || 0,
       }

--- a/apps/mobile/features/groups/types.ts
+++ b/apps/mobile/features/groups/types.ts
@@ -103,6 +103,12 @@ export interface GroupMember {
   last_name: string;
   email?: string;
   profile_photo?: string;
+  /**
+   * True when the user has no push tokens for the current environment —
+   * used to render the slashed-bell badge on their avatar in `MembersRow`
+   * and other consumers. See `lib/notifications/enabledStatus.ts`.
+   */
+  notificationsDisabled?: boolean;
   // Request tracking fields
   request_status?: string | null;
   requested_at?: string | null;

--- a/apps/mobile/features/leader-tools/components/MemberItem.tsx
+++ b/apps/mobile/features/leader-tools/components/MemberItem.tsx
@@ -40,6 +40,7 @@ function MemberItemInner({
           name={`${member.first_name} ${member.last_name}`}
           imageUrl={member.profile_photo}
           size={40}
+          notificationsDisabled={!!member.notifications_disabled}
         />
         <View style={styles.memberDetails}>
           <Text style={[styles.memberName, { color: colors.text }]}>

--- a/apps/mobile/hooks/useMemberSearch.ts
+++ b/apps/mobile/hooks/useMemberSearch.ts
@@ -96,6 +96,7 @@ function transformMember(m: any): CommunityMember {
     is_admin: m.isAdmin ?? false,
     last_login: m.lastLogin ?? null,
     created_at: null, // Backend doesn't return this field
+    notifications_disabled: !!m.notificationsDisabled,
   };
 }
 

--- a/apps/mobile/types/community.ts
+++ b/apps/mobile/types/community.ts
@@ -21,6 +21,13 @@ export interface CommunityMember {
   is_admin: boolean;
   last_login: string | null;
   created_at: string | null;
+  /**
+   * True when the user has no push tokens for the current environment —
+   * UI surfaces overlay a slashed-bell badge on the avatar so admins/leaders
+   * know not to expect immediate delivery for any notification-emitting
+   * action they take. See `lib/notifications/enabledStatus.ts`.
+   */
+  notifications_disabled?: boolean;
 }
 
 /**

--- a/apps/mobile/utils/channel-members.ts
+++ b/apps/mobile/utils/channel-members.ts
@@ -16,6 +16,13 @@ export interface ChannelMember {
    * UI can show channel ownership and group leadership independently.
    */
   groupRole?: string;
+  /**
+   * True when the user has no push tokens for the current environment.
+   * UI surfaces overlay a slashed-bell badge on the avatar so senders
+   * know not to expect immediate delivery. Source: `pushTokens` (see
+   * `lib/notifications/enabledStatus.ts` on the server).
+   */
+  notificationsDisabled?: boolean;
   syncSource?: string;
   syncMetadata?: {
     serviceTypeName?: string;


### PR DESCRIPTION
## Summary

Following PR #368 which wired the notifications-disabled badge into chat surfaces and group-page member rows, you flagged that the **admin People tab** and **leader-tools members screen** weren't showing the badge. This PR closes those gaps + extends to adjacent member-management surfaces.

## What's wired now

### P0 (the screenshots you sent)

- **Admin People tab** (`PeopleContent.tsx` `MemberCard`) — every row in the community-wide member list. Backend: `searchCommunityMembers` / `listCommunityMembers` now embed `notificationsDisabled`.
- **Admin Person Detail screen** (`PersonDetailScreen.tsx` profile header avatar). Backend: `getCommunityMemberById`.
- **Leader-tools members screen** (`ChannelMemberRows.tsx` `SyncedMemberRowContent`) — used by both `/leader-tools/[group]/members` and channel-info member lists. Backend already returned the field from PR #368; this just plumbs it through the `ChannelMember` type and overlays the badge.

### P1 (adjacent member-management)

- **Group page MEMBERS preview** (`MembersRow.tsx`) — horizontal stacked avatars on the group detail page. Both full member rows and the public `member_preview` / `leader_preview` paths.
- **Add-member picker** (`MemberSearch.tsx` `DefaultMemberItem`) — used by admin add-member flows + leader-tools add-member.
- **Chat @mention autocomplete** (`MessageInput.tsx` dropdown).
- **Attendance member rows** (`MemberItem.tsx`).
- **Inbox 1:1 stacked-avatar fallback** (`StackedMemberAvatars.tsx`, single-member case).

## Backend changes

- `apps/convex/lib/memberSearch.ts` — `MemberSearchResult` shape gets `notificationsDisabled`. Both fast and filtered paths in `searchCommunityMembersPaginated`, plus the standalone `searchCommunityMembers`, do one batched `getUsersWithNotificationsDisabled(ids)` lookup per page.
- `apps/convex/functions/admin/members.ts` — inline `searchCommunityMembers` + `getCommunityMemberById` carry the field through.

## Avatar-wrapper fix

Several existing avatars used `overflow: "hidden"` + `borderRadius` on the wrapper to crop circular shape — that was clipping the slashed-bell at the corner. Changed to the same pattern as the shared `<Avatar>` primitive: drop `overflow:"hidden"` from the wrapper, move `borderRadius` to the inner Image/placeholder. The circle stays; the badge peeks past the corner. Applied in `ChannelMemberRows`, `PeopleContent`, `PersonDetailScreen`, and `MemberSearch`.

## Verification

- **635 / 636 mobile tests pass** (1 skipped, pre-existing)
- **1014 / 1023 convex tests pass** (9 skipped, pre-existing)
- Mobile + convex typecheck clean for changed files; remaining noise (`MessageInput.tsx` Timeout typing, `TasksTabScreen.helpers.test.ts` Id branding) is pre-existing on `origin/main`.

## Out of scope (note in PR; happy to follow up)

- **RSVP guest list** — `meetingRsvps.list` would need to return `notificationsDisabled`. ~10-line backend extension.
- **Multi-avatar stacks** in `StackedMemberAvatars` (2/3/4-cluster variants) — individual avatars get too small for a legible per-avatar badge. Could add a single cluster-level indicator if you want.
- **Thread-replies stacked replier avatars** — same multi-avatar caveat.
- **`HighlightsGrid`** — uses `AppImage` for highlight photos, not user avatars per se.

## Test plan

- [ ] Open Admin → People tab. Members with notifications disabled show the slashed-bell badge over their avatar.
- [ ] Tap a member to open the detail screen. Profile header avatar shows the badge if disabled.
- [ ] Open a group → members management (leader tools) → member rows show the badge.
- [ ] Open a channel info screen → member list shows the badge.
- [ ] On any group page, members with notifications disabled in the horizontal preview stack show the badge.
- [ ] In a chat, type `@` to trigger mention autocomplete; suggestions for users with notifications disabled show the badge.
- [ ] Add-member picker (admin search): search results show the badge.
- [ ] Attendance edit mode: member rows show the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)