### PR TITLE
feat(landing-page): auto-reply SMS composed from automation rule snippets

### DIFF
--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -156,6 +156,7 @@ import type * as lib_membership from "../lib/membership.js";
 import type * as lib_notifications_definitions from "../lib/notifications/definitions.js";
 import type * as lib_notifications_emailTemplates from "../lib/notifications/emailTemplates.js";
 import type * as lib_notifications_enabledCounter from "../lib/notifications/enabledCounter.js";
+import type * as lib_notifications_enabledStatus from "../lib/notifications/enabledStatus.js";
 import type * as lib_notifications_index from "../lib/notifications/index.js";
 import type * as lib_notifications_registry from "../lib/notifications/registry.js";
 import type * as lib_notifications_send from "../lib/notifications/send.js";
@@ -330,6 +331,7 @@ declare const fullApi: ApiFromModules<{
   "lib/notifications/definitions": typeof lib_notifications_definitions;
   "lib/notifications/emailTemplates": typeof lib_notifications_emailTemplates;
   "lib/notifications/enabledCounter": typeof lib_notifications_enabledCounter;
+  "lib/notifications/enabledStatus": typeof lib_notifications_enabledStatus;
   "lib/notifications/index": typeof lib_notifications_index;
   "lib/notifications/registry": typeof lib_notifications_registry;
   "lib/notifications/send": typeof lib_notifications_send;

--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -18,7 +18,7 @@ import { VALID_CUSTOM_SLOTS } from "../lib/followupConstants";
 import { normalizePhone, buildSearchText, now } from "../lib/utils";
 import { syncUserChannelMembershipsLogic } from "./sync/memberships";
 import { ensureChannelsForGroupLogic } from "./messaging/channels";
-import { checkRateLimit } from "../lib/rateLimit";
+import { checkRateLimit, RateLimitExceededError } from "../lib/rateLimit";
 import { parseDateOptional } from "../lib/validation";
 
 // ============================================================================
@@ -159,8 +159,15 @@ export const dispatchAutoReplySmsIfAllowed = internalMutation({
     const ONE_DAY_MS = 24 * 60 * 60 * 1000;
     try {
       await checkRateLimit(ctx, rateLimitKey, 2, ONE_DAY_MS);
-    } catch {
-      return "suppressed_cap";
+    } catch (err) {
+      // Only translate true cap-reached signals into "suppressed_cap".
+      // Re-throw anything else (DB errors, etc.) so the caller's outer
+      // try/catch logs the operational failure instead of misreporting
+      // it as a daily-cap hit.
+      if (err instanceof RateLimitExceededError) {
+        return "suppressed_cap";
+      }
+      throw err;
     }
     await ctx.scheduler.runAfter(
       0,

--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -131,54 +131,90 @@ export const checkFormRateLimit = internalMutation({
 });
 
 /**
- * Try to consume a landing-page auto-reply SMS quota slot for this phone.
- * Returns true if allowed, false if the recipient has hit the daily cap.
+ * Atomically check the per-phone SMS daily cap and (if allowed) schedule
+ * the outbound SMS-with-audit action. Doing the cap check and the schedule
+ * in one mutation prevents the quota from being burned when the schedule
+ * step never lands — which would silently suppress future legitimate
+ * auto-replies to the same recipient.
  *
- * The form submission itself is already capped at 5/hour by phone, but a
- * tighter SMS cap (2 per 24h) prevents repeat submissions from spamming
- * the same recipient with auto-reply texts.
+ * Returns:
+ *   - "scheduled": within cap, dispatch action is queued; that action will
+ *     write the real outcome (sent/send_failed) to the audit note
+ *   - "suppressed_cap": cap hit, nothing queued; caller writes the audit
+ *
+ * The form submission itself is already capped at 5/hour by phone, but the
+ * tighter 2/24h SMS cap stops repeat submissions from spamming the same
+ * recipient with auto-replies.
  */
-export const tryConsumeSmsRateLimit = internalMutation({
-  args: { phone: v.string() },
-  returns: v.boolean(),
-  handler: async (ctx, args): Promise<boolean> => {
+export const dispatchAutoReplySmsIfAllowed = internalMutation({
+  args: {
+    phone: v.string(),
+    message: v.string(),
+    followupNoteId: v.union(v.id("memberFollowups"), v.null()),
+  },
+  returns: v.union(v.literal("scheduled"), v.literal("suppressed_cap")),
+  handler: async (ctx, args): Promise<"scheduled" | "suppressed_cap"> => {
     const normalizedPhone = normalizePhone(args.phone);
     const rateLimitKey = `landing_sms:${normalizedPhone}`;
     const ONE_DAY_MS = 24 * 60 * 60 * 1000;
     try {
       await checkRateLimit(ctx, rateLimitKey, 2, ONE_DAY_MS);
-      return true;
     } catch {
-      return false;
+      return "suppressed_cap";
     }
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.communityLandingPageActions.sendAutoReplySmsAndAudit,
+      {
+        phone: args.phone,
+        message: args.message,
+        followupNoteId: args.followupNoteId,
+      },
+    );
+    return "scheduled";
   },
 });
 
 /**
  * Append an audit trail to the landing-page submission note describing
- * the auto-reply SMS outcome. Called by the submitForm action once the
- * SMS attempt resolves so staff reviewing follow-ups see exactly what
- * the submitter received.
+ * the auto-reply SMS outcome. Called once the SMS attempt resolves so
+ * staff reviewing follow-ups see exactly what the submitter received
+ * (or didn't, and why).
  *
  * Outcomes:
  *   - "sent": include the rendered body so staff can reproduce what was texted
  *   - "suppressed_cap": the per-phone daily SMS cap was hit; SMS not sent
+ *   - "send_failed": the Twilio dispatch errored — body still recorded so
+ *     staff know what the recipient missed and can follow up manually
  */
 export const recordSmsAuditOnNote = internalMutation({
   args: {
     noteId: v.id("memberFollowups"),
-    outcome: v.union(v.literal("sent"), v.literal("suppressed_cap")),
+    outcome: v.union(
+      v.literal("sent"),
+      v.literal("suppressed_cap"),
+      v.literal("send_failed"),
+    ),
     body: v.optional(v.string()),
+    error: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     const note = await ctx.db.get(args.noteId);
     if (!note) return null;
 
-    const block =
-      args.outcome === "sent"
-        ? `\n\n---\nAuto-Reply SMS sent:\n${args.body ?? ""}`
-        : `\n\n---\nAuto-Reply SMS suppressed: this phone has already received 2 auto-replies in the last 24 hours.`;
+    let block: string;
+    switch (args.outcome) {
+      case "sent":
+        block = `\n\n---\nAuto-Reply SMS sent:\n${args.body ?? ""}`;
+        break;
+      case "suppressed_cap":
+        block = `\n\n---\nAuto-Reply SMS suppressed: this phone has already received 2 auto-replies in the last 24 hours.`;
+        break;
+      case "send_failed":
+        block = `\n\n---\nAuto-Reply SMS FAILED to send${args.error ? ` (${args.error})` : ""}. The recipient did not receive this message:\n${args.body ?? ""}`;
+        break;
+    }
 
     const updatedContent = `${note.content}${block}`;
     await ctx.db.patch(args.noteId, { content: updatedContent });

--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -131,6 +131,76 @@ export const checkFormRateLimit = internalMutation({
 });
 
 /**
+ * Try to consume a landing-page auto-reply SMS quota slot for this phone.
+ * Returns true if allowed, false if the recipient has hit the daily cap.
+ *
+ * The form submission itself is already capped at 5/hour by phone, but a
+ * tighter SMS cap (2 per 24h) prevents repeat submissions from spamming
+ * the same recipient with auto-reply texts.
+ */
+export const tryConsumeSmsRateLimit = internalMutation({
+  args: { phone: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, args): Promise<boolean> => {
+    const normalizedPhone = normalizePhone(args.phone);
+    const rateLimitKey = `landing_sms:${normalizedPhone}`;
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+    try {
+      await checkRateLimit(ctx, rateLimitKey, 2, ONE_DAY_MS);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+});
+
+/**
+ * Append an audit trail to the landing-page submission note describing
+ * the auto-reply SMS outcome. Called by the submitForm action once the
+ * SMS attempt resolves so staff reviewing follow-ups see exactly what
+ * the submitter received.
+ *
+ * Outcomes:
+ *   - "sent": include the rendered body so staff can reproduce what was texted
+ *   - "suppressed_cap": the per-phone daily SMS cap was hit; SMS not sent
+ */
+export const recordSmsAuditOnNote = internalMutation({
+  args: {
+    noteId: v.id("memberFollowups"),
+    outcome: v.union(v.literal("sent"), v.literal("suppressed_cap")),
+    body: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const note = await ctx.db.get(args.noteId);
+    if (!note) return null;
+
+    const block =
+      args.outcome === "sent"
+        ? `\n\n---\nAuto-Reply SMS sent:\n${args.body ?? ""}`
+        : `\n\n---\nAuto-Reply SMS suppressed: this phone has already received 2 auto-replies in the last 24 hours.`;
+
+    const updatedContent = `${note.content}${block}`;
+    await ctx.db.patch(args.noteId, { content: updatedContent });
+
+    // Mirror to latest-note denormalization on the score doc, if any
+    const groupMember = await ctx.db.get(note.groupMemberId);
+    if (groupMember) {
+      const scoreDoc = await ctx.db
+        .query("memberFollowupScores")
+        .withIndex("by_groupMember", (q) =>
+          q.eq("groupMemberId", note.groupMemberId),
+        )
+        .first();
+      if (scoreDoc && scoreDoc.latestNoteAt === note.createdAt) {
+        await ctx.db.patch(scoreDoc._id, { latestNote: updatedContent });
+      }
+    }
+    return null;
+  },
+});
+
+/**
  * Find existing user by phone or create a new one.
  * Returns the user ID.
  */
@@ -371,11 +441,19 @@ export const setCustomFieldsAndNotes = internalMutation({
           type: v.string(),
           assigneePhone: v.optional(v.string()),
           assigneeUserId: v.optional(v.id("users")),
+          snippet: v.optional(v.string()),
         }),
       })
     ),
   },
-  handler: async (ctx, args) => {
+  returns: v.object({
+    smsSnippets: v.array(v.string()),
+    followupNoteId: v.union(v.id("memberFollowups"), v.null()),
+  }),
+  handler: async (ctx, args): Promise<{
+    smsSnippets: string[];
+    followupNoteId: Id<"memberFollowups"> | null;
+  }> => {
     const timestamp = now();
 
     // Find announcement group
@@ -385,7 +463,7 @@ export const setCustomFieldsAndNotes = internalMutation({
       .filter((q) => q.eq(q.field("isAnnouncementGroup"), true))
       .first();
 
-    if (!announcementGroup) return;
+    if (!announcementGroup) return { smsSnippets: [], followupNoteId: null };
 
     // Find group membership
     const groupMember = await ctx.db
@@ -395,7 +473,7 @@ export const setCustomFieldsAndNotes = internalMutation({
       )
       .first();
 
-    if (!groupMember) return;
+    if (!groupMember) return { smsSnippets: [], followupNoteId: null };
 
     // Find or create memberFollowupScores record
     let scoreDoc = await ctx.db
@@ -441,7 +519,7 @@ export const setCustomFieldsAndNotes = internalMutation({
       scoreDoc = await ctx.db.get(scoreDocId);
     }
 
-    if (!scoreDoc) return;
+    if (!scoreDoc) return { smsSnippets: [], followupNoteId: null };
 
     // Update denormalized zipCode/dateOfBirth on existing score docs
     const scoreUpdates: Record<string, any> = {};
@@ -465,6 +543,7 @@ export const setCustomFieldsAndNotes = internalMutation({
     }
 
     // Generate notes summary
+    let followupNoteId: Id<"memberFollowups"> | null = null;
     if (args.generateNoteSummary) {
       const date = new Date(timestamp);
       const dateStr = date.toLocaleDateString("en-US", {
@@ -495,7 +574,7 @@ export const setCustomFieldsAndNotes = internalMutation({
 
       const noteContent = lines.join("\n");
 
-      await ctx.db.insert("memberFollowups", {
+      followupNoteId = await ctx.db.insert("memberFollowups", {
         groupMemberId: groupMember._id,
         createdById: args.userId, // Self-submitted
         type: "note",
@@ -510,13 +589,19 @@ export const setCustomFieldsAndNotes = internalMutation({
       });
     }
 
-    // Run automation rules (first matching rule wins for set_assignee)
+    // Run automation rules.
+    //   - set_assignee: first matching rule wins (preserves prior deterministic behavior)
+    //   - append_sms: every matching rule contributes a snippet, in rule order
+    let assigneeAssigned = false;
+    const smsSnippets: string[] = [];
+
     for (const rule of args.automationRules) {
       if (!rule.isEnabled) continue;
 
       const conditionMet = evaluateCondition(rule.condition, args.customFields);
+      if (!conditionMet) continue;
 
-      if (conditionMet && rule.action.type === "set_assignee") {
+      if (rule.action.type === "set_assignee" && !assigneeAssigned) {
         let assigneeId = rule.action.assigneeUserId;
 
         // Look up assignee by phone if no direct ID
@@ -544,9 +629,11 @@ export const setCustomFieldsAndNotes = internalMutation({
             groupMemberId: groupMember._id,
           });
 
-          // Stop after first matching assignee rule to provide deterministic behavior
-          break;
+          assigneeAssigned = true;
         }
+      } else if (rule.action.type === "append_sms") {
+        const snippet = rule.action.snippet?.trim();
+        if (snippet) smsSnippets.push(snippet);
       }
     }
 
@@ -555,6 +642,8 @@ export const setCustomFieldsAndNotes = internalMutation({
       communityId: args.communityId,
       userId: args.userId,
     });
+
+    return { smsSnippets, followupNoteId };
   },
 });
 
@@ -687,14 +776,59 @@ export const saveConfig = mutation({
           type: v.string(),
           assigneePhone: v.optional(v.string()),
           assigneeUserId: v.optional(v.id("users")),
+          snippet: v.optional(v.string()),
         }),
       })
+    ),
+    autoReplySms: v.optional(
+      v.object({
+        enabled: v.boolean(),
+        intro: v.string(),
+        outro: v.string(),
+        sendIfNoSnippetsMatch: v.boolean(),
+      }),
     ),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
     await requireCommunityAdmin(ctx, args.communityId, userId);
     const timestamp = Date.now();
+
+    // Validate automation rule actions
+    for (const rule of args.automationRules) {
+      if (rule.action.type === "append_sms") {
+        if (!rule.action.snippet?.trim()) {
+          throw new Error(
+            `Rule "${rule.name}" needs a snippet to append to the auto-reply SMS`,
+          );
+        }
+      } else if (rule.action.type === "set_assignee") {
+        // Existing behavior: assigneePhone or assigneeUserId is checked at runtime;
+        // saveConfig doesn't enforce so admins can stage rules before assignees exist
+      } else {
+        throw new Error(
+          `Rule "${rule.name}" has unknown action type "${rule.action.type}"`,
+        );
+      }
+    }
+
+    // Validate auto-reply SMS template if enabled
+    if (args.autoReplySms?.enabled) {
+      const intro = args.autoReplySms.intro.trim();
+      const outro = args.autoReplySms.outro.trim();
+      if (!intro && !outro) {
+        throw new Error(
+          "Auto-reply SMS needs at least an intro or outro before it can be enabled",
+        );
+      }
+      // Hard cap to keep auto-replies from blowing past Twilio's 1600-char limit
+      // before we even append rule snippets. Snippets get capped at send time.
+      if (intro.length + outro.length > 800) {
+        throw new Error(
+          "Auto-reply SMS intro + outro must be under 800 characters combined",
+        );
+      }
+    }
 
     // Slot prefix to allowed types mapping
     const SLOT_PREFIX_TYPE: Record<string, string[]> = {
@@ -771,6 +905,7 @@ export const saveConfig = mutation({
       requireBirthday: args.requireBirthday,
       formFields: args.formFields,
       automationRules: args.automationRules,
+      autoReplySms: args.autoReplySms,
       updatedAt: timestamp,
     };
 

--- a/apps/convex/functions/communityLandingPageActions.ts
+++ b/apps/convex/functions/communityLandingPageActions.ts
@@ -175,6 +175,23 @@ export const submitForm = action({
 const SMS_BODY_MAX = 1600;
 
 /**
+ * Truncate at most `max` UTF-16 code units without splitting a surrogate
+ * pair. Naive `String.prototype.slice` can leave a lone high surrogate at
+ * the boundary, producing an invalid string that downstream JSON
+ * serialization or the Twilio HTTP layer may reject.
+ */
+function truncateSmsBody(body: string, max: number): string {
+  if (body.length <= max) return body;
+  const sliced = body.slice(0, max);
+  const lastCode = sliced.charCodeAt(sliced.length - 1);
+  // High surrogate (0xD800–0xDBFF): drop it so we don't leave half a pair
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    return sliced.slice(0, -1);
+  }
+  return sliced;
+}
+
+/**
  * Substitute {firstName} placeholders. Falls back to "there" so an unset
  * first name doesn't leave a literal "{firstName}" in the message body.
  */
@@ -202,7 +219,7 @@ function composeAutoReplyBody(args: {
   }
   if (outro) parts.push(outro);
   const body = parts.join("\n\n");
-  return body.length > SMS_BODY_MAX ? body.slice(0, SMS_BODY_MAX) : body;
+  return truncateSmsBody(body, SMS_BODY_MAX);
 }
 
 async function maybeSendAutoReplySms(

--- a/apps/convex/functions/communityLandingPageActions.ts
+++ b/apps/convex/functions/communityLandingPageActions.ts
@@ -6,7 +6,7 @@
  */
 
 import { v } from "convex/values";
-import { action } from "../_generated/server";
+import { action, type ActionCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 
@@ -124,7 +124,7 @@ export const submitForm = action({
 
     // 4. Set custom field values + notes + automation
     // Always call even without custom fields — ensures followup record, notes, and automation rules run
-    await ctx.runMutation(
+    const { smsSnippets, followupNoteId } = await ctx.runMutation(
       internal.functions.communityLandingPage.setCustomFieldsAndNotes,
       {
         communityId: community._id as Id<"communities">,
@@ -137,6 +137,15 @@ export const submitForm = action({
       }
     );
 
+    // 5. Auto-reply SMS — best-effort, never fails the submission
+    await maybeSendAutoReplySms(ctx, {
+      autoReplySms: landingPage.autoReplySms ?? null,
+      phone: trimmedPhone,
+      firstName: trimmedFirstName,
+      smsSnippets,
+      followupNoteId,
+    });
+
     return {
       success: true,
       user: {
@@ -147,3 +156,114 @@ export const submitForm = action({
     };
   },
 });
+
+// ============================================================================
+// Auto-reply SMS helpers
+// ============================================================================
+
+// Twilio's hard cap. sendSMS truncates as a backstop, but we want our own
+// bound so what staff see in admin matches what gets sent.
+const SMS_BODY_MAX = 1600;
+
+/**
+ * Substitute {firstName} placeholders. Falls back to "there" so an unset
+ * first name doesn't leave a literal "{firstName}" in the message body.
+ */
+function renderTemplate(template: string, firstName: string): string {
+  const safeName = firstName.trim() || "there";
+  return template.replace(/\{firstName\}/g, safeName);
+}
+
+/**
+ * Compose an auto-reply SMS body from the saved intro/outro and the
+ * snippets collected from matching automation rules.
+ */
+function composeAutoReplyBody(args: {
+  intro: string;
+  outro: string;
+  snippets: string[];
+  firstName: string;
+}): string {
+  const parts: string[] = [];
+  const intro = renderTemplate(args.intro, args.firstName).trim();
+  const outro = renderTemplate(args.outro, args.firstName).trim();
+  if (intro) parts.push(intro);
+  if (args.snippets.length > 0) {
+    parts.push(args.snippets.map((s) => renderTemplate(s, args.firstName)).join("\n"));
+  }
+  if (outro) parts.push(outro);
+  const body = parts.join("\n\n");
+  return body.length > SMS_BODY_MAX ? body.slice(0, SMS_BODY_MAX) : body;
+}
+
+async function maybeSendAutoReplySms(
+  ctx: ActionCtx,
+  params: {
+    autoReplySms:
+      | {
+          enabled: boolean;
+          intro: string;
+          outro: string;
+          sendIfNoSnippetsMatch: boolean;
+        }
+      | null
+      | undefined;
+    phone: string;
+    firstName: string;
+    smsSnippets: string[];
+    followupNoteId: Id<"memberFollowups"> | null;
+  },
+): Promise<void> {
+  const cfg = params.autoReplySms;
+  if (!cfg || !cfg.enabled) return;
+
+  const hasSnippets = params.smsSnippets.length > 0;
+  if (!hasSnippets && !cfg.sendIfNoSnippetsMatch) return;
+
+  const body = composeAutoReplyBody({
+    intro: cfg.intro,
+    outro: cfg.outro,
+    snippets: params.smsSnippets,
+    firstName: params.firstName,
+  });
+  if (!body) return;
+
+  // Per-recipient daily cap so repeat submissions don't spam the same phone
+  const allowed = await ctx.runMutation(
+    internal.functions.communityLandingPage.tryConsumeSmsRateLimit,
+    { phone: params.phone },
+  );
+
+  if (!allowed) {
+    console.warn(
+      `[landing-page] Auto-reply SMS suppressed for ${params.phone}: daily cap reached`,
+    );
+    if (params.followupNoteId) {
+      await ctx.runMutation(
+        internal.functions.communityLandingPage.recordSmsAuditOnNote,
+        {
+          noteId: params.followupNoteId,
+          outcome: "suppressed_cap",
+        },
+      );
+    }
+    return;
+  }
+
+  // Fire via scheduler so a Twilio outage can't fail the form submission
+  await ctx.scheduler.runAfter(0, internal.functions.auth.phoneOtp.sendSMS, {
+    phone: params.phone,
+    message: body,
+  });
+
+  if (params.followupNoteId) {
+    await ctx.runMutation(
+      internal.functions.communityLandingPage.recordSmsAuditOnNote,
+      {
+        noteId: params.followupNoteId,
+        outcome: "sent",
+        body,
+      },
+    );
+  }
+}

--- a/apps/convex/functions/communityLandingPageActions.ts
+++ b/apps/convex/functions/communityLandingPageActions.ts
@@ -6,7 +6,7 @@
  */
 
 import { v } from "convex/values";
-import { action, type ActionCtx } from "../_generated/server";
+import { action, internalAction, type ActionCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 
@@ -137,14 +137,23 @@ export const submitForm = action({
       }
     );
 
-    // 5. Auto-reply SMS — best-effort, never fails the submission
-    await maybeSendAutoReplySms(ctx, {
-      autoReplySms: landingPage.autoReplySms ?? null,
-      phone: trimmedPhone,
-      firstName: trimmedFirstName,
-      smsSnippets,
-      followupNoteId,
-    });
+    // 5. Auto-reply SMS — best-effort, never fails the submission.
+    // Wrap so any internal-mutation/scheduler error here cannot reject the
+    // action after the user, membership, and follow-up records are written.
+    try {
+      await maybeSendAutoReplySms(ctx, {
+        autoReplySms: landingPage.autoReplySms ?? null,
+        phone: trimmedPhone,
+        firstName: trimmedFirstName,
+        smsSnippets,
+        followupNoteId,
+      });
+    } catch (err) {
+      console.error(
+        `[landing-page] Auto-reply SMS dispatch failed for ${trimmedPhone}:`,
+        err,
+      );
+    }
 
     return {
       success: true,
@@ -228,13 +237,19 @@ async function maybeSendAutoReplySms(
   });
   if (!body) return;
 
-  // Per-recipient daily cap so repeat submissions don't spam the same phone
-  const allowed = await ctx.runMutation(
-    internal.functions.communityLandingPage.tryConsumeSmsRateLimit,
-    { phone: params.phone },
+  // Atomic check-cap-and-schedule — Twilio is invoked from the scheduled
+  // sendAutoReplySmsAndAudit action, so Twilio outages can't fail this form
+  // submission AND the actual sent/failed outcome lands in the audit note.
+  const outcome = await ctx.runMutation(
+    internal.functions.communityLandingPage.dispatchAutoReplySmsIfAllowed,
+    {
+      phone: params.phone,
+      message: body,
+      followupNoteId: params.followupNoteId,
+    },
   );
 
-  if (!allowed) {
+  if (outcome === "suppressed_cap") {
     console.warn(
       `[landing-page] Auto-reply SMS suppressed for ${params.phone}: daily cap reached`,
     );
@@ -247,23 +262,58 @@ async function maybeSendAutoReplySms(
         },
       );
     }
-    return;
   }
-
-  // Fire via scheduler so a Twilio outage can't fail the form submission
-  await ctx.scheduler.runAfter(0, internal.functions.auth.phoneOtp.sendSMS, {
-    phone: params.phone,
-    message: body,
-  });
-
-  if (params.followupNoteId) {
-    await ctx.runMutation(
-      internal.functions.communityLandingPage.recordSmsAuditOnNote,
-      {
-        noteId: params.followupNoteId,
-        outcome: "sent",
-        body,
-      },
-    );
-  }
+  // outcome === "scheduled": the dispatched action will write the audit
+  // (either "sent" or "send_failed") once Twilio resolves.
 }
+
+/**
+ * Dispatch a queued landing-page auto-reply SMS, then record the outcome
+ * (sent vs. failed) on the submission note. Scheduled by
+ * dispatchAutoReplySmsIfAllowed so Twilio errors land in the staff-visible
+ * note instead of bubbling into the form submission.
+ */
+export const sendAutoReplySmsAndAudit = internalAction({
+  args: {
+    phone: v.string(),
+    message: v.string(),
+    followupNoteId: v.union(v.id("memberFollowups"), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    let outcome: "sent" | "send_failed" = "sent";
+    let errorMessage: string | undefined;
+    try {
+      const result = await ctx.runAction(
+        internal.functions.auth.phoneOtp.sendSMS,
+        { phone: args.phone, message: args.message },
+      );
+      // sendSMS returns { success: false } when Twilio env vars are missing
+      if (!result.success) {
+        outcome = "send_failed";
+        errorMessage = "Twilio credentials not configured";
+      }
+    } catch (err: unknown) {
+      outcome = "send_failed";
+      errorMessage =
+        err instanceof Error ? err.message : String(err ?? "unknown error");
+      console.error(
+        `[landing-page] Auto-reply SMS dispatch failed for ${args.phone}:`,
+        err,
+      );
+    }
+
+    if (args.followupNoteId) {
+      await ctx.runMutation(
+        internal.functions.communityLandingPage.recordSmsAuditOnNote,
+        {
+          noteId: args.followupNoteId,
+          outcome,
+          body: args.message,
+          error: errorMessage,
+        },
+      );
+    }
+    return null;
+  },
+});

--- a/apps/convex/lib/rateLimit.ts
+++ b/apps/convex/lib/rateLimit.ts
@@ -11,10 +11,23 @@
 import type { MutationCtx } from "../_generated/server";
 
 /**
+ * Thrown by checkRateLimit when the caller has exceeded the allowed
+ * attempts inside the current window. Distinct from generic errors
+ * (DB failures, validation, etc.) so callers can branch on cap-reached
+ * vs. unexpected operational failure without string-matching.
+ */
+export class RateLimitExceededError extends Error {
+  constructor(message = "Too many attempts. Please try again later.") {
+    super(message);
+    this.name = "RateLimitExceededError";
+  }
+}
+
+/**
  * Check and increment rate limit counter.
  *
  * If the caller has exceeded `maxAttempts` within `windowMs`, throws
- * with a generic "Too many attempts" error (no details leaked).
+ * `RateLimitExceededError` with a generic message (no details leaked).
  *
  * If the previous window has expired, the counter resets automatically.
  *
@@ -50,7 +63,7 @@ export async function checkRateLimit(
 
     // Still within the window
     if (existing.attempts >= maxAttempts) {
-      throw new Error("Too many attempts. Please try again later.");
+      throw new RateLimitExceededError();
     }
 
     // Increment

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2096,10 +2096,27 @@ export default defineSchema({
           value: v.optional(v.string()),
         }),
         action: v.object({
-          type: v.string(), // "set_assignee"
+          type: v.string(), // "set_assignee" | "append_sms"
           assigneePhone: v.optional(v.string()),
           assigneeUserId: v.optional(v.id("users")),
+          // For append_sms: a single bullet/line appended to the auto-reply SMS
+          // when the rule's condition matches. Supports {firstName} substitution.
+          snippet: v.optional(v.string()),
         }),
+      }),
+    ),
+    // Auto-reply SMS sent to the submitter after their form submission.
+    // Each matching automation rule with type "append_sms" contributes a
+    // snippet between the intro and outro. Snippets and the intro/outro
+    // support {firstName} substitution.
+    autoReplySms: v.optional(
+      v.object({
+        enabled: v.boolean(),
+        intro: v.string(),
+        outro: v.string(),
+        // If true, the intro+outro is sent even when no append_sms rules match.
+        // If false, no SMS is sent unless at least one snippet is collected.
+        sendIfNoSnippetsMatch: v.boolean(),
       }),
     ),
     createdAt: v.number(),

--- a/apps/mobile/features/admin/components/LandingPageContent.tsx
+++ b/apps/mobile/features/admin/components/LandingPageContent.tsx
@@ -89,10 +89,25 @@ type AutomationRule = {
     value?: string;
   };
   action: {
-    type: string;
+    type: string; // "set_assignee" | "append_sms"
     assigneePhone?: string;
     assigneeUserId?: Id<"users">;
+    snippet?: string;
   };
+};
+
+type AutoReplySmsConfig = {
+  enabled: boolean;
+  intro: string;
+  outro: string;
+  sendIfNoSnippetsMatch: boolean;
+};
+
+const DEFAULT_AUTO_REPLY_SMS: AutoReplySmsConfig = {
+  enabled: false,
+  intro: "Hey {firstName}! Thanks for connecting with us 🙌\nBased on what you shared:",
+  outro: "Someone from our team will follow up with you soon!",
+  sendIfNoSnippetsMatch: true,
 };
 
 export function LandingPageContent() {
@@ -115,6 +130,9 @@ export function LandingPageContent() {
 
   // Automation rules state
   const [automationRules, setAutomationRules] = useState<AutomationRule[]>([]);
+
+  // Auto-reply SMS state
+  const [autoReplySms, setAutoReplySms] = useState<AutoReplySmsConfig>(DEFAULT_AUTO_REPLY_SMS);
 
   // Modal state
   const [showFieldModal, setShowFieldModal] = useState(false);
@@ -176,8 +194,19 @@ export function LandingPageContent() {
             type: r.action.type,
             assigneePhone: r.action.assigneePhone,
             assigneeUserId: r.action.assigneeUserId,
+            snippet: r.action.snippet,
           },
         }))
+      );
+      setAutoReplySms(
+        config.autoReplySms
+          ? {
+              enabled: config.autoReplySms.enabled,
+              intro: config.autoReplySms.intro,
+              outro: config.autoReplySms.outro,
+              sendIfNoSnippetsMatch: config.autoReplySms.sendIfNoSnippetsMatch,
+            }
+          : DEFAULT_AUTO_REPLY_SMS
       );
       setIsDirty(false);
     }
@@ -213,6 +242,7 @@ export function LandingPageContent() {
         requireBirthday,
         formFields,
         automationRules,
+        autoReplySms,
       });
       setIsDirty(false);
       Alert.alert("Saved", "Landing page configuration saved successfully.");
@@ -546,7 +576,79 @@ export function LandingPageContent() {
       </View>
 
       {/* ================================================================ */}
-      {/* Section 3: Automation Rules */}
+      {/* Section 3: Auto-Reply SMS */}
+      {/* ================================================================ */}
+      <View style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Auto-Reply SMS</Text>
+        <Text style={[styles.sectionHint, { color: colors.textTertiary }]}>
+          One text is sent to the submitter after they fill out the form. Each
+          enabled rule below with action "Append to auto-reply" adds a line in
+          between. {"{firstName}"} is replaced with their first name.
+        </Text>
+
+        <View style={[styles.row, { borderBottomColor: colors.borderLight }]}>
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.rowLabel, { color: colors.text }]}>Enabled</Text>
+            <Text style={[styles.rowHint, { color: colors.textTertiary }]}>
+              Sends a text to the submitter on each submission (capped at 2 per phone per 24h)
+            </Text>
+          </View>
+          <Switch
+            value={autoReplySms.enabled}
+            onValueChange={(v) => {
+              setAutoReplySms((prev) => ({ ...prev, enabled: v }));
+              markDirty();
+            }}
+          />
+        </View>
+
+        <View style={styles.field}>
+          <Text style={[styles.fieldLabel, { color: colors.text }]}>Intro</Text>
+          <TextInput
+            style={[styles.textInput, styles.multilineInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+            value={autoReplySms.intro}
+            onChangeText={(v) => {
+              setAutoReplySms((prev) => ({ ...prev, intro: v }));
+              markDirty();
+            }}
+            placeholder="Hey {firstName}! Thanks for connecting with us..."
+            multiline
+          />
+        </View>
+
+        <View style={styles.field}>
+          <Text style={[styles.fieldLabel, { color: colors.text }]}>Outro</Text>
+          <TextInput
+            style={[styles.textInput, styles.multilineInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+            value={autoReplySms.outro}
+            onChangeText={(v) => {
+              setAutoReplySms((prev) => ({ ...prev, outro: v }));
+              markDirty();
+            }}
+            placeholder="Someone from our team will follow up soon!"
+            multiline
+          />
+        </View>
+
+        <View style={[styles.row, { borderBottomColor: colors.borderLight }]}>
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.rowLabel, { color: colors.text }]}>Send even when no rules match</Text>
+            <Text style={[styles.rowHint, { color: colors.textTertiary }]}>
+              If off, the SMS is only sent when at least one append-SMS rule matches the submission
+            </Text>
+          </View>
+          <Switch
+            value={autoReplySms.sendIfNoSnippetsMatch}
+            onValueChange={(v) => {
+              setAutoReplySms((prev) => ({ ...prev, sendIfNoSnippetsMatch: v }));
+              markDirty();
+            }}
+          />
+        </View>
+      </View>
+
+      {/* ================================================================ */}
+      {/* Section 4: Automation Rules */}
       {/* ================================================================ */}
       <View style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}>
         <View style={styles.sectionHeader}>
@@ -586,7 +688,9 @@ export function LandingPageContent() {
                   {rule.condition.value ? ` "${rule.condition.value}"` : ""} →{" "}
                   {rule.action.type === "set_assignee"
                     ? `assign to ${rule.action.assigneePhone || "..."}`
-                    : rule.action.type}
+                    : rule.action.type === "append_sms"
+                      ? `append SMS: "${(rule.action.snippet || "").slice(0, 60)}${(rule.action.snippet || "").length > 60 ? "…" : ""}"`
+                      : rule.action.type}
                 </Text>
               </View>
               <TouchableOpacity
@@ -964,6 +1068,11 @@ function FieldEditorModal({
 // Rule Editor Modal
 // ============================================================================
 
+const ACTION_TYPES = [
+  { value: "set_assignee", label: "Assign to person" },
+  { value: "append_sms", label: "Append to auto-reply SMS" },
+];
+
 function RuleEditorModal({
   visible,
   rule,
@@ -982,7 +1091,9 @@ function RuleEditorModal({
   const [conditionField, setConditionField] = useState("");
   const [conditionOperator, setConditionOperator] = useState("is_true");
   const [conditionValue, setConditionValue] = useState("");
+  const [actionType, setActionType] = useState<string>("set_assignee");
   const [assigneePhone, setAssigneePhone] = useState("");
+  const [snippet, setSnippet] = useState("");
 
   useEffect(() => {
     if (visible) {
@@ -990,7 +1101,9 @@ function RuleEditorModal({
       setConditionField(rule?.condition.field || "");
       setConditionOperator(rule?.condition.operator || "is_true");
       setConditionValue(rule?.condition.value || "");
+      setActionType(rule?.action.type || "set_assignee");
       setAssigneePhone(rule?.action.assigneePhone || "");
+      setSnippet(rule?.action.snippet || "");
     }
   }, [visible, rule]);
 
@@ -1004,6 +1117,13 @@ function RuleEditorModal({
       return;
     }
 
+    if (actionType === "append_sms") {
+      if (!snippet.trim()) {
+        Alert.alert("Error", "Add the SMS snippet to append");
+        return;
+      }
+    }
+
     onSave({
       id: rule?.id || `rule_${Date.now()}`,
       name: name.trim(),
@@ -1013,11 +1133,17 @@ function RuleEditorModal({
         operator: conditionOperator,
         value: conditionValue || undefined,
       },
-      action: {
-        type: "set_assignee",
-        assigneePhone: assigneePhone || undefined,
-        assigneeUserId: rule?.action.assigneeUserId,
-      },
+      action:
+        actionType === "append_sms"
+          ? {
+              type: "append_sms",
+              snippet: snippet.trim(),
+            }
+          : {
+              type: "set_assignee",
+              assigneePhone: assigneePhone || undefined,
+              assigneeUserId: rule?.action.assigneeUserId,
+            },
     });
   };
 
@@ -1115,17 +1241,59 @@ function RuleEditorModal({
 
             <Text style={[styles.fieldLabel, { marginTop: 8, color: colors.text }]}>Action</Text>
             <View style={styles.field}>
-              <Text style={[styles.fieldHint, { color: colors.textTertiary }]}>
-                Set assignee (enter phone number)
-              </Text>
-              <TextInput
-                style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
-                value={assigneePhone}
-                onChangeText={setAssigneePhone}
-                placeholder="(555) 555-5555"
-                keyboardType="phone-pad"
-              />
+              <View style={modalStyles.chipContainer}>
+                {ACTION_TYPES.map((a) => (
+                  <TouchableOpacity
+                    key={a.value}
+                    style={[
+                      modalStyles.chip, { borderColor: colors.inputBorder, backgroundColor: colors.buttonSecondary },
+                      actionType === a.value && { borderColor: colors.success, backgroundColor: colors.selectedBackground },
+                    ]}
+                    onPress={() => setActionType(a.value)}
+                  >
+                    <Text
+                      style={[
+                        modalStyles.chipText, { color: colors.textSecondary },
+                        actionType === a.value && { color: colors.success },
+                      ]}
+                    >
+                      {a.label}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
             </View>
+
+            {actionType === "set_assignee" && (
+              <View style={styles.field}>
+                <Text style={[styles.fieldHint, { color: colors.textTertiary }]}>
+                  Phone number of the person to assign this lead to
+                </Text>
+                <TextInput
+                  style={[styles.textInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+                  value={assigneePhone}
+                  onChangeText={setAssigneePhone}
+                  placeholder="(555) 555-5555"
+                  keyboardType="phone-pad"
+                />
+              </View>
+            )}
+
+            {actionType === "append_sms" && (
+              <View style={styles.field}>
+                <Text style={[styles.fieldHint, { color: colors.textTertiary }]}>
+                  Line added to the auto-reply SMS when this rule matches.
+                  Supports {"{firstName}"}. Make sure the Auto-Reply SMS section above is enabled.
+                </Text>
+                <TextInput
+                  style={[styles.textInput, styles.multilineInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+                  value={snippet}
+                  onChangeText={setSnippet}
+                  placeholder="• Dinner Party — find one near you in our app: https://..."
+                  multiline
+                />
+              </View>
+            )}
           </ScrollView>
 
           <TouchableOpacity style={[modalStyles.saveButton, { backgroundColor: colors.buttonPrimary }]} onPress={handleSave}>

--- a/apps/mobile/features/admin/hooks/useLandingPageConfig.ts
+++ b/apps/mobile/features/admin/hooks/useLandingPageConfig.ts
@@ -66,8 +66,15 @@ export function useLandingPageConfig() {
           type: string;
           assigneePhone?: string;
           assigneeUserId?: Id<"users">;
+          snippet?: string;
         };
       }>;
+      autoReplySms?: {
+        enabled: boolean;
+        intro: string;
+        outro: string;
+        sendIfNoSnippetsMatch: boolean;
+      };
     }) => {
       if (!community?.id || !token) {
         throw new Error("Not authenticated");


### PR DESCRIPTION
## Summary

Lets community admins configure a single SMS auto-reply that fires when a visitor submits the landing-page form. The body is built from a fixed intro + per-rule snippets (one bullet per matching automation rule with the new "Append to auto-reply SMS" action) + a fixed outro, with `{firstName}` substitution.

Use case from the field: Brittany at Fount wants visitors who check "Dinner Party + Foundations + Baptisms" to get **one** text covering all three selections, not three separate texts. Today there's no way to send any auto-reply at all.

## What changed

**Schema** (`apps/convex/schema.ts`)
- `automationRules.action` gets optional `snippet` (for the new `append_sms` action type)
- New optional `autoReplySms` config on `communityLandingPages` — `{ enabled, intro, outro, sendIfNoSnippetsMatch }`

**Backend** (`apps/convex/functions/communityLandingPage.ts`, `communityLandingPageActions.ts`)
- Rule evaluator collects every matching `append_sms` snippet while preserving first-match-wins for `set_assignee`
- `saveConfig` validates snippet presence and an 800-char intro+outro cap
- New `tryConsumeSmsRateLimit` — 2 sends per phone per 24h, returns boolean instead of throwing
- New `recordSmsAuditOnNote` — appends "Auto-Reply SMS sent: <body>" or "suppressed: ..." to the existing landing-page submission note
- `submitForm` action composes the SMS, enforces the per-phone cap, dispatches via the existing `internal.functions.auth.phoneOtp.sendSMS` action through the scheduler so a Twilio outage cannot fail the form submission

**Admin UI** (`apps/mobile/features/admin/components/LandingPageContent.tsx`)
- New "Auto-Reply SMS" card above Automation Rules with intro/outro/enabled/sendIfNoSnippetsMatch
- Rule editor modal gets an action-type picker; snippet textarea swaps in when "Append to auto-reply SMS" is chosen
- Rule list summary shows snippet preview

## Safety nets

- Form-submission rate limit (5/h per phone, existing) gates the source
- New SMS-specific cap (2/24h per phone) stops repeat submissions from spamming the same recipient with auto-replies
- Twilio's 1600-char body limit enforced at compose time
- SMS dispatched via scheduler — Twilio errors never fail the form
- Test phones short-circuit in `sendSMS` (existing infra)
- Existing schema field stays optional → no migration needed

## Test plan

- [x] Convex + mobile typecheck pass
- [x] Browser E2E (Playwright):
  - [x] Admin UI: enable Auto-Reply SMS, edit intro/outro, save
  - [x] Add `append_sms` rule via modal (action-type picker, snippet textarea)
  - [x] Submit form with one matching rule → SMS dispatched with composed body
  - [x] Submit form with two matching rules (Dinner Party + Foundations) → both bullets in one composed SMS
  - [x] Submission audit appended to follow-up note (verified `memberFollowups.content` in DB)
  - [x] 3rd submission within 24h → rate-limit cap fires, "suppressed" audit recorded, form submission still succeeds
- [ ] Reviewer to sanity-check Twilio path on staging with a non-test phone

## Follow-ups (out of scope)

UX-review subagent flagged these — worth a separate PR:
- Live SMS preview in the auto-reply card
- Cross-section warnings (SMS enabled with no append rules; rules exist with SMS disabled)
- "Insert {firstName}" affordance + plain-language hint
- Friendlier action-type label ("Add a line to the auto-reply text")

🤖 Generated with [Claude Code](https://claude.com/claude-code)