### PR TITLE
feat(chat): opt-in Announcements channel with leader-only posting

### DIFF
--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -499,7 +499,9 @@ export const getChannelBySlug = query({
     }
 
     if (
-      (isCustomChannel(resolvedChannel.channelType) || resolvedChannel.channelType === "pco_services") &&
+      (isCustomChannel(resolvedChannel.channelType) ||
+        resolvedChannel.channelType === "pco_services" ||
+        resolvedChannel.channelType === "announcements") &&
       !channelEffectiveEnabledForGroup(resolvedChannel, args.groupId) &&
       !isLeaderOrAdmin
     ) {
@@ -2848,6 +2850,12 @@ export const leaveChannel = mutation({
           code: "CANNOT_LEAVE_AUTO_CHANNEL",
           message:
             "You can't leave the Leaders channel directly. You're in this channel because you're a group leader. Ask another leader to change your role to Member, and you'll be automatically removed.",
+        });
+      } else if (channel.channelType === "announcements") {
+        throw new ConvexError({
+          code: "CANNOT_LEAVE_AUTO_CHANNEL",
+          message:
+            "You can't leave the Announcements channel directly. Membership is automatic for active group members. Leave the group entirely if you want to opt out.",
         });
       }
     }

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -3903,20 +3903,21 @@ export const toggleAnnouncementsChannel = mutation({
         // "announcements" before this feature shipped. Convex has no unique
         // constraint, so inserting here would silently produce two rows
         // sharing (groupId, slug) — getChannelBySlug uses .first() and could
-        // resolve to either, breaking routing. Refuse and let the leader
-        // rename the existing channel first.
+        // resolve to either, breaking routing. Reject any row regardless of
+        // archive state: getChannelBySlug({ includeArchived: true }) is used
+        // by the channel-info / active-state screens, so even an archived
+        // collision would resolve to the wrong row from those entry points.
         const slugCollision = await ctx.db
           .query("chatChannels")
           .withIndex("by_group_slug", (q) =>
             q.eq("groupId", args.groupId).eq("slug", "announcements")
           )
-          .filter((q) => q.eq(q.field("isArchived"), false))
           .first();
         if (slugCollision) {
           throw new ConvexError({
             code: "SLUG_CONFLICT",
             message:
-              "This group already has a channel using the slug \"announcements\". Rename or archive it before enabling the Announcements broadcast channel.",
+              "This group already has a channel using the slug \"announcements\" (possibly archived). Rename it before enabling the Announcements broadcast channel.",
           });
         }
         channelId = await ctx.db.insert("chatChannels", {

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -3899,6 +3899,26 @@ export const toggleAnnouncementsChannel = mutation({
         });
         channelId = existingChannel._id;
       } else {
+        // A leader may already have created a *custom* channel with the slug
+        // "announcements" before this feature shipped. Convex has no unique
+        // constraint, so inserting here would silently produce two rows
+        // sharing (groupId, slug) — getChannelBySlug uses .first() and could
+        // resolve to either, breaking routing. Refuse and let the leader
+        // rename the existing channel first.
+        const slugCollision = await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group_slug", (q) =>
+            q.eq("groupId", args.groupId).eq("slug", "announcements")
+          )
+          .filter((q) => q.eq(q.field("isArchived"), false))
+          .first();
+        if (slugCollision) {
+          throw new ConvexError({
+            code: "SLUG_CONFLICT",
+            message:
+              "This group already has a channel using the slug \"announcements\". Rename or archive it before enabling the Announcements broadcast channel.",
+          });
+        }
         channelId = await ctx.db.insert("chatChannels", {
           groupId: args.groupId,
           slug: "announcements",

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -73,11 +73,15 @@ function sortChannelsByPinOrder<T extends {
     if (a.channelType === "main" && b.channelType !== "main") return -1;
     if (a.channelType !== "main" && b.channelType === "main") return 1;
 
-    // Leaders channel second
+    // Announcements channel second (broadcast channel surfaces near General)
+    if (a.channelType === "announcements" && b.channelType !== "announcements") return -1;
+    if (a.channelType !== "announcements" && b.channelType === "announcements") return 1;
+
+    // Leaders channel third
     if (a.channelType === "leaders" && b.channelType !== "leaders") return -1;
     if (a.channelType !== "leaders" && b.channelType === "leaders") return 1;
 
-    // Reach out channel third
+    // Reach out channel fourth
     if (a.channelType === "reach_out" && b.channelType !== "reach_out") return -1;
     if (a.channelType !== "reach_out" && b.channelType === "reach_out") return 1;
 
@@ -1455,7 +1459,9 @@ export const getInboxChannels = query({
           // User must be a member of the channel
           if (!userChannelIds.has(ch._id)) return false;
           if (
-            (isCustomChannel(ch.channelType) || ch.channelType === "pco_services") &&
+            (isCustomChannel(ch.channelType) ||
+              ch.channelType === "pco_services" ||
+              ch.channelType === "announcements") &&
             !channelIsLeaderEnabled(ch) &&
             !isLeaderOrAdmin
           ) {
@@ -1512,6 +1518,8 @@ export const getInboxChannels = query({
           displayName = "General";
         } else if (ch.channelType === "leaders") {
           displayName = "Leaders";
+        } else if (ch.channelType === "announcements") {
+          displayName = "Announcements";
         } else {
           // Custom channels use their actual name
           displayName = ch.name;
@@ -3805,6 +3813,175 @@ export const toggleReachOutChannel = mutation({
 
       return { channelId: existingChannel._id, status: "disabled" };
     }
+  },
+});
+
+/**
+ * Toggle the Announcements channel for a group.
+ *
+ * Announcements is an opt-in, leader-broadcast channel: visible to all
+ * active group members (read-only) while only leaders can post. Posting is
+ * gated in `sendMessage`; visibility/membership flows through the standard
+ * `chatChannelMembers` table so unread counts and inbox previews work.
+ *
+ * When enabled:
+ * - Lazy-creates the channel if it doesn't exist (slug "announcements")
+ * - Re-enables (clears `isEnabled: false`) if previously disabled
+ * - Adds all active group members
+ *
+ * When disabled:
+ * - Sets `isEnabled: false` (channel is hidden from members but memberships
+ *   stay so re-enabling later is cheap and history is preserved).
+ */
+export const toggleAnnouncementsChannel = mutation({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    enabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const now = Date.now();
+
+    const groupMembership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", args.groupId).eq("userId", userId)
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+
+    if (!groupMembership) {
+      throw new ConvexError({
+        code: "FORBIDDEN",
+        message: "Not a member of this group",
+      });
+    }
+
+    if (!isLeaderRole(groupMembership.role)) {
+      throw new ConvexError({
+        code: "FORBIDDEN",
+        message: "Only group leaders can toggle the Announcements channel",
+      });
+    }
+
+    const existingChannel = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_group_type", (q) =>
+        q.eq("groupId", args.groupId).eq("channelType", "announcements")
+      )
+      .first();
+
+    if (args.enabled) {
+      let channelId: Id<"chatChannels">;
+
+      if (existingChannel) {
+        // Already an announcements channel for this group — flip it back on.
+        const wasArchived = existingChannel.isArchived === true;
+        const wasDisabled = existingChannel.isEnabled === false;
+        if (!wasArchived && !wasDisabled) {
+          return { channelId: existingChannel._id, status: "already_enabled" as const };
+        }
+        await ctx.db.patch(existingChannel._id, {
+          isArchived: false,
+          archivedAt: undefined,
+          isEnabled: true,
+          disabledByUserId: undefined,
+          updatedAt: now,
+        });
+        channelId = existingChannel._id;
+      } else {
+        channelId = await ctx.db.insert("chatChannels", {
+          groupId: args.groupId,
+          slug: "announcements",
+          channelType: "announcements",
+          name: "Announcements",
+          description:
+            "Leader announcements — visible to all members; only leaders can post.",
+          createdById: userId,
+          createdAt: now,
+          updatedAt: now,
+          isArchived: false,
+          isEnabled: true,
+          memberCount: 0,
+        });
+      }
+
+      // Add ALL active group members so unread counts work for everyone.
+      const allMembers = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .collect();
+
+      for (const member of allMembers) {
+        const user = await ctx.db.get(member.userId);
+        const displayName = user
+          ? getDisplayName(user.firstName, user.lastName)
+          : undefined;
+        const profilePhoto = user ? getMediaUrl(user.profilePhoto) : undefined;
+
+        const existingMembership = await ctx.db
+          .query("chatChannelMembers")
+          .withIndex("by_channel_user", (q) =>
+            q.eq("channelId", channelId).eq("userId", member.userId)
+          )
+          .first();
+
+        // Channel role mirrors group role so the member list shows leaders
+        // distinctly. Posting permission is enforced server-side in
+        // sendMessage by re-reading the group membership.
+        const channelRole = isLeaderRole(member.role) ? "admin" : "member";
+
+        if (existingMembership) {
+          if (existingMembership.leftAt !== undefined) {
+            await ctx.db.patch(existingMembership._id, {
+              leftAt: undefined,
+              joinedAt: now,
+              role: channelRole,
+              displayName,
+              profilePhoto,
+            });
+          } else if (existingMembership.role !== channelRole) {
+            await ctx.db.patch(existingMembership._id, {
+              role: channelRole,
+              displayName,
+              profilePhoto,
+            });
+          }
+        } else {
+          await ctx.db.insert("chatChannelMembers", {
+            channelId,
+            userId: member.userId,
+            role: channelRole,
+            joinedAt: now,
+            isMuted: false,
+            displayName,
+            profilePhoto,
+          });
+        }
+      }
+
+      await updateChannelMemberCount(ctx, channelId);
+
+      return { channelId, status: "enabled" as const };
+    }
+
+    // DISABLE
+    if (!existingChannel) {
+      return { channelId: undefined, status: "already_disabled" as const };
+    }
+    if (existingChannel.isEnabled === false || existingChannel.isArchived) {
+      return { channelId: existingChannel._id, status: "already_disabled" as const };
+    }
+
+    await ctx.db.patch(existingChannel._id, {
+      isEnabled: false,
+      disabledByUserId: userId,
+      updatedAt: now,
+    });
+
+    return { channelId: existingChannel._id, status: "disabled" as const };
   },
 });
 

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -378,7 +378,9 @@ export const getMessages = query({
       // Disabled leader-only channel for a non-leader viewer: same reasoning
       // as above — return empty rather than crash the chat screen.
       if (
-        (isCustomChannel(channel.channelType) || channel.channelType === "pco_services") &&
+        (isCustomChannel(channel.channelType) ||
+          channel.channelType === "pco_services" ||
+          channel.channelType === "announcements") &&
         !effectiveEnabled &&
         !isOwningGroupLeader &&
         !isLinkedGroupLeader

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -699,6 +699,33 @@ export const sendMessage = mutation({
           throw new Error("This channel is disabled");
         }
       }
+
+      // Announcements channels are leader-broadcast: every active group
+      // member is a channel member (so unread counts work) but only group
+      // leaders can post. Block sends from non-leaders here regardless of
+      // channel-member role, since channel role is denormalized at sync time
+      // and may lag the source-of-truth on `groupMembers`.
+      if (channel.channelType === "announcements") {
+        if (!channelIsLeaderEnabled(channel) || channel.isArchived) {
+          throw new Error("This channel is disabled");
+        }
+        if (!channel.groupId) {
+          throw new Error("Invalid announcements channel");
+        }
+        const groupMembership = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", channel.groupId!).eq("userId", userId)
+          )
+          .filter((q) => q.eq(q.field("leftAt"), undefined))
+          .first();
+        if (!isLeaderRole(groupMembership?.role)) {
+          throw new ConvexError({
+            code: "FORBIDDEN",
+            message: "Only group leaders can post in Announcements",
+          });
+        }
+      }
     }
 
     // Get user info for denormalized fields

--- a/apps/convex/functions/sync/memberships.ts
+++ b/apps/convex/functions/sync/memberships.ts
@@ -236,6 +236,10 @@ export async function syncUserChannelMembershipsLogic(
       shouldBeInChannel = isActiveGroupMember && isLeaderOrAdmin;
     } else if (channel.channelType === "reach_out") {
       shouldBeInChannel = isActiveGroupMember;
+    } else if (channel.channelType === "announcements") {
+      // Announcements: every active group member is a channel member so they
+      // can read; posting is gated to leaders in sendMessage.
+      shouldBeInChannel = isActiveGroupMember;
     }
 
     // Get current channel membership

--- a/apps/convex/lib/helpers.ts
+++ b/apps/convex/lib/helpers.ts
@@ -109,8 +109,9 @@ export function isActiveLeader<T extends SoftDeletableRecord & RoleRecord>(
  * Auto-managed channel types where membership is automatic.
  * - "main": General channel for all group members
  * - "leaders": Channel for leader/admin role members
+ * - "announcements": Leader-broadcast channel for all group members (opt-in per group)
  */
-export const AUTO_CHANNEL_TYPES = ["main", "leaders"] as const;
+export const AUTO_CHANNEL_TYPES = ["main", "leaders", "announcements"] as const;
 export type AutoChannelType = (typeof AUTO_CHANNEL_TYPES)[number];
 
 /**

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1474,10 +1474,11 @@ export default defineSchema({
    *   - "custom" - Custom channel with manual membership
    *   - "pco_services" - Auto channel synced from PCO Services
    *   - "event" - Event-tied channel scoped to a meeting
+   *   - "announcements" - Leader-broadcast channel; visible to all members, only leaders can post (opt-in per group)
    *   - Future: "elvanto", "ccb", etc.
    *
    * Invariant: exactly one of `groupId` or `communityId` is set.
-   *   - groupId set: traditional group-channel ("main" | "leaders" | "custom" | "pco_services" | "event" | "reach_out")
+   *   - groupId set: traditional group-channel ("main" | "leaders" | "custom" | "pco_services" | "event" | "reach_out" | "announcements")
    *   - communityId set: ad-hoc channel ("dm" | "group_dm"), with `isAdHoc: true`
    * Enforced in mutations, not at the DB level (Convex has no constraints).
    */
@@ -1490,7 +1491,7 @@ export default defineSchema({
     /** For 1:1 DMs: deterministic key for dedup, sorted "userIdA::userIdB". */
     dmPairKey: v.optional(v.string()),
     slug: v.optional(v.string()), // URL-friendly, unique per group, immutable (optional for migration)
-    channelType: v.string(), // "main" | "leaders" | "dm" | "group_dm" | "custom" | "pco_services" | "event" | "reach_out"
+    channelType: v.string(), // "main" | "leaders" | "dm" | "group_dm" | "custom" | "pco_services" | "event" | "reach_out" | "announcements"
     name: v.string(),
     description: v.optional(v.string()),
     createdById: v.id("users"),

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
@@ -6,14 +6,15 @@
  * Explicit Active / Disabled choice with consequence text under each
  * option — NOT a single-tap toggle. Wires to whichever toggle mutation
  * exists per channel type:
- *   - "leaders":      toggleLeadersChannel
- *   - "reach_out":    toggleReachOutChannel
- *   - "custom":       setCustomChannelLeaderEnabled
- *   - "pco_services": togglePcoChannel
- *   - "main":         toggleMainChannel  (the General row in the group
- *                     page CHANNELS card always navigates to chat, so
- *                     this path isn't currently reachable from the UI,
- *                     but is wired for completeness)
+ *   - "leaders":       toggleLeadersChannel
+ *   - "reach_out":     toggleReachOutChannel
+ *   - "announcements": toggleAnnouncementsChannel
+ *   - "custom":        setCustomChannelLeaderEnabled
+ *   - "pco_services":  togglePcoChannel
+ *   - "main":          toggleMainChannel  (the General row in the group
+ *                      page CHANNELS card always navigates to chat, so
+ *                      this path isn't currently reachable from the UI,
+ *                      but is wired for completeness)
  *
  * Reach Out: when the Leaders channel is disabled at the group level,
  * the "Active" option is itself disabled and we surface a hint at the
@@ -82,6 +83,9 @@ export default function ChannelActiveStateRoute() {
   const toggleReachOutChannelMutation = useAuthenticatedMutation(
     api.functions.messaging.channels.toggleReachOutChannel,
   );
+  const toggleAnnouncementsChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.toggleAnnouncementsChannel,
+  );
   const toggleMainChannelMutation = useAuthenticatedMutation(
     api.functions.messaging.channels.toggleMainChannel,
   );
@@ -135,6 +139,11 @@ export default function ChannelActiveStateRoute() {
             groupId: groupId as Id<"groups">,
             enabled: next,
           });
+        } else if (channelType === "announcements") {
+          await toggleAnnouncementsChannelMutation({
+            groupId: groupId as Id<"groups">,
+            enabled: next,
+          });
         } else if (channelType === "main") {
           await toggleMainChannelMutation({
             groupId: groupId as Id<"groups">,
@@ -170,6 +179,7 @@ export default function ChannelActiveStateRoute() {
       currentEnabled,
       toggleLeadersChannelMutation,
       toggleReachOutChannelMutation,
+      toggleAnnouncementsChannelMutation,
       toggleMainChannelMutation,
       togglePcoChannelMutation,
       setCustomChannelLeaderEnabledMutation,
@@ -273,6 +283,11 @@ function consequenceFor(channelType: string, active: boolean): string {
     return active
       ? "Reach Out is available to leaders for one-on-one outreach."
       : "Reach Out is hidden. Leaders won't see it in their tabs.";
+  }
+  if (channelType === "announcements") {
+    return active
+      ? "Announcements is visible to all members. Only leaders can post."
+      : "Announcements is hidden. Memberships are kept so re-enabling restores history.";
   }
   if (channelType === "main") {
     return active

--- a/apps/mobile/features/chat/components/ChatNavigation.tsx
+++ b/apps/mobile/features/chat/components/ChatNavigation.tsx
@@ -68,6 +68,7 @@ export const ChatTabBar = memo(function ChatTabBar({
   const getDisplayName = (channel: ChannelTab): string => {
     if (channel.channelType === "main") return "General";
     if (channel.channelType === "leaders") return "Leaders";
+    if (channel.channelType === "announcements") return "Announcements";
     if (channel.channelType === "reach_out") return channel.name || "Reach Out";
     return channel.name;
   };

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -376,13 +376,23 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const groupTypeIdSource = groupTypeIdParam || groupDetails?.groupTypeId || groupData?.groupTypeId;
   const groupTypeId = parseGroupTypeId(groupTypeIdSource);
   const isAnnouncementGroup = isAnnouncementGroupParam === "1" || groupDetails?.isAnnouncementGroup || false;
-  const canSendMessages = !isAnnouncementGroup || isUserLeader;
 
   // Determine if the active channel is a reach_out channel
   const isReachOutChannel = useMemo(() => {
     const activeTab = channelTabs.find((t) => t.slug === activeSlug);
     return activeTab?.channelType === "reach_out";
   }, [channelTabs, activeSlug]);
+
+  // Announcements channels: only group leaders may post. Everyone else falls
+  // through to the read-only banner.
+  const isAnnouncementsChannel = useMemo(() => {
+    const activeTab = channelTabs.find((t) => t.slug === activeSlug);
+    return activeTab?.channelType === "announcements";
+  }, [channelTabs, activeSlug]);
+
+  const canSendMessages =
+    (!isAnnouncementGroup || isUserLeader) &&
+    (!isAnnouncementsChannel || isUserLeader);
 
   // UI state
   const [menuVisible, setMenuVisible] = useState(false);
@@ -1199,7 +1209,9 @@ const ConvexChatRoomScreenInner: React.FC = () => {
             ) : (
               <View style={[styles.readOnlyBanner, { backgroundColor: colors.surfaceSecondary, borderTopColor: colors.border }]}>
                 <Text style={[styles.readOnlyText, { color: colors.textSecondary }]}>
-                  Only admins can post in this channel. You can react to messages.
+                  {isAnnouncementsChannel
+                    ? "Only leaders can post in Announcements. You can react to messages."
+                    : "Only admins can post in this channel. You can react to messages."}
                 </Text>
               </View>
             )}

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -20,17 +20,22 @@
  * bottom of this section now live in GROUP ACTIONS on
  * GroupDetailScreen.
  */
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
+  Alert,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import { useQuery, api } from "@services/api/convex";
+import {
+  useQuery,
+  api,
+  useAuthenticatedMutation,
+} from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
@@ -95,12 +100,39 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
   const mainChannel = channels?.find((c: Channel) => c.channelType === "main");
   const leadersChannel = channels?.find((c: Channel) => c.channelType === "leaders");
   const reachOutChannel = channels?.find((c: Channel) => c.channelType === "reach_out");
+  const announcementsChannel = channels?.find(
+    (c: Channel) => c.channelType === "announcements"
+  );
   const pcoSyncedChannels = channels?.filter((c: Channel) => c.channelType === "pco_services") ?? [];
   const customChannels = channels?.filter((c: Channel) => c.channelType === "custom") ?? [];
 
   const leadersEnabled = !!leadersChannel && !leadersChannel.isArchived;
   const mainEnabled = !!mainChannel && !mainChannel.isArchived;
   const reachOutEnabled = !!reachOutChannel && !reachOutChannel.isArchived;
+  const announcementsEnabled =
+    !!announcementsChannel &&
+    !announcementsChannel.isArchived &&
+    announcementsChannel.isEnabled !== false;
+
+  const toggleAnnouncementsChannelMutation = useAuthenticatedMutation(
+    api.functions.messaging.channels.toggleAnnouncementsChannel
+  );
+  const [enablingAnnouncements, setEnablingAnnouncements] = useState(false);
+
+  const handleEnableAnnouncements = useCallback(async () => {
+    if (enablingAnnouncements) return;
+    setEnablingAnnouncements(true);
+    try {
+      await toggleAnnouncementsChannelMutation({
+        groupId: groupId as Id<"groups">,
+        enabled: true,
+      });
+    } catch (e: any) {
+      Alert.alert("Error", e?.message || "Failed to enable Announcements");
+    } finally {
+      setEnablingAnnouncements(false);
+    }
+  }, [enablingAnnouncements, groupId, toggleAnnouncementsChannelMutation]);
 
   const navigateToChannelChat = useCallback(
     (slug: string) => router.push(`/inbox/${groupId}/${slug}` as any),
@@ -188,6 +220,37 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
         : undefined,
       unreadCount: leadersChannel?.unreadCount,
       pinned: leadersChannel?.isPinned,
+    });
+  }
+
+  // Announcements: opt-in leader-broadcast channel. Leaders see the row
+  // even before the channel exists so they can enable it; members only see
+  // it once a leader has turned it on.
+  if (announcementsChannel || isLeader) {
+    const hasAnnouncementsRecord = !!announcementsChannel;
+    rows.push({
+      key: announcementsChannel?._id ?? "announcements-placeholder",
+      icon: "megaphone",
+      iconColor: "#E11D48",
+      iconBg: "#E11D4815",
+      name: "Announcements",
+      subtitle: hasAnnouncementsRecord
+        ? announcementsEnabled
+          ? `${announcementsChannel!.memberCount} member${announcementsChannel!.memberCount !== 1 ? "s" : ""} · Leaders post`
+          : "Disabled"
+        : enablingAnnouncements
+          ? "Enabling…"
+          : "Tap to enable — leaders post, members read",
+      enabled: announcementsEnabled,
+      // Placeholder (no record yet) tap → lazy-create via mutation.
+      // Existing record tap → channel info screen for further toggling.
+      onPress: hasAnnouncementsRecord
+        ? () => navigateToChannelInfo(announcementsChannel!.slug)
+        : isLeader
+          ? handleEnableAnnouncements
+          : undefined,
+      unreadCount: announcementsChannel?.unreadCount,
+      pinned: announcementsChannel?.isPinned,
     });
   }
 


### PR DESCRIPTION
## Summary
- New `"announcements"` channel type, available to **every** group type (DP, small groups, teams, etc.). Visible to all members; only group leaders can post.
- **Disabled by default, opt-in.** Channel is lazy-created the first time a leader taps the placeholder row in the group's CHANNELS card — no migration, no backfill. All active group members are added at that moment so unread counts work for everyone.
- Disabling sets `isEnabled: false` (memberships preserved, history kept, cheap re-enable).
- Posting is gated server-side in `sendMessage` against the live `groupMembers.role` (the channel-member role is denormalized at sync time and may lag); non-leaders fall through to a read-only banner in the chat composer ("Only leaders can post in Announcements").
- Sort order: General → Announcements → Leaders → Reach Out → custom.

## Files
- **Backend**
  - `apps/convex/schema.ts` — document new channelType
  - `apps/convex/lib/helpers.ts` — add `announcements` to `AUTO_CHANNEL_TYPES`
  - `apps/convex/functions/messaging/channels.ts` — new `toggleAnnouncementsChannel` mutation + sort/visibility wiring
  - `apps/convex/functions/messaging/messages.ts` — leader gate in `sendMessage`
  - `apps/convex/functions/sync/memberships.ts` — auto-add new joiners (announcements case in sync logic)
- **Mobile**
  - `apps/mobile/features/groups/components/ChannelsSection.tsx` — Announcements row (placeholder tap → lazy-create)
  - `apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx` — wires the new mutation for re-enable/disable
  - `apps/mobile/features/chat/components/ChatNavigation.tsx` — `"Announcements"` tab label
  - `apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx` — composer gate + read-only banner copy

## Test plan
- [x] `pnpm --filter ./apps/convex test` (1412 tests pass)
- [x] `npx tsc --noEmit` — no new errors in any touched file
- [x] **Browser (Playwright) as leader (Seyi, Small Group Alpha):**
  - Group CHANNELS card shows "Announcements — Tap to enable — leaders post, members read"
  - Tap the placeholder → channel lazy-created, row updates to "8 members · Leaders post"
  - Tab bar in chat shows General → Announcements → Leaders
  - Posted "First test announcement from leader" successfully
- [ ] Non-leader read-only banner: not tested in browser (no second OTP-bypass test phone seeded). Covered by code review — `canSendMessages = ... && (!isAnnouncementsChannel || isUserLeader)` plus server-side `sendMessage` reject for non-leaders.
- [ ] Disable → re-enable round-trip
- [ ] New joiner auto-added to existing announcements channel
- [ ] Member promoted to leader can immediately post (sync path in `syncUserChannelMembershipsLogic`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)