### PR TITLE
feat(groups): leader Add people tile + PCO unmatched section with quick actions

### DIFF
--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -1017,3 +1017,133 @@ export const listJoinRequests = query({
   },
 });
 
+/**
+ * Add a Togather user to a group, resolved by their linked PCO person ID.
+ *
+ * Powers the "Add to group" quick action on PCO synced channels for entries
+ * where the unmatched reason is `not_in_group` — the person is already in
+ * the community (matched via phone/email), but isn't in the group that
+ * owns this PCO channel. Resolution uses the
+ * `userCommunities.by_community_pcoPersonId` index so we can find the
+ * Togather userId from the PCO person ID alone.
+ */
+export const addByPcoPersonId = mutation({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    pcoPersonId: v.string(),
+    role: v.optional(groupRoleValidator),
+  },
+  handler: async (ctx, args) => {
+    const addedBy = await requireAuth(ctx, args.token);
+    const timestamp = now();
+
+    const group = await ctx.db.get(args.groupId);
+    if (!group) {
+      throw new Error("Group not found");
+    }
+
+    // Caller must be a leader of this group OR a community admin.
+    const callerMembership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", args.groupId).eq("userId", addedBy)
+      )
+      .first();
+    const isGroupLeaderOrAdmin = isActiveLeader(callerMembership);
+    const isCommAdmin = await isCommunityAdmin(ctx, group.communityId, addedBy);
+    if (!isGroupLeaderOrAdmin && !isCommAdmin) {
+      throw new Error("Only group leaders or community admins can add members");
+    }
+
+    // Resolve the Togather user via the community-scoped PCO index. The
+    // query is keyed by (communityId, pcoPersonId) so the lookup is safe
+    // across communities even if the same PCO person ID exists elsewhere.
+    const linkedMembership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_community_pcoPersonId", (q) =>
+        q.eq("communityId", group.communityId).eq("pcoPersonId", args.pcoPersonId)
+      )
+      .first();
+
+    if (!linkedMembership || linkedMembership.status !== 1) {
+      // Reason classification on the channel-info screen is what surfaces
+      // this case to leaders; keep the message specific so they can route
+      // to "Invite via SMS" instead.
+      throw new Error(
+        "This person isn't linked to a Togather account in this community yet."
+      );
+    }
+
+    const userId = linkedMembership.userId;
+    const userToAdd = await ctx.db.get(userId);
+    if (!userToAdd) {
+      throw new Error("User not found");
+    }
+
+    const existingMember = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", args.groupId).eq("userId", userId)
+      )
+      .first();
+
+    if (existingMember && !existingMember.leftAt) {
+      throw new Error("User is already a member of this group");
+    }
+
+    if (existingMember) {
+      await ctx.db.patch(existingMember._id, {
+        role: args.role || "member",
+        leftAt: undefined,
+        joinedAt: timestamp,
+        notificationsEnabled: true,
+      });
+
+      await syncUserChannelMembershipsLogic(ctx, userId, args.groupId);
+
+      await ctx.scheduler.runAfter(
+        2000,
+        internal.functions.pcoServices.rotation.checkAndSyncUserToAutoChannels,
+        { userId, groupId: args.groupId }
+      );
+
+      return {
+        id: existingMember._id,
+        userId,
+        role: args.role || "member",
+        reactivated: true,
+      };
+    }
+
+    const memberId = await ctx.db.insert("groupMembers", {
+      groupId: args.groupId,
+      userId,
+      role: args.role || "member",
+      joinedAt: timestamp,
+      notificationsEnabled: true,
+    });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduledJobs.sendWelcomeMessage,
+      { groupId: args.groupId, userId }
+    );
+
+    await syncUserChannelMembershipsLogic(ctx, userId, args.groupId);
+
+    await ctx.scheduler.runAfter(
+      2000,
+      internal.functions.pcoServices.rotation.checkAndSyncUserToAutoChannels,
+      { userId, groupId: args.groupId }
+    );
+
+    return {
+      id: memberId,
+      userId,
+      role: args.role || "member",
+      reactivated: false,
+    };
+  },
+});
+

--- a/apps/mobile/features/channels/components/AutoChannelSettings.tsx
+++ b/apps/mobile/features/channels/components/AutoChannelSettings.tsx
@@ -333,6 +333,9 @@ export function AutoChannelSettings({
           {config.lastSyncResults?.unmatchedPeople && config.lastSyncResults.unmatchedPeople.length > 0 && (
             <View style={[styles.unmatchedSection, { backgroundColor: isDark ? '#332b00' : '#FFF8E6' }]}>
               <Text style={[styles.unmatchedTitle, { color: isDark ? '#FFD60A' : '#B25000' }]}>People not found in Togather:</Text>
+              <Text style={[styles.unmatchedSubtitle, { color: isDark ? '#E5C870' : '#8A4500' }]}>
+                Matching is by phone number. Make sure each person's phone in PCO matches their Togather account.
+              </Text>
               {config.lastSyncResults.unmatchedPeople.map((person, index) => (
                 <View key={person.pcoPersonId} style={[
                   styles.unmatchedPerson,
@@ -672,6 +675,11 @@ const styles = StyleSheet.create({
   unmatchedTitle: {
     fontSize: 13,
     fontWeight: "600",
+    marginBottom: 4,
+  },
+  unmatchedSubtitle: {
+    fontSize: 12,
+    lineHeight: 16,
     marginBottom: 8,
   },
   unmatchedPerson: {

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -35,6 +35,7 @@ import {
   Platform,
   TextInput,
   Modal,
+  Linking,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
@@ -55,6 +56,10 @@ import {
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { DOMAIN_CONFIG } from "@togather/shared";
+import {
+  getDebugReasonText,
+  type UnsyncedPerson,
+} from "@/utils/channel-members";
 
 type Props = {
   groupId: string;
@@ -156,6 +161,19 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   const enableInviteLinkMutation = useAuthenticatedMutation(
     api.functions.messaging.channelInvites.enableInviteLink,
   );
+  const addByPcoPersonId = useAuthenticatedMutation(
+    api.functions.groupMembers.addByPcoPersonId,
+  );
+
+  // Auto channel config — drives the "Not in channel" section for PCO synced
+  // channels. Backend gates by leader role + community-admin, so a non-leader
+  // viewer just gets `null` here and the section won't render.
+  const autoChannelConfig = useQuery(
+    api.functions.pcoServices.queries.getAutoChannelConfigByChannel,
+    token && channel?._id && channel.channelType === "pco_services"
+      ? { token, channelId: channel._id }
+      : "skip",
+  );
 
   const [renameVisible, setRenameVisible] = useState(false);
   const [renameValue, setRenameValue] = useState("");
@@ -167,6 +185,9 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   const [leaving, setLeaving] = useState(false);
   const [pcoSettingsVisible, setPcoSettingsVisible] = useState(false);
   const [requestInFlight, setRequestInFlight] = useState<string | null>(null);
+  const [unmatchedActionInFlight, setUnmatchedActionInFlight] = useState<
+    string | null
+  >(null);
 
   const handleJoinMode = useCallback(() => {
     router.push(`/inbox/${groupId}/${channelSlug}/info/join-mode` as any);
@@ -322,6 +343,72 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
     }
   }, [channel?._id, archiveCustomChannelMutation, groupId, router]);
 
+  const handleAddUnmatchedToGroup = useCallback(
+    async (person: UnsyncedPerson) => {
+      if (!groupId) return;
+      setUnmatchedActionInFlight(person.pcoPersonId);
+      try {
+        await addByPcoPersonId({
+          groupId: groupId as Id<"groups">,
+          pcoPersonId: person.pcoPersonId,
+        });
+        Alert.alert(
+          "Added to group",
+          `${person.pcoName} was added. They'll be synced into this channel on the next PCO sync.`,
+        );
+      } catch (e: any) {
+        Alert.alert(
+          "Couldn't add to group",
+          e?.message ?? "Please try again.",
+        );
+      } finally {
+        setUnmatchedActionInFlight(null);
+      }
+    },
+    [addByPcoPersonId, groupId],
+  );
+
+  const handleInviteUnmatchedBySMS = useCallback(
+    async (person: UnsyncedPerson) => {
+      if (!person.pcoPhone) return;
+      const groupName = groupData?.name?.trim() || "our group";
+      const shortId = groupData?.shortId;
+      const groupUrl = shortId
+        ? DOMAIN_CONFIG.groupShareUrl(shortId)
+        : DOMAIN_CONFIG.landingUrl;
+      // SMS originates from the leader's own number, so address the recipient
+      // directly by first name. PCO returns names as "First Last" (composed
+      // from first_name + last_name), so the first whitespace-separated
+      // token is the first name. Falls back to the full pcoName if empty.
+      const firstName =
+        person.pcoName?.trim().split(/\s+/)[0] || person.pcoName || "there";
+      const body =
+        `Hey ${firstName}, join the #${channelDisplayName} channel in ${groupName} on Togather so you can stay in the loop: ${groupUrl}`;
+
+      // sms: separator differs by platform — `?` on Android, `&` on iOS.
+      // See https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/SMSLinks/SMSLinks.html
+      const separator = Platform.OS === "ios" ? "&" : "?";
+      const phone = person.pcoPhone.replace(/\s+/g, "");
+      const url = `sms:${phone}${separator}body=${encodeURIComponent(body)}`;
+
+      try {
+        const can = await Linking.canOpenURL(url);
+        if (!can) {
+          Alert.alert(
+            "Can't open Messages",
+            "This device doesn't support SMS. The link has been copied so you can paste it into another app.",
+          );
+          await Clipboard.setStringAsync(body);
+          return;
+        }
+        await Linking.openURL(url);
+      } catch (e: any) {
+        Alert.alert("Couldn't open Messages", e?.message ?? "Please try again.");
+      }
+    },
+    [channelDisplayName, groupData?.name, groupData?.shortId],
+  );
+
   const handleRename = useCallback(async () => {
     const trimmed = renameValue.trim();
     if (!trimmed) {
@@ -401,6 +488,10 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   const memberRows = channelMembers?.members ?? [];
   const totalMemberCount = channelMembers?.totalCount ?? channel.memberCount ?? 0;
   const ownerId = (channel as { createdById?: Id<"users"> }).createdById;
+  const unmatchedPeople: UnsyncedPerson[] =
+    (autoChannelConfig?.lastSyncResults?.unmatchedPeople as
+      | UnsyncedPerson[]
+      | undefined) ?? [];
 
   return (
     <View
@@ -631,6 +722,159 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
                 </Text>
               </Pressable>
             )}
+          </>
+        )}
+
+        {/* Not in channel — PCO synced channels only. Lists people scheduled
+            in PCO who couldn't be matched into the channel, with the reason
+            and quick actions. Mirrors the unmatched panel in PCO sync
+            settings (image 5 in the original spec). Only renders when the
+            backend returns unmatched data — leader access is enforced server
+            side via `getAutoChannelConfigByChannel`. */}
+        {isPco && isLeader && unmatchedPeople.length > 0 && (
+          <>
+            <SectionHeader
+              colors={colors}
+              label={`Not in channel · ${unmatchedPeople.length}`}
+            />
+            <View
+              style={[
+                styles.unmatchedHelperBox,
+                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+            >
+              <Ionicons name="information-circle" size={16} color={colors.textSecondary} />
+              <Text style={[styles.unmatchedHelperText, { color: colors.textSecondary }]}>
+                PCO matches Togather users by phone number. Make sure each
+                person's phone in PCO matches their Togather account.
+              </Text>
+            </View>
+            <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
+              {unmatchedPeople.map((person, idx) => {
+                const inFlight = unmatchedActionInFlight === person.pcoPersonId;
+                const canAddToGroup = person.reason === "not_in_group";
+                const canSmsInvite = !!person.pcoPhone;
+                return (
+                  <View
+                    key={person.pcoPersonId}
+                    style={[
+                      styles.unmatchedRow,
+                      idx > 0 && {
+                        borderTopWidth: StyleSheet.hairlineWidth,
+                        borderTopColor: colors.border,
+                      },
+                    ]}
+                  >
+                    <View style={styles.unmatchedHeaderRow}>
+                      <View style={styles.unmatchedAvatarWarn}>
+                        <Ionicons name="warning" size={20} color="#B25000" />
+                      </View>
+                      <View style={styles.unmatchedTextWrap}>
+                        <Text
+                          style={[styles.memberRowName, { color: colors.text }]}
+                          numberOfLines={1}
+                        >
+                          {person.pcoName}
+                        </Text>
+                        {(person.teamName || person.position) && (
+                          <Text
+                            style={[styles.unmatchedSubLabel, { color: colors.textSecondary }]}
+                            numberOfLines={1}
+                          >
+                            {[person.teamName, person.position]
+                              .filter(Boolean)
+                              .join(" · ")}
+                          </Text>
+                        )}
+                        {person.pcoPhone ? (
+                          <Text
+                            style={[styles.unmatchedContactLine, { color: colors.textSecondary }]}
+                            numberOfLines={1}
+                          >
+                            {`📱 ${person.pcoPhone}`}
+                          </Text>
+                        ) : null}
+                        {person.pcoEmail ? (
+                          <Text
+                            style={[styles.unmatchedContactLine, { color: colors.textSecondary }]}
+                            numberOfLines={1}
+                          >
+                            {`✉️ ${person.pcoEmail}`}
+                          </Text>
+                        ) : null}
+                        <Text
+                          style={[styles.unmatchedReasonText, { color: "#B25000" }]}
+                          numberOfLines={2}
+                        >
+                          {getDebugReasonText(person.reason, person)}
+                        </Text>
+                      </View>
+                    </View>
+                    {(canAddToGroup || canSmsInvite) && (
+                      <View style={styles.unmatchedActionsRow}>
+                        {canAddToGroup && (
+                          <Pressable
+                            onPress={() => handleAddUnmatchedToGroup(person)}
+                            disabled={inFlight}
+                            style={({ pressed }) => [
+                              styles.unmatchedActionBtn,
+                              {
+                                backgroundColor: pressed
+                                  ? primaryColor + "CC"
+                                  : primaryColor,
+                                opacity: inFlight ? 0.6 : 1,
+                              },
+                            ]}
+                          >
+                            {inFlight ? (
+                              <ActivityIndicator size="small" color="#fff" />
+                            ) : (
+                              <>
+                                <Ionicons name="person-add" size={14} color="#fff" />
+                                <Text style={styles.unmatchedActionLabelLight}>
+                                  Add to group
+                                </Text>
+                              </>
+                            )}
+                          </Pressable>
+                        )}
+                        {canSmsInvite && (
+                          <Pressable
+                            onPress={() => handleInviteUnmatchedBySMS(person)}
+                            disabled={inFlight}
+                            style={({ pressed }) => [
+                              styles.unmatchedActionBtn,
+                              {
+                                backgroundColor: pressed
+                                  ? colors.selectedBackground
+                                  : colors.surface,
+                                borderWidth: StyleSheet.hairlineWidth,
+                                borderColor: colors.border,
+                                opacity: inFlight ? 0.6 : 1,
+                              },
+                            ]}
+                          >
+                            <Ionicons
+                              name="chatbubble-ellipses-outline"
+                              size={14}
+                              color={colors.text}
+                            />
+                            <Text
+                              style={[
+                                styles.unmatchedActionLabel,
+                                { color: colors.text },
+                              ]}
+                            >
+                              Invite via SMS
+                            </Text>
+                          </Pressable>
+                        )}
+                      </View>
+                    )}
+                  </View>
+                );
+              })}
+            </View>
           </>
         )}
 
@@ -1252,6 +1496,79 @@ const styles = StyleSheet.create({
   helperText: {
     fontSize: 12,
     lineHeight: 16,
+  },
+  unmatchedHelperBox: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    marginHorizontal: 12,
+    marginBottom: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  unmatchedHelperText: {
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  unmatchedRow: {
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    gap: 10,
+  },
+  unmatchedHeaderRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  unmatchedAvatarWarn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#FFE0B2",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  unmatchedTextWrap: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  unmatchedSubLabel: {
+    fontSize: 12,
+  },
+  unmatchedContactLine: {
+    fontSize: 12,
+  },
+  unmatchedReasonText: {
+    marginTop: 4,
+    fontSize: 12,
+    fontWeight: "500",
+  },
+  unmatchedActionsRow: {
+    flexDirection: "row",
+    gap: 8,
+    paddingLeft: 52,
+  },
+  unmatchedActionBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    minHeight: 32,
+  },
+  unmatchedActionLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  unmatchedActionLabelLight: {
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "600",
   },
   renameInput: {
     borderWidth: 1,

--- a/apps/mobile/features/groups/components/AddGroupMembersModal.tsx
+++ b/apps/mobile/features/groups/components/AddGroupMembersModal.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { CustomModal } from "@components/ui/Modal";
+import { MemberSearch, CommunityMember } from "@components/ui";
+import { useTheme } from "@hooks/useTheme";
+import {
+  useAuthenticatedMutation,
+  api,
+  type Id,
+} from "@services/api/convex";
+import { formatError } from "@/utils/error-handling";
+
+interface AddGroupMembersModalProps {
+  visible: boolean;
+  onClose: () => void;
+  groupId: string;
+  onAdded?: (member: CommunityMember) => void;
+}
+
+export function AddGroupMembersModal({
+  visible,
+  onClose,
+  groupId,
+  onAdded,
+}: AddGroupMembersModalProps) {
+  const { colors } = useTheme();
+  const addMember = useAuthenticatedMutation(api.functions.groupMembers.add);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastAddedName, setLastAddedName] = useState<string | null>(null);
+
+  const handleSelect = async (member: CommunityMember) => {
+    if (!member.user_id || !groupId) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await addMember({
+        groupId: groupId as Id<"groups">,
+        userId: String(member.user_id) as Id<"users">,
+        role: "member",
+      });
+      setLastAddedName(`${member.first_name} ${member.last_name}`.trim());
+      onAdded?.(member);
+    } catch (e) {
+      setError(formatError(e, "Failed to add member."));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    setError(null);
+    setLastAddedName(null);
+    onClose();
+  };
+
+  return (
+    <CustomModal visible={visible} onClose={handleClose} title="Add people">
+      <View style={styles.container}>
+        {lastAddedName ? (
+          <Text style={[styles.success, { color: colors.success }]}>
+            Added {lastAddedName}. Search to add more.
+          </Text>
+        ) : null}
+        {error ? (
+          <Text style={[styles.error, { color: colors.destructive }]}>
+            {error}
+          </Text>
+        ) : null}
+        <MemberSearch
+          onSelect={handleSelect}
+          excludeGroupMembersOfGroupId={groupId}
+          isDisabled={submitting}
+          placeholder="Search by name, email, or phone..."
+          maxResults={5}
+          showEmptyState={false}
+          clearOnSelect
+        />
+      </View>
+    </CustomModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    minHeight: 320,
+  },
+  success: {
+    fontSize: 14,
+    marginBottom: 8,
+  },
+  error: {
+    fontSize: 14,
+    marginBottom: 8,
+  },
+});

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -29,6 +29,7 @@ import {
 import { useWithdrawJoinRequest } from "../hooks/useWithdrawJoinRequest";
 import { useMyPendingJoinRequests } from "../hooks/useMyPendingJoinRequests";
 import { PendingRequestLimitModal } from "./PendingRequestLimitModal";
+import { AddGroupMembersModal } from "./AddGroupMembersModal";
 import { isGroupMember } from "../utils";
 import { useUserData } from "@features/profile/hooks/useUserData";
 import { GroupHeader } from "./GroupHeader";
@@ -58,6 +59,7 @@ export function GroupDetailScreen() {
   const [showOptionsModal, setShowOptionsModal] = useState(false);
   const [showJoinSuccessModal, setShowJoinSuccessModal] = useState(false);
   const [showPendingLimitModal, setShowPendingLimitModal] = useState(false);
+  const [showAddPeopleModal, setShowAddPeopleModal] = useState(false);
 
   const {
     isAtLimit: isAtPendingLimit,
@@ -467,6 +469,34 @@ export function GroupDetailScreen() {
           </View>
         )}
 
+        {/* Add people — leader/admin only. Mirrors the DM chat-info pattern:
+            a standalone tile sitting just under the members card.
+            Hidden on announcement groups (membership is implicit/community-wide). */}
+        {(isLeader || isAdmin) && group._id && !group.is_announcement_group && (
+          <View style={{ paddingHorizontal: 12, marginTop: 4 }}>
+            <TouchableOpacity
+              onPress={() => setShowAddPeopleModal(true)}
+              activeOpacity={0.7}
+              style={[
+                styles.addPeopleTile,
+                { backgroundColor: colors.surfaceSecondary },
+              ]}
+            >
+              <View
+                style={[
+                  styles.addPeopleIcon,
+                  { backgroundColor: colors.link + "1A" },
+                ]}
+              >
+                <Ionicons name="person-add" size={18} color={colors.link} />
+              </View>
+              <Text style={[styles.actionLabel, { color: colors.text }]}>
+                Add people
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
         {/* UPCOMING EVENTS — horizontal scroll, sits between Members and
             Channels per product design. Hidden when there are no upcoming
             events. */}
@@ -676,6 +706,14 @@ export function GroupDetailScreen() {
         isLeaving={leaveGroupMutation.isPending}
         isArchiving={archiveGroupMutation.isPending}
       />
+      {group._id && (isLeader || isAdmin) && (
+        <AddGroupMembersModal
+          visible={showAddPeopleModal}
+          onClose={() => setShowAddPeopleModal(false)}
+          groupId={group._id}
+          onAdded={() => refetch()}
+        />
+      )}
     </>
   );
 }
@@ -747,6 +785,22 @@ const styles = StyleSheet.create({
   actionLabel: {
     fontSize: 16,
     fontWeight: "500",
+  },
+  addPeopleTile: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    minHeight: 48,
+  },
+  addPeopleIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
   },
   externalRow: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary

Two related leader-facing polishes on the group / PCO channel surfaces:

1. **Group detail "Add people" tile** under "View all members" mirrors the DM chat-info pattern — opens an inline modal that wraps the existing `MemberSearch` and calls `groupMembers.add`. Hidden on announcement groups (membership is implicit/community-wide there).
2. **PCO synced channel info "Not in channel" section** surfaces `lastSyncResults.unmatchedPeople` to leaders with each row's reason (Phone not found, Not in group, etc.) and contact info, plus two quick actions per row:
   - **Add to group** (when reason is `not_in_group`) — new `groupMembers.addByPcoPersonId` mutation resolves the `userId` via the `userCommunities.by_community_pcoPersonId` index, runs the same add-or-reactivate flow as `add`, and triggers a PCO resync so the new member gets pulled into the channel.
   - **Invite via SMS** (when a PCO phone exists) — opens the device's native Messages app via an `sms:` deep link with a personalized template ("Hey {firstName}, join the #{channel} channel in {group} on Togather…") plus the group share URL. No Twilio cost; the SMS comes from the leader's own number.

Both unmatched surfaces (channel info + the existing PCO sync settings panel) include guidance that PCO matches by phone number, so leaders know what to fix when an entry is unmatched.

## Test plan

- [x] Verified in iOS simulator: PCO synced channel `#Brooklyn Production` shows "NOT IN CHANNEL · 2" with helper note, two unmatched people (Lindsay Ross, Marshall Moran), reason text, and "Invite via SMS" buttons (both have `phone_mismatch` reason so no "Add to group" — as expected).
- [ ] Manual: tap "Invite via SMS" → native Messages app opens with template + group URL prefilled.
- [ ] Manual: navigate to a group where I'm a leader → "Add people" tile shows under "View all members" → tap → modal opens with `MemberSearch` → pick a community member → success message; verify the member is added.
- [ ] Manual: on a PCO channel with a `not_in_group` person, tap "Add to group" → confirm Alert shows; verify they appear in the channel after the next sync.
- [ ] Verify the "Add people" tile is hidden on announcement groups.
- [ ] Non-leader on a PCO channel: "Not in channel" section is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)