### PR TITLE
fix(events): invite sheet freeze + send hardening + UX cleanup

### DIFF
--- a/apps/convex/functions/eventInvites.ts
+++ b/apps/convex/functions/eventInvites.ts
@@ -99,7 +99,8 @@ export const list = query({
  *   - alreadyInvited: existing eventInvites row for this meeting+user
  *   - alreadyRsvped: existing RSVP for this meeting+user (any option)
  *
- * Skips the caller — leaders don't need to invite themselves.
+ * Includes the caller themselves — handy for sending a test invite to your
+ * own number/push token to preview what recipients will see.
  */
 export const listGroupMembersForInvite = query({
   args: {
@@ -123,9 +124,7 @@ export const listGroupMembersForInvite = query({
       (m) => !m.requestStatus || m.requestStatus === "accepted" || m.requestStatus === "approved",
     );
 
-    const memberUserIds = accepted
-      .map((m) => m.userId)
-      .filter((id) => id !== userId);
+    const memberUserIds = accepted.map((m) => m.userId);
 
     // Batch fetch users
     const users = await Promise.all(memberUserIds.map((id) => ctx.db.get(id)));
@@ -181,12 +180,14 @@ export const listGroupMembersForInvite = query({
           inviteRound: existing?.inviteRound ?? 0,
           lastSentAt: existing?.lastSentAt ?? null,
           alreadyRsvped: rsvpUserIds.has(id),
+          isSelf: id === userId,
         };
       })
       .filter((m): m is NonNullable<typeof m> => m !== null)
       .sort((a, b) => {
-        // Already-invited last, then members with no reachable channel last,
-        // then alphabetical.
+        // Self first (for the "test invite to me" workflow), then
+        // already-invited last, then unreachable last, then alphabetical.
+        if (a.isSelf !== b.isSelf) return a.isSelf ? -1 : 1;
         if (a.alreadyInvited !== b.alreadyInvited) return a.alreadyInvited ? 1 : -1;
         const aReachable = a.hasPhone || a.hasPushTokens;
         const bReachable = b.hasPhone || b.hasPushTokens;
@@ -480,7 +481,7 @@ export const send = internalAction({
       const title = `${senderFirstName} invited you to ${eventTitle}`;
       const body = inv.personalNote
         ? `"${inv.personalNote}"`
-        : formatWhenAndWhere(meetingInfo);
+        : formatScheduledAt(meetingInfo.scheduledAt);
       for (const token of tokens) {
         pushPayloads.push({
           token,
@@ -550,16 +551,25 @@ export const send = internalAction({
           const body = buildInviteSmsBody({
             senderFirstName,
             eventTitle,
-            whenAndWhere: formatWhenAndWhere(meetingInfo),
+            when: formatScheduledAt(meetingInfo.scheduledAt),
             personalNote: inv.personalNote ?? null,
             eventUrl,
           });
           try {
-            await ctx.runAction(internal.functions.auth.phoneOtp.sendSMS, {
-              phone: inv.phone,
-              message: body,
-            });
-            smsStatus = "succeeded";
+            const r = await ctx.runAction(
+              internal.functions.auth.phoneOtp.sendSMS,
+              { phone: inv.phone, message: body },
+            );
+            // sendSMS returns { success: false } without throwing for
+            // misconfigured Twilio creds and for the OTP_TEST_PHONE_NUMBERS
+            // bypass. Don't mark "succeeded" when the underlying action
+            // explicitly said it didn't deliver.
+            if (r?.success) {
+              smsStatus = "succeeded";
+            } else {
+              smsStatus = "failed";
+              failureReason = "sendSMS returned success: false";
+            }
           } catch (err) {
             smsStatus = "failed";
             failureReason = err instanceof Error ? err.message : String(err);
@@ -621,8 +631,6 @@ export const getMeetingForInvite = internalQuery({
       communityId: meeting.communityId,
       shortId: meeting.shortId,
       scheduledAt: meeting.scheduledAt,
-      locationOverride: meeting.locationOverride,
-      meetingType: meeting.meetingType,
     };
   },
 });
@@ -663,22 +671,6 @@ export const updateInviteStatus = internalMutation({
 // Body formatting
 // ============================================================================
 
-type MeetingForInvite = {
-  title: string | undefined;
-  scheduledAt: number;
-  locationOverride: string | undefined;
-  meetingType: number;
-};
-
-function formatWhenAndWhere(meeting: MeetingForInvite): string {
-  const when = formatScheduledAt(meeting.scheduledAt);
-  const where =
-    meeting.meetingType === 2
-      ? "Online"
-      : meeting.locationOverride || null;
-  return where ? `${when} · ${where}` : when;
-}
-
 function formatScheduledAt(ts: number): string {
   // Eastern is the default community timezone; date formatting in SMS is
   // intentionally simple — we don't ship the recipient's timezone server-side.
@@ -700,14 +692,14 @@ function formatScheduledAt(ts: number): string {
 function buildInviteSmsBody(parts: {
   senderFirstName: string;
   eventTitle: string;
-  whenAndWhere: string;
+  when: string;
   personalNote: string | null;
   eventUrl: string;
 }): string {
   const lead = `${parts.senderFirstName} invited you to ${parts.eventTitle}`;
   const note = parts.personalNote ? `\n\n"${parts.personalNote}"` : "";
   const link = parts.eventUrl ? `\n\n${parts.eventUrl}` : "";
-  const body = `${lead}\n${parts.whenAndWhere}${note}${link}`;
+  const body = `${lead}\n${parts.when}${note}${link}`;
   if (body.length <= SMS_MAX_LEN) return body;
   // Personal note is the most likely thing to push us over the limit — truncate it.
   const overage = body.length - SMS_MAX_LEN;

--- a/apps/convex/lib/twilio.ts
+++ b/apps/convex/lib/twilio.ts
@@ -38,6 +38,12 @@ export function isTestPhone(phone: string): boolean {
 
   return testPhoneList.some((testPhone: string) => {
     const testCleaned = testPhone.replace(/\D/g, "");
+    // Guard against empty entries — without this, a stray placeholder like
+    // "-" or an empty token in OTP_TEST_PHONE_NUMBERS would match EVERY phone
+    // because every string `.endsWith("")` returns true. We hit this in prod
+    // on 2026-05-12: a misconfigured env var (`-`) silently turned the entire
+    // SMS pipeline into a test-only no-op.
+    if (!testCleaned) return false;
     return cleaned === testCleaned || cleaned.endsWith(testCleaned);
   });
 }

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -1173,11 +1173,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                 ? Date.parse(eventData.scheduledAt) || undefined
                 : undefined
           }
-          eventLocation={
-            (eventData as any).locationOverride ?? eventData.groupName ?? null
-          }
           eventShortId={eventData.shortId ?? null}
-          senderFirstName={user?.firstName || "Someone"}
           onClose={() => setShowInviteSheet(false)}
         />
       )}

--- a/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
@@ -197,12 +197,18 @@ export function InviteGroupMembersSheet({
       setConfirming(false);
       onSent?.(result);
       onClose();
-      Alert.alert(
-        "Invites sent",
-        result.alreadyInvited > 0
-          ? `${result.invited} invited, ${result.alreadyInvited} were already sent.`
-          : `${result.invited} on the way.`,
-      );
+      // Defer the Alert until after the Modal's dismissal animation has run.
+      // Firing Alert.alert in the same tick as Modal dismissal causes iOS
+      // touch handlers to deadlock — the parent screen looks fine but won't
+      // accept scrolls or taps until the app is restarted.
+      setTimeout(() => {
+        Alert.alert(
+          "Invites sent",
+          result.alreadyInvited > 0
+            ? `${result.invited} invited, ${result.alreadyInvited} were already sent.`
+            : `${result.invited} on the way.`,
+        );
+      }, 350);
     } catch (err) {
       console.error("Invite send error:", err);
       Alert.alert("Error", "Failed to send invites. Please try again.");
@@ -443,14 +449,20 @@ export function InviteGroupMembersSheet({
           </TouchableOpacity>
         </TouchableOpacity>
 
-        {/* Confirm sub-sheet */}
-        <Modal
-          visible={confirming}
-          transparent
-          animationType="fade"
-          onRequestClose={() => !sending && setConfirming(false)}
-        >
-          <View style={[styles.confirmOverlay, { backgroundColor: colors.overlay }]}>
+        {/* Confirm overlay — inline (NOT a nested Modal). React Native's
+            iOS dismissal animation gets confused when a Modal-in-a-Modal
+            unmounts simultaneously with the parent, leaving the underlying
+            screen unresponsive to touches until the app restarts. */}
+        {confirming && (
+          <View
+            style={[styles.confirmOverlay, { backgroundColor: colors.overlay }]}
+            pointerEvents="box-none"
+          >
+            <TouchableOpacity
+              activeOpacity={1}
+              style={StyleSheet.absoluteFill}
+              onPress={() => !sending && setConfirming(false)}
+            />
             <View
               style={[
                 styles.confirmCard,
@@ -491,7 +503,7 @@ export function InviteGroupMembersSheet({
               </TouchableOpacity>
             </View>
           </View>
-        </Modal>
+        )}
       </KeyboardAvoidingView>
     </Modal>
   );
@@ -671,7 +683,7 @@ const styles = StyleSheet.create({
   sendButtonText: { color: "#fff", fontSize: 15, fontWeight: "600" },
 
   confirmOverlay: {
-    flex: 1,
+    ...StyleSheet.absoluteFillObject,
     alignItems: "center",
     justifyContent: "center",
     padding: 24,

--- a/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
@@ -211,12 +211,26 @@ export function InviteGroupMembersSheet({
     }
   };
 
+  // Android hardware-back routes to the outer Modal's onRequestClose. When the
+  // confirm overlay is open it should close the overlay only, not the whole
+  // sheet (matches what the previous nested Modal did via its own
+  // onRequestClose). While a send is in-flight, swallow the back-press so the
+  // sheet can't be dismissed mid-mutation.
+  const handleRequestClose = () => {
+    if (sending) return;
+    if (confirming) {
+      setConfirming(false);
+      return;
+    }
+    onClose();
+  };
+
   return (
     <Modal
       visible={visible}
       transparent
       animationType="slide"
-      onRequestClose={onClose}
+      onRequestClose={handleRequestClose}
     >
       <KeyboardAvoidingView
         style={{ flex: 1 }}

--- a/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
@@ -28,9 +28,7 @@ interface InviteGroupMembersSheetProps {
   meetingId: string;
   eventTitle: string;
   eventScheduledAt?: number;
-  eventLocation?: string | null;
   eventShortId?: string | null;
-  senderFirstName: string;
   onClose: () => void;
   onSent?: (counts: { invited: number; alreadyInvited: number }) => void;
 }
@@ -42,9 +40,7 @@ export function InviteGroupMembersSheet({
   meetingId,
   eventTitle,
   eventScheduledAt,
-  eventLocation,
   eventShortId,
-  senderFirstName,
   onClose,
   onSent,
 }: InviteGroupMembersSheetProps) {
@@ -60,6 +56,17 @@ export function InviteGroupMembersSheet({
     api.functions.eventInvites.listGroupMembersForInvite,
     visible ? { meetingId: meetingId as Id<"meetings"> } : "skip",
   );
+
+  // Fetch the caller from Convex so the preview shows their actual first
+  // name. The auth-context user can be undefined here in cross-community
+  // share-link contexts, which previously left the preview saying
+  // "Someone invited you to …" while the server-rendered SMS used the
+  // real name.
+  const currentUser = useAuthenticatedQuery(
+    api.functions.users.getCurrentUser,
+    visible ? {} : "skip",
+  );
+  const senderFirstName = currentUser?.firstName?.trim() || "Someone";
 
   const initiate = useAuthenticatedMutation(
     api.functions.eventInvites.initiate,
@@ -79,7 +86,10 @@ export function InviteGroupMembersSheet({
     const defaultIds = new Set<string>();
     for (const m of members) {
       const reachable = m.hasPhone || m.hasPushTokens;
-      if (reachable && !m.alreadyInvited && !m.alreadyRsvped) {
+      // Self is included in the roster (for test sends) but excluded from
+      // the default selection so a routine "Invite everyone" tap doesn't
+      // text the host themselves.
+      if (reachable && !m.alreadyInvited && !m.alreadyRsvped && !m.isSelf) {
         defaultIds.add(m.userId);
       }
     }
@@ -98,15 +108,16 @@ export function InviteGroupMembersSheet({
   }, [members, search]);
 
   // "Eligible" = reachable (phone or push), not already invited, not already
-  // RSVP'd. Reachable-via-push-only members are included because the backend
-  // treats SMS-skipped as a non-failing channel.
+  // RSVP'd, and not self. Self stays tappable individually for test sends but
+  // is excluded from bulk Select All.
   const eligibleCount = useMemo(
     () =>
       members?.filter(
         (m) =>
           (m.hasPhone || m.hasPushTokens) &&
           !m.alreadyInvited &&
-          !m.alreadyRsvped,
+          !m.alreadyRsvped &&
+          !m.isSelf,
       ).length ?? 0,
     [members],
   );
@@ -118,7 +129,8 @@ export function InviteGroupMembersSheet({
         (m) =>
           (m.hasPhone || m.hasPushTokens) &&
           !m.alreadyInvited &&
-          !m.alreadyRsvped,
+          !m.alreadyRsvped &&
+          !m.isSelf,
       )
       .every((m) => selectedIds.has(m.userId));
   }, [members, selectedIds]);
@@ -139,7 +151,7 @@ export function InviteGroupMembersSheet({
       const next = new Set(prev);
       for (const m of members) {
         const reachable = m.hasPhone || m.hasPushTokens;
-        if (reachable && !m.alreadyInvited && !m.alreadyRsvped) {
+        if (reachable && !m.alreadyInvited && !m.alreadyRsvped && !m.isSelf) {
           next.add(m.userId);
         }
       }
@@ -148,34 +160,16 @@ export function InviteGroupMembersSheet({
   };
 
   const previewBody = useMemo(() => {
-    const firstSelectedFirstName =
-      (members ?? []).find((m) => selectedIds.has(m.userId))?.firstName ||
-      "Friend";
     const lead = `${senderFirstName} invited you to ${eventTitle}`;
     const when = eventScheduledAt
       ? formatScheduledForPreview(eventScheduledAt)
       : null;
-    const where = eventLocation || null;
-    const whenAndWhere = [when, where].filter(Boolean).join(" · ");
     const noteLine = note.trim() ? `\n\n"${note.trim()}"` : "";
     const link = eventShortId
       ? `\n\ntogather.app/e/${eventShortId}`
       : "";
-    // Preview swaps in the first recipient's first name for the leading line
-    // so the host sees a concrete example. The server uses the same template
-    // per recipient.
-    void firstSelectedFirstName; // reserved for {first_name} merge in v2
-    return `${lead}${whenAndWhere ? `\n${whenAndWhere}` : ""}${noteLine}${link}`;
-  }, [
-    members,
-    selectedIds,
-    senderFirstName,
-    eventTitle,
-    eventScheduledAt,
-    eventLocation,
-    eventShortId,
-    note,
-  ]);
+    return `${lead}${when ? `\n${when}` : ""}${noteLine}${link}`;
+  }, [senderFirstName, eventTitle, eventScheduledAt, eventShortId, note]);
 
   const handleSendPress = () => {
     if (selectedIds.size === 0) {
@@ -313,20 +307,23 @@ export function InviteGroupMembersSheet({
                   // A member is unreachable only if they have neither a phone
                   // nor an active push token. RSVP'd members are disabled to
                   // prevent accidental re-invites — Text Blast handles that
-                  // path.
+                  // path. Self stays tappable so the host can fire a test
+                  // invite to themselves.
                   const reachable = m.hasPhone || m.hasPushTokens;
                   const disabled =
                     !reachable || m.alreadyInvited || m.alreadyRsvped;
                   const selected = selectedIds.has(m.userId);
-                  const badge = m.alreadyInvited
-                    ? "Invited"
-                    : !reachable
-                      ? "Unreachable"
-                      : !m.hasPhone
-                        ? "Push only"
-                        : m.alreadyRsvped
-                          ? "Going"
-                          : null;
+                  const badge = m.isSelf
+                    ? "You"
+                    : m.alreadyInvited
+                      ? "Invited"
+                      : !reachable
+                        ? "Unreachable"
+                        : !m.hasPhone
+                          ? "Push only"
+                          : m.alreadyRsvped
+                            ? "Going"
+                            : null;
                   return (
                     <TouchableOpacity
                       key={m.userId}
@@ -363,7 +360,9 @@ export function InviteGroupMembersSheet({
                               color:
                                 badge === "Going"
                                   ? "#16A34A"
-                                  : colors.textSecondary,
+                                  : badge === "You"
+                                    ? DEFAULT_PRIMARY_COLOR
+                                    : colors.textSecondary,
                             },
                           ]}
                         >


### PR DESCRIPTION
## Summary

Five issues bundled — one freeze bug, three behavior bugs, one UX cleanup.

### Bugs

1. **iOS freeze after send** (commit 044255c) — confirm sub-sheet was a `Modal` nested inside the outer invite-sheet `Modal`, and `Alert.alert` fired in the same tick as both dismissed. iOS deadlocked the underlying view's touch handlers until app restart. Fixed by collapsing the confirm into an inline `absoluteFill` overlay View (no nested native modal) and deferring the success Alert by ~350ms so it fires after the outer Modal animates out.

2. **`isTestPhone` empty-string match** (`apps/convex/lib/twilio.ts`) — `cleaned.endsWith("")` returns `true` for every string. A stray `"-"` or empty CSV token in `OTP_TEST_PHONE_NUMBERS` would turn every phone into a test phone and silently no-op the entire SMS pipeline. We hit this in prod today. Added an explicit guard that skips empty entries after digit-stripping.

3. **`eventInvites.send` ignored `sendSMS`'s return** (`apps/convex/functions/eventInvites.ts`) — `sendSMS` returns `{ success: false }` (without throwing) for the test-phone bypass AND when Twilio creds are missing. The previous `try { await … } catch` only caught throws, so configuration failures got marked as `smsStatus: "succeeded"`. Now inspect the return value.

### UX

4. **Preview said "Someone invited you to …"** — the prop-driven `senderFirstName` from `useAuth` could be `undefined` in cross-community share-link contexts, while the server-side SMS used the real name from `senderInfo.firstName`. Now the sheet fetches the caller via `users.getCurrentUser` so the preview matches what gets sent.

5. **Dropped location from SMS body + preview** — title + when + share URL is enough; the location was redundant with what recipients see on the share page.

6. **Self in invite picker for test sends** — `listGroupMembersForInvite` no longer filters the caller and returns an `isSelf` flag. The sheet pins self to the top with a "You" badge, but excludes self from Select All / eligibleCount / the default seed so a routine "Invite everyone" doesn't text the host.

## Test plan
- [ ] iOS: send invite → screen remains responsive (no freeze, no app restart needed)
- [ ] Twilio receives the SMS (the prod outage repro)
- [ ] Preview shows the host's actual first name, not "Someone"
- [ ] Preview body has no location line
- [ ] Picker shows the host with a "You" badge at the top, default unchecked
- [ ] Manually checking self → Send → recipient row appears in EventInvitesLog with status `sent`
- [ ] Select All does NOT include self