### PR TITLE
Defer invite SMS to publish, differentiate placeholder copy

### DIFF
--- a/apps/convex/__tests__/scheduling/assignments.test.ts
+++ b/apps/convex/__tests__/scheduling/assignments.test.ts
@@ -60,6 +60,21 @@ async function makeEvent(
   return planId;
 }
 
+/**
+ * Flip a plan to `status: "published"` directly via the DB — bypasses the
+ * `publishEvent` action's fan-out side effects so tests of other paths
+ * (e.g. immediate-SMS in `inviteAndAssign`) aren't entangled with the
+ * publish notification machinery.
+ */
+async function markPlanPublished(
+  t: ReturnType<typeof import("convex-test").convexTest>,
+  planId: Id<"eventPlans">,
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.patch(planId, { status: "published", updatedAt: Date.now() });
+  });
+}
+
 describe("assignment state machine", () => {
   it("new assignments start as unconfirmed", async () => {
     const { t, world } = await setupSchedulingWorld();
@@ -756,6 +771,9 @@ describe("inviteAndAssign", () => {
     const { t, world } = await setupSchedulingWorld();
     const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
     const planId = await makeEvent(t, world, leaderToken, 7);
+    // Immediate-SMS path only fires when the plan is already published —
+    // draft plans defer the invite until `publishEvent`'s fan-out runs.
+    await markPlanPublished(t, planId);
 
     const inviteePhone = "2025550100";
     vi.stubEnv("OTP_TEST_PHONE_NUMBERS", inviteePhone);
@@ -764,6 +782,7 @@ describe("inviteAndAssign", () => {
       assignmentId: Id<"roleAssignments">;
       invitedUserId: Id<"users">;
       sentInvite: boolean;
+      deferred: boolean;
     };
     try {
       result = await t.action(
@@ -782,6 +801,7 @@ describe("inviteAndAssign", () => {
     }
 
     expect(result.sentInvite).toBe(true);
+    expect(result.deferred).toBe(false);
 
     // The placeholder user row was created with isPlaceholder/isActive
     // flags and the normalized phone.
@@ -828,6 +848,7 @@ describe("inviteAndAssign", () => {
     const { t, world } = await setupSchedulingWorld();
     const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
     const planId = await makeEvent(t, world, leaderToken, 7);
+    await markPlanPublished(t, planId);
 
     // No OTP_TEST_PHONE_NUMBERS, no Twilio creds → sendSMS returns
     // { success: false } and inviteAndAssign reports it accordingly.
@@ -844,12 +865,61 @@ describe("inviteAndAssign", () => {
     );
 
     expect(result.sentInvite).toBe(false);
+    expect(result.deferred).toBe(false);
 
     // The DB writes still happened — the leader still gets the role filled.
     const user = await t.run((ctx) => ctx.db.get(result.invitedUserId));
     expect(user?.isPlaceholder).toBe(true);
     const assignment = await t.run((ctx) => ctx.db.get(result.assignmentId));
     expect(assignment?.userId).toBe(result.invitedUserId);
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
+  it("defers the SMS when the plan is still a draft, but still lands the DB writes", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    // Default plan status is "draft" — no `markPlanPublished` here.
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // Even with a test phone configured, the SMS path is skipped because
+    // the plan isn't published yet — `publishEvent`'s fan-out will send
+    // the placeholder-specific invite at publish time instead.
+    const inviteePhone = "2025550102";
+    vi.stubEnv("OTP_TEST_PHONE_NUMBERS", inviteePhone);
+
+    let result: {
+      assignmentId: Id<"roleAssignments">;
+      invitedUserId: Id<"users">;
+      sentInvite: boolean;
+      deferred: boolean;
+    };
+    try {
+      result = await t.action(
+        api.functions.scheduling.assignments.inviteAndAssign,
+        {
+          token: leaderToken,
+          planId,
+          teamId: world.teamId,
+          roleId: world.roleId,
+          firstName: "Della",
+          phone: inviteePhone,
+        },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(result.deferred).toBe(true);
+    expect(result.sentInvite).toBe(false);
+
+    // The placeholder, memberships, and assignment all landed.
+    const user = await t.run((ctx) => ctx.db.get(result.invitedUserId));
+    expect(user?.isPlaceholder).toBe(true);
+    expect(user?.firstName).toBe("Della");
+    const assignment = await t.run((ctx) => ctx.db.get(result.assignmentId));
+    expect(assignment?.userId).toBe(result.invitedUserId);
+    expect(assignment?.status).toBe("unconfirmed");
 
     await t.finishInProgressScheduledFunctions();
   });

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -514,6 +514,9 @@ export const inviteAndAssignInternal = internalMutation({
       communityName: community?.name ?? "Togather",
       teamName: team?.name ?? "your team",
       leaderFirstName: caller?.firstName?.trim() || "Someone",
+      // The action gates SMS send on whether the plan is already public —
+      // a draft plan should not text the invitee until the leader publishes.
+      planStatus: plan.status,
     };
   },
 });
@@ -554,6 +557,8 @@ export const inviteAndAssign = action({
     assignmentId: Id<"roleAssignments">;
     invitedUserId: Id<"users">;
     sentInvite: boolean;
+    /** True when SMS was intentionally not sent because the plan is still a draft. */
+    deferred: boolean;
   }> => {
     const callerId = await requireAuthFromTokenAction(ctx, args.token);
 
@@ -572,6 +577,7 @@ export const inviteAndAssign = action({
       communityName: string;
       teamName: string;
       leaderFirstName: string;
+      planStatus: string;
     } = await ctx.runMutation(
       internal.functions.scheduling.assignments.inviteAndAssignInternal,
       {
@@ -584,6 +590,20 @@ export const inviteAndAssign = action({
         callerId: callerId as Id<"users">,
       },
     );
+
+    // Defer the SMS until the leader hits publish when the plan is still a
+    // draft — `publishEvent`'s fan-out (`sendAssignmentRequests`) re-sends
+    // the placeholder-specific invite then. For a plan that is already
+    // published, send immediately (the leader is making post-publish
+    // additions and wants the invitee notified right away).
+    if (result.planStatus !== "published") {
+      return {
+        assignmentId: result.assignmentId,
+        invitedUserId: result.invitedUserId,
+        sentInvite: false,
+        deferred: true,
+      };
+    }
 
     // SMS the invite. Twilio config issues / network failures are captured
     // and reported via `sentInvite: false` — we do NOT roll back the DB
@@ -624,6 +644,7 @@ export const inviteAndAssign = action({
       assignmentId: result.assignmentId,
       invitedUserId: result.invitedUserId,
       sentInvite,
+      deferred: false,
     };
   },
 });
@@ -815,7 +836,7 @@ export const publishEvent = action({
       await ctx.scheduler.runAfter(
         0,
         internal.functions.scheduling.assignments.sendAssignmentRequests,
-        { planId: args.planId },
+        { planId: args.planId, publisherId: callerId as Id<"users"> },
       );
     }
 
@@ -878,7 +899,10 @@ export const markPublished = internalMutation({
  * info plus, per unconfirmed-assignment volunteer, their phone number.
  */
 export const getAssignmentRequestTargets = internalQuery({
-  args: { planId: v.id("eventPlans") },
+  args: {
+    planId: v.id("eventPlans"),
+    publisherId: v.id("users"),
+  },
   handler: async (ctx, args) => {
     const plan = await ctx.db.get(args.planId);
     if (!plan) return null;
@@ -889,17 +913,29 @@ export const getAssignmentRequestTargets = internalQuery({
       .collect();
     const unconfirmed = assignments.filter((a) => a.status === "unconfirmed");
 
+    const [community, publisher] = await Promise.all([
+      ctx.db.get(plan.communityId),
+      ctx.db.get(args.publisherId),
+    ]);
+
     const recipients = await Promise.all(
       unconfirmed.map(async (assignment) => {
-        const [user, role] = await Promise.all([
+        const [user, role, team] = await Promise.all([
           ctx.db.get(assignment.userId),
           ctx.db.get(assignment.roleId),
+          ctx.db.get(assignment.teamId),
         ]);
         return {
           assignmentId: assignment._id,
           userId: assignment.userId,
           phone: user?.phone ?? null,
           roleName: role?.name ?? "a role",
+          // Placeholder context — these recipients get the join-the-app SMS
+          // instead of the accept/decline SMS, since they don't have the
+          // app yet (`inviteAndAssign` created them on a draft plan).
+          isPlaceholder: user?.isPlaceholder === true,
+          firstName: user?.firstName?.trim() || "you",
+          teamName: team?.name ?? "the team",
         };
       }),
     );
@@ -909,6 +945,8 @@ export const getAssignmentRequestTargets = internalQuery({
       eventDate: plan.eventDate,
       groupId: plan.groupId,
       communityId: plan.communityId,
+      communityName: community?.name ?? "Togather",
+      publisherFirstName: publisher?.firstName?.trim() || "Someone",
       recipients,
     };
   },
@@ -961,11 +999,14 @@ export const recordAssignmentNotifications = internalMutation({
  * Each request links to the assignment's accept/decline deep link.
  */
 export const sendAssignmentRequests = internalAction({
-  args: { planId: v.id("eventPlans") },
+  args: {
+    planId: v.id("eventPlans"),
+    publisherId: v.id("users"),
+  },
   handler: async (ctx, args) => {
     const targets = await ctx.runQuery(
       internal.functions.scheduling.assignments.getAssignmentRequestTargets,
-      { planId: args.planId },
+      { planId: args.planId, publisherId: args.publisherId },
     );
     if (!targets || targets.recipients.length === 0) {
       return { pushSent: 0, smsSent: 0 };
@@ -981,9 +1022,22 @@ export const sendAssignmentRequests = internalAction({
     // the volunteer's accept/decline screen.
     const linkFor = (assignmentId: string) =>
       `${DOMAIN_CONFIG.appUrl}/scheduling/assignment/${assignmentId}`;
+    // Placeholder users don't have the app yet — point them at the signup
+    // deeplink with phone prefilled. The phone-OTP claim logic takes over
+    // and the assignment is inherited via the placeholder's stable `_id`.
+    const signupLinkFor = (phone: string) =>
+      `${DOMAIN_CONFIG.appUrl}/signup?phone=${encodeURIComponent(phone)}`;
+
+    // Real users get push + the accept/decline SMS. Placeholder recipients
+    // can't receive in-app push (no tokens), so we only SMS them — and we
+    // SMS them differently (signup + context, not accept/decline).
+    const realRecipients = targets.recipients.filter((r) => !r.isPlaceholder);
+    const placeholderRecipients = targets.recipients.filter(
+      (r) => r.isPlaceholder,
+    );
 
     // --- Push -------------------------------------------------------------
-    const userIds = targets.recipients.map((r) => r.userId);
+    const userIds = realRecipients.map((r) => r.userId);
     const tokenResults: Array<{ userId: string; tokens: string[] }> =
       await ctx.runQuery(
         internal.functions.notifications.tokens.getActiveTokensForUsers,
@@ -993,7 +1047,7 @@ export const sendAssignmentRequests = internalAction({
       tokenResults.map((r) => [r.userId, r.tokens]),
     );
 
-    const pushNotifications = targets.recipients.flatMap((recipient) => {
+    const pushNotifications = realRecipients.flatMap((recipient) => {
       const tokens = tokensByUser.get(recipient.userId) ?? [];
       const title = `You're scheduled: ${targets.title}`;
       const body = `${recipient.roleName} on ${eventDate}. Tap to accept or decline.`;
@@ -1020,9 +1074,9 @@ export const sendAssignmentRequests = internalAction({
       pushSent = pushResult.success ? pushNotifications.length : 0;
     }
 
-    // --- SMS --------------------------------------------------------------
+    // --- SMS — real users: accept/decline -------------------------------
     let smsSent = 0;
-    for (const recipient of targets.recipients) {
+    for (const recipient of realRecipients) {
       if (!recipient.phone) continue;
       const smsBody =
         `You're scheduled for ${recipient.roleName} at ${targets.title} ` +
@@ -1038,11 +1092,38 @@ export const sendAssignmentRequests = internalAction({
       }
     }
 
+    // --- SMS — placeholder users: join-the-app invite -------------------
+    // Different copy + a signup deeplink instead of the accept/decline link
+    // (they don't have the app yet). Phone-OTP claim path links the
+    // placeholder to the new account on signup so the assignment is preserved.
+    let invitesSent = 0;
+    for (const recipient of placeholderRecipients) {
+      if (!recipient.phone) continue;
+      const smsBody =
+        `${targets.publisherFirstName} added you to ${recipient.teamName} ` +
+        `at ${targets.communityName} as ${recipient.roleName} for ` +
+        `${targets.title} on ${eventDate}.\n\n` +
+        `Join Togather to confirm: ${signupLinkFor(recipient.phone)}`;
+      try {
+        await ctx.runAction(internal.functions.auth.phoneOtp.sendSMS, {
+          phone: recipient.phone,
+          message: smsBody,
+        });
+        invitesSent += 1;
+      } catch {
+        // Best-effort.
+      }
+    }
+    smsSent += invitesSent;
+
     // --- In-app inbox records --------------------------------------------
+    // Only for real users — placeholder users have no app to read the
+    // inbox in yet. Their notification arrives via SMS only; once they
+    // sign up and the placeholder is claimed, future updates flow normally.
     await ctx.runMutation(
       internal.functions.scheduling.assignments.recordAssignmentNotifications,
       {
-        notifications: targets.recipients.map((recipient) => ({
+        notifications: realRecipients.map((recipient) => ({
           userId: recipient.userId,
           communityId: targets.communityId,
           groupId: targets.groupId,

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -94,6 +94,7 @@ function useDebouncedValue<T>(value: T, delay: number): T {
 export function AssignSheet({
   visible,
   planId,
+  planStatus,
   groupId,
   teamId,
   roleId,
@@ -104,6 +105,12 @@ export function AssignSheet({
 }: {
   visible: boolean;
   planId: Id<"eventPlans">;
+  /**
+   * Whether the plan is still a draft or already published. Controls whether
+   * the "Invite someone new" form sends the SMS immediately or defers it
+   * until the plan is published — see `inviteAndAssign`'s `deferred` return.
+   */
+  planStatus: "draft" | "published";
   /** The event plan's owning group — its members are the assignable pool. */
   groupId: Id<"groups">;
   teamId: Id<"teams">;
@@ -311,20 +318,37 @@ export function AssignSheet({
     }
     setInvitingSubmit(true);
     try {
-      const result = await inviteAndAssign({
+      const result = (await inviteAndAssign({
         planId,
         teamId,
         roleId,
         firstName,
         phone,
         timeLabel,
-      });
-      Alert.alert(
-        "Invite sent",
-        result?.sentInvite
-          ? `An SMS invite was sent to ${firstName} and they're assigned to ${roleName}.`
-          : `Couldn't send the SMS, but ${firstName} is created and assigned. You can resend later.`,
-      );
+      })) as
+        | {
+            assignmentId: Id<"roleAssignments">;
+            invitedUserId: Id<"users">;
+            sentInvite: boolean;
+            deferred?: boolean;
+          }
+        | undefined;
+      if (result?.deferred) {
+        Alert.alert(
+          "Added to the plan",
+          `${firstName} is on the roster as ${roleName}. They'll get an SMS invite when you publish.`,
+        );
+      } else if (result?.sentInvite) {
+        Alert.alert(
+          "Invite sent",
+          `An SMS invite was sent to ${firstName} and they're assigned to ${roleName}.`,
+        );
+      } else {
+        Alert.alert(
+          "Invite sent",
+          `Couldn't send the SMS, but ${firstName} is created and assigned. You can resend later.`,
+        );
+      }
       onClose();
     } catch (e) {
       surfaceError("Couldn't invite", e);
@@ -660,7 +684,11 @@ export function AssignSheet({
                     onPress={handleInviteSubmit}
                     disabled={invitingSubmit}
                     accessibilityRole="button"
-                    accessibilityLabel="Send invite and assign"
+                    accessibilityLabel={
+                      planStatus === "draft"
+                        ? "Invite and assign"
+                        : "Send invite and assign"
+                    }
                   >
                     <View
                       style={[
@@ -677,12 +705,24 @@ export function AssignSheet({
                         <Text
                           style={[styles.inviteSubmitText, { color: colors.surface }]}
                         >
-                          Send invite & assign
+                          {planStatus === "draft"
+                            ? "Invite & assign"
+                            : "Send invite & assign"}
                         </Text>
                       )}
                     </View>
                   </Pressable>
                 </View>
+                <Text
+                  style={[
+                    styles.inviteHelperText,
+                    { color: colors.textSecondary },
+                  ]}
+                >
+                  {planStatus === "draft"
+                    ? `We'll text ${inviteFirstName.trim() || "them"} the invite when you publish this event plan.`
+                    : "An SMS invite will be sent now."}
+                </Text>
               </View>
             ) : (
               <Pressable
@@ -875,5 +915,10 @@ const styles = StyleSheet.create({
   inviteSubmitText: {
     fontSize: 14,
     fontWeight: "600",
+  },
+  inviteHelperText: {
+    fontSize: 12,
+    lineHeight: 16,
+    marginTop: 2,
   },
 });

--- a/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
@@ -515,6 +515,7 @@ export function EventEditorScreen() {
         <AssignSheet
           visible
           planId={planId}
+          planStatus={event.status as "draft" | "published"}
           groupId={event.groupId}
           teamId={assignTarget.teamId}
           roleId={assignTarget.roleId}


### PR DESCRIPTION
## Summary

Right now, "Invite someone new" in the AssignSheet sends an SMS the moment the leader hits the button — even if the event plan is still a draft. This PR defers that text until the leader publishes the plan. For plans that are already published, the immediate-SMS path keeps working as today (the leader is making post-publish additions and wants the invitee notified right away).

At publish time, the existing fan-out (`sendAssignmentRequests`) already texts every unconfirmed assignee — this PR makes it send **different copy** to placeholder invitees (a join-the-app SMS with a phone-prefilled signup link) than to real users (the existing accept/decline link). Push notifications and in-app inbox records continue to go to real users only — placeholders have no app to receive them in yet.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Invite-new on draft plan | SMS sent immediately | Placeholder + assignment land; **no SMS** until publish |
| Invite-new on published plan | SMS sent immediately | unchanged — SMS sent immediately |
| `publishEvent` fan-out | Same SMS to everyone | Real users → accept/decline SMS; placeholders → join-the-app SMS w/ signup link |

## SMS copy

**Real user (existing):**
```
You're scheduled for {role} at {event} on {date}.

Accept or decline: {accept-decline link}
```

**Placeholder (new):**
```
{publisher} added you to {team} at {community} as {role} for {event} on {date}.

Join Togather to confirm: {signup link with ?phone=… prefilled}
```

The signup link routes through the existing phone-OTP claim path (PR #404) — the placeholder's `_id` is preserved on signup, so the assignment, group membership, and community membership are inherited automatically.

## Frontend (commit `344a4b6`)

- `EventEditorScreen` passes `planStatus={event.status}` to `AssignSheet`.
- `AssignSheet` adapts the invite-form's button and helper text:
  - Draft → button `Invite & assign`, helper `We'll text {firstName} the invite when you publish this event plan.`
  - Published → button `Send invite & assign`, helper `An SMS invite will be sent now.`
- Success `Alert.alert` branches on `result.deferred`:
  - Deferred → `Added to the plan` / `{firstName} is on the roster as {role}. They'll get an SMS invite when you publish.`
  - Published / sent → `Invite sent` / standard message.
  - Published / sentInvite:false → unchanged fallback.

## Backend (new commit)

- `inviteAndAssignInternal` returns `planStatus`.
- `inviteAndAssign` action gates the SMS block on `planStatus === "published"`; returns `{ deferred: true, sentInvite: false }` otherwise.
- `publishEvent` threads the publisher's user id through `sendAssignmentRequests`.
- `getAssignmentRequestTargets` adds `isPlaceholder`, `firstName`, `teamName` per recipient + top-level `communityName`, `publisherFirstName`.
- `sendAssignmentRequests` splits `realRecipients` vs `placeholderRecipients` — different SMS bodies + signup deeplink for placeholders; push + inbox stay for real users only.

No schema changes.

## Tests

- New test: `inviteAndAssign` on a draft plan → `deferred: true, sentInvite: false`, DB writes still land.
- Existing immediate-SMS tests now `markPlanPublished` before running so they exercise the published path.
- **125 scheduling tests pass**, `apps/convex` typechecks clean, `apps/mobile` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
