### PR TITLE
feat(prayer): church Prayer feature with tiered moderation + member reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,21 @@ PCO_DEV_COMMUNITY_ID=          # Planning Center development community ID
 EXPO_PUBLIC_KLIPY_API_KEY=       # KLIPY API key (get from partner.klipy.com)
 
 # =============================================================================
+# OPENAI (Optional - poster keyword generation + church Prayer moderation)
+# =============================================================================
+OPENAI_SECRET_KEY=              # OpenAI API key (sk-...). Used by poster
+                                # keywording and the prayer-request moderator.
+
+# =============================================================================
+# PRAYER MODERATION ESCAPE HATCH (Optional)
+# =============================================================================
+# The moderator currently uses OPENAI_SECRET_KEY (gpt-4o-mini). If OpenAI
+# spend ever becomes a problem, flip PROVIDER to "ollama" in
+# apps/convex/lib/moderation/prayer.ts and set OLLAMA_API_KEY below. See
+# https://ollama.com/pricing for the open-source-model hosted API.
+OLLAMA_API_KEY=
+
+# =============================================================================
 # IMAGE CDN (Optional - custom domain)
 # =============================================================================
 EXPO_PUBLIC_IMAGE_CDN_URL=      # Custom image CDN URL

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -119,6 +119,7 @@ import type * as functions_pcoServices_runSheet from "../functions/pcoServices/r
 import type * as functions_pcoServices_servingHistory from "../functions/pcoServices/servingHistory.js";
 import type * as functions_peopleSavedViews from "../functions/peopleSavedViews.js";
 import type * as functions_posters from "../functions/posters.js";
+import type * as functions_prayers from "../functions/prayers.js";
 import type * as functions_proposals from "../functions/proposals.js";
 import type * as functions_resources from "../functions/resources.js";
 import type * as functions_scheduledJobs from "../functions/scheduledJobs.js";
@@ -169,6 +170,7 @@ import type * as lib_meetingPermissions from "../lib/meetingPermissions.js";
 import type * as lib_meetingSearchText from "../lib/meetingSearchText.js";
 import type * as lib_memberSearch from "../lib/memberSearch.js";
 import type * as lib_membership from "../lib/membership.js";
+import type * as lib_moderation_prayer from "../lib/moderation/prayer.js";
 import type * as lib_notifications_definitions from "../lib/notifications/definitions.js";
 import type * as lib_notifications_emailTemplates from "../lib/notifications/emailTemplates.js";
 import type * as lib_notifications_enabledCounter from "../lib/notifications/enabledCounter.js";
@@ -310,6 +312,7 @@ declare const fullApi: ApiFromModules<{
   "functions/pcoServices/servingHistory": typeof functions_pcoServices_servingHistory;
   "functions/peopleSavedViews": typeof functions_peopleSavedViews;
   "functions/posters": typeof functions_posters;
+  "functions/prayers": typeof functions_prayers;
   "functions/proposals": typeof functions_proposals;
   "functions/resources": typeof functions_resources;
   "functions/scheduledJobs": typeof functions_scheduledJobs;
@@ -360,6 +363,7 @@ declare const fullApi: ApiFromModules<{
   "lib/meetingSearchText": typeof lib_meetingSearchText;
   "lib/memberSearch": typeof lib_memberSearch;
   "lib/membership": typeof lib_membership;
+  "lib/moderation/prayer": typeof lib_moderation_prayer;
   "lib/notifications/definitions": typeof lib_notifications_definitions;
   "lib/notifications/emailTemplates": typeof lib_notifications_emailTemplates;
   "lib/notifications/enabledCounter": typeof lib_notifications_enabledCounter;

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -222,4 +222,17 @@ crons.daily(
   internal.functions.notifications.dailyEnabledSnapshot.runDaily
 );
 
+// =============================================================================
+// PRAYER ARCHIVAL
+// =============================================================================
+// Runs daily at 6:00 UTC to archive active prayers older than 30 days.
+// Authors can still see archived prayers under My Prayers.
+
+crons.daily(
+  "prayer-archive-stale",
+  { hourUTC: 6, minuteUTC: 0 },
+  internal.functions.prayers.archiveStalePrayers,
+  {}
+);
+
 export default crons;

--- a/apps/convex/functions/admin/settings.ts
+++ b/apps/convex/functions/admin/settings.ts
@@ -49,6 +49,7 @@ export const getCommunitySettings = query({
       secondaryColor: community.secondaryColor,
       exploreDefaultGroupTypes: community.exploreDefaultGroupTypes,
       exploreDefaultMeetingType: community.exploreDefaultMeetingType || null,
+      churchFeatures: community.churchFeatures ?? { prayerEnabled: false },
     };
   },
 });
@@ -73,6 +74,11 @@ export const updateCommunitySettings = mutation({
     logo: v.optional(v.string()),
     exploreDefaultGroupTypes: v.optional(v.array(v.id("groupTypes"))),
     exploreDefaultMeetingType: v.optional(v.number()),
+    churchFeatures: v.optional(
+      v.object({
+        prayerEnabled: v.boolean(),
+      }),
+    ),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -140,21 +140,6 @@ export const feed = query({
     await assertPrayerEnabled(ctx, args.communityId);
     await assertCommunityMember(ctx, userId, args.communityId);
 
-    // Pull a small candidate set ordered by prayedForCount asc. The
-    // moderation predicate is in the index — without it, pending/rejected
-    // rows (also `status: "active"`) could fill this window and starve
-    // approved prayers from ever being seen.
-    const candidates = await ctx.db
-      .query("prayers")
-      .withIndex("by_community_status_modStatus_count", (q) =>
-        q
-          .eq("communityId", args.communityId)
-          .eq("status", "active")
-          .eq("moderationStatus", "approved"),
-      )
-      .order("asc")
-      .take(50);
-
     const myResponses = await ctx.db
       .query("prayerResponses")
       .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -169,20 +154,46 @@ export const feed = query({
       .collect();
     const reportedIds = new Set(myReports.map((r) => r.prayerId));
 
-    const visible = candidates.filter(
-      (p) =>
-        p.authorUserId !== userId &&
-        !prayedIds.has(p._id) &&
-        !reportedIds.has(p._id),
-    );
-
-    visible.sort((a, b) => {
-      if (a.prayedForCount !== b.prayedForCount) {
-        return a.prayedForCount - b.prayedForCount;
+    // Paginate candidates ordered by prayedForCount asc. Without this
+    // loop, a long-time member could have the first 50 candidates all
+    // filtered out (own + already-prayed + reported) and see a false
+    // "all caught up" while plenty of eligible prayers exist further
+    // down the index. We page until we have FEED_LIMIT visible or
+    // exhaust the index (or hit MAX_PAGES as a safety cap).
+    //
+    // The moderation predicate is in the index — without it, pending/
+    // rejected rows (also `status: "active"`) could fill the window and
+    // starve approved prayers from ever being seen.
+    const MAX_PAGES = 10; // 10 * 50 = 500 candidates max per feed call
+    const visible: Doc<"prayers">[] = [];
+    let cursor: string | null = null;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const result = await ctx.db
+        .query("prayers")
+        .withIndex("by_community_status_modStatus_count", (q) =>
+          q
+            .eq("communityId", args.communityId)
+            .eq("status", "active")
+            .eq("moderationStatus", "approved"),
+        )
+        .order("asc")
+        .paginate({ numItems: 50, cursor });
+      for (const p of result.page) {
+        if (
+          p.authorUserId !== userId &&
+          !prayedIds.has(p._id) &&
+          !reportedIds.has(p._id)
+        ) {
+          visible.push(p);
+        }
       }
-      return a.createdAt - b.createdAt;
-    });
+      if (visible.length >= FEED_LIMIT || result.isDone) break;
+      cursor = result.continueCursor;
+    }
 
+    // Already ordered by prayedForCount asc via the index; ties broken by
+    // createdAt asc are best-effort here since the index doesn't include it,
+    // but the natural Convex insertion order serves as a reasonable proxy.
     const top = visible.slice(0, FEED_LIMIT);
     // Batch-load authors only for non-anonymous prayers — anonymous ones
     // never trigger a user fetch, guaranteeing identity never leaks.
@@ -281,6 +292,22 @@ export const getDetail = query({
     const userId = await requireAuth(ctx, args.token);
     const prayer = await ctx.db.get(args.prayerId);
     if (!prayer) return null;
+
+    // Re-check gating: a user who left the community (or whose community
+    // disabled prayer) shouldn't be able to deep-link into a detail page
+    // from an old notification and keep reading follow-ups. Returning
+    // null instead of throwing keeps the URL safe to share — the page
+    // just renders an empty state for ineligible viewers.
+    const community = await ctx.db.get(prayer.communityId);
+    if (!community?.churchFeatures?.prayerEnabled) return null;
+    const membership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", userId).eq("communityId", prayer.communityId),
+      )
+      .filter((q) => q.eq(q.field("status"), 1))
+      .first();
+    if (!membership) return null;
 
     const isAuthor = prayer.authorUserId === userId;
     const hasPrayed = !isAuthor
@@ -1077,26 +1104,39 @@ export const archiveStalePrayers = internalMutation({
   args: {},
   handler: async (ctx) => {
     const cutoff = now() - STALE_PRAYER_MS;
-    // Paginate via index — keep batch small to stay under txn limits.
-    const stale = await ctx.db
-      .query("prayers")
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("status"), "active"),
-          q.lt(q.field("createdAt"), cutoff),
-        ),
-      )
-      .take(200);
-
     const ts = now();
-    for (const p of stale) {
-      await ctx.db.patch(p._id, {
-        status: "archived",
-        archivedAt: ts,
-        updatedAt: ts,
-      });
+    // Keep paging until we drain the backlog. Without this loop, a
+    // single daily run only archived 200 — a long quiet period followed
+    // by a moderation rollout could leave thousands of stale prayers
+    // active well past the 30-day retention window. The MAX_PAGES cap
+    // bounds worst-case txn cost (200 * 50 = 10 000 archives per run);
+    // anything beyond that gets the next day's run.
+    const PAGE = 200;
+    const MAX_PAGES = 50;
+    let total = 0;
+    let cursor: string | null = null;
+    for (let i = 0; i < MAX_PAGES; i++) {
+      const result = await ctx.db
+        .query("prayers")
+        .filter((q) =>
+          q.and(
+            q.eq(q.field("status"), "active"),
+            q.lt(q.field("createdAt"), cutoff),
+          ),
+        )
+        .paginate({ numItems: PAGE, cursor });
+      for (const p of result.page) {
+        await ctx.db.patch(p._id, {
+          status: "archived",
+          archivedAt: ts,
+          updatedAt: ts,
+        });
+        total++;
+      }
+      if (result.isDone) break;
+      cursor = result.continueCursor;
     }
-    return { archived: stale.length };
+    return { archived: total };
   },
 });
 

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -140,12 +140,17 @@ export const feed = query({
     await assertPrayerEnabled(ctx, args.communityId);
     await assertCommunityMember(ctx, userId, args.communityId);
 
-    // Pull a small candidate set ordered by prayedForCount asc (the index
-    // is on [communityId, status, prayedForCount]).
+    // Pull a small candidate set ordered by prayedForCount asc. The
+    // moderation predicate is in the index — without it, pending/rejected
+    // rows (also `status: "active"`) could fill this window and starve
+    // approved prayers from ever being seen.
     const candidates = await ctx.db
       .query("prayers")
-      .withIndex("by_community_status_count", (q) =>
-        q.eq("communityId", args.communityId).eq("status", "active"),
+      .withIndex("by_community_status_modStatus_count", (q) =>
+        q
+          .eq("communityId", args.communityId)
+          .eq("status", "active")
+          .eq("moderationStatus", "approved"),
       )
       .order("asc")
       .take(50);
@@ -166,7 +171,6 @@ export const feed = query({
 
     const visible = candidates.filter(
       (p) =>
-        p.moderationStatus === "approved" &&
         p.authorUserId !== userId &&
         !prayedIds.has(p._id) &&
         !reportedIds.has(p._id),
@@ -757,7 +761,11 @@ export const listPendingForReview = query({
 
     return Promise.all(
       pending.map(async (p) => {
-        const author = await ctx.db.get(p.authorUserId);
+        // Anonymity contract: anonymous = hidden from admins too. Skip the
+        // author lookup entirely so identity never reaches an admin client
+        // or log pipeline. The UI renders "Anonymous" when display name
+        // is null.
+        const author = p.isAnonymous ? null : await ctx.db.get(p.authorUserId);
         return {
           id: p._id,
           bodyText: p.bodyText,
@@ -765,8 +773,9 @@ export const listPendingForReview = query({
           createdAt: p.createdAt,
           moderationDetail: p.moderationDetail ?? null,
           crisisFlag: p.crisisFlag === true,
-          authorDisplayName:
-            firstNameLastInitial(author?.firstName, author?.lastName) ?? "Unknown",
+          authorDisplayName: p.isAnonymous
+            ? null
+            : firstNameLastInitial(author?.firstName, author?.lastName) ?? "Unknown",
         };
       }),
     );

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -203,7 +203,7 @@ export const feed = query({
  * later if it matters for engagement metrics.
  */
 export const myPrayedThisWeekCount = query({
-  args: { token: v.string() },
+  args: { token: v.string(), communityId: v.id("communities") },
   handler: async (ctx, args): Promise<{ today: number; week: number }> => {
     const userId = await requireAuth(ctx, args.token);
 
@@ -216,9 +216,14 @@ export const myPrayedThisWeekCount = query({
     startOfWeek.setUTCDate(startOfWeek.getUTCDate() - startOfWeek.getUTCDay());
     const weekThreshold = startOfWeek.getTime();
 
+    // Scoped by community so a multi-community account doesn't leak
+    // counts across communities (would prematurely fire "You prayed for 3"
+    // in a community where they haven't actually prayed for anyone yet).
     const weekResponses = await ctx.db
       .query("prayerResponses")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", userId).eq("communityId", args.communityId),
+      )
       .filter((q) => q.gte(q.field("prayedAt"), weekThreshold))
       .collect();
 
@@ -423,6 +428,7 @@ export const recordPrayerSession = mutation({
     await ctx.db.insert("prayerResponses", {
       prayerId: prayer._id,
       userId,
+      communityId: prayer.communityId,
       prayedAt: ts,
     });
     await ctx.db.patch(prayer._id, {
@@ -449,6 +455,11 @@ export const addFollowUp = mutation({
     const userId = await requireAuth(ctx, args.token);
     const prayer = await ctx.db.get(args.prayerId);
     if (!prayer) throw new ConvexError("prayer_not_found");
+    // Re-enforce feature gating + membership: if the community disabled
+    // prayer or this user is no longer a member, no further follow-ups
+    // (and no more notifyPrayedUsers fan-outs).
+    await assertPrayerEnabled(ctx, prayer.communityId);
+    await assertCommunityMember(ctx, userId, prayer.communityId);
     if (prayer.authorUserId !== userId) {
       throw new ConvexError("not_prayer_author");
     }
@@ -488,6 +499,8 @@ export const markAnswered = mutation({
     const userId = await requireAuth(ctx, args.token);
     const prayer = await ctx.db.get(args.prayerId);
     if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertPrayerEnabled(ctx, prayer.communityId);
+    await assertCommunityMember(ctx, userId, prayer.communityId);
     if (prayer.authorUserId !== userId) {
       throw new ConvexError("not_prayer_author");
     }
@@ -524,6 +537,8 @@ export const archivePrayer = mutation({
     const userId = await requireAuth(ctx, args.token);
     const prayer = await ctx.db.get(args.prayerId);
     if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertPrayerEnabled(ctx, prayer.communityId);
+    await assertCommunityMember(ctx, userId, prayer.communityId);
     if (prayer.authorUserId !== userId) {
       throw new ConvexError("not_prayer_author");
     }

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -1,0 +1,1078 @@
+/**
+ * Prayer requests — backend for the church-feature prayer flow.
+ *
+ * Anonymity contract: every read API that returns prayers to a non-author
+ * MUST pass them through `stripAuthor()`. That helper is the only place
+ * `authorUserId` is allowed to leak out of this module.
+ *
+ * Feature gating: every public mutation/query asserts the calling user's
+ * community has `churchFeatures.prayerEnabled === true`.
+ */
+
+import { v, ConvexError } from "convex/values";
+import {
+  query,
+  mutation,
+  internalMutation,
+  internalAction,
+  internalQuery,
+  type QueryCtx,
+  type MutationCtx,
+} from "../_generated/server";
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+import { requireAuth } from "../lib/auth";
+import { now } from "../lib/utils";
+import { moderatePrayerText, type ModerationResult } from "../lib/moderation/prayer";
+import { notify, notifyBatch, notifyCommunityAdmins } from "../lib/notifications/send";
+
+const MAX_BODY_LENGTH = 500;
+const FEED_LIMIT = 3;
+const STALE_PRAYER_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function assertPrayerEnabled(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+): Promise<Doc<"communities">> {
+  const community = await ctx.db.get(communityId);
+  if (!community) {
+    throw new ConvexError("community_not_found");
+  }
+  if (!community.churchFeatures?.prayerEnabled) {
+    throw new ConvexError("prayer_not_enabled");
+  }
+  return community;
+}
+
+async function assertCommunityMember(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+  communityId: Id<"communities">,
+): Promise<void> {
+  const membership = await ctx.db
+    .query("userCommunities")
+    .withIndex("by_user_community", (q) =>
+      q.eq("userId", userId).eq("communityId", communityId),
+    )
+    .filter((q) => q.eq(q.field("status"), 1))
+    .first();
+  if (!membership) {
+    throw new ConvexError("not_a_community_member");
+  }
+}
+
+interface PublicPrayer {
+  id: Id<"prayers">;
+  bodyText: string;
+  prayedForCount: number;
+  status: Doc<"prayers">["status"];
+  createdAt: number;
+  archivedAt: number | null;
+  /**
+   * Author display in the form "First L." (first name + last initial).
+   * Always `null` when the prayer was posted anonymously — anonymous
+   * prayers never expose author identity at the data layer, even to admins.
+   */
+  authorDisplayName: string | null;
+  /**
+   * When true, the moderator flagged this as first-person crisis content.
+   * The client overlays a 988 / Crisis Text Line resource card. We DO NOT
+   * use this to hide the post — "triage, not suppression" (7 Cups, Crisis
+   * Text Line). Visible to everyone who sees the prayer.
+   */
+  crisisFlag: boolean;
+}
+
+/** Compute "First L." (first name + last initial). Falls back to "First" if no last name. */
+function firstNameLastInitial(firstName?: string, lastName?: string): string | null {
+  const f = (firstName ?? "").trim();
+  const l = (lastName ?? "").trim();
+  if (!f && !l) return null;
+  if (!l) return f;
+  return `${f} ${l.charAt(0).toUpperCase()}.`;
+}
+
+/**
+ * Single chokepoint for the anonymity contract. Every read API that returns
+ * prayers to anyone other than the author MUST route through here. Pass
+ * `null` for `author` whenever the prayer is anonymous.
+ */
+function publicPrayerFrom(
+  prayer: Doc<"prayers">,
+  author: Doc<"users"> | null,
+): PublicPrayer {
+  const authorDisplayName =
+    prayer.isAnonymous || author === null
+      ? null
+      : firstNameLastInitial(author.firstName, author.lastName);
+  return {
+    id: prayer._id,
+    bodyText: prayer.bodyText,
+    prayedForCount: prayer.prayedForCount,
+    status: prayer.status,
+    createdAt: prayer.createdAt,
+    archivedAt: prayer.archivedAt ?? null,
+    authorDisplayName,
+    crisisFlag: prayer.crisisFlag === true,
+  };
+}
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+/**
+ * Up to `FEED_LIMIT` active+approved prayers, sorted by fewest pray-count
+ * first then oldest. Excludes prayers the caller has already prayed for or
+ * authored. Author identity is never returned.
+ */
+export const feed = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+  },
+  handler: async (ctx, args): Promise<PublicPrayer[]> => {
+    const userId = await requireAuth(ctx, args.token);
+    await assertPrayerEnabled(ctx, args.communityId);
+    await assertCommunityMember(ctx, userId, args.communityId);
+
+    // Pull a small candidate set ordered by prayedForCount asc (the index
+    // is on [communityId, status, prayedForCount]).
+    const candidates = await ctx.db
+      .query("prayers")
+      .withIndex("by_community_status_count", (q) =>
+        q.eq("communityId", args.communityId).eq("status", "active"),
+      )
+      .order("asc")
+      .take(50);
+
+    const myResponses = await ctx.db
+      .query("prayerResponses")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const prayedIds = new Set(myResponses.map((r) => r.prayerId));
+
+    // Also drop anything the caller has already reported — they shouldn't
+    // keep seeing prayers they flagged.
+    const myReports = await ctx.db
+      .query("prayerReports")
+      .withIndex("by_reporter", (q) => q.eq("reporterUserId", userId))
+      .collect();
+    const reportedIds = new Set(myReports.map((r) => r.prayerId));
+
+    const visible = candidates.filter(
+      (p) =>
+        p.moderationStatus === "approved" &&
+        p.authorUserId !== userId &&
+        !prayedIds.has(p._id) &&
+        !reportedIds.has(p._id),
+    );
+
+    visible.sort((a, b) => {
+      if (a.prayedForCount !== b.prayedForCount) {
+        return a.prayedForCount - b.prayedForCount;
+      }
+      return a.createdAt - b.createdAt;
+    });
+
+    const top = visible.slice(0, FEED_LIMIT);
+    // Batch-load authors only for non-anonymous prayers — anonymous ones
+    // never trigger a user fetch, guaranteeing identity never leaks.
+    const authors = await Promise.all(
+      top.map((p) => (p.isAnonymous ? Promise.resolve(null) : ctx.db.get(p.authorUserId))),
+    );
+    return top.map((p, i) => publicPrayerFrom(p, authors[i]));
+  },
+});
+
+/**
+ * How many distinct prayers the caller has prayed for this week (since
+ * Sunday UTC midnight). Used in the Prayer screen header as a soft
+ * "you've been showing up" signal — only surfaced past a threshold so it
+ * stays celebratory and doesn't read as a guilt-trip stat for new users.
+ *
+ * UTC chosen for simplicity; a per-user-timezone variant could fold in
+ * later if it matters for engagement metrics.
+ */
+export const myPrayedThisWeekCount = query({
+  args: { token: v.string() },
+  handler: async (ctx, args): Promise<{ today: number; week: number }> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const startOfDay = new Date();
+    startOfDay.setUTCHours(0, 0, 0, 0);
+    const dayThreshold = startOfDay.getTime();
+
+    const startOfWeek = new Date(startOfDay);
+    // Roll back to Sunday UTC (getUTCDay: Sun=0).
+    startOfWeek.setUTCDate(startOfWeek.getUTCDate() - startOfWeek.getUTCDay());
+    const weekThreshold = startOfWeek.getTime();
+
+    const weekResponses = await ctx.db
+      .query("prayerResponses")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.gte(q.field("prayedAt"), weekThreshold))
+      .collect();
+
+    let today = 0;
+    for (const r of weekResponses) {
+      if (r.prayedAt >= dayThreshold) today++;
+    }
+    return { today, week: weekResponses.length };
+  },
+});
+
+/**
+ * Caller's own prayers — active, answered, and archived. Includes counts.
+ * Returns author-visible fields (author IS the caller here).
+ */
+export const myPrayers = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const prayers = await ctx.db
+      .query("prayers")
+      .withIndex("by_author", (q) => q.eq("authorUserId", userId))
+      .collect();
+
+    prayers.sort((a, b) => b.createdAt - a.createdAt);
+
+    return prayers.map((p) => ({
+      id: p._id,
+      bodyText: p.bodyText,
+      isAnonymous: p.isAnonymous,
+      status: p.status,
+      prayedForCount: p.prayedForCount,
+      moderationStatus: p.moderationStatus,
+      moderationDetail: p.moderationDetail ?? null,
+      crisisFlag: p.crisisFlag === true,
+      createdAt: p.createdAt,
+      updatedAt: p.updatedAt,
+      archivedAt: p.archivedAt ?? null,
+    }));
+  },
+});
+
+/**
+ * Detail view for a single prayer. Author OR users who prayed for it
+ * can read; everyone else gets `null`. Author info only when caller is
+ * the author.
+ */
+export const getDetail = query({
+  args: {
+    token: v.string(),
+    prayerId: v.id("prayers"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) return null;
+
+    const isAuthor = prayer.authorUserId === userId;
+    const hasPrayed = !isAuthor
+      ? !!(await ctx.db
+          .query("prayerResponses")
+          .withIndex("by_prayer_user", (q) =>
+            q.eq("prayerId", prayer._id).eq("userId", userId),
+          )
+          .first())
+      : false;
+
+    if (!isAuthor && !hasPrayed) return null;
+
+    const followUps = await ctx.db
+      .query("prayerFollowUps")
+      .withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id))
+      .collect();
+    followUps.sort((a, b) => a.createdAt - b.createdAt);
+
+    // Author display: shown only when the prayer is not anonymous. The
+    // author themselves always sees themselves; prayed-for viewers see
+    // "First L." for non-anon prayers and nothing for anonymous ones.
+    const author = prayer.isAnonymous ? null : await ctx.db.get(prayer.authorUserId);
+    const authorDisplayName = prayer.isAnonymous
+      ? null
+      : firstNameLastInitial(author?.firstName, author?.lastName);
+
+    return {
+      id: prayer._id,
+      bodyText: prayer.bodyText,
+      status: prayer.status,
+      prayedForCount: prayer.prayedForCount,
+      createdAt: prayer.createdAt,
+      archivedAt: prayer.archivedAt ?? null,
+      isAuthor,
+      authorDisplayName,
+      crisisFlag: prayer.crisisFlag === true,
+      // Only include author-only fields when caller is the author. The
+      // moderationDetail (with category + admin note) is for author
+      // transparency on rejected/pending prayers — never leaked to viewers.
+      ...(isAuthor
+        ? {
+            isAnonymous: prayer.isAnonymous,
+            moderationStatus: prayer.moderationStatus,
+            moderationDetail: prayer.moderationDetail ?? null,
+          }
+        : {}),
+      followUps: followUps.map((f) => ({
+        id: f._id,
+        kind: f.kind,
+        bodyText: f.bodyText,
+        createdAt: f.createdAt,
+      })),
+    };
+  },
+});
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+export const createPrayer = mutation({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    bodyText: v.string(),
+    isAnonymous: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await assertPrayerEnabled(ctx, args.communityId);
+    await assertCommunityMember(ctx, userId, args.communityId);
+
+    const body = args.bodyText.trim();
+    if (body.length === 0) {
+      throw new ConvexError("prayer_body_empty");
+    }
+    if (body.length > MAX_BODY_LENGTH) {
+      throw new ConvexError("prayer_body_too_long");
+    }
+
+    const ts = now();
+    const prayerId = await ctx.db.insert("prayers", {
+      communityId: args.communityId,
+      authorUserId: userId,
+      isAnonymous: args.isAnonymous,
+      bodyText: body,
+      status: "active",
+      prayedForCount: 0,
+      // Always inserted "pending" so borderline/yellow content can't leak
+      // into the feed in the 1-5s window before the LLM responds. Most
+      // green prayers flip to approved within ~2s via the moderation
+      // action below.
+      moderationStatus: "pending",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    await ctx.scheduler.runAfter(0, internal.functions.prayers.moderatePrayer, {
+      prayerId,
+    });
+
+    return { prayerId };
+  },
+});
+
+/**
+ * Called when the 3-min timer completes OR the user taps "I prayed, mark
+ * done." Idempotent per (prayer, user): double-tap returns ok without
+ * re-incrementing or re-notifying.
+ */
+export const recordPrayerSession = mutation({
+  args: {
+    token: v.string(),
+    prayerId: v.id("prayers"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertPrayerEnabled(ctx, prayer.communityId);
+    await assertCommunityMember(ctx, userId, prayer.communityId);
+
+    if (prayer.authorUserId === userId) {
+      throw new ConvexError("cannot_pray_for_own_prayer");
+    }
+    if (prayer.status !== "active") {
+      throw new ConvexError("prayer_not_active");
+    }
+    if (prayer.moderationStatus !== "approved") {
+      throw new ConvexError("prayer_not_approved");
+    }
+
+    const existing = await ctx.db
+      .query("prayerResponses")
+      .withIndex("by_prayer_user", (q) =>
+        q.eq("prayerId", prayer._id).eq("userId", userId),
+      )
+      .first();
+    if (existing) {
+      return { alreadyPrayed: true };
+    }
+
+    const ts = now();
+    await ctx.db.insert("prayerResponses", {
+      prayerId: prayer._id,
+      userId,
+      prayedAt: ts,
+    });
+    await ctx.db.patch(prayer._id, {
+      prayedForCount: prayer.prayedForCount + 1,
+      updatedAt: ts,
+    });
+
+    await ctx.scheduler.runAfter(0, internal.functions.prayers.notifyAuthor, {
+      prayerId: prayer._id,
+    });
+
+    return { alreadyPrayed: false };
+  },
+});
+
+export const addFollowUp = mutation({
+  args: {
+    token: v.string(),
+    prayerId: v.id("prayers"),
+    kind: v.union(v.literal("update"), v.literal("praise_report")),
+    bodyText: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    if (prayer.authorUserId !== userId) {
+      throw new ConvexError("not_prayer_author");
+    }
+
+    const body = args.bodyText.trim();
+    if (body.length === 0) throw new ConvexError("follow_up_body_empty");
+    if (body.length > MAX_BODY_LENGTH) {
+      throw new ConvexError("follow_up_body_too_long");
+    }
+
+    const ts = now();
+    const followUpId = await ctx.db.insert("prayerFollowUps", {
+      prayerId: prayer._id,
+      authorUserId: userId,
+      kind: args.kind,
+      bodyText: body,
+      createdAt: ts,
+    });
+    await ctx.db.patch(prayer._id, { updatedAt: ts });
+
+    await ctx.scheduler.runAfter(0, internal.functions.prayers.notifyPrayedUsers, {
+      prayerId: prayer._id,
+      followUpId,
+    });
+
+    return { followUpId };
+  },
+});
+
+export const markAnswered = mutation({
+  args: {
+    token: v.string(),
+    prayerId: v.id("prayers"),
+    praiseReportText: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    if (prayer.authorUserId !== userId) {
+      throw new ConvexError("not_prayer_author");
+    }
+
+    const ts = now();
+    await ctx.db.patch(prayer._id, { status: "answered", updatedAt: ts });
+
+    if (args.praiseReportText && args.praiseReportText.trim().length > 0) {
+      const body = args.praiseReportText.trim().slice(0, MAX_BODY_LENGTH);
+      const followUpId = await ctx.db.insert("prayerFollowUps", {
+        prayerId: prayer._id,
+        authorUserId: userId,
+        kind: "praise_report",
+        bodyText: body,
+        createdAt: ts,
+      });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.prayers.notifyPrayedUsers,
+        { prayerId: prayer._id, followUpId },
+      );
+    }
+
+    return { ok: true };
+  },
+});
+
+export const archivePrayer = mutation({
+  args: {
+    token: v.string(),
+    prayerId: v.id("prayers"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    if (prayer.authorUserId !== userId) {
+      throw new ConvexError("not_prayer_author");
+    }
+
+    const ts = now();
+    await ctx.db.patch(prayer._id, {
+      status: "archived",
+      archivedAt: ts,
+      updatedAt: ts,
+    });
+    return { ok: true };
+  },
+});
+
+// ============================================================================
+// Internal queries (helpers for actions)
+// ============================================================================
+
+export const _getPrayerForAction = internalQuery({
+  args: { prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) return null;
+    const community = await ctx.db.get(prayer.communityId);
+    return {
+      prayer,
+      communityName: community?.name ?? null,
+    };
+  },
+});
+
+export const _getResponderIds = internalQuery({
+  args: { prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const responses = await ctx.db
+      .query("prayerResponses")
+      .withIndex("by_prayer", (q) => q.eq("prayerId", args.prayerId))
+      .collect();
+    return responses.map((r) => r.userId);
+  },
+});
+
+export const _getFollowUp = internalQuery({
+  args: { followUpId: v.id("prayerFollowUps") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.followUpId);
+  },
+});
+
+export const _setModerationRejected = internalMutation({
+  args: { prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.prayerId, {
+      moderationStatus: "rejected",
+      updatedAt: now(),
+    });
+  },
+});
+
+/**
+ * Apply a tiered moderation result. Sets status (approved/pending_review/
+ * rejected), crisis flag, and a detail blob the author + admins can see.
+ * Schedules the admin-review notification fan-out when severity = yellow.
+ */
+export const _applyModerationResult = internalMutation({
+  args: {
+    prayerId: v.id("prayers"),
+    severity: v.union(v.literal("green"), v.literal("yellow"), v.literal("red")),
+    crisis: v.boolean(),
+    category: v.optional(v.string()),
+    note: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const status: Doc<"prayers">["moderationStatus"] =
+      args.severity === "green"
+        ? "approved"
+        : args.severity === "yellow"
+          ? "pending_review"
+          : "rejected";
+    await ctx.db.patch(args.prayerId, {
+      moderationStatus: status,
+      crisisFlag: args.crisis,
+      moderationDetail: {
+        severity: args.severity,
+        category: args.category,
+        note: args.note,
+      },
+      updatedAt: now(),
+    });
+
+    if (status === "pending_review") {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.prayers.notifyAdminsOfPendingReview,
+        { prayerId: args.prayerId },
+      );
+    }
+  },
+});
+
+// ============================================================================
+// Internal actions
+// ============================================================================
+
+export const moderatePrayer = internalAction({
+  args: { prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const data = await ctx.runQuery(
+      internal.functions.prayers._getPrayerForAction,
+      { prayerId: args.prayerId },
+    );
+    if (!data) return;
+    const result: ModerationResult = await moderatePrayerText(data.prayer.bodyText);
+    await ctx.runMutation(
+      internal.functions.prayers._applyModerationResult,
+      {
+        prayerId: args.prayerId,
+        severity: result.severity,
+        crisis: result.crisis,
+        category: result.category,
+        note: result.note,
+      },
+    );
+  },
+});
+
+export const notifyAuthor = internalAction({
+  args: { prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const data = await ctx.runQuery(
+      internal.functions.prayers._getPrayerForAction,
+      { prayerId: args.prayerId },
+    );
+    if (!data) return;
+    await notify(ctx, {
+      type: "prayer.prayed_for",
+      userId: data.prayer.authorUserId,
+      communityId: data.prayer.communityId,
+      data: {
+        prayerId: String(data.prayer._id),
+        communityId: String(data.prayer.communityId),
+        communityName: data.communityName ?? undefined,
+      },
+    });
+  },
+});
+
+export const notifyPrayedUsers = internalAction({
+  args: {
+    prayerId: v.id("prayers"),
+    followUpId: v.id("prayerFollowUps"),
+  },
+  handler: async (ctx, args) => {
+    const followUp = await ctx.runQuery(
+      internal.functions.prayers._getFollowUp,
+      { followUpId: args.followUpId },
+    );
+    if (!followUp) return;
+
+    const data = await ctx.runQuery(
+      internal.functions.prayers._getPrayerForAction,
+      { prayerId: args.prayerId },
+    );
+    if (!data) return;
+
+    const responderIds = await ctx.runQuery(
+      internal.functions.prayers._getResponderIds,
+      { prayerId: args.prayerId },
+    );
+    if (responderIds.length === 0) return;
+
+    const bodySnippet = followUp.bodyText.slice(0, 80);
+    const notificationType =
+      followUp.kind === "praise_report" ? "prayer.praise_report" : "prayer.update";
+
+    await notifyBatch(ctx, {
+      type: notificationType,
+      userIds: responderIds,
+      communityId: data.prayer.communityId,
+      data: {
+        prayerId: String(args.prayerId),
+        followUpId: String(args.followUpId),
+        bodySnippet,
+        communityId: String(data.prayer.communityId),
+      },
+    });
+  },
+});
+
+// ============================================================================
+// Admin review queue
+// ============================================================================
+
+async function assertCommunityAdmin(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+  communityId: Id<"communities">,
+): Promise<void> {
+  const membership = await ctx.db
+    .query("userCommunities")
+    .withIndex("by_user_community", (q) =>
+      q.eq("userId", userId).eq("communityId", communityId),
+    )
+    .filter((q) => q.eq(q.field("status"), 1))
+    .first();
+  // role >= 3 matches COMMUNITY_ADMIN_THRESHOLD from lib/permissions.ts.
+  if (!membership || (membership.roles ?? 0) < 3) {
+    throw new ConvexError("not_a_community_admin");
+  }
+}
+
+/**
+ * Admin-only: list all prayers currently held for review in a community.
+ * Returns full content + the LLM's category/note so the admin has the
+ * context the classifier had. Author identity is included since admins
+ * may need to follow up — anonymous-mode prayers still surface ID here
+ * because the prayer needed human eyes anyway.
+ */
+export const listPendingForReview = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await assertCommunityAdmin(ctx, userId, args.communityId);
+
+    const pending = await ctx.db
+      .query("prayers")
+      .withIndex("by_community_moderationStatus", (q) =>
+        q.eq("communityId", args.communityId).eq("moderationStatus", "pending_review"),
+      )
+      .collect();
+    pending.sort((a, b) => a.createdAt - b.createdAt);
+
+    return Promise.all(
+      pending.map(async (p) => {
+        const author = await ctx.db.get(p.authorUserId);
+        return {
+          id: p._id,
+          bodyText: p.bodyText,
+          isAnonymous: p.isAnonymous,
+          createdAt: p.createdAt,
+          moderationDetail: p.moderationDetail ?? null,
+          crisisFlag: p.crisisFlag === true,
+          authorDisplayName:
+            firstNameLastInitial(author?.firstName, author?.lastName) ?? "Unknown",
+        };
+      }),
+    );
+  },
+});
+
+export const approvePending = mutation({
+  args: { token: v.string(), prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertCommunityAdmin(ctx, userId, prayer.communityId);
+    if (prayer.moderationStatus !== "pending_review") {
+      throw new ConvexError("prayer_not_pending");
+    }
+    await ctx.db.patch(args.prayerId, {
+      moderationStatus: "approved",
+      updatedAt: now(),
+    });
+    return { ok: true };
+  },
+});
+
+export const rejectPending = mutation({
+  args: { token: v.string(), prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertCommunityAdmin(ctx, userId, prayer.communityId);
+    if (prayer.moderationStatus !== "pending_review") {
+      throw new ConvexError("prayer_not_pending");
+    }
+    await ctx.db.patch(args.prayerId, {
+      moderationStatus: "rejected",
+      updatedAt: now(),
+    });
+    return { ok: true };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// Member reports
+// ----------------------------------------------------------------------------
+
+const REPORT_REASONS = [
+  "names_person",
+  "intimate_explicit",
+  "spam_solicitation",
+  "hateful",
+  "crisis_needs_resources",
+  "other",
+] as const;
+type ReportReason = (typeof REPORT_REASONS)[number];
+
+/**
+ * Any community member can report a prayer they're seeing. Idempotent per
+ * (prayer, reporter) — a second report from the same user is a no-op.
+ * Schedules a fan-out push to admins so reports don't sit cold.
+ */
+export const reportPrayer = mutation({
+  args: {
+    token: v.string(),
+    prayerId: v.id("prayers"),
+    reason: v.union(
+      v.literal("names_person"),
+      v.literal("intimate_explicit"),
+      v.literal("spam_solicitation"),
+      v.literal("hateful"),
+      v.literal("crisis_needs_resources"),
+      v.literal("other"),
+    ),
+    customNote: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertCommunityMember(ctx, userId, prayer.communityId);
+    if (prayer.authorUserId === userId) {
+      throw new ConvexError("cannot_report_own_prayer");
+    }
+
+    // Dedupe per (prayer, reporter). Second report = no-op.
+    const existing = await ctx.db
+      .query("prayerReports")
+      .withIndex("by_prayer_reporter", (q) =>
+        q.eq("prayerId", args.prayerId).eq("reporterUserId", userId),
+      )
+      .first();
+    if (existing) return { alreadyReported: true };
+
+    const customNote = args.customNote?.trim().slice(0, 300) || undefined;
+
+    const reportId = await ctx.db.insert("prayerReports", {
+      prayerId: args.prayerId,
+      communityId: prayer.communityId,
+      reporterUserId: userId,
+      reason: args.reason,
+      customNote,
+      status: "open",
+      createdAt: now(),
+    });
+
+    await ctx.scheduler.runAfter(0, internal.functions.prayers.notifyAdminsOfReport, {
+      reportId,
+    });
+
+    return { alreadyReported: false, reportId };
+  },
+});
+
+/**
+ * Admin-only: open member reports for a community. Returns one row per
+ * report, with the underlying prayer body + reporter "First L." attached
+ * so admins have what they need to triage in one screen.
+ */
+export const listReportedPrayers = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await assertCommunityAdmin(ctx, userId, args.communityId);
+
+    const reports = await ctx.db
+      .query("prayerReports")
+      .withIndex("by_community_status", (q) =>
+        q.eq("communityId", args.communityId).eq("status", "open"),
+      )
+      .collect();
+    reports.sort((a, b) => a.createdAt - b.createdAt);
+
+    return Promise.all(
+      reports.map(async (r) => {
+        const prayer = await ctx.db.get(r.prayerId);
+        const reporter = await ctx.db.get(r.reporterUserId);
+        return {
+          reportId: r._id,
+          prayerId: r.prayerId,
+          reason: r.reason,
+          customNote: r.customNote ?? null,
+          createdAt: r.createdAt,
+          reporterDisplayName:
+            firstNameLastInitial(reporter?.firstName, reporter?.lastName) ??
+            "Unknown",
+          prayerBody: prayer?.bodyText ?? "(deleted)",
+          prayerCreatedAt: prayer?.createdAt ?? r.createdAt,
+          // Still-visible? Admin needs to know if action is needed urgently.
+          prayerStatus: prayer?.moderationStatus ?? "rejected",
+        };
+      }),
+    );
+  },
+});
+
+/**
+ * Admin uphold: reject the prayer + mark all its reports as actioned.
+ * Idempotent — safe to call repeatedly even if other admins act concurrently.
+ */
+export const upholdReport = mutation({
+  args: { token: v.string(), prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertCommunityAdmin(ctx, userId, prayer.communityId);
+
+    const ts = now();
+    if (prayer.moderationStatus !== "rejected") {
+      await ctx.db.patch(args.prayerId, {
+        moderationStatus: "rejected",
+        updatedAt: ts,
+      });
+    }
+    const reports = await ctx.db
+      .query("prayerReports")
+      .withIndex("by_prayer", (q) => q.eq("prayerId", args.prayerId))
+      .collect();
+    for (const r of reports) {
+      if (r.status === "open") {
+        await ctx.db.patch(r._id, { status: "actioned" });
+      }
+    }
+    return { ok: true };
+  },
+});
+
+/**
+ * Admin dismiss: keep the prayer up, mark reports as dismissed.
+ */
+export const dismissReports = mutation({
+  args: { token: v.string(), prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const prayer = await ctx.db.get(args.prayerId);
+    if (!prayer) throw new ConvexError("prayer_not_found");
+    await assertCommunityAdmin(ctx, userId, prayer.communityId);
+
+    const reports = await ctx.db
+      .query("prayerReports")
+      .withIndex("by_prayer", (q) => q.eq("prayerId", args.prayerId))
+      .collect();
+    for (const r of reports) {
+      if (r.status === "open") {
+        await ctx.db.patch(r._id, { status: "dismissed" });
+      }
+    }
+    return { ok: true };
+  },
+});
+
+export const notifyAdminsOfReport = internalAction({
+  args: { reportId: v.id("prayerReports") },
+  handler: async (ctx, args) => {
+    const report = await ctx.runQuery(
+      internal.functions.prayers._getReportForAction,
+      { reportId: args.reportId },
+    );
+    if (!report) return;
+    const snippet = report.prayerBody.slice(0, 80);
+    await notifyCommunityAdmins(ctx, {
+      type: "prayer.member_reported",
+      communityId: report.communityId,
+      data: {
+        prayerId: String(report.prayerId),
+        communityId: String(report.communityId),
+        snippet,
+        reason: report.reason,
+      },
+    });
+  },
+});
+
+export const _getReportForAction = internalQuery({
+  args: { reportId: v.id("prayerReports") },
+  handler: async (ctx, args) => {
+    const report = await ctx.db.get(args.reportId);
+    if (!report) return null;
+    const prayer = await ctx.db.get(report.prayerId);
+    return {
+      prayerId: report.prayerId,
+      communityId: report.communityId,
+      reason: report.reason,
+      prayerBody: prayer?.bodyText ?? "",
+    };
+  },
+});
+
+void REPORT_REASONS;
+
+export const notifyAdminsOfPendingReview = internalAction({
+  args: { prayerId: v.id("prayers") },
+  handler: async (ctx, args) => {
+    const data = await ctx.runQuery(
+      internal.functions.prayers._getPrayerForAction,
+      { prayerId: args.prayerId },
+    );
+    if (!data) return;
+    // We can't pull a category off `data.prayer.moderationDetail` here
+    // because internalQuery returns the doc with that field — re-read note
+    // so this fan-out stays simple. Keep body snippet short for the push.
+    const snippet = data.prayer.bodyText.slice(0, 80);
+    await notifyCommunityAdmins(ctx, {
+      type: "prayer.admin_review_needed",
+      communityId: data.prayer.communityId,
+      data: {
+        prayerId: String(args.prayerId),
+        communityId: String(data.prayer.communityId),
+        snippet,
+        category: data.prayer.moderationDetail?.category ?? "borderline_other",
+      },
+    });
+  },
+});
+
+// ============================================================================
+// Cron handler
+// ============================================================================
+
+export const archiveStalePrayers = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = now() - STALE_PRAYER_MS;
+    // Paginate via index — keep batch small to stay under txn limits.
+    const stale = await ctx.db
+      .query("prayers")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("status"), "active"),
+          q.lt(q.field("createdAt"), cutoff),
+        ),
+      )
+      .take(200);
+
+    const ts = now();
+    for (const p of stale) {
+      await ctx.db.patch(p._id, {
+        status: "archived",
+        archivedAt: ts,
+        updatedAt: ts,
+      });
+    }
+    return { archived: stale.length };
+  },
+});
+

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -644,6 +644,7 @@ export const me = query({
     let activeCommunityName: string | null = null;
     let activeCommunityPrimaryColor: string | null = null;
     let activeCommunitySecondaryColor: string | null = null;
+    let activeCommunityChurchFeatures: { prayerEnabled: boolean } | null = null;
 
     if (user.activeCommunityId) {
       const activeCommunity = await ctx.db.get(user.activeCommunityId);
@@ -651,6 +652,7 @@ export const me = query({
         activeCommunityName = activeCommunity.name || null;
         activeCommunityPrimaryColor = activeCommunity.primaryColor || null;
         activeCommunitySecondaryColor = activeCommunity.secondaryColor || null;
+        activeCommunityChurchFeatures = activeCommunity.churchFeatures ?? null;
       }
     }
 
@@ -685,6 +687,7 @@ export const me = query({
       activeCommunityName,
       activeCommunityPrimaryColor,
       activeCommunitySecondaryColor,
+      activeCommunityChurchFeatures,
       communityMemberships: communityMemberships.filter(Boolean),
     };
   },

--- a/apps/convex/lib/moderation/prayer.ts
+++ b/apps/convex/lib/moderation/prayer.ts
@@ -1,0 +1,232 @@
+/**
+ * Prayer request moderation — tiered Green/Yellow/Red.
+ *
+ * Currently uses OpenAI's `gpt-4o-mini` because we already have
+ * `OPENAI_SECRET_KEY` configured (also used by `functions/posters.ts`).
+ *
+ * Provider swap: if/when cost becomes a problem, flip `PROVIDER` below to
+ * `"ollama"` and set `OLLAMA_API_KEY`. Both branches conform to the same
+ * OpenAI-style chat-completions JSON contract; the rest of the system
+ * (prayers.ts, the rejection UI) stays untouched. See ollama.com/pricing.
+ *
+ * Tier philosophy (informed by 7 Cups + Crisis Text Line research):
+ *
+ * - **GREEN**: publish. Optionally `crisis: true` — first-person language
+ *   that suggests struggle (depression, suicidal ideation without plan/
+ *   means/timeframe). We DO NOT block this content; we publish it and the
+ *   client overlays crisis-resource info ("triage, not suppression").
+ *
+ * - **YELLOW**: hold for a human community admin to review. Borderline
+ *   content where context matters more than text — third-party named with
+ *   identifying detail, borderline solicitation, accusations against a
+ *   real person.
+ *
+ * - **RED**: reject. Clear policy violations — graphic violence/sexual
+ *   content, an explicit suicide plan with means + timeframe, slurs,
+ *   doxing of named third parties, obvious spam/MLM.
+ *
+ * Fail-open: any error returns GREEN. Better to ship a request that might
+ * need cleanup than to block a vulnerable user from asking for prayer.
+ */
+
+type Provider = "openai" | "ollama";
+const PROVIDER: Provider = "openai";
+
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const OPENAI_MODEL = "gpt-4o-mini";
+
+const OLLAMA_URL = "https://ollama.com/api/chat";
+const OLLAMA_MODEL = "gpt-oss:20b";
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export type Severity = "green" | "yellow" | "red";
+
+export type ModerationCategory =
+  // RED categories
+  | "violence"
+  | "self_harm_plan"
+  | "explicit"
+  | "doxing"
+  | "hate"
+  | "spam"
+  // YELLOW categories
+  | "third_party_named"
+  | "intimate_explicit"
+  | "borderline_solicitation"
+  | "borderline_other"
+  // catch-all
+  | "other";
+
+export interface ModerationResult {
+  severity: Severity;
+  /** First-person mental-health struggle that warrants a resource card. */
+  crisis: boolean;
+  /** Why this severity was chosen. Only meaningful when severity != green. */
+  category?: ModerationCategory;
+  /** Short admin-facing note explaining the YELLOW judgment, e.g. "Names
+   * 'Mike' alongside an accusation of abuse." Empty for GREEN/RED. */
+  note?: string;
+}
+
+const SYSTEM_PROMPT = `You are a moderator for a community prayer-request app used by churches. Decide how to handle a prayer request.
+
+Return a tier: GREEN (publish), YELLOW (hold for human admin review), or RED (reject). Separately, flag CRISIS when the author describes their own mental-health struggle.
+
+# Tiers
+
+## GREEN — publish
+
+Allow requests for: health, family, work, faith, grief, addiction recovery, relationships, financial hardship, parenting struggles, asks for guidance/wisdom, mental-health struggles spoken in the FIRST PERSON without a plan + means + timeframe.
+
+Examples:
+- "Pray for my mom's recovery from surgery this week."
+- "Asking for prayers — I'm exhausted and overwhelmed."
+- "I've been struggling with depression. Please pray I keep showing up."  ← GREEN + crisis: true
+- "I don't want to be here anymore."  ← GREEN + crisis: true (no plan/means stated)
+- "Pray for our youth group mission trip."
+
+## YELLOW — hold for admin review
+
+Hold when the post is borderline and a human admin should make the call. Specifically:
+- **Third-party named with identifying detail AND an accusation, complaint, or sensitive disclosure** — naming someone publicly in a way that exposes them. ("Please pray for my husband Mark — he's been struggling with a porn addiction and lying about it.") The fact that it's a real name + a sensitive disclosure makes this a privacy/defamation risk even without bad intent.
+- **Intimate / explicit disclosures, even when sincere** (category: \`intimate_explicit\`) — first-person posts that mention specifics of one's own sex life, sexual struggles, masturbation, pornography use, or other bedroom-intimacy detail. These are usually well-intentioned but too detailed for a public community prayer wall. Example: "My wife and I are having a hard time in our sex life, we are praying for a spark." → YELLOW. (A general "pray for our marriage" stays GREEN.) The admin can approve as-is or reject so the author can rephrase.
+- **Borderline solicitation** — mentions a fundraiser, GoFundMe, business product, or "DM me to learn more" but is wrapped in a sincere prayer request. Pure asks for prayer about financial hardship are GREEN.
+- **Borderline proselytizing** — "Pray that everyone in our community recognizes [specific doctrine/denomination is the only truth]". Generic asks for faith/wisdom are GREEN.
+- **Anything you genuinely cannot decide between GREEN and RED.**
+
+Note: a real name BY ITSELF — "Pray for Mike" or "Pray for my sister Sarah's cancer treatment" — is GREEN. Our compose UI nudges users away from names at submit time; if they posted with a name anyway, the moderator's job is only to catch the *accusation + name* combination (or other YELLOW criteria above), not the name alone.
+
+## RED — reject
+
+Reject only when clearly policy-violating:
+- Graphic violence or sexual content (gratuitous, not a clinical health mention).
+- Explicit suicide/self-harm PLAN — names a method AND access to means AND a timeframe.
+- Doxing — third party's full name + address/phone/employer/identifying details + accusatory framing.
+- Slurs or targeted hate against protected groups.
+- Obvious spam: MLM recruiting, GoFundMe-only post with no prayer ask, copy-pasted promotional text, scams.
+
+# Crisis flag (independent of tier)
+
+Set crisis: true when the author describes their OWN mental-health struggle in first person — depression, suicidal thoughts, self-harm ideation, severe anxiety, addiction relapse, abuse they're enduring. The flag fires for GREEN content too; it does NOT block. It triggers a 988/Crisis Text Line resource card on the rendered prayer. Err on the side of true.
+
+DO NOT set crisis: true for third-party requests ("pray for my brother who is depressed") — the resource overlay only makes sense for the author themselves.
+
+# Default
+
+When in doubt, prefer GREEN over YELLOW, and YELLOW over RED. Prayer requests are often vulnerable; the cost of blocking is high.
+
+# Output
+
+Respond with strict JSON ONLY:
+{"severity": "green" | "yellow" | "red", "crisis": boolean, "category"?: "violence" | "self_harm_plan" | "explicit" | "doxing" | "hate" | "spam" | "third_party_named" | "intimate_explicit" | "borderline_solicitation" | "borderline_other" | "other", "note"?: string}
+
+- For GREEN, omit category and note.
+- For YELLOW, include category and a short note (≤ 120 chars) the admin can read.
+- For RED, include category. Note optional.`;
+
+export async function moderatePrayerText(text: string): Promise<ModerationResult> {
+  try {
+    const content =
+      PROVIDER === "openai" ? await callOpenAI(text) : await callOllama(text);
+    if (!content) return { severity: "green", crisis: false };
+
+    const parsed = JSON.parse(content) as Partial<ModerationResult>;
+    const severity: Severity =
+      parsed.severity === "yellow" || parsed.severity === "red"
+        ? parsed.severity
+        : "green";
+    const crisis = parsed.crisis === true;
+    const result: ModerationResult = { severity, crisis };
+    if (parsed.category) result.category = parsed.category as ModerationCategory;
+    if (parsed.note) result.note = String(parsed.note).slice(0, 240);
+    return result;
+  } catch (err) {
+    console.error("[moderatePrayerText] error:", err);
+    return { severity: "green", crisis: false };
+  }
+}
+
+async function callOpenAI(userText: string): Promise<string | null> {
+  const apiKey = process.env.OPENAI_SECRET_KEY;
+  if (!apiKey) {
+    console.warn("[moderatePrayerText] OPENAI_SECRET_KEY not set, allowing by default");
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(OPENAI_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        response_format: { type: "json_object" },
+        temperature: 0,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: userText },
+        ],
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      console.error(
+        `[moderatePrayerText] OpenAI ${response.status}: ${errBody.slice(0, 200)}`,
+      );
+      return null;
+    }
+    const json = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    return json?.choices?.[0]?.message?.content?.trim() ?? null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function callOllama(userText: string): Promise<string | null> {
+  const apiKey = process.env.OLLAMA_API_KEY;
+  if (!apiKey) {
+    console.warn("[moderatePrayerText] OLLAMA_API_KEY not set, allowing by default");
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(OLLAMA_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OLLAMA_MODEL,
+        stream: false,
+        format: "json",
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: userText },
+        ],
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      console.error(
+        `[moderatePrayerText] Ollama ${response.status}: ${errBody.slice(0, 200)}`,
+      );
+      return null;
+    }
+    const json = (await response.json()) as { message?: { content?: string } };
+    return json?.message?.content?.trim() ?? null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -792,6 +792,10 @@ export const prayerPraiseReport: NotificationDefinition<PrayerFollowUpData> = {
         prayerId: ctx.data.prayerId,
         followUpId: ctx.data.followUpId,
         communityId: ctx.data.communityId,
+        // Routes the recipient (someone who prayed for this request) to
+        // the detail screen where they can read the follow-up.
+        // getDetail re-gates on community membership before returning.
+        url: `/(user)/my-prayers/${ctx.data.prayerId}`,
       },
     }),
   },
@@ -810,6 +814,7 @@ export const prayerUpdate: NotificationDefinition<PrayerFollowUpData> = {
         prayerId: ctx.data.prayerId,
         followUpId: ctx.data.followUpId,
         communityId: ctx.data.communityId,
+        url: `/(user)/my-prayers/${ctx.data.prayerId}`,
       },
     }),
   },

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -744,6 +744,133 @@ export const followupAssigned: NotificationDefinition<FollowupAssignedData> = {
 };
 
 // ============================================================================
+// Prayer Definitions
+// ============================================================================
+
+interface PrayerPrayedForData {
+  prayerId: string;
+  communityId?: string;
+  communityName?: string;
+}
+
+interface PrayerFollowUpData {
+  prayerId: string;
+  followUpId: string;
+  bodySnippet: string;
+  communityId?: string;
+}
+
+export const prayerPrayedFor: NotificationDefinition<PrayerPrayedForData> = {
+  type: 'prayer.prayed_for',
+  description: 'Sent to a prayer author when another member completes praying for them',
+  formatters: {
+    push: (ctx) => ({
+      title: 'Someone prayed for you',
+      body: ctx.data.communityName
+        ? `Your prayer was just prayed for in ${ctx.data.communityName}.`
+        : 'Your prayer was just prayed for.',
+      data: {
+        type: 'prayer.prayed_for',
+        prayerId: ctx.data.prayerId,
+        communityId: ctx.data.communityId,
+        url: '/(user)/my-prayers',
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
+export const prayerPraiseReport: NotificationDefinition<PrayerFollowUpData> = {
+  type: 'prayer.praise_report',
+  description: 'Sent to everyone who prayed for a request when the author posts a praise report',
+  formatters: {
+    push: (ctx) => ({
+      title: 'Praise report',
+      body: ctx.data.bodySnippet,
+      data: {
+        type: 'prayer.praise_report',
+        prayerId: ctx.data.prayerId,
+        followUpId: ctx.data.followUpId,
+        communityId: ctx.data.communityId,
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
+export const prayerUpdate: NotificationDefinition<PrayerFollowUpData> = {
+  type: 'prayer.update',
+  description: 'Sent to everyone who prayed for a request when the author posts an update',
+  formatters: {
+    push: (ctx) => ({
+      title: 'Prayer update',
+      body: ctx.data.bodySnippet,
+      data: {
+        type: 'prayer.update',
+        prayerId: ctx.data.prayerId,
+        followUpId: ctx.data.followUpId,
+        communityId: ctx.data.communityId,
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
+interface PrayerAdminReviewData {
+  prayerId: string;
+  communityId?: string;
+  snippet: string;
+  category: string;
+}
+
+export const prayerAdminReviewNeeded: NotificationDefinition<PrayerAdminReviewData> = {
+  type: 'prayer.admin_review_needed',
+  description:
+    'Sent to community admins when a prayer is flagged YELLOW and held for human review',
+  formatters: {
+    push: (ctx) => ({
+      title: 'Prayer needs review',
+      body: ctx.data.snippet,
+      data: {
+        type: 'prayer.admin_review_needed',
+        prayerId: ctx.data.prayerId,
+        communityId: ctx.data.communityId,
+        category: ctx.data.category,
+        url: '/(user)/admin/prayer-reviews',
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
+interface PrayerMemberReportedData {
+  prayerId: string;
+  communityId?: string;
+  snippet: string;
+  reason: string;
+}
+
+export const prayerMemberReported: NotificationDefinition<PrayerMemberReportedData> = {
+  type: 'prayer.member_reported',
+  description:
+    'Sent to community admins when a member files a report against a published prayer',
+  formatters: {
+    push: (ctx) => ({
+      title: 'Prayer was reported',
+      body: ctx.data.snippet,
+      data: {
+        type: 'prayer.member_reported',
+        prayerId: ctx.data.prayerId,
+        communityId: ctx.data.communityId,
+        reason: ctx.data.reason,
+        url: '/(user)/admin/prayer-reviews',
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
+// ============================================================================
 // Test Definitions
 // ============================================================================
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2683,11 +2683,17 @@ export default defineSchema({
   prayerResponses: defineTable({
     prayerId: v.id("prayers"),
     userId: v.id("users"),
+    // Denormalized so per-community counts (today/week pill) don't have
+    // to load every prayer doc to check membership. Optional only to
+    // accommodate any pre-migration rows; new inserts always set it.
+    communityId: v.optional(v.id("communities")),
     prayedAt: v.number(),
   })
     .index("by_prayer", ["prayerId"])
     .index("by_user", ["userId"])
-    .index("by_prayer_user", ["prayerId", "userId"]),
+    .index("by_prayer_user", ["prayerId", "userId"])
+    // Powers `myPrayedThisWeekCount` scoped per community.
+    .index("by_user_community", ["userId", "communityId"]),
 
   /**
    * Author-posted follow-ups on a prayer: updates and "praise reports"

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2661,9 +2661,17 @@ export default defineSchema({
   })
     .index("by_community", ["communityId"])
     .index("by_author", ["authorUserId"])
-    // Powers the feed: active+approved prayers sorted by count asc (fewest
-    // prayers first), ties broken by createdAt asc via _creationTime.
-    .index("by_community_status_count", ["communityId", "status", "prayedForCount"])
+    // Powers the feed: active+APPROVED prayers sorted by count asc (fewest
+    // prayers first). The moderation predicate is in the index, not a
+    // post-filter — without it, pending/rejected rows (which are also
+    // `status: "active"`) can fill the candidate window and starve
+    // approved prayers from ever being seen.
+    .index("by_community_status_modStatus_count", [
+      "communityId",
+      "status",
+      "moderationStatus",
+      "prayedForCount",
+    ])
     // Powers the admin review queue: pending_review prayers per community.
     .index("by_community_moderationStatus", ["communityId", "moderationStatus"]),
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -67,6 +67,14 @@ export default defineSchema({
     // Explore page default filters (admin-configurable)
     exploreDefaultGroupTypes: v.optional(v.array(v.id("groupTypes"))),
     exploreDefaultMeetingType: v.optional(v.number()), // 1=In-Person, 2=Online
+    // Church-specific feature toggles. Absent / undefined = all off.
+    // Forward-compat object so we can add more religious-tradition features
+    // (e.g. confessionEnabled) without further schema changes.
+    churchFeatures: v.optional(
+      v.object({
+        prayerEnabled: v.boolean(),
+      }),
+    ),
     // Community-level custom field definitions for People tab
     peopleCustomFields: v.optional(
       v.array(
@@ -2593,4 +2601,134 @@ export default defineSchema({
     // powers team auto-sync: desired members of a team within a rotation
     // window are derived from assignments matched by team + date.
     .index("by_team_eventDate", ["teamId", "eventDate"]),
+
+  // =============================================================================
+  // PRAYERS (Church feature, gated by communities.churchFeatures.prayerEnabled)
+  // =============================================================================
+
+  /**
+   * A single prayer request posted by a community member.
+   *
+   * Anonymity contract: `authorUserId` is ALWAYS stored so the author can
+   * receive notifications when others pray for them, but `feed`/`getDetail`
+   * NEVER expose it when `isAnonymous` is true — not even to community admins.
+   * The single chokepoint is `stripAuthor()` in functions/prayers.ts.
+   */
+  prayers: defineTable({
+    communityId: v.id("communities"),
+    authorUserId: v.id("users"),
+    isAnonymous: v.boolean(),
+    bodyText: v.string(),
+    status: v.union(
+      v.literal("active"),
+      v.literal("answered"),
+      v.literal("archived"),
+    ),
+    // Denormalized count, source of truth is `prayerResponses`. Indexed so
+    // the feed query can sort cheaply by "needs prayer most" (fewest first).
+    prayedForCount: v.number(),
+    // Tiered moderation outcome:
+    //   pending          — newly inserted; LLM hasn't responded yet.
+    //                      Hidden from feed so borderline content never leaks
+    //                      in the 1-5s before the LLM resolves.
+    //   approved         — green: safe to publish.
+    //   pending_review   — yellow: held for community admin to approve/reject.
+    //                      Hidden from feed; visible in admin queue.
+    //   rejected         — red: never publishes, author sees a reason.
+    moderationStatus: v.union(
+      v.literal("pending"),
+      v.literal("approved"),
+      v.literal("pending_review"),
+      v.literal("rejected"),
+    ),
+    // Crisis flag is independent of severity — a prayer can be APPROVED + flagged
+    // (the "show resources, don't suppress" pattern from 7 Cups / Crisis Text
+    // Line). When true, viewers see a 988 / Find-a-Helpline resource card
+    // attached above the body.
+    crisisFlag: v.optional(v.boolean()),
+    // Detail surfaced to author (transparency) and to admins (review queue).
+    // Never sent to other viewers.
+    moderationDetail: v.optional(
+      v.object({
+        severity: v.union(v.literal("green"), v.literal("yellow"), v.literal("red")),
+        category: v.optional(v.string()),
+        note: v.optional(v.string()),
+      }),
+    ),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    archivedAt: v.optional(v.number()),
+  })
+    .index("by_community", ["communityId"])
+    .index("by_author", ["authorUserId"])
+    // Powers the feed: active+approved prayers sorted by count asc (fewest
+    // prayers first), ties broken by createdAt asc via _creationTime.
+    .index("by_community_status_count", ["communityId", "status", "prayedForCount"])
+    // Powers the admin review queue: pending_review prayers per community.
+    .index("by_community_moderationStatus", ["communityId", "moderationStatus"]),
+
+  /**
+   * A single 3-minute prayer session a user completed for a prayer.
+   * Uniqueness on (prayerId, userId) is enforced in the mutation by
+   * checking `by_prayer_user` before inserting.
+   */
+  prayerResponses: defineTable({
+    prayerId: v.id("prayers"),
+    userId: v.id("users"),
+    prayedAt: v.number(),
+  })
+    .index("by_prayer", ["prayerId"])
+    .index("by_user", ["userId"])
+    .index("by_prayer_user", ["prayerId", "userId"]),
+
+  /**
+   * Author-posted follow-ups on a prayer: updates and "praise reports"
+   * (celebrating answered prayer). Visible to everyone who prayed.
+   */
+  prayerFollowUps: defineTable({
+    prayerId: v.id("prayers"),
+    authorUserId: v.id("users"),
+    kind: v.union(v.literal("update"), v.literal("praise_report")),
+    bodyText: v.string(),
+    createdAt: v.number(),
+  }).index("by_prayer", ["prayerId"]),
+
+  /**
+   * Member-filed reports against a published prayer — the last-line
+   * defense after our LLM and any author-side nudges. Each report is one
+   * (prayer, reporter) pair; we enforce uniqueness in the mutation via
+   * `by_prayer_reporter`. `communityId` is denormalized so admins can
+   * query their queue without joining through prayers.
+   *
+   * Status:
+   *   open      — visible in admin queue.
+   *   actioned  — admin took action (typically rejected the prayer).
+   *   dismissed — admin reviewed and chose to leave the prayer up.
+   */
+  prayerReports: defineTable({
+    prayerId: v.id("prayers"),
+    communityId: v.id("communities"),
+    reporterUserId: v.id("users"),
+    reason: v.union(
+      v.literal("names_person"),
+      v.literal("intimate_explicit"),
+      v.literal("spam_solicitation"),
+      v.literal("hateful"),
+      v.literal("crisis_needs_resources"),
+      v.literal("other"),
+    ),
+    customNote: v.optional(v.string()),
+    status: v.union(
+      v.literal("open"),
+      v.literal("actioned"),
+      v.literal("dismissed"),
+    ),
+    createdAt: v.number(),
+  })
+    .index("by_prayer", ["prayerId"])
+    .index("by_reporter", ["reporterUserId"])
+    // Admin queue: open reports in this community, oldest first.
+    .index("by_community_status", ["communityId", "status"])
+    // Uniqueness check inside reportPrayer.
+    .index("by_prayer_reporter", ["prayerId", "reporterUserId"]),
 });

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -125,6 +125,25 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="prayer"
+        options={{
+          title: 'Prayer',
+          // Visible only when the active community has opted into the church
+          // prayer feature. Gated on community.churchFeatures.prayerEnabled.
+          href:
+            hasCommunity && community?.churchFeatures?.prayerEnabled
+              ? '/(tabs)/prayer'
+              : null,
+          tabBarIcon: ({ color, focused }) => (
+            <Ionicons
+              name={focused ? 'heart' : 'heart-outline'}
+              size={24}
+              color={color}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="admin"
         options={{
           title: 'Admin',

--- a/apps/mobile/app/(tabs)/prayer.tsx
+++ b/apps/mobile/app/(tabs)/prayer.tsx
@@ -1,0 +1,3 @@
+import { PrayerScreen } from '@features/prayer/components/PrayerScreen';
+
+export default PrayerScreen;

--- a/apps/mobile/app/(user)/admin/prayer-reviews/index.tsx
+++ b/apps/mobile/app/(user)/admin/prayer-reviews/index.tsx
@@ -1,0 +1,5 @@
+import { AdminPrayerReviewsScreen } from "@features/prayer/components/AdminPrayerReviewsScreen";
+
+export default function AdminPrayerReviewsRoute() {
+  return <AdminPrayerReviewsScreen />;
+}

--- a/apps/mobile/app/(user)/my-prayers/[prayerId].tsx
+++ b/apps/mobile/app/(user)/my-prayers/[prayerId].tsx
@@ -1,0 +1,5 @@
+import { MyPrayerDetailScreen } from '@features/prayer/components/MyPrayerDetailScreen';
+
+export default function MyPrayerDetailRoute() {
+  return <MyPrayerDetailScreen />;
+}

--- a/apps/mobile/app/(user)/my-prayers/index.tsx
+++ b/apps/mobile/app/(user)/my-prayers/index.tsx
@@ -1,0 +1,5 @@
+import { MyPrayersScreen } from '@features/prayer/components/MyPrayersScreen';
+
+export default function MyPrayersRoute() {
+  return <MyPrayersScreen />;
+}

--- a/apps/mobile/features/admin/components/SettingsContent.tsx
+++ b/apps/mobile/features/admin/components/SettingsContent.tsx
@@ -21,6 +21,7 @@ import {
   Alert,
   ActivityIndicator,
   Platform,
+  Switch,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -107,6 +108,9 @@ export function SettingsContent() {
   const [exploreGroupTypes, setExploreGroupTypes] = useState<string[]>([]);
   const [exploreDefaultMeetingType, setExploreDefaultMeetingType] = useState<number | null>(null);
   const [isSavingExplore, setIsSavingExplore] = useState(false);
+
+  // Church Features state (opt-in religious features)
+  const [isSavingChurchFeatures, setIsSavingChurchFeatures] = useState(false);
 
   // Populate form with current settings
   useEffect(() => {
@@ -247,6 +251,23 @@ export function SettingsContent() {
     }
   };
 
+  const handleToggleChurchFeature = async (
+    feature: "prayerEnabled",
+    value: boolean,
+  ) => {
+    setIsSavingChurchFeatures(true);
+    try {
+      const current = settings?.churchFeatures ?? { prayerEnabled: false };
+      await updateSettings({
+        churchFeatures: { ...current, [feature]: value },
+      });
+    } catch (error: any) {
+      Alert.alert("Error", formatError(error, "Failed to update church features"));
+    } finally {
+      setIsSavingChurchFeatures(false);
+    }
+  };
+
   const toggleExploreGroupType = (groupTypeId: string) => {
     setExploreGroupTypes((prev) =>
       prev.includes(groupTypeId)
@@ -352,6 +373,23 @@ export function SettingsContent() {
             </View>
             <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
           </TouchableOpacity>
+          {settings?.churchFeatures?.prayerEnabled ? (
+            <TouchableOpacity
+              style={[styles.quickLinkItem, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
+              onPress={() => router.push("/(user)/admin/prayer-reviews")}
+            >
+              <View style={[styles.quickLinkIcon, { backgroundColor: colors.surface }]}>
+                <Ionicons name="shield-checkmark-outline" size={20} color={themePrimaryColor} />
+              </View>
+              <View style={styles.quickLinkInfo}>
+                <Text style={[styles.quickLinkName, { color: colors.text }]}>Prayer Reviews</Text>
+                <Text style={[styles.quickLinkDescription, { color: colors.textSecondary }]}>
+                  Approve or reject prayers our moderator held for human review
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+            </TouchableOpacity>
+          ) : null}
         </View>
 
         {/* Basic Info Section */}
@@ -623,6 +661,28 @@ export function SettingsContent() {
               <Text style={styles.exploreSaveButtonText}>Save Explore Defaults</Text>
             )}
           </TouchableOpacity>
+        </View>
+
+        {/* Church Features Section */}
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>Church Features</Text>
+          <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
+            Opt-in features for religious communities. Off by default.
+          </Text>
+
+          <View style={styles.churchFeatureRow}>
+            <View style={{ flex: 1, paddingRight: 12 }}>
+              <Text style={[styles.churchFeatureName, { color: colors.text }]}>Prayer Requests</Text>
+              <Text style={[styles.churchFeatureHint, { color: colors.textTertiary }]}>
+                Members can post prayer requests and pray for each other. Adds a Prayer tab.
+              </Text>
+            </View>
+            <Switch
+              value={settings?.churchFeatures?.prayerEnabled ?? false}
+              onValueChange={(v) => handleToggleChurchFeature("prayerEnabled", v)}
+              disabled={isSavingChurchFeatures}
+            />
+          </View>
         </View>
 
         {/* Group Types Section */}
@@ -1065,5 +1125,19 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 15,
     fontWeight: "600",
+  },
+  churchFeatureRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+  churchFeatureName: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  churchFeatureHint: {
+    fontSize: 13,
+    marginTop: 4,
+    lineHeight: 18,
   },
 });

--- a/apps/mobile/features/admin/hooks/useCommunitySettings.ts
+++ b/apps/mobile/features/admin/hooks/useCommunitySettings.ts
@@ -49,6 +49,7 @@ export function useCommunitySettings() {
       logo?: string;
       exploreDefaultGroupTypes?: Id<"groupTypes">[];
       exploreDefaultMeetingType?: number;
+      churchFeatures?: { prayerEnabled: boolean };
     }) => {
       if (!community?.id || !user?.id || !token) {
         throw new Error("Not authenticated");

--- a/apps/mobile/features/prayer/components/AddPrayerSheet.tsx
+++ b/apps/mobile/features/prayer/components/AddPrayerSheet.tsx
@@ -1,0 +1,365 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  Modal,
+  Switch,
+  Alert,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useAuth } from '@providers/AuthProvider';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedMutation, api } from '@services/api/convex';
+import { formatError } from '@/utils/error-handling';
+import type { Id } from '@services/api/convex';
+
+const MAX_BODY = 500;
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onPosted: () => void;
+}
+
+function displayInitial(firstName?: string, lastName?: string): string {
+  const f = (firstName ?? '').trim();
+  const l = (lastName ?? '').trim();
+  if (!f && !l) return 'Anonymous';
+  if (!l) return f;
+  return `${f} ${l.charAt(0).toUpperCase()}.`;
+}
+
+// Common relationship words people use when describing another person.
+const RELATIONSHIP_WORDS = [
+  'husband','wife','spouse','partner','boyfriend','girlfriend','ex',
+  'son','daughter','child','kid',
+  'mom','mother','dad','father','parent','sister','brother','sibling',
+  'aunt','uncle','cousin','niece','nephew','grandma','grandpa','grandmother','grandfather',
+  'friend','neighbor','coworker','boss','colleague','classmate','roommate',
+  'pastor','elder','leader','teacher',
+];
+const ACCUSATION_WORDS = [
+  'abusive','abuse','abuser','beat','beats','beating','hits','hit',
+  'cheating','cheated','cheats','affair','unfaithful',
+  'lying','lies','liar','deceitful','manipulative','narcissist','narcissistic','toxic',
+  'alcoholic','addict','addicted','using','drinking','drugs',
+  'stealing','stole','steals','fraud',
+  'porn','pornography','adultery',
+  'absent','abandoned','neglecting','neglect',
+  'angry','rage','rageful','violent','controlling','gaslighting','gaslights',
+];
+
+/**
+ * Catches "my <relationship> <CapitalizedWord>" — the strongest signal that
+ * a specific third party is being named. Capitalized word must come AFTER
+ * the relationship (so "My brother is sick" doesn't match, but
+ * "my brother John is sick" does).
+ *
+ * We also catch a standalone "<CapitalizedName> is/has/needs/got" pattern
+ * for cases like "Mike got laid off, pray for him" — common but still
+ * exposes someone unnecessarily.
+ *
+ * Both patterns deliberately allow common false-positives through (e.g.
+ * "I" as a standalone capitalized word) — better to underfire than to
+ * cry wolf and train the user to dismiss the warning.
+ */
+const NAME_AFTER_RELATIONSHIP = new RegExp(
+  `\\bmy\\s+(?:${RELATIONSHIP_WORDS.join('|')})\\s+([A-Z][a-z]{2,})\\b`,
+);
+const NAME_AS_SUBJECT = /\b([A-Z][a-z]{2,})\s+(?:is|has|needs|got|just|recently|will|was|got)\b/;
+
+/** Reserved first words & common false positives that aren't names. */
+const NOT_NAMES = new Set([
+  'Please','God','Jesus','Lord','Christ','Father','Holy','Spirit',
+  'Today','Tomorrow','Yesterday','This','That','We','They','He','She','It',
+  'My','Our','Their','His','Her',
+  'Pray','Asking','Hoping','Praying',
+]);
+
+function detectsSpecificName(text: string): boolean {
+  const checkMatch = (match: RegExpMatchArray | null): boolean =>
+    !!match && !NOT_NAMES.has(match[1]);
+  return (
+    checkMatch(text.match(NAME_AFTER_RELATIONSHIP)) ||
+    checkMatch(text.match(NAME_AS_SUBJECT))
+  );
+}
+
+/**
+ * Catches intimate/explicit phrasing that doesn't belong on a public
+ * community prayer feed even when the post is sincere. The author
+ * usually didn't intend to overshare — they just used the most natural
+ * words. The nudge suggests the closest gentler phrasing.
+ */
+const INTIMATE_PATTERNS: { test: RegExp; suggest: string }[] = [
+  { test: /\bsex(ual)?\s+life\b/i,            suggest: '"intimacy in our marriage"' },
+  { test: /\bhaving\s+sex\b/i,                suggest: '"closeness in our marriage"' },
+  { test: /\bour\s+sex\b/i,                   suggest: '"our marriage"' },
+  { test: /\bporn(ography)?\b/i,              suggest: '"an addiction"' },
+  { test: /\bmasturbat/i,                     suggest: '"a private struggle"' },
+  { test: /\b(bedroom|sexual)\s+(struggle|issue|problem|trouble)/i, suggest: '"a private struggle in our marriage"' },
+  { test: /\bintimacy\s+(issue|struggle|problem|trouble|lack)/i,     suggest: '"closeness in our marriage"' },
+];
+
+function detectsIntimate(text: string): { suggest: string } | null {
+  for (const p of INTIMATE_PATTERNS) {
+    if (p.test.test(text)) return { suggest: p.suggest };
+  }
+  return null;
+}
+
+function detectsAccusation(text: string): boolean {
+  const lower = text.toLowerCase();
+  const hasRelationship = RELATIONSHIP_WORDS.some((w) =>
+    new RegExp(`\\bmy\\s+${w}\\b`, 'i').test(lower),
+  );
+  const hasAccusation = ACCUSATION_WORDS.some((w) =>
+    new RegExp(`\\b${w}\\b`, 'i').test(lower),
+  );
+  return hasRelationship && hasAccusation;
+}
+
+export function AddPrayerSheet({ visible, onClose, onPosted }: Props) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const { user, community } = useAuth();
+  const [text, setText] = useState('');
+  const [isAnonymous, setIsAnonymous] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const createPrayer = useAuthenticatedMutation(api.functions.prayers.createPrayer);
+
+  useEffect(() => {
+    if (visible) {
+      setText('');
+      setIsAnonymous(false);
+    }
+  }, [visible]);
+
+  const submitNow = async () => {
+    const body = text.trim();
+    if (body.length === 0) return;
+    if (!community?.id) return;
+
+    setIsSubmitting(true);
+    try {
+      await createPrayer({
+        communityId: community.id as Id<'communities'>,
+        bodyText: body,
+        isAnonymous,
+      });
+      onPosted();
+      onClose();
+    } catch (e: any) {
+      const msg = formatError(e, 'Could not post your prayer');
+      Alert.alert('Prayer not posted', msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmit = () => {
+    const body = text.trim();
+    if (body.length === 0) return;
+
+    // Intimate/explicit phrasing first — these are usually sincere posts
+    // where the author didn't realize the wording was too detailed for a
+    // public church feed. Surface a gentler suggestion before they post.
+    const intimate = detectsIntimate(body);
+    if (intimate) {
+      Alert.alert(
+        'Keep it more general?',
+        `This is a public prayer feed, so it helps to keep intimate details general. Try ${intimate.suggest} instead — your community will know how to pray.`,
+        [
+          { text: 'Edit', style: 'cancel' },
+          { text: 'Post anyway', onPress: submitNow },
+        ],
+      );
+      return;
+    }
+
+    // Stronger warning takes precedence. Naming + accusation is the legal/
+    // defamation hazard; naming alone is just a courtesy nudge.
+    if (detectsAccusation(body)) {
+      Alert.alert(
+        'Protect their privacy',
+        "It looks like you're sharing sensitive details about someone else. We don't recommend posting accusations publicly — consider sharing this more privately with your church staff instead.",
+        [
+          { text: 'Edit', style: 'cancel' },
+          { text: 'Post anyway', style: 'destructive', onPress: submitNow },
+        ],
+      );
+      return;
+    }
+    if (detectsSpecificName(body)) {
+      Alert.alert(
+        'Skip the name?',
+        'We try not to use real names here, even when the request is positive. Try "my brother" or "a friend" instead — God knows who you mean.',
+        [
+          { text: 'Edit', style: 'cancel' },
+          { text: 'Post anyway', onPress: submitNow },
+        ],
+      );
+      return;
+    }
+    void submitNow();
+  };
+
+  const charsLeft = MAX_BODY - text.length;
+  const previewName = isAnonymous
+    ? 'Anonymous'
+    : displayInitial(user?.first_name, user?.last_name);
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.backdrop}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={[styles.sheet, { backgroundColor: colors.surface }]}>
+          <View style={styles.headerRow}>
+            <Text style={[styles.title, { color: colors.text }]}>Share a prayer request</Text>
+            <TouchableOpacity onPress={onClose} hitSlop={12} disabled={isSubmitting}>
+              <Ionicons name="close" size={24} color={colors.iconSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          <TextInput
+            style={[
+              styles.input,
+              {
+                backgroundColor: colors.inputBackground,
+                color: colors.text,
+                borderColor: colors.inputBorder,
+              },
+            ]}
+            value={text}
+            onChangeText={setText}
+            placeholder="What can your community pray for? (Skip real names.)"
+            placeholderTextColor={colors.inputPlaceholder}
+            multiline
+            maxLength={MAX_BODY}
+            editable={!isSubmitting}
+          />
+          <View style={styles.metaRow}>
+            <Text style={[styles.hint, { color: colors.textTertiary }]}>
+              Try not to use real names — "my brother" or "a friend" is best.
+            </Text>
+            <Text style={[styles.charCount, { color: colors.textTertiary }]}>
+              {charsLeft} left
+            </Text>
+          </View>
+
+          <View style={styles.anonRow}>
+            <View style={{ flex: 1, paddingRight: 12 }}>
+              <Text style={[styles.anonTitle, { color: colors.text }]}>Post anonymously</Text>
+              <Text style={[styles.anonHint, { color: colors.textTertiary }]}>
+                Shown as: {previewName}
+              </Text>
+            </View>
+            <Switch
+              value={isAnonymous}
+              onValueChange={setIsAnonymous}
+              disabled={isSubmitting}
+            />
+          </View>
+
+          <TouchableOpacity
+            style={[
+              styles.submitButton,
+              { backgroundColor: primaryColor },
+              (isSubmitting || text.trim().length === 0) && { opacity: 0.5 },
+            ]}
+            onPress={handleSubmit}
+            disabled={isSubmitting || text.trim().length === 0}
+            activeOpacity={0.85}
+          >
+            {isSubmitting ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text style={styles.submitText}>Post Prayer</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 20,
+    paddingBottom: 36,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    fontSize: 16,
+    minHeight: 120,
+    textAlignVertical: 'top',
+    marginBottom: 6,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  hint: {
+    fontSize: 12,
+    flex: 1,
+    paddingRight: 8,
+  },
+  charCount: {
+    fontSize: 12,
+    textAlign: 'right',
+  },
+  anonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    marginBottom: 16,
+  },
+  anonTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  anonHint: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  submitButton: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  submitText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/features/prayer/components/AdminPrayerReviewsScreen.tsx
+++ b/apps/mobile/features/prayer/components/AdminPrayerReviewsScreen.tsx
@@ -1,0 +1,460 @@
+/**
+ * Community-admin queue for prayer moderation. Two sections:
+ *
+ * 1. **Held by moderator** — prayers our LLM flagged YELLOW. Admin can
+ *    Approve (publishes) or Keep private (rejects).
+ * 2. **Reported by members** — published prayers that one or more members
+ *    flagged. Admin can Keep private (rejects + marks reports actioned)
+ *    or Dismiss (leaves it up + marks reports dismissed).
+ *
+ * Verb choice: we call the rejection action "Keep private" everywhere
+ * users see it (author-side too) so the language is consistent with the
+ * compassionate framing. "Reject" reads as punitive in a prayer context.
+ *
+ * Anonymous prayers still show the author's identity HERE — admins can't
+ * moderate effectively without it. Members never see anything beyond
+ * what the regular feed already shows.
+ */
+
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useAuth } from '@providers/AuthProvider';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from '@services/api/convex';
+import { formatError } from '@/utils/error-handling';
+import type { Id } from '@services/api/convex';
+
+const CATEGORY_LABELS: Record<string, string> = {
+  third_party_named: 'Third party named with detail',
+  intimate_explicit: 'Intimate / explicit detail',
+  borderline_solicitation: 'Possible solicitation',
+  borderline_other: 'Borderline',
+  violence: 'Violence',
+  self_harm_plan: 'Self-harm with plan',
+  explicit: 'Explicit content',
+  doxing: 'Doxing',
+  hate: 'Hate',
+  spam: 'Spam',
+  other: 'Other',
+};
+
+const REPORT_REASON_LABELS: Record<string, string> = {
+  names_person: 'Names a specific person',
+  intimate_explicit: 'Too intimate / explicit',
+  spam_solicitation: 'Spam or solicitation',
+  hateful: 'Hateful or hurtful',
+  crisis_needs_resources: 'Needs crisis resources',
+  other: 'Other',
+};
+
+export function AdminPrayerReviewsScreen() {
+  const insets = useSafeAreaInsets();
+  const { community } = useAuth();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const heldQueue = useAuthenticatedQuery(
+    api.functions.prayers.listPendingForReview,
+    community?.id ? { communityId: community.id as Id<'communities'> } : 'skip',
+  );
+  const reportedQueue = useAuthenticatedQuery(
+    api.functions.prayers.listReportedPrayers,
+    community?.id ? { communityId: community.id as Id<'communities'> } : 'skip',
+  );
+
+  const approve = useAuthenticatedMutation(api.functions.prayers.approvePending);
+  const rejectHeld = useAuthenticatedMutation(api.functions.prayers.rejectPending);
+  const upholdReport = useAuthenticatedMutation(api.functions.prayers.upholdReport);
+  const dismissReports = useAuthenticatedMutation(api.functions.prayers.dismissReports);
+
+  const loading = heldQueue === undefined || reportedQueue === undefined;
+  const empty = !loading && (heldQueue?.length ?? 0) === 0 && (reportedQueue?.length ?? 0) === 0;
+
+  // Group reports by prayer so one prayer with 3 reports renders as one card.
+  const reportsByPrayer = (() => {
+    const map = new Map<string, NonNullable<typeof reportedQueue>>();
+    for (const r of reportedQueue ?? []) {
+      const existing = map.get(r.prayerId) ?? [];
+      existing.push(r);
+      map.set(r.prayerId, existing);
+    }
+    return map;
+  })();
+
+  const handleApproveHeld = async (id: Id<'prayers'>) => {
+    setBusyId(id);
+    try {
+      await approve({ prayerId: id });
+    } catch (e) {
+      Alert.alert('Error', formatError(e, 'Could not approve'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleKeepPrivateHeld = (id: Id<'prayers'>) => {
+    Alert.alert(
+      'Keep this prayer private?',
+      'The prayer will not post publicly. The author will see a gentle "kept private" notice.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Keep private',
+          style: 'destructive',
+          onPress: async () => {
+            setBusyId(id);
+            try {
+              await rejectHeld({ prayerId: id });
+            } catch (e) {
+              Alert.alert('Error', formatError(e, 'Could not keep private'));
+            } finally {
+              setBusyId(null);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const handleKeepPrivateReported = (id: Id<'prayers'>) => {
+    Alert.alert(
+      'Keep this prayer private?',
+      'The prayer will be removed from the feed. The author will see a gentle "kept private" notice and reports close.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Keep private',
+          style: 'destructive',
+          onPress: async () => {
+            setBusyId(id);
+            try {
+              await upholdReport({ prayerId: id });
+            } catch (e) {
+              Alert.alert('Error', formatError(e, 'Could not keep private'));
+            } finally {
+              setBusyId(null);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const handleDismissReports = async (id: Id<'prayers'>) => {
+    setBusyId(id);
+    try {
+      await dismissReports({ prayerId: id });
+    } catch (e) {
+      Alert.alert('Error', formatError(e, 'Could not dismiss reports'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: 'Prayer Reviews',
+          headerBackTitle: 'Back',
+        }}
+      />
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: 32 + insets.bottom },
+        ]}
+      >
+        {loading ? (
+          <View style={styles.center}>
+            <ActivityIndicator color={primaryColor} />
+          </View>
+        ) : empty ? (
+          <View style={styles.empty}>
+            <Ionicons name="checkmark-circle-outline" size={36} color={colors.iconSecondary} />
+            <Text style={[styles.emptyTitle, { color: colors.text }]}>Nothing to review</Text>
+            <Text style={[styles.emptyBody, { color: colors.textSecondary }]}>
+              We'll surface borderline prayers and member reports here so you can act on them.
+            </Text>
+          </View>
+        ) : (
+          <>
+            {/* SECTION 1 — held by moderator */}
+            {heldQueue && heldQueue.length > 0 ? (
+              <>
+                <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+                  Held by moderator
+                </Text>
+                {heldQueue.map((p) => {
+                  const categoryLabel =
+                    CATEGORY_LABELS[p.moderationDetail?.category ?? ''] ?? 'Held for review';
+                  return (
+                    <View
+                      key={p.id}
+                      style={[
+                        styles.card,
+                        { backgroundColor: colors.surface, borderColor: colors.border },
+                      ]}
+                    >
+                      <View style={styles.chipRow}>
+                        <View style={[styles.chip, { backgroundColor: '#FFF3DD', borderColor: '#FFC53D' }]}>
+                          <Text style={styles.chipText}>{categoryLabel}</Text>
+                        </View>
+                        {p.crisisFlag ? (
+                          <View style={[styles.chip, { backgroundColor: '#FFE3E3', borderColor: '#FFAAAA' }]}>
+                            <Ionicons name="heart-circle" size={12} color="#C0392B" />
+                            <Text style={[styles.chipText, { color: '#C0392B' }]}>Crisis flagged</Text>
+                          </View>
+                        ) : null}
+                      </View>
+
+                      <Text style={[styles.body, { color: colors.text }]}>{p.bodyText}</Text>
+
+                      {p.moderationDetail?.note ? (
+                        <Text style={[styles.aiNote, { color: colors.textSecondary }]}>
+                          Moderator note: {p.moderationDetail.note}
+                        </Text>
+                      ) : null}
+
+                      <View style={styles.metaRow}>
+                        <Text style={[styles.meta, { color: colors.textTertiary }]}>
+                          {p.isAnonymous ? 'Anonymous (admin view)' : p.authorDisplayName}
+                        </Text>
+                        <Text style={[styles.meta, { color: colors.textTertiary }]}>
+                          {new Date(p.createdAt).toLocaleString()}
+                        </Text>
+                      </View>
+
+                      <View style={styles.actionsRow}>
+                        <TouchableOpacity
+                          style={[styles.action, { backgroundColor: '#34C759', opacity: busyId === p.id ? 0.5 : 1 }]}
+                          onPress={() => handleApproveHeld(p.id)}
+                          disabled={busyId === p.id}
+                          activeOpacity={0.85}
+                        >
+                          <Ionicons name="checkmark" size={16} color="#fff" />
+                          <Text style={styles.actionText}>Approve</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                          style={[
+                            styles.action,
+                            {
+                              backgroundColor: colors.surface,
+                              borderColor: colors.border,
+                              borderWidth: 1,
+                              opacity: busyId === p.id ? 0.5 : 1,
+                            },
+                          ]}
+                          onPress={() => handleKeepPrivateHeld(p.id)}
+                          disabled={busyId === p.id}
+                          activeOpacity={0.85}
+                        >
+                          <Ionicons name="lock-closed-outline" size={16} color={colors.text} />
+                          <Text style={[styles.actionText, { color: colors.text }]}>Keep private</Text>
+                        </TouchableOpacity>
+                      </View>
+                    </View>
+                  );
+                })}
+              </>
+            ) : null}
+
+            {/* SECTION 2 — reported by members (grouped per prayer) */}
+            {reportsByPrayer.size > 0 ? (
+              <>
+                <Text style={[styles.sectionHeader, { color: colors.textSecondary, marginTop: 18 }]}>
+                  Reported by members
+                </Text>
+                {Array.from(reportsByPrayer.entries()).map(([prayerId, reports]) => {
+                  const first = reports[0];
+                  return (
+                    <View
+                      key={prayerId}
+                      style={[
+                        styles.card,
+                        { backgroundColor: colors.surface, borderColor: colors.border },
+                      ]}
+                    >
+                      <View style={styles.chipRow}>
+                        <View style={[styles.chip, { backgroundColor: '#FFE0E0', borderColor: '#FF8E8E' }]}>
+                          <Ionicons name="flag" size={11} color="#C0392B" />
+                          <Text style={[styles.chipText, { color: '#C0392B' }]}>
+                            {reports.length === 1 ? '1 report' : `${reports.length} reports`}
+                          </Text>
+                        </View>
+                        {first.prayerStatus !== 'approved' ? (
+                          <View style={[styles.chip, { backgroundColor: '#E0E0E0', borderColor: '#A0A0A0' }]}>
+                            <Text style={styles.chipText}>
+                              Already {first.prayerStatus === 'rejected' ? 'kept private' : first.prayerStatus}
+                            </Text>
+                          </View>
+                        ) : null}
+                      </View>
+
+                      <Text style={[styles.body, { color: colors.text }]}>{first.prayerBody}</Text>
+
+                      {reports.map((r) => (
+                        <View key={r.reportId} style={styles.reportItem}>
+                          <Text style={[styles.reportReason, { color: colors.text }]}>
+                            {REPORT_REASON_LABELS[r.reason] ?? r.reason}
+                          </Text>
+                          {r.customNote ? (
+                            <Text style={[styles.reportNote, { color: colors.textSecondary }]}>
+                              “{r.customNote}”
+                            </Text>
+                          ) : null}
+                          <Text style={[styles.reportMeta, { color: colors.textTertiary }]}>
+                            {r.reporterDisplayName} · {new Date(r.createdAt).toLocaleString()}
+                          </Text>
+                        </View>
+                      ))}
+
+                      {first.prayerStatus === 'approved' ? (
+                        <View style={styles.actionsRow}>
+                          <TouchableOpacity
+                            style={[styles.action, { backgroundColor: '#34C759', opacity: busyId === prayerId ? 0.5 : 1 }]}
+                            onPress={() => handleDismissReports(prayerId as Id<'prayers'>)}
+                            disabled={busyId === prayerId}
+                            activeOpacity={0.85}
+                          >
+                            <Ionicons name="checkmark" size={16} color="#fff" />
+                            <Text style={styles.actionText}>Leave up</Text>
+                          </TouchableOpacity>
+                          <TouchableOpacity
+                            style={[
+                              styles.action,
+                              {
+                                backgroundColor: colors.surface,
+                                borderColor: colors.border,
+                                borderWidth: 1,
+                                opacity: busyId === prayerId ? 0.5 : 1,
+                              },
+                            ]}
+                            onPress={() => handleKeepPrivateReported(prayerId as Id<'prayers'>)}
+                            disabled={busyId === prayerId}
+                            activeOpacity={0.85}
+                          >
+                            <Ionicons name="lock-closed-outline" size={16} color={colors.text} />
+                            <Text style={[styles.actionText, { color: colors.text }]}>Keep private</Text>
+                          </TouchableOpacity>
+                        </View>
+                      ) : (
+                        <TouchableOpacity
+                          style={[
+                            styles.action,
+                            {
+                              backgroundColor: colors.surface,
+                              borderColor: colors.border,
+                              borderWidth: 1,
+                              opacity: busyId === prayerId ? 0.5 : 1,
+                              marginTop: 4,
+                            },
+                          ]}
+                          onPress={() => handleDismissReports(prayerId as Id<'prayers'>)}
+                          disabled={busyId === prayerId}
+                          activeOpacity={0.85}
+                        >
+                          <Text style={[styles.actionText, { color: colors.text }]}>
+                            Dismiss reports
+                          </Text>
+                        </TouchableOpacity>
+                      )}
+                    </View>
+                  );
+                })}
+              </>
+            ) : null}
+          </>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scrollContent: { padding: 16 },
+  center: { paddingVertical: 40, alignItems: 'center' },
+  empty: {
+    paddingVertical: 60,
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  emptyTitle: { fontSize: 17, fontWeight: '600', marginTop: 12, marginBottom: 6 },
+  emptyBody: { fontSize: 14, textAlign: 'center', lineHeight: 20 },
+  sectionHeader: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    marginBottom: 8,
+    marginTop: 4,
+  },
+  card: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    marginBottom: 12,
+  },
+  chipRow: { flexDirection: 'row', gap: 8, marginBottom: 10, flexWrap: 'wrap' },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  chipText: { fontSize: 11, fontWeight: '700', color: '#7C5500' },
+  body: { fontSize: 15, lineHeight: 21, marginBottom: 10 },
+  aiNote: { fontSize: 12, fontStyle: 'italic', marginBottom: 10 },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  meta: { fontSize: 12 },
+  reportItem: {
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: 'rgba(0,0,0,0.06)',
+  },
+  reportReason: { fontSize: 13, fontWeight: '600', marginBottom: 2 },
+  reportNote: { fontSize: 13, fontStyle: 'italic', marginBottom: 2 },
+  reportMeta: { fontSize: 11 },
+  actionsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 8,
+  },
+  action: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  actionText: { color: '#fff', fontSize: 14, fontWeight: '600' },
+});

--- a/apps/mobile/features/prayer/components/AdminPrayerReviewsScreen.tsx
+++ b/apps/mobile/features/prayer/components/AdminPrayerReviewsScreen.tsx
@@ -11,9 +11,10 @@
  * users see it (author-side too) so the language is consistent with the
  * compassionate framing. "Reject" reads as punitive in a prayer context.
  *
- * Anonymous prayers still show the author's identity HERE — admins can't
- * moderate effectively without it. Members never see anything beyond
- * what the regular feed already shows.
+ * Anonymous prayers stay anonymous to admins too — the backend never
+ * sends author identity for `isAnonymous` prayers. Admins moderate on
+ * the body content. Members never see anything beyond what the regular
+ * feed already shows.
  */
 
 import React, { useState } from 'react';
@@ -236,7 +237,7 @@ export function AdminPrayerReviewsScreen() {
 
                       <View style={styles.metaRow}>
                         <Text style={[styles.meta, { color: colors.textTertiary }]}>
-                          {p.isAnonymous ? 'Anonymous (admin view)' : p.authorDisplayName}
+                          {p.isAnonymous ? 'Anonymous' : p.authorDisplayName}
                         </Text>
                         <Text style={[styles.meta, { color: colors.textTertiary }]}>
                           {new Date(p.createdAt).toLocaleString()}

--- a/apps/mobile/features/prayer/components/CrisisResourceCard.tsx
+++ b/apps/mobile/features/prayer/components/CrisisResourceCard.tsx
@@ -1,0 +1,109 @@
+/**
+ * Crisis resource card.
+ *
+ * Rendered above a prayer's body when the moderator flagged it as
+ * first-person mental-health / crisis content. We DON'T block these
+ * prayers — the research from 7 Cups + Crisis Text Line is unanimous:
+ * blocking "I want to die" leaves a vulnerable person unsupported. The
+ * right move is to publish the prayer AND surface crisis-line links
+ * inline so the author (and anyone who comes to pray) sees them.
+ *
+ * Numbers used are US-centric. Find-a-Helpline is the global escape
+ * hatch for other locales.
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+
+export function CrisisResourceCard() {
+  const { colors } = useTheme();
+  return (
+    <View style={[styles.card, { borderColor: '#FFD2D2', backgroundColor: '#FFF6F6' }]}>
+      <View style={styles.header}>
+        <Ionicons name="heart-circle" size={20} color="#C0392B" />
+        <Text style={styles.headerText}>You are not alone</Text>
+      </View>
+      <Text style={[styles.body, { color: colors.text }]}>
+        If you or someone you love is in crisis, please reach out — these lines
+        are free, confidential, and 24/7.
+      </Text>
+      <View style={styles.row}>
+        <TouchableOpacity
+          style={styles.link}
+          onPress={() => Linking.openURL('tel:988')}
+          accessibilityRole="link"
+          accessibilityLabel="Call or text 9 8 8"
+        >
+          <Ionicons name="call-outline" size={14} color="#C0392B" />
+          <Text style={styles.linkText}>988 — call or text</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.link}
+          onPress={() => Linking.openURL('sms:741741&body=HOME')}
+          accessibilityRole="link"
+          accessibilityLabel="Text Crisis Text Line"
+        >
+          <Ionicons name="chatbubble-outline" size={14} color="#C0392B" />
+          <Text style={styles.linkText}>Text HOME to 741741</Text>
+        </TouchableOpacity>
+      </View>
+      <TouchableOpacity
+        onPress={() => Linking.openURL('https://findahelpline.com')}
+        accessibilityRole="link"
+      >
+        <Text style={styles.linkSecondary}>Outside the US? findahelpline.com</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 12,
+    marginBottom: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 6,
+  },
+  headerText: {
+    color: '#C0392B',
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+  },
+  body: {
+    fontSize: 13,
+    lineHeight: 18,
+    marginBottom: 10,
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    marginBottom: 6,
+  },
+  link: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingVertical: 4,
+  },
+  linkText: {
+    color: '#C0392B',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  linkSecondary: {
+    color: '#C0392B',
+    fontSize: 12,
+    fontWeight: '500',
+    paddingTop: 2,
+  },
+});

--- a/apps/mobile/features/prayer/components/MyPrayerDetailScreen.tsx
+++ b/apps/mobile/features/prayer/components/MyPrayerDetailScreen.tsx
@@ -1,0 +1,445 @@
+/**
+ * MyPrayerDetailScreen — author view of a single prayer, with follow-up
+ * composer and lifecycle actions (mark answered / archive).
+ *
+ * Also reachable by users who prayed for the request — they see the body
+ * + follow-ups (the "praise reports" they got notified about), but no
+ * authoring actions.
+ */
+
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedQuery, useAuthenticatedMutation, api } from '@services/api/convex';
+import { formatError } from '@/utils/error-handling';
+import { CrisisResourceCard } from './CrisisResourceCard';
+import type { Id } from '@services/api/convex';
+
+// Human-readable copy for moderation outcomes shown on the author's detail
+// screen. Generic by category so we don't leak the LLM's exact reasoning
+// (which can read as accusatory and is also exploitable for jailbreaks).
+function moderationCopy(
+  modStatus: string | undefined,
+  category: string | undefined,
+): { title: string; body: string; color: string } | null {
+  if (!modStatus || modStatus === 'approved') return null;
+  if (modStatus === 'pending') {
+    return {
+      title: 'Reviewing your prayer',
+      body: 'Usually takes a few seconds. You can leave this screen — we’ll publish it as soon as it’s approved.',
+      color: '#8E8E93',
+    };
+  }
+  if (modStatus === 'pending_review') {
+    return {
+      title: 'A community admin will review this',
+      body:
+        category === 'third_party_named'
+          ? 'You appear to be naming someone else with sensitive detail. An admin will review before it posts. You can also share more privately with your church staff.'
+          : category === 'intimate_explicit'
+            ? 'Your post has intimate detail that may be too explicit for a public community feed. An admin will review — you might also consider rephrasing more generally, like "praying for closeness in our marriage."'
+            : category === 'borderline_solicitation'
+              ? 'Your post might be read as a fundraiser or solicitation. An admin will review before it posts.'
+              : 'Your post is held for a community admin to review before it goes public.',
+      color: '#FF9500',
+    };
+  }
+  if (modStatus === 'rejected') {
+    return {
+      title: 'Kept private',
+      body:
+        category === 'self_harm_plan'
+          ? 'This one stays between us — please reach out using one of the lines above. Talking with your church staff or a counselor can help too.'
+          : category === 'doxing' || category === 'third_party_named'
+            ? 'To protect others’ privacy, we kept this one between you and us. Try rephrasing without specific names — “my friend” or “a family member” works.'
+            : category === 'spam' || category === 'borderline_solicitation'
+              ? 'We kept this one private — posts that read as fundraising, promotion, or solicitation don’t go public on the prayer feed.'
+              : 'We kept this one private. Try rephrasing without names or graphic details and post again.',
+      color: '#8E8E93',
+    };
+  }
+  return null;
+}
+
+const MAX_FOLLOWUP = 500;
+
+export function MyPrayerDetailScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const params = useLocalSearchParams<{ prayerId: string }>();
+  const prayerId = params.prayerId as Id<'prayers'> | undefined;
+
+  const [followUpText, setFollowUpText] = useState('');
+  const [followUpKind, setFollowUpKind] = useState<'update' | 'praise_report'>('update');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const detail = useAuthenticatedQuery(
+    api.functions.prayers.getDetail,
+    prayerId ? { prayerId } : 'skip',
+  );
+
+  const addFollowUp = useAuthenticatedMutation(api.functions.prayers.addFollowUp);
+  const markAnswered = useAuthenticatedMutation(api.functions.prayers.markAnswered);
+  const archivePrayer = useAuthenticatedMutation(api.functions.prayers.archivePrayer);
+
+  if (!prayerId) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+        <Text style={{ color: colors.text, padding: 20 }}>Missing prayer ID</Text>
+      </View>
+    );
+  }
+
+  if (detail === undefined) {
+    return (
+      <View style={[styles.container, styles.center, { backgroundColor: colors.surfaceSecondary }]}>
+        <ActivityIndicator color={primaryColor} />
+      </View>
+    );
+  }
+  if (detail === null) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+        <Stack.Screen options={{ title: 'Prayer', headerShown: true }} />
+        <Text style={{ color: colors.text, padding: 20 }}>This prayer is not available.</Text>
+      </View>
+    );
+  }
+
+  const isAuthor = detail.isAuthor;
+  const isActive = detail.status === 'active';
+
+  const handleAddFollowUp = async () => {
+    const body = followUpText.trim();
+    if (body.length === 0) return;
+    setIsSubmitting(true);
+    try {
+      await addFollowUp({ prayerId, kind: followUpKind, bodyText: body });
+      setFollowUpText('');
+      setFollowUpKind('update');
+    } catch (e) {
+      Alert.alert('Error', formatError(e, 'Could not post your update'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleMarkAnswered = () => {
+    Alert.alert('Mark as answered?', 'You can also share a short praise report below first.', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Mark answered',
+        style: 'default',
+        onPress: async () => {
+          try {
+            await markAnswered({ prayerId });
+          } catch (e) {
+            Alert.alert('Error', formatError(e, 'Could not update'));
+          }
+        },
+      },
+    ]);
+  };
+
+  const handleArchive = () => {
+    Alert.alert('Archive this prayer?', 'It will be hidden from the feed. You can still see it under My Prayers.', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Archive',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await archivePrayer({ prayerId });
+            router.back();
+          } catch (e) {
+            Alert.alert('Error', formatError(e, 'Could not archive'));
+          }
+        },
+      },
+    ]);
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+      <Stack.Screen options={{ title: 'Prayer', headerShown: true }} />
+      <ScrollView contentContainerStyle={[styles.scrollContent, { paddingBottom: 40 + insets.bottom }]}>
+        {(() => {
+          const copy = moderationCopy(
+            (detail as any).moderationStatus,
+            (detail as any).moderationDetail?.category,
+          );
+          if (!copy) return null;
+          return (
+            <View
+              style={[
+                styles.modBanner,
+                { borderColor: copy.color, backgroundColor: colors.surface },
+              ]}
+            >
+              <Text style={[styles.modBannerTitle, { color: copy.color }]}>{copy.title}</Text>
+              <Text style={[styles.modBannerBody, { color: colors.text }]}>{copy.body}</Text>
+            </View>
+          );
+        })()}
+
+        {detail.crisisFlag ? <CrisisResourceCard /> : null}
+
+        {/* Body */}
+        <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+          <Text style={[styles.bodyText, { color: colors.text }]}>{detail.bodyText}</Text>
+          <View style={styles.metaRow}>
+            <Ionicons name="people-outline" size={14} color={colors.textTertiary} />
+            <Text style={[styles.metaText, { color: colors.textTertiary }]}>
+              {detail.prayedForCount} {detail.prayedForCount === 1 ? 'person' : 'people'} prayed
+            </Text>
+            <Text style={[styles.metaText, { color: colors.textTertiary, marginLeft: 'auto' }]}>
+              {new Date(detail.createdAt).toLocaleDateString()}
+            </Text>
+          </View>
+        </View>
+
+        {/* Author-only lifecycle actions */}
+        {isAuthor && isActive && (
+          <View style={styles.actionsRow}>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: '#34C759' }]}
+              onPress={handleMarkAnswered}
+              activeOpacity={0.85}
+            >
+              <Ionicons name="checkmark-circle-outline" size={16} color="#fff" />
+              <Text style={styles.actionButtonText}>Mark answered</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.surface, borderColor: colors.border, borderWidth: 1 }]}
+              onPress={handleArchive}
+              activeOpacity={0.85}
+            >
+              <Ionicons name="archive-outline" size={16} color={colors.text} />
+              <Text style={[styles.actionButtonText, { color: colors.text }]}>Archive</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* Follow-ups */}
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Updates</Text>
+        {detail.followUps.length === 0 ? (
+          <Text style={[styles.emptyText, { color: colors.textTertiary }]}>
+            No updates yet.
+          </Text>
+        ) : (
+          detail.followUps.map((f) => (
+            <View
+              key={f.id}
+              style={[styles.followUp, { backgroundColor: colors.surface, borderColor: colors.border }]}
+            >
+              <View style={styles.followUpHeader}>
+                <View
+                  style={[
+                    styles.followUpBadge,
+                    {
+                      backgroundColor:
+                        f.kind === 'praise_report' ? '#34C759' : colors.textTertiary,
+                    },
+                  ]}
+                >
+                  <Text style={styles.followUpBadgeText}>
+                    {f.kind === 'praise_report' ? 'Praise report' : 'Update'}
+                  </Text>
+                </View>
+                <Text style={[styles.followUpDate, { color: colors.textTertiary }]}>
+                  {new Date(f.createdAt).toLocaleDateString()}
+                </Text>
+              </View>
+              <Text style={[styles.followUpBody, { color: colors.text }]}>{f.bodyText}</Text>
+            </View>
+          ))
+        )}
+
+        {/* Author follow-up composer */}
+        {isAuthor && (
+          <View style={[styles.composer, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+            <Text style={[styles.composerTitle, { color: colors.text }]}>Add an update</Text>
+            <View style={styles.kindRow}>
+              <TouchableOpacity
+                style={[
+                  styles.kindChip,
+                  { borderColor: colors.border },
+                  followUpKind === 'update' && { backgroundColor: primaryColor, borderColor: primaryColor },
+                ]}
+                onPress={() => setFollowUpKind('update')}
+              >
+                <Text
+                  style={[
+                    styles.kindChipText,
+                    { color: colors.text },
+                    followUpKind === 'update' && { color: '#fff' },
+                  ]}
+                >
+                  Update
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.kindChip,
+                  { borderColor: colors.border },
+                  followUpKind === 'praise_report' && { backgroundColor: '#34C759', borderColor: '#34C759' },
+                ]}
+                onPress={() => setFollowUpKind('praise_report')}
+              >
+                <Text
+                  style={[
+                    styles.kindChipText,
+                    { color: colors.text },
+                    followUpKind === 'praise_report' && { color: '#fff' },
+                  ]}
+                >
+                  Praise report
+                </Text>
+              </TouchableOpacity>
+            </View>
+            <TextInput
+              style={[
+                styles.composerInput,
+                {
+                  backgroundColor: colors.inputBackground,
+                  color: colors.text,
+                  borderColor: colors.inputBorder,
+                },
+              ]}
+              value={followUpText}
+              onChangeText={setFollowUpText}
+              placeholder="Share an update for those who prayed…"
+              placeholderTextColor={colors.inputPlaceholder}
+              multiline
+              maxLength={MAX_FOLLOWUP}
+              editable={!isSubmitting}
+            />
+            <TouchableOpacity
+              style={[
+                styles.composerSubmit,
+                { backgroundColor: primaryColor },
+                (isSubmitting || followUpText.trim().length === 0) && { opacity: 0.5 },
+              ]}
+              onPress={handleAddFollowUp}
+              disabled={isSubmitting || followUpText.trim().length === 0}
+              activeOpacity={0.85}
+            >
+              {isSubmitting ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <Text style={styles.composerSubmitText}>Post update</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { justifyContent: 'center', alignItems: 'center' },
+  scrollContent: { padding: 16 },
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    marginBottom: 12,
+  },
+  bodyText: { fontSize: 16, lineHeight: 22, marginBottom: 12 },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  metaText: { fontSize: 13 },
+  actionsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 20,
+  },
+  actionButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 10,
+    borderRadius: 10,
+  },
+  actionButtonText: { color: '#fff', fontSize: 14, fontWeight: '600' },
+  sectionTitle: { fontSize: 16, fontWeight: '600', marginTop: 8, marginBottom: 10 },
+  emptyText: { fontSize: 14, marginBottom: 20 },
+  followUp: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 12,
+    marginBottom: 10,
+  },
+  followUpHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  followUpBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  followUpBadgeText: { color: '#fff', fontSize: 11, fontWeight: '600' },
+  followUpDate: { fontSize: 12, marginLeft: 'auto' },
+  followUpBody: { fontSize: 14, lineHeight: 19 },
+  composer: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    marginTop: 12,
+  },
+  composerTitle: { fontSize: 15, fontWeight: '600', marginBottom: 10 },
+  kindRow: { flexDirection: 'row', gap: 8, marginBottom: 10 },
+  kindChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+  },
+  kindChipText: { fontSize: 13, fontWeight: '500' },
+  composerInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    fontSize: 15,
+    minHeight: 90,
+    textAlignVertical: 'top',
+    marginBottom: 10,
+  },
+  composerSubmit: {
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  composerSubmitText: { color: '#fff', fontSize: 15, fontWeight: '600' },
+  modBanner: {
+    borderRadius: 12,
+    borderLeftWidth: 4,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    padding: 14,
+    marginBottom: 12,
+  },
+  modBannerTitle: { fontSize: 14, fontWeight: '700', marginBottom: 6 },
+  modBannerBody: { fontSize: 13, lineHeight: 19 },
+});

--- a/apps/mobile/features/prayer/components/MyPrayersScreen.tsx
+++ b/apps/mobile/features/prayer/components/MyPrayersScreen.tsx
@@ -1,0 +1,164 @@
+/**
+ * MyPrayersScreen — author's own list of prayers across all statuses.
+ * Shown via the Profile → My Prayers menu entry.
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter, Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedQuery, api } from '@services/api/convex';
+
+function statusBadge(status: string): { label: string; color: string } {
+  switch (status) {
+    case 'answered':
+      return { label: 'Answered', color: '#34C759' };
+    case 'archived':
+      return { label: 'Archived', color: '#8E8E93' };
+    case 'active':
+    default:
+      return { label: 'Active', color: '#007AFF' };
+  }
+}
+
+function moderationBadge(modStatus: string): { label: string; color: string } | null {
+  switch (modStatus) {
+    case 'pending':
+      return { label: 'Reviewing…', color: '#8E8E93' };
+    case 'pending_review':
+      return { label: 'Awaiting admin', color: '#FF9500' };
+    case 'rejected':
+      // Softer than "Rejected" — a prayer is a vulnerable thing to share,
+      // and the existing copy implies failure. "Kept private" frames it as
+      // "the post didn't go public, but it's still yours."
+      return { label: 'Kept private', color: '#8E8E93' };
+    case 'approved':
+    default:
+      return null;
+  }
+}
+
+export function MyPrayersScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const prayers = useAuthenticatedQuery(api.functions.prayers.myPrayers, {});
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+      <Stack.Screen options={{ title: 'My Prayers', headerShown: true }} />
+      <ScrollView contentContainerStyle={[styles.scrollContent, { paddingTop: 16, paddingBottom: 24 + insets.bottom }]}>
+        {prayers === undefined ? (
+          <View style={styles.center}>
+            <ActivityIndicator color={primaryColor} />
+          </View>
+        ) : prayers.length === 0 ? (
+          <View style={[styles.emptyCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+            <Ionicons name="heart-outline" size={36} color={colors.iconSecondary} />
+            <Text style={[styles.emptyTitle, { color: colors.text }]}>No prayers yet</Text>
+            <Text style={[styles.emptyBody, { color: colors.textSecondary }]}>
+              When you post a prayer request, it'll show up here.
+            </Text>
+          </View>
+        ) : (
+          prayers.map((p) => {
+            const badge = statusBadge(p.status);
+            const modBadge = moderationBadge(p.moderationStatus);
+            return (
+              <TouchableOpacity
+                key={p.id}
+                style={[styles.row, { backgroundColor: colors.surface, borderColor: colors.border }]}
+                onPress={() => router.push(`/(user)/my-prayers/${p.id}`)}
+                activeOpacity={0.85}
+              >
+                <Text style={[styles.body, { color: colors.text }]} numberOfLines={3}>
+                  {p.bodyText}
+                </Text>
+                <View style={styles.metaRow}>
+                  {/* Hide the lifecycle "Active" pill when moderation is in
+                     flight or held — the moderation status is the more
+                     urgent thing for the author to see. */}
+                  {modBadge ? (
+                    <View style={[styles.badge, { backgroundColor: modBadge.color }]}>
+                      <Text style={styles.badgeText}>{modBadge.label}</Text>
+                    </View>
+                  ) : (
+                    <View style={[styles.badge, { backgroundColor: badge.color }]}>
+                      <Text style={styles.badgeText}>{badge.label}</Text>
+                    </View>
+                  )}
+                  {p.isAnonymous && (
+                    <View style={[styles.badge, { backgroundColor: colors.textTertiary }]}>
+                      <Text style={styles.badgeText}>Anonymous</Text>
+                    </View>
+                  )}
+                  {p.crisisFlag && (
+                    <View style={[styles.badge, { backgroundColor: '#C0392B' }]}>
+                      <Text style={styles.badgeText}>Resource added</Text>
+                    </View>
+                  )}
+                  <Text style={[styles.countText, { color: colors.textTertiary }]}>
+                    {p.prayedForCount} prayed
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scrollContent: { padding: 16 },
+  center: { paddingVertical: 40, alignItems: 'center' },
+  emptyCard: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 24,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  emptyTitle: { fontSize: 17, fontWeight: '600', marginTop: 12, marginBottom: 6 },
+  emptyBody: { fontSize: 14, textAlign: 'center', lineHeight: 20 },
+  row: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 14,
+    marginBottom: 10,
+  },
+  body: { fontSize: 15, lineHeight: 20, marginBottom: 10 },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  badgeText: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  countText: {
+    fontSize: 12,
+    marginLeft: 'auto',
+  },
+});

--- a/apps/mobile/features/prayer/components/PraySession.tsx
+++ b/apps/mobile/features/prayer/components/PraySession.tsx
@@ -1,0 +1,241 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Modal, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedMutation, api } from '@services/api/convex';
+import { formatError } from '@/utils/error-handling';
+import { CrisisResourceCard } from './CrisisResourceCard';
+import type { PrayerCardData } from './PrayerCard';
+
+const TIMER_SECONDS = 180;
+const CONFIRM_HOLD_MS = 1000;
+const COMPLETED_GREEN = '#34C759';
+
+interface Props {
+  prayer: PrayerCardData | null;
+  visible: boolean;
+  onClose: () => void;
+  onPrayed: () => void;
+}
+
+/**
+ * 3-minute trust-based prayer session.
+ *
+ * Timer continues counting regardless of foreground/background — closing
+ * the modal only cancels the visual countdown, it doesn't punish the user.
+ * "I prayed, mark done" is enabled at any time. Auto-fires at 0:00.
+ *
+ * After the mutation lands, the modal stays open for ~1s with a checkmark
+ * + "Prayed for {Name}" so the action feels real before the next card
+ * slides in. Without this beat, the feed advance is invisible and users
+ * don't trust they did anything.
+ */
+export function PraySession({ prayer, visible, onClose, onPrayed }: Props) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const [secondsLeft, setSecondsLeft] = useState(TIMER_SECONDS);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const submittedRef = useRef(false);
+  const recordSession = useAuthenticatedMutation(
+    api.functions.prayers.recordPrayerSession,
+  );
+
+  useEffect(() => {
+    if (!visible || !prayer) return;
+    setSecondsLeft(TIMER_SECONDS);
+    setShowConfirm(false);
+    submittedRef.current = false;
+
+    const start = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - start) / 1000);
+      const remaining = Math.max(0, TIMER_SECONDS - elapsed);
+      setSecondsLeft(remaining);
+      if (remaining === 0) {
+        clearInterval(interval);
+        void handleMarkPrayed(true);
+      }
+    }, 250);
+
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleMarkPrayed is stable enough; visible/prayer drive lifecycle
+  }, [visible, prayer?.id]);
+
+  const handleMarkPrayed = async (_auto = false) => {
+    if (!prayer || submittedRef.current) return;
+    submittedRef.current = true;
+    setIsSubmitting(true);
+    try {
+      await recordSession({ prayerId: prayer.id });
+      setShowConfirm(true);
+      // Hold the confirmation for a beat, then advance.
+      setTimeout(() => {
+        onPrayed();
+      }, CONFIRM_HOLD_MS);
+    } catch (e) {
+      submittedRef.current = false;
+      Alert.alert('Error', formatError(e, 'Could not record your prayer'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!prayer) return null;
+
+  const mins = Math.floor(secondsLeft / 60);
+  const secs = secondsLeft % 60;
+  const timeLabel = `${mins}:${secs.toString().padStart(2, '0')}`;
+  const progress = 1 - secondsLeft / TIMER_SECONDS;
+  const confirmTarget = prayer.authorDisplayName ?? 'your community';
+
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        {showConfirm ? (
+          <View style={[styles.confirmSheet, { backgroundColor: colors.surface }]}>
+            <View style={[styles.confirmCircle, { backgroundColor: COMPLETED_GREEN }]}>
+              <Ionicons name="checkmark" size={40} color="#fff" />
+            </View>
+            <Text style={[styles.confirmTitle, { color: colors.text }]}>
+              Prayed for {confirmTarget}
+            </Text>
+            <Text style={[styles.confirmBody, { color: colors.textSecondary }]}>
+              Your prayer was sent.
+            </Text>
+          </View>
+        ) : (
+          <View style={[styles.sheet, { backgroundColor: colors.surface }]}>
+            <View style={styles.headerRow}>
+              <Text style={[styles.title, { color: colors.text }]}>Praying</Text>
+              <TouchableOpacity onPress={onClose} hitSlop={12}>
+                <Ionicons name="close" size={24} color={colors.iconSecondary} />
+              </TouchableOpacity>
+            </View>
+
+            {prayer.crisisFlag ? <CrisisResourceCard /> : null}
+            <Text style={[styles.body, { color: colors.text }]}>{prayer.bodyText}</Text>
+
+            <View style={styles.timerContainer}>
+              <View style={[styles.progressTrack, { backgroundColor: colors.surfaceSecondary }]}>
+                <View
+                  style={[
+                    styles.progressFill,
+                    { backgroundColor: primaryColor, width: `${Math.min(100, progress * 100)}%` },
+                  ]}
+                />
+              </View>
+              <Text style={[styles.timeText, { color: colors.text }]}>{timeLabel}</Text>
+              <Text style={[styles.helperText, { color: colors.textTertiary }]}>
+                Take 3 minutes to pray for this request.
+              </Text>
+            </View>
+
+            <TouchableOpacity
+              style={[
+                styles.doneButton,
+                { backgroundColor: primaryColor },
+                isSubmitting && { opacity: 0.6 },
+              ]}
+              onPress={() => handleMarkPrayed(false)}
+              disabled={isSubmitting}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.doneButtonText}>
+                {secondsLeft > 0 ? 'I prayed, mark done' : 'Done'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  sheet: {
+    borderRadius: 20,
+    padding: 24,
+  },
+  confirmSheet: {
+    borderRadius: 20,
+    paddingVertical: 36,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+  },
+  confirmCircle: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  confirmTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginBottom: 6,
+  },
+  confirmBody: {
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  body: {
+    fontSize: 16,
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  timerContainer: {
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  progressTrack: {
+    width: '100%',
+    height: 6,
+    borderRadius: 3,
+    overflow: 'hidden',
+    marginBottom: 12,
+  },
+  progressFill: {
+    height: '100%',
+  },
+  timeText: {
+    fontSize: 36,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+    marginBottom: 8,
+  },
+  helperText: {
+    fontSize: 13,
+    textAlign: 'center',
+  },
+  doneButton: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  doneButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/features/prayer/components/PrayerCard.tsx
+++ b/apps/mobile/features/prayer/components/PrayerCard.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import type { Id } from '@services/api/convex';
+
+export interface PrayerCardData {
+  id: Id<'prayers'>;
+  bodyText: string;
+  prayedForCount: number;
+  createdAt: number;
+  /** "First L." for non-anonymous prayers, null when posted anonymously. */
+  authorDisplayName: string | null;
+  /**
+   * When true, the moderator flagged this as first-person crisis content
+   * (depression, suicidal ideation without plan/means). The card renders
+   * a small 988 / crisis-line resource above the body. We DON'T block
+   * these — "triage, not suppression."
+   */
+  crisisFlag: boolean;
+}
+
+interface Props {
+  prayer: PrayerCardData;
+  onPressPray: (prayer: PrayerCardData) => void;
+}
+
+export function PrayerCard({ prayer, onPressPray }: Props) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const count = prayer.prayedForCount;
+  const countLabel =
+    count === 0 ? 'Be the first to pray' : count === 1 ? '1 person prayed' : `${count} people prayed`;
+
+  const authorLabel = prayer.authorDisplayName ?? 'Anonymous';
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+      <View style={styles.authorRow}>
+        <Ionicons
+          name={prayer.authorDisplayName ? 'person-outline' : 'eye-off-outline'}
+          size={13}
+          color={colors.textTertiary}
+        />
+        <Text style={[styles.authorLabel, { color: colors.textTertiary }]}>{authorLabel}</Text>
+      </View>
+      <Text style={[styles.body, { color: colors.text }]}>{prayer.bodyText}</Text>
+
+      <View style={styles.row}>
+        <View style={styles.metaRow}>
+          <Ionicons name="people-outline" size={14} color={colors.textTertiary} />
+          <Text style={[styles.meta, { color: colors.textTertiary }]}>{countLabel}</Text>
+        </View>
+
+        <TouchableOpacity
+          style={[styles.prayButton, { backgroundColor: primaryColor }]}
+          onPress={() => onPressPray(prayer)}
+          activeOpacity={0.85}
+        >
+          <Ionicons name="heart" size={16} color="#fff" />
+          <Text style={styles.prayButtonText}>Pray</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    marginBottom: 12,
+  },
+  authorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    marginBottom: 8,
+  },
+  authorLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  body: {
+    fontSize: 16,
+    lineHeight: 22,
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  meta: {
+    fontSize: 13,
+  },
+  prayButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+  },
+  prayButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/features/prayer/components/PrayerScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayerScreen.tsx
@@ -109,7 +109,9 @@ export function PrayerScreen() {
   );
   const counts = useAuthenticatedQuery(
     api.functions.prayers.myPrayedThisWeekCount,
-    community?.id ? {} : 'skip',
+    community?.id
+      ? { communityId: community.id as Id<'communities'> }
+      : 'skip',
   );
   const todayCount = counts?.today ?? 0;
   const weekCount = counts?.week ?? 0;

--- a/apps/mobile/features/prayer/components/PrayerScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayerScreen.tsx
@@ -1,0 +1,537 @@
+/**
+ * PrayerScreen — the church-feature prayer tab.
+ *
+ * Single full-screen prayer at a time, anchored as a card high in the
+ * viewport. The user prays for 3 in a "session"; a "Prayer N of 3"
+ * header with inline dots shows progress, and a checkmark celebrates
+ * the finished set. They can opt to "Pray for more" to start another
+ * set — but the friction-free path is to stop after 3.
+ *
+ * Picking through a list felt too lightweight for the weight of the
+ * ask, so there is no "next" or "skip"; the only forward motion is
+ * praying. After each pray, the PraySession modal shows a brief
+ * confirmation overlay ("Prayed for Sarah") so the action feels real
+ * before the next card slides in.
+ *
+ * Feed ordering is set on the backend: fewest pray-count first, oldest
+ * as tiebreaker, excluding prayers the caller authored or already prayed
+ * for. See `apps/convex/functions/prayers.ts:feed`.
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useAuth } from '@providers/AuthProvider';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedQuery, api } from '@services/api/convex';
+import type { Id } from '@services/api/convex';
+import { PraySession } from './PraySession';
+import { AddPrayerSheet } from './AddPrayerSheet';
+import { CrisisResourceCard } from './CrisisResourceCard';
+import { ReportPrayerSheet } from './ReportPrayerSheet';
+import type { PrayerCardData } from './PrayerCard';
+
+const SESSION_TARGET = 3;
+// Don't surface the "this week" pill until the user has prayed enough that
+// the number feels affirming rather than judgey. Below this it just looks
+// like a stat; past it, it lands as "wow, I've actually been showing up."
+const WEEK_PILL_MIN = 6;
+const COMPLETED_GREEN = '#34C759';
+
+// Deterministic palette so the same name always gets the same avatar color.
+const AVATAR_COLORS = [
+  '#FFB4A2', '#FFD6A5', '#FDFFB6', '#CAFFBF',
+  '#9BF6FF', '#A0C4FF', '#BDB2FF', '#FFC6FF',
+];
+
+function hashToIndex(input: string, mod: number): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) & 0xffffffff;
+  return Math.abs(h) % mod;
+}
+
+function avatarBgFor(name: string): string {
+  return AVATAR_COLORS[hashToIndex(name, AVATAR_COLORS.length)];
+}
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 1).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function relativeTime(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const min = Math.round(diffMs / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.round(hr / 24);
+  if (d < 7) return `${d}d ago`;
+  const w = Math.round(d / 7);
+  if (w < 5) return `${w}w ago`;
+  const mo = Math.round(d / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.round(d / 365)}y ago`;
+}
+
+export function PrayerScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { community } = useAuth();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const [praySessionOpen, setPraySessionOpen] = useState(false);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
+  // Whether the user has dismissed today's "you prayed for 3" celebration.
+  // Local + session-scoped: a fresh app open *does* re-show the celebration
+  // if they cross 3 again, but tapping "Pray for more" hides it for the rest
+  // of this app session. After they're past 3 today, the N-of-3 framing
+  // disappears entirely — it'd be a lie to keep showing "Prayer 2 of 3" when
+  // they're on their 7th.
+  const [celebrationDismissed, setCelebrationDismissed] = useState(false);
+
+  const feed = useAuthenticatedQuery(
+    api.functions.prayers.feed,
+    community?.id ? { communityId: community.id as Id<'communities'> } : 'skip',
+  );
+  const counts = useAuthenticatedQuery(
+    api.functions.prayers.myPrayedThisWeekCount,
+    community?.id ? {} : 'skip',
+  );
+  const todayCount = counts?.today ?? 0;
+  const weekCount = counts?.week ?? 0;
+
+  const isLoading = feed === undefined && !!community?.id;
+  const current: PrayerCardData | undefined = feed?.[0];
+
+  // Are we still inside the initial set-of-3 onboarding framing? Once the
+  // user has prayed 3+ today, drop the dots and the "N of 3" label — at
+  // that point they're committed and the framing would just be noise.
+  const inFirstSet = todayCount < SESSION_TARGET;
+  // Celebration fires only at the *exact* moment they cross 3, and only
+  // until dismissed for this app session. If they re-open the app already
+  // past 3 today, skip straight to the prayer card — interrupting them
+  // with the celebration on every launch would feel ceremonious in a bad
+  // way.
+  const showCelebration = todayCount === SESSION_TARGET && !celebrationDismissed;
+
+  const handlePrayed = useCallback(() => {
+    setPraySessionOpen(false);
+    // todayCount auto-updates via reactive query.
+  }, []);
+
+  const dismissCelebration = useCallback(() => setCelebrationDismissed(true), []);
+
+  const isAnonymous = current && !current.authorDisplayName;
+  const authorLabel = current?.authorDisplayName ?? 'Anonymous';
+  const avatarBg = current && !isAnonymous ? avatarBgFor(authorLabel) : '#E5E5EA';
+  const avatarInitials = current && !isAnonymous ? initialsOf(authorLabel) : '?';
+
+  // Hero region — either the prayer card, the celebration, an empty state,
+  // or a loading spinner. Pulled inline so the wrapping <View> can keep
+  // layout consistent.
+  let hero: React.ReactNode;
+  if (isLoading) {
+    hero = (
+      <View style={styles.heroCenter}>
+        <ActivityIndicator color={primaryColor} />
+      </View>
+    );
+  } else if (showCelebration) {
+    hero = (
+      <View style={styles.heroCenter}>
+        <View style={[styles.checkCircle, { backgroundColor: COMPLETED_GREEN }]}>
+          <Ionicons name="checkmark" size={44} color="#fff" />
+        </View>
+        <Text style={[styles.celebTitle, { color: colors.text }]}>You prayed for 3</Text>
+        <Text style={[styles.celebBody, { color: colors.textSecondary }]}>
+          Thank you for taking the time. Your community is held up because of it.
+        </Text>
+        {current ? (
+          <TouchableOpacity
+            style={[styles.secondaryButton, { borderColor: colors.border }]}
+            onPress={dismissCelebration}
+            activeOpacity={0.85}
+          >
+            <Text style={[styles.secondaryButtonText, { color: colors.text }]}>Pray for more</Text>
+          </TouchableOpacity>
+        ) : (
+          <Text style={[styles.celebFootnote, { color: colors.textTertiary }]}>
+            No more prayer requests right now — check back later.
+          </Text>
+        )}
+      </View>
+    );
+  } else if (!current && todayCount > 0) {
+    hero = (
+      <View style={styles.heroCenter}>
+        <View style={[styles.checkCircle, { backgroundColor: COMPLETED_GREEN }]}>
+          <Ionicons name="checkmark" size={36} color="#fff" />
+        </View>
+        <Text style={[styles.celebTitle, { color: colors.text }]}>
+          You prayed for {todayCount} today
+        </Text>
+        <Text style={[styles.celebBody, { color: colors.textSecondary }]}>
+          That's everyone waiting for prayer right now. Check back later.
+        </Text>
+      </View>
+    );
+  } else if (!current) {
+    hero = (
+      <View style={styles.heroCenter}>
+        <Ionicons name="heart-outline" size={44} color={colors.iconSecondary} />
+        <Text style={[styles.emptyTitle, { color: colors.text }]}>All caught up</Text>
+        <Text style={[styles.emptyBody, { color: colors.textSecondary }]}>
+          There's no one waiting for prayer right now. Add a request for your community.
+        </Text>
+      </View>
+    );
+  } else {
+    const countLabel =
+      current.prayedForCount === 0
+        ? 'Be the first to pray'
+        : current.prayedForCount === 1
+          ? '1 other prayed'
+          : `${current.prayedForCount} others prayed`;
+
+    hero = (
+      <View style={styles.cardWrap}>
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: colors.surface,
+              borderColor: colors.border,
+              shadowColor: colors.text,
+            },
+          ]}
+        >
+          {current.crisisFlag ? <CrisisResourceCard /> : null}
+          <View style={styles.cardHeader}>
+            {/*
+             * Initials-only on purpose — NEVER swap in a profile photo here.
+             * A prayer request is a vulnerable moment and showing a face
+             * pulls in social-media energy ("who's this person, what do
+             * they look like") that the prayer screen should resist. The
+             * deterministic background color gives enough identity texture
+             * without making it about appearance.
+             */}
+            <View style={[styles.avatar, { backgroundColor: avatarBg }]}>
+              {isAnonymous ? (
+                <Ionicons name="eye-off-outline" size={18} color="#5C5C66" />
+              ) : (
+                <Text style={styles.avatarText}>{avatarInitials}</Text>
+              )}
+            </View>
+            <View style={styles.cardHeaderText}>
+              <Text style={[styles.authorName, { color: colors.text }]}>{authorLabel}</Text>
+              <Text style={[styles.authorMeta, { color: colors.textTertiary }]}>
+                {relativeTime(current.createdAt)} · {countLabel}
+              </Text>
+            </View>
+            <TouchableOpacity
+              style={styles.overflowButton}
+              onPress={() => setReportOpen(true)}
+              hitSlop={10}
+              accessibilityLabel="Report this prayer"
+            >
+              <Ionicons name="ellipsis-horizontal" size={20} color={colors.iconSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.bodyWrap}>
+            <Text
+              style={[styles.quoteMark, { color: primaryColor }]}
+              accessibilityElementsHidden
+              importantForAccessibility="no"
+            >
+              “
+            </Text>
+            <Text style={[styles.body, { color: colors.text }]}>{current.bodyText}</Text>
+          </View>
+
+          <TouchableOpacity
+            style={[styles.prayButton, { backgroundColor: primaryColor }]}
+            onPress={() => setPraySessionOpen(true)}
+            activeOpacity={0.85}
+          >
+            <Ionicons name="heart" size={18} color="#fff" />
+            <Text style={styles.prayButtonText}>Pray</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+
+  // Header progress framing — only meaningful for the initial set of 3.
+  // Past that, the dots + "N of 3" would lie (no, you're not on prayer 2,
+  // you're on your 7th today), so we hide them entirely and only keep the
+  // cumulative "today" pill.
+  const setLabel = !isLoading && inFirstSet
+    ? `Prayer ${Math.min(SESSION_TARGET, todayCount + 1)} of ${SESSION_TARGET}`
+    : null;
+  const weekLabel = weekCount >= WEEK_PILL_MIN ? `${weekCount} this week` : null;
+  const showHeaderRow = !isLoading && (setLabel || weekLabel);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.surfaceSecondary, paddingTop: insets.top + 12 },
+      ]}
+    >
+      <View style={styles.topBar}>
+        <Text style={[styles.heading, { color: colors.text }]}>Pray for your community</Text>
+        <View style={styles.topRightRow}>
+          <TouchableOpacity
+            style={styles.topAction}
+            onPress={() => setIsAddOpen(true)}
+            hitSlop={8}
+            accessibilityLabel="Request prayer"
+          >
+            <Ionicons name="add-circle-outline" size={22} color={primaryColor} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.topAction}
+            onPress={() => router.push('/(user)/my-prayers')}
+            hitSlop={8}
+            accessibilityLabel="My prayers"
+          >
+            <Text style={[styles.topActionText, { color: primaryColor }]}>My prayers</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {showHeaderRow ? (
+        <View style={styles.progressRow}>
+          {setLabel ? (
+            <>
+              <Text style={[styles.progressLabel, { color: colors.textSecondary }]}>{setLabel}</Text>
+              <ProgressDots
+                count={SESSION_TARGET}
+                filled={Math.min(SESSION_TARGET, todayCount)}
+                complete={false}
+                baseColor={colors.border}
+              />
+            </>
+          ) : null}
+          {weekLabel ? (
+            <View style={[styles.todayPill, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+              <Ionicons name="flame" size={11} color={COMPLETED_GREEN} />
+              <Text style={[styles.todayPillText, { color: colors.textSecondary }]}>{weekLabel}</Text>
+            </View>
+          ) : null}
+        </View>
+      ) : null}
+
+      <View style={styles.heroFill}>{hero}</View>
+
+      <PraySession
+        prayer={current ?? null}
+        visible={praySessionOpen && !!current}
+        onClose={() => setPraySessionOpen(false)}
+        onPrayed={handlePrayed}
+      />
+      <AddPrayerSheet
+        visible={isAddOpen}
+        onClose={() => setIsAddOpen(false)}
+        onPosted={() => setIsAddOpen(false)}
+      />
+      <ReportPrayerSheet
+        prayerId={current?.id ?? null}
+        visible={reportOpen && !!current}
+        onClose={() => setReportOpen(false)}
+        onReported={() => setReportOpen(false)}
+      />
+    </View>
+  );
+}
+
+function ProgressDots({
+  count,
+  filled,
+  complete,
+  baseColor,
+}: {
+  count: number;
+  filled: number;
+  complete: boolean;
+  baseColor: string;
+}) {
+  return (
+    <View style={styles.dotsRow}>
+      {Array.from({ length: count }).map((_, i) => {
+        const isFilled = i < filled;
+        return (
+          <View
+            key={i}
+            style={[
+              styles.dot,
+              { backgroundColor: isFilled ? COMPLETED_GREEN : baseColor },
+            ]}
+          />
+        );
+      })}
+      {complete ? (
+        <View style={[styles.dotCheck, { backgroundColor: COMPLETED_GREEN }]}>
+          <Ionicons name="checkmark" size={12} color="#fff" />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    marginBottom: 6,
+  },
+  heading: { fontSize: 20, fontWeight: '700', flex: 1 },
+  topRightRow: { flexDirection: 'row', alignItems: 'center', gap: 14 },
+  topAction: { paddingVertical: 4 },
+  topActionText: { fontSize: 14, fontWeight: '600' },
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 20,
+    marginBottom: 18,
+  },
+  progressLabel: { fontSize: 12, fontWeight: '600', letterSpacing: 0.4 },
+  dotsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  dot: { width: 8, height: 8, borderRadius: 4 },
+  todayPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginLeft: 'auto',
+  },
+  todayPillText: { fontSize: 11, fontWeight: '600' },
+  dotCheck: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 2,
+  },
+  heroFill: { flex: 1 },
+  heroCenter: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 36,
+  },
+  cardWrap: {
+    paddingHorizontal: 16,
+    paddingTop: 4,
+  },
+  card: {
+    borderRadius: 20,
+    padding: 22,
+    borderWidth: StyleSheet.hairlineWidth,
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.08,
+    shadowRadius: 16,
+    elevation: 4,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 18,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#3A3A3F',
+  },
+  cardHeaderText: { flex: 1 },
+  overflowButton: {
+    padding: 4,
+  },
+  authorName: { fontSize: 16, fontWeight: '700' },
+  authorMeta: { fontSize: 12, marginTop: 2 },
+  bodyWrap: {
+    position: 'relative',
+    paddingLeft: 24,
+    paddingRight: 4,
+    paddingTop: 8,
+    paddingBottom: 22,
+  },
+  quoteMark: {
+    position: 'absolute',
+    top: -12,
+    left: -2,
+    fontSize: 64,
+    fontWeight: '700',
+    lineHeight: 64,
+    opacity: 0.35,
+  },
+  body: {
+    fontSize: 19,
+    lineHeight: 28,
+    fontWeight: '500',
+  },
+  prayButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 14,
+    borderRadius: 14,
+  },
+  prayButtonText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  emptyTitle: { fontSize: 18, fontWeight: '600', marginTop: 14, marginBottom: 8 },
+  emptyBody: { fontSize: 15, textAlign: 'center', lineHeight: 22 },
+  checkCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 18,
+  },
+  celebTitle: { fontSize: 22, fontWeight: '700', marginBottom: 8, textAlign: 'center' },
+  celebBody: { fontSize: 15, textAlign: 'center', lineHeight: 22, marginBottom: 24 },
+  celebFootnote: { fontSize: 13, textAlign: 'center' },
+  secondaryButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 24,
+    borderWidth: 1,
+  },
+  secondaryButtonText: { fontSize: 15, fontWeight: '600' },
+});

--- a/apps/mobile/features/prayer/components/ReportPrayerSheet.tsx
+++ b/apps/mobile/features/prayer/components/ReportPrayerSheet.tsx
@@ -1,0 +1,304 @@
+/**
+ * Member-facing report sheet.
+ *
+ * Final defense layer after the LLM moderator + author-side nudges. Any
+ * community member can flag a prayer they're seeing. The reasons are a
+ * predefined list — keeps the response taxonomy clean for admin triage
+ * and means the reporter doesn't have to find words for something
+ * uncomfortable. The optional note is for context, not required.
+ *
+ * After submission, the prayer disappears from the reporter's feed and
+ * an admin notification fires. Idempotent on the backend per
+ * (prayer, reporter).
+ *
+ * Privacy: the reporter's identity goes to community admins, not to the
+ * prayer's author. We disclose this in the sheet so no one is surprised.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Modal,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedMutation, api } from '@services/api/convex';
+import { formatError } from '@/utils/error-handling';
+import type { Id } from '@services/api/convex';
+
+const MAX_NOTE = 300;
+
+type ReasonId =
+  | 'names_person'
+  | 'intimate_explicit'
+  | 'spam_solicitation'
+  | 'hateful'
+  | 'crisis_needs_resources'
+  | 'other';
+
+interface ReasonOption {
+  id: ReasonId;
+  label: string;
+  helper: string;
+}
+
+const REASONS: ReasonOption[] = [
+  {
+    id: 'names_person',
+    label: 'Names a specific person',
+    helper: 'Uses a real name or identifying detail about someone else.',
+  },
+  {
+    id: 'intimate_explicit',
+    label: 'Too intimate or explicit',
+    helper: 'Shares details that don\'t belong on a public feed.',
+  },
+  {
+    id: 'spam_solicitation',
+    label: 'Spam or solicitation',
+    helper: 'Promotes a product, fundraiser, or business.',
+  },
+  {
+    id: 'hateful',
+    label: 'Hateful or hurtful',
+    helper: 'Slurs, hateful framing, or targeted attacks.',
+  },
+  {
+    id: 'crisis_needs_resources',
+    label: 'Needs crisis resources',
+    helper: 'Author describes a crisis without a resource link attached.',
+  },
+  {
+    id: 'other',
+    label: 'Something else',
+    helper: 'Use the note below to explain.',
+  },
+];
+
+interface Props {
+  prayerId: Id<'prayers'> | null;
+  visible: boolean;
+  onClose: () => void;
+  onReported: () => void;
+}
+
+export function ReportPrayerSheet({ prayerId, visible, onClose, onReported }: Props) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const [reason, setReason] = useState<ReasonId | null>(null);
+  const [note, setNote] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const reportPrayer = useAuthenticatedMutation(api.functions.prayers.reportPrayer);
+
+  useEffect(() => {
+    if (visible) {
+      setReason(null);
+      setNote('');
+    }
+  }, [visible]);
+
+  const handleSubmit = async () => {
+    if (!prayerId || !reason) return;
+    setIsSubmitting(true);
+    try {
+      await reportPrayer({
+        prayerId,
+        reason,
+        customNote: note.trim() || undefined,
+      });
+      onReported();
+      onClose();
+      // Soft acknowledgement — no celebration here. Reporting is a serious act.
+      Alert.alert('Thanks for reporting', 'A community admin will review this prayer.');
+    } catch (e) {
+      Alert.alert('Error', formatError(e, 'Could not submit your report'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!prayerId) return null;
+
+  const charsLeft = MAX_NOTE - note.length;
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.backdrop}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={[styles.sheet, { backgroundColor: colors.surface }]}>
+          <View style={styles.headerRow}>
+            <Text style={[styles.title, { color: colors.text }]}>Report this prayer</Text>
+            <TouchableOpacity onPress={onClose} hitSlop={12} disabled={isSubmitting}>
+              <Ionicons name="close" size={24} color={colors.iconSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+            Why are you reporting this?
+          </Text>
+
+          {REASONS.map((r) => {
+            const selected = reason === r.id;
+            return (
+              <TouchableOpacity
+                key={r.id}
+                onPress={() => setReason(r.id)}
+                style={[
+                  styles.reasonRow,
+                  {
+                    borderColor: selected ? primaryColor : colors.border,
+                    backgroundColor: selected ? `${primaryColor}11` : 'transparent',
+                  },
+                ]}
+                activeOpacity={0.85}
+                disabled={isSubmitting}
+              >
+                <View
+                  style={[
+                    styles.radio,
+                    {
+                      borderColor: selected ? primaryColor : colors.border,
+                      backgroundColor: selected ? primaryColor : 'transparent',
+                    },
+                  ]}
+                >
+                  {selected ? <Ionicons name="checkmark" size={12} color="#fff" /> : null}
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={[styles.reasonLabel, { color: colors.text }]}>{r.label}</Text>
+                  <Text style={[styles.reasonHelper, { color: colors.textTertiary }]}>
+                    {r.helper}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+
+          <TextInput
+            style={[
+              styles.noteInput,
+              {
+                backgroundColor: colors.inputBackground,
+                color: colors.text,
+                borderColor: colors.inputBorder,
+              },
+            ]}
+            value={note}
+            onChangeText={setNote}
+            placeholder="Anything else the admin should know? (Optional)"
+            placeholderTextColor={colors.inputPlaceholder}
+            multiline
+            maxLength={MAX_NOTE}
+            editable={!isSubmitting}
+          />
+          <Text style={[styles.charCount, { color: colors.textTertiary }]}>
+            {charsLeft} left
+          </Text>
+
+          <Text style={[styles.privacyDisclosure, { color: colors.textTertiary }]}>
+            Your name is shared with community admins for follow-up. It is not shared with
+            the prayer's author.
+          </Text>
+
+          <TouchableOpacity
+            style={[
+              styles.submitButton,
+              {
+                backgroundColor: primaryColor,
+                opacity: !reason || isSubmitting ? 0.5 : 1,
+              },
+            ]}
+            onPress={handleSubmit}
+            disabled={!reason || isSubmitting}
+            activeOpacity={0.85}
+          >
+            {isSubmitting ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text style={styles.submitText}>Submit report</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 20,
+    paddingBottom: 36,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  title: { fontSize: 18, fontWeight: '700' },
+  subtitle: { fontSize: 13, marginBottom: 12 },
+  reasonRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderRadius: 10,
+    marginBottom: 8,
+  },
+  radio: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 2,
+  },
+  reasonLabel: { fontSize: 14, fontWeight: '600' },
+  reasonHelper: { fontSize: 12, marginTop: 2, lineHeight: 16 },
+  noteInput: {
+    marginTop: 8,
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    fontSize: 14,
+    minHeight: 70,
+    textAlignVertical: 'top',
+  },
+  charCount: {
+    fontSize: 11,
+    textAlign: 'right',
+    marginTop: 4,
+    marginBottom: 12,
+  },
+  privacyDisclosure: {
+    fontSize: 11,
+    lineHeight: 16,
+    marginBottom: 14,
+  },
+  submitButton: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  submitText: { color: '#fff', fontSize: 15, fontWeight: '600' },
+});

--- a/apps/mobile/features/prayer/index.ts
+++ b/apps/mobile/features/prayer/index.ts
@@ -1,0 +1,4 @@
+export { PrayerScreen } from './components/PrayerScreen';
+export { MyPrayersScreen } from './components/MyPrayersScreen';
+export { MyPrayerDetailScreen } from './components/MyPrayerDetailScreen';
+export { AdminPrayerReviewsScreen } from './components/AdminPrayerReviewsScreen';

--- a/apps/mobile/features/profile/components/ProfileMenu.tsx
+++ b/apps/mobile/features/profile/components/ProfileMenu.tsx
@@ -118,6 +118,20 @@ export function ProfileMenu() {
           <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
         </TouchableOpacity>
 
+        {community?.churchFeatures?.prayerEnabled ? (
+          <TouchableOpacity
+            style={[styles.menuItem, { borderBottomColor: colors.border }]}
+            onPress={() => router.push('/(user)/my-prayers')}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
+              <Ionicons name="heart-outline" size={20} color={colors.text} />
+            </View>
+            <Text style={[styles.menuText, { color: colors.text }]}>My Prayers</Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
+          </TouchableOpacity>
+        ) : null}
+
         <TouchableOpacity
           style={[styles.menuItem, styles.menuItemLast, { borderBottomColor: colors.border }]}
           onPress={() => router.push('/(user)/settings')}

--- a/apps/mobile/providers/AuthProvider.tsx
+++ b/apps/mobile/providers/AuthProvider.tsx
@@ -409,6 +409,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         ? {
             id: convexUser.activeCommunityId,
             name: convexUser.activeCommunityName ?? undefined,
+            churchFeatures: convexUser.activeCommunityChurchFeatures ?? undefined,
           }
         : null;
 

--- a/apps/mobile/types/shared.ts
+++ b/apps/mobile/types/shared.ts
@@ -81,5 +81,13 @@ export interface Community {
   name?: string;
   subdomain?: string;
   logo?: string; // Community logo URL (S3 URL or relative path)
+  /**
+   * Church-specific feature toggles (opt-in per community, off by default).
+   * Surfaced so conditional UI (e.g. the Prayer tab) can render without
+   * a second query.
+   */
+  churchFeatures?: {
+    prayerEnabled: boolean;
+  };
   [key: string]: any; // Allow additional community properties
 }

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -112,6 +112,13 @@ pnpm dev
 |--------|-------------|-------------|
 | `EXPO_PUBLIC_KLIPY_API_KEY` | KLIPY API key (from partner.klipy.com) | GIF picker hidden |
 
+### Prayer-request moderation (Church Prayer feature)
+
+| Secret | Description | Degradation |
+|--------|-------------|-------------|
+| `OPENAI_SECRET_KEY` | OpenAI API key (already used by poster keywording). The prayer moderator calls `gpt-4o-mini` in JSON mode. | Moderator fails open — every prayer is accepted without LLM screening. |
+| `OLLAMA_API_KEY` | **Escape hatch only.** Used if you flip `PROVIDER` to `"ollama"` in `apps/convex/lib/moderation/prayer.ts` (e.g. if OpenAI spend gets too high). See https://ollama.com/pricing. | Same fail-open behavior when unset. |
+
 ### Development Settings
 
 | Secret | Description |


### PR DESCRIPTION
## Summary

New opt-in **Prayer** feature for church communities — short prayer requests, a focused 3-minute praying flow, and a defense-in-depth moderation pipeline. Gated behind `community.churchFeatures.prayerEnabled` so general-purpose communities are unaffected.

- **Feed UX**: one prayer at a time, no skip; after 3 prayers you hit a celebration screen with a "Pray for more" option. Past 3, the dots/N-of-3 framing drops and an `N this week` pill appears (gated past 5).
- **Moderation** (4 layers, in order):
  1. **Compose nudges** — privacy hint always visible; three regex detectors fire on submit (intimate phrasing → suggests rephrasing, relationship+accusation → "Protect their privacy," relationship+capitalized name → "Skip the name?").
  2. **Backend LLM** — OpenAI `gpt-4o-mini` JSON mode, tiered Green/Yellow/Red with an independent `crisis` flag. Posts insert as `pending` so borderline content can't leak. Provider swap to Ollama is a single constant.
  3. **Admin review queue** — Held-by-moderator (yellow) + Reported-by-members in one screen at `Admin → Settings → Quick Links → Prayer Reviews`. Action verb is "Keep private," not "Reject."
  4. **Member reports** — "···" overflow opens a sheet with 6 predefined reasons + optional note. Idempotent per (prayer, reporter). Reported prayers disappear from the reporter's feed.
- **Crisis flag** — when the moderator detects first-person crisis content, a 988 / Crisis Text Line / findahelpline.com card renders above the body. The prayer **still publishes** — "triage, not suppression" (research backed by 7 Cups + Crisis Text Line patterns).
- **Privacy** — `feed` never returns `authorUserId`; anonymous prayers never trigger a user fetch. Avatar is initials-only, with an explicit comment forbidding profile photos. Anonymous = hidden from everyone, even admins (so author can still receive notifications, identity never exposed).

## What's in the diff

**Backend (`apps/convex/`)**
- 4 new tables: `prayers`, `prayerResponses`, `prayerFollowUps`, `prayerReports` (schema.ts).
- `functions/prayers.ts` — feed, myPrayers, getDetail, createPrayer, recordPrayerSession, addFollowUp, markAnswered, archivePrayer, reportPrayer + admin queue (listPendingForReview, listReportedPrayers, approvePending, upholdReport, dismissReports, etc).
- `lib/moderation/prayer.ts` — tiered prompt + OpenAI/Ollama caller, fail-open on errors.
- 4 new notification types: `prayer.prayed_for`, `prayer.praise_report`/`prayer.update`, `prayer.admin_review_needed`, `prayer.member_reported`.
- Daily cron archives `active` prayers older than 30 days.
- `communities.churchFeatures.prayerEnabled` admin toggle.

**Mobile (`apps/mobile/features/prayer/`)**
- `PrayerScreen` (full-screen feed), `PraySession` (3-min countdown modal with crisis-card and confirmation hold), `AddPrayerSheet` (compose with 3 client-side nudges), `MyPrayersScreen` + `MyPrayerDetailScreen` (status banners per category), `AdminPrayerReviewsScreen` (unified Held/Reported queue), `ReportPrayerSheet` (6 predefined reasons), `CrisisResourceCard`.
- Routes: `(tabs)/prayer.tsx`, `(user)/my-prayers/*`, `(user)/admin/prayer-reviews/`.
- Conditional Prayer tab in `(tabs)/_layout.tsx`, conditional My Prayers in `ProfileMenu`, conditional Prayer Reviews quick-link in admin Settings.

## Required config

- `OPENAI_SECRET_KEY` — already configured. Used by the moderator (`gpt-4o-mini` JSON mode). Fail-open if missing.
- `OLLAMA_API_KEY` — optional cost-escape-hatch (flip `PROVIDER` constant in `apps/convex/lib/moderation/prayer.ts`).

## Test plan

Tested end-to-end in iOS sim (Expo Go on Demo Community):

- [x] Admin flips `Prayer Requests` toggle → tab appears
- [x] Green path: benign prayer → posts within ~2s
- [x] Yellow path: "my husband Mark, he has been abusive" → client warning; if posted → `pending_review`, admin sees it in queue with the category label
- [x] Red path: violent / hateful text → "Kept private" banner with category-specific copy
- [x] Pre-submit name nudge fires on "my brother John"
- [x] Intimate nudge fires on "our sex life" — backend also catches it as `intimate_explicit` yellow if user proceeds
- [x] 3-min session: trust-based "I prayed, mark done"; auto-fires at 0:00; confirmation overlay holds for 1s
- [x] Praise report fans out to everyone who prayed
- [x] Push notifications fire (`prayer.prayed_for` confirmed status=sent in Convex)
- [x] Admin queue Approve / Keep private both work; reports group per prayer; "Leave up" vs "Keep private" path depending on whether prayer was still approved
- [x] Member report sheet — 6 reasons render, submit + Alert acknowledgement, prayer disappears from feed
- [ ] Manual QA from a fresh signup on a non-church community (Prayer tab should stay hidden)
- [ ] Confirm crisis card displays on a freshly-classified crisis post (haven't seen the LLM trigger this in test data; worth a manual content-policy run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)