### PR TITLE
fix(updates): correct post-update banner detection logic

### DIFF
--- a/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
+++ b/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
@@ -7,11 +7,15 @@
  * thread keeps running so this banner still appears, telling the user
  * how to recover (force-close + reopen) even when taps are dead.
  *
- * Detection: compare Updates.updateId against the last value we
- * persisted to AsyncStorage. If both are present and they differ, the
- * app just transitioned to a new bundle — show the banner. On the
- * very first launch (no stored value) we silently persist and skip
- * the banner, since there's nothing to recover from.
+ * Detection: bail entirely on embedded launches (Updates.isEmbeddedLaunch
+ * = true — fresh installs, App Store updates, emergency fallback to the
+ * embedded bundle); none of those carry a reloadAsync race. On OTA
+ * bundles, compare Updates.updateId against the value persisted to
+ * AsyncStorage from the previous OTA launch and show the banner if it's
+ * absent (first OTA launch with the banner code on this user's device,
+ * or first OTA after a native install) or different (a real OTA
+ * transition). The current id is then persisted so the banner is
+ * one-shot per bundle.
  *
  * Auto-dismisses after AUTO_DISMISS_MS (wedged users can't tap, but JS
  * setTimeout still fires). Tap-X works for non-wedged users.
@@ -41,9 +45,15 @@ export function PostUpdateRecoveryBanner() {
     let cancelled = false;
 
     (async () => {
+      // Bail out on embedded launches BEFORE touching storage. The
+      // embedded bundle's updateId changes with every native (App Store)
+      // update; reading and overwriting our stored OTA id here would
+      // falsely flag a native install as an OTA transition AND would
+      // corrupt the baseline for detecting the next *real* OTA. Native
+      // installs carry no reloadAsync race; nothing to recover from.
+      if (Updates.isEmbeddedLaunch) return;
+
       const currentUpdateId = Updates.updateId;
-      // Embedded launches have no updateId — there's no transition to
-      // recover from.
       if (!currentUpdateId) return;
 
       let stored: string | null = null;
@@ -56,7 +66,7 @@ export function PostUpdateRecoveryBanner() {
 
       if (cancelled) return;
 
-      // Persist the current id either way so the banner is one-shot.
+      // Persist the current id so the banner is one-shot per bundle.
       try {
         await AsyncStorage.setItem(STORAGE_KEY, currentUpdateId);
       } catch {
@@ -64,14 +74,13 @@ export function PostUpdateRecoveryBanner() {
         // next launch. Acceptable.
       }
 
-      // First-ever launch (or fresh install / cleared storage): nothing
-      // to recover from. Silently seed the value and skip.
-      if (!stored) return;
+      // We're on an OTA bundle. Show the banner when we have no prior
+      // record (first launch with the banner code on this user's
+      // device, or first OTA after a native install) or when the stored
+      // id differs from the current one (a tracked OTA transition).
+      const isTransition = !stored || stored !== currentUpdateId;
+      if (!isTransition) return;
 
-      // Same id: no transition happened.
-      if (stored === currentUpdateId) return;
-
-      // We just transitioned to a new bundle.
       setIsVisible(true);
       dismissTimerRef.current = setTimeout(() => {
         setIsVisible(false);

--- a/apps/mobile/components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx
+++ b/apps/mobile/components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx
@@ -15,12 +15,19 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 jest.mock('expo-updates', () => {
   let _updateId: string | null = null;
+  let _isEmbeddedLaunch = false;
   return {
     get updateId() {
       return _updateId;
     },
     set updateId(v: string | null) {
       _updateId = v;
+    },
+    get isEmbeddedLaunch() {
+      return _isEmbeddedLaunch;
+    },
+    set isEmbeddedLaunch(v: boolean) {
+      _isEmbeddedLaunch = v;
     },
   };
 });
@@ -42,6 +49,10 @@ const setUpdateId = (id: string | null) => {
   (Updates as { updateId: string | null }).updateId = id;
 };
 
+const setIsEmbeddedLaunch = (v: boolean) => {
+  (Updates as { isEmbeddedLaunch: boolean }).isEmbeddedLaunch = v;
+};
+
 const BANNER_TEXT = /app just updated/i;
 
 describe('PostUpdateRecoveryBanner', () => {
@@ -50,6 +61,7 @@ describe('PostUpdateRecoveryBanner', () => {
     mockGetItem.mockResolvedValue(null);
     mockSetItem.mockResolvedValue(undefined);
     setUpdateId(null);
+    setIsEmbeddedLaunch(false);
   });
 
   it('renders nothing in dev mode', async () => {
@@ -87,16 +99,54 @@ describe('PostUpdateRecoveryBanner', () => {
       expect(screen.queryByText(BANNER_TEXT)).toBeNull();
     });
 
-    it('seeds storage on first-ever launch and shows no banner', async () => {
-      setUpdateId('update-first');
+    it('embedded launch (fresh install): no storage activity, no banner', async () => {
+      setUpdateId('update-embedded');
+      setIsEmbeddedLaunch(true);
+      mockGetItem.mockResolvedValue(null);
+
+      render(<PostUpdateRecoveryBanner />);
+      await act(async () => {});
+
+      expect(mockGetItem).not.toHaveBeenCalled();
+      expect(mockSetItem).not.toHaveBeenCalled();
+      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    });
+
+    it('embedded launch with a prior stored OTA id (App Store update): does not overwrite, no banner', async () => {
+      // A native App Store update bumps the embedded updateId. Without
+      // the isEmbeddedLaunch short-circuit the previous code would have
+      // read the (different) stored OTA id, treated it as a transition,
+      // shown the banner, AND overwritten the stored baseline — making
+      // the next *real* OTA transition impossible to detect.
+      setUpdateId('update-new-embedded');
+      setIsEmbeddedLaunch(true);
+      mockGetItem.mockResolvedValue('update-old-ota');
+
+      render(<PostUpdateRecoveryBanner />);
+      await act(async () => {});
+
+      expect(mockGetItem).not.toHaveBeenCalled();
+      expect(mockSetItem).not.toHaveBeenCalled();
+      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    });
+
+    it('first launch with banner code on an OTA bundle (no stored id + non-embedded): SHOWS banner', async () => {
+      // The bug that shipped in PR #393's squash: existing users
+      // upgrading from a pre-banner bundle write nothing to storage on
+      // their old bundle, so `stored` is null. The original logic
+      // treated `!stored` as "fresh install" and suppressed the banner
+      // on the exact transition it's meant to help. Without the
+      // isEmbeddedLaunch disambiguation this user would never see it.
+      setUpdateId('update-with-banner');
+      setIsEmbeddedLaunch(false);
       mockGetItem.mockResolvedValue(null);
 
       render(<PostUpdateRecoveryBanner />);
 
       await waitFor(() => {
-        expect(mockSetItem).toHaveBeenCalledWith(STORAGE_KEY, 'update-first');
+        expect(screen.getByText(BANNER_TEXT)).toBeTruthy();
       });
-      expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+      expect(mockSetItem).toHaveBeenCalledWith(STORAGE_KEY, 'update-with-banner');
     });
 
     it('does NOT show banner when updateId matches the stored value', async () => {


### PR DESCRIPTION
## Summary
Follow-up to #393. Two related defects shipped in that PR's squash that prevent the recovery banner from doing its job — user reported "I just updated and I don't see the banner." Codex flagged both in iterative review but the fix commits never landed because the PR was merged before they were applied.

### Bugs

**1. Banner suppressed on the very transition it was built for.**
Existing users moving from a pre-banner bundle to the banner-enabled bundle write nothing to storage on their old bundle. The current logic reads `stored === null` and treats it as a fresh install:
```ts
if (!stored) return; // skip if no stored value
```
This is the most important case — every existing user the first time the banner code reaches them — and it's silently no-op'd.

**2. Native (App Store) updates falsely trigger the banner and corrupt the OTA baseline.**
In production, `Updates.isEmbeddedLaunch` can be `true` while `Updates.updateId` is still non-null (it's the embedded bundle's id, which bumps with each native App Store update). The current `if (!currentUpdateId) return` doesn't catch this case. After an App Store update:
- code reads the stored OTA id
- sees `stored !== currentUpdateId` → "OTA transition" → shows banner (false positive — no `reloadAsync` race)
- overwrites stored value → next *real* OTA transition is undetectable

### Fix

- Short-circuit on `Updates.isEmbeddedLaunch` at the very top of the effect, before any AsyncStorage activity.
- On OTA bundles, show banner when `!stored || stored !== currentUpdateId`. The `!stored` branch is what now catches V+2 → V+3 transitions for users who were on a pre-banner bundle.

Test mock extended to expose a settable `isEmbeddedLaunch`. Four new test cases:
- embedded launch (fresh install) — no storage, no banner
- embedded launch with a prior stored OTA id (App Store update over an OTA install) — does not overwrite, no banner
- first launch with banner code on an OTA bundle (no stored id) — SHOWS banner
- existing matching-id and differing-id cases continue to pass

## Test plan
- [x] `pnpm --filter mobile test components/ui/__tests__/PostUpdateRecoveryBanner.test.tsx` — 11 tests pass.
- [ ] Watch Sentry after deploy. Users transitioning V+2 → V+3 should hit `!stored` branch on the first launch and see the banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)