### PR TITLE
Add cross-team channel backend with role-based membership sync

### DIFF
--- a/apps/convex/__tests__/scheduling/crossTeamChannels.test.ts
+++ b/apps/convex/__tests__/scheduling/crossTeamChannels.test.ts
@@ -15,9 +15,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../../schema";
 import { modules } from "../../test.setup";
-import { internal } from "../../_generated/api";
+import { api, internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
+import { generateTokens } from "../../lib/auth";
 import { buildSchedulingWorld, ts, type SchedulingWorld } from "./fixtures";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
 let activeHandle: ReturnType<typeof convexTest> | null = null;
 
@@ -386,6 +389,261 @@ describe("cross-team channel — membership across multiple source teams", () =>
     const result = await reconcileCross(t, world);
     expect(result.removed).toBe(1);
     expect((await crossMemberIds(t, world)).has(world.techUserId)).toBe(false);
+  });
+});
+
+/**
+ * A cross-GROUP test world: the base scheduling world (Brooklyn group + its
+ * "worship" serving team), plus a SECOND group in the same community with its
+ * own serving team and roster. Used to exercise cross-team channels that draw
+ * from teams across more than one group.
+ */
+interface CrossGroupWorld {
+  t: ReturnType<typeof convexTest>;
+  base: SchedulingWorld;
+  /** Second group in the same community. */
+  groupBId: Id<"groups">;
+  /** Serving-team channel on the second group. */
+  teamBId: Id<"chatChannels">;
+  /** A role on the second group's team. */
+  roleBId: Id<"teamRoles">;
+  /** Member of group B, rostered on team B. */
+  groupBRosteredId: Id<"users">;
+  /** Member of group B, NOT rostered on any team. */
+  groupBBystanderId: Id<"users">;
+  /** A non-serving channel in the base group — invalid as a selector source. */
+  plainChannelId: Id<"chatChannels">;
+}
+
+async function setupCrossGroupWorld(): Promise<CrossGroupWorld> {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const base = await buildSchedulingWorld(t);
+
+  const extra = await t.run(async (ctx) => {
+    const baseGroup = (await ctx.db.get(base.groupId))!;
+
+    const groupBId = await ctx.db.insert("groups", {
+      communityId: base.communityId,
+      groupTypeId: baseGroup.groupTypeId,
+      name: "Manhattan Campus",
+      isArchived: false,
+      createdAt: ts(),
+      updatedAt: ts(),
+    });
+
+    const teamBId = await ctx.db.insert("chatChannels", {
+      groupId: groupBId,
+      communityId: base.communityId,
+      name: "MH Worship Team",
+      channelType: "custom",
+      memberCount: 0,
+      isArchived: false,
+      isServingTeam: true,
+      createdById: base.channelAdminId,
+      createdAt: ts(),
+      updatedAt: ts(),
+    });
+
+    const roleBId = await ctx.db.insert("teamRoles", {
+      channelId: teamBId,
+      communityId: base.communityId,
+      name: "Worship Leader",
+      sortOrder: 0,
+      defaultNeeded: 1,
+      isArchived: false,
+      createdAt: ts(),
+      createdById: base.channelAdminId,
+    });
+
+    const plainChannelId = await ctx.db.insert("chatChannels", {
+      groupId: base.groupId,
+      communityId: base.communityId,
+      name: "Just A Channel",
+      channelType: "custom",
+      memberCount: 0,
+      isArchived: false,
+      createdById: base.channelAdminId,
+      createdAt: ts(),
+      updatedAt: ts(),
+    });
+
+    const mkGroupBUser = async (firstName: string): Promise<Id<"users">> => {
+      const userId = await ctx.db.insert("users", {
+        firstName,
+        lastName: "Test",
+        email: `${firstName.toLowerCase()}@example.com`,
+        isActive: true,
+        roles: 1,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: groupBId,
+        userId,
+        role: "member",
+        joinedAt: ts(),
+        notificationsEnabled: true,
+      });
+      return userId;
+    };
+    const groupBRosteredId = await mkGroupBUser("Rostered");
+    const groupBBystanderId = await mkGroupBUser("Bystander");
+
+    return {
+      groupBId,
+      teamBId,
+      roleBId,
+      plainChannelId,
+      groupBRosteredId,
+      groupBBystanderId,
+    };
+  });
+
+  return { t, base, ...extra };
+}
+
+describe("cross-team channel — cross-group sharing", () => {
+  it("creating a channel with a foreign source team shares it into that group", async () => {
+    const { t, base, groupBId, teamBId, roleBId } =
+      await setupCrossGroupWorld();
+    const { accessToken } = await generateTokens(base.groupLeaderId);
+
+    const { channelId } = await t.mutation(
+      api.functions.scheduling.crossTeamChannels.createCrossTeamChannel,
+      {
+        token: accessToken,
+        groupId: base.groupId,
+        name: "Broadcast",
+        selectors: [
+          { sourceChannelId: base.channelId },
+          { sourceChannelId: teamBId, roleId: roleBId },
+        ],
+      },
+    );
+
+    const channel = await t.run((ctx) => ctx.db.get(channelId));
+    expect(channel?.isShared).toBe(true);
+    expect(channel?.sharedGroups?.map((s) => s.groupId)).toEqual([groupBId]);
+    expect(channel?.sharedGroups?.[0].status).toBe("accepted");
+  });
+
+  it("a same-group-only channel is not marked as shared", async () => {
+    const { t, base } = await setupCrossGroupWorld();
+    const { accessToken } = await generateTokens(base.groupLeaderId);
+
+    const { channelId } = await t.mutation(
+      api.functions.scheduling.crossTeamChannels.createCrossTeamChannel,
+      {
+        token: accessToken,
+        groupId: base.groupId,
+        name: "Local Only",
+        selectors: [{ sourceChannelId: base.channelId }],
+      },
+    );
+
+    const channel = await t.run((ctx) => ctx.db.get(channelId));
+    expect(channel?.isShared).toBeFalsy();
+    expect(channel?.sharedGroups).toBeUndefined();
+  });
+
+  it("rejects a source channel that is not a serving team", async () => {
+    const { t, base, plainChannelId } = await setupCrossGroupWorld();
+    const { accessToken } = await generateTokens(base.groupLeaderId);
+
+    await expect(
+      t.mutation(
+        api.functions.scheduling.crossTeamChannels.createCrossTeamChannel,
+        {
+          token: accessToken,
+          groupId: base.groupId,
+          name: "Bad Source",
+          selectors: [{ sourceChannelId: plainChannelId }],
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("a cross-group rostered member sees the channel under their own group", async () => {
+    const { t, base, groupBId, teamBId, roleBId, groupBRosteredId } =
+      await setupCrossGroupWorld();
+    const { accessToken } = await generateTokens(base.groupLeaderId);
+
+    const { channelId } = await t.mutation(
+      api.functions.scheduling.crossTeamChannels.createCrossTeamChannel,
+      {
+        token: accessToken,
+        groupId: base.groupId,
+        name: "Broadcast",
+        selectors: [{ sourceChannelId: teamBId, roleId: roleBId }],
+      },
+    );
+
+    // Roster the group-B user onto team B inside the rotation window.
+    const eventDate = Date.now() + 3 * DAY;
+    await t.run(async (ctx) => {
+      const planId = await ctx.db.insert("eventPlans", {
+        groupId: groupBId,
+        communityId: base.communityId,
+        title: "Sunday Service",
+        eventDate,
+        times: [{ label: "9 AM", startsAt: eventDate }],
+        status: "draft",
+        createdById: base.groupLeaderId,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+      await ctx.db.insert("roleAssignments", {
+        planId,
+        channelId: teamBId,
+        roleId: roleBId,
+        userId: groupBRosteredId,
+        eventDate,
+        status: "unconfirmed",
+        assignedById: base.groupLeaderId,
+        assignedAt: Date.now(),
+      });
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
+      { channelId },
+    );
+
+    const rosteredToken = (await generateTokens(groupBRosteredId)).accessToken;
+    const inbox = await t.query(
+      api.functions.messaging.channels.getInboxChannels,
+      { token: rosteredToken },
+    );
+    const groupBSection = inbox.find((s) => s.group._id === groupBId);
+    expect(
+      groupBSection?.channels.some((c) => c._id === channelId),
+    ).toBe(true);
+  });
+
+  it("a non-rostered member of the shared group does not see the channel", async () => {
+    const { t, base, teamBId, roleBId, groupBBystanderId } =
+      await setupCrossGroupWorld();
+    const { accessToken } = await generateTokens(base.groupLeaderId);
+
+    const { channelId } = await t.mutation(
+      api.functions.scheduling.crossTeamChannels.createCrossTeamChannel,
+      {
+        token: accessToken,
+        groupId: base.groupId,
+        name: "Broadcast",
+        selectors: [{ sourceChannelId: teamBId, roleId: roleBId }],
+      },
+    );
+
+    const bystanderToken = (await generateTokens(groupBBystanderId)).accessToken;
+    const inbox = await t.query(
+      api.functions.messaging.channels.getInboxChannels,
+      { token: bystanderToken },
+    );
+    const hasChannel = inbox.some((s) =>
+      s.channels.some((c) => c._id === channelId),
+    );
+    expect(hasChannel).toBe(false);
   });
 });
 

--- a/apps/convex/__tests__/scheduling/crossTeamChannels.test.ts
+++ b/apps/convex/__tests__/scheduling/crossTeamChannels.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Tests for cross-team channels (crossTeamChannels.ts + the cross-team paths
+ * of teamChannelSync.ts).
+ *
+ * A cross-team channel's membership is derived from `roleAssignments` across
+ * MULTIPLE source serving-team channels, optionally filtered per-selector to a
+ * single role. It uses the SAME rotation window (added ~5 days before the
+ * event, removed ~1 day after) and `event_plan` syncSource as a serving-team
+ * channel. These tests drive `reconcileTeamChannel` directly so the window is
+ * exercised deterministically, plus the `reconcileCrossTeamChannelsForSource`
+ * fan-out trigger.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld, ts, type SchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+const DAY = 86400000;
+
+/**
+ * A cross-team test world: the base scheduling world (one serving team — the
+ * "worship" team), plus a second serving-team channel (the "tech" team) with
+ * its own role, plus a cross-team channel selecting from both.
+ */
+interface CrossTeamWorld extends SchedulingWorld {
+  /** Second serving-team channel — the "tech" team. */
+  techChannelId: Id<"chatChannels">;
+  /** A role on the tech team. */
+  techRoleId: Id<"teamRoles">;
+  /** A second role on the worship team (world.roleId is the first). */
+  worshipRoleId: Id<"teamRoles">;
+  /** The cross-team channel under test. */
+  crossChannelId: Id<"chatChannels">;
+  /** Extra users for assignment scenarios. */
+  worshipUserId: Id<"users">;
+  techUserId: Id<"users">;
+  techUserBId: Id<"users">;
+}
+
+async function setupCrossTeamWorld(opts?: {
+  /** When set, the worship selector is filtered to this role. */
+  worshipRoleFilter?: "first" | "second";
+}): Promise<{ t: ReturnType<typeof convexTest>; world: CrossTeamWorld }> {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const base = await buildSchedulingWorld(t);
+
+  const extra = await t.run(async (ctx): Promise<{
+    techChannelId: Id<"chatChannels">;
+    techRoleId: Id<"teamRoles">;
+    worshipRoleId: Id<"teamRoles">;
+    worshipUserId: Id<"users">;
+    techUserId: Id<"users">;
+    techUserBId: Id<"users">;
+  }> => {
+    const techChannelId = await ctx.db.insert("chatChannels", {
+      groupId: base.groupId,
+      communityId: base.communityId,
+      name: "Tech Team",
+      channelType: "custom",
+      memberCount: 0,
+      isArchived: false,
+      isServingTeam: true,
+      createdById: base.channelAdminId,
+      createdAt: ts(),
+      updatedAt: ts(),
+    });
+
+    const techRoleId = await ctx.db.insert("teamRoles", {
+      channelId: techChannelId,
+      communityId: base.communityId,
+      name: "Technical Director",
+      sortOrder: 0,
+      defaultNeeded: 1,
+      isArchived: false,
+      createdAt: ts(),
+      createdById: base.channelAdminId,
+    });
+
+    // A second role on the worship team for the roleId-filter test.
+    const worshipRoleId = await ctx.db.insert("teamRoles", {
+      channelId: base.channelId,
+      communityId: base.communityId,
+      name: "Worship Leader",
+      sortOrder: 1,
+      defaultNeeded: 1,
+      isArchived: false,
+      createdAt: ts(),
+      createdById: base.channelAdminId,
+    });
+
+    const mkUser = (firstName: string) =>
+      ctx.db.insert("users", {
+        firstName,
+        lastName: "Test",
+        email: `${firstName.toLowerCase()}@example.com`,
+        isActive: true,
+        roles: 1,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+    const worshipUserId = await mkUser("Worshipper");
+    const techUserId = await mkUser("Techie");
+    const techUserBId = await mkUser("Techbee");
+
+    return {
+      techChannelId,
+      techRoleId,
+      worshipRoleId,
+      worshipUserId,
+      techUserId,
+      techUserBId,
+    };
+  });
+
+  // The cross-team channel: worship-team selector (optionally role-filtered)
+  // plus a tech-team selector (no role filter).
+  const worshipSelectorRoleId =
+    opts?.worshipRoleFilter === "first"
+      ? base.roleId
+      : opts?.worshipRoleFilter === "second"
+        ? extra.worshipRoleId
+        : undefined;
+
+  const crossChannelId = await t.run((ctx) =>
+    ctx.db.insert("chatChannels", {
+      groupId: base.groupId,
+      communityId: base.communityId,
+      name: "Service Leads",
+      channelType: "cross_team",
+      memberCount: 0,
+      isArchived: false,
+      createdById: base.channelAdminId,
+      createdAt: ts(),
+      updatedAt: ts(),
+      crossTeamSync: {
+        selectors: [
+          {
+            sourceChannelId: base.channelId,
+            ...(worshipSelectorRoleId
+              ? { roleId: worshipSelectorRoleId }
+              : {}),
+          },
+          { sourceChannelId: extra.techChannelId },
+        ],
+      },
+    }),
+  );
+
+  return { t, world: { ...base, ...extra, crossChannelId } };
+}
+
+/** Insert an event plan row directly for a given day offset. */
+async function insertPlan(
+  t: ReturnType<typeof convexTest>,
+  world: CrossTeamWorld,
+  dayOffset: number,
+): Promise<Id<"eventPlans">> {
+  const eventDate = Date.now() + dayOffset * DAY;
+  return t.run((ctx) =>
+    ctx.db.insert("eventPlans", {
+      groupId: world.groupId,
+      communityId: world.communityId,
+      title: "Sunday Service",
+      eventDate,
+      times: [{ label: "9 AM", startsAt: eventDate }],
+      status: "draft",
+      createdById: world.groupLeaderId,
+      createdAt: ts(),
+      updatedAt: ts(),
+    }),
+  );
+}
+
+/** Insert a roleAssignments row on a given source channel/role. */
+async function insertAssignment(
+  t: ReturnType<typeof convexTest>,
+  world: CrossTeamWorld,
+  opts: {
+    planId: Id<"eventPlans">;
+    channelId: Id<"chatChannels">;
+    roleId: Id<"teamRoles">;
+    userId: Id<"users">;
+    eventDate: number;
+    status?: "unconfirmed" | "confirmed" | "declined";
+  },
+): Promise<Id<"roleAssignments">> {
+  return t.run((ctx) =>
+    ctx.db.insert("roleAssignments", {
+      planId: opts.planId,
+      channelId: opts.channelId,
+      roleId: opts.roleId,
+      userId: opts.userId,
+      eventDate: opts.eventDate,
+      status: opts.status ?? "unconfirmed",
+      assignedById: world.groupLeaderId,
+      assignedAt: Date.now(),
+    }),
+  );
+}
+
+/** Active (non-left) auto-synced member userIds for the cross-team channel. */
+async function crossMemberIds(
+  t: ReturnType<typeof convexTest>,
+  world: CrossTeamWorld,
+): Promise<Set<string>> {
+  const rows = await t.run((ctx) =>
+    ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_syncSource", (q) =>
+        q.eq("channelId", world.crossChannelId).eq("syncSource", "event_plan"),
+      )
+      .collect(),
+  );
+  return new Set(
+    rows.filter((r) => r.leftAt === undefined).map((r) => r.userId as string),
+  );
+}
+
+/** Reconcile the cross-team channel directly. */
+async function reconcileCross(
+  t: ReturnType<typeof convexTest>,
+  world: CrossTeamWorld,
+) {
+  return t.mutation(
+    internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
+    { channelId: world.crossChannelId },
+  );
+}
+
+describe("cross-team channel — membership across multiple source teams", () => {
+  it("pulls members from two different source teams' assignments", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 3);
+
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.channelId,
+      roleId: world.roleId,
+      userId: world.worshipUserId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.techChannelId,
+      roleId: world.techRoleId,
+      userId: world.techUserId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+
+    const result = await reconcileCross(t, world);
+    expect(result.added).toBe(2);
+
+    const members = await crossMemberIds(t, world);
+    expect(members.has(world.worshipUserId)).toBe(true);
+    expect(members.has(world.techUserId)).toBe(true);
+  });
+
+  it("a roleId-filtered selector includes only matching-role assignments", async () => {
+    // Worship selector filtered to the FIRST worship role (world.roleId).
+    const { t, world } = await setupCrossTeamWorld({
+      worshipRoleFilter: "first",
+    });
+    const planId = await insertPlan(t, world, 3);
+
+    // Matching role — included.
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.channelId,
+      roleId: world.roleId,
+      userId: world.worshipUserId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+    // Non-matching role on the same source team — excluded.
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.channelId,
+      roleId: world.worshipRoleId,
+      userId: world.outsiderId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+
+    await reconcileCross(t, world);
+
+    const members = await crossMemberIds(t, world);
+    expect(members.has(world.worshipUserId)).toBe(true);
+    expect(members.has(world.outsiderId)).toBe(false);
+  });
+
+  it("a selector with no roleId includes assignments for any role on that team", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 3);
+
+    // The tech selector has no roleId filter — both tech-team assignments
+    // (here both happen to be the same role) should be included.
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.techChannelId,
+      roleId: world.techRoleId,
+      userId: world.techUserId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.techChannelId,
+      roleId: world.techRoleId,
+      userId: world.techUserBId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+
+    await reconcileCross(t, world);
+
+    const members = await crossMemberIds(t, world);
+    expect(members.has(world.techUserId)).toBe(true);
+    expect(members.has(world.techUserBId)).toBe(true);
+  });
+
+  it("declined assignments never put a user in the cross-team channel", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 3);
+
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.techChannelId,
+      roleId: world.techRoleId,
+      userId: world.techUserId,
+      eventDate: Date.now() + 3 * DAY,
+      status: "declined",
+    });
+
+    const result = await reconcileCross(t, world);
+    expect(result.added).toBe(0);
+    expect((await crossMemberIds(t, world)).has(world.techUserId)).toBe(false);
+  });
+
+  it("does not add a user whose event is beyond the rotation window", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 30);
+
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.channelId,
+      roleId: world.roleId,
+      userId: world.worshipUserId,
+      eventDate: Date.now() + 30 * DAY,
+    });
+
+    await reconcileCross(t, world);
+    expect((await crossMemberIds(t, world)).has(world.worshipUserId)).toBe(
+      false,
+    );
+  });
+
+  it("soft-removes a user once the rotation window has passed", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 3);
+    const assignmentId = await insertAssignment(t, world, {
+      planId,
+      channelId: world.techChannelId,
+      roleId: world.techRoleId,
+      userId: world.techUserId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+
+    await reconcileCross(t, world);
+    expect((await crossMemberIds(t, world)).has(world.techUserId)).toBe(true);
+
+    // Move the event well into the past — past the 1-day remove window.
+    await t.run((ctx) =>
+      ctx.db.patch(assignmentId, { eventDate: Date.now() - 5 * DAY }),
+    );
+
+    const result = await reconcileCross(t, world);
+    expect(result.removed).toBe(1);
+    expect((await crossMemberIds(t, world)).has(world.techUserId)).toBe(false);
+  });
+});
+
+describe("cross-team channel — reconcileCrossTeamChannelsForSource", () => {
+  it("reconciles a cross-team channel when a source team's assignment changes", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 3);
+
+    await insertAssignment(t, world, {
+      planId,
+      channelId: world.techChannelId,
+      roleId: world.techRoleId,
+      userId: world.techUserId,
+      eventDate: Date.now() + 3 * DAY,
+    });
+
+    // The fan-out trigger keyed by the SOURCE serving-team channel id should
+    // pick up the cross-team channel that selects from it.
+    const result = await t.mutation(
+      internal.functions.scheduling.teamChannelSync
+        .reconcileCrossTeamChannelsForSource,
+      { sourceChannelId: world.techChannelId },
+    );
+    expect(result.processed).toBe(1);
+    expect(result.totalAdded).toBe(1);
+
+    expect((await crossMemberIds(t, world)).has(world.techUserId)).toBe(true);
+  });
+
+  it("ignores cross-team channels that do not select the given source", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+
+    // A serving-team channel id that no cross-team channel selects from.
+    const unrelatedChannelId = await t.run((ctx) =>
+      ctx.db.insert("chatChannels", {
+        groupId: world.groupId,
+        communityId: world.communityId,
+        name: "Hospitality Team",
+        channelType: "custom",
+        memberCount: 0,
+        isArchived: false,
+        isServingTeam: true,
+        createdById: world.channelAdminId,
+        createdAt: ts(),
+        updatedAt: ts(),
+      }),
+    );
+
+    const result = await t.mutation(
+      internal.functions.scheduling.teamChannelSync
+        .reconcileCrossTeamChannelsForSource,
+      { sourceChannelId: unrelatedChannelId },
+    );
+    expect(result.processed).toBe(0);
+  });
+});

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -312,8 +312,21 @@ export const getChannel = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
-    // Must be a group member to access any channel
+    // Cross-team channels draw their members from serving teams that may live
+    // on other groups, so a synced member is often NOT in the channel's home
+    // group. Their auto-synced membership row IS the authorization — grant
+    // access on that alone, mirroring how event channels bypass the group gate.
     if (!groupMembership) {
+      if (channel.channelType === "cross_team" && membership) {
+        return {
+          ...channel,
+          slug: getChannelSlug(channel),
+          myRequestState: undefined as string | undefined,
+          inviterDisplayName: undefined as string | undefined,
+          recipientPending: false,
+        };
+      }
+      // Must be a group member to access any other channel
       return null;
     }
 
@@ -494,8 +507,12 @@ export const getChannelBySlug = query({
     }
 
     // Custom and pco_services channels require membership (or leader/admin access)
-    // For shared channels accessed from secondary group, channel membership is required
-    if ((isCustomChannel(resolvedChannel.channelType) || resolvedChannel.channelType === "pco_services") &&
+    // For shared channels accessed from secondary group, channel membership is required.
+    // Cross-team channels are roster-synced: only an auto-synced member (or a
+    // managing leader) may open them, never an arbitrary group member.
+    if ((isCustomChannel(resolvedChannel.channelType) ||
+         resolvedChannel.channelType === "pco_services" ||
+         resolvedChannel.channelType === "cross_team") &&
         !isMember && !isLeaderOrAdmin) {
       return null;
     }

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -188,11 +188,18 @@ export const assignRole = mutation({
       assignedAt: Date.now(),
     });
 
-    // Auto-sync the team channel's membership off the new assignment.
+    // Auto-sync the team channel's membership off the new assignment, and any
+    // cross-team channel that draws from this serving team.
     await ctx.scheduler.runAfter(
       0,
       internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
       { channelId: args.channelId },
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.teamChannelSync
+        .reconcileCrossTeamChannelsForSource,
+      { sourceChannelId: args.channelId },
     );
 
     return { assignmentId, doubleBooked };
@@ -221,11 +228,18 @@ export const unassign = mutation({
     await ctx.db.delete(args.assignmentId);
 
     // Auto-sync the team channel — the removed assignment may drop the user
-    // out of the channel's derived membership.
+    // out of the channel's derived membership — and any cross-team channel
+    // that draws from this serving team.
     await ctx.scheduler.runAfter(
       0,
       internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
       { channelId: assignment.channelId },
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.teamChannelSync
+        .reconcileCrossTeamChannelsForSource,
+      { sourceChannelId: assignment.channelId },
     );
 
     return { assignmentId: args.assignmentId };
@@ -265,11 +279,18 @@ export const respondToAssignment = mutation({
 
     // A decline drops the user from the channel's derived membership; a
     // confirm has no membership effect, but reconciling on both keeps the
-    // sync trigger uniform and cheap.
+    // sync trigger uniform and cheap. Also reconcile any cross-team channel
+    // that draws from this serving team.
     await ctx.scheduler.runAfter(
       0,
       internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
       { channelId: assignment.channelId },
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.teamChannelSync
+        .reconcileCrossTeamChannelsForSource,
+      { sourceChannelId: assignment.channelId },
     );
 
     return { assignmentId: args.assignmentId, status: args.status };
@@ -377,12 +398,19 @@ export const publishEvent = action({
     }
 
     // Auto-sync every team channel that has assignments on this event so
-    // publishing pulls confirmed/unconfirmed volunteers into their channels.
+    // publishing pulls confirmed/unconfirmed volunteers into their channels,
+    // plus any cross-team channel that draws from those serving teams.
     for (const channelId of result.channelIds) {
       await ctx.scheduler.runAfter(
         0,
         internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
         { channelId },
+      );
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.scheduling.teamChannelSync
+          .reconcileCrossTeamChannelsForSource,
+        { sourceChannelId: channelId },
       );
     }
 

--- a/apps/convex/functions/scheduling/crossTeamChannels.ts
+++ b/apps/convex/functions/scheduling/crossTeamChannels.ts
@@ -17,6 +17,8 @@
 
 import { ConvexError, v } from "convex/values";
 import { mutation, query } from "../../_generated/server";
+import type { MutationCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
 import { generateChannelSlug } from "../../lib/slugs";
@@ -28,6 +30,91 @@ const selectorValidator = v.object({
   sourceChannelId: v.id("chatChannels"),
   roleId: v.optional(v.id("teamRoles")),
 });
+
+/** A single `chatChannels.sharedGroups` entry. */
+type SharedGroupEntry = {
+  groupId: Id<"groups">;
+  status: "accepted";
+  invitedById: Id<"users">;
+  invitedAt: number;
+  respondedById: Id<"users">;
+  respondedAt: number;
+};
+
+/**
+ * Resolve a cross-team channel's selectors into its channel-sharing config.
+ *
+ * A cross-team channel's source serving teams may live on OTHER campus groups
+ * (e.g. a "Broadcast" channel drawing worship leaders from the Brooklyn AND
+ * Manhattan campuses). For a synced member to see the channel nested under
+ * their own campus in the inbox — rather than as a floating channel — the
+ * channel is shared into every campus group that contributes a source team.
+ *
+ * Validates each distinct source channel: it must exist, be a serving team,
+ * and belong to the same community as the cross-team channel's home group —
+ * so a selector cannot reach into another community's teams.
+ *
+ * Returns `isShared`/`sharedGroups` to persist on the channel. When every
+ * source team is in the home group, `isShared` is false and `sharedGroups` is
+ * cleared (an entirely same-campus cross-team channel needs no sharing).
+ */
+async function resolveCrossTeamSharing(
+  ctx: MutationCtx,
+  selectors: Array<{ sourceChannelId: Id<"chatChannels">; roleId?: Id<"teamRoles"> }>,
+  homeGroupId: Id<"groups">,
+  userId: Id<"users">,
+): Promise<{ isShared: boolean; sharedGroups: SharedGroupEntry[] | undefined }> {
+  const homeGroup = await ctx.db.get(homeGroupId);
+  if (!homeGroup) {
+    throw new ConvexError("Cross-team channel's home group not found.");
+  }
+
+  const sourceGroupIds = new Set<Id<"groups">>();
+  const seenChannels = new Set<string>();
+  for (const selector of selectors) {
+    if (seenChannels.has(selector.sourceChannelId)) continue;
+    seenChannels.add(selector.sourceChannelId);
+
+    const sourceChannel = await ctx.db.get(selector.sourceChannelId);
+    if (!sourceChannel) {
+      throw new ConvexError("A selected source team no longer exists.");
+    }
+    if (sourceChannel.isServingTeam !== true) {
+      throw new ConvexError(
+        "A cross-team channel can only draw from serving teams.",
+      );
+    }
+    if (!sourceChannel.groupId) {
+      throw new ConvexError(
+        "A selected source team is not attached to a campus group.",
+      );
+    }
+    const sourceGroup = await ctx.db.get(sourceChannel.groupId);
+    if (!sourceGroup || sourceGroup.communityId !== homeGroup.communityId) {
+      throw new ConvexError(
+        "Cross-team source teams must be in the same community.",
+      );
+    }
+    sourceGroupIds.add(sourceChannel.groupId);
+  }
+
+  const now = Date.now();
+  const sharedGroups: SharedGroupEntry[] = [...sourceGroupIds]
+    .filter((groupId) => groupId !== homeGroupId)
+    .map((groupId) => ({
+      groupId,
+      status: "accepted" as const,
+      invitedById: userId,
+      invitedAt: now,
+      respondedById: userId,
+      respondedAt: now,
+    }));
+
+  return {
+    isShared: sharedGroups.length > 0,
+    sharedGroups: sharedGroups.length > 0 ? sharedGroups : undefined,
+  };
+}
 
 /**
  * Create a cross-team channel and immediately populate its auto-synced
@@ -89,6 +176,16 @@ export const createCrossTeamChannel = mutation({
       .filter((slug): slug is string => slug !== undefined);
     const slug = generateChannelSlug(trimmedName, existingSlugs);
 
+    // Share the channel into every other campus group that contributes a
+    // source team, so cross-campus synced members see it under their own
+    // group. Also validates the selectors all point at same-community teams.
+    const { isShared, sharedGroups } = await resolveCrossTeamSharing(
+      ctx,
+      args.selectors,
+      args.groupId,
+      userId,
+    );
+
     const now = Date.now();
     const channelId = await ctx.db.insert("chatChannels", {
       groupId: args.groupId,
@@ -102,6 +199,8 @@ export const createCrossTeamChannel = mutation({
       isArchived: false,
       memberCount: 0,
       crossTeamSync: { selectors: args.selectors },
+      isShared,
+      sharedGroups,
     });
 
     // Populate the channel's derived membership now rather than waiting for
@@ -139,9 +238,25 @@ export const updateCrossTeamChannel = mutation({
     if (args.selectors.length === 0) {
       throw new ConvexError("A cross-team channel needs at least one selector.");
     }
+    if (!channel.groupId) {
+      throw new ConvexError(
+        "Cross-team channel is not attached to a campus group.",
+      );
+    }
+
+    // Recompute channel sharing from the new selectors — a campus group may
+    // have just been added to (or dropped from) the channel's source teams.
+    const { isShared, sharedGroups } = await resolveCrossTeamSharing(
+      ctx,
+      args.selectors,
+      channel.groupId,
+      userId,
+    );
 
     await ctx.db.patch(args.channelId, {
       crossTeamSync: { selectors: args.selectors },
+      isShared,
+      sharedGroups,
       updatedAt: Date.now(),
     });
 

--- a/apps/convex/functions/scheduling/crossTeamChannels.ts
+++ b/apps/convex/functions/scheduling/crossTeamChannels.ts
@@ -1,0 +1,210 @@
+/**
+ * Cross-team channels — config mutations & queries
+ *
+ * A "cross-team channel" is a `chatChannels` row with
+ * `channelType === "cross_team"`. It owns no roles or events of its own; its
+ * membership is auto-synced — same rotation window and `event_plan` syncSource
+ * as a serving-team channel — from `roleAssignments` across MULTIPLE source
+ * serving-team channels. Each `crossTeamSync.selectors` entry pulls in everyone
+ * assigned `roleId` on `sourceChannelId`, or — when `roleId` is omitted —
+ * everyone assigned any role on that source team.
+ *
+ * The actual membership reconcile lives in `teamChannelSync.ts`
+ * (`reconcileTeamChannelImpl`, which handles both serving-team and cross-team
+ * channels). These functions only manage the channel's config and trigger a
+ * reconcile after a change.
+ */
+
+import { ConvexError, v } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import { requireAuth } from "../../lib/auth";
+import { isLeaderRole } from "../../lib/helpers";
+import { generateChannelSlug } from "../../lib/slugs";
+import { requireGroupMember, requireScheduler } from "./permissions";
+import { reconcileTeamChannelImpl } from "./teamChannelSync";
+
+/** Validator for a single cross-team membership selector. */
+const selectorValidator = v.object({
+  sourceChannelId: v.id("chatChannels"),
+  roleId: v.optional(v.id("teamRoles")),
+});
+
+/**
+ * Create a cross-team channel and immediately populate its auto-synced
+ * membership.
+ *
+ * Auth: `requireAuth`, then group-leader (matching `createCustomChannel`'s
+ * creation gate). The creator is NOT added as a member — like an Event Team
+ * channel, membership is purely auto-synced from event-plan assignments.
+ *
+ * Returns the new `channelId` and its generated `slug`.
+ */
+export const createCrossTeamChannel = mutation({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    name: v.string(),
+    description: v.optional(v.string()),
+    selectors: v.array(selectorValidator),
+  },
+  returns: v.object({
+    channelId: v.id("chatChannels"),
+    slug: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    // Creation gate — mirrors `createCustomChannel`: group leader only.
+    const groupMembership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", args.groupId).eq("userId", userId),
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+    if (!groupMembership || !isLeaderRole(groupMembership.role)) {
+      throw new ConvexError("Only group leaders can create cross-team channels.");
+    }
+
+    const trimmedName = args.name.trim();
+    if (trimmedName.length < 1 || trimmedName.length > 50) {
+      throw new ConvexError("Channel name must be 1-50 characters.");
+    }
+    if (!/[a-zA-Z0-9]/.test(trimmedName)) {
+      throw new ConvexError(
+        "Channel name must contain at least one letter or number.",
+      );
+    }
+    if (args.selectors.length === 0) {
+      throw new ConvexError("A cross-team channel needs at least one selector.");
+    }
+
+    // Unique slug among the group's channels — same approach as createChannel.
+    const existingChannels = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .collect();
+    const existingSlugs = existingChannels
+      .map((ch) => ch.slug)
+      .filter((slug): slug is string => slug !== undefined);
+    const slug = generateChannelSlug(trimmedName, existingSlugs);
+
+    const now = Date.now();
+    const channelId = await ctx.db.insert("chatChannels", {
+      groupId: args.groupId,
+      slug,
+      channelType: "cross_team",
+      name: trimmedName,
+      description: args.description,
+      createdById: userId,
+      createdAt: now,
+      updatedAt: now,
+      isArchived: false,
+      memberCount: 0,
+      crossTeamSync: { selectors: args.selectors },
+    });
+
+    // Populate the channel's derived membership now rather than waiting for
+    // the daily cron.
+    await reconcileTeamChannelImpl(ctx, channelId);
+
+    return { channelId, slug };
+  },
+});
+
+/**
+ * Update a cross-team channel's selectors and re-reconcile its membership.
+ *
+ * Auth: `requireScheduler` — channel admin/moderator, campus group leader, or
+ * community admin.
+ */
+export const updateCrossTeamChannel = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    selectors: v.array(selectorValidator),
+  },
+  returns: v.object({
+    channelId: v.id("chatChannels"),
+    addedCount: v.number(),
+    removedCount: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const channel = await requireScheduler(ctx, args.channelId, userId);
+
+    if (channel.channelType !== "cross_team") {
+      throw new ConvexError("Channel is not a cross-team channel");
+    }
+    if (args.selectors.length === 0) {
+      throw new ConvexError("A cross-team channel needs at least one selector.");
+    }
+
+    await ctx.db.patch(args.channelId, {
+      crossTeamSync: { selectors: args.selectors },
+      updatedAt: Date.now(),
+    });
+
+    const result = await reconcileTeamChannelImpl(ctx, args.channelId);
+    return {
+      channelId: args.channelId,
+      addedCount: result.added,
+      removedCount: result.removed,
+    };
+  },
+});
+
+/**
+ * List a campus group's cross-team channels, each with its selectors enriched
+ * with the source team channel name and role name for UI display.
+ *
+ * Auth: an active member of the group, or a community admin — same read gate
+ * as `listTeamChannels`.
+ */
+export const listCrossTeamChannels = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupMember(ctx, args.groupId, userId);
+
+    const channels = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .filter((q) => q.eq(q.field("isArchived"), false))
+      .collect();
+
+    const crossTeam = channels.filter(
+      (channel) => channel.channelType === "cross_team",
+    );
+
+    return Promise.all(
+      crossTeam.map(async (channel) => {
+        const selectors = await Promise.all(
+          (channel.crossTeamSync?.selectors ?? []).map(async (selector) => {
+            const sourceChannel = await ctx.db.get(selector.sourceChannelId);
+            const role = selector.roleId
+              ? await ctx.db.get(selector.roleId)
+              : null;
+            return {
+              sourceChannelId: selector.sourceChannelId,
+              sourceChannelName: sourceChannel?.name ?? "Unknown team",
+              roleId: selector.roleId,
+              roleName: role?.name ?? null,
+            };
+          }),
+        );
+        return {
+          _id: channel._id,
+          name: channel.name,
+          description: channel.description,
+          channelType: channel.channelType,
+          memberCount: channel.memberCount,
+          selectors,
+        };
+      }),
+    );
+  },
+});

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -224,6 +224,12 @@ export const updateEvent = mutation({
           internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
           { channelId },
         );
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.scheduling.teamChannelSync
+            .reconcileCrossTeamChannelsForSource,
+          { sourceChannelId: channelId },
+        );
       }
     }
 
@@ -269,12 +275,19 @@ export const deleteEvent = mutation({
 
     // Auto-sync each affected team channel so its derived membership drops
     // the now-deleted assignees immediately rather than waiting for the
-    // daily cron — mirrors `unassign`'s reconcile trigger.
+    // daily cron — mirrors `unassign`'s reconcile trigger — plus any
+    // cross-team channel that draws from those serving teams.
     for (const channelId of channelIds) {
       await ctx.scheduler.runAfter(
         0,
         internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
         { channelId },
+      );
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.scheduling.teamChannelSync
+          .reconcileCrossTeamChannelsForSource,
+        { sourceChannelId: channelId },
       );
     }
 

--- a/apps/convex/functions/scheduling/teamChannelSync.ts
+++ b/apps/convex/functions/scheduling/teamChannelSync.ts
@@ -77,8 +77,17 @@ const SYNC_SOURCE = "event_plan";
  * and the cron, and the public `triggerTeamChannelSync`). A mutation cannot
  * `ctx.runMutation` another mutation, so both entrypoints call this helper
  * directly to guarantee identical behavior.
+ *
+ * Handles two kinds of auto-synced channel:
+ *   - a serving-team channel (`isServingTeam === true`): desired members come
+ *     from `roleAssignments` on the channel itself; or
+ *   - a cross-team channel (`channelType === "cross_team"`): desired members
+ *     come from `roleAssignments` across the source serving-team channels
+ *     named in `crossTeamSync.selectors` (optionally filtered by role).
+ * Any other channel early-returns untouched. Both paths feed the identical
+ * desired-set diff/add/remove logic below.
  */
-async function reconcileTeamChannelImpl(
+export async function reconcileTeamChannelImpl(
   ctx: MutationCtx,
   channelId: Id<"chatChannels">,
 ): Promise<{ added: number; removed: number; desiredCount: number }> {
@@ -86,24 +95,52 @@ async function reconcileTeamChannelImpl(
   const now = Date.now();
 
   const channel = await ctx.db.get(args.channelId);
-  if (!channel || channel.isServingTeam !== true) {
+  const isCrossTeam =
+    channel?.channelType === "cross_team" && channel.crossTeamSync !== undefined;
+  if (!channel || (channel.isServingTeam !== true && !isCrossTeam)) {
     return { added: 0, removed: 0, desiredCount: 0 };
   }
 
   const windowStart = now - REMOVE_DAYS_AFTER * MS_PER_DAY;
   const windowEnd = now + ADD_DAYS_BEFORE * MS_PER_DAY;
 
-  // Assignments for this channel whose event date falls inside the rotation
-  // window. The `by_channel_eventDate` index bounds the scan to the window.
-  const assignmentsInWindow = await ctx.db
-    .query("roleAssignments")
-    .withIndex("by_channel_eventDate", (q) =>
-      q
-        .eq("channelId", args.channelId)
-        .gte("eventDate", windowStart)
-        .lte("eventDate", windowEnd),
-    )
-    .collect();
+  // Assignments whose event date falls inside the rotation window. The
+  // `by_channel_eventDate` index bounds the scan to the window.
+  //   - Serving-team channel: the channel's own assignments.
+  //   - Cross-team channel: assignments across each selector's source
+  //     serving-team channel, optionally filtered to a single role.
+  let assignmentsInWindow;
+  if (isCrossTeam) {
+    const collected = [];
+    for (const selector of channel.crossTeamSync!.selectors) {
+      const rows = await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_channel_eventDate", (q) =>
+          q
+            .eq("channelId", selector.sourceChannelId)
+            .gte("eventDate", windowStart)
+            .lte("eventDate", windowEnd),
+        )
+        .collect();
+      for (const row of rows) {
+        if (selector.roleId !== undefined && row.roleId !== selector.roleId) {
+          continue;
+        }
+        collected.push(row);
+      }
+    }
+    assignmentsInWindow = collected;
+  } else {
+    assignmentsInWindow = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_channel_eventDate", (q) =>
+        q
+          .eq("channelId", args.channelId)
+          .gte("eventDate", windowStart)
+          .lte("eventDate", windowEnd),
+      )
+      .collect();
+  }
 
   // Desired member set: distinct userId, declined assignments excluded.
   // We keep the soonest in-window assignment per user for sync metadata and
@@ -163,8 +200,17 @@ async function reconcileTeamChannelImpl(
     const displayName = user
       ? getDisplayName(user.firstName, user.lastName)
       : "Unknown";
+    // For a serving-team channel the team name is the channel itself. For a
+    // cross-team channel a member can be drawn from any source team, so the
+    // metadata names the source serving-team channel that owns the role —
+    // making the member's metadata read e.g. "Worship Team / Worship Leader".
+    let teamName = channel.name;
+    if (isCrossTeam && role) {
+      const sourceChannel = await ctx.db.get(role.channelId);
+      teamName = sourceChannel?.name ?? channel.name;
+    }
     const syncMetadata = {
-      teamName: channel.name,
+      teamName,
       position: role?.name ?? undefined,
       serviceDate: info.eventDate,
       serviceName: plan?.title ?? undefined,
@@ -393,15 +439,70 @@ export const reconcileAllTeamChannels = internalAction({
 });
 
 /**
- * Internal: ids of every channel flagged as a serving team.
+ * Internal: ids of every auto-synced channel — serving-team channels
+ * (`isServingTeam === true`) plus cross-team channels
+ * (`channelType === "cross_team"`). The daily cron reconciles all of them so
+ * the rotation window advances even when no assignment mutation fires.
  */
 export const listTeamChannelIds = internalQuery({
   args: {},
   handler: async (ctx): Promise<Id<"chatChannels">[]> => {
     const channels = await ctx.db
       .query("chatChannels")
-      .filter((q) => q.eq(q.field("isServingTeam"), true))
+      .filter((q) =>
+        q.or(
+          q.eq(q.field("isServingTeam"), true),
+          q.eq(q.field("channelType"), "cross_team"),
+        ),
+      )
       .collect();
     return channels.map((c) => c._id);
+  },
+});
+
+// ============================================================================
+// reconcileCrossTeamChannelsForSource — cross-team fan-out trigger
+// ============================================================================
+
+/**
+ * Reconcile every cross-team channel that draws from a given serving-team
+ * source channel. Called alongside `reconcileTeamChannel` at each assignment-
+ * /event-mutation trigger site so an assignment change on a source team also
+ * updates any cross-team channel that selects from it.
+ *
+ * Scans `chatChannels` for `channelType === "cross_team"` and keeps those
+ * whose `crossTeamSync.selectors` include `sourceChannelId`. Cross-team
+ * channels are rare, so a filtered `.collect()` scan is acceptable. Calls
+ * `reconcileTeamChannelImpl` directly because a mutation cannot
+ * `ctx.runMutation` another mutation.
+ */
+export const reconcileCrossTeamChannelsForSource = internalMutation({
+  args: {
+    sourceChannelId: v.id("chatChannels"),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ processed: number; totalAdded: number; totalRemoved: number }> => {
+    const crossTeamChannels = await ctx.db
+      .query("chatChannels")
+      .filter((q) => q.eq(q.field("channelType"), "cross_team"))
+      .collect();
+
+    let processed = 0;
+    let totalAdded = 0;
+    let totalRemoved = 0;
+    for (const channel of crossTeamChannels) {
+      const selectsSource = channel.crossTeamSync?.selectors.some(
+        (s) => s.sourceChannelId === args.sourceChannelId,
+      );
+      if (!selectsSource) continue;
+      const result = await reconcileTeamChannelImpl(ctx, channel._id);
+      processed += 1;
+      totalAdded += result.added;
+      totalRemoved += result.removed;
+    }
+
+    return { processed, totalAdded, totalRemoved };
   },
 });

--- a/apps/convex/functions/scheduling/teams.ts
+++ b/apps/convex/functions/scheduling/teams.ts
@@ -8,6 +8,7 @@
 
 import { ConvexError, v } from "convex/values";
 import { mutation, query } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { updateChannelMemberCount } from "../messaging/helpers";
@@ -93,6 +94,96 @@ export const listTeamChannels = query({
         channelType: channel.channelType,
         memberCount: channel.memberCount,
       }));
+  },
+});
+
+/**
+ * List every serving-team channel across the caller's community, organized by
+ * the group that owns it and enriched with each team's (non-archived) roles.
+ *
+ * Powers the cross-team channel picker: a leader first narrows down which
+ * groups to draw from, then picks roles from the teams in those groups. Only
+ * groups that actually have a serving team are returned, so the picker never
+ * lists groups with nothing to offer.
+ *
+ * Auth: an active member of `groupId` (the group the picker is opened from),
+ * or a community admin — the same read gate as `listTeamChannels`.
+ */
+export const listCommunityServingTeams = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const group = await requireGroupMember(ctx, args.groupId, userId);
+
+    const communityGroups = await ctx.db
+      .query("groups")
+      .withIndex("by_community", (q) => q.eq("communityId", group.communityId))
+      .filter((q) => q.eq(q.field("isArchived"), false))
+      .collect();
+
+    const result: Array<{
+      group: { _id: Id<"groups">; name: string };
+      teams: Array<{
+        _id: Id<"chatChannels">;
+        name: string;
+        channelType: string;
+        memberCount: number;
+        roles: Array<{
+          _id: Id<"teamRoles">;
+          name: string;
+          color?: string;
+          sortOrder: number;
+        }>;
+      }>;
+    }> = [];
+
+    for (const g of communityGroups) {
+      const channels = await ctx.db
+        .query("chatChannels")
+        .withIndex("by_group", (q) => q.eq("groupId", g._id))
+        .filter((q) => q.eq(q.field("isArchived"), false))
+        .collect();
+      const teamChannels = channels.filter((c) => c.isServingTeam === true);
+      if (teamChannels.length === 0) continue;
+
+      const teams = await Promise.all(
+        teamChannels.map(async (team) => {
+          const roles = await ctx.db
+            .query("teamRoles")
+            .withIndex("by_channel", (q) => q.eq("channelId", team._id))
+            .collect();
+          return {
+            _id: team._id,
+            name: team.name,
+            channelType: team.channelType,
+            memberCount: team.memberCount,
+            roles: roles
+              .filter((role) => role.isArchived !== true)
+              .sort((a, b) => a.sortOrder - b.sortOrder)
+              .map((role) => ({
+                _id: role._id,
+                name: role.name,
+                color: role.color,
+                sortOrder: role.sortOrder,
+              })),
+          };
+        }),
+      );
+
+      result.push({ group: { _id: g._id, name: g.name }, teams });
+    }
+
+    // The picker's own group first, then alphabetical by group name.
+    result.sort((a, b) => {
+      if (a.group._id === args.groupId) return -1;
+      if (b.group._id === args.groupId) return 1;
+      return a.group.name.localeCompare(b.group.name);
+    });
+
+    return result;
   },
 });
 

--- a/apps/convex/functions/sync/memberships.ts
+++ b/apps/convex/functions/sync/memberships.ts
@@ -227,6 +227,13 @@ export async function syncUserChannelMembershipsLogic(
     if (channel.channelType === "custom") {
       continue;
     }
+    // Skip cross-team channels - their membership is auto-synced from
+    // role assignments across multiple serving teams (teamChannelSync.ts),
+    // NOT from this group's membership. Adding a group member here would
+    // give them a stray non-synced row the rotation engine never removes.
+    if (channel.channelType === "cross_team") {
+      continue;
+    }
 
     // Determine if user SHOULD be in this channel
     let shouldBeInChannel = false;

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1519,7 +1519,7 @@ export default defineSchema({
     /** For 1:1 DMs: deterministic key for dedup, sorted "userIdA::userIdB". */
     dmPairKey: v.optional(v.string()),
     slug: v.optional(v.string()), // URL-friendly, unique per group, immutable (optional for migration)
-    channelType: v.string(), // "main" | "leaders" | "dm" | "group_dm" | "custom" | "pco_services" | "event" | "reach_out" | "announcements"
+    channelType: v.string(), // "main" | "leaders" | "dm" | "group_dm" | "custom" | "pco_services" | "event" | "reach_out" | "announcements" | "cross_team"
     name: v.string(),
     description: v.optional(v.string()),
     createdById: v.id("users"),
@@ -1566,6 +1566,24 @@ export default defineSchema({
      * See ADR-023. Undefined/false = ordinary channel.
      */
     isServingTeam: v.optional(v.boolean()),
+    /**
+     * Set for `channelType === "cross_team"` channels. A cross-team channel
+     * owns no roles or events of its own; its membership is auto-synced (same
+     * rotation window + `event_plan` syncSource as a serving-team channel)
+     * from `roleAssignments` across the listed source serving-team channels.
+     * Each selector pulls in everyone assigned `roleId` on `sourceChannelId`,
+     * or — when `roleId` is omitted — everyone assigned any role there.
+     */
+    crossTeamSync: v.optional(
+      v.object({
+        selectors: v.array(
+          v.object({
+            sourceChannelId: v.id("chatChannels"),
+            roleId: v.optional(v.id("teamRoles")),
+          }),
+        ),
+      }),
+    ),
   })
     .index("by_group", ["groupId"])
     .index("by_group_type", ["groupId", "channelType"])

--- a/apps/mobile/app/inbox/[groupId]/create.tsx
+++ b/apps/mobile/app/inbox/[groupId]/create.tsx
@@ -28,9 +28,14 @@ import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { PcoAutoChannelConfig, type AutoChannelConfig } from "@features/channels";
+import {
+  CrossTeamSelectorPicker,
+  createCrossTeamChannelRef,
+  type CrossTeamSelector,
+} from "@features/scheduling";
 import type { Id } from "@services/api/convex";
 
-type ChannelType = "custom" | "team" | "pco_services";
+type ChannelType = "custom" | "team" | "pco_services" | "cross_team";
 
 const MAX_NAME_LENGTH = 50;
 
@@ -56,6 +61,10 @@ export default function CreateChannelScreen() {
   // Channel type state
   const [channelType, setChannelType] = useState<ChannelType>("custom");
   const [autoConfig, setAutoConfig] = useState<AutoChannelConfig | null>(null);
+  // Cross-team channel: the auto-sync selectors chosen by the leader.
+  const [crossTeamSelectors, setCrossTeamSelectors] = useState<
+    CrossTeamSelector[]
+  >([]);
 
   // Form state
   const [name, setName] = useState("");
@@ -81,6 +90,9 @@ export default function CreateChannelScreen() {
   const createAutoChannel = useAuthenticatedMutation(
     api.functions.messaging.channels.createAutoChannel
   );
+  const createCrossTeamChannel = useAuthenticatedMutation(
+    createCrossTeamChannelRef
+  );
 
   // Get communityId from group or fallback to auth context
   const communityId = group?.communityId || (community?.id as Id<"communities"> | undefined);
@@ -101,11 +113,13 @@ export default function CreateChannelScreen() {
   };
 
   const isNameValid = name.trim().length > 0;
-  // PCO channels also require autoConfig; custom + team need only a name.
+  // PCO channels also require autoConfig; cross-team channels require at least
+  // one selector; custom + team need only a name.
   const canCreate =
     isNameValid &&
     !isLoading &&
-    (channelType !== "pco_services" || autoConfig !== null);
+    (channelType !== "pco_services" || autoConfig !== null) &&
+    (channelType !== "cross_team" || crossTeamSelectors.length > 0);
 
   const handleCreate = async () => {
     if (!canCreate) return;
@@ -124,6 +138,20 @@ export default function CreateChannelScreen() {
           description: description.trim() || undefined,
           integrationType: "pco_services",
           autoChannelConfig: autoConfig,
+        });
+        router.replace(`/inbox/${groupId}/${result.slug}`);
+        return;
+      }
+
+      if (channelType === "cross_team") {
+        // Cross-team channel — membership is auto-synced from event-plan role
+        // assignments across the chosen serving teams. No creator/manual
+        // membership; navigate to the channel like a custom channel.
+        const result = await createCrossTeamChannel({
+          groupId: groupId as Id<"groups">,
+          name: name.trim(),
+          description: description.trim() || undefined,
+          selectors: crossTeamSelectors,
         });
         router.replace(`/inbox/${groupId}/${result.slug}`);
         return;
@@ -314,13 +342,47 @@ export default function CreateChannelScreen() {
                   Planning Center
                 </Text>
               </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.segmentButton,
+                  { borderColor: colors.inputBorder, backgroundColor: colors.surface },
+                  channelType === "cross_team" && [
+                    { backgroundColor: colors.selectedBackground },
+                    { borderColor: primaryColor },
+                  ],
+                ]}
+                onPress={() => setChannelType("cross_team")}
+                disabled={isLoading}
+              >
+                <Ionicons
+                  name="git-merge-outline"
+                  size={18}
+                  color={channelType === "cross_team" ? primaryColor : colors.textSecondary}
+                  style={styles.segmentIcon}
+                />
+                <Text
+                  numberOfLines={2}
+                  style={[
+                    styles.segmentText,
+                    { color: colors.textSecondary },
+                    channelType === "cross_team" && [
+                      styles.segmentTextSelected,
+                      { color: primaryColor },
+                    ],
+                  ]}
+                >
+                  Cross-team channel
+                </Text>
+              </TouchableOpacity>
             </View>
             <Text style={[styles.channelTypeHint, { color: colors.textTertiary }]}>
               {channelType === "custom"
                 ? "A permanent channel — you choose who is in it. Best for ongoing, not time-bound groups."
                 : channelType === "team"
                   ? "Time-bound: membership syncs automatically from event plans — whoever is scheduled to a role is added around the event date and removed afterward."
-                  : "Automatically sync members from Planning Center Services"}
+                  : channelType === "cross_team"
+                    ? "Auto-syncs members rostered for chosen roles across multiple teams."
+                    : "Automatically sync members from Planning Center Services"}
             </Text>
             {!isCommunityAdmin && (
               <Text style={[styles.adminOnlyHint, { color: colors.textTertiary }]}>
@@ -335,6 +397,26 @@ export default function CreateChannelScreen() {
               <PcoAutoChannelConfig
                 communityId={communityId}
                 onChange={setAutoConfig}
+              />
+            </View>
+          )}
+
+          {/* Cross-team Selector Picker — choose which teams + roles feed the
+              channel's auto-synced membership. */}
+          {channelType === "cross_team" && groupId && (
+            <View style={[styles.section, { backgroundColor: colors.surface }]}>
+              <Text style={[styles.label, { color: colors.textSecondary }]}>
+                Synced roles <Text style={{ color: colors.error }}>*</Text>
+              </Text>
+              <Text style={[styles.channelTypeHint, { color: colors.textTertiary, marginBottom: 12 }]}>
+                Pick a team, then choose specific roles or any role on it.
+                Anyone rostered for those roles is auto-added.
+              </Text>
+              <CrossTeamSelectorPicker
+                groupId={groupId as Id<"groups">}
+                selectors={crossTeamSelectors}
+                onChange={setCrossTeamSelectors}
+                disabled={isLoading}
               />
             </View>
           )}
@@ -586,11 +668,13 @@ const styles = StyleSheet.create({
   },
   segmentedControl: {
     flexDirection: "row",
+    flexWrap: "wrap",
     gap: 12,
     marginBottom: 8,
   },
   segmentButton: {
-    flex: 1,
+    flexGrow: 1,
+    flexBasis: "40%",
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -46,6 +46,13 @@ import { AdminViewNote } from "@components/ui/AdminViewNote";
 import { ConfirmModal } from "@components/ui/ConfirmModal";
 import { CustomModal } from "@components/ui/Modal";
 import { AutoChannelSettings } from "@features/channels";
+import {
+  CrossTeamSelectorPicker,
+  listCrossTeamChannelsRef,
+  updateCrossTeamChannelRef,
+  type CrossTeamChannel,
+  type CrossTeamSelector,
+} from "@features/scheduling";
 import { useAuth } from "@providers/AuthProvider";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
@@ -66,7 +73,13 @@ type Props = {
   channelSlug: string;
 };
 
-type ChannelType = "main" | "leaders" | "reach_out" | "pco_services" | "custom";
+type ChannelType =
+  | "main"
+  | "leaders"
+  | "reach_out"
+  | "pco_services"
+  | "custom"
+  | "cross_team";
 
 type ChannelIconConfig = {
   icon: React.ComponentProps<typeof Ionicons>["name"];
@@ -88,6 +101,8 @@ function getChannelIconConfig(
       return { icon: "hand-left", color: "#8E44AD", bg: "#8E44AD15", defaultName: "Reach Out" };
     case "pco_services":
       return { icon: "sync", color: "#2196F3", bg: "#2196F315", defaultName: "PCO Channel" };
+    case "cross_team":
+      return { icon: "git-merge", color: "#00897B", bg: "#00897B15", defaultName: "Cross-team Channel" };
     default:
       return { icon: "chatbubble", color: "#00BCD4", bg: "#00BCD415", defaultName: "Channel" };
   }
@@ -178,6 +193,20 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
       : "skip",
   );
 
+  // Cross-team channels: list the group's cross-team channels so we can find
+  // THIS channel's current selectors to prefill the edit picker. The backend
+  // has no per-channel getter, so we filter the group-scoped list.
+  const crossTeamChannels = useQuery(
+    listCrossTeamChannelsRef,
+    token && channel?._id && channel.channelType === "cross_team"
+      ? { token, groupId: groupId as Id<"groups"> }
+      : "skip",
+  ) as CrossTeamChannel[] | undefined;
+
+  const updateCrossTeamChannel = useAuthenticatedMutation(
+    updateCrossTeamChannelRef,
+  );
+
   const [renameVisible, setRenameVisible] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const [renameSubmitting, setRenameSubmitting] = useState(false);
@@ -187,6 +216,9 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   const [archiving, setArchiving] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [pcoSettingsVisible, setPcoSettingsVisible] = useState(false);
+  const [crossTeamEditVisible, setCrossTeamEditVisible] = useState(false);
+  const [crossTeamDraft, setCrossTeamDraft] = useState<CrossTeamSelector[]>([]);
+  const [crossTeamSaving, setCrossTeamSaving] = useState(false);
   const [teamSyncing, setTeamSyncing] = useState(false);
   const [requestInFlight, setRequestInFlight] = useState<string | null>(null);
   const [unmatchedActionInFlight, setUnmatchedActionInFlight] = useState<
@@ -250,6 +282,13 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
   const isLeadersChannel = channelType === "leaders";
   const isReachOut = channelType === "reach_out";
   const isPco = channelType === "pco_services";
+  const isCrossTeam = channelType === "cross_team";
+
+  // This channel's current cross-team config (selectors), if any.
+  const thisCrossTeamChannel = useMemo(
+    () => crossTeamChannels?.find((c) => c._id === channel?._id),
+    [crossTeamChannels, channel?._id],
+  );
 
   const iconCfg = getChannelIconConfig(channelType, primaryColor);
   const channelDisplayName = channel?.name?.trim() || iconCfg.defaultName;
@@ -364,6 +403,49 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
       setTeamSyncing(false);
     }
   }, [channel?._id, teamSyncing, triggerTeamChannelSync]);
+
+  const handleOpenCrossTeamEdit = useCallback(() => {
+    // Prefill the picker draft from the channel's current selectors. The
+    // enriched selectors carry extra display fields — strip them down to the
+    // { sourceChannelId, roleId? } shape the picker/mutation expect.
+    const current: CrossTeamSelector[] = (
+      thisCrossTeamChannel?.selectors ?? []
+    ).map((s) => ({
+      sourceChannelId: s.sourceChannelId,
+      ...(s.roleId ? { roleId: s.roleId } : {}),
+    }));
+    setCrossTeamDraft(current);
+    setCrossTeamEditVisible(true);
+  }, [thisCrossTeamChannel?.selectors]);
+
+  const handleSaveCrossTeam = useCallback(async () => {
+    if (!channel?._id || crossTeamSaving) return;
+    if (crossTeamDraft.length === 0) {
+      Alert.alert(
+        "Pick at least one role",
+        "A cross-team channel needs at least one team + role selector.",
+      );
+      return;
+    }
+    setCrossTeamSaving(true);
+    try {
+      const result = await updateCrossTeamChannel({
+        channelId: channel._id,
+        selectors: crossTeamDraft,
+      });
+      setCrossTeamEditVisible(false);
+      const { addedCount, removedCount } = result;
+      const message =
+        addedCount === 0 && removedCount === 0
+          ? "Synced roles updated. Membership is unchanged."
+          : `Synced roles updated. ${addedCount} added, ${removedCount} removed.`;
+      Alert.alert("Saved", message);
+    } catch (e: any) {
+      Alert.alert("Couldn't save", e?.message || "Please try again.");
+    } finally {
+      setCrossTeamSaving(false);
+    }
+  }, [channel?._id, crossTeamSaving, crossTeamDraft, updateCrossTeamChannel]);
 
   const handleAddUnmatchedToGroup = useCallback(
     async (person: UnsyncedPerson) => {
@@ -1049,6 +1131,38 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
                 </Pressable>
               )}
 
+              {/* Edit synced roles — cross-team channels. Reopens the
+                  selector picker prefilled from the current config and
+                  saves via updateCrossTeamChannel. */}
+              {isCrossTeam && (
+                <Pressable
+                  onPress={handleOpenCrossTeamEdit}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons
+                    name="git-merge-outline"
+                    size={20}
+                    color={colors.icon}
+                  />
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>
+                    Edit synced roles
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                    style={{ marginLeft: "auto" }}
+                  />
+                </Pressable>
+              )}
+
               {/* Serving team — custom channels can opt into the native
                   scheduling engine (ADR-023). Routes to the team setup /
                   roles editor; `markChannelAsTeam` runs idempotently there. */}
@@ -1358,6 +1472,76 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
           />
         )}
       </Modal>
+
+      {/* Edit synced roles — cross-team channels. Full-screen modal mounting
+          the same selector picker used in channel creation. */}
+      <Modal
+        visible={crossTeamEditVisible}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => {
+          if (!crossTeamSaving) setCrossTeamEditVisible(false);
+        }}
+      >
+        <View
+          style={[
+            styles.container,
+            { paddingTop: insets.top, backgroundColor: colors.surface },
+          ]}
+        >
+          <View
+            style={[
+              styles.headerBar,
+              {
+                backgroundColor: colors.surface,
+                borderBottomColor: colors.border,
+              },
+            ]}
+          >
+            <TouchableOpacity
+              onPress={() => setCrossTeamEditVisible(false)}
+              disabled={crossTeamSaving}
+              style={styles.headerBackButton}
+              hitSlop={12}
+            >
+              <Ionicons name="close" size={26} color={colors.text} />
+            </TouchableOpacity>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>
+              Edit synced roles
+            </Text>
+            <TouchableOpacity
+              onPress={handleSaveCrossTeam}
+              disabled={crossTeamSaving}
+              style={styles.headerBackButton}
+              hitSlop={12}
+            >
+              {crossTeamSaving ? (
+                <ActivityIndicator size="small" color={primaryColor} />
+              ) : (
+                <Text
+                  style={[styles.crossTeamSaveLabel, { color: primaryColor }]}
+                >
+                  Save
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={{
+              padding: 16,
+              paddingBottom: insets.bottom + 24,
+            }}
+          >
+            <CrossTeamSelectorPicker
+              groupId={groupId as Id<"groups">}
+              selectors={crossTeamDraft}
+              onChange={setCrossTeamDraft}
+              disabled={crossTeamSaving}
+            />
+          </ScrollView>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -1425,6 +1609,10 @@ const styles = StyleSheet.create({
   },
   headerSpacer: {
     width: 36,
+  },
+  crossTeamSaveLabel: {
+    fontSize: 16,
+    fontWeight: "600",
   },
   scroll: {
     flex: 1,

--- a/apps/mobile/features/chat/components/GroupChatsScreen.tsx
+++ b/apps/mobile/features/chat/components/GroupChatsScreen.tsx
@@ -58,13 +58,21 @@ export const GroupChatsScreen: React.FC = () => {
         >
           <View style={styles.chatIcon}>
             <Text style={styles.chatIconText}>
-              {chat.channelType === 'leaders' ? '👑' : '💬'}
+              {chat.channelType === 'leaders'
+                ? '👑'
+                : chat.channelType === 'cross_team'
+                  ? '🔀'
+                  : '💬'}
             </Text>
           </View>
           <View style={styles.chatInfo}>
             <Text style={styles.chatName}>{chat.name}</Text>
             <Text style={styles.chatType}>
-              {chat.channelType === 'leaders' ? 'Leaders Hub' : 'General Chat'}
+              {chat.channelType === 'leaders'
+                ? 'Leaders Hub'
+                : chat.channelType === 'cross_team'
+                  ? 'Cross-team channel'
+                  : 'General Chat'}
             </Text>
           </View>
         </TouchableOpacity>

--- a/apps/mobile/features/scheduling/api/crossTeamChannels.ts
+++ b/apps/mobile/features/scheduling/api/crossTeamChannels.ts
@@ -1,0 +1,99 @@
+/**
+ * Typed function references for the cross-team channel backend.
+ *
+ * Why this file exists: the Convex backend module
+ * `functions/scheduling/crossTeamChannels` is deployed, but the committed
+ * `apps/convex/_generated/api.d.ts` in this repo can be stale offline and not
+ * yet list it. Accessing `api.functions.scheduling.crossTeamChannels.*`
+ * directly would therefore be a type error until the next `npx convex dev`
+ * regenerates the api map.
+ *
+ * Rather than scattering `as any` casts across the UI, we isolate a single
+ * typed indirection here: at runtime the app's `api` IS `anyApi` (a proxy that
+ * resolves any path), so `(api as AnyApiShape)....` resolves correctly; we
+ * then re-assert the precise `FunctionReference` arg/return types — matching
+ * the validators in `crossTeamChannels.ts` — so every call site is fully
+ * type-checked. Once the generated api map includes the module, this file can
+ * be deleted and call sites can use `api.functions.scheduling.crossTeamChannels`
+ * directly.
+ */
+import type { FunctionReference } from "convex/server";
+import { api, type Id } from "@services/api/convex";
+
+/** One cross-team membership selector: a source team channel + optional role. */
+export type CrossTeamSelector = {
+  sourceChannelId: Id<"chatChannels">;
+  roleId?: Id<"teamRoles">;
+};
+
+/** A selector enriched with display names, as returned by `listCrossTeamChannels`. */
+export type EnrichedCrossTeamSelector = {
+  sourceChannelId: Id<"chatChannels">;
+  sourceChannelName: string;
+  roleId: Id<"teamRoles"> | null;
+  roleName: string | null;
+};
+
+export type CrossTeamChannel = {
+  _id: Id<"chatChannels">;
+  name: string;
+  description?: string;
+  channelType: string;
+  memberCount: number;
+  selectors: EnrichedCrossTeamSelector[];
+};
+
+type CreateCrossTeamChannelRef = FunctionReference<
+  "mutation",
+  "public",
+  {
+    token: string;
+    groupId: Id<"groups">;
+    name: string;
+    description?: string;
+    selectors: CrossTeamSelector[];
+  },
+  { channelId: Id<"chatChannels">; slug: string }
+>;
+
+type UpdateCrossTeamChannelRef = FunctionReference<
+  "mutation",
+  "public",
+  {
+    token: string;
+    channelId: Id<"chatChannels">;
+    selectors: CrossTeamSelector[];
+  },
+  { channelId: Id<"chatChannels">; addedCount: number; removedCount: number }
+>;
+
+type ListCrossTeamChannelsRef = FunctionReference<
+  "query",
+  "public",
+  { token: string; groupId: Id<"groups"> },
+  CrossTeamChannel[]
+>;
+
+// The runtime `api` is `anyApi`, so any property path resolves to a valid
+// function reference proxy. We narrow the path's type to the precise
+// reference above. This is the single, intentional cast — see file header.
+const crossTeamChannelsApi = (
+  api as unknown as {
+    functions: {
+      scheduling: {
+        crossTeamChannels: {
+          createCrossTeamChannel: CreateCrossTeamChannelRef;
+          updateCrossTeamChannel: UpdateCrossTeamChannelRef;
+          listCrossTeamChannels: ListCrossTeamChannelsRef;
+        };
+      };
+    };
+  }
+).functions.scheduling.crossTeamChannels;
+
+export const createCrossTeamChannelRef =
+  crossTeamChannelsApi.createCrossTeamChannel;
+export const updateCrossTeamChannelRef =
+  crossTeamChannelsApi.updateCrossTeamChannel;
+export const listCrossTeamChannelsRef =
+  crossTeamChannelsApi.listCrossTeamChannels;

--- a/apps/mobile/features/scheduling/api/crossTeamChannels.ts
+++ b/apps/mobile/features/scheduling/api/crossTeamChannels.ts
@@ -4,21 +4,19 @@
  * Why this file exists: the Convex backend module
  * `functions/scheduling/crossTeamChannels` is deployed, but the committed
  * `apps/convex/_generated/api.d.ts` in this repo can be stale offline and not
- * yet list it. Accessing `api.functions.scheduling.crossTeamChannels.*`
- * directly would therefore be a type error until the next `npx convex dev`
- * regenerates the api map.
+ * yet list it — so `api.functions.scheduling.crossTeamChannels.*` would be a
+ * type error until the next `npx convex dev` regenerates the api map.
  *
- * Rather than scattering `as any` casts across the UI, we isolate a single
- * typed indirection here: at runtime the app's `api` IS `anyApi` (a proxy that
- * resolves any path), so `(api as AnyApiShape)....` resolves correctly; we
- * then re-assert the precise `FunctionReference` arg/return types — matching
- * the validators in `crossTeamChannels.ts` — so every call site is fully
- * type-checked. Once the generated api map includes the module, this file can
- * be deleted and call sites can use `api.functions.scheduling.crossTeamChannels`
- * directly.
+ * Rather than depend on the generated `api` object, we build the references
+ * directly from their function paths with `makeFunctionReference`, asserting
+ * the precise arg/return types — matching the validators in
+ * `crossTeamChannels.ts`. This is fully type-checked at every call site and,
+ * unlike traversing the `api` proxy, evaluates safely under test mocks. Once
+ * the generated api map includes the module, this file can be deleted and
+ * call sites can use `api.functions.scheduling.crossTeamChannels` directly.
  */
-import type { FunctionReference } from "convex/server";
-import { api, type Id } from "@services/api/convex";
+import { makeFunctionReference } from "convex/server";
+import type { Id } from "@services/api/convex";
 
 /** One cross-team membership selector: a source team channel + optional role. */
 export type CrossTeamSelector = {
@@ -43,9 +41,8 @@ export type CrossTeamChannel = {
   selectors: EnrichedCrossTeamSelector[];
 };
 
-type CreateCrossTeamChannelRef = FunctionReference<
+export const createCrossTeamChannelRef = makeFunctionReference<
   "mutation",
-  "public",
   {
     token: string;
     groupId: Id<"groups">;
@@ -54,46 +51,20 @@ type CreateCrossTeamChannelRef = FunctionReference<
     selectors: CrossTeamSelector[];
   },
   { channelId: Id<"chatChannels">; slug: string }
->;
+>("functions/scheduling/crossTeamChannels:createCrossTeamChannel");
 
-type UpdateCrossTeamChannelRef = FunctionReference<
+export const updateCrossTeamChannelRef = makeFunctionReference<
   "mutation",
-  "public",
   {
     token: string;
     channelId: Id<"chatChannels">;
     selectors: CrossTeamSelector[];
   },
   { channelId: Id<"chatChannels">; addedCount: number; removedCount: number }
->;
+>("functions/scheduling/crossTeamChannels:updateCrossTeamChannel");
 
-type ListCrossTeamChannelsRef = FunctionReference<
+export const listCrossTeamChannelsRef = makeFunctionReference<
   "query",
-  "public",
   { token: string; groupId: Id<"groups"> },
   CrossTeamChannel[]
->;
-
-// The runtime `api` is `anyApi`, so any property path resolves to a valid
-// function reference proxy. We narrow the path's type to the precise
-// reference above. This is the single, intentional cast — see file header.
-const crossTeamChannelsApi = (
-  api as unknown as {
-    functions: {
-      scheduling: {
-        crossTeamChannels: {
-          createCrossTeamChannel: CreateCrossTeamChannelRef;
-          updateCrossTeamChannel: UpdateCrossTeamChannelRef;
-          listCrossTeamChannels: ListCrossTeamChannelsRef;
-        };
-      };
-    };
-  }
-).functions.scheduling.crossTeamChannels;
-
-export const createCrossTeamChannelRef =
-  crossTeamChannelsApi.createCrossTeamChannel;
-export const updateCrossTeamChannelRef =
-  crossTeamChannelsApi.updateCrossTeamChannel;
-export const listCrossTeamChannelsRef =
-  crossTeamChannelsApi.listCrossTeamChannels;
+>("functions/scheduling/crossTeamChannels:listCrossTeamChannels");

--- a/apps/mobile/features/scheduling/components/CrossTeamSelectorPicker.tsx
+++ b/apps/mobile/features/scheduling/components/CrossTeamSelectorPicker.tsx
@@ -5,15 +5,18 @@
  * source serving-team channel with an optional role on that team — omitting
  * the role means "anyone assigned any role on this team".
  *
- * The leader expands a team to reveal its roles, then taps "Any role" or one
- * or more specific roles. Each tap toggles a selector in/out of the chosen
- * list. Chosen selectors are shown as removable chips.
+ * Two-step flow: the leader first chooses which groups to draw from, then —
+ * for each chosen group — expands a team to pick "Any role" or specific roles.
+ * Groups can sit on different campuses; only the chosen groups (those that
+ * actually contribute a team) end up sharing the channel. Chosen selectors are
+ * shown as removable chips.
  *
- * Backend: scheduling.teams.listTeamChannels (source teams) +
- * scheduling.roles.listRoles (roles per team). The resulting `selectors`
- * array is consumed by createCrossTeamChannel / updateCrossTeamChannel.
+ * Backend: scheduling.teams.listCommunityServingTeams returns every group in
+ * the community that has a serving team, each team enriched with its roles.
+ * The resulting `selectors` array is consumed by createCrossTeamChannel /
+ * updateCrossTeamChannel.
  */
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -28,20 +31,24 @@ import type { Id } from "@services/api/convex";
 import { DEFAULT_ROLE_COLOR } from "../utils/format";
 import type { CrossTeamSelector } from "../api/crossTeamChannels";
 
-type TeamChannel = {
-  _id: Id<"chatChannels">;
-  name: string;
-  channelType: string;
-  memberCount: number;
-};
-
 type Role = {
   _id: Id<"teamRoles">;
   name: string;
   color?: string;
   sortOrder: number;
-  defaultNeeded?: number;
-  isArchived: boolean;
+};
+
+type TeamChannel = {
+  _id: Id<"chatChannels">;
+  name: string;
+  channelType: string;
+  memberCount: number;
+  roles: Role[];
+};
+
+type CommunityGroup = {
+  group: { _id: Id<"groups">; name: string };
+  teams: TeamChannel[];
 };
 
 type Props = {
@@ -66,16 +73,81 @@ export function CrossTeamSelectorPicker({
 }: Props) {
   const { colors } = useTheme();
 
-  const teams = useAuthenticatedQuery(
-    api.functions.scheduling.teams.listTeamChannels,
+  const communityGroups = useAuthenticatedQuery(
+    api.functions.scheduling.teams.listCommunityServingTeams,
     { groupId },
-  ) as TeamChannel[] | undefined;
+  ) as CommunityGroup[] | undefined;
 
-  // Which team rows are expanded to show their roles.
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  // Lookups derived from the loaded data.
+  const { teamToGroup, teamById } = useMemo(() => {
+    const teamToGroup = new Map<string, string>();
+    const teamById = new Map<string, TeamChannel>();
+    for (const cg of communityGroups ?? []) {
+      for (const team of cg.teams) {
+        teamToGroup.set(team._id, cg.group._id);
+        teamById.set(team._id, team);
+      }
+    }
+    return { teamToGroup, teamById };
+  }, [communityGroups]);
 
-  const toggleExpanded = useCallback((channelId: string) => {
-    setExpanded((prev) => ({ ...prev, [channelId]: !prev[channelId] }));
+  // Step 1: which groups are open for role-picking.
+  const [openGroupIds, setOpenGroupIds] = useState<Set<string>>(new Set());
+  // Step 2: which team rows are expanded to reveal their roles.
+  const [expandedTeams, setExpandedTeams] = useState<Set<string>>(new Set());
+
+  // Any group already referenced by an existing selector must stay open so the
+  // leader can see (and edit) what they previously chose.
+  useEffect(() => {
+    if (!communityGroups) return;
+    const implied = new Set<string>();
+    for (const selector of selectors) {
+      const g = teamToGroup.get(selector.sourceChannelId);
+      if (g) implied.add(g);
+    }
+    if (implied.size === 0) return;
+    setOpenGroupIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const g of implied) {
+        if (!next.has(g)) {
+          next.add(g);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [communityGroups, selectors, teamToGroup]);
+
+  const toggleGroup = useCallback(
+    (cg: CommunityGroup) => {
+      if (disabled) return;
+      const isOpen = openGroupIds.has(cg.group._id);
+      if (isOpen) {
+        // Closing a group drops every selector pointing at one of its teams.
+        const teamIds = new Set(cg.teams.map((t) => t._id));
+        const remaining = selectors.filter(
+          (s) => !teamIds.has(s.sourceChannelId),
+        );
+        if (remaining.length !== selectors.length) onChange(remaining);
+      }
+      setOpenGroupIds((prev) => {
+        const next = new Set(prev);
+        if (isOpen) next.delete(cg.group._id);
+        else next.add(cg.group._id);
+        return next;
+      });
+    },
+    [disabled, openGroupIds, selectors, onChange],
+  );
+
+  const toggleTeamExpanded = useCallback((teamId: string) => {
+    setExpandedTeams((prev) => {
+      const next = new Set(prev);
+      if (next.has(teamId)) next.delete(teamId);
+      else next.add(teamId);
+      return next;
+    });
   }, []);
 
   const toggleSelector = useCallback(
@@ -91,7 +163,7 @@ export function CrossTeamSelectorPicker({
     [disabled, selectors, onChange],
   );
 
-  if (teams === undefined) {
+  if (communityGroups === undefined) {
     return (
       <View style={styles.loading}>
         <ActivityIndicator size="small" color={colors.text} />
@@ -99,7 +171,7 @@ export function CrossTeamSelectorPicker({
     );
   }
 
-  if (teams.length === 0) {
+  if (communityGroups.length === 0) {
     return (
       <View
         style={[styles.emptyBox, { backgroundColor: colors.surfaceSecondary }]}
@@ -110,12 +182,16 @@ export function CrossTeamSelectorPicker({
           color={colors.textSecondary}
         />
         <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-          This group has no serving teams yet. Set up at least one serving-team
-          channel with roles before creating a cross-team channel.
+          No group in this community has a serving team yet. Set up at least one
+          serving-team channel with roles before creating a cross-team channel.
         </Text>
       </View>
     );
   }
+
+  const openGroups = communityGroups.filter((cg) =>
+    openGroupIds.has(cg.group._id),
+  );
 
   return (
     <View>
@@ -126,8 +202,7 @@ export function CrossTeamSelectorPicker({
             <SelectorChip
               key={`${selector.sourceChannelId}:${selector.roleId ?? "any"}`}
               selector={selector}
-              teams={teams}
-              groupId={groupId}
+              teamById={teamById}
               onRemove={() => toggleSelector(selector)}
               disabled={disabled}
             />
@@ -135,24 +210,130 @@ export function CrossTeamSelectorPicker({
         </View>
       )}
 
-      {/* Team list */}
+      {/* Step 1: choose groups */}
+      <Text style={[styles.stepLabel, { color: colors.textSecondary }]}>
+        1. Choose groups to draw from
+      </Text>
       <View
         style={[styles.teamGroup, { backgroundColor: colors.surfaceSecondary }]}
       >
-        {teams.map((team, idx) => (
-          <TeamRow
-            key={team._id}
-            team={team}
-            isExpanded={!!expanded[team._id]}
+        {communityGroups.map((cg, idx) => (
+          <GroupRow
+            key={cg.group._id}
+            communityGroup={cg}
+            isOpen={openGroupIds.has(cg.group._id)}
             isFirst={idx === 0}
             selectors={selectors}
-            onToggleExpanded={() => toggleExpanded(team._id)}
-            onToggleSelector={toggleSelector}
+            onToggle={() => toggleGroup(cg)}
             disabled={disabled}
           />
         ))}
       </View>
+
+      {/* Step 2: choose roles within the chosen groups */}
+      {openGroups.length > 0 && (
+        <>
+          <Text
+            style={[
+              styles.stepLabel,
+              { color: colors.textSecondary, marginTop: 20 },
+            ]}
+          >
+            2. Choose roles
+          </Text>
+          {openGroups.map((cg) => (
+            <View key={cg.group._id} style={styles.groupSection}>
+              <Text
+                style={[styles.groupSectionTitle, { color: colors.text }]}
+                numberOfLines={1}
+              >
+                {cg.group.name}
+              </Text>
+              <View
+                style={[
+                  styles.teamGroup,
+                  { backgroundColor: colors.surfaceSecondary },
+                ]}
+              >
+                {cg.teams.map((team, idx) => (
+                  <TeamRow
+                    key={team._id}
+                    team={team}
+                    isExpanded={expandedTeams.has(team._id)}
+                    isFirst={idx === 0}
+                    selectors={selectors}
+                    onToggleExpanded={() => toggleTeamExpanded(team._id)}
+                    onToggleSelector={toggleSelector}
+                    disabled={disabled}
+                  />
+                ))}
+              </View>
+            </View>
+          ))}
+        </>
+      )}
     </View>
+  );
+}
+
+/** A single group row in step 1 — checkbox-style toggle. */
+function GroupRow({
+  communityGroup,
+  isOpen,
+  isFirst,
+  selectors,
+  onToggle,
+  disabled,
+}: {
+  communityGroup: CommunityGroup;
+  isOpen: boolean;
+  isFirst: boolean;
+  selectors: CrossTeamSelector[];
+  onToggle: () => void;
+  disabled?: boolean;
+}) {
+  const { colors } = useTheme();
+
+  // How many selectors target a team in this group — surfaced as a badge.
+  const teamIds = new Set(communityGroup.teams.map((t) => t._id));
+  const groupSelectorCount = selectors.filter((s) =>
+    teamIds.has(s.sourceChannelId),
+  ).length;
+
+  return (
+    <Pressable
+      onPress={onToggle}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.teamRow,
+        !isFirst && {
+          borderTopWidth: StyleSheet.hairlineWidth,
+          borderTopColor: colors.border,
+        },
+        pressed && { backgroundColor: colors.selectedBackground },
+        disabled && { opacity: 0.5 },
+      ]}
+    >
+      <Ionicons
+        name={isOpen ? "checkbox" : "square-outline"}
+        size={22}
+        color={isOpen ? colors.text : colors.textTertiary}
+      />
+      <Text style={[styles.teamName, { color: colors.text }]} numberOfLines={1}>
+        {communityGroup.group.name}
+      </Text>
+      {groupSelectorCount > 0 && (
+        <View style={[styles.countBadge, { backgroundColor: colors.text }]}>
+          <Text style={[styles.countBadgeText, { color: colors.surface }]}>
+            {groupSelectorCount}
+          </Text>
+        </View>
+      )}
+      <Text style={[styles.teamMeta, { color: colors.textTertiary }]}>
+        {communityGroup.teams.length} team
+        {communityGroup.teams.length === 1 ? "" : "s"}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -198,11 +379,7 @@ function TeamRow({
           pressed && { backgroundColor: colors.selectedBackground },
         ]}
       >
-        <Ionicons
-          name="people-outline"
-          size={20}
-          color={colors.textSecondary}
-        />
+        <Ionicons name="people-outline" size={20} color={colors.textSecondary} />
         <Text
           style={[styles.teamName, { color: colors.text }]}
           numberOfLines={1}
@@ -225,7 +402,7 @@ function TeamRow({
 
       {isExpanded && (
         <TeamRoles
-          channelId={team._id}
+          team={team}
           selectors={selectors}
           onToggleSelector={onToggleSelector}
           disabled={disabled}
@@ -237,38 +414,25 @@ function TeamRow({
 
 /** Role options for an expanded team: "Any role" + each specific role. */
 function TeamRoles({
-  channelId,
+  team,
   selectors,
   onToggleSelector,
   disabled,
 }: {
-  channelId: Id<"chatChannels">;
+  team: TeamChannel;
   selectors: CrossTeamSelector[];
   onToggleSelector: (selector: CrossTeamSelector) => void;
   disabled?: boolean;
 }) {
   const { colors } = useTheme();
 
-  const roles = useAuthenticatedQuery(
-    api.functions.scheduling.roles.listRoles,
-    { channelId },
-  ) as Role[] | undefined;
-
   const isChosen = useCallback(
     (roleId?: Id<"teamRoles">) =>
       selectors.some(
-        (s) => s.sourceChannelId === channelId && s.roleId === roleId,
+        (s) => s.sourceChannelId === team._id && s.roleId === roleId,
       ),
-    [selectors, channelId],
+    [selectors, team._id],
   );
-
-  if (roles === undefined) {
-    return (
-      <View style={styles.rolesLoading}>
-        <ActivityIndicator size="small" color={colors.textSecondary} />
-      </View>
-    );
-  }
 
   return (
     <View style={styles.rolesWrap}>
@@ -276,22 +440,22 @@ function TeamRoles({
         label="Any role on this team"
         color={colors.textSecondary}
         selected={isChosen(undefined)}
-        onPress={() => onToggleSelector({ sourceChannelId: channelId })}
+        onPress={() => onToggleSelector({ sourceChannelId: team._id })}
         disabled={disabled}
       />
-      {roles.map((role) => (
+      {team.roles.map((role) => (
         <RoleOption
           key={role._id}
           label={role.name}
           color={role.color ?? DEFAULT_ROLE_COLOR}
           selected={isChosen(role._id)}
           onPress={() =>
-            onToggleSelector({ sourceChannelId: channelId, roleId: role._id })
+            onToggleSelector({ sourceChannelId: team._id, roleId: role._id })
           }
           disabled={disabled}
         />
       ))}
-      {roles.length === 0 && (
+      {team.roles.length === 0 && (
         <Text style={[styles.noRolesText, { color: colors.textTertiary }]}>
           This team has no roles yet. "Any role on this team" still works.
         </Text>
@@ -342,35 +506,22 @@ function RoleOption({
 /** A removable chip for one chosen selector. */
 function SelectorChip({
   selector,
-  teams,
-  groupId,
+  teamById,
   onRemove,
   disabled,
 }: {
   selector: CrossTeamSelector;
-  teams: TeamChannel[];
-  groupId: Id<"groups">;
+  teamById: Map<string, TeamChannel>;
   onRemove: () => void;
   disabled?: boolean;
 }) {
   const { colors } = useTheme();
 
-  const teamName =
-    teams.find((t) => t._id === selector.sourceChannelId)?.name ??
-    "Unknown team";
-
-  // Fetch the source team's roles only to resolve the chosen role's name.
-  const roles = useAuthenticatedQuery(
-    api.functions.scheduling.roles.listRoles,
-    selector.roleId ? { channelId: selector.sourceChannelId } : "skip",
-  ) as Role[] | undefined;
-
+  const team = teamById.get(selector.sourceChannelId);
+  const teamName = team?.name ?? "Unknown team";
   const roleLabel = selector.roleId
-    ? (roles?.find((r) => r._id === selector.roleId)?.name ?? "Role")
+    ? (team?.roles.find((r) => r._id === selector.roleId)?.name ?? "Role")
     : "Any role";
-
-  // groupId is accepted for API symmetry with the picker; unused here.
-  void groupId;
 
   return (
     <View style={[styles.chip, { backgroundColor: colors.selectedBackground }]}>
@@ -421,6 +572,21 @@ const styles = StyleSheet.create({
     fontWeight: "500",
     flexShrink: 1,
   },
+  stepLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    marginBottom: 8,
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  groupSection: {
+    marginTop: 12,
+  },
+  groupSectionTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    marginBottom: 6,
+  },
   teamGroup: {
     borderRadius: 12,
     overflow: "hidden",
@@ -438,6 +604,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "500",
   },
+  teamMeta: {
+    fontSize: 13,
+  },
   countBadge: {
     minWidth: 20,
     height: 20,
@@ -449,10 +618,6 @@ const styles = StyleSheet.create({
   countBadgeText: {
     fontSize: 12,
     fontWeight: "700",
-  },
-  rolesLoading: {
-    paddingVertical: 12,
-    alignItems: "center",
   },
   rolesWrap: {
     paddingBottom: 8,

--- a/apps/mobile/features/scheduling/components/CrossTeamSelectorPicker.tsx
+++ b/apps/mobile/features/scheduling/components/CrossTeamSelectorPicker.tsx
@@ -1,0 +1,483 @@
+/**
+ * CrossTeamSelectorPicker
+ *
+ * Builds the `selectors` array for a cross-team channel. Each selector pairs a
+ * source serving-team channel with an optional role on that team — omitting
+ * the role means "anyone assigned any role on this team".
+ *
+ * The leader expands a team to reveal its roles, then taps "Any role" or one
+ * or more specific roles. Each tap toggles a selector in/out of the chosen
+ * list. Chosen selectors are shown as removable chips.
+ *
+ * Backend: scheduling.teams.listTeamChannels (source teams) +
+ * scheduling.roles.listRoles (roles per team). The resulting `selectors`
+ * array is consumed by createCrossTeamChannel / updateCrossTeamChannel.
+ */
+import React, { useCallback, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ActivityIndicator,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { DEFAULT_ROLE_COLOR } from "../utils/format";
+import type { CrossTeamSelector } from "../api/crossTeamChannels";
+
+type TeamChannel = {
+  _id: Id<"chatChannels">;
+  name: string;
+  channelType: string;
+  memberCount: number;
+};
+
+type Role = {
+  _id: Id<"teamRoles">;
+  name: string;
+  color?: string;
+  sortOrder: number;
+  defaultNeeded?: number;
+  isArchived: boolean;
+};
+
+type Props = {
+  groupId: Id<"groups">;
+  /** Current selectors — fully controlled by the parent. */
+  selectors: CrossTeamSelector[];
+  onChange: (selectors: CrossTeamSelector[]) => void;
+  /** Disables all interaction (e.g. while a create/update is in flight). */
+  disabled?: boolean;
+};
+
+/** Two selectors are equal iff they point at the same team + same role. */
+function sameSelector(a: CrossTeamSelector, b: CrossTeamSelector): boolean {
+  return a.sourceChannelId === b.sourceChannelId && a.roleId === b.roleId;
+}
+
+export function CrossTeamSelectorPicker({
+  groupId,
+  selectors,
+  onChange,
+  disabled,
+}: Props) {
+  const { colors } = useTheme();
+
+  const teams = useAuthenticatedQuery(
+    api.functions.scheduling.teams.listTeamChannels,
+    { groupId },
+  ) as TeamChannel[] | undefined;
+
+  // Which team rows are expanded to show their roles.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const toggleExpanded = useCallback((channelId: string) => {
+    setExpanded((prev) => ({ ...prev, [channelId]: !prev[channelId] }));
+  }, []);
+
+  const toggleSelector = useCallback(
+    (selector: CrossTeamSelector) => {
+      if (disabled) return;
+      const exists = selectors.some((s) => sameSelector(s, selector));
+      onChange(
+        exists
+          ? selectors.filter((s) => !sameSelector(s, selector))
+          : [...selectors, selector],
+      );
+    },
+    [disabled, selectors, onChange],
+  );
+
+  if (teams === undefined) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="small" color={colors.text} />
+      </View>
+    );
+  }
+
+  if (teams.length === 0) {
+    return (
+      <View
+        style={[styles.emptyBox, { backgroundColor: colors.surfaceSecondary }]}
+      >
+        <Ionicons
+          name="people-circle-outline"
+          size={28}
+          color={colors.textSecondary}
+        />
+        <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+          This group has no serving teams yet. Set up at least one serving-team
+          channel with roles before creating a cross-team channel.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      {/* Chosen selectors */}
+      {selectors.length > 0 && (
+        <View style={styles.chipWrap}>
+          {selectors.map((selector) => (
+            <SelectorChip
+              key={`${selector.sourceChannelId}:${selector.roleId ?? "any"}`}
+              selector={selector}
+              teams={teams}
+              groupId={groupId}
+              onRemove={() => toggleSelector(selector)}
+              disabled={disabled}
+            />
+          ))}
+        </View>
+      )}
+
+      {/* Team list */}
+      <View
+        style={[styles.teamGroup, { backgroundColor: colors.surfaceSecondary }]}
+      >
+        {teams.map((team, idx) => (
+          <TeamRow
+            key={team._id}
+            team={team}
+            isExpanded={!!expanded[team._id]}
+            isFirst={idx === 0}
+            selectors={selectors}
+            onToggleExpanded={() => toggleExpanded(team._id)}
+            onToggleSelector={toggleSelector}
+            disabled={disabled}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+/** A single team row — header tap expands its roles. */
+function TeamRow({
+  team,
+  isExpanded,
+  isFirst,
+  selectors,
+  onToggleExpanded,
+  onToggleSelector,
+  disabled,
+}: {
+  team: TeamChannel;
+  isExpanded: boolean;
+  isFirst: boolean;
+  selectors: CrossTeamSelector[];
+  onToggleExpanded: () => void;
+  onToggleSelector: (selector: CrossTeamSelector) => void;
+  disabled?: boolean;
+}) {
+  const { colors } = useTheme();
+
+  // Count how many selectors target this team — surfaced as a badge.
+  const teamSelectorCount = selectors.filter(
+    (s) => s.sourceChannelId === team._id,
+  ).length;
+
+  return (
+    <View
+      style={
+        !isFirst && {
+          borderTopWidth: StyleSheet.hairlineWidth,
+          borderTopColor: colors.border,
+        }
+      }
+    >
+      <Pressable
+        onPress={onToggleExpanded}
+        disabled={disabled}
+        style={({ pressed }) => [
+          styles.teamRow,
+          pressed && { backgroundColor: colors.selectedBackground },
+        ]}
+      >
+        <Ionicons
+          name="people-outline"
+          size={20}
+          color={colors.textSecondary}
+        />
+        <Text
+          style={[styles.teamName, { color: colors.text }]}
+          numberOfLines={1}
+        >
+          {team.name}
+        </Text>
+        {teamSelectorCount > 0 && (
+          <View style={[styles.countBadge, { backgroundColor: colors.text }]}>
+            <Text style={[styles.countBadgeText, { color: colors.surface }]}>
+              {teamSelectorCount}
+            </Text>
+          </View>
+        )}
+        <Ionicons
+          name={isExpanded ? "chevron-up" : "chevron-down"}
+          size={18}
+          color={colors.textTertiary}
+        />
+      </Pressable>
+
+      {isExpanded && (
+        <TeamRoles
+          channelId={team._id}
+          selectors={selectors}
+          onToggleSelector={onToggleSelector}
+          disabled={disabled}
+        />
+      )}
+    </View>
+  );
+}
+
+/** Role options for an expanded team: "Any role" + each specific role. */
+function TeamRoles({
+  channelId,
+  selectors,
+  onToggleSelector,
+  disabled,
+}: {
+  channelId: Id<"chatChannels">;
+  selectors: CrossTeamSelector[];
+  onToggleSelector: (selector: CrossTeamSelector) => void;
+  disabled?: boolean;
+}) {
+  const { colors } = useTheme();
+
+  const roles = useAuthenticatedQuery(
+    api.functions.scheduling.roles.listRoles,
+    { channelId },
+  ) as Role[] | undefined;
+
+  const isChosen = useCallback(
+    (roleId?: Id<"teamRoles">) =>
+      selectors.some(
+        (s) => s.sourceChannelId === channelId && s.roleId === roleId,
+      ),
+    [selectors, channelId],
+  );
+
+  if (roles === undefined) {
+    return (
+      <View style={styles.rolesLoading}>
+        <ActivityIndicator size="small" color={colors.textSecondary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.rolesWrap}>
+      <RoleOption
+        label="Any role on this team"
+        color={colors.textSecondary}
+        selected={isChosen(undefined)}
+        onPress={() => onToggleSelector({ sourceChannelId: channelId })}
+        disabled={disabled}
+      />
+      {roles.map((role) => (
+        <RoleOption
+          key={role._id}
+          label={role.name}
+          color={role.color ?? DEFAULT_ROLE_COLOR}
+          selected={isChosen(role._id)}
+          onPress={() =>
+            onToggleSelector({ sourceChannelId: channelId, roleId: role._id })
+          }
+          disabled={disabled}
+        />
+      ))}
+      {roles.length === 0 && (
+        <Text style={[styles.noRolesText, { color: colors.textTertiary }]}>
+          This team has no roles yet. "Any role on this team" still works.
+        </Text>
+      )}
+    </View>
+  );
+}
+
+/** A single tappable role option (checkbox-style). */
+function RoleOption({
+  label,
+  color,
+  selected,
+  onPress,
+  disabled,
+}: {
+  label: string;
+  color: string;
+  selected: boolean;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
+  const { colors } = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.roleOption,
+        pressed && { backgroundColor: colors.selectedBackground },
+        disabled && { opacity: 0.5 },
+      ]}
+    >
+      <View style={[styles.roleSwatch, { backgroundColor: color }]} />
+      <Text style={[styles.roleOptionLabel, { color: colors.text }]}>
+        {label}
+      </Text>
+      <Ionicons
+        name={selected ? "checkbox" : "square-outline"}
+        size={22}
+        color={selected ? colors.text : colors.textTertiary}
+        style={{ marginLeft: "auto" }}
+      />
+    </Pressable>
+  );
+}
+
+/** A removable chip for one chosen selector. */
+function SelectorChip({
+  selector,
+  teams,
+  groupId,
+  onRemove,
+  disabled,
+}: {
+  selector: CrossTeamSelector;
+  teams: TeamChannel[];
+  groupId: Id<"groups">;
+  onRemove: () => void;
+  disabled?: boolean;
+}) {
+  const { colors } = useTheme();
+
+  const teamName =
+    teams.find((t) => t._id === selector.sourceChannelId)?.name ??
+    "Unknown team";
+
+  // Fetch the source team's roles only to resolve the chosen role's name.
+  const roles = useAuthenticatedQuery(
+    api.functions.scheduling.roles.listRoles,
+    selector.roleId ? { channelId: selector.sourceChannelId } : "skip",
+  ) as Role[] | undefined;
+
+  const roleLabel = selector.roleId
+    ? (roles?.find((r) => r._id === selector.roleId)?.name ?? "Role")
+    : "Any role";
+
+  // groupId is accepted for API symmetry with the picker; unused here.
+  void groupId;
+
+  return (
+    <View style={[styles.chip, { backgroundColor: colors.selectedBackground }]}>
+      <Text style={[styles.chipText, { color: colors.text }]} numberOfLines={1}>
+        {teamName} — {roleLabel}
+      </Text>
+      <Pressable onPress={onRemove} disabled={disabled} hitSlop={8}>
+        <Ionicons name="close-circle" size={18} color={colors.textSecondary} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: {
+    paddingVertical: 24,
+    alignItems: "center",
+  },
+  emptyBox: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderRadius: 12,
+    padding: 16,
+  },
+  emptyText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  chipWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 12,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    maxWidth: "100%",
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: "500",
+    flexShrink: 1,
+  },
+  teamGroup: {
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  teamRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+    minHeight: 48,
+  },
+  teamName: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  countBadge: {
+    minWidth: 20,
+    height: 20,
+    borderRadius: 10,
+    paddingHorizontal: 6,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  countBadgeText: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  rolesLoading: {
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  rolesWrap: {
+    paddingBottom: 8,
+    paddingLeft: 12,
+  },
+  roleOption: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    minHeight: 44,
+  },
+  roleSwatch: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  roleOptionLabel: {
+    fontSize: 15,
+  },
+  noRolesText: {
+    fontSize: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    lineHeight: 16,
+  },
+});

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -5,6 +5,17 @@
  */
 export { TeamSetupScreen } from "./components/TeamSetupScreen";
 export { RolesEditor } from "./components/RolesEditor";
+export { CrossTeamSelectorPicker } from "./components/CrossTeamSelectorPicker";
+export type {
+  CrossTeamSelector,
+  CrossTeamChannel,
+  EnrichedCrossTeamSelector,
+} from "./api/crossTeamChannels";
+export {
+  createCrossTeamChannelRef,
+  updateCrossTeamChannelRef,
+  listCrossTeamChannelsRef,
+} from "./api/crossTeamChannels";
 export { EventListScreen } from "./components/EventListScreen";
 export { EventEditorScreen } from "./components/EventEditorScreen";
 export { MyScheduleScreen } from "./components/MyScheduleScreen";


### PR DESCRIPTION
Cross-team channels auto-sync membership from event-plan role assignments
across multiple serving teams (e.g. all worship leaders + technical
directors), reusing the existing event_plan rotation window so members
rotate in ~5 days before an event and out ~1 day after.

- Add "cross_team" channelType and crossTeamSync selectors to chatChannels
- Generalize reconcileTeamChannelImpl to union assignments across selectors
- Fan out reconcile to cross-team channels on assignment/event mutations
- Add create/update/list config functions and a daily-cron entry
- Exclude cross-team channels from group-membership sync

https://claude.ai/code/session_013Nfg5etobZzcXsLuwPCuh5