### PR TITLE
Inline-create keyboard fix + assign from community / invite new person

### DIFF
--- a/apps/convex/__tests__/auth/placeholder-claim.test.ts
+++ b/apps/convex/__tests__/auth/placeholder-claim.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Tests for the placeholder claim path introduced alongside
+ * `inviteAndAssign` (commit cf0fd57):
+ *
+ *   - A placeholder `users` row (created by inviteAndAssign with
+ *     `isPlaceholder: true`, `isActive: false`) is claimed in-place when
+ *     the owner of the phone signs up via the normal OTP flow.
+ *   - The placeholder's `_id` is preserved, so pre-existing
+ *     `roleAssignments` / `groupMembers` / `userCommunities` rows still
+ *     point at the same user.
+ *   - A real (non-placeholder) user is never claimed.
+ *   - Email collisions during claim error out cleanly.
+ *
+ * Driving `registerNewUser` end-to-end requires a phone verification token
+ * (the action's first guard). `verifyPhoneOTP` is a Twilio-backed action,
+ * so we bypass it by seeding the token directly via the internal mutation
+ * `storePhoneVerificationToken` — the same mutation `verifyPhoneOTP` would
+ * have called. This is sufficient to exercise the claim mechanism (the
+ * only branch this commit changes).
+ */
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { api, internal } from "../../_generated/api";
+import { modules } from "../../test.setup";
+import type { Id } from "../../_generated/dataModel";
+
+/**
+ * Seed a placeholder user (mirrors what `inviteAndAssign` would have
+ * written) plus a community + group + active membership rows for that
+ * placeholder. Returns the ids so claim tests can assert preservation.
+ */
+async function seedPlaceholderWithMemberships(
+  t: ReturnType<typeof convexTest>,
+  phone: string,
+) {
+  return await t.run(async (ctx) => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug: "test",
+      isPublic: true,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Campus",
+      slug: "campus",
+      isActive: true,
+      createdAt: Date.now(),
+      displayOrder: 1,
+    });
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Brooklyn Campus",
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const placeholderId = await ctx.db.insert("users", {
+      firstName: "Pat",
+      phone,
+      isActive: false,
+      isPlaceholder: true,
+      phoneVerified: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const communityMembershipId = await ctx.db.insert("userCommunities", {
+      userId: placeholderId,
+      communityId,
+      roles: 1,
+      status: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const groupMembershipId = await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: placeholderId,
+      role: "member",
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+
+    return {
+      placeholderId,
+      communityId,
+      groupId,
+      communityMembershipId,
+      groupMembershipId,
+    } as {
+      placeholderId: Id<"users">;
+      communityId: Id<"communities">;
+      groupId: Id<"groups">;
+      communityMembershipId: Id<"userCommunities">;
+      groupMembershipId: Id<"groupMembers">;
+    };
+  });
+}
+
+/**
+ * Plant a phone verification token so `registerNewUser` accepts the call.
+ * `verifyPhoneOTP` writes the same row via the same internal mutation; we
+ * bypass it to keep tests off Twilio.
+ */
+async function plantPhoneToken(
+  t: ReturnType<typeof convexTest>,
+  phone: string,
+): Promise<string> {
+  const token = "test-phone-verification-token-" + Math.random().toString(36).slice(2);
+  await t.mutation(
+    internal.functions.authInternal.storePhoneVerificationToken,
+    { phone, token },
+  );
+  return token;
+}
+
+describe("placeholder claim on phone-OTP registration", () => {
+  it("claims an existing placeholder in-place (no new users row, _id preserved, flags cleared)", async () => {
+    const t = convexTest(schema, modules);
+    const phone = "+12025550555";
+    const {
+      placeholderId,
+      communityMembershipId,
+      groupMembershipId,
+    } = await seedPlaceholderWithMemberships(t, phone);
+
+    const tokenStr = await plantPhoneToken(t, phone);
+
+    const result = await t.action(
+      api.functions.auth.registration.registerNewUser,
+      {
+        phone,
+        firstName: "Pat",
+        lastName: "Smith",
+        email: "pat.smith@example.com",
+        otp: "000000",
+        phoneVerificationToken: tokenStr,
+      },
+    );
+
+    // The claimed user id MUST be the same row.
+    expect(result.user.id).toBe(placeholderId);
+
+    // Exactly one users row for this phone — no duplicate insert.
+    const usersForPhone = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("by_phone", (q) => q.eq("phone", phone))
+        .collect(),
+    );
+    expect(usersForPhone).toHaveLength(1);
+    expect(usersForPhone[0]._id).toBe(placeholderId);
+
+    // Flags cleared, isActive flipped, name/email from registration applied.
+    const claimed = await t.run((ctx) => ctx.db.get(placeholderId));
+    expect(claimed?.isPlaceholder).toBeUndefined();
+    expect(claimed?.isActive).toBe(true);
+    expect(claimed?.phoneVerified).toBe(true);
+    expect(claimed?.firstName).toBe("Pat");
+    expect(claimed?.lastName).toBe("Smith");
+    expect(claimed?.email).toBe("pat.smith@example.com");
+
+    // Pre-existing memberships still point at the same user id (no rewrites).
+    const com = await t.run((ctx) => ctx.db.get(communityMembershipId));
+    expect(com?.userId).toBe(placeholderId);
+    const gm = await t.run((ctx) => ctx.db.get(groupMembershipId));
+    expect(gm?.userId).toBe(placeholderId);
+  });
+
+  it("a pre-existing role assignment for the placeholder survives the claim", async () => {
+    const t = convexTest(schema, modules);
+    const phone = "+12025550556";
+    const seeded = await seedPlaceholderWithMemberships(t, phone);
+
+    // Plant a team + role + assignment owned by the placeholder, as if
+    // `inviteAndAssign` had run earlier.
+    const { teamId, roleId, planId, assignmentId } = await t.run(async (ctx) => {
+      const teamId = await ctx.db.insert("teams", {
+        groupId: seeded.groupId,
+        communityId: seeded.communityId,
+        name: "Worship Team",
+        isArchived: false,
+        createdAt: Date.now(),
+        createdById: seeded.placeholderId,
+        updatedAt: Date.now(),
+      });
+      const roleId = await ctx.db.insert("teamRoles", {
+        teamId,
+        communityId: seeded.communityId,
+        name: "Drums",
+        sortOrder: 0,
+        isArchived: false,
+        createdAt: Date.now(),
+        createdById: seeded.placeholderId,
+      });
+      const eventDate = Date.now() + 7 * 86400000;
+      const planId = await ctx.db.insert("eventPlans", {
+        groupId: seeded.groupId,
+        communityId: seeded.communityId,
+        title: "Sunday Service",
+        eventDate,
+        times: [{ label: "9 AM", startsAt: eventDate }],
+        status: "draft",
+        createdById: seeded.placeholderId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      const assignmentId = await ctx.db.insert("roleAssignments", {
+        planId,
+        teamId,
+        roleId,
+        userId: seeded.placeholderId,
+        eventDate,
+        status: "unconfirmed",
+        assignedById: seeded.placeholderId,
+        assignedAt: Date.now(),
+      });
+      return { teamId, roleId, planId, assignmentId };
+    });
+
+    const tokenStr = await plantPhoneToken(t, phone);
+    const result = await t.action(
+      api.functions.auth.registration.registerNewUser,
+      {
+        phone,
+        firstName: "Pat",
+        lastName: "Smith",
+        otp: "000000",
+        phoneVerificationToken: tokenStr,
+      },
+    );
+    expect(result.user.id).toBe(seeded.placeholderId);
+
+    // The assignment still points at the claimed user.
+    const assignment = await t.run((ctx) => ctx.db.get(assignmentId));
+    expect(assignment?.userId).toBe(seeded.placeholderId);
+    expect(assignment?.planId).toBe(planId);
+    expect(assignment?.teamId).toBe(teamId);
+    expect(assignment?.roleId).toBe(roleId);
+  });
+
+  it("never claims a real (non-placeholder) user with the same phone — logs them in instead", async () => {
+    const t = convexTest(schema, modules);
+    const phone = "+12025550557";
+
+    // Real user, no isPlaceholder flag.
+    const realUserId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Real",
+        lastName: "User",
+        email: "real@example.com",
+        phone,
+        isActive: true,
+        phoneVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const tokenStr = await plantPhoneToken(t, phone);
+    const result = await t.action(
+      api.functions.auth.registration.registerNewUser,
+      {
+        phone,
+        firstName: "Pretender",
+        lastName: "Smith",
+        email: "pretender@example.com",
+        otp: "000000",
+        phoneVerificationToken: tokenStr,
+      },
+    );
+
+    // Action returns existing user (idempotent), not a claim of theirs.
+    expect(result.user.id).toBe(realUserId);
+
+    // Their record is unchanged: firstName/lastName/email NOT overwritten.
+    const after = await t.run((ctx) => ctx.db.get(realUserId));
+    expect(after?.firstName).toBe("Real");
+    expect(after?.lastName).toBe("User");
+    expect(after?.email).toBe("real@example.com");
+    expect(after?.isPlaceholder).toBeUndefined();
+
+    // No duplicate user row.
+    const usersForPhone = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("by_phone", (q) => q.eq("phone", phone))
+        .collect(),
+    );
+    expect(usersForPhone).toHaveLength(1);
+  });
+
+  it("rejects claim cleanly when registration supplies an email that already belongs to another user", async () => {
+    const t = convexTest(schema, modules);
+    const phone = "+12025550558";
+    await seedPlaceholderWithMemberships(t, phone);
+
+    // Another, unrelated real user already owns this email.
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Other",
+        email: "shared@example.com",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const tokenStr = await plantPhoneToken(t, phone);
+
+    await expect(
+      t.action(api.functions.auth.registration.registerNewUser, {
+        phone,
+        firstName: "Pat",
+        lastName: "Smith",
+        email: "shared@example.com",
+        otp: "000000",
+        phoneVerificationToken: tokenStr,
+      }),
+    ).rejects.toThrow(/email already exists/i);
+  });
+
+  it("internal claimPlaceholderByPhoneInternal returns null for a non-placeholder user", async () => {
+    const t = convexTest(schema, modules);
+    const phone = "+12025550559";
+
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Real",
+        phone,
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const claimedId = await t.mutation(
+      internal.functions.authInternal.claimPlaceholderByPhoneInternal,
+      { phone, firstName: "X", lastName: "Y" },
+    );
+    expect(claimedId).toBeNull();
+  });
+
+  it("internal claimPlaceholderByPhoneInternal claims a placeholder and clears its flags", async () => {
+    const t = convexTest(schema, modules);
+    const phone = "+12025550560";
+    const placeholderId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Old",
+        phone,
+        isActive: false,
+        isPlaceholder: true,
+        phoneVerified: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const claimedId = await t.mutation(
+      internal.functions.authInternal.claimPlaceholderByPhoneInternal,
+      {
+        phone,
+        firstName: "New",
+        lastName: "Name",
+        email: "new@example.com",
+      },
+    );
+    expect(claimedId).toBe(placeholderId);
+
+    const after = await t.run((ctx) => ctx.db.get(placeholderId));
+    expect(after?.isPlaceholder).toBeUndefined();
+    expect(after?.isActive).toBe(true);
+    expect(after?.phoneVerified).toBe(true);
+    expect(after?.firstName).toBe("New");
+    expect(after?.lastName).toBe("Name");
+    expect(after?.email).toBe("new@example.com");
+  });
+});

--- a/apps/convex/__tests__/scheduling/assignments.test.ts
+++ b/apps/convex/__tests__/scheduling/assignments.test.ts
@@ -3,7 +3,7 @@
  * `previousFillers` quicklink query (ADR-023).
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { ConvexError } from "convex/values";
 import { convexTest } from "convex-test";
 import schema from "../../schema";
@@ -536,5 +536,358 @@ describe("previousFillers", () => {
       { token: leaderToken, roleId: world.roleId },
     );
     expect(fillers).toHaveLength(0);
+  });
+});
+
+describe("assignFromCommunity", () => {
+  it("auto-adds a community member to the group and creates the assignment", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // Sanity: communityOnlyA is not yet in the group.
+    const before = await t.run((ctx) =>
+      ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", world.communityOnlyAId),
+        )
+        .first(),
+    );
+    expect(before).toBeNull();
+
+    const { assignmentId, addedToGroup } = await t.mutation(
+      api.functions.scheduling.assignments.assignFromCommunity,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.communityOnlyAId,
+      },
+    );
+    expect(addedToGroup).toBe(true);
+
+    // Group membership now exists, role:"member", and is active.
+    const after = await t.run((ctx) =>
+      ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", world.communityOnlyAId),
+        )
+        .first(),
+    );
+    expect(after).not.toBeNull();
+    expect(after?.role).toBe("member");
+    expect(after?.leftAt).toBeUndefined();
+    expect(after?.requestStatus === undefined || after?.requestStatus === "accepted").toBe(
+      true,
+    );
+
+    // The assignment row exists and points at the right user.
+    const assignment = await t.run((ctx) => ctx.db.get(assignmentId));
+    expect(assignment?.userId).toBe(world.communityOnlyAId);
+    expect(assignment?.status).toBe("unconfirmed");
+  });
+
+  it("reactivates a leftAt / pending group-member row instead of inserting a duplicate", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // Seed a stale "left" group membership for communityOnlyA.
+    const existingMemberId = await t.run(async (ctx) =>
+      ctx.db.insert("groupMembers", {
+        groupId: world.groupId,
+        userId: world.communityOnlyAId,
+        role: "member",
+        joinedAt: Date.now() - 30 * 86400000,
+        leftAt: Date.now() - 86400000,
+        notificationsEnabled: true,
+      }),
+    );
+
+    const { addedToGroup } = await t.mutation(
+      api.functions.scheduling.assignments.assignFromCommunity,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.communityOnlyAId,
+      },
+    );
+    expect(addedToGroup).toBe(true);
+
+    // Same row, now reactivated.
+    const memberships = await t.run((ctx) =>
+      ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", world.communityOnlyAId),
+        )
+        .collect(),
+    );
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0]._id).toBe(existingMemberId);
+    expect(memberships[0].leftAt).toBeUndefined();
+    expect(memberships[0].requestStatus).toBe("accepted");
+  });
+
+  it("rejects a user from a different community", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // Insert a user belonging to an unrelated community — the same id will
+    // be passed to assignFromCommunity. The scheduler is authorized for
+    // their own community/plan, so this validates the cross-community guard.
+    const foreignUserId = await t.run(async (ctx) => {
+      const otherCommunityId = await ctx.db.insert("communities", {
+        name: "Other Community",
+        slug: "other",
+        isPublic: true,
+      });
+      const userId = await ctx.db.insert("users", {
+        firstName: "Foreign",
+        lastName: "User",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId,
+        communityId: otherCommunityId,
+        roles: 1,
+        status: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      return userId;
+    });
+
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignFromCommunity, {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: foreignUserId,
+      }),
+    ).rejects.toThrow(/not a member of the event's community/);
+  });
+
+  it("rejects a non-scheduler caller (requirePlanScheduler guard)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // channelMember is in the group but not a leader / community admin —
+    // they cannot schedule.
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignFromCommunity, {
+        token: memberToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.communityOnlyAId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects assigning to a role on an archived team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // Archive the team directly.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(world.teamId, { isArchived: true });
+    });
+
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignFromCommunity, {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.communityOnlyAId,
+      }),
+    ).rejects.toThrow(/archived team/);
+  });
+
+  it("rejects assigning the same user twice (already-assigned guard)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    await t.mutation(api.functions.scheduling.assignments.assignFromCommunity, {
+      token: leaderToken,
+      planId,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.communityOnlyAId,
+    });
+
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignFromCommunity, {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.communityOnlyAId,
+      }),
+    ).rejects.toThrow(/already assigned/);
+  });
+});
+
+describe("inviteAndAssign", () => {
+  /**
+   * `sendSMS` is wired through `ctx.runAction(internal...sendSMS, ...)`.
+   * Without Twilio creds (default test env), `sendSMS` returns
+   * `{ success: false }` → `sentInvite: false`. To exercise the happy
+   * `sentInvite: true` path we set `OTP_TEST_PHONE_NUMBERS` so the invitee
+   * phone is treated as a test phone and `sendSMS` short-circuits to
+   * `{ success: true }` without hitting Twilio.
+   */
+
+  it("creates a placeholder user, memberships, and assignment; sentInvite reflects SMS outcome", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    const inviteePhone = "2025550100";
+    vi.stubEnv("OTP_TEST_PHONE_NUMBERS", inviteePhone);
+
+    let result: {
+      assignmentId: Id<"roleAssignments">;
+      invitedUserId: Id<"users">;
+      sentInvite: boolean;
+    };
+    try {
+      result = await t.action(
+        api.functions.scheduling.assignments.inviteAndAssign,
+        {
+          token: leaderToken,
+          planId,
+          teamId: world.teamId,
+          roleId: world.roleId,
+          firstName: "Nora",
+          phone: inviteePhone,
+        },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(result.sentInvite).toBe(true);
+
+    // The placeholder user row was created with isPlaceholder/isActive
+    // flags and the normalized phone.
+    const newUser = await t.run((ctx) => ctx.db.get(result.invitedUserId));
+    expect(newUser?.firstName).toBe("Nora");
+    expect(newUser?.isPlaceholder).toBe(true);
+    expect(newUser?.isActive).toBe(false);
+    expect(newUser?.phone).toBe("+12025550100");
+
+    // userCommunities (active) for the invitee.
+    const comMembership = await t.run((ctx) =>
+      ctx.db
+        .query("userCommunities")
+        .withIndex("by_user_community", (q) =>
+          q
+            .eq("userId", result.invitedUserId)
+            .eq("communityId", world.communityId),
+        )
+        .first(),
+    );
+    expect(comMembership?.status).toBe(1);
+
+    // groupMembers (active) for the invitee.
+    const groupMembership = await t.run((ctx) =>
+      ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", result.invitedUserId),
+        )
+        .first(),
+    );
+    expect(groupMembership?.role).toBe("member");
+    expect(groupMembership?.leftAt).toBeUndefined();
+
+    // roleAssignments points at the new user.
+    const assignment = await t.run((ctx) => ctx.db.get(result.assignmentId));
+    expect(assignment?.userId).toBe(result.invitedUserId);
+    expect(assignment?.status).toBe("unconfirmed");
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
+  it("returns sentInvite: false when SMS isn't configured but still lands the DB writes", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // No OTP_TEST_PHONE_NUMBERS, no Twilio creds → sendSMS returns
+    // { success: false } and inviteAndAssign reports it accordingly.
+    const result = await t.action(
+      api.functions.scheduling.assignments.inviteAndAssign,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        firstName: "Mara",
+        phone: "2025550101",
+      },
+    );
+
+    expect(result.sentInvite).toBe(false);
+
+    // The DB writes still happened — the leader still gets the role filled.
+    const user = await t.run((ctx) => ctx.db.get(result.invitedUserId));
+    expect(user?.isPlaceholder).toBe(true);
+    const assignment = await t.run((ctx) => ctx.db.get(result.assignmentId));
+    expect(assignment?.userId).toBe(result.invitedUserId);
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
+  it("rejects when a non-placeholder user already owns the phone", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // The fixture channelAdmin has phone +12025550001 — a real user already
+    // owns it, so inviteAndAssign should refuse to create a duplicate.
+    await expect(
+      t.action(api.functions.scheduling.assignments.inviteAndAssign, {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        firstName: "Dup",
+        phone: "+12025550001",
+      }),
+    ).rejects.toThrow(/already in Togather/);
+  });
+
+  it("rejects an unauthorized caller with a ConvexError", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    await expect(
+      t.action(api.functions.scheduling.assignments.inviteAndAssign, {
+        token: memberToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        firstName: "Nope",
+        phone: "2025550199",
+      }),
+    ).rejects.toThrow(ConvexError);
   });
 });

--- a/apps/convex/__tests__/scheduling/fixtures.ts
+++ b/apps/convex/__tests__/scheduling/fixtures.ts
@@ -42,6 +42,19 @@ export interface SchedulingWorld {
   communityAdminId: Id<"users">;
   /** No memberships anywhere */
   outsiderId: Id<"users">;
+  /**
+   * Active community member ("Comonly") who is NOT in the group. Used by the
+   * AssignSheet community-search / `assignFromCommunity` tests.
+   */
+  communityOnlyAId: Id<"users">;
+  /** A second community-only member ("Casey") to test name sort/filter. */
+  communityOnlyBId: Id<"users">;
+  /**
+   * Placeholder user inserted by a previous `inviteAndAssign` call. Has an
+   * active community + group membership but `isPlaceholder: true` and
+   * `isActive: false`. Used by people-search / claim tests.
+   */
+  placeholderUserId: Id<"users">;
 }
 
 async function insertUser(
@@ -94,12 +107,32 @@ export async function buildSchedulingWorld(
       updatedAt: ts(),
     });
 
-    const channelAdminId = await insertUser(ctx, "Adminda", "2025550001");
-    const channelModeratorId = await insertUser(ctx, "Modesto", "2025550002");
-    const channelMemberId = await insertUser(ctx, "Memberly", "2025550003");
-    const groupLeaderId = await insertUser(ctx, "Leandra", "2025550004");
-    const communityAdminId = await insertUser(ctx, "Comadmin", "2025550005");
-    const outsiderId = await insertUser(ctx, "Outsider", "2025550006");
+    // Phones are stored normalized (E.164) to mirror production — the auth
+    // pipeline normalizes before insert. Tests that look up by phone via
+    // `by_phone` rely on this.
+    const channelAdminId = await insertUser(ctx, "Adminda", "+12025550001");
+    const channelModeratorId = await insertUser(ctx, "Modesto", "+12025550002");
+    const channelMemberId = await insertUser(ctx, "Memberly", "+12025550003");
+    const groupLeaderId = await insertUser(ctx, "Leandra", "+12025550004");
+    const communityAdminId = await insertUser(ctx, "Comadmin", "+12025550005");
+    const outsiderId = await insertUser(ctx, "Outsider", "+12025550006");
+    // Community-only members (not in the group). Names chosen for alphabetic
+    // sort: "Casey" < "Comonly", so the search ordering is predictable.
+    const communityOnlyAId = await insertUser(ctx, "Casey", "+12025550007");
+    const communityOnlyBId = await insertUser(ctx, "Comonly", "+12025550008");
+    // Placeholder user — inserted as if `inviteAndAssign` had created them.
+    // Active in community + group, but flagged so the UI / claim path can
+    // recognise them.
+    const placeholderUserId = await ctx.db.insert("users", {
+      firstName: "Phoebe",
+      lastName: "Placeholder",
+      phone: "+12025550009",
+      isActive: false,
+      isPlaceholder: true,
+      phoneVerified: false,
+      createdAt: ts(),
+      updatedAt: ts(),
+    });
 
     const channelId = await ctx.db.insert("chatChannels", {
       groupId,
@@ -162,6 +195,47 @@ export async function buildSchedulingWorld(
       updatedAt: ts(),
     });
 
+    // Active community memberships for the in-group users (so the people
+    // search has a complete view). Channel/group users above don't otherwise
+    // exist in `userCommunities`.
+    for (const userId of [
+      channelAdminId,
+      channelModeratorId,
+      channelMemberId,
+      groupLeaderId,
+    ]) {
+      await ctx.db.insert("userCommunities", {
+        communityId,
+        userId,
+        roles: 1,
+        status: 1,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+    }
+
+    // Community-only members and the placeholder all live in the community.
+    for (const userId of [communityOnlyAId, communityOnlyBId, placeholderUserId]) {
+      await ctx.db.insert("userCommunities", {
+        communityId,
+        userId,
+        roles: 1,
+        status: 1,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+    }
+
+    // The placeholder is "already in the group" (the leader added them when
+    // they were invited), but the community-only members are NOT.
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: placeholderUserId,
+      role: "member",
+      joinedAt: ts(),
+      notificationsEnabled: true,
+    });
+
     // The first-class serving team (ADR-025). It owns the chat channel above
     // and the roles below; assignments and needed-roles key off `teamId`.
     const teamId = await ctx.db.insert("teams", {
@@ -198,6 +272,9 @@ export async function buildSchedulingWorld(
       groupLeaderId,
       communityAdminId,
       outsiderId,
+      communityOnlyAId,
+      communityOnlyBId,
+      placeholderUserId,
     };
   });
 

--- a/apps/convex/__tests__/scheduling/people.test.ts
+++ b/apps/convex/__tests__/scheduling/people.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for `searchCommunityPeople` — the AssignSheet "search by name" leg
+ * of the assign-from-community flow. Covers sort order (in-group first,
+ * alpha within bucket), case-insensitive substring matching, caller
+ * exclusion, placeholder visibility, the limit cap, and auth gating.
+ */
+
+import { describe, it, expect } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import { buildSchedulingWorld } from "./fixtures";
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+describe("searchCommunityPeople", () => {
+  it("returns in-group members first, then community-only, alpha within each bucket", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    // Leader is a group member — passes the requireGroupMember gate.
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const results = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId: world.groupId, search: "" },
+    );
+
+    // In-group bucket: channel admin/moderator/member + placeholder (added
+    // by `inviteAndAssign` in fixtures). Group leader excluded as caller.
+    const inGroup = results.filter((r) => r.inGroup);
+    const outOfGroup = results.filter((r) => !r.inGroup);
+
+    // Every in-group result precedes every out-of-group result.
+    if (results.length > 0 && inGroup.length > 0 && outOfGroup.length > 0) {
+      const firstOutOfGroupIndex = results.findIndex((r) => !r.inGroup);
+      const lastInGroupIndex = results.length -
+        1 -
+        [...results].reverse().findIndex((r) => r.inGroup);
+      expect(lastInGroupIndex).toBeLessThan(firstOutOfGroupIndex);
+    }
+
+    // Alpha sort within each bucket.
+    const inGroupNames = inGroup.map((r) => r.displayName);
+    expect(inGroupNames).toEqual([...inGroupNames].sort((a, b) => a.localeCompare(b)));
+    const outOfGroupNames = outOfGroup.map((r) => r.displayName);
+    expect(outOfGroupNames).toEqual([...outOfGroupNames].sort((a, b) => a.localeCompare(b)));
+
+    // Community-only members are present in the out-of-group bucket.
+    const outIds = new Set(outOfGroup.map((r) => r.userId));
+    expect(outIds.has(world.communityOnlyAId)).toBe(true);
+    expect(outIds.has(world.communityOnlyBId)).toBe(true);
+  });
+
+  it("is case-insensitive across firstName, lastName, and combined display name", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Community-only "Casey Test" matches each of these queries.
+    for (const needle of ["casey", "CASEY", "Cas", "test", "casey test"]) {
+      const results = await t.query(
+        api.functions.scheduling.people.searchCommunityPeople,
+        { token: leaderToken, groupId: world.groupId, search: needle },
+      );
+      const userIds = results.map((r) => r.userId);
+      expect(userIds, `expected Casey in results for "${needle}"`).toContain(
+        world.communityOnlyAId,
+      );
+    }
+  });
+
+  it("excludes the caller from results", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    // Use channelAdmin as the caller — they're a community member, so they
+    // would otherwise appear in results.
+    const callerToken = (await generateTokens(world.channelAdminId)).accessToken;
+
+    const results = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: callerToken, groupId: world.groupId, search: "" },
+    );
+    expect(results.find((r) => r.userId === world.channelAdminId)).toBeUndefined();
+  });
+
+  it("includes placeholders with isPlaceholder: true and correct inGroup", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const results = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId: world.groupId, search: "phoebe" },
+    );
+    const placeholder = results.find((r) => r.userId === world.placeholderUserId);
+    expect(placeholder).toBeDefined();
+    expect(placeholder!.isPlaceholder).toBe(true);
+    // The fixture placeholder is in-group (added when "invited").
+    expect(placeholder!.inGroup).toBe(true);
+
+    // Non-placeholders should not be flagged.
+    const casey = results.find((r) => r.userId === world.channelMemberId);
+    if (casey) expect(casey.isPlaceholder).toBe(false);
+  });
+
+  it("limit caps the result count; default applies when omitted", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const unlimited = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId: world.groupId, search: "" },
+    );
+
+    const limited = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId: world.groupId, search: "", limit: 2 },
+    );
+    expect(limited).toHaveLength(2);
+
+    // Default limit applies — the world has fewer than 30 candidates, so the
+    // unlimited call returns everything that matched (no truncation).
+    // This protects against a regression that drops the default cap.
+    expect(unlimited.length).toBeGreaterThan(limited.length);
+    expect(unlimited.length).toBeLessThanOrEqual(30);
+  });
+
+  it("rejects a non-group, non-community-admin caller with a ConvexError", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const outsiderToken = (await generateTokens(world.outsiderId)).accessToken;
+
+    await expect(
+      t.query(api.functions.scheduling.people.searchCommunityPeople, {
+        token: outsiderToken,
+        groupId: world.groupId,
+        search: "",
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("a community admin (not in the group) may search", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+
+    const results = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: adminToken, groupId: world.groupId, search: "" },
+    );
+    // No throw, and the caller (community admin) is excluded.
+    expect(results.find((r) => r.userId === world.communityAdminId)).toBeUndefined();
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -127,6 +127,7 @@ import type * as functions_scheduling_crossTeamChannels from "../functions/sched
 import type * as functions_scheduling_events from "../functions/scheduling/events.js";
 import type * as functions_scheduling_index from "../functions/scheduling/index.js";
 import type * as functions_scheduling_mySchedule from "../functions/scheduling/mySchedule.js";
+import type * as functions_scheduling_people from "../functions/scheduling/people.js";
 import type * as functions_scheduling_permissions from "../functions/scheduling/permissions.js";
 import type * as functions_scheduling_roles from "../functions/scheduling/roles.js";
 import type * as functions_scheduling_starterRoles from "../functions/scheduling/starterRoles.js";
@@ -317,6 +318,7 @@ declare const fullApi: ApiFromModules<{
   "functions/scheduling/events": typeof functions_scheduling_events;
   "functions/scheduling/index": typeof functions_scheduling_index;
   "functions/scheduling/mySchedule": typeof functions_scheduling_mySchedule;
+  "functions/scheduling/people": typeof functions_scheduling_people;
   "functions/scheduling/permissions": typeof functions_scheduling_permissions;
   "functions/scheduling/roles": typeof functions_scheduling_roles;
   "functions/scheduling/starterRoles": typeof functions_scheduling_starterRoles;

--- a/apps/convex/functions/auth/phoneOtp.ts
+++ b/apps/convex/functions/auth/phoneOtp.ts
@@ -280,6 +280,29 @@ export const verifyPhoneOTP = action({
       { phone: normalizedPhone }
     );
 
+    // Placeholder branch: a leader pre-created this row via inviteAndAssign
+    // (see scheduling/assignments.ts). We do NOT log them in as the
+    // placeholder — they need to finish registration (first/last/DOB) so the
+    // account is real. Route them through the new-user registration flow;
+    // the row gets claimed in `registerNewUser` via
+    // `claimPlaceholderByPhoneInternal`.
+    if (result?.user?.isPlaceholder === true) {
+      const phoneVerificationToken = crypto.randomUUID();
+      await ctx.runMutation(
+        internal.functions.authInternal.storePhoneVerificationToken,
+        {
+          phone: normalizedPhone,
+          token: phoneVerificationToken,
+        }
+      );
+      return {
+        verified: true,
+        requiresCommunitySelection: false,
+        phoneVerificationToken,
+        communities: [],
+      };
+    }
+
     // If confirmIdentity is false, unlink phone and generate token for new registration
     if (!confirmIdentity && result?.user) {
       await ctx.runMutation(

--- a/apps/convex/functions/auth/registration.ts
+++ b/apps/convex/functions/auth/registration.ts
@@ -102,6 +102,43 @@ export const registerNewUser = action({
       { phone: normalizedPhone }
     );
 
+    // Placeholder branch: a leader pre-created this row via inviteAndAssign
+    // (see scheduling/assignments.ts). Claim it — the row's `_id` is stable,
+    // so existing roleAssignments / groupMembers / userCommunities rows that
+    // pointed at the placeholder transparently belong to the new account.
+    if (existingUser && existingUser.isPlaceholder === true) {
+      const claimedId: string | null = await ctx.runMutation(
+        internal.functions.authInternal.claimPlaceholderByPhoneInternal,
+        {
+          phone: normalizedPhone,
+          firstName: args.firstName,
+          lastName: args.lastName,
+          email: args.email,
+          dateOfBirth,
+        }
+      );
+
+      if (claimedId) {
+        const tokens = await generateTokens(claimedId);
+        return {
+          access_token: tokens.accessToken,
+          refresh_token: tokens.refreshToken,
+          expires_in: tokens.expiresIn,
+          user: {
+            id: claimedId,
+            firstName: args.firstName,
+            lastName: args.lastName,
+            email: args.email || "",
+            phone: normalizedPhone,
+            phoneVerified: true,
+          },
+        };
+      }
+      // claimPlaceholderByPhoneInternal returned null — the row was no
+      // longer a placeholder by the time we got there (concurrent claim).
+      // Fall through to the existing-user branch below.
+    }
+
     if (existingUser) {
       // User already exists - this is a retry or race condition
       // Return their info instead of erroring (idempotent behavior)

--- a/apps/convex/functions/authInternal.ts
+++ b/apps/convex/functions/authInternal.ts
@@ -241,6 +241,99 @@ export const createUserInternal = internalMutation({
 });
 
 /**
+ * Internal: Claim a placeholder `users` row by phone, promoting it into a
+ * real account. Returns the claimed user id, or `null` when no claim is
+ * applicable.
+ *
+ * Triggered from the phone-OTP signup paths (`verifyPhoneOTP` and
+ * `registerNewUser` in `auth/phoneOtp.ts` / `auth/registration.ts`). A
+ * claim is only performed when the row is explicitly flagged
+ * `isPlaceholder === true` — we never overwrite a real existing user, even
+ * if their `isActive` is false for unrelated reasons.
+ *
+ * After a successful claim, every `roleAssignments` / `groupMembers` /
+ * `userCommunities` row that referenced the placeholder by `userId` keeps
+ * working (the `_id` is stable), so the new account inherits the
+ * memberships and assignments the leader pre-loaded.
+ *
+ * If `firstName`/`lastName`/`dateOfBirth` are provided, they overwrite the
+ * placeholder's values — the placeholder's `firstName` came from the
+ * leader; the user's own signup-form input is authoritative.
+ */
+export const claimPlaceholderByPhoneInternal = internalMutation({
+  args: {
+    phone: v.string(),
+    firstName: v.optional(v.string()),
+    lastName: v.optional(v.string()),
+    email: v.optional(v.string()),
+    dateOfBirth: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const normalized = normalizePhone(args.phone);
+    const existing = await ctx.db
+      .query("users")
+      .withIndex("by_phone", (q) => q.eq("phone", normalized))
+      .first();
+
+    if (!existing || existing.isPlaceholder !== true) {
+      // No placeholder to claim — caller falls back to its normal "create
+      // new user" / "log in existing user" branch.
+      return null;
+    }
+
+    const timestamp = now();
+
+    // Merge: keep the existing record's fields, overwrite with whatever
+    // the signup form provided. The placeholder had no email, no
+    // password, and only the leader-supplied first name.
+    const firstName = args.firstName?.trim() || existing.firstName || "";
+    const lastName = args.lastName?.trim() || existing.lastName;
+    const email =
+      args.email?.trim().toLowerCase() || existing.email?.toLowerCase();
+
+    // If a non-placeholder user happens to own this email, abort — we'd
+    // otherwise create a duplicate-email situation by claiming.
+    if (email && email !== existing.email) {
+      const conflict = await ctx.db
+        .query("users")
+        .withIndex("by_email", (q) => q.eq("email", email))
+        .first();
+      if (conflict && conflict._id !== existing._id) {
+        throw new Error("User with this email already exists");
+      }
+    }
+
+    await ctx.db.patch(existing._id, {
+      isPlaceholder: undefined,
+      isActive: true,
+      phoneVerified: true,
+      firstName,
+      lastName,
+      email,
+      dateOfBirth: args.dateOfBirth ?? existing.dateOfBirth,
+      dateJoined: existing.dateJoined ?? timestamp,
+      updatedAt: timestamp,
+      searchText: buildSearchText({
+        firstName,
+        lastName,
+        email,
+        phone: normalized,
+      }),
+    });
+
+    // Mirror `createUserInternal`'s post-commit hook so any placeholder
+    // workflow tasks tied to this phone get linked.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.tasks.index.linkPlaceholderTasksForUser,
+      { userId: existing._id },
+    );
+
+    return existing._id;
+  },
+});
+
+/**
  * Internal: Create user with password (legacy signup)
  */
 export const createUserWithPasswordInternal = internalMutation({

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -242,8 +242,12 @@ async function ensureActiveGroupMembership(
       return { addedToGroup: false };
     }
     // Reactivate an archived membership (leftAt set, or a stale "pending"
-    // request) — the scheduler is implicitly approving them.
+    // request) — the scheduler is implicitly approving them. The role is
+    // reset to "member" so we don't silently restore historical leadership
+    // (or other elevated roles) just because someone left and got assigned
+    // back via the assign-from-community flow.
     await ctx.db.patch(existing._id, {
+      role: "member",
       leftAt: undefined,
       requestStatus: "accepted",
       requestReviewedAt: timestamp,
@@ -328,6 +332,15 @@ export const assignFromCommunity = mutation({
     const target = await ctx.db.get(args.userId);
     if (!target) {
       throw new ConvexError("Person not found");
+    }
+    // Deactivated accounts must not be re-introduced into scheduling — this
+    // also blocks placeholder users (`isPlaceholder: true` / `isActive:
+    // false`) from being assigned via this path; placeholders are only
+    // assigned through `inviteAndAssign`, which creates them.
+    if (target.isActive === false) {
+      throw new ConvexError(
+        "This person's account is deactivated and cannot be scheduled",
+      );
     }
     const communityMembership = await ctx.db
       .query("userCommunities")

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -25,8 +25,14 @@ import {
 } from "../../_generated/server";
 import type { QueryCtx, MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
-import type { Id } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth, requireAuthFromTokenAction } from "../../lib/auth";
+import {
+  buildSearchText,
+  isValidPhone,
+  normalizePhone,
+} from "../../lib/utils";
+import { COMMUNITY_ROLES } from "../../lib/permissions";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { requireTeamGroupMember, requirePlanScheduler } from "./permissions";
 
@@ -117,6 +123,145 @@ async function requireActiveGroupMember(
 }
 
 /**
+ * Shared assignment-write helper. Used by `assignRole`, `assignFromCommunity`,
+ * and `inviteAndAssign` — they all converge on the same writes once auth and
+ * any prerequisite group-membership work is done.
+ *
+ * Performs the role-pair guard, the active-group-member check, the
+ * already-assigned guard, double-booking detection, the `roleAssignments`
+ * insert, and the team-channel reconciliation schedules. Returns the new
+ * assignment id and the advisory `doubleBooked` flag.
+ *
+ * Auth: the caller MUST already have been authorized by
+ * `requirePlanScheduler` (or stricter) before this is invoked.
+ */
+async function performAssignment(
+  ctx: MutationCtx,
+  args: {
+    plan: Doc<"eventPlans">;
+    teamId: Id<"teams">;
+    roleId: Id<"teamRoles">;
+    userId: Id<"users">;
+    timeLabel?: string;
+    callerId: Id<"users">;
+  },
+): Promise<{ assignmentId: Id<"roleAssignments">; doubleBooked: boolean }> {
+  const { plan, teamId, roleId, userId, timeLabel, callerId } = args;
+
+  // Security: the teamId/roleId pair must be consistent and belong to this
+  // event's group — otherwise a scheduler for one group could inject
+  // volunteers into an unrelated group's team channel via the later sync.
+  await requireTeamRolePair(ctx, teamId, roleId, plan.groupId);
+
+  // The assignee must be an active member of the event's group — channel
+  // membership is derived from assignments, so an unchecked userId would
+  // expose the serving-team channel to an arbitrary person.
+  await requireActiveGroupMember(ctx, plan.groupId, userId);
+
+  // Guard against assigning the same person to the same role twice.
+  const roleAssignments = await ctx.db
+    .query("roleAssignments")
+    .withIndex("by_plan_role", (q) =>
+      q.eq("planId", plan._id).eq("roleId", roleId),
+    )
+    .collect();
+  if (roleAssignments.some((a) => a.userId === userId)) {
+    throw new ConvexError("This person is already assigned to this role");
+  }
+
+  // Double-booking detection: any other assignment for this user that
+  // falls on the same calendar day (across all teams/events). We compare
+  // by UTC day bucket — two events on the same day at 9 AM and 11 AM have
+  // different `eventDate` values but still collide. Assignments on the
+  // current plan are excluded so re-assigning within an event never warns.
+  const targetDay = utcDayBucket(plan.eventDate);
+  const userAssignments = await ctx.db
+    .query("roleAssignments")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+  const doubleBooked = userAssignments.some(
+    (a) =>
+      a.planId !== plan._id && utcDayBucket(a.eventDate) === targetDay,
+  );
+
+  const assignmentId = await ctx.db.insert("roleAssignments", {
+    planId: plan._id,
+    teamId,
+    roleId,
+    userId,
+    eventDate: plan.eventDate,
+    status: "unconfirmed",
+    timeLabel,
+    assignedById: callerId,
+    assignedAt: Date.now(),
+  });
+
+  // Auto-sync the team channel's membership off the new assignment, and any
+  // cross-team channel that draws from this serving team.
+  await ctx.scheduler.runAfter(
+    0,
+    internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
+    { teamId },
+  );
+  await ctx.scheduler.runAfter(
+    0,
+    internal.functions.scheduling.teamChannelSync
+      .reconcileCrossTeamChannelsForSource,
+    { sourceTeamId: teamId },
+  );
+
+  return { assignmentId, doubleBooked };
+}
+
+/**
+ * Ensure `userId` has an active `groupMembers` row in `groupId`. Returns
+ * whether a new row was created (existing-but-archived rows are reactivated
+ * by clearing `leftAt`; new rows are inserted as role:"member").
+ *
+ * Used by the assign-from-community / invite-new-person flows. Callers MUST
+ * have passed `requirePlanScheduler` for the plan's group before invoking.
+ */
+async function ensureActiveGroupMembership(
+  ctx: MutationCtx,
+  groupId: Id<"groups">,
+  userId: Id<"users">,
+): Promise<{ addedToGroup: boolean }> {
+  const existing = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", groupId).eq("userId", userId),
+    )
+    .first();
+
+  const timestamp = Date.now();
+  if (existing) {
+    const active =
+      !existing.leftAt &&
+      (!existing.requestStatus || existing.requestStatus === "accepted");
+    if (active) {
+      return { addedToGroup: false };
+    }
+    // Reactivate an archived membership (leftAt set, or a stale "pending"
+    // request) — the scheduler is implicitly approving them.
+    await ctx.db.patch(existing._id, {
+      leftAt: undefined,
+      requestStatus: "accepted",
+      requestReviewedAt: timestamp,
+    });
+    return { addedToGroup: true };
+  }
+
+  await ctx.db.insert("groupMembers", {
+    groupId,
+    userId,
+    role: "member",
+    joinedAt: timestamp,
+    notificationsEnabled: true,
+  });
+  return { addedToGroup: true };
+}
+
+/**
  * Assign a channel member to a role on an event. Creates an `unconfirmed`
  * assignment and denormalizes the event's `eventDate` for double-booking
  * queries.
@@ -140,70 +285,333 @@ export const assignRole = mutation({
     const callerId = await requireAuth(ctx, args.token);
     const { plan } = await requirePlanScheduler(ctx, args.planId, callerId);
 
-    // Security: the teamId/roleId pair must be consistent and belong to this
-    // event's group — otherwise a scheduler for one group could inject
-    // volunteers into an unrelated group's team channel via the later sync.
-    await requireTeamRolePair(ctx, args.teamId, args.roleId, plan.groupId);
-
-    // The assignee must be an active member of the event's group — channel
-    // membership is derived from assignments, so an unchecked userId would
-    // expose the serving-team channel to an arbitrary person.
-    await requireActiveGroupMember(ctx, plan.groupId, args.userId);
-
-    // Guard against assigning the same person to the same role twice.
-    const roleAssignments = await ctx.db
-      .query("roleAssignments")
-      .withIndex("by_plan_role", (q) =>
-        q.eq("planId", args.planId).eq("roleId", args.roleId),
-      )
-      .collect();
-    if (roleAssignments.some((a) => a.userId === args.userId)) {
-      throw new ConvexError("This person is already assigned to this role");
-    }
-
-    // Double-booking detection: any other assignment for this user that
-    // falls on the same calendar day (across all teams/events). We compare
-    // by UTC day bucket — two events on the same day at 9 AM and 11 AM have
-    // different `eventDate` values but still collide. Assignments on the
-    // current plan are excluded so re-assigning within an event never warns.
-    const targetDay = utcDayBucket(plan.eventDate);
-    const userAssignments = await ctx.db
-      .query("roleAssignments")
-      .withIndex("by_user", (q) => q.eq("userId", args.userId))
-      .collect();
-    const doubleBooked = userAssignments.some(
-      (a) =>
-        a.planId !== args.planId &&
-        utcDayBucket(a.eventDate) === targetDay,
-    );
-
-    const assignmentId = await ctx.db.insert("roleAssignments", {
-      planId: args.planId,
+    return performAssignment(ctx, {
+      plan,
       teamId: args.teamId,
       roleId: args.roleId,
       userId: args.userId,
-      eventDate: plan.eventDate,
-      status: "unconfirmed",
       timeLabel: args.timeLabel,
-      assignedById: callerId,
-      assignedAt: Date.now(),
+      callerId,
+    });
+  },
+});
+
+/**
+ * Assign a community member who is *not yet in the plan's group* to a role:
+ * adds them to the group as a "member" if needed, then performs the same
+ * assignment writes as `assignRole` (including the same-day double-booking
+ * advisory and the team/role-pair / archived-team guards).
+ *
+ * Powers the second leg of the AssignSheet community search — a one-tap
+ * "add to group + assign" for an existing community member.
+ *
+ * Auth: group leader or community admin for the event's group
+ * (`requirePlanScheduler`). The new group membership is implicitly
+ * "scheduler-approved" — we do NOT require the assignee to pre-accept.
+ */
+export const assignFromCommunity = mutation({
+  args: {
+    token: v.string(),
+    planId: v.id("eventPlans"),
+    teamId: v.id("teams"),
+    roleId: v.id("teamRoles"),
+    userId: v.id("users"),
+    timeLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+    const { plan } = await requirePlanScheduler(ctx, args.planId, callerId);
+
+    // Verify the target is at least an active *community* member — a
+    // scheduler must not be able to add an arbitrary cross-community user
+    // into their group by id-guessing.
+    const target = await ctx.db.get(args.userId);
+    if (!target) {
+      throw new ConvexError("Person not found");
+    }
+    const communityMembership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", args.userId).eq("communityId", plan.communityId),
+      )
+      .first();
+    if (!communityMembership || communityMembership.status !== 1) {
+      throw new ConvexError(
+        "This person is not a member of the event's community",
+      );
+    }
+
+    const { addedToGroup } = await ensureActiveGroupMembership(
+      ctx,
+      plan.groupId,
+      args.userId,
+    );
+
+    const { assignmentId } = await performAssignment(ctx, {
+      plan,
+      teamId: args.teamId,
+      roleId: args.roleId,
+      userId: args.userId,
+      timeLabel: args.timeLabel,
+      callerId,
     });
 
-    // Auto-sync the team channel's membership off the new assignment, and any
-    // cross-team channel that draws from this serving team.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
-      { teamId: args.teamId },
+    return { assignmentId, addedToGroup };
+  },
+});
+
+// ============================================================================
+// inviteAndAssign — placeholder user + SMS invite + immediate assignment
+// ============================================================================
+
+/**
+ * Max name length we accept for the invitee's `firstName`. Anything beyond
+ * this is almost certainly a paste accident; truncating silently would hide
+ * it from the scheduler.
+ */
+const INVITE_FIRST_NAME_MAX = 50;
+
+/**
+ * Validate the invitee's first name. Must be 1–50 chars and contain at
+ * least one alphanumeric character (so we reject pure-punctuation names
+ * that would render as blanks in the UI).
+ */
+function validateInviteFirstName(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new ConvexError("First name is required");
+  }
+  if (trimmed.length > INVITE_FIRST_NAME_MAX) {
+    throw new ConvexError(
+      `First name must be ${INVITE_FIRST_NAME_MAX} characters or fewer`,
     );
-    await ctx.scheduler.runAfter(
-      0,
-      internal.functions.scheduling.teamChannelSync
-        .reconcileCrossTeamChannelsForSource,
-      { sourceTeamId: args.teamId },
+  }
+  if (!/[\p{L}\p{N}]/u.test(trimmed)) {
+    throw new ConvexError("First name must contain at least one letter or digit");
+  }
+  return trimmed;
+}
+
+/**
+ * Internal: create a placeholder `users` row + community/group memberships,
+ * then run the same assignment writes as `assignRole`. Used by the
+ * `inviteAndAssign` action so the writes happen in a single transaction —
+ * an SMS send failure later does NOT leave half-formed rows.
+ *
+ * Auth: `requirePlanScheduler` on `planId`. Inputs are expected to be
+ * pre-validated by the caller (normalized phone, validated first name).
+ */
+export const inviteAndAssignInternal = internalMutation({
+  args: {
+    planId: v.id("eventPlans"),
+    teamId: v.id("teams"),
+    roleId: v.id("teamRoles"),
+    firstName: v.string(),
+    normalizedPhone: v.string(),
+    timeLabel: v.optional(v.string()),
+    callerId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const { plan } = await requirePlanScheduler(
+      ctx,
+      args.planId,
+      args.callerId,
     );
 
-    return { assignmentId, doubleBooked };
+    // Idempotency: if a user already owns this phone — placeholder or
+    // real — we refuse to create a duplicate. The leader should search
+    // by name and assign the existing record instead. We deliberately
+    // surface this loudly rather than silently merging: a silent merge
+    // would assign someone else's account to a role without their consent.
+    const existing = await ctx.db
+      .query("users")
+      .withIndex("by_phone", (q) => q.eq("phone", args.normalizedPhone))
+      .first();
+    if (existing) {
+      throw new ConvexError(
+        "A person with this phone is already in Togather — search by name instead.",
+      );
+    }
+
+    const timestamp = Date.now();
+
+    // 1. Placeholder user. `isActive: false` until claim — keeps them out
+    //    of any "active users" filters and matches how a non-signed-up
+    //    account *should* look. `isPlaceholder: true` is the signal that
+    //    the phone-OTP signup flow uses to claim instead of insert.
+    const newUserId = await ctx.db.insert("users", {
+      firstName: args.firstName,
+      phone: args.normalizedPhone,
+      phoneVerified: false,
+      isActive: false,
+      isPlaceholder: true,
+      isStaff: false,
+      isSuperuser: false,
+      dateJoined: timestamp,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      searchText: buildSearchText({
+        firstName: args.firstName,
+        phone: args.normalizedPhone,
+      }),
+    });
+
+    // 2. Community membership — they need to exist in the community for
+    //    the assignment to be coherent with reconciliation. Status=1
+    //    (active), role=MEMBER, matching `communityLandingPage` insert.
+    await ctx.db.insert("userCommunities", {
+      userId: newUserId,
+      communityId: plan.communityId,
+      roles: COMMUNITY_ROLES.MEMBER,
+      status: 1,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    // 3. Group membership — `requireActiveGroupMember` (inside
+    //    `performAssignment`) will then succeed.
+    await ctx.db.insert("groupMembers", {
+      groupId: plan.groupId,
+      userId: newUserId,
+      role: "member",
+      joinedAt: timestamp,
+      notificationsEnabled: true,
+    });
+
+    // 4. Pull the community and team for the SMS body — the action needs
+    //    these to construct the message.
+    const community = await ctx.db.get(plan.communityId);
+    const team = await ctx.db.get(args.teamId);
+    const caller = await ctx.db.get(args.callerId);
+
+    // 5. The actual assignment writes (same path as `assignRole`).
+    const { assignmentId } = await performAssignment(ctx, {
+      plan,
+      teamId: args.teamId,
+      roleId: args.roleId,
+      userId: newUserId,
+      timeLabel: args.timeLabel,
+      callerId: args.callerId,
+    });
+
+    return {
+      assignmentId,
+      invitedUserId: newUserId,
+      // Context the action needs to build the SMS body without re-querying.
+      communityName: community?.name ?? "Togather",
+      teamName: team?.name ?? "your team",
+      leaderFirstName: caller?.firstName?.trim() || "Someone",
+    };
+  },
+});
+
+/**
+ * Create a placeholder user for a person who is NOT yet in Togather, add
+ * them to the plan's community + group, assign them to a role on the event,
+ * and SMS-invite them to sign up. Their `_id` is stable across the eventual
+ * phone-OTP signup claim, so the assignment is preserved.
+ *
+ * This is exposed as an `action` (not a plain mutation) because the SMS
+ * send goes through Twilio inside a Node action — running it inline lets
+ * us report actual delivery status via `sentInvite` rather than reporting
+ * a scheduling success. The DB writes are batched into
+ * `inviteAndAssignInternal` so we never leave half-formed rows.
+ *
+ * If the SMS send fails, the placeholder + memberships + assignment are
+ * kept (we still have a record of the invite) and `sentInvite: false` is
+ * returned with a `console.error` for the operator.
+ *
+ * Auth: group leader or community admin for the event's group
+ * (re-asserted inside `inviteAndAssignInternal`).
+ */
+export const inviteAndAssign = action({
+  args: {
+    token: v.string(),
+    planId: v.id("eventPlans"),
+    teamId: v.id("teams"),
+    roleId: v.id("teamRoles"),
+    firstName: v.string(),
+    phone: v.string(),
+    timeLabel: v.optional(v.string()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    assignmentId: Id<"roleAssignments">;
+    invitedUserId: Id<"users">;
+    sentInvite: boolean;
+  }> => {
+    const callerId = await requireAuthFromTokenAction(ctx, args.token);
+
+    // Validate inputs before any DB work — failing here is cheap and
+    // produces clear errors for the client.
+    const firstName = validateInviteFirstName(args.firstName);
+    if (!isValidPhone(args.phone)) {
+      throw new ConvexError("Enter a valid phone number");
+    }
+    const normalizedPhone = normalizePhone(args.phone);
+
+    // Run all DB writes in a single internal mutation transaction.
+    const result: {
+      assignmentId: Id<"roleAssignments">;
+      invitedUserId: Id<"users">;
+      communityName: string;
+      teamName: string;
+      leaderFirstName: string;
+    } = await ctx.runMutation(
+      internal.functions.scheduling.assignments.inviteAndAssignInternal,
+      {
+        planId: args.planId,
+        teamId: args.teamId,
+        roleId: args.roleId,
+        firstName,
+        normalizedPhone,
+        timeLabel: args.timeLabel,
+        callerId: callerId as Id<"users">,
+      },
+    );
+
+    // SMS the invite. Twilio config issues / network failures are captured
+    // and reported via `sentInvite: false` — we do NOT roll back the DB
+    // writes, because the leader still wants the role filled.
+    //
+    // The deeplink target is the app's normal phone-signup URL with the
+    // phone prefilled. The phone-OTP flow's claim logic (see
+    // `verifyPhoneOTP` / `registerNewUser`) takes over from there.
+    const signupUrl = `${DOMAIN_CONFIG.appUrl}/signup?phone=${encodeURIComponent(
+      normalizedPhone,
+    )}`;
+    const smsBody =
+      `${result.leaderFirstName} added you to ${result.teamName} at ` +
+      `${result.communityName}. Tap to join: ${signupUrl}`;
+
+    let sentInvite = false;
+    try {
+      const smsResult = await ctx.runAction(
+        internal.functions.auth.phoneOtp.sendSMS,
+        { phone: normalizedPhone, message: smsBody },
+      );
+      sentInvite = smsResult?.success === true;
+      if (!sentInvite) {
+        console.error(
+          "[inviteAndAssign] sendSMS returned success: false — Twilio likely not configured",
+          { invitedUserId: result.invitedUserId },
+        );
+      }
+    } catch (err) {
+      console.error("[inviteAndAssign] SMS send threw", {
+        invitedUserId: result.invitedUserId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      sentInvite = false;
+    }
+
+    return {
+      assignmentId: result.assignmentId,
+      invitedUserId: result.invitedUserId,
+      sentInvite,
+    };
   },
 });
 

--- a/apps/convex/functions/scheduling/index.ts
+++ b/apps/convex/functions/scheduling/index.ts
@@ -55,11 +55,18 @@ export {
 // ============================================================================
 export {
   assignRole,
+  assignFromCommunity,
+  inviteAndAssign,
   unassign,
   respondToAssignment,
   previousFillers,
   publishEvent,
 } from "./assignments";
+
+// ============================================================================
+// Community-people search (assign-from-community flow)
+// ============================================================================
+export { searchCommunityPeople } from "./people";
 
 // ============================================================================
 // My Schedule (volunteer view)

--- a/apps/convex/functions/scheduling/people.ts
+++ b/apps/convex/functions/scheduling/people.ts
@@ -1,0 +1,155 @@
+/**
+ * Scheduling — community-people search for the AssignSheet
+ *
+ * Powers the "search by name" leg of the assign-from-community flow
+ * (see `assignFromCommunity` in `./assignments.ts`). Returns active members
+ * of the group's community whose name matches the search, flagging which
+ * ones are already in the group so the UI can branch between
+ *   • "Assign" (in-group)
+ *   • "Add to group + assign" (community-only).
+ *
+ * Read gate matches `listTeams` — any active group member may search. The
+ * write side (`assignFromCommunity` / `inviteAndAssign`) re-asserts the
+ * stricter `requirePlanScheduler` check.
+ */
+
+import { v } from "convex/values";
+import { query } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { getMediaUrl } from "../../lib/utils";
+import { requireGroupMember } from "./permissions";
+
+/** Default cap on returned candidates. */
+const DEFAULT_LIMIT = 30;
+/** Hard cap to keep the query bounded even when callers pass a large limit. */
+const MAX_LIMIT = 100;
+
+/**
+ * Build the user's display name the same way the rest of the app does:
+ * "first last", trimmed, falling back to first name alone.
+ */
+function buildDisplayName(
+  firstName: string | undefined,
+  lastName: string | undefined,
+): string {
+  const first = (firstName ?? "").trim();
+  const last = (lastName ?? "").trim();
+  if (first && last) return `${first} ${last}`;
+  return first || last || "Someone";
+}
+
+/**
+ * Case-insensitive substring match across firstName, lastName, and the
+ * combined "first last" display name. Empty search returns everything (the
+ * cap still applies).
+ */
+function matchesName(
+  search: string,
+  firstName: string | undefined,
+  lastName: string | undefined,
+): boolean {
+  const needle = search.trim().toLowerCase();
+  if (!needle) return true;
+  const haystacks = [
+    (firstName ?? "").toLowerCase(),
+    (lastName ?? "").toLowerCase(),
+    buildDisplayName(firstName, lastName).toLowerCase(),
+  ];
+  return haystacks.some((h) => h.includes(needle));
+}
+
+/**
+ * Search active members of a group's community by name, flagging in-group
+ * status. The caller is excluded — you cannot assign yourself through this
+ * sheet, and listing yourself in the candidate set would be noise.
+ *
+ * Sort: in-group candidates first (alpha by display name), then
+ * community-only candidates (alpha by display name). Capped at `limit`.
+ *
+ * Auth: active group member or community admin (same gate as `listTeams`).
+ */
+export const searchCommunityPeople = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    search: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+    const group = await requireGroupMember(ctx, args.groupId, callerId);
+
+    const limit = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+    // Active community members (status === 1). The community-people list is
+    // the candidate pool; we'll annotate each with their in-group status.
+    const memberships = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_community", (q) => q.eq("communityId", group.communityId))
+      .filter((q) => q.eq(q.field("status"), 1))
+      .collect();
+
+    // Pre-fetch active group memberships once so we can flag candidates
+    // without N round-trips.
+    const groupMemberships = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .collect();
+    const activeGroupUserIds = new Set<string>(
+      groupMemberships
+        .filter(
+          (m) =>
+            !m.leftAt &&
+            (!m.requestStatus || m.requestStatus === "accepted"),
+        )
+        .map((m) => m.userId),
+    );
+
+    type Candidate = {
+      userId: Id<"users">;
+      firstName: string;
+      lastName?: string;
+      displayName: string;
+      profilePhoto?: string;
+      phone?: string;
+      isPlaceholder: boolean;
+      inGroup: boolean;
+    };
+
+    const candidates: Candidate[] = [];
+    for (const membership of memberships) {
+      if (membership.userId === callerId) continue;
+      const user = await ctx.db.get(membership.userId);
+      if (!user) continue;
+      // isActive can be undefined for legacy rows — treat undefined as active
+      // to match the rest of the app, but exclude rows explicitly flagged false
+      // (e.g. unclaimed placeholders are surfaced via `isPlaceholder`, not by
+      // becoming searchable as real users — but we still want them in the
+      // pool so leaders see "already invited" rather than re-inviting).
+      // We deliberately keep placeholders in results; the `isPlaceholder` flag
+      // lets the UI render them distinctly.
+      if (!matchesName(args.search, user.firstName, user.lastName)) continue;
+
+      const firstName = (user.firstName ?? "").trim();
+      candidates.push({
+        userId: user._id,
+        firstName,
+        lastName: user.lastName?.trim() || undefined,
+        displayName: buildDisplayName(user.firstName, user.lastName),
+        profilePhoto: getMediaUrl(user.profilePhoto),
+        phone: user.phone || undefined,
+        isPlaceholder: user.isPlaceholder === true,
+        inGroup: activeGroupUserIds.has(user._id),
+      });
+    }
+
+    // In-group first, then community-only; alpha within each bucket.
+    candidates.sort((a, b) => {
+      if (a.inGroup !== b.inGroup) return a.inGroup ? -1 : 1;
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    return candidates.slice(0, limit);
+  },
+});

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -133,6 +133,15 @@ export default defineSchema({
     lastName: v.optional(v.string()),
     isStaff: v.optional(v.boolean()),
     isActive: v.optional(v.boolean()),
+    // True when a leader created a *provisional* user via the
+    // assign-from-community "invite new person" flow — the row carries a
+    // name + phone but no real account behind it. Cleared (and `isActive`
+    // flipped to true) when that phone completes phone-OTP signup; until
+    // then `users` rows with this flag must not be treated as real accounts.
+    // See `assignFromCommunity` / `inviteAndAssign` in
+    // `functions/scheduling/assignments.ts` and the claim path in
+    // `verifyPhoneOTP` / `registerNewUser`.
+    isPlaceholder: v.optional(v.boolean()),
     dateJoined: v.optional(v.number()), // Unix timestamp ms
     roles: v.optional(v.number()), // Was: SmallInt bitmask
     profilePhoto: v.optional(v.string()),

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -1,18 +1,38 @@
 /**
  * AssignSheet
  *
- * A bottom sheet for assigning a person to a role slot. Lists the event's
- * group members as the assignable pool — team-channel membership is now
- * auto-derived from assignments (see scheduling/teamChannelSync), so listing
- * the channel's members here would be circular. People who have previously
- * filled this role are floated to the top under a "Previously filled by"
- * header. After an assignment, a soft double-booking warning surfaces if the
- * backend reports a same-day conflict — it never hard-blocks.
+ * A modal sheet for assigning a person to a role slot. Backed by three
+ * sections:
  *
- * Backend: groupMembers.list,
- * scheduling.assignments.previousFillers / assignRole.
+ *   1. PREVIOUSLY FILLED BY — recent confirmed fillers of *this role*, kept
+ *      at the top as a convenience. Hidden while the scheduler is searching.
+ *   2. GROUP — community people who are already in the event's group. Tapping
+ *      a row runs `assignRole` (no group write needed).
+ *   3. COMMUNITY — community people who are NOT yet in the event's group.
+ *      Tapping "+ Add & assign" runs `assignFromCommunity`, which adds them
+ *      to the group and assigns in a single transaction. Placeholder users
+ *      (already invited, not yet claimed) appear here as disabled rows with
+ *      an "Invited" badge.
+ *
+ * The candidate pool comes from `searchCommunityPeople`, which already
+ * annotates `inGroup` / `isPlaceholder` so the two sections are a simple
+ * partition. Search input is debounced 300ms to keep the query under
+ * control while typing.
+ *
+ * The "Invite someone new" form at the bottom calls `inviteAndAssign` (an
+ * action: it creates a placeholder user, assigns them, then SMS-invites
+ * them in one shot). The form is collapsed behind a button by default so
+ * the candidate list is the primary affordance.
+ *
+ * Backend:
+ *   - scheduling.people.searchCommunityPeople
+ *   - scheduling.assignments.previousFillers
+ *   - scheduling.assignments.assignRole
+ *   - scheduling.assignments.assignFromCommunity
+ *   - scheduling.assignments.inviteAndAssign
+ *   - scheduling.teams.getTeam (for the "Vocals · Worship Team" subtitle)
  */
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -30,30 +50,25 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { Avatar } from "@components/ui/Avatar";
 import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import {
   useAuthenticatedQuery,
   useAuthenticatedMutation,
+  useAuthenticatedAction,
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 
-/** A normalized assignable person (sourced from the event's group roster). */
-type AssignablePerson = {
-  id: string;
+/** Row shape returned by `searchCommunityPeople`. */
+type CommunityPerson = {
   userId: Id<"users">;
-  displayName?: string;
+  firstName: string;
+  lastName?: string;
+  displayName: string;
   profilePhoto?: string;
-};
-
-/** Raw row shape returned by `groupMembers.list`. */
-type GroupMemberRow = {
-  id: string;
-  user: {
-    id: Id<"users">;
-    firstName: string;
-    lastName: string;
-    profileImage?: string;
-  } | null;
+  phone?: string;
+  isPlaceholder: boolean;
+  inGroup: boolean;
 };
 
 type PreviousFiller = {
@@ -61,6 +76,20 @@ type PreviousFiller = {
   userName: string;
   lastServedDate: number;
 };
+
+/**
+ * Debounce a value by `delay` ms. Defined locally to avoid a shared-hook
+ * round-trip — other scheduling screens roll the same pattern (see
+ * FollowupDesktopTable).
+ */
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
 
 export function AssignSheet({
   visible,
@@ -87,124 +116,361 @@ export function AssignSheet({
   onClose: () => void;
 }) {
   const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
 
-  const memberData = useAuthenticatedQuery(
-    api.functions.groupMembers.list,
-    visible ? { groupId, limit: 200 } : "skip",
-  ) as { items: GroupMemberRow[] } | undefined;
+  // ---------------------------------------------------------------------------
+  // Local UI state
+  // ---------------------------------------------------------------------------
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteFirstName, setInviteFirstName] = useState("");
+  const [invitePhone, setInvitePhone] = useState("");
+  const [invitingSubmit, setInvitingSubmit] = useState(false);
 
-  // Normalize the group roster into the assignable-person shape.
-  const members = useMemo<AssignablePerson[]>(() => {
-    return (memberData?.items ?? [])
-      .filter((row): row is GroupMemberRow & { user: NonNullable<GroupMemberRow["user"]> } => row.user !== null)
-      .map((row) => ({
-        id: row.id,
-        userId: row.user.id,
-        displayName:
-          `${row.user.firstName} ${row.user.lastName}`.trim() || "Member",
-        profilePhoto: row.user.profileImage,
-      }));
-  }, [memberData?.items]);
+  // Reset transient state whenever the sheet closes so a re-open starts
+  // clean (the parent unmounts us when assignTarget clears, but be defensive).
+  useEffect(() => {
+    if (!visible) {
+      setSearch("");
+      setBusyUserId(null);
+      setInviteOpen(false);
+      setInviteFirstName("");
+      setInvitePhone("");
+      setInvitingSubmit(false);
+    }
+  }, [visible]);
+
+  // ---------------------------------------------------------------------------
+  // Data
+  // ---------------------------------------------------------------------------
+  const candidates = useAuthenticatedQuery(
+    api.functions.scheduling.people.searchCommunityPeople,
+    visible ? { groupId, search: debouncedSearch, limit: 30 } : "skip",
+  ) as CommunityPerson[] | undefined;
 
   const previous = useAuthenticatedQuery(
     api.functions.scheduling.assignments.previousFillers,
     visible ? { roleId, limit: 8 } : "skip",
   ) as PreviousFiller[] | undefined;
 
+  const team = useAuthenticatedQuery(
+    api.functions.scheduling.teams.getTeam,
+    visible ? { teamId } : "skip",
+  ) as { _id: Id<"teams">; name: string } | undefined;
+
   const assignRole = useAuthenticatedMutation(
     api.functions.scheduling.assignments.assignRole,
   );
-  const [assigning, setAssigning] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
+  const assignFromCommunity = useAuthenticatedMutation(
+    api.functions.scheduling.assignments.assignFromCommunity,
+  );
+  const inviteAndAssign = useAuthenticatedAction(
+    api.functions.scheduling.assignments.inviteAndAssign,
+  );
 
-  // Float previously-confirmed fillers to the top, de-duplicated against
-  // the rest of the roster. While a search query is active, the
-  // "previously filled by" section is hidden and every matching member is
-  // shown under "Group members" — simpler than filtering both sections.
-  const { topMembers, restMembers } = useMemo(() => {
-    const needle = search.trim().toLowerCase();
-    if (needle) {
-      const matches = members.filter((m) =>
-        (m.displayName ?? "").toLowerCase().includes(needle),
-      );
-      return { topMembers: [] as AssignablePerson[], restMembers: matches };
+  // ---------------------------------------------------------------------------
+  // Section partition
+  //
+  // `previousFillers` returns users-by-id with their display name, but it
+  // does not tell us whether they are still in the group or whether they're
+  // placeholders. We hydrate against the community-search results so the
+  // "previous" rows render with the same avatar/display-name pipeline as
+  // every other row. While the user is searching, the "previous" section
+  // is hidden — the candidate list IS the result of their query.
+  // ---------------------------------------------------------------------------
+  const { previousRows, groupRows, communityRows } = useMemo(() => {
+    const list = candidates ?? [];
+    const byUser = new Map<string, CommunityPerson>(
+      list.map((c) => [c.userId as string, c]),
+    );
+    const isSearching = debouncedSearch.trim().length > 0;
+
+    const previousRows: CommunityPerson[] = isSearching
+      ? []
+      : (previous ?? [])
+          .map((p) => byUser.get(p.userId as string))
+          .filter((c): c is CommunityPerson => !!c);
+    const previousIds = new Set(previousRows.map((p) => p.userId as string));
+
+    const groupRows: CommunityPerson[] = [];
+    const communityRows: CommunityPerson[] = [];
+    for (const c of list) {
+      if (previousIds.has(c.userId as string)) continue;
+      // Placeholders are always shown under COMMUNITY — they're not real
+      // group members yet even if `inGroup` happens to be true.
+      if (c.inGroup && !c.isPlaceholder) {
+        groupRows.push(c);
+      } else {
+        communityRows.push(c);
+      }
     }
-    const byUser = new Map(members.map((m) => [m.userId as string, m]));
-    const prevIds = new Set((previous ?? []).map((p) => p.userId as string));
-    const top = (previous ?? [])
-      .map((p) => byUser.get(p.userId as string))
-      .filter((m): m is AssignablePerson => !!m);
-    const rest = members.filter((m) => !prevIds.has(m.userId as string));
-    return { topMembers: top, restMembers: rest };
-  }, [members, previous, search]);
+    return { previousRows, groupRows, communityRows };
+  }, [candidates, previous, debouncedSearch]);
 
-  const handleAssign = useCallback(
-    async (member: AssignablePerson) => {
-      if (assignedUserIds.has(member.userId as string)) return;
-      setAssigning(member.userId as string);
+  // ---------------------------------------------------------------------------
+  // Mutation handlers
+  // ---------------------------------------------------------------------------
+  const surfaceError = useCallback(
+    (title: string, e: unknown) => {
+      const err = e as { data?: { message?: string }; message?: string };
+      const msg =
+        err?.data?.message ?? err?.message ?? "Something went wrong";
+      Alert.alert(title, msg);
+    },
+    [],
+  );
+
+  const handleAssignFromGroup = useCallback(
+    async (person: CommunityPerson) => {
+      if (assignedUserIds.has(person.userId as string)) return;
+      setBusyUserId(person.userId as string);
       try {
         const result = await assignRole({
           planId,
           teamId,
           roleId,
-          userId: member.userId,
+          userId: person.userId,
           timeLabel,
         });
-        if (result.doubleBooked) {
+        if (result?.doubleBooked) {
           Alert.alert(
             "Heads up — double-booked",
-            `${member.displayName ?? "This person"} is already scheduled somewhere else this day. They've still been assigned — they can sort it out when they respond.`,
+            `${person.displayName} is already scheduled somewhere else this day. They've still been assigned — they can sort it out when they respond.`,
           );
         }
         onClose();
-      } catch (e: any) {
-        Alert.alert("Couldn't assign", e?.message ?? "Please try again.");
+      } catch (e) {
+        surfaceError("Couldn't assign", e);
       } finally {
-        setAssigning(null);
+        setBusyUserId(null);
       }
     },
-    [assignedUserIds, assignRole, planId, teamId, roleId, timeLabel, onClose],
+    [
+      assignedUserIds,
+      assignRole,
+      planId,
+      teamId,
+      roleId,
+      timeLabel,
+      onClose,
+      surfaceError,
+    ],
   );
 
-  const renderMember = (member: AssignablePerson, prior: boolean) => {
-    const already = assignedUserIds.has(member.userId as string);
-    const busy = assigning === (member.userId as string);
+  const handleAddAndAssign = useCallback(
+    async (person: CommunityPerson) => {
+      if (assignedUserIds.has(person.userId as string)) return;
+      setBusyUserId(person.userId as string);
+      try {
+        const result = await assignFromCommunity({
+          planId,
+          teamId,
+          roleId,
+          userId: person.userId,
+          timeLabel,
+        });
+        const firstName = person.firstName?.trim() || person.displayName;
+        Alert.alert(
+          "Assigned",
+          result?.addedToGroup
+            ? `Added ${firstName} to the group and assigned to ${roleName}.`
+            : `Assigned ${firstName} to ${roleName}.`,
+        );
+        onClose();
+      } catch (e) {
+        surfaceError("Couldn't add & assign", e);
+      } finally {
+        setBusyUserId(null);
+      }
+    },
+    [
+      assignedUserIds,
+      assignFromCommunity,
+      planId,
+      teamId,
+      roleId,
+      timeLabel,
+      onClose,
+      roleName,
+      surfaceError,
+    ],
+  );
+
+  const handleInviteSubmit = useCallback(async () => {
+    const firstName = inviteFirstName.trim();
+    const phone = invitePhone.trim();
+    if (!firstName) {
+      Alert.alert("First name required", "Enter the person's first name.");
+      return;
+    }
+    if (!phone) {
+      Alert.alert("Phone required", "Enter a phone number for the SMS invite.");
+      return;
+    }
+    setInvitingSubmit(true);
+    try {
+      const result = await inviteAndAssign({
+        planId,
+        teamId,
+        roleId,
+        firstName,
+        phone,
+        timeLabel,
+      });
+      Alert.alert(
+        "Invite sent",
+        result?.sentInvite
+          ? `An SMS invite was sent to ${firstName} and they're assigned to ${roleName}.`
+          : `Couldn't send the SMS, but ${firstName} is created and assigned. You can resend later.`,
+      );
+      onClose();
+    } catch (e) {
+      surfaceError("Couldn't invite", e);
+    } finally {
+      setInvitingSubmit(false);
+    }
+  }, [
+    inviteFirstName,
+    invitePhone,
+    inviteAndAssign,
+    planId,
+    teamId,
+    roleId,
+    timeLabel,
+    roleName,
+    onClose,
+    surfaceError,
+  ]);
+
+  // ---------------------------------------------------------------------------
+  // Row renderers
+  //
+  // RN-Web gotcha: a function-style `style` prop on Pressable silently drops
+  // layout (gap / flexDirection / padding) on web. We keep layout on a
+  // static-styled inner <View> and only use Pressable for the tap target.
+  // ---------------------------------------------------------------------------
+  const renderGroupRow = (person: CommunityPerson, prior: boolean) => {
+    const already = assignedUserIds.has(person.userId as string);
+    const busy = busyUserId === (person.userId as string);
+    const disabled = already || !!busyUserId || invitingSubmit;
     return (
       <Pressable
-        key={member.id}
-        onPress={() => handleAssign(member)}
-        disabled={already || !!assigning}
-        style={({ pressed }) => [
-          styles.memberRow,
-          pressed && !already && { backgroundColor: colors.selectedBackground },
-          already && { opacity: 0.5 },
-        ]}
+        key={person.userId as string}
+        onPress={() => handleAssignFromGroup(person)}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={`Assign ${person.displayName}`}
       >
-        <Avatar
-          name={member.displayName ?? "Member"}
-          imageUrl={member.profilePhoto}
-          size={40}
-        />
-        <Text
-          style={[styles.memberName, { color: colors.text }]}
-          numberOfLines={1}
+        <View
+          style={[
+            styles.memberRow,
+            already && { opacity: 0.5 },
+          ]}
         >
-          {member.displayName ?? "Member"}
-        </Text>
-        {busy ? (
-          <ActivityIndicator size="small" color={colors.text} />
-        ) : already ? (
-          <Text style={[styles.alreadyText, { color: colors.textSecondary }]}>
-            Assigned
+          <Avatar
+            name={person.displayName}
+            imageUrl={person.profilePhoto}
+            size={40}
+          />
+          <Text
+            style={[styles.memberName, { color: colors.text }]}
+            numberOfLines={1}
+          >
+            {person.displayName}
           </Text>
-        ) : prior ? (
-          <Ionicons name="star" size={16} color={colors.warning} />
-        ) : (
-          <Ionicons name="add" size={20} color={colors.textSecondary} />
-        )}
+          {busy ? (
+            <ActivityIndicator size="small" color={colors.text} />
+          ) : already ? (
+            <Text style={[styles.metaText, { color: colors.textSecondary }]}>
+              Assigned
+            </Text>
+          ) : prior ? (
+            <Ionicons name="star" size={16} color={colors.warning} />
+          ) : (
+            <Ionicons name="add" size={20} color={colors.textSecondary} />
+          )}
+        </View>
       </Pressable>
     );
   };
+
+  const renderCommunityRow = (person: CommunityPerson) => {
+    const already = assignedUserIds.has(person.userId as string);
+    const busy = busyUserId === (person.userId as string);
+    const isPlaceholder = person.isPlaceholder;
+    // Placeholders are informational — they can't be re-invited from here.
+    const disabled =
+      isPlaceholder || already || !!busyUserId || invitingSubmit;
+    return (
+      <Pressable
+        key={person.userId as string}
+        onPress={() => handleAddAndAssign(person)}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={`Add ${person.displayName} to the group and assign`}
+      >
+        <View
+          style={[
+            styles.memberRow,
+            (isPlaceholder || already) && { opacity: 0.55 },
+          ]}
+        >
+          <Avatar
+            name={person.displayName}
+            imageUrl={person.profilePhoto}
+            size={40}
+          />
+          <Text
+            style={[styles.memberName, { color: colors.text }]}
+            numberOfLines={1}
+          >
+            {person.displayName}
+          </Text>
+          {busy ? (
+            <ActivityIndicator size="small" color={colors.text} />
+          ) : isPlaceholder ? (
+            <View
+              style={[
+                styles.badge,
+                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+            >
+              <Text style={[styles.badgeText, { color: colors.textSecondary }]}>
+                Invited
+              </Text>
+            </View>
+          ) : already ? (
+            <Text style={[styles.metaText, { color: colors.textSecondary }]}>
+              Assigned
+            </Text>
+          ) : (
+            <View style={styles.addAssignWrap}>
+              <Ionicons name="add" size={16} color={primaryColor} />
+              <Text
+                style={[styles.addAssignText, { color: primaryColor }]}
+              >
+                Add & assign
+              </Text>
+            </View>
+          )}
+        </View>
+      </Pressable>
+    );
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+  const loading = candidates === undefined;
+  const teamName = team?.name;
+  const subtitle = [roleName, teamName].filter(Boolean).join(" · ");
+  const showEmpty =
+    !loading &&
+    previousRows.length === 0 &&
+    groupRows.length === 0 &&
+    communityRows.length === 0;
 
   return (
     <Modal
@@ -214,35 +480,28 @@ export function AssignSheet({
       onRequestClose={onClose}
     >
       <View style={[styles.container, { backgroundColor: colors.surface }]}>
-        <View
-          style={[styles.header, { borderBottomColor: colors.border }]}
-        >
+        <View style={[styles.header, { borderBottomColor: colors.border }]}>
+          <TouchableOpacity onPress={onClose} hitSlop={12} style={styles.headerClose}>
+            <Ionicons name="chevron-back" size={26} color={colors.text} />
+          </TouchableOpacity>
           <View style={styles.headerTextWrap}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>
-              Assign {roleName}
+              Assign someone
             </Text>
-            {timeLabel ? (
-              <Text
-                style={[styles.headerSub, { color: colors.textSecondary }]}
-              >
-                {timeLabel}
-              </Text>
-            ) : null}
+            <Text
+              style={[styles.headerSub, { color: colors.textSecondary }]}
+              numberOfLines={1}
+            >
+              {subtitle}
+              {timeLabel ? ` · ${timeLabel}` : ""}
+            </Text>
           </View>
-          <TouchableOpacity onPress={onClose} hitSlop={12}>
-            <Ionicons name="close" size={26} color={colors.text} />
-          </TouchableOpacity>
         </View>
 
-        {memberData === undefined ? (
-          <View style={styles.centered}>
-            <ActivityIndicator size="small" color={colors.text} />
-          </View>
-        ) : (
-          <KeyboardAvoidingView
-            style={styles.flex}
-            behavior={Platform.OS === "ios" ? "padding" : undefined}
-          >
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
           <ScrollView
             contentContainerStyle={styles.scrollContent}
             keyboardShouldPersistTaps="handled"
@@ -257,7 +516,7 @@ export function AssignSheet({
               <Ionicons name="search" size={16} color={colors.textSecondary} />
               <TextInput
                 style={[styles.searchInput, { color: colors.text }]}
-                placeholder="Search members"
+                placeholder="Search by name…"
                 placeholderTextColor={colors.textSecondary}
                 value={search}
                 onChangeText={setSearch}
@@ -265,51 +524,196 @@ export function AssignSheet({
                 autoCapitalize="none"
               />
             </View>
-            {topMembers.length > 0 && (
+
+            {loading ? (
+              <View style={styles.centered}>
+                <ActivityIndicator size="small" color={colors.text} />
+              </View>
+            ) : (
               <>
-                <Text
-                  style={[styles.sectionLabel, { color: colors.textSecondary }]}
-                >
-                  PREVIOUSLY FILLED BY
-                </Text>
-                <View
-                  style={[
-                    styles.group,
-                    { backgroundColor: colors.surfaceSecondary },
-                  ]}
-                >
-                  {topMembers.map((m) => renderMember(m, true))}
-                </View>
+                {previousRows.length > 0 && (
+                  <>
+                    <Text
+                      style={[styles.sectionLabel, { color: colors.textSecondary }]}
+                    >
+                      PREVIOUSLY FILLED BY
+                    </Text>
+                    <View
+                      style={[
+                        styles.group,
+                        { backgroundColor: colors.surfaceSecondary },
+                      ]}
+                    >
+                      {previousRows.map((m) => renderGroupRow(m, true))}
+                    </View>
+                  </>
+                )}
+
+                {groupRows.length > 0 && (
+                  <>
+                    <Text
+                      style={[styles.sectionLabel, { color: colors.textSecondary }]}
+                    >
+                      GROUP
+                    </Text>
+                    <View
+                      style={[
+                        styles.group,
+                        { backgroundColor: colors.surfaceSecondary },
+                      ]}
+                    >
+                      {groupRows.map((m) => renderGroupRow(m, false))}
+                    </View>
+                  </>
+                )}
+
+                {communityRows.length > 0 && (
+                  <>
+                    <Text
+                      style={[styles.sectionLabel, { color: colors.textSecondary }]}
+                    >
+                      COMMUNITY
+                    </Text>
+                    <View
+                      style={[
+                        styles.group,
+                        { backgroundColor: colors.surfaceSecondary },
+                      ]}
+                    >
+                      {communityRows.map(renderCommunityRow)}
+                    </View>
+                  </>
+                )}
+
+                {showEmpty && (
+                  <Text
+                    style={[styles.emptyText, { color: colors.textSecondary }]}
+                  >
+                    {debouncedSearch.trim()
+                      ? `No one in this community matches "${debouncedSearch.trim()}".`
+                      : "No assignable people yet — invite someone new below."}
+                  </Text>
+                )}
               </>
             )}
+
+            {/* Invite someone new — collapsed by default. */}
             <Text
               style={[styles.sectionLabel, { color: colors.textSecondary }]}
             >
-              GROUP MEMBERS
+              INVITE SOMEONE NEW
             </Text>
-            <View
-              style={[
-                styles.group,
-                { backgroundColor: colors.surfaceSecondary },
-              ]}
-            >
-              {restMembers.length === 0 ? (
-                <Text
-                  style={[styles.emptyText, { color: colors.textSecondary }]}
+            {inviteOpen ? (
+              <View
+                style={[
+                  styles.inviteCard,
+                  { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                ]}
+              >
+                <TextInput
+                  style={[
+                    styles.inviteInput,
+                    { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
+                  ]}
+                  placeholder="First name"
+                  placeholderTextColor={colors.textSecondary}
+                  value={inviteFirstName}
+                  onChangeText={setInviteFirstName}
+                  autoCapitalize="words"
+                  autoCorrect={false}
+                  editable={!invitingSubmit}
+                />
+                <TextInput
+                  style={[
+                    styles.inviteInput,
+                    { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
+                  ]}
+                  placeholder="Phone (e.g. (555) 123-4567)"
+                  placeholderTextColor={colors.textSecondary}
+                  value={invitePhone}
+                  onChangeText={setInvitePhone}
+                  keyboardType="phone-pad"
+                  autoCorrect={false}
+                  editable={!invitingSubmit}
+                />
+                <View style={styles.inviteActions}>
+                  <Pressable
+                    onPress={() => {
+                      if (invitingSubmit) return;
+                      setInviteOpen(false);
+                      setInviteFirstName("");
+                      setInvitePhone("");
+                    }}
+                    disabled={invitingSubmit}
+                    accessibilityRole="button"
+                    accessibilityLabel="Cancel invite"
+                  >
+                    <View style={styles.inviteCancelInner}>
+                      <Text
+                        style={[styles.inviteCancelText, { color: colors.textSecondary }]}
+                      >
+                        Cancel
+                      </Text>
+                    </View>
+                  </Pressable>
+                  <Pressable
+                    onPress={handleInviteSubmit}
+                    disabled={invitingSubmit}
+                    accessibilityRole="button"
+                    accessibilityLabel="Send invite and assign"
+                  >
+                    <View
+                      style={[
+                        styles.inviteSubmitInner,
+                        {
+                          backgroundColor: primaryColor,
+                          opacity: invitingSubmit ? 0.6 : 1,
+                        },
+                      ]}
+                    >
+                      {invitingSubmit ? (
+                        <ActivityIndicator size="small" color={colors.surface} />
+                      ) : (
+                        <Text
+                          style={[styles.inviteSubmitText, { color: colors.surface }]}
+                        >
+                          Send invite & assign
+                        </Text>
+                      )}
+                    </View>
+                  </Pressable>
+                </View>
+              </View>
+            ) : (
+              <Pressable
+                onPress={() => setInviteOpen(true)}
+                accessibilityRole="button"
+                accessibilityLabel="Invite someone new"
+              >
+                <View
+                  style={[
+                    styles.inviteToggle,
+                    { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                  ]}
                 >
-                  {search.trim()
-                    ? `No members match "${search.trim()}"`
-                    : topMembers.length > 0
-                      ? "Everyone in this group is already an option above."
-                      : "No group members to assign yet."}
-                </Text>
-              ) : (
-                restMembers.map((m) => renderMember(m, false))
-              )}
-            </View>
+                  <Ionicons
+                    name="add-circle-outline"
+                    size={18}
+                    color={primaryColor}
+                  />
+                  <Text
+                    style={[
+                      styles.inviteToggleText,
+                      { color: primaryColor },
+                    ]}
+                  >
+                    Invite someone new
+                  </Text>
+                </View>
+              </Pressable>
+            )}
           </ScrollView>
-          </KeyboardAvoidingView>
-        )}
+        </KeyboardAvoidingView>
       </View>
     </Modal>
   );
@@ -325,9 +729,13 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: 16,
+    paddingHorizontal: 12,
     paddingVertical: 14,
     borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 8,
+  },
+  headerClose: {
+    paddingHorizontal: 4,
   },
   headerTextWrap: {
     flex: 1,
@@ -341,12 +749,13 @@ const styles = StyleSheet.create({
     marginTop: 2,
   },
   centered: {
-    flex: 1,
+    paddingVertical: 32,
     alignItems: "center",
     justifyContent: "center",
   },
   scrollContent: {
     padding: 16,
+    paddingBottom: 32,
   },
   searchBox: {
     flexDirection: "row",
@@ -386,12 +795,85 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "500",
   },
-  alreadyText: {
+  metaText: {
     fontSize: 13,
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: "600",
+    letterSpacing: 0.4,
+  },
+  addAssignWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  addAssignText: {
+    fontSize: 14,
+    fontWeight: "600",
   },
   emptyText: {
     fontSize: 14,
-    padding: 16,
+    paddingVertical: 16,
     lineHeight: 20,
+  },
+  inviteToggle: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  inviteToggleText: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  inviteCard: {
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    gap: 10,
+  },
+  inviteInput: {
+    fontSize: 15,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  inviteActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: 8,
+    marginTop: 4,
+  },
+  inviteCancelInner: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  inviteCancelText: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  inviteSubmitInner: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+    minWidth: 180,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  inviteSubmitText: {
+    fontSize: 14,
+    fontWeight: "600",
   },
 });

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -24,6 +24,8 @@ import {
   ScrollView,
   TextInput,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { Avatar } from "@components/ui/Avatar";
@@ -237,9 +239,14 @@ export function AssignSheet({
             <ActivityIndicator size="small" color={colors.text} />
           </View>
         ) : (
+          <KeyboardAvoidingView
+            style={styles.flex}
+            behavior={Platform.OS === "ios" ? "padding" : undefined}
+          >
           <ScrollView
             contentContainerStyle={styles.scrollContent}
             keyboardShouldPersistTaps="handled"
+            automaticallyAdjustKeyboardInsets={Platform.OS === "ios"}
           >
             <View
               style={[
@@ -301,6 +308,7 @@ export function AssignSheet({
               )}
             </View>
           </ScrollView>
+          </KeyboardAvoidingView>
         )}
       </View>
     </Modal>
@@ -309,6 +317,9 @@ export function AssignSheet({
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+  },
+  flex: {
     flex: 1,
   },
   header: {

--- a/apps/mobile/features/scheduling/components/NeededRolesModal.tsx
+++ b/apps/mobile/features/scheduling/components/NeededRolesModal.tsx
@@ -27,6 +27,8 @@ import {
   TextInput,
   Switch,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
@@ -195,9 +197,14 @@ export function NeededRolesModal({
             <ActivityIndicator size="small" color={colors.text} />
           </View>
         ) : (
+          <KeyboardAvoidingView
+            style={styles.flex}
+            behavior={Platform.OS === "ios" ? "padding" : undefined}
+          >
           <ScrollView
             contentContainerStyle={styles.scrollContent}
             keyboardShouldPersistTaps="handled"
+            automaticallyAdjustKeyboardInsets={Platform.OS === "ios"}
           >
             {teams.length === 0 ? (
               <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
@@ -330,6 +337,7 @@ export function NeededRolesModal({
               </Pressable>
             )}
           </ScrollView>
+          </KeyboardAvoidingView>
         )}
       </View>
     </Modal>
@@ -607,6 +615,9 @@ function Stepper({
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+  },
+  flex: {
     flex: 1,
   },
   header: {

--- a/apps/mobile/features/scheduling/components/TeamCreateScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TeamCreateScreen.tsx
@@ -22,6 +22,8 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -105,12 +107,17 @@ export function TeamCreateScreen() {
         <View style={styles.headerSpacer} />
       </View>
 
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
       <ScrollView
         contentContainerStyle={[
           styles.scrollContent,
           { paddingBottom: insets.bottom + 32 },
         ]}
         keyboardShouldPersistTaps="handled"
+        automaticallyAdjustKeyboardInsets={Platform.OS === "ios"}
       >
         <Text style={[styles.label, { color: colors.textSecondary }]}>
           Team name
@@ -197,12 +204,16 @@ export function TeamCreateScreen() {
           You'll add roles to the team next.
         </Text>
       </ScrollView>
+      </KeyboardAvoidingView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+  },
+  flex: {
     flex: 1,
   },
   header: {


### PR DESCRIPTION
## Summary

Two pieces, shipped together because they showed up in the same testing session on prod:

1. **Keyboard fix** — on iOS, the keyboard was covering the inline "+ Add a role to {Team}" / "+ Create a new team" inputs in `NeededRolesModal` and the name/description inputs in `TeamCreateScreen`. Same fix added to `AssignSheet` since it now also has text inputs (see piece 2).
2. **Assign from community + invite a brand-new person** — `AssignSheet` is no longer limited to group members. Search the whole community, one-tap "Add & assign" for community members not in the group, and an inline invite form (first name + phone) that sends an SMS and creates a placeholder user assigned to the role. When the invitee signs up via the normal phone-OTP flow, the placeholder is *claimed* — same `_id`, so the existing `roleAssignments` / `groupMembers` / `userCommunities` rows it already has just become real.

## Backend (commit `cf0fd57`)

- **Schema** — adds `users.isPlaceholder: v.optional(v.boolean())`. Single additive change; no migration.
- **New** `apps/convex/functions/scheduling/people.ts` exports `searchCommunityPeople({ token, groupId, search, limit? })` — name-substring search across active community members, returning `{ userId, displayName, firstName, lastName?, phone?, isPlaceholder, inGroup }`. In-group first, then community-only; placeholders carry `isPlaceholder: true` so the UI can badge them.
- **New** mutations / actions in `scheduling/assignments.ts`:
  - `assignFromCommunity({ planId, teamId, roleId, userId, timeLabel? })` — adds the user to the group if needed (reactivates `leftAt` / pending rows; inserts otherwise), then assigns. Returns `{ assignmentId, addedToGroup }`.
  - `inviteAndAssign({ planId, teamId, roleId, firstName, phone, timeLabel? })` — *action* (Twilio is a Node action). Validates name + phone, inserts a placeholder `users` row, `userCommunities`, `groupMembers`, the role assignment, then dispatches the SMS via the existing `internal.functions.auth.phoneOtp.sendSMS` path. Returns `{ assignmentId, invitedUserId, sentInvite }`. Loud error if a real (non-placeholder) user already has that phone.
  - `assignRole`'s observable behavior unchanged — it just shares a `performAssignment` helper with the two new entry points.
- **Claim on signup** — `apps/convex/functions/authInternal.ts`'s new `claimPlaceholderByPhoneInternal` is called from `registerNewUser` (and `verifyPhoneOTP` reroutes placeholder phones through registration instead of returning an empty profile). Claim clears `isPlaceholder`, sets `isActive: true`, applies the supplied name/email, and keeps the `_id` stable so every pre-existing reference is preserved. Real users (`isPlaceholder !== true`) are never claimed.

## Frontend (commit `f68be25`)

`apps/mobile/features/scheduling/components/AssignSheet.tsx` rewritten:

- Top search bar (debounced ~300ms) drives `searchCommunityPeople`.
- **GROUP** section — already-in-group rows, fast-path via existing `assignRole`.
- **COMMUNITY** section — community-only rows with an `+ Add & assign` affordance. Tap → `assignFromCommunity`; on success the sheet dismisses and a toast confirms.
- **Placeholder rows** appear in COMMUNITY disabled with an "Invited" badge so leaders see who's already been invited.
- **+ Invite someone new** — collapsed by default; expands to a first-name + phone form with a "Send invite & assign" submit calling `inviteAndAssign`. The keyboard fix from commit `ccc23f1` keeps the form visible.
- Errors surface via `Alert.alert` with `e.data?.message` when present.

## Tests (commit `5762df8`)

- **+7 tests** in new `__tests__/scheduling/people.test.ts` — auth gating, sort order (in-group first then community-only), case-insensitive matching across firstName/lastName/displayName, limit cap, placeholder inclusion.
- **+10 tests** added to `__tests__/scheduling/assignments.test.ts` covering `assignFromCommunity` (auto-join, reactivation, cross-community defense, shared guards) and `inviteAndAssign` (placeholder row + memberships + assignment, `sentInvite` paths, duplicate-phone rejection, auth gate).
- **+6 tests** in new `__tests__/auth/placeholder-claim.test.ts` — placeholder claim preserves `_id` and pre-existing memberships, real users are never claimed, email-collision guard.
- `SchedulingWorld` fixture extended with `communityOnlyAId` / `communityOnlyBId` / `placeholderUserId` (additive; existing tests untouched).
- **130/130 scheduling + auth tests pass.**

## Verification

- `apps/convex` typechecks clean; 130 scheduling + auth tests pass.
- `apps/mobile` typechecks clean (13 pre-existing errors in unrelated files); 1030 mobile tests pass.

## Notes

- The schema change (`users.isPlaceholder`) is fully additive — safe to deploy at any time, no migration step needed.
- The SMS deeplink is the app's standard signup URL with a `?phone=` query param; if/when a dedicated invite-link route is added it can swap in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
