### PR TITLE
fix(nav): break /groups self-redirect loop (Sentry: Maximum update depth)

### DIFF
--- a/apps/mobile/app/(tabs)/groups.tsx
+++ b/apps/mobile/app/(tabs)/groups.tsx
@@ -1,6 +1,6 @@
 import { Redirect } from 'expo-router';
 
 export default function GroupsTab() {
-  return <Redirect href="/groups" />;
+  return <Redirect href="/(tabs)/search" />;
 }
 


### PR DESCRIPTION
## Summary

Fix infinite redirect loop in `app/(tabs)/groups.tsx`. The route did `<Redirect href="/groups" />`, but with `(tabs)` being a group route and no `app/groups/index.tsx`, `/groups` resolved back to the same file → loop in `BottomTabNavigator > TabRouter.getStateForRouteFocus`.

Surface: **99 events / 36 unique users in 14 days** across iOS, Android, and web ([example user.id](https://sentry.io/organizations/supa-media/issues/?query=user.id%3Am97080zjjj84t0rv8esv6wbczs85vafa)).

## Root cause

`37e3a9e` ("Explore→Groups, add Events tab") repointed the visible "Groups" tab to the `search` route file (`<Tabs.Screen name="search" options={{ title: 'Groups' }} />`), leaving `(tabs)/groups.tsx` as a self-referential redirect.

## Trigger paths (5)

All five send users to `/groups`:

1. `useLeaveGroup` fallback when `router.canGoBack()` is false (deep-link / push-notification entry)
2. `useArchiveGroup` fallback when no backstack
3. `GroupHeader.handleBack` fallback
4. `GroupDetailScreen` "Group not found" Go Back button — likely the dominant volume since it triggers on stale share links
5. `TopNavigation` desktop web "Groups" nav button — every click loops on web

## Fix

One-line change: redirect target → `/(tabs)/search`. This is the actual route file backing the visible Groups tab, so all five callsites resolve to a real distinct file (no self-loop) without touching any of them.

```diff
-  return <Redirect href="/groups" />;
+  return <Redirect href="/(tabs)/search" />;
```

## Test plan

- [ ] On Android (deep-link directly to a group page), tap Leave → confirm app navigates to Groups tab without crashing
- [ ] On a stale group URL, tap "Go Back" → lands on Groups tab cleanly
- [ ] On desktop web, click "Groups" in TopNavigation → loads Groups tab
- [ ] Sentry "Maximum update depth" issue stops accruing new events post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)