### PR TITLE
fix(chat): refresh sender avatar/name from live user record on read

### DIFF
--- a/apps/convex/__tests__/messaging/messages.test.ts
+++ b/apps/convex/__tests__/messaging/messages.test.ts
@@ -1403,6 +1403,91 @@ describe("Get Single Message", () => {
 });
 
 // ============================================================================
+// Live sender profile (always-fresh avatar/name)
+// ============================================================================
+
+describe("Live Sender Profile Override", () => {
+  test("getMessage returns the sender's current profile photo, not the snapshot", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, channelId, accessToken } = await seedTestData(t);
+
+    // Send a message with the original profile photo set on the user.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(userId, { profilePhoto: "https://example.com/old.jpg" });
+    });
+    const messageId = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Hello",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    // Now the user uploads a new photo (simulates updateProfile).
+    await t.run(async (ctx) => {
+      await ctx.db.patch(userId, {
+        profilePhoto: "https://example.com/new.jpg",
+        firstName: "Renamed",
+        lastName: "User",
+      });
+    });
+
+    const single = await t.query(api.functions.messaging.messages.getMessage, {
+      token: accessToken,
+      messageId,
+    });
+    expect(single?.senderProfilePhoto).toContain("https://example.com/new.jpg");
+    expect(single?.senderProfilePhoto).not.toContain("https://example.com/old.jpg");
+    expect(single?.senderName).toBe("Renamed User");
+
+    const list = await t.query(api.functions.messaging.messages.getMessages, {
+      token: accessToken,
+      channelId,
+    });
+    expect(list.messages[0].senderProfilePhoto).toContain("https://example.com/new.jpg");
+    expect(list.messages[0].senderName).toBe("Renamed User");
+  });
+
+  test("getThreadReplies returns the sender's current profile photo", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, channelId, accessToken } = await seedTestData(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(userId, { profilePhoto: "https://example.com/stale.jpg" });
+    });
+    const parentId = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Parent",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "Reply",
+      parentMessageId: parentId,
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(userId, { profilePhoto: "https://example.com/fresh.jpg" });
+    });
+
+    const result = await t.query(api.functions.messaging.messages.getThreadReplies, {
+      token: accessToken,
+      parentMessageId: parentId,
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].senderProfilePhoto).toContain("https://example.com/fresh.jpg");
+  });
+});
+
+// ============================================================================
 // Thread Reply Count Display Tests
 // ============================================================================
 

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -48,6 +48,57 @@ async function attachSenderNotifsDisabled(
 }
 
 /**
+ * Override the denormalized `senderName` / `senderProfilePhoto` snapshots on a
+ * single message with the sender's current values from the `users` table.
+ *
+ * Why: messages snapshot the sender's name + avatar at send time so reads can
+ * stay single-table. When a user updates their profile, those snapshots go
+ * stale on every existing message they sent. Resolving live at read time keeps
+ * old chats in sync without touching every historical row.
+ *
+ * Falls back to the snapshot when the sender is missing (system/bot messages
+ * without a senderId, or users that have since been deleted).
+ */
+function applyLiveSenderProfile<M extends Doc<"chatMessages">>(
+  message: M,
+  user: Doc<"users"> | null,
+): M {
+  if (!user) return message;
+  return {
+    ...message,
+    senderName: getDisplayName(user.firstName, user.lastName),
+    senderProfilePhoto: getMediaUrl(user.profilePhoto),
+  };
+}
+
+/**
+ * Batched form of `applyLiveSenderProfile` — fetches each unique sender once
+ * and rewrites every message in the page with their current name + avatar.
+ */
+async function attachLiveSenderProfile<M extends Doc<"chatMessages">>(
+  ctx: QueryCtx,
+  messages: M[],
+): Promise<M[]> {
+  const uniqueSenderIds = Array.from(
+    new Set(
+      messages
+        .map((m) => m.senderId)
+        .filter((id): id is Id<"users"> => !!id),
+    ),
+  );
+  if (uniqueSenderIds.length === 0) return messages;
+  const users = await Promise.all(uniqueSenderIds.map((id) => ctx.db.get(id)));
+  const userById = new Map<Id<"users">, Doc<"users">>();
+  uniqueSenderIds.forEach((id, i) => {
+    const u = users[i];
+    if (u) userById.set(id, u);
+  });
+  return messages.map((m) =>
+    m.senderId ? applyLiveSenderProfile(m, userById.get(m.senderId) ?? null) : m,
+  );
+}
+
+/**
  * Same access check as `canAccessEventChannel` but keyed off a meeting doc
  * directly — used when the caller hasn't resolved a channel yet (e.g. the
  * first `sendMessage` call that lazy-creates the event channel).
@@ -182,6 +233,9 @@ export const getMessage = query({
         return null;
       }
 
+      const sender = message.senderId ? await ctx.db.get(message.senderId) : null;
+      const enriched = applyLiveSenderProfile(message, sender);
+
       // Event channels use meeting-based access rather than chatChannelMembers
       // (non-group-members can still participate via RSVP).
       const channel = await ctx.db.get(message.channelId);
@@ -189,7 +243,7 @@ export const getMessage = query({
         if (!(await canAccessEventChannel(ctx, userId, channel))) {
           return null;
         }
-        return message;
+        return enriched;
       }
 
       // Check if user has access to the channel
@@ -205,7 +259,7 @@ export const getMessage = query({
         return null;
       }
 
-      return message;
+      return enriched;
     } catch (error) {
       console.error("[getMessage] Failed to fetch message:", error);
       return null;
@@ -455,7 +509,8 @@ export const getMessages = query({
     // Reverse to chronological order (oldest first, newest at bottom)
     // This is the expected order for chat UIs
     const chronologicalMessages = [...pageMessages].reverse();
-    const decorated = await attachSenderNotifsDisabled(ctx, chronologicalMessages);
+    const withLiveProfile = await attachLiveSenderProfile(ctx, chronologicalMessages);
+    const decorated = await attachSenderNotifsDisabled(ctx, withLiveProfile);
 
     return {
       messages: decorated,
@@ -514,7 +569,8 @@ export const getThreadReplies = query({
 
     const hasMore = replies.length === limit;
     const cursor = replies.length > 0 ? replies[replies.length - 1]._id : undefined;
-    const decorated = await attachSenderNotifsDisabled(ctx, replies);
+    const withLiveProfile = await attachLiveSenderProfile(ctx, replies);
+    const decorated = await attachSenderNotifsDisabled(ctx, withLiveProfile);
 
     return {
       messages: decorated,


### PR DESCRIPTION
## Summary

Profile pictures in chat go stale after a user updates their photo because messages denormalize `senderName` + `senderProfilePhoto` at send time and that snapshot is never refreshed on historical rows.

This PR overrides the snapshot at read time by batch-fetching the sender's `users` record in `getMessage`, `getMessages`, and `getThreadReplies`. The denormalized fields are still written on send and used as a fallback for system/bot messages and deleted users, so historical context isn't lost.

- `applyLiveSenderProfile(message, user)` — single-message override
- `attachLiveSenderProfile(ctx, messages)` — one `users` lookup per unique `senderId` per page

DM inbox + channel list previews already pull `lastMessageSenderName` and `chatChannelMembers.profilePhoto`, both of which `syncUserProfileToChannels` already keeps fresh — those are unchanged.

## Test plan

- [x] New unit tests under "Live Sender Profile Override" assert that `getMessage`, `getMessages`, and `getThreadReplies` return the user's current avatar after a profile update, not the snapshot
- [x] Full convex suite: 1412/1412 passing across 80 files
- [ ] Manual: change profile photo in dev, scroll back through an old DM thread, confirm previously-sent messages now show the new avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)