### PR TITLE
fix(chat): stop chat-path queries/mutations from throwing on lost membership

### DIFF
--- a/apps/convex/__tests__/messaging/readState.test.ts
+++ b/apps/convex/__tests__/messaging/readState.test.ts
@@ -745,7 +745,9 @@ describe("Get Message Read By", () => {
     expect(result.totalMembers).toBe(2);
   });
 
-  test("should throw error if user is not a member of the channel", async () => {
+  test("returns zero counts if user is not a member of the channel", async () => {
+    // Reactive query: must not throw on lost membership or it crashes the
+    // chat screen via ErrorBoundary.
     const t = convexTest(schema, modules);
     const { communityId, channelId } = await seedTestData(t);
 
@@ -775,32 +777,30 @@ describe("Get Message Read By", () => {
       });
     });
 
-    await expect(
-      t.query(api.functions.messaging.readState.getMessageReadBy, {
-        token: unauthorizedToken,
-        messageId,
-        channelId,
-      })
-    ).rejects.toThrow("Not a member of this channel");
+    const result = await t.query(api.functions.messaging.readState.getMessageReadBy, {
+      token: unauthorizedToken,
+      messageId,
+      channelId,
+    });
+    expect(result).toEqual({ readByCount: 0, totalMembers: 0 });
   });
 
-  test("should throw error if message does not exist", async () => {
+  test("returns zero counts if message does not exist", async () => {
+    // Reactive query: stale message id from a deleted message must not crash.
     const t = convexTest(schema, modules);
     const { userId, channelId, accessToken } = await seedTestData(t);
 
-    // Create a message and then delete it to get a valid but non-existent ID
     const messageId = await sendMessage(t, channelId, userId, "Test");
     await t.run(async (ctx) => {
       await ctx.db.delete(messageId);
     });
 
-    await expect(
-      t.query(api.functions.messaging.readState.getMessageReadBy, {
-        token: accessToken,
-        messageId,
-        channelId,
-      })
-    ).rejects.toThrow("Message not found");
+    const result = await t.query(api.functions.messaging.readState.getMessageReadBy, {
+      token: accessToken,
+      messageId,
+      channelId,
+    });
+    expect(result).toEqual({ readByCount: 0, totalMembers: 0 });
   });
 
   test("should throw error if message does not belong to channel", async () => {

--- a/apps/convex/__tests__/messaging/typing.test.ts
+++ b/apps/convex/__tests__/messaging/typing.test.ts
@@ -243,7 +243,10 @@ describe("Start Typing", () => {
     expect(indicator2?.expiresAt).toBeGreaterThan(indicator1?.expiresAt || 0);
   });
 
-  test("should reject from non-channel-member", async () => {
+  test("silently no-ops for a non-channel-member", async () => {
+    // Mutation is fired on every keystroke from the chat composer; a throw
+    // becomes an unhandled rejection if the user lost membership while the
+    // screen is still mounted. Verify it returns cleanly and writes nothing.
     const t = convexTest(schema, modules);
     const { channelId, communityId } = await seedTestData(t);
 
@@ -261,12 +264,20 @@ describe("Start Typing", () => {
 
     const { accessToken: nonMemberToken } = await generateTokens(nonMemberId);
 
-    await expect(
-      t.mutation(api.functions.messaging.typing.startTyping, {
-        token: nonMemberToken,
-        channelId,
-      })
-    ).rejects.toThrow();
+    await t.mutation(api.functions.messaging.typing.startTyping, {
+      token: nonMemberToken,
+      channelId,
+    });
+
+    const indicator = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatTypingIndicators")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", nonMemberId)
+        )
+        .first()
+    );
+    expect(indicator).toBeNull();
   });
 });
 

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -286,7 +286,7 @@ export const getMessages = query({
     // Get the channel to check group membership
     const channel = await ctx.db.get(args.channelId);
     if (!channel) {
-      throw new Error("Channel not found");
+      throw new ConvexError("Channel not found");
     }
 
     // Event channels use meeting-based access (RSVPers may not be group members).
@@ -345,9 +345,14 @@ export const getMessages = query({
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
 
-      // If not a channel member, only group leaders/admins may load messages
+      // If not a channel member, only group leaders/admins may load messages.
+      // Return empty instead of throwing — `getMessages` is a reactive query and
+      // a throw crashes the chat screen via ErrorBoundary when membership is
+      // lost mid-session (e.g. user confirms a Leave Group alert while the
+      // chat screen is still mounted). The screen's own navigation flow handles
+      // the redirect; we just need to stop replying with messages.
       if (!channelMembership && !isLeaderRole(groupMembership?.role)) {
-        throw new Error("Not a member of this channel");
+        return { messages: [], hasMore: false, cursor: undefined };
       }
 
       // For bypassing global disabled check, consider leadership in owning group OR linked group
@@ -370,13 +375,15 @@ export const getMessages = query({
       const effectiveEnabled = args.viewingGroupId
         ? channelEffectiveEnabledForGroup(channel, args.viewingGroupId)
         : channelIsLeaderEnabled(channel);
+      // Disabled leader-only channel for a non-leader viewer: same reasoning
+      // as above — return empty rather than crash the chat screen.
       if (
         (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
         !effectiveEnabled &&
         !isOwningGroupLeader &&
         !isLinkedGroupLeader
       ) {
-        throw new Error("Channel is not available");
+        return { messages: [], hasMore: false, cursor: undefined };
       }
     }
 

--- a/apps/convex/functions/messaging/readState.ts
+++ b/apps/convex/functions/messaging/readState.ts
@@ -4,7 +4,7 @@
  * Track unread counts and mark messages as read.
  */
 
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
@@ -140,18 +140,22 @@ export const getMessageReadBy = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
+    // Lost-membership / stale-args during reactive re-fire: return a zero
+    // result instead of throwing. `getMessageReadBy` is rendered per message
+    // in the chat list and a throw crashes the screen via ErrorBoundary.
     if (!membership) {
-      throw new Error("Not a member of this channel");
+      return { readByCount: 0, totalMembers: 0 };
     }
 
     // Get the message to find its timestamp and sender
     const message = await ctx.db.get(args.messageId);
     if (!message) {
-      throw new Error("Message not found");
+      return { readByCount: 0, totalMembers: 0 };
     }
 
     if (message.channelId !== args.channelId) {
-      throw new Error("Message does not belong to this channel");
+      // Genuine arg mismatch — surface in Sentry rather than silently zero.
+      throw new ConvexError("Message does not belong to this channel");
     }
 
     // Get all active members of the channel (excluding the sender). Members
@@ -237,8 +241,12 @@ export const markAsRead = mutation({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
+    // Lost-membership during reactive re-fire: silent no-op. The chat screen
+    // fires `markAsRead` from a useEffect without a .catch, so a throw
+    // surfaces as an unhandled rejection. There's nothing to mark read for
+    // a viewer who's no longer a member anyway.
     if (!membership) {
-      throw new Error("Not a member of this channel");
+      return;
     }
 
     // Ad-hoc channels (DM, group_dm) require an active profile photo on

--- a/apps/convex/functions/messaging/typing.ts
+++ b/apps/convex/functions/messaging/typing.ts
@@ -120,8 +120,12 @@ export const startTyping = mutation({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
+    // Lost-membership: silent no-op. The chat composer fires `startTyping`
+    // on every keystroke; a throw surfaces as an unhandled rejection if the
+    // user lost membership while the screen is still mounted. There's
+    // nothing to record for a non-member anyway.
     if (!membership) {
-      throw new Error("Not a member of this channel");
+      return;
     }
 
     const now = Date.now();

--- a/apps/mobile/features/chat/hooks/__tests__/useMessages.access-revoked.test.ts
+++ b/apps/mobile/features/chat/hooks/__tests__/useMessages.access-revoked.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression: when the live query returns 0 messages after the viewer loses
+ * access (or messages are deleted), the hook must not keep showing buffered
+ * older pages. See PR #378 — codex flagged that `getMessages` returning a
+ * normal empty page on lost membership would still render pre-revocation
+ * history because `olderMessagesRef` was preferred over an empty live result.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+let mockLiveMessages: any[] = [
+  { _id: 'live-1', content: 'Live', createdAt: 100 },
+];
+let mockOlderHasMore = true;
+let mockLiveCursor: string | undefined = 'older-cursor';
+
+const mockOlderPage = {
+  messages: [{ _id: 'old-1', content: 'Old', createdAt: 50 }],
+  hasMore: false,
+  cursor: undefined,
+};
+
+jest.mock('@services/api/convex', () => ({
+  useQuery: jest.fn((_api: unknown, args: unknown) => {
+    if (args === 'skip') return undefined;
+    const a = args as { cursor?: string };
+    if (a.cursor != null) {
+      return mockOlderPage;
+    }
+    return {
+      messages: mockLiveMessages,
+      hasMore: mockOlderHasMore,
+      cursor: mockLiveCursor,
+    };
+  }),
+  useStoredAuthToken: jest.fn(() => 'test-token'),
+  api: {
+    functions: {
+      messaging: {
+        messages: {
+          getMessages: 'getMessages',
+        },
+      },
+    },
+  },
+}));
+
+jest.mock('../../../../stores/messageCache', () => ({
+  useMessageCache: jest.fn(() => ({
+    getChannelMessages: jest.fn((): null => null),
+    setChannelMessages: jest.fn(),
+  })),
+}));
+
+import { useMessages } from '../useMessages';
+
+describe('useMessages access-revoked', () => {
+  beforeEach(() => {
+    mockLiveMessages = [{ _id: 'live-1', content: 'Live', createdAt: 100 }];
+    mockOlderHasMore = true;
+    mockLiveCursor = 'older-cursor';
+  });
+
+  it('clears buffered older messages when live query returns empty', async () => {
+    const { result, rerender } = renderHook(() => useMessages('ch-1' as any, 20));
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0]._id).toBe('live-1');
+    });
+
+    await act(async () => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages.map((m: any) => m._id).sort()).toEqual([
+        'live-1',
+        'old-1',
+      ]);
+    });
+
+    mockLiveMessages = [];
+    mockOlderHasMore = false;
+    mockLiveCursor = undefined;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(0);
+      expect(result.current.hasMore).toBe(false);
+    });
+  });
+});

--- a/apps/mobile/features/chat/hooks/__tests__/useMessages.access-revoked.test.ts
+++ b/apps/mobile/features/chat/hooks/__tests__/useMessages.access-revoked.test.ts
@@ -44,10 +44,14 @@ jest.mock('@services/api/convex', () => ({
   },
 }));
 
+const mockClearChannel = jest.fn();
+const mockSetChannelMessages = jest.fn();
+
 jest.mock('../../../../stores/messageCache', () => ({
   useMessageCache: jest.fn(() => ({
     getChannelMessages: jest.fn((): null => null),
-    setChannelMessages: jest.fn(),
+    setChannelMessages: mockSetChannelMessages,
+    clearChannel: mockClearChannel,
   })),
 }));
 
@@ -58,9 +62,11 @@ describe('useMessages access-revoked', () => {
     mockLiveMessages = [{ _id: 'live-1', content: 'Live', createdAt: 100 }];
     mockOlderHasMore = true;
     mockLiveCursor = 'older-cursor';
+    mockClearChannel.mockClear();
+    mockSetChannelMessages.mockClear();
   });
 
-  it('clears buffered older messages when live query returns empty', async () => {
+  it('clears buffered older messages and persisted cache when live query returns empty', async () => {
     const { result, rerender } = renderHook(() => useMessages('ch-1' as any, 20));
 
     await waitFor(() => {
@@ -88,5 +94,7 @@ describe('useMessages access-revoked', () => {
       expect(result.current.messages).toHaveLength(0);
       expect(result.current.hasMore).toBe(false);
     });
+
+    expect(mockClearChannel).toHaveBeenCalledWith('ch-1');
   });
 });

--- a/apps/mobile/features/chat/hooks/useMessages.ts
+++ b/apps/mobile/features/chat/hooks/useMessages.ts
@@ -40,7 +40,7 @@ export function useMessages(
   viewingGroupId?: Id<"groups"> | null
 ): UseMessagesResult {
   const token = useStoredAuthToken();
-  const { getChannelMessages, setChannelMessages } = useMessageCache();
+  const { getChannelMessages, setChannelMessages, clearChannel } = useMessageCache();
 
   // Pagination cursor — set temporarily during pagination, then reset to undefined
   // so the live subscription always watches the latest messages.
@@ -120,12 +120,16 @@ export function useMessages(
         // Live subscription result — clear pagination loading state
         isLoadingMoreRef.current = false;
         if (result.messages.length === 0) {
-          // Live query returned 0 messages — buffered older pages are stale
-          // (viewer lost channel access, all messages deleted, etc.). Drop
-          // them so the UI doesn't keep showing pre-revocation history.
+          // Live query returned 0 messages — buffered older pages and the
+          // persisted cache are stale (viewer lost channel access, all
+          // messages deleted, etc.). Drop both so the UI doesn't keep
+          // showing pre-revocation history, including on remount where the
+          // cache would otherwise hydrate the loading-state list before
+          // the next reactive empty page arrives.
           if (olderMessagesRef.current.messages.length > 0) {
             olderMessagesRef.current = { channelId: null, messages: [] };
           }
+          clearChannel(channelId);
           setHasMore(false);
           lastCursorRef.current = result.cursor;
         } else if (olderMessagesRef.current.messages.length === 0) {
@@ -135,7 +139,7 @@ export function useMessages(
         }
       }
     }
-  }, [result, cursor, channelId]);
+  }, [result, cursor, channelId, clearChannel]);
 
   // Cache messages for offline use (only the live page)
   useEffect(() => {

--- a/apps/mobile/features/chat/hooks/useMessages.ts
+++ b/apps/mobile/features/chat/hooks/useMessages.ts
@@ -119,8 +119,17 @@ export function useMessages(
       } else {
         // Live subscription result — clear pagination loading state
         isLoadingMoreRef.current = false;
-        // Only update these from the live query if we haven't paginated yet
-        if (olderMessagesRef.current.messages.length === 0) {
+        if (result.messages.length === 0) {
+          // Live query returned 0 messages — buffered older pages are stale
+          // (viewer lost channel access, all messages deleted, etc.). Drop
+          // them so the UI doesn't keep showing pre-revocation history.
+          if (olderMessagesRef.current.messages.length > 0) {
+            olderMessagesRef.current = { channelId: null, messages: [] };
+          }
+          setHasMore(false);
+          lastCursorRef.current = result.cursor;
+        } else if (olderMessagesRef.current.messages.length === 0) {
+          // Only update these from the live query if we haven't paginated yet
           setHasMore(result.hasMore || false);
           lastCursorRef.current = result.cursor;
         }
@@ -161,7 +170,12 @@ export function useMessages(
       : [];
 
     if (olderMessages.length === 0) return liveMessages;
-    if (liveMessages.length === 0) return olderMessages;
+    if (liveMessages.length === 0) {
+      // Live says 0 messages — trust it. Buffered older pages are stale
+      // (the live useEffect clears the ref on the next tick); returning
+      // them here would leak pre-revocation history for one render.
+      return [];
+    }
 
     // Merge: live messages (newest) + older messages, deduplicating by ID
     const seenIds = new Set<string>();


### PR DESCRIPTION
## Summary

When a user loses access to a channel mid-session — confirms a Leave Group alert, gets demoted from leader, has a channel disabled by an admin from another session — the still-mounted chat screen's reactive queries and auto-fired mutations re-execute on the now-stale viewer. Several of them threw `new Error(...)`, which crashed the screen via ErrorBoundary (queries) or surfaced as unhandled rejections (mutations from `useEffect` / keystroke handlers without `.catch`).

This PR sweeps the chat-screen backend surface and converts the membership/access throws to the same return-empty pattern the rest of the file already uses.

| Function | File | Before | After |
| -------- | ---- | ------ | ----- |
| `getMessages` | `messages.ts` | throw on lost membership / disabled leader channel; throw `Error("Channel not found")` | return `{ messages: [], hasMore: false, cursor: undefined }` for membership/disabled cases; `ConvexError` for channel-not-found |
| `getMessageReadBy` | `readState.ts` | throw on lost membership / deleted message; throw `Error` on channel mismatch | return `{ readByCount: 0, totalMembers: 0 }` for the first two; `ConvexError` for channel mismatch |
| `markAsRead` | `readState.ts` | throw on lost membership | silent no-op (matches the existing ad-hoc-channel no-op a few lines below) |
| `startTyping` | `typing.ts` | throw on lost membership | silent no-op |

## Why these specifically

Identified from a Sentry investigation of user `m97607fsnnzp5cwcknqdmhw7mx860f9t` (eventID `bdc338e1b5ec48dda1953d676af2354d`, 2026-05-07T21:00:14Z). Breadcrumbs:

```
21:00:13.559Z  RCTAlertController presented — title: "Leave Group"
21:00:14.590Z  ErrorBoundary caught getMessages Server Error
```

`getMessages` was the only function that had actually crashed the UI tree in production — aggregating 30d of Sentry events by groupID:

| Sentry issue | Events | Latest      |
| ------------ | ------ | ----------- |
| 7347937366   | 15     | 2026-04-14  |
| 7393363858   | 21     | 2026-04-09  |
| 7430608070   | 21     | 2026-04-30  |
| 7466431624   | 21     | 2026-05-07  |

Each cluster is a single user; the ~20 events per incident are Convex sync-worker retries of the same failing query, not 20 different users. All four currently share the generic `"Server Error"` title because plain `Error` (vs `ConvexError`) is sanitized before the message reaches the client.

`getMessageReadBy`, `markAsRead`, and `startTyping` had the same shape and would fire from the same chat screen during the same Leave-Group transition; they aren't currently a top issue in Sentry but they're firing as unhandled rejections during the ~1s gap between membership loss and screen unmount. `ConvexChatRoomScreen.tsx:434` is the smoking gun — `useEffect` calls `markAsRead()` without a `.catch`.

## Why empty-return is the right shape

The same files already use it elsewhere:

- `messages.ts:298-301` (event channels) — with a comment explaining the exact reasoning: *"callers are React useQuery hooks, and a hard throw crashes the UI tree via the error boundary."*
- `messages.ts:222-266` (`getMessage` singular) — `try`/`catch` returns `null` for any access failure
- `readState.ts:36-38` (`getUnreadCount`) — returns `0`
- `channels.ts:521-540` (`getChannelsByGroup`), `656-716` (`getChannelMembers`), `910-955` (`listGroupChannels`), `1594-1613` (`hasAutoChannels`)
- `typing.ts:42-44` (`getTypingUsers`)
- `blocking.ts` (all) — no membership checks needed

## Audit notes

These chat-path queries/mutations were checked and were already safe:

- `messaging/readState:getUnreadCount`, `getUnreadCounts`
- `messaging/channels:getChannelsByGroup`, `getUserChannels`, `getChannelMembers`, `listGroupChannels`, `getInboxChannels`, `hasAutoChannels`
- `messaging/typing:getTypingUsers`, `stopTyping`
- `messaging/blocking:getBlockedUsers`, `isBlocked`, `isBlockedBy`

DM-inbox functions (`directMessages:listChatRequests`, `getDirectInbox`) were not audited in this PR — different surface, different lost-state semantics.

## Follow-ups (not in this PR)

- Enable a Convex Log Stream → Sentry sink in the dashboard so future incidents surface their actual server-side error message in Sentry without log archeology. Convex MCP retention is too short to retrieve 4-6h-old request IDs (this is what made today's investigation harder than it needed to be).

## Test plan

- [x] `pnpm -w exec tsc -p apps/convex/tsconfig.json --noEmit` clean
- [x] `pnpm test` in `apps/convex` — 80 files / 1412 tests pass
- [x] Updated three existing tests that asserted the old throw-on-lost-membership behavior:
  - `readState.test.ts`: "should throw error if user is not a member of the channel" → "returns zero counts if user is not a member of the channel"
  - `readState.test.ts`: "should throw error if message does not exist" → "returns zero counts if message does not exist"
  - `typing.test.ts`: "should reject from non-channel-member" → "silently no-ops for a non-channel-member" (also asserts no indicator row was written)
- [ ] Manual: open a group chat as a non-leader member → confirm Leave Group → expect smooth navigation away with no ErrorBoundary screen and no Sentry events from `getMessages`, `getMessageReadBy`, `markAsRead`, or `startTyping` during the transition
- [ ] Manual: open a group chat → admin disables the channel from another session → expect: chat shows empty (no crash), screen remains responsive
- [ ] Watch Sentry for ~1w after merge — the four recurring `getMessages: Server Error` clusters should taper off, and any remaining occurrences should be true `Channel not found` cases (now distinguishable by message via `ConvexError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)