### PR TITLE
Surface auth errors as ConvexError, not opaque Server Error

### DIFF
--- a/apps/convex/lib/auth.ts
+++ b/apps/convex/lib/auth.ts
@@ -27,6 +27,7 @@
  * @see apps/api-trpc/src/lib/jwt.ts for the original tRPC implementation
  */
 
+import { ConvexError } from "convex/values";
 import * as jose from "jose";
 import type { Id } from "../_generated/dataModel";
 import type { QueryCtx, MutationCtx, ActionCtx } from "../_generated/server";
@@ -78,8 +79,15 @@ function getJwtSecret(): Uint8Array {
 
 /**
  * Authentication error thrown when token verification fails.
+ *
+ * Extends `ConvexError` (not plain `Error`) so the message reaches the
+ * mobile client cleanly — a plain `Error` would surface as a generic
+ * "Server Error" in the Convex client, dead-ending the user. By carrying
+ * the message via `ConvexError`'s `data`, the mobile `AuthErrorBoundary`
+ * can recognize the failure and prompt for re-authentication instead.
+ * See repo memory: `feedback_convex_require_auth`.
  */
-export class AuthenticationError extends Error {
+export class AuthenticationError extends ConvexError<string> {
   constructor(message: string = "Not authenticated") {
     super(message);
     this.name = "AuthenticationError";
@@ -522,23 +530,23 @@ export async function requireAuth(
   token: string,
 ): Promise<Id<"users">> {
   if (!token) {
-    throw new Error("Not authenticated");
+    throw new ConvexError("Not authenticated");
   }
 
   const payload = await verifyAccessToken(token);
   if (!payload) {
-    throw new Error("Not authenticated");
+    throw new ConvexError("Not authenticated");
   }
 
   // Resolve user ID (handles both Convex and legacy IDs)
   const userId = await resolveUserId(ctx, payload.userId);
   if (!userId) {
-    throw new Error("Not authenticated");
+    throw new ConvexError("Not authenticated");
   }
 
   // Check if the token was revoked (issued before the user's last signout)
   if (await isTokenRevoked(ctx, userId, payload.issuedAt)) {
-    throw new Error("Not authenticated");
+    throw new ConvexError("Not authenticated");
   }
 
   return userId;
@@ -555,17 +563,17 @@ export async function requireAuthIgnoringRevocation(
   token: string,
 ): Promise<Id<"users">> {
   if (!token) {
-    throw new Error("Not authenticated");
+    throw new ConvexError("Not authenticated");
   }
 
   const payload = await verifyAccessTokenIgnoringExpiration(token);
   if (!payload) {
-    throw new Error("Not authenticated");
+    throw new ConvexError("Not authenticated");
   }
 
   const userId = await resolveUserId(ctx, payload.userId);
   if (!userId) {
-    throw new Error("Not authenticated");
+    throw new ConvexError("Not authenticated");
   }
 
   return userId;
@@ -639,7 +647,7 @@ export async function requireAuthUser(
   const userId = await requireAuth(ctx, token);
   const user = await ctx.db.get(userId);
   if (!user) {
-    throw new Error("User not found");
+    throw new ConvexError("User not found");
   }
   return user;
 }


### PR DESCRIPTION
## Summary

A leader on prod tonight hit `[CONVEX A(scheduling/assignments:inviteAndAssign)] [Request ID: fd174ff46c8bd300] Server Error / Called by client` from the AssignSheet's invite-new form. That generic "Server Error" copy is what Convex shows when a non-`ConvexError` exception escapes a function — the real reason is swallowed. The actual log entry rolled out of Convex's ~30-min retention window before I could inspect it.

The most likely culprit was `AuthenticationError`, which `requireAuthFromTokenAction` throws on every Convex action — and which extended plain `Error`, not `ConvexError`. Same problem with `requireAuth` (mutation/query side) — it threw `new Error("Not authenticated")`.

This PR makes both paths throw `ConvexError`, so the client receives the actual message and the mobile `AuthErrorBoundary` can recover instead of dead-ending the user.

## Changes

`apps/convex/lib/auth.ts`:
- `AuthenticationError extends ConvexError<string>` (was: `extends Error`).
- `requireAuth` / `requireAuthIgnoringRevocation` / `requireAuthUser` throw `ConvexError("Not authenticated")` / `ConvexError("User not found")` instead of plain `Error(...)`.

This closes the repo memory note `feedback_convex_require_auth` that's been on the books for ~7 weeks.

## Why this likely fixes the user's invite error

`inviteAndAssign` starts with `await requireAuthFromTokenAction(ctx, args.token)` — token expiry / refresh races make this the highest-probability throw point in the action's path. The other throws inside the action body are all explicit `ConvexError`s, so they'd surface user-friendly messages on the client. A future hit will now show the precise reason rather than "Server Error".

## Verification

- 133 scheduling + auth tests pass.
- `apps/convex` typechecks clean.
- No behavior change for happy paths — only auth-failure paths now produce ConvexError-shaped client errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)