### PR TITLE
fix(scheduling): stop all_in_series edits from collapsing occurrence dates

### DIFF
--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -1224,4 +1224,59 @@ describe("communityWideEvents.repairCollapsedChildDates", () => {
     );
     expect(second.meetingsRepaired).toBe(0);
   });
+
+  test("leaves cancelled children untouched", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    const date1 = new Date("2026-04-10T18:00:00Z").getTime();
+    const date2 = new Date("2026-04-17T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [date1, date2],
+        title: "Dinner",
+        meetingType: 1,
+      }
+    );
+
+    // Collapse occurrence 2's children onto date1; cancel one of them.
+    let cancelledId: Id<"meetings">;
+    await t.run(async (ctx) => {
+      const occ2 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      for (const [i, m] of occ2.entries()) {
+        if (i === 0) {
+          cancelledId = m._id;
+          await ctx.db.patch(m._id, { scheduledAt: date1, status: "cancelled" });
+        } else {
+          await ctx.db.patch(m._id, { scheduledAt: date1 });
+        }
+      }
+    });
+
+    const result = await t.mutation(
+      internal.functions.communityWideEvents.repairCollapsedChildDates,
+      {}
+    );
+
+    // Only the 2 non-cancelled collapsed children are repaired.
+    expect(result.meetingsRepaired).toBe(2);
+
+    await t.run(async (ctx) => {
+      const cancelled = await ctx.db.get(cancelledId);
+      // Cancelled meeting is never repaired or rescheduled.
+      expect(cancelled!.status).toBe("cancelled");
+      expect(cancelled!.scheduledAt).toBe(date1);
+    });
+  });
 });

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -1005,6 +1005,75 @@ describe("communityWideEvents.update with scope", () => {
     });
   });
 
+  test("scope=all_in_series skips cancelled direct children", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    const date1 = new Date("2026-04-10T18:00:00Z").getTime();
+    const date2 = new Date("2026-04-17T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [date1, date2],
+        title: "Original",
+        meetingType: 1,
+      }
+    );
+
+    // One group's occurrence-1 meeting is already cancelled.
+    let cancelledId: Id<"meetings">;
+    await t.run(async (ctx) => {
+      const occ1 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      cancelledId = occ1[0]._id;
+      await ctx.db.patch(cancelledId, { status: "cancelled" });
+    });
+
+    const newDate1 = new Date("2026-04-11T19:00:00Z").getTime();
+    const updateResult = await t.mutation(
+      api.functions.communityWideEvents.update,
+      {
+        token: setup.adminToken,
+        communityWideEventId: createResult.communityWideEventIds[0],
+        title: "Updated",
+        scheduledAt: newDate1,
+        scope: "all_in_series",
+      }
+    );
+
+    // occ1: 2 non-cancelled children; occ2: 3 — the cancelled one is skipped.
+    expect(updateResult.meetingsUpdated).toBe(5);
+
+    await t.run(async (ctx) => {
+      const cancelled = await ctx.db.get(cancelledId);
+      // Untouched by the update: still cancelled, original title and date.
+      expect(cancelled!.status).toBe("cancelled");
+      expect(cancelled!.title).toBe("Original");
+      expect(cancelled!.scheduledAt).toBe(date1);
+
+      const occ1 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      for (const m of occ1) {
+        if (m._id === cancelledId) continue;
+        expect(m.title).toBe("Updated");
+        expect(m.scheduledAt).toBe(newDate1);
+      }
+    });
+  });
+
   test("scope=all_in_series cascades even when edited occurrence is fully overridden", async () => {
     const t = convexTest(schema, modules);
     const setup = await setupCommunityWideTestData(t);

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -40,6 +40,9 @@ process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
 beforeEach(() => {
   vi.useFakeTimers();
+  // Pin "now" well before every date these tests use, so series occurrences
+  // are deterministically in the future regardless of the machine clock.
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
 });
 
 afterEach(() => {
@@ -933,6 +936,72 @@ describe("communityWideEvents.update with scope", () => {
       // The second occurrence's parent CWE also keeps its own date.
       const cwe2 = await ctx.db.get(createResult.communityWideEventIds[1]);
       expect(cwe2!.scheduledAt).toBe(date2);
+    });
+  });
+
+  test("scope=all_in_series leaves PAST occurrences untouched", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    // System time is pinned to 2026-01-01 (see beforeEach).
+    const pastDate = new Date("2025-12-01T18:00:00Z").getTime();
+    const futureDate1 = new Date("2026-04-10T18:00:00Z").getTime();
+    const futureDate2 = new Date("2026-04-17T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [pastDate, futureDate1, futureDate2],
+        title: "Original",
+        meetingType: 1,
+      }
+    );
+
+    // Edit the first FUTURE occurrence with scope: "all_in_series".
+    const updateResult = await t.mutation(
+      api.functions.communityWideEvents.update,
+      {
+        token: setup.adminToken,
+        communityWideEventId: createResult.communityWideEventIds[1],
+        title: "Updated",
+        scope: "all_in_series",
+      }
+    );
+
+    // Only the two future occurrences' meetings (3 groups x 2 dates).
+    expect(updateResult.meetingsUpdated).toBe(6);
+
+    await t.run(async (ctx) => {
+      // Past occurrence: untouched.
+      const pastMeetings = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      for (const m of pastMeetings) {
+        expect(m.title).toBe("Original");
+      }
+
+      // Both future occurrences: updated.
+      for (const cweId of [
+        createResult.communityWideEventIds[1],
+        createResult.communityWideEventIds[2],
+      ]) {
+        const meetings = await ctx.db
+          .query("meetings")
+          .withIndex("by_communityWideEvent", (q) =>
+            q.eq("communityWideEventId", cweId)
+          )
+          .collect();
+        for (const m of meetings) {
+          expect(m.title).toBe("Updated");
+        }
+      }
     });
   });
 });

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -1281,6 +1281,70 @@ describe("communityWideEvents.update with scope", () => {
       expect(pastParent!.title).toBe("Original");
     });
   });
+
+  test("scope=all_in_series anchored on a past occurrence skips that anchor", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    // System time is 2026-01-01 (see beforeEach).
+    const pastDate = new Date("2025-12-01T18:00:00Z").getTime();
+    const futureDate = new Date("2026-04-10T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [pastDate, futureDate],
+        title: "Original",
+        meetingType: 1,
+      }
+    );
+
+    // Anchor the all_in_series edit on the PAST occurrence.
+    const updateResult = await t.mutation(
+      api.functions.communityWideEvents.update,
+      {
+        token: setup.adminToken,
+        communityWideEventId: createResult.communityWideEventIds[0],
+        title: "Updated",
+        scope: "all_in_series",
+      }
+    );
+
+    // Only the future occurrence's 3 children — the past anchor is skipped.
+    expect(updateResult.meetingsUpdated).toBe(3);
+
+    await t.run(async (ctx) => {
+      // Past anchor: parent and children untouched.
+      const pastParent = await ctx.db.get(createResult.communityWideEventIds[0]);
+      expect(pastParent!.title).toBe("Original");
+      const pastChildren = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      for (const m of pastChildren) {
+        expect(m.title).toBe("Original");
+      }
+
+      // Future occurrence: parent and children updated.
+      const futureParent = await ctx.db.get(createResult.communityWideEventIds[1]);
+      expect(futureParent!.title).toBe("Updated");
+      const futureChildren = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      for (const m of futureChildren) {
+        expect(m.title).toBe("Updated");
+      }
+    });
+  });
 });
 
 // ============================================================================

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -1215,6 +1215,72 @@ describe("communityWideEvents.update with scope", () => {
       }
     });
   });
+
+  test("scope=all_in_series skips a past occurrence even if its child dates are corrupt", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    // System time is 2026-01-01 (see beforeEach).
+    const pastDate = new Date("2025-12-01T18:00:00Z").getTime();
+    const futureDate = new Date("2026-04-10T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [pastDate, futureDate],
+        title: "Original",
+        meetingType: 1,
+      }
+    );
+
+    // Simulate the collapsed-date corruption: the PAST occurrence's children
+    // carry a future scheduledAt. The parent CWE keeps its real past date.
+    const corruptDate = new Date("2026-06-01T18:00:00Z").getTime();
+    await t.run(async (ctx) => {
+      const pastChildren = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      for (const m of pastChildren) {
+        await ctx.db.patch(m._id, { scheduledAt: corruptDate });
+      }
+    });
+
+    const updateResult = await t.mutation(
+      api.functions.communityWideEvents.update,
+      {
+        token: setup.adminToken,
+        communityWideEventId: createResult.communityWideEventIds[1],
+        title: "Updated",
+        scope: "all_in_series",
+      }
+    );
+
+    // Only the future occurrence's 3 children — the past occurrence is excluded
+    // because its parent CWE date is in the past, not its (corrupt) child date.
+    expect(updateResult.meetingsUpdated).toBe(3);
+
+    await t.run(async (ctx) => {
+      const pastChildren = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      for (const m of pastChildren) {
+        expect(m.title).toBe("Original");
+      }
+      // The past occurrence's parent record is left stale too.
+      const pastParent = await ctx.db.get(createResult.communityWideEventIds[0]);
+      expect(pastParent!.title).toBe("Original");
+    });
+  });
 });
 
 // ============================================================================

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -1002,6 +1002,18 @@ describe("communityWideEvents.update with scope", () => {
           expect(m.title).toBe("Updated");
         }
       }
+
+      // Parent communityWideEvents: future ones cascade, the past one does not.
+      // The Events feed renders titles from the parent record.
+      const pastParent = await ctx.db.get(createResult.communityWideEventIds[0]);
+      expect(pastParent!.title).toBe("Original");
+      for (const cweId of [
+        createResult.communityWideEventIds[1],
+        createResult.communityWideEventIds[2],
+      ]) {
+        const parent = await ctx.db.get(cweId);
+        expect(parent!.title).toBe("Updated");
+      }
     });
   });
 

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -1004,6 +1004,76 @@ describe("communityWideEvents.update with scope", () => {
       }
     });
   });
+
+  test("scope=all_in_series cascades even when edited occurrence is fully overridden", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    const date1 = new Date("2026-04-10T18:00:00Z").getTime();
+    const date2 = new Date("2026-04-17T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [date1, date2],
+        title: "Original",
+        meetingType: 1,
+      }
+    );
+
+    // Every direct child of occurrence 1 is overridden. Series discovery must
+    // still find the seriesId from these rows so the cascade reaches occ 2.
+    await t.run(async (ctx) => {
+      const occ1 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      for (const m of occ1) {
+        await ctx.db.patch(m._id, { isOverridden: true });
+      }
+    });
+
+    const updateResult = await t.mutation(
+      api.functions.communityWideEvents.update,
+      {
+        token: setup.adminToken,
+        communityWideEventId: createResult.communityWideEventIds[0],
+        title: "Updated",
+        scope: "all_in_series",
+      }
+    );
+
+    // Occurrence 1's children are all overridden — only occ 2's 3 update.
+    expect(updateResult.meetingsUpdated).toBe(3);
+
+    await t.run(async (ctx) => {
+      const occ1 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      for (const m of occ1) {
+        expect(m.title).toBe("Original");
+      }
+
+      const occ2 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      for (const m of occ2) {
+        expect(m.title).toBe("Updated");
+      }
+    });
+  });
 });
 
 // ============================================================================

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -32,7 +32,7 @@ vi.mock("jose", () => ({
 
 import { convexTest } from "convex-test";
 import schema from "../schema";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { modules } from "../test.setup";
 
@@ -866,5 +866,154 @@ describe("communityWideEvents.update with scope", () => {
         }
       }
     });
+  });
+
+  test("scope=all_in_series does NOT collapse other occurrences' dates", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    const date1 = new Date("2026-04-10T18:00:00Z").getTime();
+    const date2 = new Date("2026-04-17T18:00:00Z").getTime();
+
+    // Create series with 2 dates, 3 groups (6 meetings)
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [date1, date2],
+        title: "Dinner",
+        meetingType: 1,
+      }
+    );
+
+    // Move the FIRST occurrence to a new time, with scope: "all_in_series".
+    // The title change should cascade to every occurrence, but the date
+    // change must apply ONLY to this occurrence — the second occurrence
+    // keeps its own date2.
+    const newDate1 = new Date("2026-04-11T19:00:00Z").getTime();
+    await t.mutation(api.functions.communityWideEvents.update, {
+      token: setup.adminToken,
+      communityWideEventId: createResult.communityWideEventIds[0],
+      title: "Renamed",
+      scheduledAt: newDate1,
+      scope: "all_in_series",
+    });
+
+    await t.run(async (ctx) => {
+      // Occurrence 1: children moved to newDate1
+      const occ1 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[0])
+        )
+        .collect();
+      expect(occ1).toHaveLength(3);
+      for (const m of occ1) {
+        expect(m.scheduledAt).toBe(newDate1);
+        expect(m.title).toBe("Renamed");
+      }
+
+      // Occurrence 2: children KEPT date2 — not collapsed onto newDate1.
+      const occ2 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      expect(occ2).toHaveLength(3);
+      for (const m of occ2) {
+        expect(m.scheduledAt).toBe(date2);
+        // Non-date fields still cascade.
+        expect(m.title).toBe("Renamed");
+      }
+
+      // The second occurrence's parent CWE also keeps its own date.
+      const cwe2 = await ctx.db.get(createResult.communityWideEventIds[1]);
+      expect(cwe2!.scheduledAt).toBe(date2);
+    });
+  });
+});
+
+// ============================================================================
+// communityWideEvents.repairCollapsedChildDates
+// ============================================================================
+
+describe("communityWideEvents.repairCollapsedChildDates", () => {
+  test("restores collapsed child dates, skips overrides", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    const date1 = new Date("2026-04-10T18:00:00Z").getTime();
+    const date2 = new Date("2026-04-17T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [date1, date2],
+        title: "Dinner",
+        meetingType: 1,
+      }
+    );
+
+    // Simulate the old bug: collapse occurrence 2's children onto date1, and
+    // mark one of them as an override that the repair must NOT touch.
+    let overriddenId: Id<"meetings">;
+    await t.run(async (ctx) => {
+      const occ2 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      for (const [i, m] of occ2.entries()) {
+        if (i === 0) {
+          // An intentional per-group override at a custom time.
+          overriddenId = m._id;
+          await ctx.db.patch(m._id, { scheduledAt: date1, isOverridden: true });
+        } else {
+          await ctx.db.patch(m._id, { scheduledAt: date1 });
+        }
+      }
+    });
+
+    const result = await t.mutation(
+      internal.functions.communityWideEvents.repairCollapsedChildDates,
+      {}
+    );
+
+    // 2 of occurrence 2's 3 children were collapsed and non-overridden.
+    expect(result.meetingsRepaired).toBe(2);
+
+    await t.run(async (ctx) => {
+      const occ2 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      for (const m of occ2) {
+        if (m._id === overriddenId) {
+          // Override left exactly as the leader set it.
+          expect(m.scheduledAt).toBe(date1);
+          expect(m.isOverridden).toBe(true);
+        } else {
+          expect(m.scheduledAt).toBe(date2);
+        }
+      }
+    });
+
+    // Idempotent — a second run finds nothing to repair.
+    const second = await t.mutation(
+      internal.functions.communityWideEvents.repairCollapsedChildDates,
+      {}
+    );
+    expect(second.meetingsRepaired).toBe(0);
   });
 });

--- a/apps/convex/__tests__/communityWideEvents-series.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-series.test.ts
@@ -1155,6 +1155,66 @@ describe("communityWideEvents.update with scope", () => {
       }
     });
   });
+
+  test("scope=all_in_series cascades to a future parent whose children are all overridden", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupCommunityWideTestData(t);
+
+    const date1 = new Date("2026-04-10T18:00:00Z").getTime();
+    const date2 = new Date("2026-04-17T18:00:00Z").getTime();
+
+    const createResult = await t.mutation(
+      api.functions.communityWideEvents.createSeries,
+      {
+        token: setup.adminToken,
+        communityId: setup.communityId,
+        groupTypeId: setup.groupTypeId,
+        seriesName: "Weekly Dinner",
+        dates: [date1, date2],
+        title: "Original",
+        meetingType: 1,
+      }
+    );
+
+    // The future occurrence 2 has every child overridden — none of its
+    // meetings will be in cascadeMeetings, but its parent record must still
+    // receive the all-series title change (the feed renders parent.title).
+    await t.run(async (ctx) => {
+      const occ2 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      for (const m of occ2) {
+        await ctx.db.patch(m._id, { isOverridden: true });
+      }
+    });
+
+    await t.mutation(api.functions.communityWideEvents.update, {
+      token: setup.adminToken,
+      communityWideEventId: createResult.communityWideEventIds[0],
+      title: "Updated",
+      scope: "all_in_series",
+    });
+
+    await t.run(async (ctx) => {
+      // Occurrence 2's parent record cascaded despite all children overridden.
+      const parent2 = await ctx.db.get(createResult.communityWideEventIds[1]);
+      expect(parent2!.title).toBe("Updated");
+
+      // Its overridden child meetings are still left untouched.
+      const occ2 = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", createResult.communityWideEventIds[1])
+        )
+        .collect();
+      for (const m of occ2) {
+        expect(m.title).toBe("Original");
+      }
+    });
+  });
 });
 
 // ============================================================================

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -285,19 +285,28 @@ export const update = mutation({
     // "all_in_series" — but only to this occurrence and *future* ones. Past
     // occurrences have already happened; editing them would rewrite history.
     // ----------------------------------------------------------------
-    const directChildren = await ctx.db
+    // All direct children of this occurrence. Overridden ones are kept here
+    // only for series discovery — a `seriesId` lives on every child, and the
+    // edited occurrence could have all of its children overridden, in which
+    // case filtering first would lose the series link entirely.
+    const allDirectChildren = await ctx.db
       .query("meetings")
       .withIndex("by_communityWideEvent", (q) =>
         q.eq("communityWideEventId", args.communityWideEventId)
       )
-      .filter((q) => q.neq(q.field("isOverridden"), true))
       .collect();
+
+    // Non-overridden children receive the edit. Overridden meetings are
+    // intentional per-group customizations and are left untouched.
+    const directChildren = allDirectChildren.filter(
+      (m) => m.isOverridden !== true
+    );
 
     // Meetings that receive non-date field edits.
     let cascadeMeetings: typeof directChildren = directChildren;
     if (args.scope === "all_in_series") {
       const seriesIds = new Set(
-        directChildren
+        allDirectChildren
           .map((m) => m.seriesId)
           .filter((id): id is Id<"eventSeries"> => !!id)
       );

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -273,124 +273,135 @@ export const update = mutation({
     // Update the parent event
     await ctx.db.patch(args.communityWideEventId, parentUpdates);
 
-    // Determine which meetings to update based on scope
-    let childMeetings;
+    // ----------------------------------------------------------------
+    // Determine which meetings receive the edit.
+    //
+    // A scheduledAt change ONLY ever applies to this occurrence's direct
+    // children. Each occurrence in a series has its own date, so cascading
+    // one absolute timestamp across the series would collapse every other
+    // occurrence (including past ones) onto the same day. Non-date fields
+    // (title, note, RSVP config, …) still cascade across the whole series
+    // when scope is "all_in_series".
+    // ----------------------------------------------------------------
+    const directChildren = await ctx.db
+      .query("meetings")
+      .withIndex("by_communityWideEvent", (q) =>
+        q.eq("communityWideEventId", args.communityWideEventId)
+      )
+      .filter((q) => q.neq(q.field("isOverridden"), true))
+      .collect();
+
+    // Meetings that receive non-date field edits.
+    let cascadeMeetings: typeof directChildren = directChildren;
     if (args.scope === "all_in_series") {
-      // Find all seriesIds from child meetings of this communityWideEvent,
-      // then gather all meetings across those series
-      const directChildren = await ctx.db
-        .query("meetings")
-        .withIndex("by_communityWideEvent", (q) =>
-          q.eq("communityWideEventId", args.communityWideEventId)
-        )
-        .collect();
-
       const seriesIds = new Set(
-        directChildren.map((m) => m.seriesId).filter((id): id is Id<"eventSeries"> => !!id)
+        directChildren
+          .map((m) => m.seriesId)
+          .filter((id): id is Id<"eventSeries"> => !!id)
       );
-
       if (seriesIds.size > 0) {
-        // Gather all meetings from all discovered series
-        const allSeriesMeetings = [];
+        const seen = new Set<string>();
+        const collected: typeof directChildren = [];
         for (const sid of seriesIds) {
           const seriesMeetings = await ctx.db
             .query("meetings")
             .withIndex("by_series", (q) => q.eq("seriesId", sid))
             .collect();
-          allSeriesMeetings.push(...seriesMeetings);
+          for (const m of seriesMeetings) {
+            if (seen.has(m._id)) continue;
+            seen.add(m._id);
+            if (m.isOverridden === true || m.status === "cancelled") continue;
+            collected.push(m);
+          }
         }
-        // Deduplicate and filter to non-overridden, non-cancelled
-        const seen = new Set<string>();
-        childMeetings = allSeriesMeetings.filter((m) => {
-          if (seen.has(m._id)) return false;
-          seen.add(m._id);
-          return m.isOverridden !== true && m.status !== "cancelled";
-        });
-      } else {
-        // No series — fall back to direct children only
-        childMeetings = directChildren.filter((m) => m.isOverridden !== true);
+        cascadeMeetings = collected;
       }
-    } else {
-      // Default: this_date_all_groups — existing behavior
-      childMeetings = await ctx.db
-        .query("meetings")
-        .withIndex("by_communityWideEvent", (q) =>
-          q.eq("communityWideEventId", args.communityWideEventId)
-        )
-        .filter((q) => q.neq(q.field("isOverridden"), true))
-        .collect();
     }
 
-    // Build update object for child meetings
-    const childUpdates: Record<string, unknown> = {};
-    if (args.title !== undefined) childUpdates.title = args.title;
-    if (args.scheduledAt !== undefined) {
-      childUpdates.scheduledAt = args.scheduledAt;
-      // Recalculate reminder and attendance confirmation times
-      childUpdates.reminderAt = args.scheduledAt - DEFAULT_REMINDER_OFFSET_MS;
-      const meetingEndTime = args.scheduledAt + DEFAULT_MEETING_DURATION_MS;
-      childUpdates.attendanceConfirmationAt = meetingEndTime + DEFAULT_ATTENDANCE_CONFIRMATION_OFFSET_MS;
-      // Reset sent flags
-      childUpdates.reminderSent = false;
-      childUpdates.attendanceConfirmationSent = false;
-    }
-    if (args.meetingType !== undefined) childUpdates.meetingType = args.meetingType;
-    if (args.meetingLink !== undefined) childUpdates.meetingLink = args.meetingLink;
-    if (args.note !== undefined) childUpdates.note = args.note;
+    // Non-date field updates — cascade to the scoped set.
+    const cascadeUpdates: Record<string, unknown> = {};
+    if (args.title !== undefined) cascadeUpdates.title = args.title;
+    if (args.meetingType !== undefined) cascadeUpdates.meetingType = args.meetingType;
+    if (args.meetingLink !== undefined) cascadeUpdates.meetingLink = args.meetingLink;
+    if (args.note !== undefined) cascadeUpdates.note = args.note;
     // coverImage is intentionally NOT cascaded — it's parent-only so that
     // admin-level cover edits don't clobber per-group leader overrides. The
     // read paths already fall back from child → parent when the child has no
     // cover of its own.
-    if (args.rsvpEnabled !== undefined) childUpdates.rsvpEnabled = args.rsvpEnabled;
-    if (args.rsvpOptions !== undefined) childUpdates.rsvpOptions = args.rsvpOptions;
-    if (args.hideRsvpCount !== undefined) childUpdates.hideRsvpCount = args.hideRsvpCount;
-    if (args.visibility !== undefined) childUpdates.visibility = args.visibility;
+    if (args.rsvpEnabled !== undefined) cascadeUpdates.rsvpEnabled = args.rsvpEnabled;
+    if (args.rsvpOptions !== undefined) cascadeUpdates.rsvpOptions = args.rsvpOptions;
+    if (args.hideRsvpCount !== undefined) cascadeUpdates.hideRsvpCount = args.hideRsvpCount;
+    if (args.visibility !== undefined) cascadeUpdates.visibility = args.visibility;
 
-    // Update all non-overridden child meetings
+    // Date update — applies ONLY to this occurrence's direct children.
+    const dateChanged = args.scheduledAt !== undefined;
+    const dateUpdates: Record<string, unknown> = {};
+    if (dateChanged) {
+      const scheduledAt = args.scheduledAt as number;
+      dateUpdates.scheduledAt = scheduledAt;
+      dateUpdates.reminderAt = scheduledAt - DEFAULT_REMINDER_OFFSET_MS;
+      dateUpdates.attendanceConfirmationAt =
+        scheduledAt + DEFAULT_MEETING_DURATION_MS + DEFAULT_ATTENDANCE_CONFIRMATION_OFFSET_MS;
+      // Reset sent flags
+      dateUpdates.reminderSent = false;
+      dateUpdates.attendanceConfirmationSent = false;
+    }
+
+    // Merge per-meeting patches so each meeting is written at most once.
+    const directIds = new Set(directChildren.map((m) => m._id));
+    const patches = new Map<
+      Id<"meetings">,
+      { meeting: (typeof directChildren)[number]; patch: Record<string, unknown> }
+    >();
+    for (const m of cascadeMeetings) {
+      patches.set(m._id, { meeting: m, patch: { ...cascadeUpdates } });
+    }
+    if (dateChanged) {
+      for (const m of directChildren) {
+        const entry = patches.get(m._id) ?? { meeting: m, patch: {} };
+        Object.assign(entry.patch, dateUpdates);
+        patches.set(m._id, entry);
+      }
+    }
+
+    // Apply patches and reschedule jobs for any occurrence whose time changed.
     let meetingsUpdated = 0;
-    for (const meeting of childMeetings) {
-      // Cancel old scheduled jobs before scheduling new ones if time changed
-      if (args.scheduledAt !== undefined) {
-        // Cancel existing reminder job if present
+    for (const { meeting, patch } of patches.values()) {
+      const timeChangedForThis = dateChanged && directIds.has(meeting._id);
+
+      // Cancel old scheduled jobs before scheduling new ones if time changed.
+      if (timeChangedForThis) {
         if (meeting.reminderJobId) {
-          try {
-            await ctx.scheduler.cancel(meeting.reminderJobId);
-          } catch {
-            // Job may have already run or been cancelled - ignore
-          }
+          try { await ctx.scheduler.cancel(meeting.reminderJobId); } catch { /* already run */ }
         }
-        // Cancel existing attendance confirmation job if present
         if (meeting.attendanceConfirmationJobId) {
-          try {
-            await ctx.scheduler.cancel(meeting.attendanceConfirmationJobId);
-          } catch {
-            // Job may have already run or been cancelled - ignore
-          }
+          try { await ctx.scheduler.cancel(meeting.attendanceConfirmationJobId); } catch { /* already run */ }
         }
       }
 
-      const patchPayload: Record<string, unknown> = { ...childUpdates };
       if (args.title !== undefined) {
         const group = await ctx.db.get(meeting.groupId);
-        patchPayload.searchText = buildMeetingSearchText({
+        patch.searchText = buildMeetingSearchText({
           title: args.title,
           locationOverride: meeting.locationOverride,
           groupName: group?.name,
         });
       }
 
-      await ctx.db.patch(meeting._id, patchPayload);
+      if (Object.keys(patch).length > 0) {
+        await ctx.db.patch(meeting._id, patch);
+      }
 
-      // Reschedule jobs if time changed and store new job IDs
-      if (args.scheduledAt !== undefined) {
-        const newReminderAt = args.scheduledAt - DEFAULT_REMINDER_OFFSET_MS;
+      // Reschedule jobs if this occurrence's time changed.
+      if (timeChangedForThis) {
+        const scheduledAt = args.scheduledAt as number;
+        const newReminderAt = scheduledAt - DEFAULT_REMINDER_OFFSET_MS;
         const newAttendanceConfirmationAt =
-          args.scheduledAt + DEFAULT_MEETING_DURATION_MS + DEFAULT_ATTENDANCE_CONFIRMATION_OFFSET_MS;
+          scheduledAt + DEFAULT_MEETING_DURATION_MS + DEFAULT_ATTENDANCE_CONFIRMATION_OFFSET_MS;
 
         let newReminderJobId = undefined;
         let newAttendanceConfirmationJobId = undefined;
 
-        // Schedule new reminder if in future (we reset reminderSent=false in childUpdates above)
         if (newReminderAt > timestamp) {
           newReminderJobId = await ctx.scheduler.runAt(
             newReminderAt,
@@ -398,8 +409,6 @@ export const update = mutation({
             { meetingId: meeting._id }
           );
         }
-
-        // Schedule new attendance confirmation if in future
         if (newAttendanceConfirmationAt > timestamp) {
           newAttendanceConfirmationJobId = await ctx.scheduler.runAt(
             newAttendanceConfirmationAt,
@@ -408,7 +417,6 @@ export const update = mutation({
           );
         }
 
-        // Store the new job IDs
         await ctx.db.patch(meeting._id, {
           reminderJobId: newReminderJobId,
           attendanceConfirmationJobId: newAttendanceConfirmationJobId,
@@ -739,6 +747,128 @@ export const createSeries = mutation({
       communityWideEventIds,
       totalMeetingsCreated,
     };
+  },
+});
+
+// ============================================================================
+// Data repair (one-off migration)
+// ============================================================================
+
+/**
+ * Restore child meeting dates that were collapsed by the old
+ * `update(scope: "all_in_series")` bug.
+ *
+ * That bug overwrote `scheduledAt` on every meeting sharing a series with a
+ * single absolute timestamp, dragging the children of past community-wide
+ * events forward onto one future date — so the Events feed rendered one card
+ * per historical occurrence all stacked on the same day.
+ *
+ * For every non-overridden child meeting whose `scheduledAt` diverges from its
+ * parent communityWideEvent, this resets the meeting to the parent's date and
+ * re-syncs the reminder / attendance-confirmation jobs. Per-group overrides are
+ * left untouched. Safe to run repeatedly — already-correct children are skipped.
+ *
+ * Run with:
+ *   npx convex run functions/communityWideEvents:repairCollapsedChildDates '{"dryRun":true}'
+ */
+export const repairCollapsedChildDates = internalMutation({
+  args: { dryRun: v.optional(v.boolean()) },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun === true;
+    const timestamp = now();
+
+    const communityWideEvents = await ctx.db.query("communityWideEvents").collect();
+
+    let meetingsRepaired = 0;
+    let jobsCancelled = 0;
+    let jobsRescheduled = 0;
+    const perEvent: Array<{
+      communityWideEventId: Id<"communityWideEvents">;
+      title: string;
+      repaired: number;
+    }> = [];
+
+    for (const cwe of communityWideEvents) {
+      const children = await ctx.db
+        .query("meetings")
+        .withIndex("by_communityWideEvent", (q) =>
+          q.eq("communityWideEventId", cwe._id)
+        )
+        .collect();
+
+      let repairedForEvent = 0;
+      for (const meeting of children) {
+        // Leave per-group overrides untouched — leaders set those on purpose.
+        if (meeting.isOverridden === true) continue;
+        if (meeting.scheduledAt === cwe.scheduledAt) continue;
+
+        repairedForEvent++;
+        meetingsRepaired++;
+        if (dryRun) continue;
+
+        // Cancel stale jobs scheduled for the wrong (collapsed) date.
+        if (meeting.reminderJobId) {
+          try {
+            await ctx.scheduler.cancel(meeting.reminderJobId);
+            jobsCancelled++;
+          } catch { /* already run */ }
+        }
+        if (meeting.attendanceConfirmationJobId) {
+          try {
+            await ctx.scheduler.cancel(meeting.attendanceConfirmationJobId);
+            jobsCancelled++;
+          } catch { /* already run */ }
+        }
+
+        const reminderAt = cwe.scheduledAt - DEFAULT_REMINDER_OFFSET_MS;
+        const attendanceConfirmationAt =
+          cwe.scheduledAt + DEFAULT_MEETING_DURATION_MS + DEFAULT_ATTENDANCE_CONFIRMATION_OFFSET_MS;
+
+        await ctx.db.patch(meeting._id, {
+          scheduledAt: cwe.scheduledAt,
+          reminderAt,
+          attendanceConfirmationAt,
+          // A window already in the past is treated as handled so no sweep
+          // re-fires it; a future window is left pending for its new job.
+          reminderSent: reminderAt <= timestamp,
+          attendanceConfirmationSent: attendanceConfirmationAt <= timestamp,
+        });
+
+        // Reschedule jobs only when the restored time is still in the future.
+        let reminderJobId = undefined;
+        let attendanceConfirmationJobId = undefined;
+        if (reminderAt > timestamp) {
+          reminderJobId = await ctx.scheduler.runAt(
+            reminderAt,
+            internal.functions.scheduledJobs.sendMeetingReminder,
+            { meetingId: meeting._id }
+          );
+          jobsRescheduled++;
+        }
+        if (attendanceConfirmationAt > timestamp) {
+          attendanceConfirmationJobId = await ctx.scheduler.runAt(
+            attendanceConfirmationAt,
+            internal.functions.scheduledJobs.sendAttendanceConfirmation,
+            { meetingId: meeting._id }
+          );
+          jobsRescheduled++;
+        }
+        await ctx.db.patch(meeting._id, {
+          reminderJobId,
+          attendanceConfirmationJobId,
+        });
+      }
+
+      if (repairedForEvent > 0) {
+        perEvent.push({
+          communityWideEventId: cwe._id,
+          title: cwe.title,
+          repaired: repairedForEvent,
+        });
+      }
+    }
+
+    return { dryRun, meetingsRepaired, jobsCancelled, jobsRescheduled, perEvent };
   },
 });
 

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -14,7 +14,7 @@
 import { v } from "convex/values";
 import { query, mutation, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
-import { Id } from "../_generated/dataModel";
+import { Doc, Id } from "../_generated/dataModel";
 import { now, generateShortId } from "../lib/utils";
 import { requireAuth } from "../lib/auth";
 import { requireCommunityAdmin } from "../lib/permissions";
@@ -305,11 +305,9 @@ export const update = mutation({
 
     // Meetings that receive non-date field edits.
     let cascadeMeetings: typeof directChildren = directChildren;
-    // Every parent communityWideEvent reachable through the series — collected
-    // independently of child override/cancel state so the parent-record
-    // cascade below isn't skipped just because an occurrence's children are
-    // all overridden.
-    const seriesParentIds = new Set<Id<"communityWideEvents">>();
+    // Future, non-cancelled parent occurrences in the series — the targets of
+    // the parent-record cascade below.
+    let futureSeriesParents: Doc<"communityWideEvents">[] = [];
     if (args.scope === "all_in_series") {
       const seriesIds = new Set(
         allDirectChildren
@@ -317,25 +315,53 @@ export const update = mutation({
           .filter((id): id is Id<"eventSeries"> => !!id)
       );
       if (seriesIds.size > 0) {
-        const byId = new Map<Id<"meetings">, (typeof directChildren)[number]>();
-        // The edited occurrence's own children always receive the edit.
-        for (const m of directChildren) byId.set(m._id, m);
+        // Gather every meeting across the series, deduplicated.
+        const seriesMeetings: (typeof directChildren)[number][] = [];
+        const seenMeeting = new Set<string>();
+        const seriesParentIds = new Set<Id<"communityWideEvents">>();
         for (const sid of seriesIds) {
-          const seriesMeetings = await ctx.db
+          const ms = await ctx.db
             .query("meetings")
             .withIndex("by_series", (q) => q.eq("seriesId", sid))
             .collect();
-          for (const m of seriesMeetings) {
-            if (m.communityWideEventId) {
-              seriesParentIds.add(m.communityWideEventId);
-            }
-            if (m.isOverridden === true || m.status === "cancelled") continue;
-            // Skip occurrences that have already happened.
-            if (m.scheduledAt < timestamp) continue;
-            byId.set(m._id, m);
+          for (const m of ms) {
+            if (seenMeeting.has(m._id)) continue;
+            seenMeeting.add(m._id);
+            seriesMeetings.push(m);
+            if (m.communityWideEventId) seriesParentIds.add(m.communityWideEventId);
           }
         }
+
+        // Fetch the parent communityWideEvents. The occurrence date comes from
+        // the parent, which stays authoritative even when a child meeting's
+        // own `scheduledAt` is corrupt (the exact state this PR repairs) — so
+        // "skip past occurrences" must key off the parent, not the child.
+        const parentById = new Map<Id<"communityWideEvents">, Doc<"communityWideEvents">>();
+        for (const pid of seriesParentIds) {
+          const parent = await ctx.db.get(pid);
+          if (parent) parentById.set(pid, parent);
+        }
+
+        // cascadeMeetings = the edited occurrence's children, plus children of
+        // future, non-cancelled occurrences (judged by the parent's date).
+        const byId = new Map<Id<"meetings">, (typeof directChildren)[number]>();
+        for (const m of directChildren) byId.set(m._id, m);
+        for (const m of seriesMeetings) {
+          if (m.isOverridden === true || m.status === "cancelled") continue;
+          if (!m.communityWideEventId) continue;
+          const parent = parentById.get(m.communityWideEventId);
+          if (!parent || parent.status === "cancelled") continue;
+          if (parent.scheduledAt < timestamp) continue;
+          byId.set(m._id, m);
+        }
         cascadeMeetings = [...byId.values()];
+
+        futureSeriesParents = [...parentById.values()].filter(
+          (p) =>
+            p._id !== args.communityWideEventId &&
+            p.status !== "cancelled" &&
+            p.scheduledAt >= timestamp
+        );
       }
     }
 
@@ -463,17 +489,10 @@ export const update = mutation({
 
       // Only cascade if there's an actual field change beyond `updatedAt`.
       if (Object.keys(parentCascadeUpdates).length > 1) {
-        // seriesParentIds covers every occurrence in the series, regardless of
-        // its children's override/cancel state. Update the future ones.
-        for (const parentId of seriesParentIds) {
-          if (parentId === args.communityWideEventId) continue;
-          const parent = await ctx.db.get(parentId);
-          if (!parent) continue;
-          // Skip cancelled parents — consistent with not editing cancelled rows.
-          if (parent.status === "cancelled") continue;
-          // Past occurrences are never rewritten.
-          if (parent.scheduledAt < timestamp) continue;
-          await ctx.db.patch(parentId, parentCascadeUpdates);
+        // futureSeriesParents is already filtered to future, non-cancelled
+        // occurrences other than the edited one.
+        for (const parent of futureSeriesParents) {
+          await ctx.db.patch(parent._id, parentCascadeUpdates);
         }
       }
     }

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -256,6 +256,16 @@ export const update = mutation({
 
     const timestamp = now();
 
+    // An "all_in_series" edit is forward-looking: this occurrence and future
+    // ones. If the edited occurrence is itself in the past, it is treated like
+    // any other past occurrence and skipped entirely — only future occurrences
+    // change. (A default-scope edit still applies to the chosen occurrence
+    // even when it's past.) This is keyed off the parent's own scheduledAt,
+    // which stays authoritative even when child meeting dates are corrupt.
+    const includeAnchor =
+      args.scope !== "all_in_series" ||
+      communityWideEvent.scheduledAt >= timestamp;
+
     // Build update object for the parent event
     const parentUpdates: Record<string, unknown> = { updatedAt: timestamp };
     if (args.title !== undefined) parentUpdates.title = args.title;
@@ -270,8 +280,10 @@ export const update = mutation({
       parentUpdates.coverImage = args.coverImage === "" ? undefined : args.coverImage;
     }
 
-    // Update the parent event
-    await ctx.db.patch(args.communityWideEventId, parentUpdates);
+    // Update the parent event (skipped when this is a past all_in_series anchor).
+    if (includeAnchor) {
+      await ctx.db.patch(args.communityWideEventId, parentUpdates);
+    }
 
     // ----------------------------------------------------------------
     // Determine which meetings receive the edit.
@@ -342,10 +354,13 @@ export const update = mutation({
           if (parent) parentById.set(pid, parent);
         }
 
-        // cascadeMeetings = the edited occurrence's children, plus children of
-        // future, non-cancelled occurrences (judged by the parent's date).
+        // cascadeMeetings = the edited occurrence's children (unless it's a
+        // past anchor), plus children of future, non-cancelled occurrences
+        // (judged by the parent's date).
         const byId = new Map<Id<"meetings">, (typeof directChildren)[number]>();
-        for (const m of directChildren) byId.set(m._id, m);
+        if (includeAnchor) {
+          for (const m of directChildren) byId.set(m._id, m);
+        }
         for (const m of seriesMeetings) {
           if (m.isOverridden === true || m.status === "cancelled") continue;
           if (!m.communityWideEventId) continue;
@@ -395,7 +410,11 @@ export const update = mutation({
     }
 
     // Merge per-meeting patches so each meeting is written at most once.
-    const directIds = new Set(directChildren.map((m) => m._id));
+    // A date change applies only to the edited occurrence's children — and
+    // not at all when it's a past all_in_series anchor.
+    const directIds = new Set(
+      includeAnchor ? directChildren.map((m) => m._id) : []
+    );
     const patches = new Map<
       Id<"meetings">,
       { meeting: (typeof directChildren)[number]; patch: Record<string, unknown> }
@@ -403,7 +422,7 @@ export const update = mutation({
     for (const m of cascadeMeetings) {
       patches.set(m._id, { meeting: m, patch: { ...cascadeUpdates } });
     }
-    if (dateChanged) {
+    if (dateChanged && includeAnchor) {
       for (const m of directChildren) {
         const entry = patches.get(m._id) ?? { meeting: m, patch: {} };
         Object.assign(entry.patch, dateUpdates);

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -439,6 +439,41 @@ export const update = mutation({
       meetingsUpdated++;
     }
 
+    // Cascade non-date fields to the other future occurrences' parent
+    // communityWideEvents. The Events feed and admin list render from the
+    // parent record (e.g. `parent.title`), so without this they'd show stale
+    // titles/notes even though the child meetings were updated.
+    if (args.scope === "all_in_series") {
+      const parentCascadeUpdates: Record<string, unknown> = { updatedAt: timestamp };
+      if (args.title !== undefined) parentCascadeUpdates.title = args.title;
+      if (args.meetingType !== undefined) parentCascadeUpdates.meetingType = args.meetingType;
+      if (args.meetingLink !== undefined) parentCascadeUpdates.meetingLink = args.meetingLink;
+      if (args.note !== undefined) parentCascadeUpdates.note = args.note;
+      if (args.coverImage !== undefined) {
+        parentCascadeUpdates.coverImage = args.coverImage === "" ? undefined : args.coverImage;
+      }
+
+      // Only cascade if there's an actual field change beyond `updatedAt`.
+      if (Object.keys(parentCascadeUpdates).length > 1) {
+        // cascadeMeetings spans this occurrence + future ones, so their
+        // parent ids are exactly the future communityWideEvents to update.
+        const otherParentIds = new Set(
+          cascadeMeetings
+            .map((m) => m.communityWideEventId)
+            .filter(
+              (id): id is Id<"communityWideEvents"> =>
+                !!id && id !== args.communityWideEventId
+            )
+        );
+        for (const parentId of otherParentIds) {
+          const parent = await ctx.db.get(parentId);
+          // Skip cancelled parents — consistent with not editing cancelled rows.
+          if (!parent || parent.status === "cancelled") continue;
+          await ctx.db.patch(parentId, parentCascadeUpdates);
+        }
+      }
+    }
+
     return { meetingsUpdated };
   },
 });

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -813,6 +813,9 @@ export const repairCollapsedChildDates = internalMutation({
       for (const meeting of children) {
         // Leave per-group overrides untouched — leaders set those on purpose.
         if (meeting.isOverridden === true) continue;
+        // Never repair or reschedule cancelled meetings — consistent with the
+        // update/cancel paths, which deliberately skip cancelled rows.
+        if (meeting.status === "cancelled") continue;
         if (meeting.scheduledAt === cwe.scheduledAt) continue;
 
         repairedForEvent++;

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -279,9 +279,11 @@ export const update = mutation({
     // A scheduledAt change ONLY ever applies to this occurrence's direct
     // children. Each occurrence in a series has its own date, so cascading
     // one absolute timestamp across the series would collapse every other
-    // occurrence (including past ones) onto the same day. Non-date fields
-    // (title, note, RSVP config, …) still cascade across the whole series
-    // when scope is "all_in_series".
+    // occurrence onto the same day.
+    //
+    // Non-date fields (title, note, RSVP config, …) cascade under
+    // "all_in_series" — but only to this occurrence and *future* ones. Past
+    // occurrences have already happened; editing them would rewrite history.
     // ----------------------------------------------------------------
     const directChildren = await ctx.db
       .query("meetings")
@@ -300,21 +302,22 @@ export const update = mutation({
           .filter((id): id is Id<"eventSeries"> => !!id)
       );
       if (seriesIds.size > 0) {
-        const seen = new Set<string>();
-        const collected: typeof directChildren = [];
+        const byId = new Map<Id<"meetings">, (typeof directChildren)[number]>();
+        // The edited occurrence's own children always receive the edit.
+        for (const m of directChildren) byId.set(m._id, m);
         for (const sid of seriesIds) {
           const seriesMeetings = await ctx.db
             .query("meetings")
             .withIndex("by_series", (q) => q.eq("seriesId", sid))
             .collect();
           for (const m of seriesMeetings) {
-            if (seen.has(m._id)) continue;
-            seen.add(m._id);
             if (m.isOverridden === true || m.status === "cancelled") continue;
-            collected.push(m);
+            // Skip occurrences that have already happened.
+            if (m.scheduledAt < timestamp) continue;
+            byId.set(m._id, m);
           }
         }
-        cascadeMeetings = collected;
+        cascadeMeetings = [...byId.values()];
       }
     }
 

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -305,6 +305,11 @@ export const update = mutation({
 
     // Meetings that receive non-date field edits.
     let cascadeMeetings: typeof directChildren = directChildren;
+    // Every parent communityWideEvent reachable through the series — collected
+    // independently of child override/cancel state so the parent-record
+    // cascade below isn't skipped just because an occurrence's children are
+    // all overridden.
+    const seriesParentIds = new Set<Id<"communityWideEvents">>();
     if (args.scope === "all_in_series") {
       const seriesIds = new Set(
         allDirectChildren
@@ -321,6 +326,9 @@ export const update = mutation({
             .withIndex("by_series", (q) => q.eq("seriesId", sid))
             .collect();
           for (const m of seriesMeetings) {
+            if (m.communityWideEventId) {
+              seriesParentIds.add(m.communityWideEventId);
+            }
             if (m.isOverridden === true || m.status === "cancelled") continue;
             // Skip occurrences that have already happened.
             if (m.scheduledAt < timestamp) continue;
@@ -455,20 +463,16 @@ export const update = mutation({
 
       // Only cascade if there's an actual field change beyond `updatedAt`.
       if (Object.keys(parentCascadeUpdates).length > 1) {
-        // cascadeMeetings spans this occurrence + future ones, so their
-        // parent ids are exactly the future communityWideEvents to update.
-        const otherParentIds = new Set(
-          cascadeMeetings
-            .map((m) => m.communityWideEventId)
-            .filter(
-              (id): id is Id<"communityWideEvents"> =>
-                !!id && id !== args.communityWideEventId
-            )
-        );
-        for (const parentId of otherParentIds) {
+        // seriesParentIds covers every occurrence in the series, regardless of
+        // its children's override/cancel state. Update the future ones.
+        for (const parentId of seriesParentIds) {
+          if (parentId === args.communityWideEventId) continue;
           const parent = await ctx.db.get(parentId);
+          if (!parent) continue;
           // Skip cancelled parents — consistent with not editing cancelled rows.
-          if (!parent || parent.status === "cancelled") continue;
+          if (parent.status === "cancelled") continue;
+          // Past occurrences are never rewritten.
+          if (parent.scheduledAt < timestamp) continue;
           await ctx.db.patch(parentId, parentCascadeUpdates);
         }
       }

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -296,10 +296,11 @@ export const update = mutation({
       )
       .collect();
 
-    // Non-overridden children receive the edit. Overridden meetings are
-    // intentional per-group customizations and are left untouched.
+    // Children that receive the edit: non-overridden and not cancelled.
+    // Overridden meetings are intentional per-group customizations; cancelled
+    // meetings must not be patched or have reminder jobs rescheduled.
     const directChildren = allDirectChildren.filter(
-      (m) => m.isOverridden !== true
+      (m) => m.isOverridden !== true && m.status !== "cancelled"
     );
 
     // Meetings that receive non-date field edits.


### PR DESCRIPTION
## Problem

On prod, the Events tab "This Week" list shows ~7 community-wide "Dinner Party" cards all stacked on Wed 5/20 — even though only **2** community-wide events are actually scheduled. The admin "Community-Wide Events" screen correctly shows "2 upcoming, 23 past".

The Events feed is fine — it collapses correctly by `communityWideEventId`. The **data** is corrupt: child meetings of ~7 *past* weekly community-wide events all have `scheduledAt = 2026-05-20`.

## Root cause

`communityWideEvents.update` with `scope: "all_in_series"` gathered **every** meeting sharing a `seriesId` and overwrote `scheduledAt` with one absolute timestamp. Since each weekly community-wide event reuses the same per-group `eventSeries`, editing one occurrence's time dragged every other occurrence — past and future — onto a single day.

Prod diagnosis (read-only query): **78 child meetings across 7 past events** collapsed onto 5/20; 247 already correct; 21 overridden (left alone).

## Fix

- A `scheduledAt` change applies **only to the directly-edited occurrence's** children — you can't sensibly set multiple occurrences to one absolute timestamp.
- Non-date fields (title, note, meeting type/link, RSVP config, visibility) cascade under `all_in_series` to **this occurrence and future ones only** — past occurrences have already happened and are never rewritten.
- Adds `repairCollapsedChildDates` internal mutation to restore already-corrupted prod data: resets each non-overridden child to its parent event's date and re-syncs reminder/attendance jobs (cancels stale future jobs, reschedules only when the restored time is still upcoming). Idempotent.

## Post-merge step

After this deploys, run the repair against prod:

```
npx convex run functions/communityWideEvents:repairCollapsedChildDates '{"dryRun":true}'   # preview
npx convex run functions/communityWideEvents:repairCollapsedChildDates '{}'                # apply
```

## Tests

`__tests__/communityWideEvents-series.test.ts` — 15 passing, including:
- `all_in_series` date change does NOT collapse other occurrences
- `all_in_series` leaves PAST occurrences untouched, still cascades to future ones
- `repairCollapsedChildDates` restores collapsed dates, skips overrides, is idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)