### PR TITLE
AssignSheet: placeholders re-assignable + show phone for disambiguation

### DIFF
--- a/apps/convex/__tests__/scheduling/assignments.test.ts
+++ b/apps/convex/__tests__/scheduling/assignments.test.ts
@@ -755,6 +755,53 @@ describe("assignFromCommunity", () => {
       }),
     ).rejects.toThrow(/already assigned/);
   });
+
+  it("permits a placeholder user (isActive: false + isPlaceholder: true)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // The fixture's `placeholderUserId` is `isActive: false, isPlaceholder: true`
+    // with active community + group memberships — exactly what a placeholder
+    // looks like after `inviteAndAssign` creates it. They must remain
+    // schedulable so a leader can put them on multiple roles, just like a
+    // real volunteer.
+    const result = await t.mutation(
+      api.functions.scheduling.assignments.assignFromCommunity,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.placeholderUserId,
+      },
+    );
+    expect(result.addedToGroup).toBe(false); // already an active group member
+    const assignment = await t.run((ctx) => ctx.db.get(result.assignmentId));
+    expect(assignment?.userId).toBe(world.placeholderUserId);
+    expect(assignment?.status).toBe("unconfirmed");
+  });
+
+  it("still rejects a deactivated non-placeholder user", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+
+    // Deactivate a real community member.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(world.communityOnlyAId, { isActive: false });
+    });
+
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignFromCommunity, {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.communityOnlyAId,
+      }),
+    ).rejects.toThrow(/deactivated/);
+  });
 });
 
 describe("inviteAndAssign", () => {

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -333,11 +333,12 @@ export const assignFromCommunity = mutation({
     if (!target) {
       throw new ConvexError("Person not found");
     }
-    // Deactivated accounts must not be re-introduced into scheduling — this
-    // also blocks placeholder users (`isPlaceholder: true` / `isActive:
-    // false`) from being assigned via this path; placeholders are only
-    // assigned through `inviteAndAssign`, which creates them.
-    if (target.isActive === false) {
+    // Truly deactivated accounts must not be re-introduced into scheduling.
+    // Placeholder users (`isPlaceholder: true`) are intentionally
+    // `isActive: false` until they sign up and claim their account; they're
+    // valid scheduling targets and can be assigned to multiple roles like
+    // any other community member.
+    if (target.isActive === false && target.isPlaceholder !== true) {
       throw new ConvexError(
         "This person's account is deactivated and cannot be scheduled",
       );

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -10,9 +10,13 @@
  *      a row runs `assignRole` (no group write needed).
  *   3. COMMUNITY — community people who are NOT yet in the event's group.
  *      Tapping "+ Add & assign" runs `assignFromCommunity`, which adds them
- *      to the group and assigns in a single transaction. Placeholder users
- *      (already invited, not yet claimed) appear here as disabled rows with
- *      an "Invited" badge.
+ *      to the group and assigns in a single transaction.
+ *
+ * Placeholder users (already invited via SMS, not yet claimed an account) are
+ * real `groupMembers` rows — they belong in whichever section their `inGroup`
+ * flag puts them. They show an inline "Invited" tag next to their name so the
+ * leader knows the person hasn't signed up yet, but the row is still tappable
+ * and can be assigned (including to a second role on the same plan).
  *
  * The candidate pool comes from `searchCommunityPeople`, which already
  * annotates `inGroup` / `isPlaceholder` so the two sections are a simple
@@ -76,6 +80,26 @@ type PreviousFiller = {
   userName: string;
   lastServedDate: number;
 };
+
+/**
+ * Format an E.164-ish phone string for display. US numbers (`+1XXXXXXXXXX`)
+ * render as `(XXX) XXX-XXXX`. Anything else falls back to the raw input so
+ * we don't lie about non-US formats. Returns `null` for empty/missing input
+ * so callers can short-circuit rendering the second line.
+ *
+ * Intentionally a tiny inline helper — no library, no native dep.
+ */
+function formatPhoneForDisplay(phone: string | undefined): string | null {
+  if (!phone) return null;
+  const trimmed = phone.trim();
+  if (!trimmed) return null;
+  // US: +1 followed by 10 digits.
+  const usMatch = trimmed.match(/^\+1(\d{3})(\d{3})(\d{4})$/);
+  if (usMatch) {
+    return `(${usMatch[1]}) ${usMatch[2]}-${usMatch[3]}`;
+  }
+  return trimmed;
+}
 
 /**
  * Debounce a value by `delay` ms. Defined locally to avoid a shared-hook
@@ -205,9 +229,10 @@ export function AssignSheet({
     const communityRows: CommunityPerson[] = [];
     for (const c of list) {
       if (previousIds.has(c.userId as string)) continue;
-      // Placeholders are always shown under COMMUNITY — they're not real
-      // group members yet even if `inGroup` happens to be true.
-      if (c.inGroup && !c.isPlaceholder) {
+      // Placeholders are real `groupMembers` rows — partition purely on
+      // `inGroup`. The "Invited" tag (rendered inline next to the name)
+      // is what flags them as awaiting signup.
+      if (c.inGroup) {
         groupRows.push(c);
       } else {
         communityRows.push(c);
@@ -375,6 +400,59 @@ export function AssignSheet({
   // layout (gap / flexDirection / padding) on web. We keep layout on a
   // static-styled inner <View> and only use Pressable for the tap target.
   // ---------------------------------------------------------------------------
+  /**
+   * Person identity block (avatar + name + optional "Invited" tag + phone).
+   * Shared between both row variants so GROUP and COMMUNITY rows show
+   * disambiguating phone numbers identically.
+   */
+  const renderPersonIdentity = (person: CommunityPerson) => {
+    const phoneLine = formatPhoneForDisplay(person.phone);
+    return (
+      <>
+        <Avatar
+          name={person.displayName}
+          imageUrl={person.profilePhoto}
+          size={40}
+        />
+        <View style={styles.identityTextWrap}>
+          <View style={styles.identityNameRow}>
+            <Text
+              style={[styles.memberName, { color: colors.text }]}
+              numberOfLines={1}
+            >
+              {person.displayName}
+            </Text>
+            {person.isPlaceholder && (
+              <View
+                style={[
+                  styles.badge,
+                  {
+                    backgroundColor: colors.surfaceSecondary,
+                    borderColor: colors.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={[styles.badgeText, { color: colors.textSecondary }]}
+                >
+                  Invited
+                </Text>
+              </View>
+            )}
+          </View>
+          {phoneLine && (
+            <Text
+              style={[styles.phoneText, { color: colors.textTertiary }]}
+              numberOfLines={1}
+            >
+              {phoneLine}
+            </Text>
+          )}
+        </View>
+      </>
+    );
+  };
+
   const renderGroupRow = (person: CommunityPerson, prior: boolean) => {
     const already = assignedUserIds.has(person.userId as string);
     const busy = busyUserId === (person.userId as string);
@@ -393,17 +471,7 @@ export function AssignSheet({
             already && { opacity: 0.5 },
           ]}
         >
-          <Avatar
-            name={person.displayName}
-            imageUrl={person.profilePhoto}
-            size={40}
-          />
-          <Text
-            style={[styles.memberName, { color: colors.text }]}
-            numberOfLines={1}
-          >
-            {person.displayName}
-          </Text>
+          {renderPersonIdentity(person)}
           {busy ? (
             <ActivityIndicator size="small" color={colors.text} />
           ) : already ? (
@@ -423,10 +491,7 @@ export function AssignSheet({
   const renderCommunityRow = (person: CommunityPerson) => {
     const already = assignedUserIds.has(person.userId as string);
     const busy = busyUserId === (person.userId as string);
-    const isPlaceholder = person.isPlaceholder;
-    // Placeholders are informational — they can't be re-invited from here.
-    const disabled =
-      isPlaceholder || already || !!busyUserId || invitingSubmit;
+    const disabled = already || !!busyUserId || invitingSubmit;
     return (
       <Pressable
         key={person.userId as string}
@@ -438,33 +503,12 @@ export function AssignSheet({
         <View
           style={[
             styles.memberRow,
-            (isPlaceholder || already) && { opacity: 0.55 },
+            already && { opacity: 0.55 },
           ]}
         >
-          <Avatar
-            name={person.displayName}
-            imageUrl={person.profilePhoto}
-            size={40}
-          />
-          <Text
-            style={[styles.memberName, { color: colors.text }]}
-            numberOfLines={1}
-          >
-            {person.displayName}
-          </Text>
+          {renderPersonIdentity(person)}
           {busy ? (
             <ActivityIndicator size="small" color={colors.text} />
-          ) : isPlaceholder ? (
-            <View
-              style={[
-                styles.badge,
-                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
-              ]}
-            >
-              <Text style={[styles.badgeText, { color: colors.textSecondary }]}>
-                Invited
-              </Text>
-            </View>
           ) : already ? (
             <Text style={[styles.metaText, { color: colors.textSecondary }]}>
               Assigned
@@ -472,9 +516,7 @@ export function AssignSheet({
           ) : (
             <View style={styles.addAssignWrap}>
               <Ionicons name="add" size={16} color={primaryColor} />
-              <Text
-                style={[styles.addAssignText, { color: primaryColor }]}
-              >
+              <Text style={[styles.addAssignText, { color: primaryColor }]}>
                 Add & assign
               </Text>
             </View>
@@ -830,10 +872,24 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     minHeight: 56,
   },
-  memberName: {
+  identityTextWrap: {
     flex: 1,
+    minWidth: 0,
+    flexDirection: "column",
+    gap: 2,
+  },
+  identityNameRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  memberName: {
+    flexShrink: 1,
     fontSize: 16,
     fontWeight: "500",
+  },
+  phoneText: {
+    fontSize: 12,
   },
   metaText: {
     fontSize: 13,


### PR DESCRIPTION
## Summary

Two small UX fixes on the AssignSheet after testing on prod:

1. **Placeholders can be assigned to multiple roles.** Previously the picker greyed them out after the first assignment and the backend's `isActive === false` guard rejected re-assignment via `assignFromCommunity`. Now they behave exactly like real volunteers — assignable to as many roles as the leader needs.
2. **Phone numbers display under every name.** Disambiguates name collisions (two "Test User"s, etc.).

## Bug 1 — placeholders blocked from re-assignment

### Frontend (`ea9a840`)
`AssignSheet` was force-routing every `isPlaceholder` row into the COMMUNITY section AND disabling the row. Two problems:
- Placeholders *are* group members (`inviteAndAssign` inserts the row). They should appear in **GROUP** based on their actual `inGroup` flag.
- Disabling the row blocks the leader from putting the same person on a second role on the same event. The existing `assignedUserIds` per-role guard already covers "already in this role" — the placeholder-wide disable was over-eager.

Fix: partition by real `inGroup`, drop the placeholder disable. Keep the small "Invited" badge inline next to the name (still useful context, no greyed-out look).

### Backend (`4d9b8e7`)
`assignFromCommunity`'s `target.isActive === false` guard was originally intended to block deactivated accounts. Placeholder users are intentionally `isActive: false` until they sign up and claim — but they're valid scheduling targets. Tightened the predicate:

```ts
if (target.isActive === false && target.isPlaceholder !== true) {
  throw new ConvexError("This person's account is deactivated and cannot be scheduled");
}
```

Defense-in-depth — the typical path is `assignRole` (placeholder appears in GROUP), but the COMMUNITY-section path also works now for the rare case where a placeholder ended up there.

## Bug 2 — show phone numbers everywhere

`searchCommunityPeople` already returns `phone` in E.164. The AssignSheet now renders it under each name in tertiary color at `fontSize: 12`. New inline helper `formatPhoneForDisplay`: `+1XXXXXXXXXX` → `(XXX) XXX-XXXX`; falls back to the raw string for non-US numbers. Missing phone → no second line.

## Tests

- `assignFromCommunity` permits a placeholder user (`addedToGroup: false`, assignment created).
- `assignFromCommunity` still rejects a deactivated non-placeholder.
- 26 assignments tests pass; full scheduling suite green.

## Verification

- `apps/convex` typechecks clean.
- `apps/mobile` typechecks clean (13 pre-existing unrelated errors).
- 1030 mobile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
