### PR TITLE
fix(updates): harden foreground OTA auto-apply against post-reload UI freeze

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -97,7 +97,15 @@ function ThemedStack() {
         }}
       />
       <Stack.Screen
-        name="groups"
+        name="groups/[group_id]/index"
+        options={{
+          presentation: "modal",
+          animation: "slide_from_bottom",
+          gestureEnabled: true,
+        }}
+      />
+      <Stack.Screen
+        name="groups/[group_id]/edit"
         options={{
           presentation: "modal",
           animation: "slide_from_bottom",
@@ -139,7 +147,7 @@ function ThemedStack() {
       />
       {/* Onboarding - browser-only flow for community proposals, setup, and billing */}
       <Stack.Screen name="onboarding" />
-      <Stack.Screen name="billing" />
+      <Stack.Screen name="billing/[communityId]" />
     </Stack>
   );
 }

--- a/apps/mobile/providers/OTAUpdateProvider.tsx
+++ b/apps/mobile/providers/OTAUpdateProvider.tsx
@@ -140,8 +140,11 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   }, []);
 
-  // Run on mount. The startup grace inside checkAndApply will still gate
-  // the actual reload — this just kicks off the first check.
+  // Defer the initial mount check until after the startup grace window.
+  // Firing immediately would self-skip via the grace guard inside
+  // checkAndApply, and — if the user never backgrounds — no later
+  // foreground transition would ever retry. That regresses the forced
+  // auto-apply requirement (raised by codex on PR #392).
   useEffect(() => {
     if (__DEV__) {
       console.log('[OTAUpdate] Development mode - skipping update check');
@@ -149,7 +152,11 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       return;
     }
 
-    checkAndApply('mount');
+    const timeoutId = setTimeout(() => {
+      checkAndApply('mount');
+    }, STARTUP_GRACE_MS);
+
+    return () => clearTimeout(timeoutId);
   }, [checkAndApply]);
 
   // Re-check on real background -> active transitions only. iOS fires

--- a/apps/mobile/providers/OTAUpdateProvider.tsx
+++ b/apps/mobile/providers/OTAUpdateProvider.tsx
@@ -9,10 +9,30 @@
  *
  * State machine:
  *   idle -> checking -> (downloading -> ready -> reload) | idle
+ *
+ * Safety guards (to mitigate post-reload UI-freeze on iOS + Fabric):
+ *   - STARTUP_GRACE_MS — refuse to reload until the JS session has been
+ *     alive for this long. Protects the cold-start redirect window
+ *     (Index -> /(tabs)/chat) and any opening animations.
+ *   - MIN_RECHECK_INTERVAL_MS — throttle foreground re-checks. iOS fires
+ *     'active' transitions for system permission/share-sheet dismissal that
+ *     are not real user resumes; without a throttle the provider could
+ *     re-enter checkAndApply on every one.
+ *   - AppState previous-state guard — only re-check on a real
+ *     background->active transition, not active->active re-entries.
+ *   - PRE_RELOAD_SETTLE_MS — after fetch completes, hold on the 'ready'
+ *     state (OTAUpdateModal full-screen) for a beat before calling
+ *     reloadAsync. Gives any in-flight animations and touch responders
+ *     a chance to drain before the JS context is recreated.
+ *
+ * Breadcrumbs are emitted at every transition so production behavior is
+ * visible in Sentry — required because this flow is unreproducible in dev
+ * (the __DEV__ short-circuit below means it never runs locally).
  */
 import React, { createContext, useContext, useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { AppState } from 'react-native';
+import { AppState, AppStateStatus } from 'react-native';
 import * as Updates from 'expo-updates';
+import { SentryUtils } from './SentryProvider';
 
 type OTAStatus = 'idle' | 'checking' | 'downloading' | 'ready' | 'error';
 
@@ -28,6 +48,11 @@ const OTAUpdateContext = createContext<OTAUpdateContextType>({
 
 export const useOTAUpdateStatus = () => useContext(OTAUpdateContext);
 
+// Tuning constants — exported for tests.
+export const STARTUP_GRACE_MS = 30_000;
+export const MIN_RECHECK_INTERVAL_MS = 5 * 60_000;
+export const PRE_RELOAD_SETTLE_MS = 1_500;
+
 export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [status, setStatus] = useState<OTAStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -35,11 +60,43 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const statusRef = useRef(status);
   statusRef.current = status;
 
-  const checkAndApply = useCallback(async () => {
-    // Don't re-enter if a check / download / reload is already in flight.
-    if (statusRef.current !== 'idle') return;
+  const sessionStartRef = useRef(Date.now());
+  const lastCheckRef = useRef(0);
+  const previousAppStateRef = useRef<AppStateStatus>(AppState.currentState);
 
-    console.log('[OTAUpdate] Starting update check...');
+  const crumb = (message: string, data?: Record<string, unknown>) => {
+    SentryUtils.addBreadcrumb(message, 'ota-update', data);
+  };
+
+  const checkAndApply = useCallback(async (trigger: 'mount' | 'foreground') => {
+    // Don't re-enter if a check / download / reload is already in flight.
+    if (statusRef.current !== 'idle') {
+      crumb('OTA check skipped: already in flight', { trigger, status: statusRef.current });
+      return;
+    }
+
+    // Startup grace: don't reload during the cold-start window where Index
+    // is still redirecting and the initial navigators are mounting. A
+    // reloadAsync that lands here is the most likely cause of the post-
+    // reload touch-handler wedge.
+    const sessionAgeMs = Date.now() - sessionStartRef.current;
+    if (sessionAgeMs < STARTUP_GRACE_MS) {
+      crumb('OTA check skipped: startup grace', { trigger, sessionAgeMs });
+      return;
+    }
+
+    // Throttle: iOS fires 'active' transitions for system dialogs / share
+    // sheets / Face ID prompts. Without a throttle each one would re-run
+    // checkAndApply, and a flapping system event could race with the
+    // reload.
+    const sinceLastCheckMs = Date.now() - lastCheckRef.current;
+    if (lastCheckRef.current > 0 && sinceLastCheckMs < MIN_RECHECK_INTERVAL_MS) {
+      crumb('OTA check skipped: throttled', { trigger, sinceLastCheckMs });
+      return;
+    }
+
+    lastCheckRef.current = Date.now();
+    crumb('OTA check started', { trigger });
     setStatus('checking');
     setErrorMessage(null);
 
@@ -47,34 +104,44 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       const checkResult = await Updates.checkForUpdateAsync();
 
       if (!checkResult.isAvailable) {
-        console.log('[OTAUpdate] No update available');
+        crumb('OTA no update available');
         setStatus('idle');
         return;
       }
 
-      console.log('[OTAUpdate] Update available, downloading...');
+      crumb('OTA update available, downloading');
       setStatus('downloading');
       const fetchResult = await Updates.fetchUpdateAsync();
 
       if (!fetchResult.isNew) {
-        console.log('[OTAUpdate] Fetched, but not new — staying idle');
+        crumb('OTA fetched but not new, staying idle');
         setStatus('idle');
         return;
       }
 
-      console.log('[OTAUpdate] Update ready, auto-applying');
+      crumb('OTA update ready, holding for settle', { settleMs: PRE_RELOAD_SETTLE_MS });
       setStatus('ready');
+
+      // Hold on 'ready' (OTAUpdateModal full-screen) for a beat before
+      // tearing down the JS context. Lets any in-flight animations and
+      // touch responders drain. Calling reloadAsync immediately after
+      // a state transition is the documented footgun.
+      await new Promise((resolve) => setTimeout(resolve, PRE_RELOAD_SETTLE_MS));
+
+      crumb('OTA reload starting');
       await Updates.reloadAsync();
     } catch (error: any) {
       // All failures — offline, disabled, server errors — are silent.
-      // The user keeps using the current build; we'll try again next foreground.
-      console.log('[OTAUpdate] Update check/apply failed (silent):', error?.message ?? error);
+      // The user keeps using the current build; we'll try again next
+      // qualifying foreground transition.
+      crumb('OTA check failed (silent)', { error: error?.message ?? String(error) });
       setStatus('idle');
       setErrorMessage(null);
     }
   }, []);
 
-  // Run on mount.
+  // Run on mount. The startup grace inside checkAndApply will still gate
+  // the actual reload — this just kicks off the first check.
   useEffect(() => {
     if (__DEV__) {
       console.log('[OTAUpdate] Development mode - skipping update check');
@@ -82,16 +149,22 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       return;
     }
 
-    checkAndApply();
+    checkAndApply('mount');
   }, [checkAndApply]);
 
-  // Re-check every time the app returns to foreground.
+  // Re-check on real background -> active transitions only. iOS fires
+  // 'active' for transient system UI (Face ID, share sheets, permissions)
+  // without backgrounding the app; those should not retrigger a check.
   useEffect(() => {
     if (__DEV__) return;
 
-    const subscription = AppState.addEventListener('change', (nextAppState: string) => {
-      if (nextAppState === 'active') {
-        checkAndApply();
+    const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
+      const previousAppState = previousAppStateRef.current;
+      previousAppStateRef.current = nextAppState;
+
+      const cameFromBackground = !!previousAppState.match(/inactive|background/);
+      if (nextAppState === 'active' && cameFromBackground) {
+        checkAndApply('foreground');
       }
     });
 

--- a/apps/mobile/providers/OTAUpdateProvider.tsx
+++ b/apps/mobile/providers/OTAUpdateProvider.tsx
@@ -159,9 +159,13 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     return () => clearTimeout(timeoutId);
   }, [checkAndApply]);
 
-  // Re-check on real background -> active transitions only. iOS fires
-  // 'active' for transient system UI (Face ID, share sheets, permissions)
-  // without backgrounding the app; those should not retrigger a check.
+  // Re-check on real background -> active transitions only. iOS reports
+  // 'inactive' for transient system UI (Notification Center, incoming
+  // calls, Control Center, Face ID, share sheets) — the app never
+  // actually suspends and the previous state goes active -> inactive ->
+  // active. Treating those as resumes would trigger a destructive
+  // reloadAsync over a still-live UI. Only an actual 'background' state
+  // (the OS marked the app as suspended) qualifies.
   useEffect(() => {
     if (__DEV__) return;
 
@@ -169,7 +173,7 @@ export const OTAUpdateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       const previousAppState = previousAppStateRef.current;
       previousAppStateRef.current = nextAppState;
 
-      const cameFromBackground = !!previousAppState.match(/inactive|background/);
+      const cameFromBackground = previousAppState === 'background';
       if (nextAppState === 'active' && cameFromBackground) {
         checkAndApply('foreground');
       }

--- a/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
+++ b/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
@@ -1,10 +1,16 @@
 /**
  * Tests for OTAUpdateProvider
- * Tests the auto-applying OTA update state machine.
+ * Tests the auto-applying OTA update state machine and its safety guards.
  */
 import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
-import { OTAUpdateProvider, useOTAUpdateStatus } from '../OTAUpdateProvider';
+import {
+  OTAUpdateProvider,
+  useOTAUpdateStatus,
+  STARTUP_GRACE_MS,
+  MIN_RECHECK_INTERVAL_MS,
+  PRE_RELOAD_SETTLE_MS,
+} from '../OTAUpdateProvider';
 import * as Updates from 'expo-updates';
 
 // --- Mocks ---
@@ -13,6 +19,12 @@ jest.mock('expo-updates', () => ({
   checkForUpdateAsync: jest.fn(),
   fetchUpdateAsync: jest.fn(),
   reloadAsync: jest.fn(),
+}));
+
+jest.mock('../SentryProvider', () => ({
+  SentryUtils: {
+    addBreadcrumb: jest.fn(),
+  },
 }));
 
 let appStateChangeHandler: ((state: string) => void) | null = null;
@@ -32,6 +44,18 @@ const mockReload = Updates.reloadAsync as jest.Mock;
 
 const wrapper = ({ children }: { children: React.ReactNode }) =>
   React.createElement(OTAUpdateProvider, null, children);
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+const triggerForeground = () => {
+  // Real background -> active transition (active -> active is ignored by the guard).
+  act(() => {
+    appStateChangeHandler!('background');
+  });
+  act(() => {
+    appStateChangeHandler!('active');
+  });
+};
 
 describe('OTAUpdateProvider', () => {
   beforeEach(() => {
@@ -55,19 +79,35 @@ describe('OTAUpdateProvider', () => {
 
     beforeEach(() => {
       (global as any).__DEV__ = false;
+      jest.useFakeTimers({ doNotFake: ['setImmediate'] });
+      jest.setSystemTime(0);
     });
 
     afterEach(() => {
+      jest.useRealTimers();
       (global as any).__DEV__ = originalDev;
     });
 
-    it('transitions to idle when no update is available', async () => {
+    it('skips initial mount check during startup grace window', async () => {
+      mockCheckForUpdate.mockResolvedValue({ isAvailable: false });
+
+      renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
+
+      // sessionAgeMs = 0, well under STARTUP_GRACE_MS.
+      expect(mockCheckForUpdate).not.toHaveBeenCalled();
+      expect(mockReload).not.toHaveBeenCalled();
+    });
+
+    it('transitions to idle when no update is available after grace passes', async () => {
       mockCheckForUpdate.mockResolvedValue({ isAvailable: false });
 
       const { result } = renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
 
-      // Initially checking
-      expect(result.current.status).toBe('checking');
+      // Advance past startup grace, then simulate a real foreground.
+      jest.setSystemTime(STARTUP_GRACE_MS + 1);
+      triggerForeground();
 
       await waitFor(() => {
         expect(result.current.status).toBe('idle');
@@ -76,32 +116,89 @@ describe('OTAUpdateProvider', () => {
       expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
       expect(mockFetchUpdate).not.toHaveBeenCalled();
       expect(mockReload).not.toHaveBeenCalled();
-      expect(result.current.errorMessage).toBeNull();
     });
 
-    it('auto-applies update when one is available', async () => {
+    it('downloads and auto-applies update after grace + settle delay', async () => {
       mockCheckForUpdate.mockResolvedValue({ isAvailable: true });
       mockFetchUpdate.mockResolvedValue({ isNew: true });
       mockReload.mockResolvedValue(undefined);
 
       const { result } = renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
 
-      expect(result.current.status).toBe('checking');
+      jest.setSystemTime(STARTUP_GRACE_MS + 1);
+      triggerForeground();
+
+      await waitFor(() => {
+        expect(mockFetchUpdate).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(result.current.status).toBe('ready');
+      });
+
+      // Reload is deferred until the settle window has elapsed.
+      expect(mockReload).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(PRE_RELOAD_SETTLE_MS);
+        await flushPromises();
+      });
 
       await waitFor(() => {
         expect(mockReload).toHaveBeenCalledTimes(1);
       });
+    });
 
+    it('does NOT reload on active->active (system dialog dismissal)', async () => {
+      mockCheckForUpdate.mockResolvedValue({ isAvailable: true });
+      mockFetchUpdate.mockResolvedValue({ isNew: true });
+
+      renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
+
+      jest.setSystemTime(STARTUP_GRACE_MS + 1);
+
+      // Fire 'active' without any preceding background — mimics Face ID /
+      // share-sheet dismissal where iOS reports the app as active again
+      // without it ever truly suspending.
+      act(() => {
+        appStateChangeHandler!('active');
+      });
+      await flushPromises();
+
+      expect(mockCheckForUpdate).not.toHaveBeenCalled();
+    });
+
+    it('throttles re-checks within MIN_RECHECK_INTERVAL_MS', async () => {
+      mockCheckForUpdate.mockResolvedValue({ isAvailable: false });
+
+      renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
+
+      jest.setSystemTime(STARTUP_GRACE_MS + 1);
+      triggerForeground();
+      await waitFor(() => expect(mockCheckForUpdate).toHaveBeenCalledTimes(1));
+
+      // Another foreground a minute later should be throttled.
+      jest.setSystemTime(STARTUP_GRACE_MS + 1 + 60_000);
+      triggerForeground();
+      await flushPromises();
       expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
-      expect(mockFetchUpdate).toHaveBeenCalledTimes(1);
-      expect(result.current.status).toBe('ready');
-      expect(result.current.errorMessage).toBeNull();
+
+      // Past the throttle window, a new check runs.
+      jest.setSystemTime(STARTUP_GRACE_MS + 1 + MIN_RECHECK_INTERVAL_MS + 1);
+      triggerForeground();
+      await waitFor(() => expect(mockCheckForUpdate).toHaveBeenCalledTimes(2));
     });
 
     it('silently returns to idle on check failure (e.g. offline)', async () => {
       mockCheckForUpdate.mockRejectedValue(new Error('Network error'));
 
       const { result } = renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
+
+      jest.setSystemTime(STARTUP_GRACE_MS + 1);
+      triggerForeground();
 
       await waitFor(() => {
         expect(result.current.status).toBe('idle');
@@ -110,31 +207,6 @@ describe('OTAUpdateProvider', () => {
       expect(result.current.errorMessage).toBeNull();
       expect(mockFetchUpdate).not.toHaveBeenCalled();
       expect(mockReload).not.toHaveBeenCalled();
-    });
-
-    it('re-checks for updates when the app returns to foreground', async () => {
-      mockCheckForUpdate.mockResolvedValue({ isAvailable: false });
-
-      renderHook(() => useOTAUpdateStatus(), { wrapper });
-
-      await waitFor(() => {
-        expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
-      });
-
-      // Ensure the listener was registered.
-      expect(appStateChangeHandler).not.toBeNull();
-
-      // Simulate background -> active transition.
-      act(() => {
-        appStateChangeHandler!('background');
-      });
-      act(() => {
-        appStateChangeHandler!('active');
-      });
-
-      await waitFor(() => {
-        expect(mockCheckForUpdate).toHaveBeenCalledTimes(2);
-      });
     });
 
     it('does not re-enter while a check is already in flight', async () => {
@@ -142,15 +214,17 @@ describe('OTAUpdateProvider', () => {
       mockCheckForUpdate.mockReturnValue(new Promise(() => {}));
 
       renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
 
-      await waitFor(() => {
-        expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
-      });
+      jest.setSystemTime(STARTUP_GRACE_MS + 1);
+      triggerForeground();
+      await waitFor(() => expect(mockCheckForUpdate).toHaveBeenCalledTimes(1));
 
-      // Foreground event during the in-flight check should be ignored.
-      act(() => {
-        appStateChangeHandler!('active');
-      });
+      // Another foreground past the throttle window — should still be blocked
+      // by the in-flight status guard.
+      jest.setSystemTime(STARTUP_GRACE_MS + 1 + MIN_RECHECK_INTERVAL_MS + 1);
+      triggerForeground();
+      await flushPromises();
 
       expect(mockCheckForUpdate).toHaveBeenCalledTimes(1);
     });

--- a/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
+++ b/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
@@ -204,6 +204,31 @@ describe('OTAUpdateProvider', () => {
       expect(mockCheckForUpdate).not.toHaveBeenCalled();
     });
 
+    it('does NOT reload on inactive->active (Notification Center / call / Control Center)', async () => {
+      // Codex P2 #2 on PR #392: iOS transient interruptions like
+      // Notification Center, incoming calls, and Control Center go
+      // active -> inactive -> active without ever hitting 'background'.
+      // The previous regex /inactive|background/ matched these and would
+      // have triggered a destructive reloadAsync over a still-live UI.
+      mockCheckForUpdate.mockResolvedValue({ isAvailable: true });
+      mockFetchUpdate.mockResolvedValue({ isNew: true });
+
+      renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
+
+      jest.setSystemTime(STARTUP_GRACE_MS + 1);
+
+      act(() => {
+        appStateChangeHandler!('inactive');
+      });
+      act(() => {
+        appStateChangeHandler!('active');
+      });
+      await flushPromises();
+
+      expect(mockCheckForUpdate).not.toHaveBeenCalled();
+    });
+
     it('throttles re-checks within MIN_RECHECK_INTERVAL_MS', async () => {
       mockCheckForUpdate.mockResolvedValue({ isAvailable: false });
 

--- a/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
+++ b/apps/mobile/providers/__tests__/OTAUpdateProvider.test.ts
@@ -88,15 +88,50 @@ describe('OTAUpdateProvider', () => {
       (global as any).__DEV__ = originalDev;
     });
 
-    it('skips initial mount check during startup grace window', async () => {
+    it('defers initial mount check until startup grace window passes', async () => {
       mockCheckForUpdate.mockResolvedValue({ isAvailable: false });
 
       renderHook(() => useOTAUpdateStatus(), { wrapper });
       await flushPromises();
 
-      // sessionAgeMs = 0, well under STARTUP_GRACE_MS.
+      // Mount-time check is scheduled via setTimeout(STARTUP_GRACE_MS);
+      // nothing fires immediately.
       expect(mockCheckForUpdate).not.toHaveBeenCalled();
       expect(mockReload).not.toHaveBeenCalled();
+    });
+
+    it('runs deferred mount check after startup grace expires (no foreground needed)', async () => {
+      // Codex P2 on PR #392: a user who opens the app after an OTA is
+      // published and stays foregrounded must still receive the update,
+      // even without a background→foreground transition.
+      mockCheckForUpdate.mockResolvedValue({ isAvailable: true });
+      mockFetchUpdate.mockResolvedValue({ isNew: true });
+      mockReload.mockResolvedValue(undefined);
+
+      renderHook(() => useOTAUpdateStatus(), { wrapper });
+      await flushPromises();
+
+      expect(mockCheckForUpdate).not.toHaveBeenCalled();
+
+      // Advance through the grace window; the deferred mount timer fires.
+      await act(async () => {
+        jest.advanceTimersByTime(STARTUP_GRACE_MS);
+        await flushPromises();
+      });
+
+      await waitFor(() => {
+        expect(mockFetchUpdate).toHaveBeenCalledTimes(1);
+      });
+
+      // Then through the settle window; reloadAsync fires.
+      await act(async () => {
+        jest.advanceTimersByTime(PRE_RELOAD_SETTLE_MS);
+        await flushPromises();
+      });
+
+      await waitFor(() => {
+        expect(mockReload).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('transitions to idle when no update is available after grace passes', async () => {


### PR DESCRIPTION
## Summary
Users report the app silently force-restarting (via `Updates.reloadAsync`) and ending up in a wedged state — tabs render but taps/scrolls don't respond until they manually kill it. Matches the iOS + Fabric touch-reattach race documented in [expo/expo#16264](https://github.com/expo/expo/issues/16264) and Expo's own docs ("Never call `reloadAsync()` without user confirmation"). Unreproducible locally because `OTAUpdateProvider` `__DEV__`-short-circuits the entire flow.

Forced auto-apply is a product requirement (frontend must stay in sync with backend; no user prompts), so background-apply and user-confirmation patterns are off the table. This PR closes every JS-side race we can without dropping the foreground apply.

### Guards added to `OTAUpdateProvider`
- **Startup grace (30s)** — refuse to reload while the JS session is still in its cold-start window. The Index → `/(tabs)/chat` redirect lands at +50ms; reloading on top of it is the most likely source of the wedge.
- **AppState previous-state guard** — only re-check on a real `background→active`. iOS fires `'active'` for Face ID, share sheets, and permission dialog dismissals where the app was never truly suspended; previously each one re-entered the check.
- **Re-check throttle (5min)** — flapping system events can't race with the reload.
- **Pre-reload settle (1.5s)** — after `fetchUpdateAsync` resolves we hold on `'ready'` (OTAUpdateModal full-screen) for a beat before calling `reloadAsync()`. Drains in-flight animations and touch responders.
- **Sentry breadcrumbs** at every state transition. Since the flow is dev-short-circuited, breadcrumbs are the only way to see whether the guards are catching the right events in prod.

### Also fixed
Two `Stack.Screen` route-name mismatches in `app/_layout.tsx` that produced `[Layout children]: No route named "groups"/"billing"` warnings on every launch. The intended modal presentation never applied because the actual routes are nested (`groups/[group_id]/{index,edit}`, `billing/[communityId]`). Visible in the same user's debug logs.

### Honest residual risk
The Fabric touch-reattach race during a live `reloadAsync` isn't fully solvable from JS. This will cut the freeze rate sharply, not zero it. If breadcrumbs still show post-reload issues after this lands, the follow-up is the **apply-on-background** pattern (reload on `AppState→background` while the app is suspended). The breadcrumbs will tell us whether we need to go there.

## Test plan
- [x] `pnpm --filter mobile test providers/__tests__/OTAUpdateProvider.test.ts` — 8 tests pass, covering each guard (startup grace skip, foreground-after-grace apply, active→active ignored, throttle, settle delay, in-flight re-entry, silent failure).
- [x] Typecheck clean for touched files.
- [ ] Ship and watch Sentry breadcrumbs (`category: ota-update`) on TestFlight before promoting to production.
- [ ] After 24h on TestFlight, confirm no new "tabs unresponsive" reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)