### PR TITLE
feat(chat,polls): voters list + avatar stack + codex follow-up fixes

### DIFF
--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -996,6 +996,23 @@ export const deleteMessage = mutation({
       deletedById: userId,
     });
 
+    // Poll messages have side data: a `polls` row + every `pollVotes` row
+    // for that poll. Without cascading here, deleting a poll message
+    // through the generic message-actions menu (long-press → Delete) would
+    // soft-delete the chat row but leave the poll active in the database
+    // — `getPoll` would still resolve, votes would persist, and the
+    // dedicated `polls.deletePoll` path becomes the only way to clean up.
+    if (message.contentType === "poll" && message.pollId) {
+      const votes = await ctx.db
+        .query("pollVotes")
+        .withIndex("by_poll", (q) => q.eq("pollId", message.pollId!))
+        .collect();
+      for (const v of votes) {
+        await ctx.db.delete(v._id);
+      }
+      await ctx.db.delete(message.pollId);
+    }
+
     // Update channel preview if the deleted message was the most recent
     // Re-read channel (already fetched above, but re-read for freshest lastMessageAt)
     const freshChannel = await ctx.db.get(message.channelId);

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -373,6 +373,23 @@ export const voteOnPoll = mutation({
         .first();
       if (!m) throw new ConvexError("Not a member of this channel");
 
+      // Disabled-channel gate. `getMessages` hides custom / pco_services /
+      // announcements channels from non-leaders when they're disabled, so
+      // a member with a stale-mounted poll card or direct pollId could
+      // otherwise still mutate poll state. Leaders can still moderate
+      // votes on disabled channels (closing the poll, etc), so we only
+      // block non-leaders here.
+      if (
+        isCustomChannel(channel.channelType) ||
+        channel.channelType === "pco_services" ||
+        channel.channelType === "announcements"
+      ) {
+        const enabled = channelIsLeaderEnabled(channel);
+        if (!enabled && !(await isChannelGroupLeader(ctx, channel, userId))) {
+          throw new ConvexError("This channel is disabled");
+        }
+      }
+
       // Ad-hoc DM/group_dm: a pending recipient can READ the request but
       // can't take any send-shape action until they accept. Voting writes
       // a row that fans out via reactivity, so it falls under the same

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -817,6 +817,19 @@ export const getPoll = query({
     const canModerate = isAuthor || isLeader;
     const canSeeIdentities = !poll.isAnonymous || isAuthor || isLeader;
 
+    // Counts always include every vote (so a blocker doesn't see a
+    // skewed total). Voter identity surfaces — preview avatars and the
+    // voters sheet — strip blocked users so the blocker doesn't see the
+    // person they explicitly hid from their feed reappear here. This
+    // mirrors how `getMessages` filters blocked senders' messages.
+    const blockedRows = await ctx.db
+      .query("chatUserBlocks")
+      .withIndex("by_blocker", (q) => q.eq("blockerId", userId))
+      .collect();
+    const blockedUserIds = new Set<string>(
+      blockedRows.map((b) => b.blockedId),
+    );
+
     // Build per-option counts AND a small voter-avatar preview (first
     // few voters per option, ordered earliest-first). Batch user
     // fetches by unique voter id so a multi-voter doesn't fan out.
@@ -838,10 +851,12 @@ export const getPoll = query({
     let voterUserById = new Map<Id<"users">, Doc<"users">>();
     if (canSeeIdentities && allVotes.length > 0) {
       // Only fetch users actually needed for previews (top N earliest
-      // voters per option) so very-large polls don't fan out user reads.
+      // voters per option, blocked users skipped) so very-large polls
+      // don't fan out user reads.
       const idsNeeded = new Set<Id<"users">>();
       for (const [, votes] of votesByOption) {
         const top = [...votes]
+          .filter((v) => !blockedUserIds.has(v.voterId))
           .sort((a, b) => a.createdAt - b.createdAt)
           .slice(0, PREVIEW_LIMIT);
         for (const v of top) idsNeeded.add(v.voterId);
@@ -864,6 +879,7 @@ export const getPoll = query({
         const optionVotes = votesByOption.get(o.id) ?? [];
         const voterPreview = canSeeIdentities
           ? [...optionVotes]
+              .filter((v) => !blockedUserIds.has(v.voterId))
               .sort((a, b) => a.createdAt - b.createdAt)
               .slice(0, PREVIEW_LIMIT)
               .map((v) => {
@@ -953,9 +969,26 @@ export const getPollVoters = query({
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
       .collect();
 
+    // Filter out users the viewer has blocked. Counts stay accurate
+    // (blocker shouldn't see a skewed total) but identities of blocked
+    // voters are stripped — same shape as `getMessages`'s blocker filter.
+    const blockedRows = await ctx.db
+      .query("chatUserBlocks")
+      .withIndex("by_blocker", (q) => q.eq("blockerId", userId))
+      .collect();
+    const blockedUserIds = new Set<string>(
+      blockedRows.map((b) => b.blockedId),
+    );
+
     // Resolve voter identities. Batch a unique-id lookup so we hit `users`
     // once per voter regardless of how many options they ticked.
-    const uniqueVoterIds = Array.from(new Set(allVotes.map((v) => v.voterId)));
+    const uniqueVoterIds = Array.from(
+      new Set(
+        allVotes
+          .filter((v) => !blockedUserIds.has(v.voterId))
+          .map((v) => v.voterId),
+      ),
+    );
     const voterUsers = await Promise.all(
       uniqueVoterIds.map((id) => ctx.db.get(id)),
     );
@@ -976,6 +1009,7 @@ export const getPollVoters = query({
       const optionVotes = votesByOption.get(opt.id) ?? [];
       const voters = canSeeIdentities
         ? optionVotes
+            .filter((v) => !blockedUserIds.has(v.voterId))
             .map((v) => {
               const user = userById.get(v.voterId);
               if (!user) return null;

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -567,13 +567,33 @@ export const editPoll = mutation({
     });
 
     // Mirror question edits on the host message so the inbox preview and
-    // any text-search paths reflect the change.
+    // any text-search paths reflect the change. Also update the channel's
+    // denormalized lastMessagePreview when the edited poll IS the channel's
+    // current last message, otherwise the inbox row keeps showing the old
+    // question until another message lands.
     if (poll.messageId && args.question !== undefined) {
       await ctx.db.patch(poll.messageId, {
         content: newQuestion.trim(),
         editedAt: now,
         updatedAt: now,
       });
+
+      const hostMessage = await ctx.db.get(poll.messageId);
+      const channel = await ctx.db.get(poll.channelId);
+      if (
+        hostMessage &&
+        channel &&
+        channel.lastMessageAt &&
+        hostMessage.createdAt >= channel.lastMessageAt
+      ) {
+        const previewBase = `📊 ${newQuestion.trim()}`;
+        const preview =
+          previewBase.length > 100 ? previewBase.slice(0, 97) + "…" : previewBase;
+        await ctx.db.patch(poll.channelId, {
+          lastMessagePreview: preview,
+          updatedAt: now,
+        });
+      }
     }
   },
 });

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -856,3 +856,110 @@ export const getPoll = query({
     };
   },
 });
+
+/**
+ * Read the per-option voter list for a poll.
+ *
+ * Returned shape groups voters by option so the UI can render sections
+ * directly. Each voter includes display name + profile photo for rendering
+ * an avatar row.
+ *
+ * Visibility: same channel-member gate as `getPoll`. When `isAnonymous`
+ * is true (reserved for v1, never set today), non-leaders see option
+ * counts but no voter identities — leaders / poll author always see
+ * full identities for moderation reasons.
+ */
+export const getPollVoters = query({
+  args: {
+    token: v.string(),
+    pollId: v.id("polls"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const poll = await ctx.db.get(args.pollId);
+    if (!poll) return null;
+
+    const channel = await ctx.db.get(poll.channelId);
+    if (!channel) return null;
+
+    if (channel.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) return null;
+    } else {
+      const m = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", poll.channelId).eq("userId", userId),
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
+      if (!m) return null;
+    }
+
+    const isAuthor = poll.authorId === userId;
+    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const canSeeIdentities =
+      !poll.isAnonymous || isAuthor || isLeader;
+
+    const allVotes = await ctx.db
+      .query("pollVotes")
+      .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
+      .collect();
+
+    // Resolve voter identities. Batch a unique-id lookup so we hit `users`
+    // once per voter regardless of how many options they ticked.
+    const uniqueVoterIds = Array.from(new Set(allVotes.map((v) => v.voterId)));
+    const voterUsers = await Promise.all(
+      uniqueVoterIds.map((id) => ctx.db.get(id)),
+    );
+    const userById = new Map<Id<"users">, Doc<"users">>();
+    uniqueVoterIds.forEach((id, i) => {
+      const u = voterUsers[i];
+      if (u) userById.set(id, u);
+    });
+
+    const votesByOption = new Map<string, Array<typeof allVotes[number]>>();
+    for (const v of allVotes) {
+      const arr = votesByOption.get(v.optionId) ?? [];
+      arr.push(v);
+      votesByOption.set(v.optionId, arr);
+    }
+
+    const options = poll.options.map((opt) => {
+      const optionVotes = votesByOption.get(opt.id) ?? [];
+      const voters = canSeeIdentities
+        ? optionVotes
+            .map((v) => {
+              const user = userById.get(v.voterId);
+              if (!user) return null;
+              return {
+                userId: v.voterId,
+                displayName: getDisplayName(user.firstName, user.lastName),
+                profilePhoto: getMediaUrl(user.profilePhoto),
+                createdAt: v.createdAt,
+              };
+            })
+            .filter(
+              (v): v is NonNullable<typeof v> => v !== null,
+            )
+            // Stable order: earliest voter first per option
+            .sort((a, b) => a.createdAt - b.createdAt)
+        : [];
+      return {
+        id: opt.id,
+        text: opt.text,
+        count: optionVotes.length,
+        voters,
+      };
+    });
+
+    return {
+      pollId: poll._id,
+      isAnonymous: poll.isAnonymous,
+      canSeeIdentities,
+      voterCount: poll.voterCount,
+      voteCount: poll.voteCount,
+      options,
+    };
+  },
+});

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -811,20 +811,48 @@ export const getPoll = query({
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
       .collect();
 
+    const isAuthor = poll.authorId === userId;
+    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const canVote = poll.status === "active";
+    const canModerate = isAuthor || isLeader;
+    const canSeeIdentities = !poll.isAnonymous || isAuthor || isLeader;
+
+    // Build per-option counts AND a small voter-avatar preview (first
+    // few voters per option, ordered earliest-first). Batch user
+    // fetches by unique voter id so a multi-voter doesn't fan out.
     const countsByOption = new Map<string, number>();
     const myVoteIds: string[] = [];
+    const votesByOption = new Map<string, Array<typeof allVotes[number]>>();
     for (const v of allVotes) {
       countsByOption.set(
         v.optionId,
         (countsByOption.get(v.optionId) ?? 0) + 1,
       );
       if (v.voterId === userId) myVoteIds.push(v.optionId);
+      const arr = votesByOption.get(v.optionId) ?? [];
+      arr.push(v);
+      votesByOption.set(v.optionId, arr);
     }
 
-    const isAuthor = poll.authorId === userId;
-    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
-    const canVote = poll.status === "active";
-    const canModerate = isAuthor || isLeader;
+    const PREVIEW_LIMIT = 4;
+    let voterUserById = new Map<Id<"users">, Doc<"users">>();
+    if (canSeeIdentities && allVotes.length > 0) {
+      // Only fetch users actually needed for previews (top N earliest
+      // voters per option) so very-large polls don't fan out user reads.
+      const idsNeeded = new Set<Id<"users">>();
+      for (const [, votes] of votesByOption) {
+        const top = [...votes]
+          .sort((a, b) => a.createdAt - b.createdAt)
+          .slice(0, PREVIEW_LIMIT);
+        for (const v of top) idsNeeded.add(v.voterId);
+      }
+      const ids = Array.from(idsNeeded);
+      const users = await Promise.all(ids.map((id) => ctx.db.get(id)));
+      ids.forEach((id, i) => {
+        const u = users[i];
+        if (u) voterUserById.set(id, u);
+      });
+    }
 
     return {
       _id: poll._id,
@@ -832,11 +860,30 @@ export const getPoll = query({
       messageId: poll.messageId,
       authorId: poll.authorId,
       question: poll.question,
-      options: poll.options.map((o) => ({
-        id: o.id,
-        text: o.text,
-        count: countsByOption.get(o.id) ?? 0,
-      })),
+      options: poll.options.map((o) => {
+        const optionVotes = votesByOption.get(o.id) ?? [];
+        const voterPreview = canSeeIdentities
+          ? [...optionVotes]
+              .sort((a, b) => a.createdAt - b.createdAt)
+              .slice(0, PREVIEW_LIMIT)
+              .map((v) => {
+                const user = voterUserById.get(v.voterId);
+                if (!user) return null;
+                return {
+                  userId: v.voterId,
+                  displayName: getDisplayName(user.firstName, user.lastName),
+                  profilePhoto: getMediaUrl(user.profilePhoto),
+                };
+              })
+              .filter((x): x is NonNullable<typeof x> => x !== null)
+          : [];
+        return {
+          id: o.id,
+          text: o.text,
+          count: countsByOption.get(o.id) ?? 0,
+          voterPreview,
+        };
+      }),
       allowMultiple: poll.allowMultiple,
       isAnonymous: poll.isAnonymous,
       status: poll.status,

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -964,10 +964,21 @@ export const getPollVoters = query({
     const canSeeIdentities =
       !poll.isAnonymous || isAuthor || isLeader;
 
-    const allVotes = await ctx.db
+    // Cap how many vote rows we materialize. Convex queries have a
+    // function-level read limit, and a poll with thousands of voters
+    // would otherwise either hit it or fan out one users.get per voter.
+    // For v1 community-app polls a few hundred is plenty; the UI shows
+    // a "+N more" hint when truncated. Move to true pagination if a
+    // real-world poll ever crosses this threshold.
+    const VOTERS_QUERY_CAP = 500;
+    const cappedVotes = await ctx.db
       .query("pollVotes")
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
-      .collect();
+      .take(VOTERS_QUERY_CAP + 1);
+    const truncated = cappedVotes.length > VOTERS_QUERY_CAP;
+    const allVotes = truncated
+      ? cappedVotes.slice(0, VOTERS_QUERY_CAP)
+      : cappedVotes;
 
     // Filter out users the viewer has blocked. Counts stay accurate
     // (blocker shouldn't see a skewed total) but identities of blocked
@@ -1041,6 +1052,10 @@ export const getPollVoters = query({
       voterCount: poll.voterCount,
       voteCount: poll.voteCount,
       options,
+      // True when the poll has more vote rows than VOTERS_QUERY_CAP and
+      // the returned `voters` arrays are a prefix of the full list. The
+      // sheet UI surfaces this with a "Showing first N voters" hint.
+      truncated,
     };
   },
 });

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -27,6 +27,7 @@ import {
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { canAccessEventChannel } from "./eventChat";
 import { generateMessagePreview } from "./messages";
+import { checkRateLimit } from "../../lib/rateLimit";
 
 const MAX_QUESTION_LENGTH = 280;
 const MAX_OPTION_TEXT_LENGTH = 120;
@@ -237,6 +238,13 @@ export const createPoll = mutation({
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
 
+    // Share the same rate-limit bucket as `sendMessage` (`msg:${userId}`,
+    // 20/min). Without this a member could fan polls out indefinitely
+    // through the same notification path while ordinary text messages
+    // are capped — and a poll fans out to every channel member just like
+    // a normal send.
+    await checkRateLimit(ctx, `msg:${userId}`, 20, 60_000);
+
     validatePollContent(args.question, args.options);
 
     const channel = await ctx.db.get(args.channelId);
@@ -364,6 +372,18 @@ export const voteOnPoll = mutation({
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
       if (!m) throw new ConvexError("Not a member of this channel");
+
+      // Ad-hoc DM/group_dm: a pending recipient can READ the request but
+      // can't take any send-shape action until they accept. Voting writes
+      // a row that fans out via reactivity, so it falls under the same
+      // gate as `sendMessage` does for ad-hoc channels.
+      if (
+        channel.isAdHoc &&
+        m.requestState !== undefined &&
+        m.requestState !== "accepted"
+      ) {
+        throw new ConvexError("Accept the request before voting");
+      }
     }
 
     // Validate option ids belong to this poll.

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -860,7 +860,13 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
     const options: Array<{ id: string; label: string; icon: keyof typeof Ionicons.glyphMap; iconColor?: string; onPress: () => void }> = [
       { id: 'media', label: 'Media', icon: 'images', iconColor: '#007AFF', onPress: pickMedia },
       { id: 'camera', label: 'Camera', icon: 'camera', iconColor: '#333', onPress: captureMedia },
-      {
+    ];
+    // Polls only make sense on top-level messages — `createPoll` doesn't
+    // accept a `parentMessageId`, so tapping it from a thread reply
+    // composer would post into the main channel instead of the thread.
+    // Hide the option when this MessageInput is rendered for a reply.
+    if (!replyToMessage) {
+      options.push({
         id: 'poll',
         label: 'Poll',
         icon: 'bar-chart-outline',
@@ -868,8 +874,8 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
         onPress: () => {
           if (channelId) setShowPollCreator(true);
         },
-      },
-    ];
+      });
+    }
     if (process.env.EXPO_PUBLIC_KLIPY_API_KEY) {
       options.push({
         id: 'gif',
@@ -889,7 +895,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
       });
     }
     return options;
-  }, [captureMedia, pickMedia, recipientPending, channelId]);
+  }, [captureMedia, pickMedia, recipientPending, channelId, replyToMessage]);
 
   const handleOptionPress = useCallback((option: { onPress: () => void }) => {
     setShowAttachmentMenu(false);

--- a/apps/mobile/features/chat/components/PollCard.tsx
+++ b/apps/mobile/features/chat/components/PollCard.tsx
@@ -20,12 +20,19 @@ import {
   Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { Avatar } from '@components/ui';
 import { useTheme } from '@hooks/useTheme';
+import type { Id } from '@services/api/convex';
 
 export interface PollCardOption {
   id: string;
   text: string;
   count: number;
+  voterPreview: Array<{
+    userId: Id<'users'>;
+    displayName: string;
+    profilePhoto?: string;
+  }>;
 }
 
 export interface PollCardProps {
@@ -283,6 +290,53 @@ export function PollCard({
                 >
                   {opt.text}
                 </Text>
+                {/* Voter avatar stack — RSVP-style. Uses voterPreview
+                    (top 4 earliest voters) returned by getPoll, with a
+                    "+N" overflow chip when there are more. Tapping
+                    surfaces the full voters list via the parent
+                    onShowVoters callback. */}
+                {opt.voterPreview.length > 0 && (
+                  <Pressable
+                    onPress={onShowVoters}
+                    hitSlop={6}
+                    style={styles.avatarStack}
+                  >
+                    {opt.voterPreview.map((v, i) => (
+                      <View
+                        key={v.userId}
+                        style={[
+                          styles.avatarStackItem,
+                          {
+                            marginLeft: i === 0 ? 0 : -8,
+                            borderColor: colors.surface,
+                            zIndex: opt.voterPreview.length - i,
+                          },
+                        ]}
+                      >
+                        <Avatar
+                          name={v.displayName}
+                          imageUrl={v.profilePhoto}
+                          size={20}
+                        />
+                      </View>
+                    ))}
+                    {opt.count > opt.voterPreview.length && (
+                      <View
+                        style={[
+                          styles.avatarOverflow,
+                          {
+                            backgroundColor: colors.surfaceSecondary,
+                            borderColor: colors.surface,
+                          },
+                        ]}
+                      >
+                        <Text style={[styles.avatarOverflowText, { color: colors.textSecondary }]}>
+                          +{opt.count - opt.voterPreview.length}
+                        </Text>
+                      </View>
+                    )}
+                  </Pressable>
+                )}
                 {totalVotes > 0 && (
                   <Text style={[styles.optionCount, { color: colors.textSecondary }]}>
                     {opt.count}
@@ -448,6 +502,27 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     minWidth: 24,
     textAlign: 'right',
+  },
+  avatarStack: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatarStackItem: {
+    borderWidth: 1.5,
+    borderRadius: 12,
+  },
+  avatarOverflow: {
+    marginLeft: -8,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarOverflowText: {
+    fontSize: 9,
+    fontWeight: '600',
   },
   submitButton: {
     marginTop: 12,

--- a/apps/mobile/features/chat/components/PollCard.tsx
+++ b/apps/mobile/features/chat/components/PollCard.tsx
@@ -47,6 +47,7 @@ export interface PollCardProps {
   onEdit: () => void;
   onClose: () => void;
   onDelete: () => void;
+  onShowVoters: () => void;
 }
 
 export function PollCard({
@@ -63,6 +64,7 @@ export function PollCard({
   onEdit,
   onClose,
   onDelete,
+  onShowVoters,
 }: PollCardProps) {
   const { colors } = useTheme();
   const isClosed = status === 'closed';
@@ -312,8 +314,14 @@ export function PollCard({
         </Pressable>
       )}
 
-      {/* Footer */}
-      <View style={styles.footer}>
+      {/* Footer — tap opens the voter list sheet (gated when there are
+          votes; tapping a "No votes yet" footer is a no-op). */}
+      <Pressable
+        onPress={voterCount > 0 ? onShowVoters : undefined}
+        disabled={voterCount === 0}
+        style={({ pressed }) => [styles.footer, pressed && voterCount > 0 && styles.footerPressed]}
+        hitSlop={6}
+      >
         <Text style={[styles.footerText, { color: colors.textSecondary }]}>
           {voterCount === 0
             ? 'No votes yet'
@@ -321,10 +329,13 @@ export function PollCard({
                 voteCount === 1 ? 'vote' : 'votes'
               }`}
         </Text>
+        {voterCount > 0 && (
+          <Ionicons name="chevron-forward" size={14} color={colors.textTertiary} />
+        )}
         {editCount > 0 && (
           <Text style={[styles.footerEdited, { color: colors.textTertiary }]}>edited</Text>
         )}
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -454,6 +465,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 10,
     gap: 8,
+  },
+  footerPressed: {
+    opacity: 0.6,
   },
   footerText: {
     fontSize: 12,

--- a/apps/mobile/features/chat/components/PollCardFromMessage.tsx
+++ b/apps/mobile/features/chat/components/PollCardFromMessage.tsx
@@ -13,6 +13,7 @@ import { api, useQuery, useStoredAuthToken, useAuthenticatedMutation } from '@se
 import { useTheme } from '@hooks/useTheme';
 import { PollCard } from './PollCard';
 import { PollCreatorSheet } from './PollCreatorSheet';
+import { PollVotersSheet } from './PollVotersSheet';
 
 interface Props {
   pollId: Id<'polls'>;
@@ -22,6 +23,7 @@ export function PollCardFromMessage({ pollId }: Props) {
   const { colors } = useTheme();
   const token = useStoredAuthToken();
   const [editing, setEditing] = useState(false);
+  const [showingVoters, setShowingVoters] = useState(false);
 
   const poll = useQuery(
     api.functions.messaging.polls.getPoll,
@@ -83,6 +85,7 @@ export function PollCardFromMessage({ pollId }: Props) {
         onEdit={() => setEditing(true)}
         onClose={handleClose}
         onDelete={handleDelete}
+        onShowVoters={() => setShowingVoters(true)}
       />
       {editing && (
         <PollCreatorSheet
@@ -95,6 +98,11 @@ export function PollCardFromMessage({ pollId }: Props) {
           onClose={() => setEditing(false)}
         />
       )}
+      <PollVotersSheet
+        visible={showingVoters}
+        pollId={showingVoters ? pollId : null}
+        onClose={() => setShowingVoters(false)}
+      />
     </>
   );
 }

--- a/apps/mobile/features/chat/components/PollVotersSheet.tsx
+++ b/apps/mobile/features/chat/components/PollVotersSheet.tsx
@@ -1,0 +1,243 @@
+/**
+ * PollVotersSheet — modal sheet showing who voted for what on a poll.
+ *
+ * Sectioned by option: each section header is the option text + vote
+ * count, followed by a list of voters with avatar + full display name.
+ * Opened by tapping the poll card's footer.
+ *
+ * v1 always returns voter identities (no anonymity yet). The query
+ * already gates this on `canSeeIdentities` so a future anonymous mode
+ * can hide non-leader views without UI changes here.
+ */
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  Pressable,
+  SectionList,
+  ActivityIndicator,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { Id } from '@services/api/convex';
+import { api, useQuery, useStoredAuthToken } from '@services/api/convex';
+import { Avatar } from '@components/ui';
+import { useTheme } from '@hooks/useTheme';
+
+interface VoterRow {
+  userId: Id<'users'>;
+  displayName: string;
+  profilePhoto?: string;
+  createdAt: number;
+}
+
+interface Section {
+  title: string;
+  count: number;
+  data: VoterRow[];
+}
+
+interface PollVotersSheetProps {
+  visible: boolean;
+  pollId: Id<'polls'> | null;
+  onClose: () => void;
+}
+
+export function PollVotersSheet({ visible, pollId, onClose }: PollVotersSheetProps) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const token = useStoredAuthToken();
+
+  const data = useQuery(
+    api.functions.messaging.polls.getPollVoters,
+    token && pollId && visible ? { token, pollId } : 'skip',
+  );
+
+  const sections: Section[] =
+    data?.options.map((opt) => ({
+      title: opt.text,
+      count: opt.count,
+      data: opt.voters,
+    })) ?? [];
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="formSheet"
+      onRequestClose={onClose}
+    >
+      <View style={[styles.root, { backgroundColor: colors.background }]}>
+        <View
+          style={[
+            styles.header,
+            {
+              borderBottomColor: colors.border,
+              paddingTop: Math.max(insets.top, 12),
+            },
+          ]}
+        >
+          <View style={styles.headerSpacer} />
+          <Text style={[styles.headerTitle, { color: colors.text }]}>Votes</Text>
+          <Pressable onPress={onClose} hitSlop={8} style={styles.headerClose}>
+            <Ionicons name="close" size={24} color={colors.textSecondary} />
+          </Pressable>
+        </View>
+
+        {data === undefined ? (
+          <View style={styles.loading}>
+            <ActivityIndicator size="large" color={colors.link} />
+          </View>
+        ) : data === null ? (
+          <View style={styles.empty}>
+            <Text style={[styles.emptyText, { color: colors.textTertiary }]}>
+              Couldn't load votes.
+            </Text>
+          </View>
+        ) : data.voterCount === 0 ? (
+          <View style={styles.empty}>
+            <Text style={[styles.emptyText, { color: colors.textTertiary }]}>
+              No votes yet.
+            </Text>
+          </View>
+        ) : (
+          <SectionList
+            sections={sections}
+            keyExtractor={(item, index) => `${item.userId}-${index}`}
+            stickySectionHeadersEnabled={false}
+            contentContainerStyle={styles.listContent}
+            renderSectionHeader={({ section }) => (
+              <View
+                style={[
+                  styles.sectionHeader,
+                  {
+                    backgroundColor: colors.surfaceSecondary,
+                    borderColor: colors.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={[styles.sectionTitle, { color: colors.text }]}
+                  numberOfLines={2}
+                >
+                  {section.title}
+                </Text>
+                <Text style={[styles.sectionCount, { color: colors.textSecondary }]}>
+                  {section.count} {section.count === 1 ? 'vote' : 'votes'}
+                </Text>
+              </View>
+            )}
+            renderItem={({ item }) => (
+              <View style={styles.voterRow}>
+                <Avatar
+                  name={item.displayName}
+                  imageUrl={item.profilePhoto}
+                  size={36}
+                />
+                <Text
+                  style={[styles.voterName, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  {item.displayName}
+                </Text>
+              </View>
+            )}
+            renderSectionFooter={({ section }) =>
+              section.data.length === 0 ? (
+                <View style={styles.emptySection}>
+                  <Text style={[styles.emptySectionText, { color: colors.textTertiary }]}>
+                    {data.canSeeIdentities ? 'No votes' : 'Anonymous votes'}
+                  </Text>
+                </View>
+              ) : null
+            }
+          />
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerSpacer: {
+    width: 28,
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  headerClose: {
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    fontSize: 15,
+  },
+  listContent: {
+    paddingBottom: 24,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    flex: 1,
+  },
+  sectionCount: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  voterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    gap: 12,
+  },
+  voterName: {
+    fontSize: 15,
+    flex: 1,
+  },
+  emptySection: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  emptySectionText: {
+    fontSize: 13,
+    fontStyle: 'italic',
+  },
+});

--- a/apps/mobile/features/chat/components/PollVotersSheet.tsx
+++ b/apps/mobile/features/chat/components/PollVotersSheet.tsx
@@ -108,6 +108,21 @@ export function PollVotersSheet({ visible, pollId, onClose }: PollVotersSheetPro
             keyExtractor={(item, index) => `${item.userId}-${index}`}
             stickySectionHeadersEnabled={false}
             contentContainerStyle={styles.listContent}
+            ListHeaderComponent={
+              data.truncated ? (
+                <View
+                  style={[
+                    styles.truncatedBanner,
+                    { backgroundColor: colors.surfaceSecondary },
+                  ]}
+                >
+                  <Ionicons name="information-circle-outline" size={14} color={colors.textSecondary} />
+                  <Text style={[styles.truncatedText, { color: colors.textSecondary }]}>
+                    Showing the first voters. The list is capped for performance.
+                  </Text>
+                </View>
+              ) : null
+            }
             renderSectionHeader={({ section }) => (
               <View
                 style={[
@@ -239,5 +254,16 @@ const styles = StyleSheet.create({
   emptySectionText: {
     fontSize: 13,
     fontStyle: 'italic',
+  },
+  truncatedBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  truncatedText: {
+    fontSize: 12,
+    flex: 1,
   },
 });


### PR DESCRIPTION
Follow-up to #385. Bundles the codex-flagged correctness/security fixes that didn't make the original merge plus the voters list + avatar stack feature.

## Why a new PR

#385 merged with only the original 2 commits; the codex round-2/3/4 fixes plus the voters/avatars work were on a stacked branch (#386) whose base was deleted before its changes reached \`main\`. This PR brings all 8 unmerged commits forward.

## Codex fixes (correctness + security)

- \`fix(chat,polls): address codex round 2\` — hide Poll in thread reply composer; refresh channel preview on poll question edits
- \`fix(chat,polls): cascade poll cleanup in messages.deleteMessage\` — generic long-press → Delete now cascades \`pollVotes\` + \`polls\` rows
- \`fix(chat,polls): apply rate limit + ad-hoc accept gate to polls\` — \`createPoll\` shares \`msg:\${userId}\` 20/min budget; \`voteOnPoll\` rejects pending ad-hoc recipients
- \`fix(chat,polls): block voting on leader-disabled channels\` — non-leaders can't vote on disabled channels
- \`fix(chat,polls): strip blocked voters from identity surfaces\` — blocker no longer sees blocked voter avatars/names

## Features

- \`feat(chat,polls): show who voted for what\` — \`getPollVoters\` query + \`PollVotersSheet\` modal grouped by option
- \`feat(chat,polls): inline avatar stack per option (RSVP-style)\` — \`getPoll\` returns \`voterPreview\` per option; \`PollCard\` renders an overlapping avatar stack with \`+N\` overflow chip

## Performance

- \`fix(chat,polls): cap getPollVoters at 500 voters\` — Convex read-limit guard with \`truncated\` flag and a banner in the sheet

## Test plan

- [x] Convex typecheck clean (no new errors)
- [x] Mobile typecheck clean (no new errors)
- [x] Manual sim: avatar stack renders inline on each option row, count + bar bar update reactively
- [x] Manual sim: footer reads "N voter · M vote ›" when there are votes
- [ ] Manual: voters sheet (verified visible UI; outer MessageItem Pressable shadowed the tap in the simulator MCP — works on real device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)