### PR TITLE
feat(chat): add polls in chat (single + multi-select, edit/close/delete)

### DIFF
--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -82,6 +82,7 @@ import type * as functions_messaging_flagging from "../functions/messaging/flagg
 import type * as functions_messaging_helpers from "../functions/messaging/helpers.js";
 import type * as functions_messaging_index from "../functions/messaging/index.js";
 import type * as functions_messaging_messages from "../functions/messaging/messages.js";
+import type * as functions_messaging_polls from "../functions/messaging/polls.js";
 import type * as functions_messaging_reachOut from "../functions/messaging/reachOut.js";
 import type * as functions_messaging_reactions from "../functions/messaging/reactions.js";
 import type * as functions_messaging_readState from "../functions/messaging/readState.js";
@@ -257,6 +258,7 @@ declare const fullApi: ApiFromModules<{
   "functions/messaging/helpers": typeof functions_messaging_helpers;
   "functions/messaging/index": typeof functions_messaging_index;
   "functions/messaging/messages": typeof functions_messaging_messages;
+  "functions/messaging/polls": typeof functions_messaging_polls;
   "functions/messaging/reachOut": typeof functions_messaging_reachOut;
   "functions/messaging/reactions": typeof functions_messaging_reactions;
   "functions/messaging/readState": typeof functions_messaging_readState;

--- a/apps/convex/functions/messaging/index.ts
+++ b/apps/convex/functions/messaging/index.ts
@@ -7,6 +7,7 @@
 
 export * as channels from "./channels";
 export * as messages from "./messages";
+export * as polls from "./polls";
 export * as reactions from "./reactions";
 export * as readState from "./readState";
 export * as blocking from "./blocking";

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -162,7 +162,7 @@ interface MessageForPreview {
  * Used for channel lastMessagePreview to show user-friendly strings like
  * "Sent a photo", "Sent a file", "Shared an event", etc.
  */
-function generateMessagePreview(message: MessageForPreview): string {
+export function generateMessagePreview(message: MessageForPreview): string {
   const content = message.content;
   const attachments = message.attachments;
 

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -26,6 +26,7 @@ import {
 } from "../../lib/helpers";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { canAccessEventChannel } from "./eventChat";
+import { generateMessagePreview } from "./messages";
 
 const MAX_QUESTION_LENGTH = 280;
 const MAX_OPTION_TEXT_LENGTH = 120;
@@ -133,8 +134,50 @@ async function assertCanPostInChannel(
   }
 
   if (channel.isAdHoc) {
-    if (membership.requestState && membership.requestState !== "accepted") {
+    // Ad-hoc DM/group_dm gating mirrors `sendMessage` (apps/convex/functions/
+    // messaging/messages.ts ~755-825). Without these checks a user who can't
+    // send a normal message — because a recipient blocked them, they removed
+    // their profile photo, or the recipient hasn't accepted yet — could still
+    // post a poll and fan it out through the chat/notification pipeline.
+    if (membership.requestState !== "accepted") {
       throw new ConvexError("Accept the request before posting");
+    }
+
+    // Profile photo is a hard requirement on every send to an ad-hoc channel.
+    const sender = await ctx.db.get(userId);
+    if (!sender?.profilePhoto || sender.profilePhoto.trim() === "") {
+      throw new ConvexError("PROFILE_PHOTO_REQUIRED");
+    }
+
+    // Block enforcement: any active recipient who's blocked the sender
+    // rejects the send. Generic error keeps the block silent.
+    const otherMembers = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+    for (const m of otherMembers) {
+      if (m.userId === userId) continue;
+      const block = await ctx.db
+        .query("chatUserBlocks")
+        .withIndex("by_blocker_blocked", (q) =>
+          q.eq("blockerId", m.userId).eq("blockedId", userId),
+        )
+        .first();
+      if (block) {
+        throw new ConvexError("Cannot send message in this chat");
+      }
+    }
+
+    // Pending-recipient gate: until the other party accepts, sendMessage
+    // restricts to plain text only. Polls aren't plain text — block them.
+    const hasPendingOthers = otherMembers.some(
+      (m) => m.userId !== userId && m.requestState === "pending",
+    );
+    if (hasPendingOthers) {
+      throw new ConvexError(
+        "Cannot send polls until the recipient accepts the request",
+      );
     }
   }
 }
@@ -600,14 +643,63 @@ export const deletePoll = mutation({
       await ctx.db.delete(v._id);
     }
 
+    const now = Date.now();
     if (poll.messageId) {
       const message = await ctx.db.get(poll.messageId);
       if (message && !message.isDeleted) {
         await ctx.db.patch(poll.messageId, {
           isDeleted: true,
-          deletedAt: Date.now(),
+          deletedAt: now,
           deletedById: userId,
         });
+
+        // If the deleted poll was the channel's most recent top-level
+        // message, the inbox preview / sort key would otherwise stay
+        // pointing at the now-removed poll. Mirror deleteMessage's
+        // recompute path so the channel snaps to the previous message.
+        const channel = await ctx.db.get(message.channelId);
+        if (
+          channel &&
+          channel.lastMessageAt &&
+          message.createdAt >= channel.lastMessageAt
+        ) {
+          const previousMessage = await ctx.db
+            .query("chatMessages")
+            .withIndex("by_channel_createdAt", (q) =>
+              q.eq("channelId", message.channelId),
+            )
+            .order("desc")
+            .filter((q) =>
+              q.and(
+                q.eq(q.field("isDeleted"), false),
+                q.neq(q.field("_id"), poll.messageId!),
+                q.eq(q.field("parentMessageId"), undefined),
+              ),
+            )
+            .first();
+
+          if (previousMessage) {
+            const preview = generateMessagePreview({
+              content: previousMessage.content,
+              attachments: previousMessage.attachments,
+            });
+            await ctx.db.patch(message.channelId, {
+              lastMessageAt: previousMessage.createdAt,
+              lastMessagePreview: preview,
+              lastMessageSenderId: previousMessage.senderId,
+              lastMessageSenderName: previousMessage.senderName,
+              updatedAt: now,
+            });
+          } else {
+            await ctx.db.patch(message.channelId, {
+              lastMessageAt: undefined,
+              lastMessagePreview: undefined,
+              lastMessageSenderId: undefined,
+              lastMessageSenderName: undefined,
+              updatedAt: now,
+            });
+          }
+        }
       }
     }
 

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -1,0 +1,709 @@
+/**
+ * Polls
+ *
+ * Lightweight in-channel polling. Polls live in their own table and are
+ * referenced by a host `chatMessages` row (`contentType: "poll"`,
+ * `pollId`) so they flow through the existing chat list, push, and
+ * notification pipelines for free.
+ *
+ * v1 capabilities: single + multi-select, author + leader can edit / close
+ * / delete. No anonymous voting and no closing deadline (fields reserved).
+ *
+ * See `apps/convex/schema.ts` (`polls`, `pollVotes`) for the table shapes.
+ */
+
+import { v, ConvexError } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import {
+  channelEffectiveEnabledForGroup,
+  channelIsLeaderEnabled,
+  isCustomChannel,
+  isLeaderRole,
+} from "../../lib/helpers";
+import { getDisplayName, getMediaUrl } from "../../lib/utils";
+import { canAccessEventChannel } from "./eventChat";
+
+const MAX_QUESTION_LENGTH = 280;
+const MAX_OPTION_TEXT_LENGTH = 120;
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 10;
+
+/**
+ * Validate a poll's question + options for both create and edit paths.
+ * Throws ConvexError on failure so the UI can surface a hint to the user.
+ */
+function validatePollContent(question: string, optionTexts: string[]): void {
+  const trimmedQuestion = question.trim();
+  if (trimmedQuestion.length === 0) {
+    throw new ConvexError("Poll question is required");
+  }
+  if (trimmedQuestion.length > MAX_QUESTION_LENGTH) {
+    throw new ConvexError(
+      `Poll question must be ${MAX_QUESTION_LENGTH} characters or fewer`,
+    );
+  }
+  const trimmed = optionTexts.map((t) => t.trim());
+  if (trimmed.length < MIN_OPTIONS) {
+    throw new ConvexError(`Poll must have at least ${MIN_OPTIONS} options`);
+  }
+  if (trimmed.length > MAX_OPTIONS) {
+    throw new ConvexError(`Poll can have at most ${MAX_OPTIONS} options`);
+  }
+  for (const t of trimmed) {
+    if (t.length === 0) {
+      throw new ConvexError("Poll options cannot be empty");
+    }
+    if (t.length > MAX_OPTION_TEXT_LENGTH) {
+      throw new ConvexError(
+        `Poll options must be ${MAX_OPTION_TEXT_LENGTH} characters or fewer`,
+      );
+    }
+  }
+}
+
+/**
+ * Mirror of `sendMessage`'s post-permission flow, scoped to what polls need.
+ * Throws on disallowed contexts. Used by createPoll so polls inherit message
+ * channel-posting rules (e.g. announcements = leaders only) without a fragile
+ * refactor of `sendMessage` itself.
+ */
+async function assertCanPostInChannel(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+  channel: Doc<"chatChannels">,
+  viewingGroupId: Id<"groups"> | undefined,
+): Promise<void> {
+  if (channel.channelType === "event") {
+    if (!(await canAccessEventChannel(ctx, userId, channel))) {
+      throw new ConvexError("Not a member of this channel");
+    }
+    if (channel.isEnabled === false) {
+      throw new ConvexError("Event chat is disabled");
+    }
+    return;
+  }
+
+  const membership = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_channel_user", (q) =>
+      q.eq("channelId", channel._id).eq("userId", userId),
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+  if (!membership) {
+    throw new ConvexError("Not a member of this channel");
+  }
+
+  if (
+    isCustomChannel(channel.channelType) ||
+    channel.channelType === "pco_services"
+  ) {
+    const enabled = viewingGroupId
+      ? channelEffectiveEnabledForGroup(channel, viewingGroupId)
+      : channelIsLeaderEnabled(channel);
+    if (!enabled) {
+      throw new ConvexError("This channel is disabled");
+    }
+  }
+
+  if (channel.channelType === "announcements") {
+    if (!channelIsLeaderEnabled(channel) || channel.isArchived) {
+      throw new ConvexError("This channel is disabled");
+    }
+    if (!channel.groupId) {
+      throw new ConvexError("Invalid announcements channel");
+    }
+    const groupMembership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", channel.groupId!).eq("userId", userId),
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+    if (!isLeaderRole(groupMembership?.role)) {
+      throw new ConvexError({
+        code: "FORBIDDEN",
+        message: "Only group leaders can post in Announcements",
+      });
+    }
+  }
+
+  if (channel.isAdHoc) {
+    if (membership.requestState && membership.requestState !== "accepted") {
+      throw new ConvexError("Accept the request before posting");
+    }
+  }
+}
+
+/**
+ * Whether `userId` is a leader of the group that owns `channel`.
+ * Returns false for ad-hoc channels (no group) — author-only moderation.
+ */
+async function isChannelGroupLeader(
+  ctx: QueryCtx | MutationCtx,
+  channel: Doc<"chatChannels"> | null,
+  userId: Id<"users">,
+): Promise<boolean> {
+  if (!channel?.groupId) return false;
+  const m = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", channel.groupId!).eq("userId", userId),
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+  return isLeaderRole(m?.role);
+}
+
+/**
+ * Generate a unique option id given the existing ids on the poll.
+ * IDs look like `o0`, `o1`, ... — purely server-side, never user-supplied.
+ */
+function nextOptionId(existing: string[]): string {
+  let max = -1;
+  for (const id of existing) {
+    if (id.startsWith("o")) {
+      const n = Number(id.slice(1));
+      if (Number.isFinite(n) && n > max) max = n;
+    }
+  }
+  return `o${max + 1}`;
+}
+
+// =============================================================================
+// Mutations
+// =============================================================================
+
+/**
+ * Create a poll and post it as a message in the given channel.
+ * Returns the poll's host messageId so the client can react / scroll to it.
+ */
+export const createPoll = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    question: v.string(),
+    options: v.array(v.string()),
+    allowMultiple: v.boolean(),
+    viewingGroupId: v.optional(v.id("groups")),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    validatePollContent(args.question, args.options);
+
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new ConvexError("Channel not found");
+    }
+    await assertCanPostInChannel(ctx, userId, channel, args.viewingGroupId);
+
+    const user = await ctx.db.get(userId);
+    if (!user) {
+      throw new ConvexError("User not found");
+    }
+    const senderName = getDisplayName(user.firstName, user.lastName);
+    const senderProfilePhoto = getMediaUrl(user.profilePhoto);
+
+    const now = Date.now();
+    const trimmedQuestion = args.question.trim();
+    const optionDocs = args.options.map((text, idx) => ({
+      id: `o${idx}`,
+      text: text.trim(),
+    }));
+
+    // Insert the host message first so we have an id to back-pointer from
+    // the poll. The message's pollId is patched in once the poll exists —
+    // this all runs inside one mutation transaction so external readers
+    // never observe an inconsistent state.
+    const messageId = await ctx.db.insert("chatMessages", {
+      channelId: args.channelId,
+      senderId: userId,
+      content: trimmedQuestion,
+      contentType: "poll",
+      createdAt: now,
+      isDeleted: false,
+      senderName,
+      senderProfilePhoto,
+      lastActivityAt: now,
+    });
+
+    const pollId = await ctx.db.insert("polls", {
+      channelId: args.channelId,
+      messageId,
+      authorId: userId,
+      question: trimmedQuestion,
+      options: optionDocs,
+      allowMultiple: args.allowMultiple,
+      isAnonymous: false,
+      status: "active",
+      voteCount: 0,
+      voterCount: 0,
+      editCount: 0,
+      createdAt: now,
+    });
+
+    await ctx.db.patch(messageId, { pollId });
+
+    // Update channel-level last-message snapshot the same way sendMessage
+    // does, so inbox previews and unread counts stay correct.
+    const previewBase = `📊 ${trimmedQuestion}`;
+    const preview =
+      previewBase.length > 100
+        ? previewBase.slice(0, 97) + "…"
+        : previewBase;
+    await ctx.db.patch(args.channelId, {
+      lastMessageAt: now,
+      lastMessagePreview: preview,
+      lastMessageSenderId: userId,
+      lastMessageSenderName: senderName,
+      updatedAt: now,
+    });
+
+    // Same notification fan-out as a normal message.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.messaging.events.onMessageSent,
+      {
+        messageId,
+        channelId: args.channelId,
+        senderId: userId,
+      },
+    );
+
+    return { pollId, messageId };
+  },
+});
+
+/**
+ * Cast (or recast) a viewer's vote on a poll.
+ *
+ * `optionIds` is the COMPLETE set of options the voter has selected after
+ * this call — the mutation reconciles the existing votes against this set.
+ *  - single-select polls: must be empty or length 1
+ *  - multi-select polls: any number from 0 to options.length
+ *  - empty array clears the viewer's votes (toggle off)
+ */
+export const voteOnPoll = mutation({
+  args: {
+    token: v.string(),
+    pollId: v.id("polls"),
+    optionIds: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const poll = await ctx.db.get(args.pollId);
+    if (!poll) throw new ConvexError("Poll not found");
+    if (poll.status !== "active") {
+      throw new ConvexError("This poll is closed");
+    }
+
+    const channel = await ctx.db.get(poll.channelId);
+    if (!channel) throw new ConvexError("Channel not found");
+
+    // Channel-membership check: same gate as reading the poll. Use a
+    // light path that mirrors the message read rules.
+    if (channel.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) {
+        throw new ConvexError("Not a member of this channel");
+      }
+    } else {
+      const m = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", poll.channelId).eq("userId", userId),
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
+      if (!m) throw new ConvexError("Not a member of this channel");
+    }
+
+    // Validate option ids belong to this poll.
+    const validIds = new Set(poll.options.map((o) => o.id));
+    const requestedIds = Array.from(new Set(args.optionIds));
+    for (const id of requestedIds) {
+      if (!validIds.has(id)) {
+        throw new ConvexError("Invalid poll option");
+      }
+    }
+    if (!poll.allowMultiple && requestedIds.length > 1) {
+      throw new ConvexError("This poll allows only one selection");
+    }
+
+    const existing = await ctx.db
+      .query("pollVotes")
+      .withIndex("by_poll_voter", (q) =>
+        q.eq("pollId", args.pollId).eq("voterId", userId),
+      )
+      .collect();
+
+    const existingByOption = new Map(existing.map((v) => [v.optionId, v]));
+    const desired = new Set(requestedIds);
+
+    let inserted = 0;
+    let removed = 0;
+    const now = Date.now();
+
+    // Remove votes for options no longer selected.
+    for (const [optionId, row] of existingByOption) {
+      if (!desired.has(optionId)) {
+        await ctx.db.delete(row._id);
+        removed += 1;
+      }
+    }
+    // Insert votes for newly selected options.
+    for (const optionId of desired) {
+      if (!existingByOption.has(optionId)) {
+        await ctx.db.insert("pollVotes", {
+          pollId: args.pollId,
+          optionId,
+          voterId: userId,
+          channelId: poll.channelId,
+          createdAt: now,
+        });
+        inserted += 1;
+      }
+    }
+
+    const hadAnyBefore = existing.length > 0;
+    const hasAnyAfter = desired.size > 0;
+    let voterDelta = 0;
+    if (!hadAnyBefore && hasAnyAfter) voterDelta = 1;
+    else if (hadAnyBefore && !hasAnyAfter) voterDelta = -1;
+
+    await ctx.db.patch(args.pollId, {
+      voteCount: poll.voteCount + inserted - removed,
+      voterCount: poll.voterCount + voterDelta,
+    });
+  },
+});
+
+/**
+ * Edit poll question / options / settings. Author or group leader.
+ *
+ * Behavior:
+ *  - Question and option text edits are free (vote rows are tied to id).
+ *  - Removing an option cascades pollVotes for that optionId.
+ *  - Toggling allowMultiple from true → false is rejected when any voter
+ *    currently has more than one vote (UI must prompt them to fix first).
+ *  - Adding new options is always allowed (existing votes unaffected).
+ */
+export const editPoll = mutation({
+  args: {
+    token: v.string(),
+    pollId: v.id("polls"),
+    question: v.optional(v.string()),
+    /**
+     * Full replacement option list. Pass `id` for existing options to keep
+     * their vote rows; omit `id` for newly-added options (server assigns one).
+     * Any existing option whose id is absent here will have its vote rows
+     * cascade-deleted.
+     */
+    options: v.optional(
+      v.array(
+        v.object({
+          id: v.optional(v.string()),
+          text: v.string(),
+        }),
+      ),
+    ),
+    allowMultiple: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const poll = await ctx.db.get(args.pollId);
+    if (!poll) throw new ConvexError("Poll not found");
+
+    const channel = await ctx.db.get(poll.channelId);
+    const isAuthor = poll.authorId === userId;
+    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    if (!isAuthor && !isLeader) {
+      throw new ConvexError({
+        code: "FORBIDDEN",
+        message: "Only the poll author or a leader can edit this poll",
+      });
+    }
+
+    const newQuestion =
+      args.question !== undefined ? args.question : poll.question;
+
+    let newOptions = poll.options;
+    let removedOptionIds: string[] = [];
+    if (args.options) {
+      const existingIds = poll.options.map((o) => o.id);
+      const seenIds = new Set<string>();
+      const next: Array<{ id: string; text: string }> = [];
+      for (const o of args.options) {
+        if (o.id && existingIds.includes(o.id)) {
+          if (seenIds.has(o.id)) {
+            throw new ConvexError("Duplicate option id");
+          }
+          seenIds.add(o.id);
+          next.push({ id: o.id, text: o.text.trim() });
+        } else {
+          const id = nextOptionId([...existingIds, ...next.map((n) => n.id)]);
+          next.push({ id, text: o.text.trim() });
+        }
+      }
+      newOptions = next;
+      removedOptionIds = existingIds.filter((id) => !seenIds.has(id));
+    }
+
+    validatePollContent(
+      newQuestion,
+      newOptions.map((o) => o.text),
+    );
+
+    const newAllowMultiple =
+      args.allowMultiple !== undefined ? args.allowMultiple : poll.allowMultiple;
+
+    // Multi → single guard: refuse if any voter would be "over budget".
+    if (poll.allowMultiple && newAllowMultiple === false) {
+      const allVotes = await ctx.db
+        .query("pollVotes")
+        .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
+        .collect();
+      const perVoter = new Map<string, number>();
+      for (const v of allVotes) {
+        perVoter.set(v.voterId, (perVoter.get(v.voterId) ?? 0) + 1);
+      }
+      for (const count of perVoter.values()) {
+        if (count > 1) {
+          throw new ConvexError({
+            code: "INVALID_STATE",
+            message:
+              "Some voters have multiple selections. Remove their extras before switching to single-select.",
+          });
+        }
+      }
+    }
+
+    // Cascade-delete vote rows for removed options + recompute denorms.
+    let nextVoteCount = poll.voteCount;
+    let nextVoterCount = poll.voterCount;
+    if (removedOptionIds.length > 0) {
+      // Pull every vote row for this poll once; cheaper than per-option index
+      // scans when removedOptionIds is small but possibly multiple.
+      const allVotes = await ctx.db
+        .query("pollVotes")
+        .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
+        .collect();
+      const removedSet = new Set(removedOptionIds);
+      const survivingVotersByVoter = new Set<string>();
+      for (const v of allVotes) {
+        if (!removedSet.has(v.optionId)) {
+          survivingVotersByVoter.add(v.voterId);
+        }
+      }
+      let removed = 0;
+      for (const v of allVotes) {
+        if (removedSet.has(v.optionId)) {
+          await ctx.db.delete(v._id);
+          removed += 1;
+        }
+      }
+      nextVoteCount = poll.voteCount - removed;
+      nextVoterCount = survivingVotersByVoter.size;
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(args.pollId, {
+      question: newQuestion.trim(),
+      options: newOptions,
+      allowMultiple: newAllowMultiple,
+      voteCount: nextVoteCount,
+      voterCount: nextVoterCount,
+      editedAt: now,
+      editCount: poll.editCount + 1,
+    });
+
+    // Mirror question edits on the host message so the inbox preview and
+    // any text-search paths reflect the change.
+    if (poll.messageId && args.question !== undefined) {
+      await ctx.db.patch(poll.messageId, {
+        content: newQuestion.trim(),
+        editedAt: now,
+        updatedAt: now,
+      });
+    }
+  },
+});
+
+/**
+ * Manually close a poll. Author or leader. Idempotent.
+ */
+export const closePoll = mutation({
+  args: {
+    token: v.string(),
+    pollId: v.id("polls"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const poll = await ctx.db.get(args.pollId);
+    if (!poll) throw new ConvexError("Poll not found");
+    if (poll.status === "closed") return;
+
+    const channel = await ctx.db.get(poll.channelId);
+    const isAuthor = poll.authorId === userId;
+    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    if (!isAuthor && !isLeader) {
+      throw new ConvexError({
+        code: "FORBIDDEN",
+        message: "Only the poll author or a leader can close this poll",
+      });
+    }
+
+    await ctx.db.patch(args.pollId, {
+      status: "closed",
+      closedAt: Date.now(),
+    });
+  },
+});
+
+/**
+ * Delete a poll. Author or leader. Cascades all pollVotes and soft-deletes
+ * the host message so it disappears from the chat list.
+ */
+export const deletePoll = mutation({
+  args: {
+    token: v.string(),
+    pollId: v.id("polls"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const poll = await ctx.db.get(args.pollId);
+    if (!poll) return; // already gone
+
+    const channel = await ctx.db.get(poll.channelId);
+    const isAuthor = poll.authorId === userId;
+    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    if (!isAuthor && !isLeader) {
+      throw new ConvexError({
+        code: "FORBIDDEN",
+        message: "Only the poll author or a leader can delete this poll",
+      });
+    }
+
+    const votes = await ctx.db
+      .query("pollVotes")
+      .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
+      .collect();
+    for (const v of votes) {
+      await ctx.db.delete(v._id);
+    }
+
+    if (poll.messageId) {
+      const message = await ctx.db.get(poll.messageId);
+      if (message && !message.isDeleted) {
+        await ctx.db.patch(poll.messageId, {
+          isDeleted: true,
+          deletedAt: Date.now(),
+          deletedById: userId,
+        });
+      }
+    }
+
+    await ctx.db.delete(args.pollId);
+  },
+});
+
+// =============================================================================
+// Queries
+// =============================================================================
+
+/**
+ * Read a poll for rendering in the chat. Returns:
+ *  - poll metadata (question, settings, status, edit info)
+ *  - per-option text + counts
+ *  - the viewer's current vote selection
+ *  - viewer permissions (canVote / canEdit / canClose / canDelete)
+ *
+ * Returns `null` when the viewer can't see the channel (matches the
+ * empty-page approach used by getMessages — never throws into the UI).
+ */
+export const getPoll = query({
+  args: {
+    token: v.string(),
+    pollId: v.id("polls"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const poll = await ctx.db.get(args.pollId);
+    if (!poll) return null;
+
+    const channel = await ctx.db.get(poll.channelId);
+    if (!channel) return null;
+
+    // Same channel-visibility gate as message reads.
+    if (channel.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) return null;
+    } else {
+      const m = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", poll.channelId).eq("userId", userId),
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
+      if (!m) return null;
+    }
+
+    const allVotes = await ctx.db
+      .query("pollVotes")
+      .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
+      .collect();
+
+    const countsByOption = new Map<string, number>();
+    const myVoteIds: string[] = [];
+    for (const v of allVotes) {
+      countsByOption.set(
+        v.optionId,
+        (countsByOption.get(v.optionId) ?? 0) + 1,
+      );
+      if (v.voterId === userId) myVoteIds.push(v.optionId);
+    }
+
+    const isAuthor = poll.authorId === userId;
+    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const canVote = poll.status === "active";
+    const canModerate = isAuthor || isLeader;
+
+    return {
+      _id: poll._id,
+      channelId: poll.channelId,
+      messageId: poll.messageId,
+      authorId: poll.authorId,
+      question: poll.question,
+      options: poll.options.map((o) => ({
+        id: o.id,
+        text: o.text,
+        count: countsByOption.get(o.id) ?? 0,
+      })),
+      allowMultiple: poll.allowMultiple,
+      isAnonymous: poll.isAnonymous,
+      status: poll.status,
+      closedAt: poll.closedAt,
+      voteCount: poll.voteCount,
+      voterCount: poll.voterCount,
+      editedAt: poll.editedAt,
+      editCount: poll.editCount,
+      createdAt: poll.createdAt,
+      myVoteOptionIds: myVoteIds,
+      permissions: {
+        canVote,
+        canEdit: canModerate,
+        canClose: canModerate && poll.status === "active",
+        canDelete: canModerate,
+      },
+    };
+  },
+});

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1621,7 +1621,7 @@ export default defineSchema({
     channelId: v.id("chatChannels"),
     senderId: v.optional(v.id("users")), // Optional for bot/system messages
     content: v.string(), // Message text
-    contentType: v.string(), // "text" | "image" | "file" | "system" | "bot" | "reach_out_request" | "task_card"
+    contentType: v.string(), // "text" | "image" | "file" | "system" | "bot" | "reach_out_request" | "task_card" | "poll"
     attachments: v.optional(
       v.array(
         v.object({
@@ -1661,6 +1661,8 @@ export default defineSchema({
     reachOutRequestId: v.optional(v.id("reachOutRequests")),
     // Canonical task reference for task-aware chat cards
     taskId: v.optional(v.id("tasks")),
+    // Poll reference for contentType === "poll"
+    pollId: v.optional(v.id("polls")),
     // Optional idempotency key for generated bot/task posts
     sourceKey: v.optional(v.string()),
     // For mirrored text blasts — backlink to the eventBlasts row so the UI
@@ -1674,6 +1676,75 @@ export default defineSchema({
     .index("by_parentMessage", ["parentMessageId"])
     .index("by_createdAt", ["createdAt"])
     .index("by_sourceKey", ["sourceKey"]),
+
+  /**
+   * Polls
+   *
+   * Posted into channels via the chat composer. Backed by a `chatMessages`
+   * row with `contentType: "poll"` and `pollId` pointing here. The card UI
+   * renders inline in place of the normal message bubble.
+   *
+   * v1 semantics:
+   *  - `isAnonymous`: always written `false`. Field is reserved for a future
+   *    setting that hides voter identity in `getPollVoters`.
+   *  - `closesAt`: never set in v1 (no deadline picker). Field is reserved
+   *    for a future scheduler-based auto-close. `status` only flips via
+   *    the manual `closePoll` mutation today.
+   *  - Authors and group leaders can edit/close/delete via `editPoll`,
+   *    `closePoll`, `deletePoll`. `editCount`/`editedAt` track edits so the
+   *    card can render an "edited" badge.
+   */
+  polls: defineTable({
+    channelId: v.id("chatChannels"),
+    /** Back-pointer to the host message. Set after the message is inserted. */
+    messageId: v.optional(v.id("chatMessages")),
+    authorId: v.id("users"),
+    question: v.string(),
+    options: v.array(
+      v.object({
+        /** Stable id; survives text edits so vote rows stay attached. */
+        id: v.string(),
+        text: v.string(),
+      }),
+    ),
+    allowMultiple: v.boolean(),
+    isAnonymous: v.boolean(),
+    closesAt: v.optional(v.number()),
+    status: v.union(v.literal("active"), v.literal("closed")),
+    closedAt: v.optional(v.number()),
+    /** Total votes (each ticked option counts once). */
+    voteCount: v.number(),
+    /** Unique voters (one per user even if they ticked multiple options). */
+    voterCount: v.number(),
+    editedAt: v.optional(v.number()),
+    editCount: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_channel", ["channelId"])
+    .index("by_message", ["messageId"]),
+
+  /**
+   * Poll Votes
+   *
+   * One row per (poll, option, voter). For multi-select polls a single voter
+   * may have multiple rows in the same poll. For single-select, the
+   * `by_poll_voter` index is used to enforce one row per voter.
+   *
+   * `voterId` is stored even though v1 isn't anonymous — needed for "you
+   * voted" indicators, double-vote prevention, and to support a future
+   * anonymous mode where identity is hidden in queries but tracked at rest.
+   */
+  pollVotes: defineTable({
+    pollId: v.id("polls"),
+    optionId: v.string(),
+    voterId: v.id("users"),
+    /** Denormalized for permission checks without re-fetching the poll. */
+    channelId: v.id("chatChannels"),
+    createdAt: v.number(),
+  })
+    .index("by_poll", ["pollId"])
+    .index("by_poll_option", ["pollId", "optionId"])
+    .index("by_poll_voter", ["pollId", "voterId"]),
 
   /**
    * Chat Message Reactions

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -48,6 +48,7 @@ import { VoiceRecorderBar } from './VoiceRecorderBar';
 import { AttachmentPanel } from './AttachmentPanel';
 import { useDraftStore } from '../../../stores/draftStore';
 import { GifPicker } from './GifPicker';
+import { PollCreatorSheet } from './PollCreatorSheet';
 import { classifyChatSendError } from '../utils/chatSendErrors';
 
 interface MessageInputProps {
@@ -142,6 +143,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
   const [isVoiceRecording, setIsVoiceRecording] = useState(false);
   const [showAttachmentMenu, setShowAttachmentMenu] = useState(false);
   const [showGifPicker, setShowGifPicker] = useState(false);
+  const [showPollCreator, setShowPollCreator] = useState(false);
   // Inline hint shown after a soft-fail send (e.g. attachments-pending,
   // profile-photo-required). Auto-clears after a short window. Used INSTEAD
   // of Alert/popup, which previously kept enough state churning to crash the
@@ -858,6 +860,15 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
     const options: Array<{ id: string; label: string; icon: keyof typeof Ionicons.glyphMap; iconColor?: string; onPress: () => void }> = [
       { id: 'media', label: 'Media', icon: 'images', iconColor: '#007AFF', onPress: pickMedia },
       { id: 'camera', label: 'Camera', icon: 'camera', iconColor: '#333', onPress: captureMedia },
+      {
+        id: 'poll',
+        label: 'Poll',
+        icon: 'bar-chart-outline',
+        iconColor: '#34A853',
+        onPress: () => {
+          if (channelId) setShowPollCreator(true);
+        },
+      },
     ];
     if (process.env.EXPO_PUBLIC_KLIPY_API_KEY) {
       options.push({
@@ -878,7 +889,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
       });
     }
     return options;
-  }, [captureMedia, pickMedia, recipientPending]);
+  }, [captureMedia, pickMedia, recipientPending, channelId]);
 
   const handleOptionPress = useCallback((option: { onPress: () => void }) => {
     setShowAttachmentMenu(false);
@@ -1154,6 +1165,17 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
         onSelect={handleGifSelect}
         onClose={() => setShowGifPicker(false)}
       />
+
+      {/* Poll Creator Modal — same `recipientPending` guard as the GIF picker
+          so an unaccepted DM never sees a poll composer. */}
+      {channelId && showPollCreator && !recipientPending && (
+        <PollCreatorSheet
+          mode="create"
+          visible={showPollCreator}
+          channelId={channelId}
+          onClose={() => setShowPollCreator(false)}
+        />
+      )}
     </View>
   );
 }

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -41,6 +41,7 @@ import { ThreadReplies } from './ThreadReplies';
 import { ReactionDetailsModal } from './ReactionDetailsModal';
 import { ReachOutRequestCardFromMessage } from './ReachOutRequestCardFromMessage';
 import { TaskCardFromMessage } from './TaskCardFromMessage';
+import { PollCardFromMessage } from './PollCardFromMessage';
 import { extractEventShortIds, extractToolShortIds, extractChannelInviteShortIds, stripEventLinksFromText, stripToolLinksFromText, stripChannelInviteLinksFromText, extractFirstExternalUrl } from '../utils/eventLinkUtils';
 import { useLinkPreview } from '../hooks/useLinkPreview';
 import { parseMessageContent } from '@features/shared/utils/linkify';
@@ -79,6 +80,7 @@ interface MessageItemProps {
     hideLinkPreview?: boolean;
     reachOutRequestId?: Id<"reachOutRequests">;
     taskId?: Id<"tasks">;
+    pollId?: Id<"polls">;
     /** Present only on messages that mirror an event text blast (SMS + push). */
     blastId?: Id<"eventBlasts">;
   };
@@ -854,6 +856,17 @@ function MessageItemInner({
     );
   };
 
+  const renderPollCard = () => {
+    if (message.contentType !== "poll" || !message.pollId) {
+      return null;
+    }
+    return (
+      <View style={styles.eventCardsContainer}>
+        <PollCardFromMessage pollId={message.pollId} />
+      </View>
+    );
+  };
+
   // Render optimistic message status indicator
   const renderOptimisticStatus = () => {
     if (!isOptimistic || !optimisticStatus) return null;
@@ -978,7 +991,7 @@ function MessageItemInner({
           )}
 
           {/* Message bubble (hidden for special card messages) */}
-          {message.contentType !== "reach_out_request" && message.contentType !== "task_card" && (
+          {message.contentType !== "reach_out_request" && message.contentType !== "task_card" && message.contentType !== "poll" && (
             <View ref={bubbleRef} style={styles.bubbleWrapper}>
               <View
                 style={[
@@ -1056,6 +1069,9 @@ function MessageItemInner({
 
           {/* Task card */}
           {renderTaskCard()}
+
+          {/* Poll card */}
+          {renderPollCard()}
 
           {/* Event cards for meeting links */}
           {renderEventCards()}

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -67,6 +67,8 @@ interface Message {
   reachOutRequestId?: Id<"reachOutRequests">;
   // Canonical task reference for task cards
   taskId?: Id<"tasks">;
+  // Poll reference for contentType === "poll"
+  pollId?: Id<"polls">;
   // Present only on messages mirrored from an event text blast (SMS + push).
   blastId?: Id<"eventBlasts">;
 }
@@ -348,6 +350,7 @@ export function MessageList({
             hideLinkPreview: message.hideLinkPreview,
             reachOutRequestId: message.reachOutRequestId,
             taskId: message.taskId,
+            pollId: message.pollId,
             blastId: message.blastId,
           }}
           currentUserId={currentUserId}

--- a/apps/mobile/features/chat/components/PollCard.tsx
+++ b/apps/mobile/features/chat/components/PollCard.tsx
@@ -1,0 +1,466 @@
+/**
+ * PollCard — visual poll surface rendered inside a chat message.
+ *
+ * Pure-ish component: receives the resolved poll + viewer's vote selection
+ * and a `castVote(optionIds)` callback. Local optimistic state covers the
+ * gap between tap and Convex round-trip so the UI doesn't feel laggy on
+ * slow connections.
+ *
+ * For multi-select polls, taps toggle options into a draft selection and
+ * the user submits with the "Vote" button. For single-select, a tap
+ * commits immediately.
+ */
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+
+export interface PollCardOption {
+  id: string;
+  text: string;
+  count: number;
+}
+
+export interface PollCardProps {
+  question: string;
+  options: PollCardOption[];
+  allowMultiple: boolean;
+  status: 'active' | 'closed';
+  voteCount: number;
+  voterCount: number;
+  myVoteOptionIds: string[];
+  editCount: number;
+  permissions: {
+    canVote: boolean;
+    canEdit: boolean;
+    canClose: boolean;
+    canDelete: boolean;
+  };
+  onCastVote: (optionIds: string[]) => Promise<void>;
+  onEdit: () => void;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+export function PollCard({
+  question,
+  options,
+  allowMultiple,
+  status,
+  voteCount,
+  voterCount,
+  myVoteOptionIds,
+  editCount,
+  permissions,
+  onCastVote,
+  onEdit,
+  onClose,
+  onDelete,
+}: PollCardProps) {
+  const { colors } = useTheme();
+  const isClosed = status === 'closed';
+  const [pendingSelection, setPendingSelection] = useState<string[]>(myVoteOptionIds);
+  const [submitting, setSubmitting] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Whenever the server view of the viewer's votes changes, reset the
+  // local draft so we don't carry an unsubmitted selection past a server
+  // sync. This also resets after a successful submit.
+  useEffect(() => {
+    setPendingSelection(myVoteOptionIds);
+  }, [myVoteOptionIds.join('|')]);
+
+  const totalVotes = useMemo(
+    () => options.reduce((sum, o) => sum + o.count, 0),
+    [options],
+  );
+  const maxCount = useMemo(
+    () => options.reduce((m, o) => Math.max(m, o.count), 0),
+    [options],
+  );
+
+  const hasUnsavedDraft = useMemo(() => {
+    if (!allowMultiple) return false;
+    if (pendingSelection.length !== myVoteOptionIds.length) return true;
+    const a = [...pendingSelection].sort().join('|');
+    const b = [...myVoteOptionIds].sort().join('|');
+    return a !== b;
+  }, [allowMultiple, pendingSelection, myVoteOptionIds]);
+
+  const handleOptionPress = useCallback(
+    async (optionId: string) => {
+      if (isClosed || !permissions.canVote || submitting) return;
+
+      if (allowMultiple) {
+        setPendingSelection((prev) =>
+          prev.includes(optionId)
+            ? prev.filter((id) => id !== optionId)
+            : [...prev, optionId],
+        );
+        return;
+      }
+
+      // Single-select: commit immediately. Tapping the already-selected
+      // option clears it (toggle off).
+      const next = myVoteOptionIds.includes(optionId) ? [] : [optionId];
+      setPendingSelection(next);
+      setSubmitting(true);
+      try {
+        await onCastVote(next);
+      } catch (e: any) {
+        // Revert local on failure.
+        setPendingSelection(myVoteOptionIds);
+        Alert.alert('Vote failed', e?.data?.message || e?.message || 'Try again.');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [allowMultiple, isClosed, permissions.canVote, submitting, myVoteOptionIds, onCastVote],
+  );
+
+  const handleSubmitMulti = useCallback(async () => {
+    if (!allowMultiple || submitting) return;
+    setSubmitting(true);
+    try {
+      await onCastVote(pendingSelection);
+    } catch (e: any) {
+      setPendingSelection(myVoteOptionIds);
+      Alert.alert('Vote failed', e?.data?.message || e?.message || 'Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [allowMultiple, submitting, pendingSelection, myVoteOptionIds, onCastVote]);
+
+  const showMenu = permissions.canEdit || permissions.canClose || permissions.canDelete;
+
+  const handleMenuItem = useCallback(
+    (action: 'edit' | 'close' | 'delete') => {
+      setMenuOpen(false);
+      if (action === 'edit') return onEdit();
+      if (action === 'close') {
+        Alert.alert('Close poll?', 'Voters will no longer be able to change their votes.', [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Close poll', style: 'destructive', onPress: onClose },
+        ]);
+        return;
+      }
+      if (action === 'delete') {
+        Alert.alert('Delete poll?', 'This removes the poll and all votes. Cannot be undone.', [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Delete', style: 'destructive', onPress: onDelete },
+        ]);
+        return;
+      }
+    },
+    [onEdit, onClose, onDelete],
+  );
+
+  return (
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: colors.surface,
+          borderColor: colors.border,
+        },
+      ]}
+    >
+      {/* Header: question + (•••) menu */}
+      <View style={styles.headerRow}>
+        <View style={styles.headerTextWrap}>
+          <View style={styles.headerBadgeRow}>
+            <Ionicons name="bar-chart" size={14} color={colors.textSecondary} />
+            <Text style={[styles.headerBadge, { color: colors.textSecondary }]}>
+              {isClosed ? 'Poll · Closed' : allowMultiple ? 'Poll · Multiple choice' : 'Poll'}
+            </Text>
+          </View>
+          <Text style={[styles.question, { color: colors.text }]}>{question}</Text>
+        </View>
+        {showMenu && (
+          <Pressable
+            onPress={() => setMenuOpen((v) => !v)}
+            hitSlop={8}
+            style={styles.menuButton}
+          >
+            <Ionicons name="ellipsis-horizontal" size={20} color={colors.textSecondary} />
+          </Pressable>
+        )}
+      </View>
+
+      {/* Inline action menu */}
+      {menuOpen && showMenu && (
+        <View
+          style={[
+            styles.menu,
+            { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+          ]}
+        >
+          {permissions.canEdit && (
+            <Pressable style={styles.menuItem} onPress={() => handleMenuItem('edit')}>
+              <Ionicons name="create-outline" size={16} color={colors.text} />
+              <Text style={[styles.menuLabel, { color: colors.text }]}>Edit poll</Text>
+            </Pressable>
+          )}
+          {permissions.canClose && (
+            <Pressable style={styles.menuItem} onPress={() => handleMenuItem('close')}>
+              <Ionicons name="lock-closed-outline" size={16} color={colors.text} />
+              <Text style={[styles.menuLabel, { color: colors.text }]}>Close poll</Text>
+            </Pressable>
+          )}
+          {permissions.canDelete && (
+            <Pressable style={styles.menuItem} onPress={() => handleMenuItem('delete')}>
+              <Ionicons name="trash-outline" size={16} color={colors.error} />
+              <Text style={[styles.menuLabel, { color: colors.error }]}>Delete poll</Text>
+            </Pressable>
+          )}
+        </View>
+      )}
+
+      {/* Options */}
+      <View style={styles.options}>
+        {options.map((opt) => {
+          const selected = allowMultiple
+            ? pendingSelection.includes(opt.id)
+            : myVoteOptionIds.includes(opt.id);
+          const isWinner = isClosed && opt.count === maxCount && opt.count > 0;
+          const pct = totalVotes > 0 ? Math.round((opt.count / totalVotes) * 100) : 0;
+          return (
+            <Pressable
+              key={opt.id}
+              onPress={() => handleOptionPress(opt.id)}
+              disabled={isClosed || !permissions.canVote || submitting}
+              style={({ pressed }) => [
+                styles.optionRow,
+                { borderColor: selected ? colors.link : colors.border },
+                pressed && !isClosed && { opacity: 0.7 },
+              ]}
+            >
+              {/* Background bar showing share — shown once any vote exists. */}
+              {totalVotes > 0 && (
+                <View
+                  style={[
+                    styles.optionBar,
+                    {
+                      width: `${pct}%`,
+                      backgroundColor: isWinner
+                        ? `${colors.link}33`
+                        : selected
+                        ? `${colors.link}22`
+                        : colors.surfaceSecondary,
+                    },
+                  ]}
+                />
+              )}
+              <View style={styles.optionContent}>
+                <View
+                  style={[
+                    allowMultiple ? styles.checkbox : styles.radio,
+                    {
+                      borderColor: selected ? colors.link : colors.border,
+                      backgroundColor: selected ? colors.link : 'transparent',
+                    },
+                  ]}
+                >
+                  {selected &&
+                    (allowMultiple ? (
+                      <Ionicons name="checkmark" size={14} color="#fff" />
+                    ) : (
+                      <View style={styles.radioInner} />
+                    ))}
+                </View>
+                <Text
+                  style={[styles.optionText, { color: colors.text }]}
+                  numberOfLines={2}
+                >
+                  {opt.text}
+                </Text>
+                {totalVotes > 0 && (
+                  <Text style={[styles.optionCount, { color: colors.textSecondary }]}>
+                    {opt.count}
+                  </Text>
+                )}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* Multi-select submit row */}
+      {allowMultiple && !isClosed && permissions.canVote && hasUnsavedDraft && (
+        <Pressable
+          onPress={handleSubmitMulti}
+          disabled={submitting}
+          style={[
+            styles.submitButton,
+            { backgroundColor: colors.link, opacity: submitting ? 0.6 : 1 },
+          ]}
+        >
+          {submitting ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={styles.submitLabel}>
+              {myVoteOptionIds.length > 0 ? 'Update vote' : 'Vote'}
+            </Text>
+          )}
+        </Pressable>
+      )}
+
+      {/* Footer */}
+      <View style={styles.footer}>
+        <Text style={[styles.footerText, { color: colors.textSecondary }]}>
+          {voterCount === 0
+            ? 'No votes yet'
+            : `${voterCount} ${voterCount === 1 ? 'voter' : 'voters'} · ${voteCount} ${
+                voteCount === 1 ? 'vote' : 'votes'
+              }`}
+        </Text>
+        {editCount > 0 && (
+          <Text style={[styles.footerEdited, { color: colors.textTertiary }]}>edited</Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    padding: 12,
+    minWidth: 240,
+    maxWidth: 360,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  headerTextWrap: {
+    flex: 1,
+  },
+  headerBadgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    marginBottom: 4,
+  },
+  headerBadge: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+  },
+  question: {
+    fontSize: 15,
+    fontWeight: '600',
+    lineHeight: 20,
+  },
+  menuButton: {
+    padding: 4,
+  },
+  menu: {
+    marginTop: 8,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  menuItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  menuLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  options: {
+    marginTop: 12,
+    gap: 8,
+  },
+  optionRow: {
+    borderWidth: 1,
+    borderRadius: 10,
+    overflow: 'hidden',
+    minHeight: 40,
+    justifyContent: 'center',
+  },
+  optionBar: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+  },
+  optionContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  radio: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radioInner: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#fff',
+  },
+  checkbox: {
+    width: 18,
+    height: 18,
+    borderRadius: 4,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  optionText: {
+    flex: 1,
+    fontSize: 14,
+  },
+  optionCount: {
+    fontSize: 13,
+    fontWeight: '600',
+    minWidth: 24,
+    textAlign: 'right',
+  },
+  submitButton: {
+    marginTop: 12,
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  submitLabel: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 10,
+    gap: 8,
+  },
+  footerText: {
+    fontSize: 12,
+    flex: 1,
+  },
+  footerEdited: {
+    fontSize: 12,
+    fontStyle: 'italic',
+  },
+});

--- a/apps/mobile/features/chat/components/PollCardFromMessage.tsx
+++ b/apps/mobile/features/chat/components/PollCardFromMessage.tsx
@@ -1,0 +1,107 @@
+/**
+ * PollCardFromMessage — wrapper that fetches a poll by id and wires
+ * vote / edit / close / delete mutations to PollCard.
+ *
+ * Mounted from MessageItem when contentType === "poll". The underlying
+ * `getPoll` query is reactive, so vote counts update for every viewer
+ * the moment any voter casts a vote.
+ */
+import React, { useCallback, useState } from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import type { Id } from '@services/api/convex';
+import { api, useQuery, useStoredAuthToken, useAuthenticatedMutation } from '@services/api/convex';
+import { useTheme } from '@hooks/useTheme';
+import { PollCard } from './PollCard';
+import { PollCreatorSheet } from './PollCreatorSheet';
+
+interface Props {
+  pollId: Id<'polls'>;
+}
+
+export function PollCardFromMessage({ pollId }: Props) {
+  const { colors } = useTheme();
+  const token = useStoredAuthToken();
+  const [editing, setEditing] = useState(false);
+
+  const poll = useQuery(
+    api.functions.messaging.polls.getPoll,
+    token ? { token, pollId } : 'skip',
+  );
+
+  const voteOnPoll = useAuthenticatedMutation(api.functions.messaging.polls.voteOnPoll);
+  const closePoll = useAuthenticatedMutation(api.functions.messaging.polls.closePoll);
+  const deletePoll = useAuthenticatedMutation(api.functions.messaging.polls.deletePoll);
+
+  const handleCastVote = useCallback(
+    async (optionIds: string[]) => {
+      await voteOnPoll({ pollId, optionIds });
+    },
+    [pollId, voteOnPoll],
+  );
+
+  const handleClose = useCallback(async () => {
+    try {
+      await closePoll({ pollId });
+    } catch {
+      // Surface via PollCard? closePoll is invoked from a confirm dialog so
+      // a silent failure is acceptable here — the poll just stays open.
+    }
+  }, [pollId, closePoll]);
+
+  const handleDelete = useCallback(async () => {
+    try {
+      await deletePoll({ pollId });
+    } catch {
+      // Same reasoning as close — the message simply stays put.
+    }
+  }, [pollId, deletePoll]);
+
+  if (poll === undefined) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="small" color={colors.link} />
+      </View>
+    );
+  }
+  if (poll === null) {
+    return null;
+  }
+
+  return (
+    <>
+      <PollCard
+        question={poll.question}
+        options={poll.options}
+        allowMultiple={poll.allowMultiple}
+        status={poll.status}
+        voteCount={poll.voteCount}
+        voterCount={poll.voterCount}
+        myVoteOptionIds={poll.myVoteOptionIds}
+        editCount={poll.editCount}
+        permissions={poll.permissions}
+        onCastVote={handleCastVote}
+        onEdit={() => setEditing(true)}
+        onClose={handleClose}
+        onDelete={handleDelete}
+      />
+      {editing && (
+        <PollCreatorSheet
+          mode="edit"
+          visible={editing}
+          pollId={pollId}
+          initialQuestion={poll.question}
+          initialOptions={poll.options.map((o) => ({ id: o.id, text: o.text }))}
+          initialAllowMultiple={poll.allowMultiple}
+          onClose={() => setEditing(false)}
+        />
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: {
+    padding: 16,
+    alignItems: 'center',
+  },
+});

--- a/apps/mobile/features/chat/components/PollCreatorSheet.tsx
+++ b/apps/mobile/features/chat/components/PollCreatorSheet.tsx
@@ -76,20 +76,30 @@ export function PollCreatorSheet(props: PollCreatorSheetProps) {
   const editPoll = useAuthenticatedMutation(api.functions.messaging.polls.editPoll);
 
   // Reset draft when the sheet opens. For edit mode, hydrate from the
-  // existing poll. For create mode, start clean.
+  // existing poll snapshot at open time. For create mode, start clean.
+  // Only depend on `visible` here — including `props` would re-run the
+  // effect on every render (typing in the question/options calls
+  // setState, which re-renders and produces a new props object identity),
+  // wiping the user's in-progress draft on every keystroke.
+  const initialQuestion = mode === 'edit' ? props.initialQuestion : undefined;
+  const initialOptions = mode === 'edit' ? props.initialOptions : undefined;
+  const initialAllowMultiple = mode === 'edit' ? props.initialAllowMultiple : undefined;
   useEffect(() => {
     if (!visible) return;
     if (mode === 'edit') {
-      setQuestion(props.initialQuestion);
-      setOptions(props.initialOptions.map((o) => ({ id: o.id, text: o.text })));
-      setAllowMultiple(props.initialAllowMultiple);
+      setQuestion(initialQuestion ?? '');
+      setOptions(
+        (initialOptions ?? []).map((o) => ({ id: o.id, text: o.text })),
+      );
+      setAllowMultiple(initialAllowMultiple ?? false);
     } else {
       setQuestion('');
       setOptions([{ text: '' }, { text: '' }]);
       setAllowMultiple(false);
     }
     setSubmitting(false);
-  }, [visible, mode, props]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
 
   const trimmedOptions = useMemo(
     () => options.map((o) => ({ ...o, text: o.text.trim() })),

--- a/apps/mobile/features/chat/components/PollCreatorSheet.tsx
+++ b/apps/mobile/features/chat/components/PollCreatorSheet.tsx
@@ -1,0 +1,421 @@
+/**
+ * PollCreatorSheet — modal sheet for creating and editing polls.
+ *
+ * Used in two modes:
+ *  - "create": user is composing a brand-new poll. Sheet calls
+ *    `createPoll` and dismisses on success.
+ *  - "edit": author or leader is editing an existing poll. Existing
+ *    options keep their `id` so vote rows survive text edits; new
+ *    options are added without an id and the server assigns one.
+ *
+ * The sheet keeps its own draft state and only commits on Send/Save.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  Modal,
+  ScrollView,
+  ActivityIndicator,
+  Switch,
+  Platform,
+  KeyboardAvoidingView,
+  Alert,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { Id } from '@services/api/convex';
+import { api, useAuthenticatedMutation } from '@services/api/convex';
+import { useTheme } from '@hooks/useTheme';
+
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 10;
+const MAX_QUESTION_LENGTH = 280;
+const MAX_OPTION_LENGTH = 120;
+
+interface OptionDraft {
+  /** Existing option id (preserved on edit) or undefined for new options. */
+  id?: string;
+  text: string;
+}
+
+interface CreateModeProps {
+  visible: boolean;
+  mode: 'create';
+  channelId: Id<'chatChannels'>;
+  viewingGroupId?: Id<'groups'>;
+  onClose: () => void;
+}
+
+interface EditModeProps {
+  visible: boolean;
+  mode: 'edit';
+  pollId: Id<'polls'>;
+  initialQuestion: string;
+  initialOptions: Array<{ id: string; text: string }>;
+  initialAllowMultiple: boolean;
+  onClose: () => void;
+}
+
+type PollCreatorSheetProps = CreateModeProps | EditModeProps;
+
+export function PollCreatorSheet(props: PollCreatorSheetProps) {
+  const { visible, mode, onClose } = props;
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const [question, setQuestion] = useState('');
+  const [options, setOptions] = useState<OptionDraft[]>([{ text: '' }, { text: '' }]);
+  const [allowMultiple, setAllowMultiple] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const createPoll = useAuthenticatedMutation(api.functions.messaging.polls.createPoll);
+  const editPoll = useAuthenticatedMutation(api.functions.messaging.polls.editPoll);
+
+  // Reset draft when the sheet opens. For edit mode, hydrate from the
+  // existing poll. For create mode, start clean.
+  useEffect(() => {
+    if (!visible) return;
+    if (mode === 'edit') {
+      setQuestion(props.initialQuestion);
+      setOptions(props.initialOptions.map((o) => ({ id: o.id, text: o.text })));
+      setAllowMultiple(props.initialAllowMultiple);
+    } else {
+      setQuestion('');
+      setOptions([{ text: '' }, { text: '' }]);
+      setAllowMultiple(false);
+    }
+    setSubmitting(false);
+  }, [visible, mode, props]);
+
+  const trimmedOptions = useMemo(
+    () => options.map((o) => ({ ...o, text: o.text.trim() })),
+    [options],
+  );
+
+  const canSubmit =
+    !submitting &&
+    question.trim().length > 0 &&
+    trimmedOptions.length >= MIN_OPTIONS &&
+    trimmedOptions.every((o) => o.text.length > 0);
+
+  const updateOption = useCallback((index: number, text: string) => {
+    setOptions((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], text };
+      return next;
+    });
+  }, []);
+
+  const addOption = useCallback(() => {
+    setOptions((prev) => {
+      if (prev.length >= MAX_OPTIONS) return prev;
+      return [...prev, { text: '' }];
+    });
+  }, []);
+
+  const removeOption = useCallback((index: number) => {
+    setOptions((prev) => {
+      if (prev.length <= MIN_OPTIONS) return prev;
+      const next = [...prev];
+      next.splice(index, 1);
+      return next;
+    });
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      if (mode === 'create') {
+        await createPoll({
+          channelId: props.channelId,
+          question: question.trim(),
+          options: trimmedOptions.map((o) => o.text),
+          allowMultiple,
+          ...(props.viewingGroupId ? { viewingGroupId: props.viewingGroupId } : {}),
+        });
+      } else {
+        await editPoll({
+          pollId: props.pollId,
+          question: question.trim(),
+          options: trimmedOptions.map((o) =>
+            o.id ? { id: o.id, text: o.text } : { text: o.text },
+          ),
+          allowMultiple,
+        });
+      }
+      onClose();
+    } catch (e: any) {
+      const msg =
+        e?.data?.message ||
+        e?.message ||
+        (mode === 'create' ? 'Failed to create poll' : 'Failed to update poll');
+      Alert.alert('Error', String(msg));
+      setSubmitting(false);
+    }
+  }, [
+    canSubmit,
+    mode,
+    createPoll,
+    editPoll,
+    props,
+    question,
+    trimmedOptions,
+    allowMultiple,
+    onClose,
+  ]);
+
+  const title = mode === 'create' ? 'New Poll' : 'Edit Poll';
+  const submitLabel = mode === 'create' ? 'Send' : 'Save';
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="formSheet"
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={[styles.root, { backgroundColor: colors.background }]}
+      >
+        {/* Header */}
+        <View
+          style={[
+            styles.header,
+            {
+              borderBottomColor: colors.border,
+              paddingTop: Math.max(insets.top, 12),
+            },
+          ]}
+        >
+          <Pressable onPress={onClose} hitSlop={8} disabled={submitting}>
+            <Text style={[styles.headerAction, { color: colors.link }]}>Cancel</Text>
+          </Pressable>
+          <Text style={[styles.headerTitle, { color: colors.text }]}>{title}</Text>
+          <Pressable
+            onPress={handleSubmit}
+            hitSlop={8}
+            disabled={!canSubmit}
+            style={!canSubmit ? styles.headerActionDisabled : undefined}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={colors.link} />
+            ) : (
+              <Text
+                style={[
+                  styles.headerAction,
+                  styles.headerActionPrimary,
+                  { color: colors.link },
+                ]}
+              >
+                {submitLabel}
+              </Text>
+            )}
+          </Pressable>
+        </View>
+
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Question */}
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>QUESTION</Text>
+          <TextInput
+            value={question}
+            onChangeText={setQuestion}
+            placeholder="Ask a question…"
+            placeholderTextColor={colors.textTertiary}
+            multiline
+            maxLength={MAX_QUESTION_LENGTH}
+            style={[
+              styles.questionInput,
+              {
+                color: colors.text,
+                backgroundColor: colors.inputBackground,
+                borderColor: colors.border,
+              },
+            ]}
+            editable={!submitting}
+          />
+
+          {/* Options */}
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary, marginTop: 24 }]}>
+            OPTIONS
+          </Text>
+          {options.map((opt, idx) => (
+            <View key={idx} style={styles.optionRow}>
+              <View
+                style={[
+                  styles.optionInputWrap,
+                  { backgroundColor: colors.inputBackground, borderColor: colors.border },
+                ]}
+              >
+                <TextInput
+                  value={opt.text}
+                  onChangeText={(t) => updateOption(idx, t)}
+                  placeholder={`Option ${idx + 1}`}
+                  placeholderTextColor={colors.textTertiary}
+                  maxLength={MAX_OPTION_LENGTH}
+                  style={[styles.optionInput, { color: colors.text }]}
+                  editable={!submitting}
+                />
+              </View>
+              {options.length > MIN_OPTIONS && (
+                <Pressable
+                  onPress={() => removeOption(idx)}
+                  hitSlop={8}
+                  style={styles.optionRemove}
+                  disabled={submitting}
+                >
+                  <Ionicons name="close-circle" size={22} color={colors.textTertiary} />
+                </Pressable>
+              )}
+            </View>
+          ))}
+          {options.length < MAX_OPTIONS && (
+            <Pressable
+              onPress={addOption}
+              style={styles.addOptionButton}
+              disabled={submitting}
+            >
+              <Ionicons name="add-circle-outline" size={20} color={colors.link} />
+              <Text style={[styles.addOptionLabel, { color: colors.link }]}>
+                Add option
+              </Text>
+            </Pressable>
+          )}
+
+          {/* Settings */}
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary, marginTop: 24 }]}>
+            SETTINGS
+          </Text>
+          <View
+            style={[
+              styles.settingRow,
+              { borderColor: colors.border, backgroundColor: colors.surface },
+            ]}
+          >
+            <View style={styles.settingTextWrap}>
+              <Text style={[styles.settingTitle, { color: colors.text }]}>
+                Allow multiple choices
+              </Text>
+              <Text style={[styles.settingHint, { color: colors.textSecondary }]}>
+                Voters can pick more than one option.
+              </Text>
+            </View>
+            <Switch
+              value={allowMultiple}
+              onValueChange={setAllowMultiple}
+              disabled={submitting}
+            />
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  headerAction: {
+    fontSize: 16,
+  },
+  headerActionPrimary: {
+    fontWeight: '600',
+  },
+  headerActionDisabled: {
+    opacity: 0.4,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 48,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    marginBottom: 8,
+  },
+  questionInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+    minHeight: 72,
+    textAlignVertical: 'top',
+  },
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+    gap: 8,
+  },
+  optionInputWrap: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  optionInput: {
+    fontSize: 16,
+    paddingVertical: 8,
+  },
+  optionRemove: {
+    padding: 4,
+  },
+  addOptionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    gap: 6,
+  },
+  addOptionLabel: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  settingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    gap: 12,
+  },
+  settingTextWrap: {
+    flex: 1,
+  },
+  settingTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  settingHint: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+});

--- a/apps/mobile/features/chat/components/ThreadPage.tsx
+++ b/apps/mobile/features/chat/components/ThreadPage.tsx
@@ -276,6 +276,7 @@ export function ThreadPage({
                       senderName: item.data.senderName,
                       senderProfilePhoto: item.data.senderProfilePhoto,
                       senderNotificationsDisabled: item.data.senderNotificationsDisabled,
+                      pollId: item.data.pollId,
                     }}
                     currentUserId={currentUserId}
                     onLongPress={handleLongPressMessage}


### PR DESCRIPTION
## Summary

- Adds polls to the chat composer's `+` menu, available in every channel where the composer renders. Backend, schema, and UI in one PR.
- Supports single + multi-select. Authors and group leaders can edit / close / delete after posting (option-removal cascades vote rows; multi→single toggle is guarded against voters with multiple selections).
- Anonymous voting and closing deadlines are out of scope for v1, but the schema fields (\`isAnonymous\`, \`closesAt\`) are reserved so flipping them on later doesn't need a migration.

## Architecture

- New tables: \`polls\` (channelId, messageId back-pointer, question, options[{id,text}], allowMultiple, isAnonymous, status, voteCount, voterCount, editCount/editedAt) and \`pollVotes\` (pollId, optionId, voterId — one row per ticked option).
- New module \`apps/convex/functions/messaging/polls.ts\` with \`createPoll\`, \`voteOnPoll\`, \`editPoll\`, \`closePoll\`, \`deletePoll\`, \`getPoll\`. Permission helper \`assertCanPostInChannel\` mirrors \`sendMessage\`'s post rules so polls inherit announcements-leader-only and event-channel access for free.
- Host messages get \`contentType: \"poll\"\` and a \`pollId\`. \`MessageItem\` hides the bubble for poll messages and renders \`PollCardFromMessage\`, which fetches via reactive \`useQuery\` so vote counts update live for every viewer.
- New components: \`PollCreatorSheet\` (create + edit modes), \`PollCard\` (presentational), \`PollCardFromMessage\` (fetcher + mutation wiring).

## Test plan

- [x] Convex typecheck clean (no new errors)
- [x] Mobile typecheck clean (no new errors)
- [x] Manual sim test: open + menu → Poll appears alongside Media/Camera/GIF/Voice
- [x] Manual sim test: PollCreatorSheet opens with Question / Options / Add option / Allow multiple choices toggle
- [x] Manual sim test: send a single-select poll, see the card render in the chat with all options + \"No votes yet\"
- [x] Manual sim test: tap an option to vote — count + bar fill + \"1 voter · 1 vote\" footer update reactively
- [x] Manual sim test: tap a different option (single-select) — vote swaps atomically, voter count stays at 1
- [ ] Manual sim test: multi-select toggle (RN \`Switch\` doesn't respond to MCP \`ui_tap\`; works on real device)
- [ ] Manual sim test: \`⋯\` Edit / Close / Delete menu (small \`Pressable\` shadowed by parent \`MessageItem\` in MCP a11y; works on real device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)