### PR TITLE
feat(updates): post-update recovery banner

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -35,6 +35,7 @@ import { StatusBar as BottomStatusBar, useStatusBarVisible, STATUS_BAR_CONTENT_H
 import { ConnectionProvider } from "@providers/ConnectionProvider";
 import { NativeUpdateModal } from "@components/ui/NativeUpdateModal";
 import { OTAUpdateModal } from "@components/ui/OTAUpdateModal";
+import { PostUpdateRecoveryBanner } from "@components/ui/PostUpdateRecoveryBanner";
 import { OTAUpdateProvider } from "@providers/OTAUpdateProvider";
 import { BirthdayCollectionModal } from "@components/legal/BirthdayCollectionModal";
 import { initializeMobileApiClient } from "@services/api/init";
@@ -225,6 +226,7 @@ function AppLayout() {
                     <NativeUpdateModal />
                     <OTAUpdateModal />
                     <BirthdayCollectionModal />
+                    <PostUpdateRecoveryBanner />
                     <TestFlightBanner />
                     <ThemedStack />
                   </StatusBarAwareContainer>

--- a/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
+++ b/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
@@ -1,0 +1,131 @@
+/**
+ * PostUpdateRecoveryBanner
+ *
+ * Renders a one-shot informational banner the first time the app boots
+ * onto a new OTA bundle. Backstop for the iOS + Fabric touch-reattach
+ * race that can wedge the UI after a foreground reloadAsync: the JS
+ * thread keeps running so this banner still appears, telling the user
+ * how to recover (force-close + reopen) even when taps are dead.
+ *
+ * Detection: compare Updates.updateId against the last value we
+ * persisted to AsyncStorage. If both are present and they differ, the
+ * app just transitioned to a new bundle — show the banner. On the
+ * very first launch (no stored value) we silently persist and skip
+ * the banner, since there's nothing to recover from.
+ *
+ * Auto-dismisses after AUTO_DISMISS_MS (wedged users can't tap, but JS
+ * setTimeout still fires). Tap-X works for non-wedged users.
+ */
+import React, { useState, useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, Pressable, Platform } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as Updates from 'expo-updates';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const STORAGE_KEY = '@togather/last_seen_update_id';
+export const AUTO_DISMISS_MS = 60_000;
+
+export function PostUpdateRecoveryBanner() {
+  const [isVisible, setIsVisible] = useState(false);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (__DEV__) return;
+
+    let cancelled = false;
+
+    (async () => {
+      const currentUpdateId = Updates.updateId;
+      // Embedded launches have no updateId — there's no transition to
+      // recover from.
+      if (!currentUpdateId) return;
+
+      let stored: string | null = null;
+      try {
+        stored = await AsyncStorage.getItem(STORAGE_KEY);
+      } catch {
+        // AsyncStorage unavailable — fail open, no banner.
+        return;
+      }
+
+      if (cancelled) return;
+
+      // Persist the current id either way so the banner is one-shot.
+      try {
+        await AsyncStorage.setItem(STORAGE_KEY, currentUpdateId);
+      } catch {
+        // Best effort — if the write fails, we may show the banner again
+        // next launch. Acceptable.
+      }
+
+      // First-ever launch (or fresh install / cleared storage): nothing
+      // to recover from. Silently seed the value and skip.
+      if (!stored) return;
+
+      // Same id: no transition happened.
+      if (stored === currentUpdateId) return;
+
+      // We just transitioned to a new bundle.
+      setIsVisible(true);
+      dismissTimerRef.current = setTimeout(() => {
+        setIsVisible(false);
+      }, AUTO_DISMISS_MS);
+    })();
+
+    return () => {
+      cancelled = true;
+      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    };
+  }, []);
+
+  const handleDismiss = () => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+    setIsVisible(false);
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <View style={styles.container}>
+      <Ionicons name="information-circle" size={18} color="#fff" style={styles.icon} />
+      <Text style={styles.text}>
+        App just updated — if anything feels stuck, force-close and reopen.
+      </Text>
+      <Pressable
+        style={styles.dismissButton}
+        onPress={handleDismiss}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="Dismiss update notice"
+      >
+        <Ionicons name="close" size={18} color="#fff" />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    backgroundColor: '#1F2937',
+  },
+  icon: {
+    marginRight: 8,
+  },
+  text: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '500',
+    flex: 1,
+  },
+  dismissButton: {
+    padding: 4,
+    marginLeft: 8,
+    ...(Platform.OS === 'web' ? { cursor: 'pointer' as const } : {}),
+  },
+});

--- a/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
+++ b/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
@@ -19,6 +19,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, Pressable, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Updates from 'expo-updates';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
@@ -28,6 +29,11 @@ export const AUTO_DISMISS_MS = 60_000;
 export function PostUpdateRecoveryBanner() {
   const [isVisible, setIsVisible] = useState(false);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // StatusBarAwareContainer only adds bottom inset padding; on iOS notched
+  // devices and Android edge-to-edge builds the banner would otherwise sit
+  // under the status bar, obscuring the recovery instruction in exactly the
+  // post-update case it is meant to address (codex P2 on PR #393).
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     if (__DEV__) return;
@@ -89,7 +95,7 @@ export function PostUpdateRecoveryBanner() {
   if (!isVisible) return null;
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: 10 + insets.top }]}>
       <Ionicons name="information-circle" size={18} color="#fff" style={styles.icon} />
       <Text style={styles.text}>
         App just updated — if anything feels stuck, force-close and reopen.
@@ -110,7 +116,9 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 10,
+    // paddingTop is applied inline together with the top safe-area inset.
+    paddingTop: 10,
+    paddingBottom: 10,
     paddingHorizontal: 16,
     backgroundColor: '#1F2937',
   },

--- a/apps/mobile/components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx
+++ b/apps/mobile/components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx
@@ -30,6 +30,10 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   setItem: jest.fn(),
 }));
 
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 0, left: 0, right: 0 }),
+}));
+
 const mockGetItem = AsyncStorage.getItem as jest.Mock;
 const mockSetItem = AsyncStorage.setItem as jest.Mock;
 
@@ -156,6 +160,27 @@ describe('PostUpdateRecoveryBanner', () => {
       fireEvent.press(screen.getByLabelText('Dismiss update notice'));
 
       expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    });
+
+    it('applies the top safe-area inset to the banner container', async () => {
+      // Codex P2 on PR #393: without the top inset the banner sat under
+      // the iOS notch / status bar in the very case it's meant to help.
+      // Mock returns top: 47 (typical iPhone notch).
+      setUpdateId('update-new');
+      mockGetItem.mockResolvedValue('update-old');
+
+      render(<PostUpdateRecoveryBanner />);
+
+      const text = await screen.findByText(BANNER_TEXT);
+      // The container is the banner View; on RN testing-library the parent
+      // node carries the merged style array.
+      const container = text.parent?.parent;
+      expect(container).toBeTruthy();
+      const styles = (container as any).props.style;
+      const flat = Array.isArray(styles)
+        ? Object.assign({}, ...styles.filter(Boolean))
+        : styles;
+      expect(flat.paddingTop).toBe(57); // 10 base + 47 inset
     });
 
     it('fails open if AsyncStorage.getItem throws', async () => {

--- a/apps/mobile/components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx
+++ b/apps/mobile/components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for PostUpdateRecoveryBanner
+ * Verifies the one-shot detection that compares Updates.updateId against
+ * the value persisted from the previous launch.
+ */
+import React from 'react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react-native';
+import {
+  PostUpdateRecoveryBanner,
+  STORAGE_KEY,
+  AUTO_DISMISS_MS,
+} from '../PostUpdateRecoveryBanner';
+import * as Updates from 'expo-updates';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('expo-updates', () => {
+  let _updateId: string | null = null;
+  return {
+    get updateId() {
+      return _updateId;
+    },
+    set updateId(v: string | null) {
+      _updateId = v;
+    },
+  };
+});
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+
+const setUpdateId = (id: string | null) => {
+  // Goes through the getter/setter pair defined on the mock.
+  (Updates as { updateId: string | null }).updateId = id;
+};
+
+const BANNER_TEXT = /app just updated/i;
+
+describe('PostUpdateRecoveryBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+    setUpdateId(null);
+  });
+
+  it('renders nothing in dev mode', async () => {
+    // __DEV__ is true by default in the test environment.
+    setUpdateId('update-a');
+    mockGetItem.mockResolvedValue('update-b');
+
+    render(<PostUpdateRecoveryBanner />);
+
+    await waitFor(() => {
+      expect(mockGetItem).not.toHaveBeenCalled();
+    });
+    expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+  });
+
+  describe('with __DEV__ = false', () => {
+    const originalDev = (global as any).__DEV__;
+
+    beforeEach(() => {
+      (global as any).__DEV__ = false;
+    });
+
+    afterEach(() => {
+      (global as any).__DEV__ = originalDev;
+    });
+
+    it('renders nothing on embedded launch (no updateId)', async () => {
+      setUpdateId(null);
+
+      render(<PostUpdateRecoveryBanner />);
+      // Allow the async effect to settle.
+      await act(async () => {});
+
+      expect(mockGetItem).not.toHaveBeenCalled();
+      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    });
+
+    it('seeds storage on first-ever launch and shows no banner', async () => {
+      setUpdateId('update-first');
+      mockGetItem.mockResolvedValue(null);
+
+      render(<PostUpdateRecoveryBanner />);
+
+      await waitFor(() => {
+        expect(mockSetItem).toHaveBeenCalledWith(STORAGE_KEY, 'update-first');
+      });
+      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    });
+
+    it('does NOT show banner when updateId matches the stored value', async () => {
+      setUpdateId('update-same');
+      mockGetItem.mockResolvedValue('update-same');
+
+      render(<PostUpdateRecoveryBanner />);
+
+      await waitFor(() => {
+        expect(mockSetItem).toHaveBeenCalledWith(STORAGE_KEY, 'update-same');
+      });
+      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    });
+
+    it('shows banner when updateId differs from stored value', async () => {
+      setUpdateId('update-new');
+      mockGetItem.mockResolvedValue('update-old');
+
+      render(<PostUpdateRecoveryBanner />);
+
+      await waitFor(() => {
+        expect(screen.getByText(BANNER_TEXT)).toBeTruthy();
+      });
+
+      // Persists the new id so the banner doesn't re-show next launch.
+      expect(mockSetItem).toHaveBeenCalledWith(STORAGE_KEY, 'update-new');
+    });
+
+    it('auto-dismisses after AUTO_DISMISS_MS', async () => {
+      jest.useFakeTimers();
+      try {
+        setUpdateId('update-new');
+        mockGetItem.mockResolvedValue('update-old');
+
+        render(<PostUpdateRecoveryBanner />);
+
+        await waitFor(() => {
+          expect(screen.getByText(BANNER_TEXT)).toBeTruthy();
+        });
+
+        act(() => {
+          jest.advanceTimersByTime(AUTO_DISMISS_MS);
+        });
+
+        expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('manual dismiss hides the banner', async () => {
+      setUpdateId('update-new');
+      mockGetItem.mockResolvedValue('update-old');
+
+      render(<PostUpdateRecoveryBanner />);
+
+      await waitFor(() => {
+        expect(screen.getByText(BANNER_TEXT)).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByLabelText('Dismiss update notice'));
+
+      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    });
+
+    it('fails open if AsyncStorage.getItem throws', async () => {
+      setUpdateId('update-new');
+      mockGetItem.mockRejectedValue(new Error('disk full'));
+
+      render(<PostUpdateRecoveryBanner />);
+      await act(async () => {});
+
+      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+      // We never reached the setItem step.
+      expect(mockSetItem).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Backstop for the iOS + Fabric touch-reattach race that can wedge the UI after a foreground `reloadAsync`. PR #392 cuts the freeze rate; this banner is the user-visible recovery instruction for the residual cases (and any future OTA-related freeze).

### How it works
- On boot, compares `Updates.updateId` against an `AsyncStorage` value persisted from the previous launch.
- If both are present and differ → app just transitioned to a new bundle → render a one-shot banner at the top.
- Banner copy: "App just updated — if anything feels stuck, force-close and reopen."
- Auto-dismisses after 60s (JS timers fire even when touch is wedged, so the affected user sees it disappear on its own).
- Tap-X dismiss for non-wedged users.
- First-ever launches silently seed storage and skip the banner.
- `AsyncStorage` failures fail open (no banner) — backstop never blocks rendering.

### Timing reality
V+1 already shipped (PR #392), so users transitioning V→V+1 won't see this. It lands permanently for all future OTA transitions.

### Mount location
Above `TestFlightBanner`, above `ThemedStack`, inside `StatusBarAwareContainer`. Sits at the very top of the visible app.

## Test plan
- [x] `pnpm --filter mobile test components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx` — 8 tests pass (dev-mode skip, embedded launch, first-ever launch seed, same-id no-op, different-id banner shown, auto-dismiss, manual dismiss, AsyncStorage failure-open).
- [ ] After merge: watch Sentry breadcrumbs (`ota-update` category from #392) for any reports tied to the banner being shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)