### PR TITLE
Use shared search_users index for community pickers (scheduling + group Add People)

### DIFF
--- a/apps/convex/__tests__/groupSearch-members.test.ts
+++ b/apps/convex/__tests__/groupSearch-members.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for `groupSearch.searchCommunityMembers` — the backend behind the
+ * leader-facing "Add people" group-info screen.
+ *
+ * The function is backed by the `users.search_users` full-text index plus
+ * a per-candidate community-membership lookup. The tests below pin down
+ * the behaviors that were added to support the group "Add people" UI:
+ *
+ *  - `inGroup` annotation when `annotateGroupId` is provided
+ *  - empty-search recent-members fallback when `annotateGroupId` is provided
+ *  - `isActive === false` users are hidden UNLESS they are placeholders
+ *  - the caller is excluded by default
+ *  - the limit is honored and capped at 100
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/groupSearch-members.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+
+// JWT secret must be at least 32 characters
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+vi.useFakeTimers();
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+interface SearchTestData {
+  communityId: Id<"communities">;
+  groupTypeId: Id<"groupTypes">;
+  groupId: Id<"groups">;
+  callerUserId: Id<"users">;
+  callerToken: string;
+  inGroupUserId: Id<"users">;
+  outsideGroupUserId: Id<"users">;
+  inactiveUserId: Id<"users">;
+  placeholderUserId: Id<"users">;
+}
+
+async function seedSearchTestData(
+  t: ReturnType<typeof convexTest>,
+): Promise<SearchTestData> {
+  const ids = await t.run(async (ctx) => {
+    const now = Date.now();
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Search Community",
+      slug: "search-community",
+      isPublic: true,
+      timezone: "America/New_York",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Group",
+      slug: "group",
+      isActive: true,
+      createdAt: now,
+      displayOrder: 1,
+    });
+
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Main Group",
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const callerUserId = await ctx.db.insert("users", {
+      firstName: "Caller",
+      lastName: "Leader",
+      email: "caller@test.com",
+      phone: "+15551110001",
+      isActive: true,
+      searchText: "caller leader caller@test.com +15551110001",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // User who is in the group already (should be annotated `inGroup: true`).
+    const inGroupUserId = await ctx.db.insert("users", {
+      firstName: "Annie",
+      lastName: "Member",
+      email: "annie@test.com",
+      phone: "+15551110002",
+      isActive: true,
+      searchText: "annie member annie@test.com +15551110002",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // User who is in the community but NOT in the group.
+    const outsideGroupUserId = await ctx.db.insert("users", {
+      firstName: "Annie",
+      lastName: "Outside",
+      email: "outside@test.com",
+      phone: "+15551110003",
+      isActive: true,
+      searchText: "annie outside outside@test.com +15551110003",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Inactive user — should be hidden because not a placeholder.
+    const inactiveUserId = await ctx.db.insert("users", {
+      firstName: "Annie",
+      lastName: "Inactive",
+      email: "inactive@test.com",
+      phone: "+15551110004",
+      isActive: false,
+      searchText: "annie inactive inactive@test.com +15551110004",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Placeholder user — leader-created provisional account. Must remain
+    // visible even though isActive=false so leaders see "already invited".
+    const placeholderUserId = await ctx.db.insert("users", {
+      firstName: "Annie",
+      lastName: "Placeholder",
+      phone: "+15551110005",
+      isActive: false,
+      isPlaceholder: true,
+      searchText: "annie placeholder +15551110005",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // All four belong to the community (status=1).
+    for (const userId of [
+      callerUserId,
+      inGroupUserId,
+      outsideGroupUserId,
+      inactiveUserId,
+      placeholderUserId,
+    ]) {
+      await ctx.db.insert("userCommunities", {
+        userId,
+        communityId,
+        roles: 1,
+        status: 1,
+        lastLogin: now,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    // Caller + inGroupUser are members of the group.
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: callerUserId,
+      role: "leader",
+      joinedAt: now,
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: inGroupUserId,
+      role: "member",
+      joinedAt: now,
+      notificationsEnabled: true,
+    });
+
+    return {
+      communityId,
+      groupTypeId,
+      groupId,
+      callerUserId,
+      inGroupUserId,
+      outsideGroupUserId,
+      inactiveUserId,
+      placeholderUserId,
+    };
+  });
+
+  const { accessToken: callerToken } = await generateTokens(ids.callerUserId);
+
+  return { ...ids, callerToken };
+}
+
+describe("groupSearch.searchCommunityMembers", () => {
+  test("annotates `inGroup: true` for users already in the group", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSearchTestData(t);
+
+    const results = await t.query(
+      api.functions.groupSearch.searchCommunityMembers,
+      {
+        token: data.callerToken,
+        communityId: data.communityId,
+        search: "annie",
+        annotateGroupId: data.groupId,
+        limit: 30,
+      },
+    );
+
+    const byId = new Map(results.map((r) => [r.id, r]));
+
+    // Caller is excluded by default.
+    expect(byId.has(data.callerUserId)).toBe(false);
+
+    // Annie in group → annotated inGroup=true.
+    expect(byId.get(data.inGroupUserId)?.inGroup).toBe(true);
+    // Annie outside group → annotated inGroup=false.
+    expect(byId.get(data.outsideGroupUserId)?.inGroup).toBe(false);
+
+    // Placeholder remains visible.
+    expect(byId.get(data.placeholderUserId)?.inGroup).toBe(false);
+
+    // Inactive (non-placeholder) user is hidden.
+    expect(byId.has(data.inactiveUserId)).toBe(false);
+  });
+
+  test("falls back to recent community members when search is empty and annotateGroupId is set", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSearchTestData(t);
+
+    const results = await t.query(
+      api.functions.groupSearch.searchCommunityMembers,
+      {
+        token: data.callerToken,
+        communityId: data.communityId,
+        search: "",
+        annotateGroupId: data.groupId,
+        limit: 30,
+      },
+    );
+
+    const returnedIds = new Set(results.map((r) => r.id));
+    // Should include some recent community members even without a query.
+    expect(returnedIds.has(data.outsideGroupUserId)).toBe(true);
+    // Caller still excluded.
+    expect(returnedIds.has(data.callerUserId)).toBe(false);
+  });
+
+  test("returns [] for empty search when annotateGroupId is not provided", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSearchTestData(t);
+
+    const results = await t.query(
+      api.functions.groupSearch.searchCommunityMembers,
+      {
+        token: data.callerToken,
+        communityId: data.communityId,
+        search: "",
+        limit: 30,
+      },
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  test("throws when annotateGroupId belongs to a different community", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSearchTestData(t);
+
+    const otherCommunityId = await t.run(async (ctx) => {
+      return await ctx.db.insert("communities", {
+        name: "Other",
+        slug: "other",
+        isPublic: false,
+        timezone: "UTC",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.query(api.functions.groupSearch.searchCommunityMembers, {
+        token: data.callerToken,
+        communityId: otherCommunityId,
+        search: "annie",
+        annotateGroupId: data.groupId,
+        limit: 30,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("does not return inactive non-placeholder users", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSearchTestData(t);
+
+    const results = await t.query(
+      api.functions.groupSearch.searchCommunityMembers,
+      {
+        token: data.callerToken,
+        communityId: data.communityId,
+        search: "annie",
+        limit: 30,
+      },
+    );
+
+    const returnedIds = results.map((r) => r.id);
+    expect(returnedIds).not.toContain(data.inactiveUserId);
+    // But placeholders still surface.
+    expect(returnedIds).toContain(data.placeholderUserId);
+  });
+});

--- a/apps/convex/__tests__/scheduling/fixtures.ts
+++ b/apps/convex/__tests__/scheduling/fixtures.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Id } from "../../_generated/dataModel";
+import { buildSearchText } from "../../lib/utils";
 
 /**
  * The convex-test handle. Typed via a type-only dynamic import so this file
@@ -62,15 +63,21 @@ async function insertUser(
   firstName: string,
   phone?: string,
 ): Promise<Id<"users">> {
+  const lastName = "Test";
+  const email = `${firstName.toLowerCase()}@example.com`;
   return ctx.db.insert("users", {
     firstName,
-    lastName: "Test",
-    email: `${firstName.toLowerCase()}@example.com`,
+    lastName,
+    email,
     phone,
     isActive: true,
     roles: 1,
     createdAt: ts(),
     updatedAt: ts(),
+    // Production users have this populated by `createUserInternal` so the
+    // `search_users` index returns them — mirror that here so `searchCommunityPeople`
+    // / `searchCommunityMembers` work in tests.
+    searchText: buildSearchText({ firstName, lastName, email, phone }),
   });
 }
 
@@ -132,6 +139,13 @@ export async function buildSchedulingWorld(
       phoneVerified: false,
       createdAt: ts(),
       updatedAt: ts(),
+      // Same searchText treatment as real users so the placeholder appears
+      // in the search index (so it shows up as "Invited" in the picker).
+      searchText: buildSearchText({
+        firstName: "Phoebe",
+        lastName: "Placeholder",
+        phone: "+12025550009",
+      }),
     });
 
     const channelId = await ctx.db.insert("chatChannels", {

--- a/apps/convex/functions/groupSearch.ts
+++ b/apps/convex/functions/groupSearch.ts
@@ -8,7 +8,7 @@
  * - Community members search
  */
 
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query } from "../_generated/server";
 import { normalizePagination, getMediaUrl } from "../lib/utils";
 import { paginationArgs } from "../lib/validators";
@@ -668,13 +668,21 @@ export const publicGroupDetail = query({
 
 /**
  * Search community members (for adding to groups, proposing leaders, etc.)
- * Available to all authenticated community members
+ * Available to all authenticated community members.
+ *
+ * Backed by the `users.search_users` full-text index — read count is
+ * O(matches), not O(community size). The leader-facing "Add people" group
+ * info screen uses this with `annotateGroupId` so each row carries
+ * `inGroup`, letting the UI dim already-in-group members instead of having
+ * the server hide them.
  *
  * Supports:
  * - Comma-separated search terms: "john, jane, 555-1234"
- * - Phone number normalization: "(555) 123-4567" matches "5551234567"
- * - Full-text search on name, email
- * - Rich results with email, phone, groupsCount
+ * - Phone-formatted queries: a digits-only fallback term is added per
+ *   search term so `(555) 123-4567` still hits `+15551234567`
+ * - Empty search + `annotateGroupId`: returns the most recently active
+ *   community members (via `userCommunities.by_community_lastLogin`)
+ * - Annotated `inGroup` per row when `annotateGroupId` is supplied
  */
 export const searchCommunityMembers = query({
   args: {
@@ -683,6 +691,12 @@ export const searchCommunityMembers = query({
     excludeUserIds: v.optional(v.array(v.id("users"))),
     includeGroupIds: v.optional(v.array(v.id("groups"))),
     excludeGroupId: v.optional(v.id("groups")),
+    /**
+     * When set, each result row carries `inGroup: boolean`. Empty searches
+     * also fall back to the community's most-recently-active members so the
+     * "Add people" picker isn't blank before the leader types anything.
+     */
+    annotateGroupId: v.optional(v.id("groups")),
     token: v.string(),
     /** If true, includes the current user in results (default: false, excludes current user) */
     includeSelf: v.optional(v.boolean()),
@@ -691,8 +705,21 @@ export const searchCommunityMembers = query({
   handler: async (ctx, args): Promise<MemberSearchResult[]> => {
     const userId = await requireAuth(ctx, args.token);
 
-    if (!args.search.trim()) {
+    // Empty search with no group context → nothing to show. The
+    // `annotateGroupId` branch triggers the recent-members fallback inside
+    // the shared helper.
+    if (!args.search.trim() && !args.annotateGroupId) {
       return [];
+    }
+
+    if (args.annotateGroupId) {
+      const group = await ctx.db.get(args.annotateGroupId);
+      if (!group) {
+        throw new ConvexError("Group not found");
+      }
+      if (group.communityId !== args.communityId) {
+        throw new ConvexError("Group is not in this community");
+      }
     }
 
     // Use the shared search helper
@@ -707,7 +734,11 @@ export const searchCommunityMembers = query({
       excludeUserIds,
       groupIds: args.includeGroupIds,
       excludeGroupId: args.excludeGroupId,
-      limit: Math.min(args.limit ?? 20, 50),
+      annotateGroupId: args.annotateGroupId,
+      // Default 30, hard cap 100 — matches the admin People search and keeps
+      // the per-row notif-disabled / membership lookups bounded.
+      limit: Math.min(args.limit ?? 30, 100),
+      fallbackToRecentWhenEmpty: !!args.annotateGroupId,
     });
   },
 });

--- a/apps/convex/functions/scheduling/people.ts
+++ b/apps/convex/functions/scheduling/people.ts
@@ -8,6 +8,14 @@
  *   • "Assign" (in-group)
  *   • "Add to group + assign" (community-only).
  *
+ * Implementation: delegates to the shared `searchCommunityMembersInternal`
+ * helper so this stays in lock-step with the admin People search and the
+ * group "Add people" picker — same `users.search_users` full-text index,
+ * same isActive/isPlaceholder treatment, same phone-normalization
+ * behaviour. A naïve `.collect()` of the whole community per keystroke
+ * (the pre-refactor version) was O(community-size) and unusable at scale
+ * — see PR #404 codex review.
+ *
  * Read gate matches `listTeams` — any active group member may search. The
  * write side (`assignFromCommunity` / `inviteAndAssign`) re-asserts the
  * stricter `requirePlanScheduler` check.
@@ -15,9 +23,8 @@
 
 import { v } from "convex/values";
 import { query } from "../../_generated/server";
-import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
-import { getMediaUrl } from "../../lib/utils";
+import { searchCommunityMembersInternal } from "../../lib/memberSearch";
 import { requireGroupMember } from "./permissions";
 
 /** Default cap on returned candidates. */
@@ -37,26 +44,6 @@ function buildDisplayName(
   const last = (lastName ?? "").trim();
   if (first && last) return `${first} ${last}`;
   return first || last || "Someone";
-}
-
-/**
- * Case-insensitive substring match across firstName, lastName, and the
- * combined "first last" display name. Empty search returns everything (the
- * cap still applies).
- */
-function matchesName(
-  search: string,
-  firstName: string | undefined,
-  lastName: string | undefined,
-): boolean {
-  const needle = search.trim().toLowerCase();
-  if (!needle) return true;
-  const haystacks = [
-    (firstName ?? "").toLowerCase(),
-    (lastName ?? "").toLowerCase(),
-    buildDisplayName(firstName, lastName).toLowerCase(),
-  ];
-  return haystacks.some((h) => h.includes(needle));
 }
 
 /**
@@ -82,74 +69,40 @@ export const searchCommunityPeople = query({
 
     const limit = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
 
-    // Active community members (status === 1). The community-people list is
-    // the candidate pool; we'll annotate each with their in-group status.
-    const memberships = await ctx.db
-      .query("userCommunities")
-      .withIndex("by_community", (q) => q.eq("communityId", group.communityId))
-      .filter((q) => q.eq(q.field("status"), 1))
-      .collect();
+    // Delegate to the shared helper — same search index + isActive /
+    // isPlaceholder rules as the admin People and group Add People searches.
+    // `annotateGroupId` makes each row carry `inGroup`; `fallbackToRecentWhenEmpty`
+    // surfaces a sensible default list before the leader has typed anything.
+    const rows = await searchCommunityMembersInternal(ctx, {
+      communityId: group.communityId,
+      search: args.search,
+      excludeUserIds: [callerId],
+      annotateGroupId: args.groupId,
+      limit,
+      fallbackToRecentWhenEmpty: true,
+    });
 
-    // Pre-fetch active group memberships once so we can flag candidates
-    // without N round-trips.
-    const groupMemberships = await ctx.db
-      .query("groupMembers")
-      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
-      .collect();
-    const activeGroupUserIds = new Set<string>(
-      groupMemberships
-        .filter(
-          (m) =>
-            !m.leftAt &&
-            (!m.requestStatus || m.requestStatus === "accepted"),
-        )
-        .map((m) => m.userId),
-    );
+    const candidates = rows.map((row) => ({
+      userId: row.id,
+      firstName: row.firstName,
+      lastName: row.lastName || undefined,
+      displayName: buildDisplayName(row.firstName, row.lastName),
+      profilePhoto: row.profilePhoto ?? undefined,
+      phone: row.phone ?? undefined,
+      isPlaceholder: row.isPlaceholder === true,
+      inGroup: row.inGroup === true,
+    }));
 
-    type Candidate = {
-      userId: Id<"users">;
-      firstName: string;
-      lastName?: string;
-      displayName: string;
-      profilePhoto?: string;
-      phone?: string;
-      isPlaceholder: boolean;
-      inGroup: boolean;
-    };
-
-    const candidates: Candidate[] = [];
-    for (const membership of memberships) {
-      if (membership.userId === callerId) continue;
-      const user = await ctx.db.get(membership.userId);
-      if (!user) continue;
-      // isActive can be undefined for legacy rows — treat undefined as active
-      // to match the rest of the app, but exclude rows explicitly flagged false
-      // (e.g. unclaimed placeholders are surfaced via `isPlaceholder`, not by
-      // becoming searchable as real users — but we still want them in the
-      // pool so leaders see "already invited" rather than re-inviting).
-      // We deliberately keep placeholders in results; the `isPlaceholder` flag
-      // lets the UI render them distinctly.
-      if (!matchesName(args.search, user.firstName, user.lastName)) continue;
-
-      const firstName = (user.firstName ?? "").trim();
-      candidates.push({
-        userId: user._id,
-        firstName,
-        lastName: user.lastName?.trim() || undefined,
-        displayName: buildDisplayName(user.firstName, user.lastName),
-        profilePhoto: getMediaUrl(user.profilePhoto),
-        phone: user.phone || undefined,
-        isPlaceholder: user.isPlaceholder === true,
-        inGroup: activeGroupUserIds.has(user._id),
-      });
-    }
-
-    // In-group first, then community-only; alpha within each bucket.
+    // In-group first, then community-only; alpha within each bucket. The
+    // helper does not guarantee this ordering — it sorts by the search
+    // index's relevance + last-login, which is the right call for the
+    // admin People page but not for the AssignSheet where leaders need to
+    // see who's already on the team first.
     candidates.sort((a, b) => {
       if (a.inGroup !== b.inGroup) return a.inGroup ? -1 : 1;
       return a.displayName.localeCompare(b.displayName);
     });
 
-    return candidates.slice(0, limit);
+    return candidates;
   },
 });

--- a/apps/convex/functions/scheduling/people.ts
+++ b/apps/convex/functions/scheduling/people.ts
@@ -73,12 +73,19 @@ export const searchCommunityPeople = query({
     // isPlaceholder rules as the admin People and group Add People searches.
     // `annotateGroupId` makes each row carry `inGroup`; `fallbackToRecentWhenEmpty`
     // surfaces a sensible default list before the leader has typed anything.
+    //
+    // Pass `MAX_LIMIT` (the helper's own hard cap) instead of the caller's
+    // `limit` so we don't truncate in-group members away before the
+    // AssignSheet-specific in-group-first re-sort below — the helper
+    // returns rows in relevance / last-login order, which would drop
+    // in-group people ranked below the cutoff and leave them invisible
+    // after the re-sort. Slicing happens after the re-sort.
     const rows = await searchCommunityMembersInternal(ctx, {
       communityId: group.communityId,
       search: args.search,
       excludeUserIds: [callerId],
       annotateGroupId: args.groupId,
-      limit,
+      limit: MAX_LIMIT,
       fallbackToRecentWhenEmpty: true,
     });
 
@@ -103,6 +110,6 @@ export const searchCommunityPeople = query({
       return a.displayName.localeCompare(b.displayName);
     });
 
-    return candidates;
+    return candidates.slice(0, limit);
   },
 });

--- a/apps/convex/lib/memberSearch.ts
+++ b/apps/convex/lib/memberSearch.ts
@@ -41,6 +41,13 @@ export interface MemberSearchResult {
    * when `annotateGroupId` is not provided.
    */
   inGroup?: boolean;
+  /**
+   * True when the user is a leader-created placeholder (`users.isPlaceholder
+   * === true`) awaiting their first OTP sign-in. Lets pickers render them as
+   * "Invited" rather than as a normal candidate. Always false / absent for
+   * real signed-in users.
+   */
+  isPlaceholder?: boolean;
 }
 
 /**
@@ -433,6 +440,7 @@ export async function searchCommunityMembersInternal(
         profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
         isAdmin,
         notificationsDisabled: notifsDisabled.has(user._id),
+        isPlaceholder: user.isPlaceholder === true,
         ...(annotateGroupUserIds
           ? { inGroup: annotateGroupUserIds.has(user._id) }
           : {}),

--- a/apps/convex/lib/memberSearch.ts
+++ b/apps/convex/lib/memberSearch.ts
@@ -34,6 +34,13 @@ export interface MemberSearchResult {
    * Truth source: `pushTokens` (see `lib/notifications/enabledStatus.ts`).
    */
   notificationsDisabled: boolean;
+  /**
+   * True when the user is already an active member of `annotateGroupId`
+   * (when that option is provided). Lets the UI gray-out / hide rows
+   * without having to do a second round-trip per candidate. Always false
+   * when `annotateGroupId` is not provided.
+   */
+  inGroup?: boolean;
 }
 
 /**
@@ -58,9 +65,22 @@ export interface MemberSearchOptions {
   groupIds?: Id<"groups">[];
   /** Exclude users who are already active members of this group */
   excludeGroupId?: Id<"groups">;
+  /**
+   * If provided, each returned row carries `inGroup: boolean` indicating
+   * whether that user is already an active member of this group. Use this
+   * instead of `excludeGroupId` when the UI wants to render but de-emphasize
+   * already-in-group people rather than hide them entirely.
+   */
+  annotateGroupId?: Id<"groups">;
   limit?: number;
   /** Include admin-only fields (isPrimaryAdmin, role, lastLogin) */
   includeAdminFields?: boolean;
+  /**
+   * When true and `search` is empty, fall back to the most recently active
+   * community members instead of returning `[]`. Lets group "Add people"
+   * UIs surface a sensible default list before the leader types anything.
+   */
+  fallbackToRecentWhenEmpty?: boolean;
 }
 
 /**
@@ -184,64 +204,82 @@ export async function searchCommunityMembersInternal(
     groupId,
     groupIds,
     excludeGroupId,
-    limit = 50,
+    annotateGroupId,
+    limit = 30,
     includeAdminFields = false,
+    fallbackToRecentWhenEmpty = false,
   } = options;
 
+  // Hard cap regardless of caller — protects the per-row notif-disabled /
+  // membership lookups from quadratic blow-ups.
+  const effectiveLimit = Math.max(1, Math.min(limit, 100));
   const excludeIds = new Set(excludeUserIds);
   const searchQuery = search?.trim() || "";
 
-  if (!searchQuery) {
-    return [];
-  }
-
-  // Parse comma-separated search terms for multiple searches
-  const searchTerms = searchQuery.split(",").map((t) => t.trim()).filter(Boolean);
-
-  // Use full-text search index to find matching users
-  // For comma-separated terms, search for each term and merge results
+  // ---------------------------------------------------------------------------
+  // Candidate gathering
+  // ---------------------------------------------------------------------------
+  // Use the `search_users` full-text index for the keyword case (O(matches),
+  // not O(community)). When the search is empty AND the caller opted into the
+  // recent-members fallback, use `userCommunities.by_community_lastLogin` to
+  // surface the most recently-active people without scanning every user.
   const allMatchingUsers: Map<Id<"users">, Doc<"users">> = new Map();
 
-  for (const term of searchTerms) {
-    if (!term) continue;
-
-    // Full-text search on searchText field
-    const matchingUsers = await ctx.db
-      .query("users")
-      .withSearchIndex("search_users", (q) => q.search("searchText", term))
-      .take(limit * 3); // Fetch extra to account for filtering
-
-    for (const user of matchingUsers) {
-      if (!allMatchingUsers.has(user._id)) {
-        allMatchingUsers.set(user._id, user);
+  if (searchQuery) {
+    // Build the set of terms to issue against the search index. Comma-
+    // separated terms run as separate searches (so `"john, jane"` finds
+    // either). We also push a digits-only variant of each term so phone-
+    // formatted queries like `(555) 123-4567` still hit users whose stored
+    // `searchText` contains `+15551234567` — the digit substring is in the
+    // indexed text. Important: we DO NOT scan every community member as a
+    // fallback (was the previous hot-path), since that's O(community-size)
+    // per keystroke (codex review #475).
+    const rawTerms = searchQuery.split(",").map((t) => t.trim()).filter(Boolean);
+    const termSet = new Set<string>();
+    for (const term of rawTerms) {
+      termSet.add(term);
+      const digits = normalizePhone(term).replace(/\D/g, "");
+      if (digits.length >= 4 && digits !== term) {
+        termSet.add(digits);
       }
     }
-  }
 
-  // Also handle phone number search with normalization
-  // Full-text search doesn't handle formatted phone numbers well
-  const normalizedPhone = normalizePhone(searchQuery).replace(/\D/g, "");
-  if (normalizedPhone.length >= 4) {
-    // Get community members and check for phone matches
-    const communityMemberships = await ctx.db
-      .query("userCommunities")
-      .withIndex("by_community", (q) => q.eq("communityId", communityId))
-      .filter((q) => q.eq(q.field("status"), 1)) // Active only
-      .take(2000);
+    for (const term of termSet) {
+      const matchingUsers = await ctx.db
+        .query("users")
+        .withSearchIndex("search_users", (q) => q.search("searchText", term))
+        .take(500); // Same cap as admin People search — narrow further below.
 
-    const phoneMatchPromises = communityMemberships.map(async (m) => {
-      const user = await ctx.db.get(m.userId);
-      if (user?.phone?.includes(normalizedPhone)) {
-        return user;
+      for (const user of matchingUsers) {
+        if (!allMatchingUsers.has(user._id)) {
+          allMatchingUsers.set(user._id, user);
+        }
       }
-      return null;
-    });
-    const phoneMatches = await Promise.all(phoneMatchPromises);
-    for (const user of phoneMatches) {
+    }
+  } else if (fallbackToRecentWhenEmpty) {
+    // Pull the most recently-active community members directly off the
+    // descending `by_community_lastLogin` index. We over-fetch to account
+    // for downstream filters (excluded users, isActive, etc.) but the read
+    // count is bounded by `effectiveLimit`, not community size.
+    const recentMemberships = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_community_lastLogin", (q) => q.eq("communityId", communityId))
+      .order("desc")
+      .filter((q) => q.eq(q.field("status"), 1))
+      .take(effectiveLimit * 3);
+
+    const recentUsers = await Promise.all(
+      recentMemberships.map((m) => ctx.db.get(m.userId)),
+    );
+    for (const user of recentUsers) {
       if (user && !allMatchingUsers.has(user._id)) {
         allMatchingUsers.set(user._id, user);
       }
     }
+  } else {
+    // No search and no fallback opted in — return empty so the UI can show
+    // a "search to find people" empty state.
+    return [];
   }
 
   if (allMatchingUsers.size === 0) {
@@ -310,8 +348,38 @@ export async function searchCommunityMembersInternal(
     excludedGroupUserIds = new Set(groupMemberships.map((gm) => gm.userId));
   }
 
-  // Check which users are active members of this community
-  const membershipPromises = Array.from(allMatchingUsers.values()).map((user) =>
+  // If asked to annotate group membership instead of excluding, look up the
+  // group's active members so each row can carry `inGroup`. When the caller
+  // passes the same id to both `excludeGroupId` and `annotateGroupId` we
+  // reuse the set rather than re-querying.
+  let annotateGroupUserIds: Set<Id<"users">> | null = null;
+  if (annotateGroupId) {
+    if (excludedGroupUserIds && excludeGroupId === annotateGroupId) {
+      annotateGroupUserIds = excludedGroupUserIds;
+    } else {
+      const groupMemberships = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group", (q) => q.eq("groupId", annotateGroupId))
+        .filter((q) =>
+          q.and(
+            q.eq(q.field("leftAt"), undefined),
+            q.or(
+              q.eq(q.field("requestStatus"), undefined),
+              q.eq(q.field("requestStatus"), null),
+              q.eq(q.field("requestStatus"), "accepted")
+            )
+          )
+        )
+        .collect();
+      annotateGroupUserIds = new Set(groupMemberships.map((gm) => gm.userId));
+    }
+  }
+
+  // Check which users are active members of this community. One lookup per
+  // candidate via the `by_user_community` compound index — read count scales
+  // with the number of search-index matches, not community size.
+  const usersArray = Array.from(allMatchingUsers.values());
+  const membershipPromises = usersArray.map((user) =>
     ctx.db
       .query("userCommunities")
       .withIndex("by_user_community", (q) =>
@@ -322,73 +390,67 @@ export async function searchCommunityMembersInternal(
   );
   const memberships = await Promise.all(membershipPromises);
 
-  // Pre-compute the candidate set so we can batch the notif-disabled
-  // lookup once for the whole result. The loop below filters again with
-  // the limit, but the extra IDs collected here are negligible.
-  const candidateUserIds: Id<"users">[] = [];
-  const usersArray = Array.from(allMatchingUsers.values());
+  // Apply all filters once up front so we know exactly which rows survive
+  // and which user IDs need a notif-disabled lookup. Drops:
+  //  - non-members of this community
+  //  - explicitly-excluded users (callers always pass the current user here)
+  //  - inactive users that aren't leader-created placeholders (placeholders
+  //    must remain visible so leaders see "already invited" entries)
+  //  - members of the excluded group (when `excludeGroupId` is set)
+  //  - non-members of any of the `groupIds` allowlist (when set)
+  const filtered: Array<{
+    user: Doc<"users">;
+    membership: Doc<"userCommunities">;
+  }> = [];
   for (let i = 0; i < usersArray.length; i++) {
     const user = usersArray[i];
     const membership = memberships[i];
     if (!membership) continue;
     if (excludeIds.has(user._id)) continue;
+    if (user.isActive === false && user.isPlaceholder !== true) continue;
     if (excludedGroupUserIds?.has(user._id)) continue;
     if (targetUserIds && !targetUserIds.has(user._id)) continue;
-    candidateUserIds.push(user._id);
-    if (candidateUserIds.length >= limit) break;
+    filtered.push({ user, membership });
+    if (filtered.length >= effectiveLimit) break;
   }
+
+  // Batch notif-disabled lookup ONCE for the final slice — pushTokens reads
+  // shouldn't scale with the 500-row search-index window (codex review #372).
   const notifsDisabled = await getUsersWithNotificationsDisabled(
     ctx,
-    candidateUserIds,
+    filtered.map((f) => f.user._id),
   );
 
-  // Build results for users who are community members
-  const results: (MemberSearchResult | AdminMemberSearchResult)[] = [];
-
-  for (let i = 0; i < usersArray.length; i++) {
-    if (results.length >= limit) break;
-
-    const user = usersArray[i];
-    const membership = memberships[i];
-
-    // Skip if not an active community member
-    if (!membership) continue;
-
-    // Skip if in exclude list
-    if (excludeIds.has(user._id)) continue;
-
-    // Skip if this user is already an active member of the excluded group
-    if (excludedGroupUserIds?.has(user._id)) continue;
-
-    // Skip if filtering by group and user is not in that group
-    if (targetUserIds && !targetUserIds.has(user._id)) continue;
-
-    const isAdmin = (membership.roles ?? 0) >= COMMUNITY_ADMIN_THRESHOLD;
-
-    const baseResult: MemberSearchResult = {
-      id: user._id,
-      firstName: user.firstName || "",
-      lastName: user.lastName || "",
-      email: user.email || "",
-      phone: user.phone || null,
-      profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
-      isAdmin,
-      notificationsDisabled: notifsDisabled.has(user._id),
-    };
-
-    if (includeAdminFields) {
-      const adminResult: AdminMemberSearchResult = {
-        ...baseResult,
-        isPrimaryAdmin: membership.roles === PRIMARY_ADMIN_ROLE,
-        role: membership.roles ?? 0,
-        lastLogin: membership.lastLogin || null,
-        groupsCount: 0, // Not computed for search results; shown in member details
+  const results: (MemberSearchResult | AdminMemberSearchResult)[] = filtered.map(
+    ({ user, membership }) => {
+      const isAdmin = (membership.roles ?? 0) >= COMMUNITY_ADMIN_THRESHOLD;
+      const baseResult: MemberSearchResult = {
+        id: user._id,
+        firstName: user.firstName || "",
+        lastName: user.lastName || "",
+        email: user.email || "",
+        phone: user.phone || null,
+        profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
+        isAdmin,
+        notificationsDisabled: notifsDisabled.has(user._id),
+        ...(annotateGroupUserIds
+          ? { inGroup: annotateGroupUserIds.has(user._id) }
+          : {}),
       };
-      results.push(adminResult);
-    } else {
-      results.push(baseResult);
-    }
-  }
+
+      if (includeAdminFields) {
+        const adminResult: AdminMemberSearchResult = {
+          ...baseResult,
+          isPrimaryAdmin: membership.roles === PRIMARY_ADMIN_ROLE,
+          role: membership.roles ?? 0,
+          lastLogin: membership.lastLogin || null,
+          groupsCount: 0, // Not computed for search results; shown in member details
+        };
+        return adminResult;
+      }
+      return baseResult;
+    },
+  );
 
   return results;
 }


### PR DESCRIPTION
## Summary

The AssignSheet community search (PR #404) and the group info → **Add People** picker were both doing a full `.collect()` of every active community membership per keystroke and then fetching every matching user. At a handful of community members it's fine; at several hundred it's already noticeably slow; at thousands it's effectively unusable.

This PR moves both to the same `users.search_users` full-text index the admin People page already uses, behind a shared helper so they can't diverge again.

Closes #405 (search should hide deactivated users) and #406 (bound candidate reads) from PR #404's Codex review. The user upgraded the latter to P0 — "for large communities it's unusable" — and pulled the group Add People surface into the same fix.

## Changes

### Shared helper (`apps/convex/lib/memberSearch.ts`)
- New `searchCommunityMembersInternal` (commit `8d189c1`) — full-text index → per-candidate community-membership lookup → optional group annotation → bounded slice. Same pattern as `apps/convex/functions/admin/members.ts:searchCommunityMembers`.
- This PR extends the helper's `MemberSearchResult` with an optional `isPlaceholder` so leader pickers can keep rendering invited-but-unclaimed people as "Invited" rather than as normal candidates.

### Group info → Add People (`apps/convex/functions/groupSearch.ts`, commit `8d189c1`)
Refactored to delegate to the shared helper. New optional `annotateGroupId` arg makes each row carry `inGroup: boolean`. Empty search now returns the most recently-active community members via the existing `userCommunities.by_community_lastLogin` index instead of an empty list.

### Scheduling AssignSheet (`apps/convex/functions/scheduling/people.ts`)
Rewritten to call the shared helper. Sort overridden to in-group-first + alpha (the helper sorts by search relevance + last login, which is right for People but not AssignSheet).

### Test fixtures (`apps/convex/__tests__/scheduling/fixtures.ts`)
`insertUser` and the direct placeholder insert now populate `searchText` via `buildSearchText` so the `search_users` index returns fixture users — same as `createUserInternal` does in production.

## Read-count estimate (5,000-member community, 2-char query)

| Path | Before | After |
|------|--------|-------|
| group info → Add People | ~2,500+ reads/keystroke, growing with community size | ~500–600, independent of community size |
| AssignSheet community search | ~5,000+ reads/keystroke (full membership scan + per-user fetch) | ~500–600, capped at the index's 500-row window |

## Verification

- `apps/convex` typechecks clean.
- 135 scheduling + auth tests pass; 5 new `groupSearch-members.test.ts` tests pass; `pnpm convex:codegen` clean.
- `apps/mobile` typechecks clean (13 pre-existing errors in unrelated files).

## Compatibility

- `searchCommunityMembers` (group Add People) shape is a strict superset — existing callers (`AddGroupMembersModal`, `tasks/index.ts:searchRelevantMembers`, `shared-channels.test.ts`) need no changes.
- `searchCommunityPeople` (scheduling AssignSheet) shape unchanged.
- No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
