### PR TITLE
fix(chat): stop chat-path queries/mutations from throwing on lost membership

### DIFF
--- a/apps/convex/__tests__/messaging/readState.test.ts
+++ b/apps/convex/__tests__/messaging/readState.test.ts
@@ -745,7 +745,9 @@ describe("Get Message Read By", () => {
     expect(result.totalMembers).toBe(2);
   });
 
-  test("should throw error if user is not a member of the channel", async () => {
+  test("returns zero counts if user is not a member of the channel", async () => {
+    // Reactive query: must not throw on lost membership or it crashes the
+    // chat screen via ErrorBoundary.
     const t = convexTest(schema, modules);
     const { communityId, channelId } = await seedTestData(t);
 
@@ -775,32 +777,30 @@ describe("Get Message Read By", () => {
       });
     });
 
-    await expect(
-      t.query(api.functions.messaging.readState.getMessageReadBy, {
-        token: unauthorizedToken,
-        messageId,
-        channelId,
-      })
-    ).rejects.toThrow("Not a member of this channel");
+    const result = await t.query(api.functions.messaging.readState.getMessageReadBy, {
+      token: unauthorizedToken,
+      messageId,
+      channelId,
+    });
+    expect(result).toEqual({ readByCount: 0, totalMembers: 0 });
   });
 
-  test("should throw error if message does not exist", async () => {
+  test("returns zero counts if message does not exist", async () => {
+    // Reactive query: stale message id from a deleted message must not crash.
     const t = convexTest(schema, modules);
     const { userId, channelId, accessToken } = await seedTestData(t);
 
-    // Create a message and then delete it to get a valid but non-existent ID
     const messageId = await sendMessage(t, channelId, userId, "Test");
     await t.run(async (ctx) => {
       await ctx.db.delete(messageId);
     });
 
-    await expect(
-      t.query(api.functions.messaging.readState.getMessageReadBy, {
-        token: accessToken,
-        messageId,
-        channelId,
-      })
-    ).rejects.toThrow("Message not found");
+    const result = await t.query(api.functions.messaging.readState.getMessageReadBy, {
+      token: accessToken,
+      messageId,
+      channelId,
+    });
+    expect(result).toEqual({ readByCount: 0, totalMembers: 0 });
   });
 
   test("should throw error if message does not belong to channel", async () => {

--- a/apps/convex/__tests__/messaging/typing.test.ts
+++ b/apps/convex/__tests__/messaging/typing.test.ts
@@ -243,7 +243,10 @@ describe("Start Typing", () => {
     expect(indicator2?.expiresAt).toBeGreaterThan(indicator1?.expiresAt || 0);
   });
 
-  test("should reject from non-channel-member", async () => {
+  test("silently no-ops for a non-channel-member", async () => {
+    // Mutation is fired on every keystroke from the chat composer; a throw
+    // becomes an unhandled rejection if the user lost membership while the
+    // screen is still mounted. Verify it returns cleanly and writes nothing.
     const t = convexTest(schema, modules);
     const { channelId, communityId } = await seedTestData(t);
 
@@ -261,12 +264,20 @@ describe("Start Typing", () => {
 
     const { accessToken: nonMemberToken } = await generateTokens(nonMemberId);
 
-    await expect(
-      t.mutation(api.functions.messaging.typing.startTyping, {
-        token: nonMemberToken,
-        channelId,
-      })
-    ).rejects.toThrow();
+    await t.mutation(api.functions.messaging.typing.startTyping, {
+      token: nonMemberToken,
+      channelId,
+    });
+
+    const indicator = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatTypingIndicators")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", channelId).eq("userId", nonMemberId)
+        )
+        .first()
+    );
+    expect(indicator).toBeNull();
   });
 });
 

--- a/apps/convex/functions/messaging/readState.ts
+++ b/apps/convex/functions/messaging/readState.ts
@@ -4,7 +4,7 @@
  * Track unread counts and mark messages as read.
  */
 
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
@@ -140,18 +140,22 @@ export const getMessageReadBy = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
+    // Lost-membership / stale-args during reactive re-fire: return a zero
+    // result instead of throwing. `getMessageReadBy` is rendered per message
+    // in the chat list and a throw crashes the screen via ErrorBoundary.
     if (!membership) {
-      throw new Error("Not a member of this channel");
+      return { readByCount: 0, totalMembers: 0 };
     }
 
     // Get the message to find its timestamp and sender
     const message = await ctx.db.get(args.messageId);
     if (!message) {
-      throw new Error("Message not found");
+      return { readByCount: 0, totalMembers: 0 };
     }
 
     if (message.channelId !== args.channelId) {
-      throw new Error("Message does not belong to this channel");
+      // Genuine arg mismatch — surface in Sentry rather than silently zero.
+      throw new ConvexError("Message does not belong to this channel");
     }
 
     // Get all active members of the channel (excluding the sender). Members
@@ -237,8 +241,12 @@ export const markAsRead = mutation({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
+    // Lost-membership during reactive re-fire: silent no-op. The chat screen
+    // fires `markAsRead` from a useEffect without a .catch, so a throw
+    // surfaces as an unhandled rejection. There's nothing to mark read for
+    // a viewer who's no longer a member anyway.
     if (!membership) {
-      throw new Error("Not a member of this channel");
+      return;
     }
 
     // Ad-hoc channels (DM, group_dm) require an active profile photo on

--- a/apps/convex/functions/messaging/typing.ts
+++ b/apps/convex/functions/messaging/typing.ts
@@ -120,8 +120,12 @@ export const startTyping = mutation({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
+    // Lost-membership: silent no-op. The chat composer fires `startTyping`
+    // on every keystroke; a throw surfaces as an unhandled rejection if the
+    // user lost membership while the screen is still mounted. There's
+    // nothing to record for a non-member anyway.
     if (!membership) {
-      throw new Error("Not a member of this channel");
+      return;
     }
 
     const now = Date.now();


### PR DESCRIPTION
## Summary

Companion sweep to #378. The same audit applied to the rest of the chat-screen backend surface — every function the chat screen mounts (reactively or via auto-fired mutation) that throws when a viewer loses membership mid-session.

| Function | File | Old behavior | New behavior |
| -------- | ---- | ------------ | ------------ |
| `getMessageReadBy` (query) | `readState.ts` | throw on lost membership / deleted message; throw `Error` on channel mismatch | return `{ readByCount: 0, totalMembers: 0 }` for the first two; `ConvexError` for channel mismatch (preserves Sentry signal) |
| `markAsRead` (mutation) | `readState.ts` | throw on lost membership | silent no-op (matches the existing ad-hoc-channel no-op a few lines below) |
| `startTyping` (mutation) | `typing.ts` | throw on lost membership | silent no-op |

## Why these specifically

Read-receipt rendering, mark-as-read, and typing indicators all fire from the chat screen without `.catch`. `ConvexChatRoomScreen.tsx:434` is the smoking gun:

```ts
useEffect(() => {
  if (activeChannelId && currentUserId) {
    markAsRead();   // no .catch — rejection → unhandled rejection → Sentry noise
  }
}, [activeChannelId, currentUserId, markAsRead]);
```

Same root cause as #378: lost membership while the chat screen is still mounted (Leave Group flow, demoted from leader, channel disabled by admin from another session, etc.). For these queries/mutations the right behavior is "do nothing" — there's nothing to mark read or type-indicate for a non-member. Empty return is consistent with the pattern already used by `getUnreadCount` (returns 0), `getChannelsByGroup` (returns []), `getChannelMembers` (returns empty), `listGroupChannels` (returns []), `hasAutoChannels` (returns false), and `getTypingUsers` (returns []) — all already safe before this PR.

## Out of scope (audit notes)

These chat-path queries/mutations were checked and are already safe (no changes needed):

- `messaging/readState:getUnreadCount`, `getUnreadCounts`
- `messaging/channels:getChannelsByGroup`, `getUserChannels`, `getChannelMembers`, `listGroupChannels`, `getInboxChannels`, `hasAutoChannels`
- `messaging/typing:getTypingUsers`, `stopTyping`
- `messaging/blocking:getBlockedUsers`, `isBlocked`, `isBlockedBy`

The DM-inbox functions (`directMessages:listChatRequests`, `getDirectInbox`) were not audited in this PR — different surface, different lost-state semantics.

## Test plan

- [x] `pnpm test` in `apps/convex` — 80 files / 1412 tests pass
- [x] Updated three existing tests that were asserting the old throw-on-lost-membership behavior:
  - `readState.test.ts`: "should throw error if user is not a member of the channel" → "returns zero counts if user is not a member of the channel"
  - `readState.test.ts`: "should throw error if message does not exist" → "returns zero counts if message does not exist"
  - `typing.test.ts`: "should reject from non-channel-member" → "silently no-ops for a non-channel-member" (also asserts no indicator row was written)
- [ ] Manual: open a group chat → leave the group → expect no Sentry events from `getMessageReadBy`, `markAsRead`, or `startTyping` during the navigation transition
- [ ] Watch Sentry for ~1w after merge (#378 + this) — the recurring `getMessages: Server Error` cluster should taper off, and no new clusters should appear for the three functions above

## Stacking

Independent of #378 — touches different files. Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)