### PR TITLE
Inline create role/team + team chat-channel toggle

### DIFF
--- a/apps/convex/__tests__/scheduling/teams.test.ts
+++ b/apps/convex/__tests__/scheduling/teams.test.ts
@@ -385,3 +385,207 @@ describe("listCommunityTeams", () => {
     ).rejects.toThrow(ConvexError);
   });
 });
+
+describe("linkChannel", () => {
+  it("creates a chat channel for a previously channel-less team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Spin up a channel-less team and confirm `getTeam` reflects that.
+    const { teamId } = await t.mutation(
+      api.functions.scheduling.teams.createServingTeam,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        name: "Hospitality",
+        withChannel: false,
+      },
+    );
+
+    const before = await t.query(api.functions.scheduling.teams.getTeam, {
+      token: leaderToken,
+      teamId,
+    });
+    expect(before.hasChannel).toBe(false);
+    expect(before.channelId).toBeNull();
+
+    const result = await t.mutation(
+      api.functions.scheduling.teams.linkChannel,
+      { token: leaderToken, teamId },
+    );
+    expect(result.channelId).toBeDefined();
+    expect(result.addedMembers).toBe(0);
+
+    const after = await t.query(api.functions.scheduling.teams.getTeam, {
+      token: leaderToken,
+      teamId,
+    });
+    expect(after.hasChannel).toBe(true);
+    expect(after.channelId).toBe(result.channelId);
+
+    await t.run(async (ctx) => {
+      const channel = await ctx.db.get(result.channelId);
+      expect(channel?.isServingTeam).toBe(true);
+      expect(channel?.channelType).toBe("custom");
+      expect(channel?.name).toBe("Hospitality");
+    });
+  });
+
+  it("rejects a team that already has a channel", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await expect(
+      t.mutation(api.functions.scheduling.teams.linkChannel, {
+        token: leaderToken,
+        teamId: world.teamId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects an archived team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { teamId } = await t.mutation(
+      api.functions.scheduling.teams.createServingTeam,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        name: "Hospitality",
+        withChannel: false,
+      },
+    );
+    await t.mutation(api.functions.scheduling.teams.archiveTeam, {
+      token: leaderToken,
+      teamId,
+    });
+
+    await expect(
+      t.mutation(api.functions.scheduling.teams.linkChannel, {
+        token: leaderToken,
+        teamId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects a non-scheduler with a ConvexError", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+
+    const { teamId } = await t.mutation(
+      api.functions.scheduling.teams.createServingTeam,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        name: "Hospitality",
+        withChannel: false,
+      },
+    );
+
+    await expect(
+      t.mutation(api.functions.scheduling.teams.linkChannel, {
+        token: memberToken,
+        teamId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("unlinkChannel", () => {
+  it("detaches the channel, clears isServingTeam, purges auto-synced members, preserves permanent members", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Seed one auto-synced member (rotation engine's row) and one permanent
+    // member (manual row, no syncSource). Only the synced one should go.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: world.channelId,
+        userId: world.channelMemberId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+        syncSource: "event_plan",
+      });
+    });
+    await t.mutation(api.functions.scheduling.teams.addPermanentMember, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelAdminId,
+    });
+
+    const result = await t.mutation(
+      api.functions.scheduling.teams.unlinkChannel,
+      { token: leaderToken, teamId: world.teamId },
+    );
+    expect(result.formerChannelId).toBe(world.channelId);
+    expect(result.removedSyncedMembers).toBe(1);
+
+    // Team is detached and the channel is no longer flagged as a team channel.
+    await t.run(async (ctx) => {
+      const team = await ctx.db.get(world.teamId);
+      expect(team?.channelId).toBeUndefined();
+      const channel = await ctx.db.get(world.channelId);
+      expect(channel).not.toBeNull();
+      expect(channel?.isServingTeam).toBeUndefined();
+      // Permanent member untouched.
+      const permanent = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q
+            .eq("channelId", world.channelId)
+            .eq("userId", world.channelAdminId),
+        )
+        .first();
+      expect(permanent?.leftAt).toBeUndefined();
+      expect(permanent?.syncSource).toBeUndefined();
+    });
+
+    // getTeam now reflects the channel-less state.
+    const after = await t.query(api.functions.scheduling.teams.getTeam, {
+      token: leaderToken,
+      teamId: world.teamId,
+    });
+    expect(after.hasChannel).toBe(false);
+    expect(after.channelId).toBeNull();
+    expect(after.channelSlug).toBeNull();
+  });
+
+  it("rejects a team that has no channel", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { teamId } = await t.mutation(
+      api.functions.scheduling.teams.createServingTeam,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        name: "Hospitality",
+        withChannel: false,
+      },
+    );
+
+    await expect(
+      t.mutation(api.functions.scheduling.teams.unlinkChannel, {
+        token: leaderToken,
+        teamId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects a non-scheduler with a ConvexError", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const memberToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+
+    await expect(
+      t.mutation(api.functions.scheduling.teams.unlinkChannel, {
+        token: memberToken,
+        teamId: world.teamId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/apps/convex/functions/scheduling/teams.ts
+++ b/apps/convex/functions/scheduling/teams.ts
@@ -11,7 +11,7 @@
  */
 
 import { ConvexError, v } from "convex/values";
-import { mutation, query } from "../../_generated/server";
+import { mutation, query, type MutationCtx } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
@@ -23,7 +23,10 @@ import {
   requireTeam,
   requireTeamScheduler,
 } from "./permissions";
-import { purgeSyncedMembers } from "./teamChannelSync";
+import {
+  purgeSyncedMembers,
+  reconcileTeamChannelImpl,
+} from "./teamChannelSync";
 
 /** Validate a team (or channel) name; returns the trimmed value. */
 function validateName(raw: string): string {
@@ -37,6 +40,54 @@ function validateName(raw: string): string {
     );
   }
   return name;
+}
+
+/**
+ * Insert the chat channel that backs a serving team — shared by
+ * `createServingTeam` (initial creation) and `linkChannel` (a team gaining a
+ * channel after the fact). Enforces the same 20-channel-per-group cap as
+ * `createCustomChannel` and computes a slug unique across archived channels
+ * too (see PR #400 thread: the `by_group_slug` index spans archived rows).
+ */
+async function createTeamChannel(
+  ctx: MutationCtx,
+  args: {
+    groupId: Id<"groups">;
+    name: string;
+    description: string | undefined;
+    createdById: Id<"users">;
+    now: number;
+  },
+): Promise<Id<"chatChannels">> {
+  const existingChannels = await ctx.db
+    .query("chatChannels")
+    .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+    .collect();
+  const activeChannelCount = existingChannels.filter(
+    (ch) => ch.isArchived === false,
+  ).length;
+  if (activeChannelCount >= 20) {
+    throw new ConvexError(
+      "This group has reached the maximum of 20 channels. Archive some channels to create new ones.",
+    );
+  }
+  const existingSlugs = existingChannels
+    .map((ch) => ch.slug)
+    .filter((slug): slug is string => slug !== undefined);
+  return ctx.db.insert("chatChannels", {
+    groupId: args.groupId,
+    slug: generateChannelSlug(args.name, existingSlugs),
+    channelType: "custom",
+    name: args.name,
+    description: args.description,
+    createdById: args.createdById,
+    createdAt: args.now,
+    updatedAt: args.now,
+    isArchived: false,
+    isServingTeam: true,
+    memberCount: 0,
+    joinMode: "open",
+  });
 }
 
 /**
@@ -66,47 +117,18 @@ export const createServingTeam = mutation({
     const now = Date.now();
     const withChannel = args.withChannel ?? true;
 
-    let channelId: Id<"chatChannels"> | undefined;
-    if (withChannel) {
-      // The team's chat channel: a custom channel flagged as a serving team.
-      // Membership is auto-synced from assignments (ADR-023), so the creator
-      // is not added as a member — they manage it as a group leader.
-      // Slug uniqueness must span archived channels too: the `by_group_slug`
-      // index does not exclude them, so reusing an archived channel's slug
-      // would create a duplicate `(groupId, slug)` pair that an
-      // `includeArchived` lookup could resolve to the wrong row.
-      const existingChannels = await ctx.db
-        .query("chatChannels")
-        .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
-        .collect();
-      // Match `createCustomChannel`'s 20-channel-per-group cap — counted over
-      // non-archived rows only, the same way the original limit works.
-      const activeChannelCount = existingChannels.filter(
-        (ch) => ch.isArchived === false,
-      ).length;
-      if (activeChannelCount >= 20) {
-        throw new ConvexError(
-          "This group has reached the maximum of 20 channels. Archive some channels to create new ones.",
-        );
-      }
-      const existingSlugs = existingChannels
-        .map((ch) => ch.slug)
-        .filter((slug): slug is string => slug !== undefined);
-      channelId = await ctx.db.insert("chatChannels", {
-        groupId: args.groupId,
-        slug: generateChannelSlug(name, existingSlugs),
-        channelType: "custom",
-        name,
-        description: args.description,
-        createdById: userId,
-        createdAt: now,
-        updatedAt: now,
-        isArchived: false,
-        isServingTeam: true,
-        memberCount: 0,
-        joinMode: "open",
-      });
-    }
+    // The team's chat channel: a custom channel flagged as a serving team.
+    // Membership is auto-synced from assignments (ADR-023), so the creator
+    // is not added as a member — they manage it as a group leader.
+    const channelId = withChannel
+      ? await createTeamChannel(ctx, {
+          groupId: args.groupId,
+          name,
+          description: args.description,
+          createdById: userId,
+          now,
+        })
+      : undefined;
 
     const teamId = await ctx.db.insert("teams", {
       groupId: args.groupId,
@@ -285,6 +307,101 @@ export const archiveTeam = mutation({
     }
 
     return { teamId: args.teamId, isArchived: archived, removedSyncedMembers };
+  },
+});
+
+// ============================================================================
+// Channel linking — turning a team's chat channel on / off
+// ============================================================================
+
+/**
+ * Turn a team's chat channel on. Creates a fresh `custom` chat channel
+ * flagged `isServingTeam`, links it to the team, and reconciles it against
+ * the team's in-window assignments so existing volunteers are populated
+ * immediately. Errors if the team already has a channel.
+ *
+ * Auth: team admin/moderator, campus group leader, or community admin.
+ */
+export const linkChannel = mutation({
+  args: {
+    token: v.string(),
+    teamId: v.id("teams"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const team = await requireTeamScheduler(ctx, args.teamId, userId);
+    if (team.channelId) {
+      throw new ConvexError("This team already has a chat channel.");
+    }
+    if (team.isArchived === true) {
+      throw new ConvexError("Cannot add a channel to an archived team.");
+    }
+
+    const now = Date.now();
+    const channelId = await createTeamChannel(ctx, {
+      groupId: team.groupId,
+      name: team.name,
+      description: team.description,
+      createdById: userId,
+      now,
+    });
+
+    await ctx.db.patch(args.teamId, { channelId, updatedAt: now });
+
+    // Populate the new channel with anyone already assigned in-window.
+    const reconcile = await reconcileTeamChannelImpl(ctx, args.teamId);
+
+    return {
+      teamId: args.teamId,
+      channelId,
+      addedMembers: reconcile.added,
+    };
+  },
+});
+
+/**
+ * Turn a team's chat channel off. The channel itself stays in the inbox as
+ * a regular custom channel (its `isServingTeam` flag is cleared and the team
+ * detaches its `channelId`); auto-synced members owned by the rotation
+ * engine are purged. Permanent members are untouched.
+ *
+ * This is team-wide — it affects every event plan the team is on. Errors if
+ * the team has no channel to unlink.
+ *
+ * Auth: team admin/moderator, campus group leader, or community admin.
+ */
+export const unlinkChannel = mutation({
+  args: {
+    token: v.string(),
+    teamId: v.id("teams"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const team = await requireTeamScheduler(ctx, args.teamId, userId);
+    if (!team.channelId) {
+      throw new ConvexError("This team has no chat channel.");
+    }
+    const formerChannelId = team.channelId;
+    const now = Date.now();
+
+    await ctx.db.patch(args.teamId, {
+      channelId: undefined,
+      updatedAt: now,
+    });
+    await ctx.db.patch(formerChannelId, {
+      isServingTeam: undefined,
+      updatedAt: now,
+    });
+    const removedSyncedMembers = await purgeSyncedMembers(
+      ctx,
+      formerChannelId,
+    );
+
+    return {
+      teamId: args.teamId,
+      formerChannelId,
+      removedSyncedMembers,
+    };
   },
 });
 

--- a/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
@@ -41,6 +41,7 @@ import { DEFAULT_ROLE_COLOR } from "../utils/format";
 import { NeededRolesModal } from "./NeededRolesModal";
 import { AssignSheet } from "./AssignSheet";
 import { TimesEditor } from "./TimesEditor";
+import { TeamChannelToggle } from "./TeamChannelToggle";
 
 /** Formats a Date as a display time label, e.g. "9:00 AM". */
 function formatTimeLabel(date: Date): string {
@@ -445,18 +446,21 @@ export function EventEditorScreen() {
           />
         </Pressable>
 
-        {/* Per-role assignment view */}
+        {/* Per-role assignment view — grouped by team so each team gets a
+            header with its chat-channel toggle + "Open chat" shortcut. */}
         {event.roles.length === 0 ? (
           <Text style={[styles.noRolesText, { color: colors.textSecondary }]}>
             No roles needed yet. Tap "Set needed roles" to declare how many of
             each role this event plan needs.
           </Text>
         ) : (
-          event.roles.map((role) => (
-            <RoleAssignmentCard
-              key={role.roleId}
-              role={role}
-              onAssign={() =>
+          groupRolesByTeam(event.roles).map((teamGroup) => (
+            <TeamRoleGroup
+              key={teamGroup.teamId}
+              groupId={event.groupId}
+              teamId={teamGroup.teamId}
+              roles={teamGroup.roles}
+              onAssign={(role) =>
                 setAssignTarget({
                   teamId: role.teamId,
                   roleId: role.roleId,
@@ -526,6 +530,130 @@ export function EventEditorScreen() {
           onClose={() => setAssignTarget(null)}
         />
       )}
+    </View>
+  );
+}
+
+/**
+ * Groups the event's flat role list by team, preserving role order within
+ * each team. Used to render a team-section header (chat toggle + "Open chat"
+ * shortcut) above each team's role cards.
+ */
+function groupRolesByTeam(roles: EventRole[]): Array<{
+  teamId: Id<"teams">;
+  roles: EventRole[];
+}> {
+  const order: Id<"teams">[] = [];
+  const byTeam = new Map<Id<"teams">, EventRole[]>();
+  for (const role of roles) {
+    const existing = byTeam.get(role.teamId);
+    if (existing) {
+      existing.push(role);
+    } else {
+      byTeam.set(role.teamId, [role]);
+      order.push(role.teamId);
+    }
+  }
+  return order.map((teamId) => ({ teamId, roles: byTeam.get(teamId)! }));
+}
+
+/**
+ * A team's section: header (name + chat toggle + "Open chat" shortcut) and
+ * its role assignment cards. Fetches the team via `getTeam` so it has the
+ * `hasChannel` / `channelSlug` / `memberCount` fields the toggle and
+ * shortcut both need.
+ */
+function TeamRoleGroup({
+  groupId,
+  teamId,
+  roles,
+  onAssign,
+  onUnassign,
+}: {
+  groupId: Id<"groups">;
+  teamId: Id<"teams">;
+  roles: EventRole[];
+  onAssign: (role: EventRole) => void;
+  onUnassign: (id: Id<"roleAssignments">) => void;
+}) {
+  const { colors } = useTheme();
+  const router = useRouter();
+  const team = useAuthenticatedQuery(
+    api.functions.scheduling.teams.getTeam,
+    { teamId },
+  ) as
+    | {
+        _id: Id<"teams">;
+        name: string;
+        hasChannel: boolean;
+        channelSlug: string | null;
+        memberCount: number;
+      }
+    | undefined;
+
+  // Fall back to the role's embedded team-less name while `getTeam` resolves.
+  const fallbackName = roles[0]?.roleName ?? "Team";
+  const teamName = team?.name ?? fallbackName;
+
+  return (
+    <View style={styles.teamGroup}>
+      <View style={styles.teamGroupHeader}>
+        <Text
+          style={[styles.teamGroupName, { color: colors.text }]}
+          numberOfLines={1}
+        >
+          {teamName}
+        </Text>
+        {team ? (
+          <View style={styles.teamGroupActions}>
+            <TeamChannelToggle
+              teamId={team._id}
+              teamName={team.name}
+              hasChannel={team.hasChannel}
+              channelMemberCount={team.memberCount}
+            />
+            {team.hasChannel && team.channelSlug ? (
+              <Pressable
+                onPress={() =>
+                  router.push(
+                    `/inbox/${groupId}/${team.channelSlug}` as never,
+                  )
+                }
+                hitSlop={6}
+                accessibilityRole="link"
+                accessibilityLabel={`Open ${team.name} chat`}
+              >
+                <View style={styles.openChatRow}>
+                  <Text
+                    style={[
+                      styles.openChatText,
+                      { color: colors.buttonPrimary },
+                    ]}
+                  >
+                    Open chat
+                  </Text>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={14}
+                    color={colors.buttonPrimary}
+                  />
+                </View>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : (
+          <ActivityIndicator size="small" color={colors.textTertiary} />
+        )}
+      </View>
+
+      {roles.map((role) => (
+        <RoleAssignmentCard
+          key={role.roleId}
+          role={role}
+          onAssign={() => onAssign(role)}
+          onUnassign={onUnassign}
+        />
+      ))}
     </View>
   );
 }
@@ -771,6 +899,35 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
     marginTop: 20,
+  },
+  teamGroup: {
+    marginTop: 20,
+  },
+  teamGroupHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 6,
+    gap: 8,
+  },
+  teamGroupName: {
+    flexShrink: 1,
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  teamGroupActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  openChatRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 2,
+  },
+  openChatText: {
+    fontSize: 13,
+    fontWeight: "600",
   },
   roleCard: {
     borderRadius: 12,

--- a/apps/mobile/features/scheduling/components/NeededRolesModal.tsx
+++ b/apps/mobile/features/scheduling/components/NeededRolesModal.tsx
@@ -6,10 +6,15 @@
  * `defaultNeeded`; the scheduler tweaks them per event. Saving replaces
  * the event's full needed-roles set.
  *
- * Backend: scheduling.teams.listTeams, scheduling.roles.listRoles,
+ * The modal is self-contained: leaders can add a new role to a team or
+ * create a brand-new team inline, without leaving the sheet (per the
+ * approved ASCII sketch).
+ *
+ * Backend: scheduling.teams.listTeams / createServingTeam,
+ * scheduling.roles.listRoles / createRole,
  * scheduling.events.setNeededRoles.
  */
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -19,10 +24,11 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   ScrollView,
+  TextInput,
+  Switch,
   Alert,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { useRouter } from "expo-router";
 import { useTheme } from "@hooks/useTheme";
 import {
   useAuthenticatedQuery,
@@ -31,8 +37,14 @@ import {
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { DEFAULT_ROLE_COLOR } from "../utils/format";
+import { TeamChannelToggle } from "./TeamChannelToggle";
 
-type Team = { _id: Id<"teams">; name: string };
+type Team = {
+  _id: Id<"teams">;
+  name: string;
+  hasChannel: boolean;
+  memberCount: number;
+};
 type Role = {
   _id: Id<"teamRoles">;
   name: string;
@@ -67,15 +79,61 @@ export function NeededRolesModal({
   const setNeededRoles = useAuthenticatedMutation(
     api.functions.scheduling.events.setNeededRoles,
   );
+  const createServingTeam = useAuthenticatedMutation(
+    api.functions.scheduling.teams.createServingTeam,
+  );
 
   const [counts, setCounts] = useState<CountMap>({});
   const [saving, setSaving] = useState(false);
 
+  // The id of the team that should auto-expand and focus its "+ Add a role"
+  // input — used right after creating a team inline.
+  const [focusedTeamId, setFocusedTeamId] = useState<Id<"teams"> | null>(null);
+
+  // Inline "create a new team" form state.
+  const [creatingTeamFormOpen, setCreatingTeamFormOpen] = useState(false);
+  const [newTeamName, setNewTeamName] = useState("");
+  const [newTeamWithChannel, setNewTeamWithChannel] = useState(true);
+  const [creatingTeam, setCreatingTeam] = useState(false);
+
   // Seed the edit map from the event's existing needed roles whenever the
   // modal opens.
   useEffect(() => {
-    if (visible) setCounts({ ...currentCounts });
+    if (visible) {
+      setCounts({ ...currentCounts });
+      // Reset inline forms each time the modal opens.
+      setCreatingTeamFormOpen(false);
+      setNewTeamName("");
+      setNewTeamWithChannel(true);
+      setFocusedTeamId(null);
+    }
   }, [visible, currentCounts]);
+
+  const handleCreateTeam = async () => {
+    const name = newTeamName.trim();
+    if (!name || creatingTeam) return;
+    setCreatingTeam(true);
+    try {
+      const result = await createServingTeam({
+        groupId,
+        name,
+        withChannel: newTeamWithChannel,
+      });
+      // listTeams will refetch reactively. Focus the new team so its role
+      // input auto-opens once it appears in the list.
+      setFocusedTeamId(result.teamId as Id<"teams">);
+      setCreatingTeamFormOpen(false);
+      setNewTeamName("");
+      setNewTeamWithChannel(true);
+    } catch (e: any) {
+      Alert.alert(
+        "Couldn't create team",
+        e?.data?.message ?? e?.message ?? "Please try again.",
+      );
+    } finally {
+      setCreatingTeam(false);
+    }
+  };
 
   return (
     <Modal
@@ -136,24 +194,141 @@ export function NeededRolesModal({
           <View style={styles.centered}>
             <ActivityIndicator size="small" color={colors.text} />
           </View>
-        ) : teams.length === 0 ? (
-          <View style={styles.centered}>
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              No serving teams in this group yet. Create a serving team first.
-            </Text>
-          </View>
         ) : (
-          <ScrollView contentContainerStyle={styles.scrollContent}>
-            {teams.map((team) => (
-              <TeamSection
-                key={team._id}
-                team={team}
-                counts={counts}
-                setCounts={setCounts}
-                groupId={groupId}
-                onClose={onClose}
-              />
-            ))}
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            {teams.length === 0 ? (
+              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                No serving teams in this group yet. Create one below.
+              </Text>
+            ) : (
+              teams.map((team) => (
+                <TeamSection
+                  key={team._id}
+                  team={team}
+                  counts={counts}
+                  setCounts={setCounts}
+                  autoFocusAddRole={team._id === focusedTeamId}
+                />
+              ))
+            )}
+
+            {/* Inline "Create a new team" affordance */}
+            {creatingTeamFormOpen ? (
+              <View
+                style={[
+                  styles.newTeamCard,
+                  { backgroundColor: colors.surfaceSecondary },
+                ]}
+              >
+                <Text style={[styles.label, { color: colors.text }]}>
+                  New team name
+                </Text>
+                <TextInput
+                  value={newTeamName}
+                  onChangeText={setNewTeamName}
+                  placeholder="e.g. Hospitality"
+                  placeholderTextColor={colors.inputPlaceholder}
+                  maxLength={50}
+                  autoFocus
+                  style={[
+                    styles.input,
+                    {
+                      color: colors.text,
+                      borderColor: colors.inputBorder,
+                      backgroundColor: colors.inputBackground,
+                    },
+                  ]}
+                />
+                <View style={styles.switchRow}>
+                  <Ionicons
+                    name="chatbubbles-outline"
+                    size={18}
+                    color={colors.text}
+                  />
+                  <Text style={[styles.switchLabel, { color: colors.text }]}>
+                    Give this team a chat channel
+                  </Text>
+                  <Switch
+                    value={newTeamWithChannel}
+                    onValueChange={setNewTeamWithChannel}
+                  />
+                </View>
+                <View style={styles.newTeamActions}>
+                  <TouchableOpacity
+                    onPress={() => {
+                      setCreatingTeamFormOpen(false);
+                      setNewTeamName("");
+                      setNewTeamWithChannel(true);
+                    }}
+                    disabled={creatingTeam}
+                    hitSlop={8}
+                    style={[
+                      styles.newTeamCancelBtn,
+                      { borderColor: colors.border },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.newTeamCancelText,
+                        { color: colors.textSecondary },
+                      ]}
+                    >
+                      Cancel
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={handleCreateTeam}
+                    disabled={creatingTeam || newTeamName.trim().length === 0}
+                    hitSlop={8}
+                    style={[
+                      styles.newTeamCreateBtn,
+                      {
+                        backgroundColor:
+                          creatingTeam || newTeamName.trim().length === 0
+                            ? colors.border
+                            : colors.buttonPrimary,
+                      },
+                    ]}
+                  >
+                    {creatingTeam ? (
+                      <ActivityIndicator size="small" color="#fff" />
+                    ) : (
+                      <Text style={styles.newTeamCreateText}>Create team</Text>
+                    )}
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ) : (
+              <Pressable
+                onPress={() => setCreatingTeamFormOpen(true)}
+                accessibilityRole="button"
+                accessibilityLabel="Create a new team"
+              >
+                <View
+                  style={[
+                    styles.createTeamRow,
+                    { borderColor: colors.border },
+                  ]}
+                >
+                  <Ionicons
+                    name="add"
+                    size={18}
+                    color={colors.buttonPrimary}
+                  />
+                  <Text
+                    style={[
+                      styles.createTeamText,
+                      { color: colors.buttonPrimary },
+                    ]}
+                  >
+                    Create a new team
+                  </Text>
+                </View>
+              </Pressable>
+            )}
           </ScrollView>
         )}
       </View>
@@ -161,26 +336,43 @@ export function NeededRolesModal({
   );
 }
 
-/** Per-team section listing its roles with steppers. */
+/** Per-team section listing its roles with steppers + inline "add role". */
 function TeamSection({
   team,
   counts,
   setCounts,
-  groupId,
-  onClose,
+  autoFocusAddRole,
 }: {
   team: Team;
   counts: CountMap;
   setCounts: React.Dispatch<React.SetStateAction<CountMap>>;
-  groupId: Id<"groups">;
-  onClose: () => void;
+  autoFocusAddRole: boolean;
 }) {
   const { colors } = useTheme();
-  const router = useRouter();
   const roles = useAuthenticatedQuery(
     api.functions.scheduling.roles.listRoles,
     { teamId: team._id },
   ) as Role[] | undefined;
+
+  const createRole = useAuthenticatedMutation(
+    api.functions.scheduling.roles.createRole,
+  );
+
+  const [newRoleName, setNewRoleName] = useState("");
+  const [addingRole, setAddingRole] = useState(false);
+  const newRoleInputRef = useRef<TextInput | null>(null);
+  const focusedOnceRef = useRef(false);
+
+  // Focus the add-role input the first time the team should be "focused"
+  // (e.g. right after the leader created the team inline).
+  useEffect(() => {
+    if (autoFocusAddRole && !focusedOnceRef.current && roles !== undefined) {
+      focusedOnceRef.current = true;
+      // Defer to next tick so layout has settled.
+      const t = setTimeout(() => newRoleInputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [autoFocusAddRole, roles]);
 
   // First time a role is touched, fall back to its defaultNeeded.
   const defaults = useMemo(() => {
@@ -220,25 +412,59 @@ function TeamSection({
     setCounts((prev) => ({ ...prev, [key]: Math.max(0, value) }));
   };
 
+  const totalNeeded = useMemo(() => {
+    if (!roles) return 0;
+    let sum = 0;
+    for (const role of roles) sum += countFor(role._id as string);
+    return sum;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roles, counts]);
+
+  const handleAddRole = async () => {
+    const name = newRoleName.trim();
+    if (!name || addingRole) return;
+    setAddingRole(true);
+    try {
+      const result = await createRole({ teamId: team._id, name });
+      // Immediately mark the new role as needed on this event (count = 1).
+      setCounts((prev) => ({
+        ...prev,
+        [`${team._id}|${result.roleId}`]: 1,
+      }));
+      setNewRoleName("");
+      // Keep focus in the input so the leader can add more roles quickly.
+      newRoleInputRef.current?.focus();
+    } catch (e: any) {
+      Alert.alert(
+        "Couldn't add role",
+        e?.data?.message ?? e?.message ?? "Please try again.",
+      );
+    } finally {
+      setAddingRole(false);
+    }
+  };
+
   return (
     <View style={styles.section}>
       <View style={styles.sectionHeaderRow}>
-        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
-          {team.name.toUpperCase()}
+        <Text style={[styles.sectionLabel, { color: colors.text }]} numberOfLines={1}>
+          {team.name}
         </Text>
-        <TouchableOpacity
-          hitSlop={8}
-          onPress={() => {
-            onClose();
-            router.push(
-              `/rostering/${groupId}/team/${team._id}`,
-            );
-          }}
-        >
-          <Text style={[styles.editRolesLink, { color: colors.buttonPrimary }]}>
-            Edit roles
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.sectionHeaderRight}>
+          <TeamChannelToggle
+            teamId={team._id}
+            teamName={team.name}
+            hasChannel={team.hasChannel}
+            channelMemberCount={team.memberCount}
+          />
+          {totalNeeded > 0 ? (
+            <Text
+              style={[styles.neededCount, { color: colors.textSecondary }]}
+            >
+              {totalNeeded} needed
+            </Text>
+          ) : null}
+        </View>
       </View>
       <View
         style={[styles.group, { backgroundColor: colors.surfaceSecondary }]}
@@ -249,43 +475,94 @@ function TeamSection({
             color={colors.text}
             style={{ padding: 16 }}
           />
-        ) : roles.length === 0 ? (
-          <Text style={[styles.emptyRow, { color: colors.textSecondary }]}>
-            No roles defined for this team.
-          </Text>
         ) : (
-          roles.map((role, idx) => {
-            const count = countFor(role._id as string);
-            return (
-              <View
-                key={role._id}
+          <>
+            {roles.length === 0 ? (
+              <Text style={[styles.emptyRow, { color: colors.textSecondary }]}>
+                No roles defined yet — add one below.
+              </Text>
+            ) : (
+              roles.map((role, idx) => {
+                const count = countFor(role._id as string);
+                return (
+                  <View
+                    key={role._id}
+                    style={[
+                      styles.roleRow,
+                      idx > 0 && {
+                        borderTopWidth: StyleSheet.hairlineWidth,
+                        borderTopColor: colors.border,
+                      },
+                    ]}
+                  >
+                    <View
+                      style={[
+                        styles.swatch,
+                        { backgroundColor: role.color ?? DEFAULT_ROLE_COLOR },
+                      ]}
+                    />
+                    <Text
+                      style={[styles.roleName, { color: colors.text }]}
+                      numberOfLines={1}
+                    >
+                      {role.name}
+                    </Text>
+                    <Stepper
+                      value={count}
+                      onChange={(v) => setCount(role._id as string, v)}
+                    />
+                  </View>
+                );
+              })
+            )}
+
+            {/* Inline "+ Add a role to {team}" */}
+            <View
+              style={[
+                styles.addRoleRow,
+                roles.length > 0 && {
+                  borderTopWidth: StyleSheet.hairlineWidth,
+                  borderTopColor: colors.border,
+                },
+              ]}
+            >
+              <Ionicons name="add" size={18} color={colors.buttonPrimary} />
+              <TextInput
+                ref={(r) => {
+                  newRoleInputRef.current = r;
+                }}
+                value={newRoleName}
+                onChangeText={setNewRoleName}
+                placeholder={`Add a role to ${team.name}`}
+                placeholderTextColor={colors.inputPlaceholder}
+                onSubmitEditing={handleAddRole}
+                returnKeyType="done"
+                maxLength={50}
+                editable={!addingRole}
+                style={[styles.addRoleInput, { color: colors.text }]}
+              />
+              <TouchableOpacity
+                onPress={handleAddRole}
+                disabled={addingRole || newRoleName.trim().length === 0}
+                hitSlop={8}
                 style={[
-                  styles.roleRow,
-                  idx > 0 && {
-                    borderTopWidth: StyleSheet.hairlineWidth,
-                    borderTopColor: colors.border,
+                  styles.addRoleBtn,
+                  {
+                    backgroundColor:
+                      addingRole || newRoleName.trim().length === 0
+                        ? colors.border
+                        : colors.buttonPrimary,
                   },
                 ]}
               >
-                <View
-                  style={[
-                    styles.swatch,
-                    { backgroundColor: role.color ?? DEFAULT_ROLE_COLOR },
-                  ]}
-                />
-                <Text
-                  style={[styles.roleName, { color: colors.text }]}
-                  numberOfLines={1}
-                >
-                  {role.name}
-                </Text>
-                <Stepper
-                  value={count}
-                  onChange={(v) => setCount(role._id as string, v)}
-                />
-              </View>
-            );
-          })
+                {addingRole ? (
+                  <ActivityIndicator size="small" color="#fff" />
+                ) : (
+                  <Text style={styles.addRoleBtnText}>Add</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </>
         )}
       </View>
     </View>
@@ -307,21 +584,22 @@ function Stepper({
         onPress={() => onChange(value - 1)}
         disabled={value <= 0}
         hitSlop={6}
-        style={[
-          styles.stepBtn,
-          { borderColor: colors.border },
-          value <= 0 && { opacity: 0.4 },
-        ]}
       >
-        <Ionicons name="remove" size={18} color={colors.text} />
+        <View
+          style={[
+            styles.stepBtn,
+            { borderColor: colors.border },
+            value <= 0 && { opacity: 0.4 },
+          ]}
+        >
+          <Ionicons name="remove" size={18} color={colors.text} />
+        </View>
       </Pressable>
       <Text style={[styles.stepValue, { color: colors.text }]}>{value}</Text>
-      <Pressable
-        onPress={() => onChange(value + 1)}
-        hitSlop={6}
-        style={[styles.stepBtn, { borderColor: colors.border }]}
-      >
-        <Ionicons name="add" size={18} color={colors.text} />
+      <Pressable onPress={() => onChange(value + 1)} hitSlop={6}>
+        <View style={[styles.stepBtn, { borderColor: colors.border }]}>
+          <Ionicons name="add" size={18} color={colors.text} />
+        </View>
       </Pressable>
     </View>
   );
@@ -360,27 +638,35 @@ const styles = StyleSheet.create({
     fontSize: 14,
     textAlign: "center",
     lineHeight: 20,
+    paddingVertical: 12,
   },
   scrollContent: {
     padding: 16,
+    paddingBottom: 48,
   },
   section: {
-    marginBottom: 8,
+    marginBottom: 16,
   },
   sectionHeaderRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    marginTop: 12,
+    marginTop: 8,
     marginBottom: 8,
+    gap: 8,
+  },
+  sectionHeaderRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
   },
   sectionLabel: {
-    fontSize: 11,
-    fontWeight: "600",
-    letterSpacing: 0.6,
+    flexShrink: 1,
+    fontSize: 15,
+    fontWeight: "700",
   },
-  editRolesLink: {
-    fontSize: 13,
+  neededCount: {
+    fontSize: 12,
     fontWeight: "600",
   },
   group: {
@@ -389,7 +675,8 @@ const styles = StyleSheet.create({
   },
   emptyRow: {
     fontSize: 14,
-    padding: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
   },
   roleRow: {
     flexDirection: "row",
@@ -426,5 +713,101 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     minWidth: 20,
     textAlign: "center",
+  },
+  addRoleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  addRoleInput: {
+    flex: 1,
+    fontSize: 15,
+    paddingVertical: 4,
+  },
+  addRoleBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    minWidth: 56,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  addRoleBtnText: {
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  createTeamRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: "dashed",
+    marginTop: 4,
+  },
+  createTeamText: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  newTeamCard: {
+    borderRadius: 12,
+    padding: 14,
+    marginTop: 4,
+    gap: 10,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  input: {
+    borderWidth: 1.5,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+  },
+  switchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  switchLabel: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  newTeamActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
+    marginTop: 4,
+  },
+  newTeamCancelBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  newTeamCancelText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  newTeamCreateBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    borderRadius: 999,
+    minWidth: 110,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  newTeamCreateText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "700",
   },
 });

--- a/apps/mobile/features/scheduling/components/TeamChannelToggle.tsx
+++ b/apps/mobile/features/scheduling/components/TeamChannelToggle.tsx
@@ -1,0 +1,164 @@
+/**
+ * TeamChannelToggle
+ *
+ * A small pill that shows a serving team's chat-channel state ("💬 Chat on /
+ * off") and toggles it via `linkChannel` / `unlinkChannel`. Used by both the
+ * NeededRolesModal and the EventEditorScreen so the confirm copy and the
+ * mutation logic stay in one place.
+ *
+ * Tapping the pill prompts an `Alert.alert` confirm — the action affects
+ * every event the team is on, so we want an explicit "yes". Errors are
+ * surfaced via `Alert.alert`.
+ *
+ * Layout pattern: the Pressable wraps a static-styled inner View — RN-Web
+ * silently drops layout on a Pressable's function-style `style` prop.
+ *
+ * Backend: scheduling.teams.linkChannel / unlinkChannel.
+ */
+import React, { useCallback, useState } from "react";
+import { View, Text, Pressable, Alert, ActivityIndicator, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { useAuthenticatedMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+export function TeamChannelToggle({
+  teamId,
+  teamName,
+  hasChannel,
+  /**
+   * Auto-synced channel member count, used in the "turn off" confirm so the
+   * leader can see the human impact before unlinking.
+   */
+  channelMemberCount = 0,
+}: {
+  teamId: Id<"teams">;
+  teamName: string;
+  hasChannel: boolean;
+  channelMemberCount?: number;
+}) {
+  const { colors } = useTheme();
+  const linkChannel = useAuthenticatedMutation(
+    api.functions.scheduling.teams.linkChannel,
+  );
+  const unlinkChannel = useAuthenticatedMutation(
+    api.functions.scheduling.teams.unlinkChannel,
+  );
+  const [busy, setBusy] = useState(false);
+
+  const performToggle = useCallback(
+    async (turningOn: boolean) => {
+      setBusy(true);
+      try {
+        if (turningOn) {
+          await linkChannel({ teamId });
+        } else {
+          await unlinkChannel({ teamId });
+        }
+        // Convex queries re-fetch reactively — no manual refresh needed.
+      } catch (e: any) {
+        Alert.alert(
+          turningOn ? "Couldn't turn on chat" : "Couldn't turn off chat",
+          e?.data?.message ?? e?.message ?? "Couldn't update the team's chat channel",
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [linkChannel, unlinkChannel, teamId],
+  );
+
+  const handlePress = useCallback(() => {
+    if (busy) return;
+    if (hasChannel) {
+      Alert.alert(
+        `Turn off chat for ${teamName}?`,
+        `The team's chat channel will be unlinked. ${channelMemberCount} auto-synced ${
+          channelMemberCount === 1 ? "member is" : "members are"
+        } removed from it; the channel itself stays in the inbox as a regular custom channel. You can turn chat back on later. This affects every event this team is on.`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Turn off",
+            style: "destructive",
+            onPress: () => void performToggle(false),
+          },
+        ],
+      );
+    } else {
+      Alert.alert(
+        `Turn on chat for ${teamName}?`,
+        "A new chat channel will be created in the inbox. Membership auto-syncs from the team's event-plan assignments. This affects every event this team is on.",
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Turn on",
+            onPress: () => void performToggle(true),
+          },
+        ],
+      );
+    }
+  }, [busy, hasChannel, teamName, channelMemberCount, performToggle]);
+
+  const tint = hasChannel ? colors.success : colors.textTertiary;
+  const bg = hasChannel ? colors.success + "22" : colors.border;
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      disabled={busy}
+      hitSlop={6}
+      accessibilityRole="button"
+      accessibilityLabel={
+        hasChannel ? `Turn chat off for ${teamName}` : `Turn chat on for ${teamName}`
+      }
+    >
+      <View style={[styles.pill, { backgroundColor: bg, opacity: busy ? 0.6 : 1 }]}>
+        <Ionicons name="chatbubbles" size={12} color={tint} />
+        <Text style={[styles.label, { color: tint }]}>Chat</Text>
+        <View
+          style={[
+            styles.stateChip,
+            { backgroundColor: hasChannel ? colors.success : colors.textTertiary },
+          ]}
+        >
+          {busy ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={styles.stateChipText}>{hasChannel ? "on" : "off"}</Text>
+          )}
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  stateChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 999,
+    minWidth: 28,
+    minHeight: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  stateChipText: {
+    fontSize: 10,
+    fontWeight: "700",
+    color: "#fff",
+    textTransform: "lowercase",
+  },
+});


### PR DESCRIPTION
## Summary

Two scoped follow-ups to PR #400, building on the ADR-025 teams model.

1. **Self-contained Needed Roles modal** — leaders never have to leave the modal to set up an event plan. Inline "+ Add a role to *Team*" per team, and an inline "+ Create a new team" form (name + "give this team a chat channel" Switch).
2. **Team chat-channel toggle** — a `💬 Chat: on/off` pill in each team's header (event plan page + Needed Roles modal). Tap → confirm → `linkChannel` / `unlinkChannel`. Team-wide: affects every event the team is on.

## Backend — `linkChannel` / `unlinkChannel`

Resolves the ADR-025 §Open-Q #2 about channel-less ↔ channeled transitions.

- `linkChannel({teamId})` — creates a fresh custom channel flagged `isServingTeam`, links it to the team, and **reconciles in-window assignments into the channel immediately** so existing volunteers populate without waiting for the next cron. Errors on already-linked or archived teams; honours the 20-channel-per-group cap.
- `unlinkChannel({teamId})` — clears `team.channelId` and the channel's `isServingTeam` flag; the channel stays in the inbox as a regular custom channel. Auto-synced (`syncSource: "event_plan"`) members are purged via `purgeSyncedMembers`; permanent members untouched.

Auth: `requireTeamScheduler` (team admin/mod, group leader, community admin) for both.

`createServingTeam` and `linkChannel` share a small `createTeamChannel` helper (slug computation + 20-channel cap) — no behaviour change to `createServingTeam`.

## Frontend

- **`NeededRolesModal.tsx`** — each team's section header now carries the chat toggle; an inline "+ Add a role to *Team*" row at the bottom of each role list (creates the role + auto-seeds `count: 1` for this event); a dashed "+ Create a new team" affordance expands into an inline form (name + channel Switch defaulting on) and on creation the new team appears expanded with its add-role input focused.
- **`EventEditorScreen.tsx`** — roles are now grouped under a per-team header with the chat toggle pill and an `Open chat ›` shortcut when the team has a channel.
- **`TeamChannelToggle.tsx`** — new shared component owning the confirm copy + mutation + spinner + error surface. Props: `{teamId, teamName, hasChannel, channelMemberCount?}`. Used in both screens.

## Verification

- `apps/convex` typechecks clean; **107 scheduling tests** pass (7 new in `teams.test.ts`).
- `apps/mobile` typechecks clean (13 pre-existing errors in unrelated files); **1030 mobile tests** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
