### PR TITLE
feat(chat): pin Announcements first, render as megaphone-only tab

### DIFF
--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -69,13 +69,15 @@ function sortChannelsByPinOrder<T extends {
   const pinnedSlugSet = new Set(pinnedChannelSlugs);
 
   return channels.sort((a, b) => {
-    // Main channel always first
-    if (a.channelType === "main" && b.channelType !== "main") return -1;
-    if (a.channelType !== "main" && b.channelType === "main") return 1;
-
-    // Announcements channel second (broadcast channel surfaces near General)
+    // Announcements pins to the very front: it's an opt-in broadcast and
+    // renders as a compact icon-only tab, so anchoring it leftmost keeps
+    // the layout predictable and lets General stretch.
     if (a.channelType === "announcements" && b.channelType !== "announcements") return -1;
     if (a.channelType !== "announcements" && b.channelType === "announcements") return 1;
+
+    // Main channel second (the default destination for in-group chat)
+    if (a.channelType === "main" && b.channelType !== "main") return -1;
+    if (a.channelType !== "main" && b.channelType === "main") return 1;
 
     // Leaders channel third
     if (a.channelType === "leaders" && b.channelType !== "leaders") return -1;

--- a/apps/mobile/features/chat/components/ChatNavigation.tsx
+++ b/apps/mobile/features/chat/components/ChatNavigation.tsx
@@ -84,6 +84,12 @@ export const ChatTabBar = memo(function ChatTabBar({
           const isActive = channel.slug === activeSlug;
           const hasUnread = !isActive && channel.unreadCount > 0;
           const displayName = getDisplayName(channel);
+          // Announcements renders as a compact megaphone-only tab to save
+          // horizontal space; the long word "Announcements" otherwise eats
+          // most of a phone-width tab bar. Accessibility label still reads
+          // the channel name for screen readers.
+          const isAnnouncements = channel.channelType === "announcements";
+          const tabColor = isActive ? primaryColor : themeColors.textSecondary;
 
           return (
             <TouchableOpacity
@@ -93,6 +99,7 @@ export const ChatTabBar = memo(function ChatTabBar({
               onLongPress={() => onTabLongPress?.(channel)}
               delayLongPress={300}
               activeOpacity={0.7}
+              accessibilityLabel={displayName}
             >
               <View style={styles.tabContent}>
                 {channel.isShared && (
@@ -103,12 +110,20 @@ export const ChatTabBar = memo(function ChatTabBar({
                     style={styles.sharedTabIcon}
                   />
                 )}
-                <Text
-                  style={[styles.tabText, { color: themeColors.textSecondary }, isActive && { color: primaryColor }]}
-                  numberOfLines={1}
-                >
-                  {displayName}
-                </Text>
+                {isAnnouncements ? (
+                  <Ionicons
+                    name="megaphone"
+                    size={18}
+                    color={tabColor}
+                  />
+                ) : (
+                  <Text
+                    style={[styles.tabText, { color: themeColors.textSecondary }, isActive && { color: primaryColor }]}
+                    numberOfLines={1}
+                  >
+                    {displayName}
+                  </Text>
+                )}
                 {hasUnread && <View style={[styles.unreadDot, { backgroundColor: themeColors.error }]} />}
               </View>
             </TouchableOpacity>


### PR DESCRIPTION
## Summary
Follow-up to #380.
- **Sort order**: Announcements now pins to the very front (left of General) in the chat tab bar, group channels card, and inbox.
- **Tab bar**: Announcements renders as a compact megaphone icon only — the long word "Announcements" otherwise eats most of a phone-width tab bar. Other channels keep their text labels; active state and unread dot still apply. Accessibility label preserves the channel name for screen readers.

## Files
- `apps/convex/functions/messaging/channels.ts` — sort helper bumps announcements ahead of main
- `apps/mobile/features/chat/components/ChatNavigation.tsx` — icon-only tab branch for `channelType === "announcements"`

## Test plan
- [x] `pnpm --filter ./apps/convex test` (1412 tests pass)
- [x] `npx tsc --noEmit` — no new errors
- [x] **Browser (Playwright)**: Small Group Alpha → tab bar shows megaphone (active, green underline) → General → Leaders. `accessibilityLabel="Announcements"` preserved on the icon tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)