### PR TITLE
fix(events): inbox row alignment + address truncation + comment reactions

### DIFF
--- a/apps/mobile/app/e/[shortId]/EventComment.tsx
+++ b/apps/mobile/app/e/[shortId]/EventComment.tsx
@@ -22,12 +22,14 @@ import {
   StyleSheet,
   Pressable,
   Linking,
+  ScrollView,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import type { Id } from '@services/api/convex';
 import { AppImage, ImageViewer } from '@components/ui';
 import { useReactions, type Reaction } from '@features/chat/hooks/useReactions';
+import { REACTIONS } from '@features/chat/components/MessageActionsOverlay';
 import { parseMessageContent } from '@features/shared/utils/linkify';
 import { getMediaUrl } from '@/utils/media';
 import { useTheme } from '@hooks/useTheme';
@@ -112,6 +114,26 @@ function EventCommentInner({ message, currentUserId, groupId, eventShortId, even
   // Image viewer for tap-to-expand on attachments.
   const [imageViewerVisible, setImageViewerVisible] = useState(false);
   const [imageViewerInitialIndex, setImageViewerInitialIndex] = useState(0);
+
+  // Inline emoji picker. Opened by the "+ react" button (in the actions
+  // row) and by long-pressing the comment body — same gestures the chat
+  // surface uses, just rendered inline instead of as a modal overlay
+  // because the activity feed is embedded in the event page's ScrollView.
+  const [reactionPickerVisible, setReactionPickerVisible] = useState(false);
+  const toggleReactionPicker = useCallback(() => {
+    setReactionPickerVisible((v) => !v);
+  }, []);
+  const handlePickerEmoji = useCallback(
+    async (emoji: string) => {
+      setReactionPickerVisible(false);
+      try {
+        await toggleReaction(emoji);
+      } catch (err) {
+        console.error('[EventComment] Failed to toggle reaction:', err);
+      }
+    },
+    [toggleReaction],
+  );
 
   // Categorize attachments — v1 only renders images.
   const { validImageAttachments, imageUrls } = useMemo(() => {
@@ -324,9 +346,78 @@ function EventCommentInner({ message, currentUserId, groupId, eventShortId, even
             )}
           </Pressable>
         ))}
+        {/* Inline "+" react opener. Pinned at the end of the existing
+            reaction pills so users can add a new emoji without leaving
+            the reading flow. */}
+        <Pressable
+          onPress={toggleReactionPicker}
+          style={[
+            styles.addReactionButton,
+            {
+              backgroundColor: themeColors.surfaceSecondary,
+              borderColor: themeColors.border,
+            },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Add a reaction"
+          hitSlop={6}
+        >
+          <Ionicons
+            name="happy-outline"
+            size={14}
+            color={themeColors.textSecondary}
+          />
+          <Ionicons
+            name="add"
+            size={12}
+            color={themeColors.textSecondary}
+            style={styles.addReactionPlus}
+          />
+        </Pressable>
       </View>
     );
   };
+
+  // Inline emoji picker — appears below the comment when the user opens
+  // it via the "+ react" button or by long-pressing the body. We use an
+  // inline horizontal ScrollView (not a Modal) because EventActivity is
+  // already nested inside the event page's outer ScrollView and modals
+  // were rendering behind the scroll content on native (same root cause
+  // as the thread-page-behind-event-page bug fixed earlier in this app).
+  const renderReactionPicker = () => {
+    if (!reactionPickerVisible || message.isDeleted) return null;
+    return (
+      <View
+        style={[
+          styles.reactionPicker,
+          {
+            backgroundColor: themeColors.surfaceSecondary,
+            borderColor: themeColors.border,
+          },
+        ]}
+      >
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.reactionPickerContent}
+        >
+          {REACTIONS.map((r) => (
+            <Pressable
+              key={r.type}
+              onPress={() => handlePickerEmoji(r.emoji)}
+              style={styles.reactionPickerItem}
+              accessibilityRole="button"
+              accessibilityLabel={`React with ${r.emoji}`}
+              hitSlop={4}
+            >
+              <Text style={styles.reactionPickerEmoji}>{r.emoji}</Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </View>
+    );
+  };
+
 
   const isEdited =
     message.editedAt != null && message.editedAt !== message.createdAt;
@@ -347,8 +438,18 @@ function EventCommentInner({ message, currentUserId, groupId, eventShortId, even
         />
       </View>
 
-      {/* Body column */}
-      <View style={styles.body}>
+      {/* Body column. Long-press anywhere on the body opens the inline
+          reaction picker — mirrors the chat MessageItem gesture so the
+          two surfaces feel consistent. */}
+      <Pressable
+        style={styles.body}
+        onLongPress={message.isDeleted ? undefined : toggleReactionPicker}
+        delayLongPress={300}
+        accessibilityRole="button"
+        accessibilityLabel={
+          message.isDeleted ? undefined : 'Long press to react'
+        }
+      >
         {/* Header: name + relative time (+ edited) */}
         <View style={styles.headerRow}>
           <Text
@@ -375,24 +476,47 @@ function EventCommentInner({ message, currentUserId, groupId, eventShortId, even
         {/* Reactions */}
         {renderReactions()}
 
-        {/* Reply button — hidden on deleted messages so there's no affordance
-            to thread off a removed comment. */}
+        {/* Inline reaction picker — appears below the comment when opened
+            via the "+ react" button or by long-pressing the body. */}
+        {renderReactionPicker()}
+
+        {/* Action row: Reply + React. React stays visible even when no
+            reactions exist yet so the affordance is discoverable. */}
         {!message.isDeleted && (
-          <Pressable
-            onPress={handleReplyPress}
-            hitSlop={8}
-            style={styles.replyButton}
-            accessibilityRole="button"
-            accessibilityLabel="Reply to this comment"
-          >
-            <Text style={[styles.replyText, { color: themeColors.textSecondary }]}>
-              {message.threadReplyCount && message.threadReplyCount > 0
-                ? `Reply · ${message.threadReplyCount}`
-                : 'Reply'}
-            </Text>
-          </Pressable>
+          <View style={styles.actionRow}>
+            <Pressable
+              onPress={handleReplyPress}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Reply to this comment"
+            >
+              <Text style={[styles.replyText, { color: themeColors.textSecondary }]}>
+                {message.threadReplyCount && message.threadReplyCount > 0
+                  ? `Reply · ${message.threadReplyCount}`
+                  : 'Reply'}
+              </Text>
+            </Pressable>
+            {/* Show the inline "React" trigger only when there are no
+                existing reaction pills — otherwise the "+" opener inside
+                the pill row already surfaces the same picker, and a
+                duplicate down here would feel noisy. */}
+            {reactions.length === 0 && (
+              <Pressable
+                onPress={toggleReactionPicker}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Add a reaction"
+              >
+                <Text
+                  style={[styles.replyText, { color: themeColors.textSecondary }]}
+                >
+                  React
+                </Text>
+              </Pressable>
+            )}
+          </View>
         )}
-      </View>
+      </Pressable>
 
       {/* Fullscreen image gallery */}
       <ImageViewer
@@ -529,9 +653,49 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginLeft: 4,
   },
-  replyButton: {
+  // Inline "+" smiley shown at the end of the existing reactions row so
+  // users can add a new emoji without leaving the reading flow. Same pill
+  // shape as the existing reaction pills for visual consistency.
+  addReactionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    paddingHorizontal: 6,
+    paddingVertical: 3,
+    marginRight: 4,
+    marginBottom: 4,
+    borderWidth: 1,
+  },
+  addReactionPlus: {
+    marginLeft: 1,
+  },
+  // Inline emoji picker — drops below the comment body when opened.
+  reactionPicker: {
     marginTop: 6,
-    alignSelf: 'flex-start',
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+  },
+  reactionPickerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  reactionPickerItem: {
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  reactionPickerEmoji: {
+    fontSize: 22,
+  },
+  // Reply + React action row.
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    marginTop: 6,
   },
   replyText: {
     fontSize: 13,

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -726,6 +726,11 @@ function DirectionsButton({
   const [isPressed, setIsPressed] = useState(false);
   return (
     <Pressable
+      // `flexShrink: 1, minWidth: 0` on the Pressable itself — this is the
+      // actual flex item in the row. Without it the inner View's
+      // flexShrink:1 can't kick in and the address text overflows past the
+      // right edge instead of truncating with ellipsis.
+      style={styles.directionsButtonPressable}
       accessibilityRole="button"
       accessibilityLabel={`Open ${location} in Maps`}
       onPress={(e) => {
@@ -1272,22 +1277,27 @@ const styles = StyleSheet.create({
   eventRow: {
     flexDirection: "row",
     alignItems: "center",
-    // Left padding is slightly reduced (13 vs 16) to make room for the 3px
-    // accent bar so overall row padding still reads as 16. Group rows use
-    // 16 — the delta here is negligible (~1–2px) and keeps the avatar's
-    // horizontal position aligned with the group rows above/below.
-    paddingLeft: 13,
+    // Match DM rows + group rows exactly — 16 left, 16 right — so avatars
+    // line up vertically across the mixed inbox. The accent bar is
+    // absolutely positioned over the leading edge instead of taking
+    // horizontal space.
+    paddingLeft: 16,
     paddingRight: 16,
     paddingVertical: 12,
+    position: "relative",
   },
-  // Thin left accent bar — the primary imminence signal.
+  // Thin left accent bar — pinned to the row's left edge as an overlay so
+  // it doesn't push the avatar out of alignment with neighboring DM /
+  // group rows. Hidden via `transparent` background when there's nothing
+  // urgent to signal.
   eventAccentBar: {
+    position: "absolute",
+    left: 0,
+    top: 8,
+    bottom: 8,
     width: 3,
-    alignSelf: "stretch",
-    borderRadius: 2,
-    marginRight: 10,
-    // When there's no accent color the bar still occupies space so avatars
-    // stay aligned with accented siblings.
+    borderTopRightRadius: 2,
+    borderBottomRightRadius: 2,
   },
   eventAvatarContainer: {
     position: "relative",
@@ -1382,6 +1392,14 @@ const styles = StyleSheet.create({
   eventMetaSeparator: {
     fontSize: 12,
     marginHorizontal: 6,
+  },
+  // Wraps the directions button. minWidth:0 + flexShrink:1 are necessary
+  // for the inner button + its `numberOfLines={1}` text to actually
+  // truncate when the row is narrow — without this the address overflows
+  // past the row's right edge.
+  directionsButtonPressable: {
+    flexShrink: 1,
+    minWidth: 0,
   },
   // Prominent filled pill next to the time — reads as a CTA. Primary-tinted
   // background so it doesn't blend into the surrounding muted row.


### PR DESCRIPTION
## Summary

Three independent bugs you reported on event surfaces, bundled in one PR.

### 1. Inbox event row — avatar misalignment

The 3px accent bar + 10px marginRight pushed the event avatar 13px right of where DM/group avatars sit, so event rows read as inset relative to the neighboring rows. **Fix**: pin the accent bar absolutely to the row's left edge and restore the row's paddingLeft to 16 (matches \`dmRow\` / \`groupItem\`). Avatars now line up vertically across the mixed inbox.

### 2. Inbox event row — address truncation

The DirectionsButton's location text was overflowing past the row's right edge instead of truncating with ellipsis. **Root cause**: \`flexShrink: 1\` was set on the inner View, but the actual flex item in the row is the outer \`Pressable\`, which had no style at all. **Fix**: \`flexShrink: 1, minWidth: 0\` on the Pressable wrapper so the inner \`numberOfLines={1}\` text truncates correctly.

### 3. Event comments — no way to add a reaction

\`EventComment\` had no gesture or button to open a reaction picker. Users could tap an existing reaction pill to toggle their vote, but adding a brand-new emoji had no entry point. **Fix**: inline emoji picker with three discoverable openers:
- "+ smiley" pill at the end of the existing reactions row
- "React" link in the action row next to "Reply" (only when no reactions exist)
- Long-press anywhere on the comment body (matches the chat \`MessageItem\` gesture)

The picker renders inline (a horizontal ScrollView below the comment) instead of as a Modal because \`EventActivity\` is embedded in the event page's outer ScrollView and modal overlays render behind it on native (same root cause as the prior thread-page-behind-event-page bug).

The picker re-uses the \`REACTIONS\` constant exported from \`MessageActionsOverlay\` so the chat + event surfaces share the same emoji set.

## Verification

- 115 / 115 chat + event tests pass
- Mobile typecheck clean for changed files

## Test plan

- [ ] Inbox: event row avatar lines up vertically with DM and group rows above/below it
- [ ] Inbox: a long event address truncates with ellipsis instead of overflowing past the right edge
- [ ] Event activity: tap an existing reaction pill — your vote toggles
- [ ] Event activity: tap the "+ smiley" pill at the end of an existing reactions row — picker opens, tap an emoji, reaction added
- [ ] Event activity: on a comment with no reactions, tap "React" next to "Reply" — picker opens
- [ ] Event activity: long-press anywhere on a comment body — picker opens
- [ ] Tapping an emoji closes the picker and adds the reaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)