### PR TITLE
feat(prayer): "Prayers you've prayed" history rail + detail view

### DIFF
--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -281,17 +281,26 @@ export const myPrayedFor = query({
     responses.sort((a, b) => b.prayedAt - a.prayedAt);
 
     const limit = Math.min(args.limit ?? 50, 200);
-    const sliced = responses.slice(0, limit);
 
-    const rows = await Promise.all(
-      sliced.map(async (r) => {
-        const prayer = await ctx.db.get(r.prayerId);
-        if (!prayer) return null;
-        if (prayer.moderationStatus === "rejected") return null;
+    // Filter visible prayers FIRST, then take `limit`. Slicing before
+    // filtering would under-fill the result whenever a user's most-recent
+    // responses point at missing or admin-rejected prayers — older eligible
+    // entries should backfill into the window. Walk responses in order so we
+    // can stop once we have enough visible items.
+    const visible: Array<{ response: Doc<"prayerResponses">; prayer: Doc<"prayers"> }> = [];
+    for (const r of responses) {
+      if (visible.length >= limit) break;
+      const prayer = await ctx.db.get(r.prayerId);
+      if (!prayer) continue;
+      if (prayer.moderationStatus === "rejected") continue;
+      visible.push({ response: r, prayer });
+    }
 
+    return Promise.all(
+      visible.map(async ({ response: r, prayer }) => {
         const followUps = await ctx.db
           .query("prayerFollowUps")
-          .withIndex("by_prayer", (q) => q.eq("prayerId", r.prayerId))
+          .withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id))
           .collect();
         const hasNewUpdate = followUps.some((f) => f.createdAt > r.prayedAt);
 
@@ -311,9 +320,6 @@ export const myPrayedFor = query({
           crisisFlag: prayer.crisisFlag === true,
         };
       }),
-    );
-    return rows.filter(
-      (x): x is NonNullable<typeof x> => x !== null,
     );
   },
 });

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -247,6 +247,78 @@ export const myPrayedThisWeekCount = query({
 });
 
 /**
+ * Prayers the caller has prayed for, newest-first. Powers the "Prayers
+ * you've prayed" rail under the prayer feed and the full-history screen.
+ *
+ * Anonymity contract holds — anonymous prayers return `authorDisplayName: null`
+ * and never trigger an author fetch.
+ *
+ * `hasNewUpdate` is true when at least one follow-up was posted AFTER the
+ * caller's most recent pray-session — gives a visual cue that the author
+ * has shared something since they prayed.
+ *
+ * Rejected prayers (admin upheld a report after the caller already prayed)
+ * are filtered out so retroactively-removed content doesn't linger in the
+ * user's history.
+ */
+export const myPrayedFor = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await assertPrayerEnabled(ctx, args.communityId);
+    await assertCommunityMember(ctx, userId, args.communityId);
+
+    const responses = await ctx.db
+      .query("prayerResponses")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", userId).eq("communityId", args.communityId),
+      )
+      .collect();
+    responses.sort((a, b) => b.prayedAt - a.prayedAt);
+
+    const limit = Math.min(args.limit ?? 50, 200);
+    const sliced = responses.slice(0, limit);
+
+    const rows = await Promise.all(
+      sliced.map(async (r) => {
+        const prayer = await ctx.db.get(r.prayerId);
+        if (!prayer) return null;
+        if (prayer.moderationStatus === "rejected") return null;
+
+        const followUps = await ctx.db
+          .query("prayerFollowUps")
+          .withIndex("by_prayer", (q) => q.eq("prayerId", r.prayerId))
+          .collect();
+        const hasNewUpdate = followUps.some((f) => f.createdAt > r.prayedAt);
+
+        const author = prayer.isAnonymous
+          ? null
+          : await ctx.db.get(prayer.authorUserId);
+
+        return {
+          id: prayer._id,
+          bodyText: prayer.bodyText,
+          status: prayer.status,
+          authorDisplayName: prayer.isAnonymous
+            ? null
+            : firstNameLastInitial(author?.firstName, author?.lastName),
+          prayedAt: r.prayedAt,
+          hasNewUpdate,
+          crisisFlag: prayer.crisisFlag === true,
+        };
+      }),
+    );
+    return rows.filter(
+      (x): x is NonNullable<typeof x> => x !== null,
+    );
+  },
+});
+
+/**
  * Caller's own prayers — active, answered, and archived. Includes counts.
  * Returns author-visible fields (author IS the caller here).
  */

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -272,29 +272,41 @@ export const myPrayedFor = query({
     await assertPrayerEnabled(ctx, args.communityId);
     await assertCommunityMember(ctx, userId, args.communityId);
 
-    const responses = await ctx.db
-      .query("prayerResponses")
-      .withIndex("by_user_community", (q) =>
-        q.eq("userId", userId).eq("communityId", args.communityId),
-      )
-      .collect();
-    responses.sort((a, b) => b.prayedAt - a.prayedAt);
-
     const limit = Math.min(args.limit ?? 50, 200);
 
-    // Filter visible prayers FIRST, then take `limit`. Slicing before
-    // filtering would under-fill the result whenever a user's most-recent
-    // responses point at missing or admin-rejected prayers — older eligible
-    // entries should backfill into the window. Walk responses in order so we
-    // can stop once we have enough visible items.
+    // We deliberately scan the by_user index (not by_user_community) and
+    // gate by `prayer.communityId` further down. Two reasons:
+    //   1. `prayerResponses.communityId` is optional for pre-migration rows
+    //      (see schema comment). Indexing on communityId would silently
+    //      drop legacy responses for long-time users.
+    //   2. Paginating the by_user index lets us bound the read cost — a
+    //      single `.collect()` on a heavy user could blow Convex limits.
+    //
+    // Pages come ordered by _creationTime desc, which is ≈ prayedAt desc.
+    // We collect candidates community-by-community until we have `limit`
+    // visible items, then sort by prayedAt for the final ordering.
+    const PAGE_SIZE = 100;
+    const MAX_PAGES = 10; // safety cap: 1000 candidates max per call
     const visible: Array<{ response: Doc<"prayerResponses">; prayer: Doc<"prayers"> }> = [];
-    for (const r of responses) {
-      if (visible.length >= limit) break;
-      const prayer = await ctx.db.get(r.prayerId);
-      if (!prayer) continue;
-      if (prayer.moderationStatus === "rejected") continue;
-      visible.push({ response: r, prayer });
+    let cursor: string | null = null;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const result = await ctx.db
+        .query("prayerResponses")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .order("desc")
+        .paginate({ numItems: PAGE_SIZE, cursor });
+      for (const r of result.page) {
+        const prayer = await ctx.db.get(r.prayerId);
+        if (!prayer) continue;
+        if (prayer.communityId !== args.communityId) continue;
+        if (prayer.moderationStatus === "rejected") continue;
+        visible.push({ response: r, prayer });
+        if (visible.length >= limit) break;
+      }
+      if (visible.length >= limit || result.isDone) break;
+      cursor = result.continueCursor;
     }
+    visible.sort((a, b) => b.response.prayedAt - a.response.prayedAt);
 
     return Promise.all(
       visible.map(async ({ response: r, prayer }) => {

--- a/apps/mobile/app/(user)/prayed-for/[prayerId].tsx
+++ b/apps/mobile/app/(user)/prayed-for/[prayerId].tsx
@@ -1,0 +1,5 @@
+import { PrayedPrayerDetailScreen } from '@features/prayer/components/PrayedPrayerDetailScreen';
+
+export default function PrayedPrayerDetailRoute() {
+  return <PrayedPrayerDetailScreen />;
+}

--- a/apps/mobile/app/(user)/prayed-for/index.tsx
+++ b/apps/mobile/app/(user)/prayed-for/index.tsx
@@ -1,0 +1,5 @@
+import { PrayedHistoryScreen } from '@features/prayer/components/PrayedHistoryScreen';
+
+export default function PrayedHistoryRoute() {
+  return <PrayedHistoryScreen />;
+}

--- a/apps/mobile/features/prayer/components/PrayedCard.tsx
+++ b/apps/mobile/features/prayer/components/PrayedCard.tsx
@@ -1,0 +1,195 @@
+/**
+ * PrayedCard — visual card for a prayer the user has already prayed for.
+ * Used in the horizontal rail under the feed (variant="rail") and in the
+ * full history list screen (variant="list").
+ *
+ * Anonymity contract: avatar shows eye-off icon when authorDisplayName is
+ * null. Same deterministic-color initials avatar pattern as the main feed
+ * card.
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+
+const COMPLETED_GREEN = '#34C759';
+
+const AVATAR_COLORS = [
+  '#FFB4A2', '#FFD6A5', '#FDFFB6', '#CAFFBF',
+  '#9BF6FF', '#A0C4FF', '#BDB2FF', '#FFC6FF',
+];
+
+function hashToIndex(input: string, mod: number): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) & 0xffffffff;
+  return Math.abs(h) % mod;
+}
+
+function avatarBgFor(name: string): string {
+  return AVATAR_COLORS[hashToIndex(name, AVATAR_COLORS.length)];
+}
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 1).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function relativeTime(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const min = Math.round(diffMs / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.round(hr / 24);
+  if (d < 7) return `${d}d ago`;
+  const w = Math.round(d / 7);
+  if (w < 5) return `${w}w ago`;
+  const mo = Math.round(d / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.round(d / 365)}y ago`;
+}
+
+export interface PrayedPrayerSummary {
+  id: string;
+  bodyText: string;
+  status: 'active' | 'answered' | 'archived';
+  authorDisplayName: string | null;
+  prayedAt: number;
+  hasNewUpdate: boolean;
+  crisisFlag: boolean;
+}
+
+export function PrayedCard({
+  prayer,
+  onPress,
+  variant,
+}: {
+  prayer: PrayedPrayerSummary;
+  onPress: () => void;
+  variant: 'rail' | 'list';
+}) {
+  const { colors } = useTheme();
+
+  const isAnonymous = prayer.authorDisplayName == null;
+  const authorLabel = prayer.authorDisplayName ?? 'Anonymous';
+  const avatarBg = isAnonymous ? '#E5E5EA' : avatarBgFor(authorLabel);
+  const avatarInitials = isAnonymous ? '?' : initialsOf(authorLabel);
+
+  const isRail = variant === 'rail';
+
+  return (
+    <TouchableOpacity
+      style={[
+        isRail ? styles.cardRail : styles.cardList,
+        { backgroundColor: colors.surface, borderColor: colors.border },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.85}
+    >
+      <View style={styles.headerRow}>
+        <View style={[styles.avatar, { backgroundColor: avatarBg }]}>
+          {isAnonymous ? (
+            <Ionicons name="eye-off-outline" size={14} color="#5C5C66" />
+          ) : (
+            <Text style={styles.avatarText}>{avatarInitials}</Text>
+          )}
+        </View>
+        <View style={styles.headerText}>
+          <Text
+            style={[styles.author, { color: colors.text }]}
+            numberOfLines={1}
+          >
+            {authorLabel}
+          </Text>
+          <Text style={[styles.meta, { color: colors.textTertiary }]} numberOfLines={1}>
+            You prayed {relativeTime(prayer.prayedAt)}
+          </Text>
+        </View>
+        {prayer.hasNewUpdate ? (
+          <View style={[styles.updateDot, { backgroundColor: COMPLETED_GREEN }]} />
+        ) : null}
+      </View>
+
+      <Text
+        style={[styles.body, { color: colors.text }]}
+        numberOfLines={isRail ? 3 : 4}
+      >
+        {prayer.bodyText}
+      </Text>
+
+      {prayer.status !== 'active' ? (
+        <View style={styles.statusRow}>
+          {prayer.status === 'answered' ? (
+            <View style={[styles.statusBadge, { backgroundColor: COMPLETED_GREEN }]}>
+              <Ionicons name="checkmark" size={11} color="#fff" />
+              <Text style={styles.statusBadgeText}>Answered</Text>
+            </View>
+          ) : (
+            <View style={[styles.statusBadge, { backgroundColor: colors.textTertiary }]}>
+              <Text style={styles.statusBadgeText}>Archived</Text>
+            </View>
+          )}
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  cardRail: {
+    width: 240,
+    minHeight: 140,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 12,
+  },
+  cardList: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 14,
+    marginBottom: 10,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+  },
+  avatar: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: { fontSize: 11, fontWeight: '700', color: '#3A3A3F' },
+  headerText: { flex: 1, minWidth: 0 },
+  author: { fontSize: 13, fontWeight: '700' },
+  meta: { fontSize: 11, marginTop: 1 },
+  updateDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  body: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    marginTop: 8,
+  },
+  statusBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  statusBadgeText: { color: '#fff', fontSize: 10, fontWeight: '600' },
+});

--- a/apps/mobile/features/prayer/components/PrayedHistoryScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayedHistoryScreen.tsx
@@ -1,0 +1,88 @@
+/**
+ * PrayedHistoryScreen — full vertical list of every prayer the user has
+ * prayed for in the current community. Reached via "See all" in the rail
+ * under the prayer feed.
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  ActivityIndicator,
+} from 'react-native';
+import { useRouter, Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useAuth } from '@providers/AuthProvider';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedQuery, api } from '@services/api/convex';
+import type { Id } from '@services/api/convex';
+import { PrayedCard } from './PrayedCard';
+
+const FULL_LIMIT = 200;
+
+export function PrayedHistoryScreen() {
+  const router = useRouter();
+  const { community } = useAuth();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const items = useAuthenticatedQuery(
+    api.functions.prayers.myPrayedFor,
+    community?.id
+      ? { communityId: community.id as Id<'communities'>, limit: FULL_LIMIT }
+      : 'skip',
+  );
+
+  const isLoading = items === undefined && !!community?.id;
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+      <Stack.Screen options={{ title: "Prayers you've prayed", headerShown: true }} />
+      {isLoading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color={primaryColor} />
+        </View>
+      ) : !items || items.length === 0 ? (
+        <View style={styles.center}>
+          <Ionicons name="heart-outline" size={36} color={colors.iconSecondary} />
+          <Text style={[styles.emptyTitle, { color: colors.text }]}>Nothing here yet</Text>
+          <Text style={[styles.emptyBody, { color: colors.textSecondary }]}>
+            Prayers you pray for in your community will show up here so you can revisit them.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={(p) => p.id}
+          contentContainerStyle={styles.listContent}
+          renderItem={({ item }) => (
+            <PrayedCard
+              prayer={item}
+              onPress={() => router.push(`/(user)/prayed-for/${item.id}`)}
+              variant="list"
+            />
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 36,
+  },
+  emptyTitle: { fontSize: 18, fontWeight: '600', marginTop: 14, marginBottom: 8 },
+  emptyBody: { fontSize: 15, textAlign: 'center', lineHeight: 22 },
+  listContent: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+});

--- a/apps/mobile/features/prayer/components/PrayedPrayerDetailScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayedPrayerDetailScreen.tsx
@@ -1,0 +1,217 @@
+/**
+ * PrayedPrayerDetailScreen — read-only view of a prayer the user has
+ * prayed for. Shows the prayer body and any author follow-ups (updates +
+ * praise reports). No composer or lifecycle actions — that's the author's
+ * MyPrayerDetailScreen.
+ *
+ * `getDetail` already gates access: returns null if the caller is neither
+ * the author nor has a prayerResponses row, so this screen renders an
+ * empty state safely if they shouldn't be here.
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useLocalSearchParams, Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedQuery, api } from '@services/api/convex';
+import type { Id } from '@services/api/convex';
+import { CrisisResourceCard } from './CrisisResourceCard';
+
+const COMPLETED_GREEN = '#34C759';
+
+export function PrayedPrayerDetailScreen() {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const params = useLocalSearchParams<{ prayerId: string }>();
+  const prayerId = params.prayerId as Id<'prayers'> | undefined;
+
+  const detail = useAuthenticatedQuery(
+    api.functions.prayers.getDetail,
+    prayerId ? { prayerId } : 'skip',
+  );
+
+  if (!prayerId) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+        <Stack.Screen options={{ title: 'Prayer', headerShown: true }} />
+        <Text style={{ color: colors.text, padding: 20 }}>Missing prayer ID</Text>
+      </View>
+    );
+  }
+
+  if (detail === undefined) {
+    return (
+      <View
+        style={[
+          styles.container,
+          styles.center,
+          { backgroundColor: colors.surfaceSecondary },
+        ]}
+      >
+        <Stack.Screen options={{ title: 'Prayer', headerShown: true }} />
+        <ActivityIndicator color={primaryColor} />
+      </View>
+    );
+  }
+
+  if (detail === null) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+        <Stack.Screen options={{ title: 'Prayer', headerShown: true }} />
+        <View style={styles.center}>
+          <Text style={[styles.emptyTitle, { color: colors.text }]}>
+            This prayer is no longer available.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const authorLabel = detail.authorDisplayName ?? 'Anonymous';
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+      <Stack.Screen options={{ title: 'Prayer', headerShown: true }} />
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: 40 + insets.bottom },
+        ]}
+      >
+        {detail.crisisFlag ? <CrisisResourceCard /> : null}
+
+        <View
+          style={[
+            styles.card,
+            { backgroundColor: colors.surface, borderColor: colors.border },
+          ]}
+        >
+          <View style={styles.authorRow}>
+            <Text style={[styles.authorName, { color: colors.text }]}>{authorLabel}</Text>
+            {detail.status === 'answered' ? (
+              <View style={[styles.statusBadge, { backgroundColor: COMPLETED_GREEN }]}>
+                <Ionicons name="checkmark" size={11} color="#fff" />
+                <Text style={styles.statusBadgeText}>Answered</Text>
+              </View>
+            ) : detail.status === 'archived' ? (
+              <View style={[styles.statusBadge, { backgroundColor: colors.textTertiary }]}>
+                <Text style={styles.statusBadgeText}>Archived</Text>
+              </View>
+            ) : null}
+          </View>
+          <Text style={[styles.bodyText, { color: colors.text }]}>{detail.bodyText}</Text>
+          <View style={styles.metaRow}>
+            <Ionicons name="people-outline" size={14} color={colors.textTertiary} />
+            <Text style={[styles.metaText, { color: colors.textTertiary }]}>
+              {detail.prayedForCount}{' '}
+              {detail.prayedForCount === 1 ? 'person' : 'people'} prayed
+            </Text>
+            <Text style={[styles.metaText, { color: colors.textTertiary, marginLeft: 'auto' }]}>
+              {new Date(detail.createdAt).toLocaleDateString()}
+            </Text>
+          </View>
+        </View>
+
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Updates</Text>
+        {detail.followUps.length === 0 ? (
+          <Text style={[styles.emptyText, { color: colors.textTertiary }]}>
+            No updates yet. When {authorLabel === 'Anonymous' ? 'the author' : authorLabel} shares an update or a praise report, it'll show here.
+          </Text>
+        ) : (
+          detail.followUps.map((f) => (
+            <View
+              key={f.id}
+              style={[
+                styles.followUp,
+                { backgroundColor: colors.surface, borderColor: colors.border },
+              ]}
+            >
+              <View style={styles.followUpHeader}>
+                <View
+                  style={[
+                    styles.followUpBadge,
+                    {
+                      backgroundColor:
+                        f.kind === 'praise_report' ? COMPLETED_GREEN : colors.textTertiary,
+                    },
+                  ]}
+                >
+                  <Text style={styles.followUpBadgeText}>
+                    {f.kind === 'praise_report' ? 'Praise report' : 'Update'}
+                  </Text>
+                </View>
+                <Text style={[styles.followUpDate, { color: colors.textTertiary }]}>
+                  {new Date(f.createdAt).toLocaleDateString()}
+                </Text>
+              </View>
+              <Text style={[styles.followUpBody, { color: colors.text }]}>{f.bodyText}</Text>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  emptyTitle: { fontSize: 16, fontWeight: '600', textAlign: 'center' },
+  scrollContent: { padding: 16 },
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    marginBottom: 16,
+  },
+  authorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 10,
+  },
+  authorName: { fontSize: 15, fontWeight: '700' },
+  bodyText: { fontSize: 16, lineHeight: 22, marginBottom: 12 },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  metaText: { fontSize: 13 },
+  sectionTitle: { fontSize: 16, fontWeight: '600', marginTop: 4, marginBottom: 10 },
+  emptyText: { fontSize: 14, lineHeight: 20 },
+  followUp: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 12,
+    marginBottom: 10,
+  },
+  followUpHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  followUpBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  followUpBadgeText: { color: '#fff', fontSize: 11, fontWeight: '600' },
+  followUpDate: { fontSize: 12, marginLeft: 'auto' },
+  followUpBody: { fontSize: 14, lineHeight: 19 },
+  statusBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+  },
+  statusBadgeText: { color: '#fff', fontSize: 11, fontWeight: '600' },
+});

--- a/apps/mobile/features/prayer/components/PrayedPrayerRail.tsx
+++ b/apps/mobile/features/prayer/components/PrayedPrayerRail.tsx
@@ -1,0 +1,91 @@
+/**
+ * PrayedPrayerRail — horizontal strip of prayers the user has prayed for,
+ * shown under the main feed card on the Prayer tab.
+ *
+ * Once you've prayed, the request leaves the feed forever — but that meant
+ * you couldn't come back to it later to follow up or see if the author
+ * posted an update. The rail keeps those prayers in reach without
+ * cluttering the focused single-card feed.
+ *
+ * A small dot on a card indicates the author has posted a follow-up since
+ * the user prayed.
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useAuthenticatedQuery, api } from '@services/api/convex';
+import type { Id } from '@services/api/convex';
+import { PrayedCard } from './PrayedCard';
+
+const RAIL_LIMIT = 10;
+
+export function PrayedPrayerRail({ communityId }: { communityId: Id<'communities'> }) {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const items = useAuthenticatedQuery(
+    api.functions.prayers.myPrayedFor,
+    { communityId, limit: RAIL_LIMIT },
+  );
+
+  if (!items || items.length === 0) return null;
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.headerRow}>
+        <Text style={[styles.title, { color: colors.text }]}>Prayers you've prayed</Text>
+        <TouchableOpacity
+          onPress={() => router.push('/(user)/prayed-for')}
+          hitSlop={8}
+          accessibilityLabel="See all prayers you've prayed for"
+        >
+          <Text style={[styles.seeAll, { color: primaryColor }]}>See all</Text>
+        </TouchableOpacity>
+      </View>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+      >
+        {items.map((p) => (
+          <PrayedCard
+            key={p.id}
+            prayer={p}
+            onPress={() => router.push(`/(user)/prayed-for/${p.id}`)}
+            variant="rail"
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginTop: 4,
+    paddingBottom: 8,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    marginBottom: 10,
+  },
+  title: { fontSize: 14, fontWeight: '700' },
+  seeAll: { fontSize: 13, fontWeight: '600' },
+  scrollContent: {
+    paddingHorizontal: 16,
+    gap: 10,
+  },
+});

--- a/apps/mobile/features/prayer/components/PrayerScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayerScreen.tsx
@@ -38,6 +38,7 @@ import { PraySession } from './PraySession';
 import { AddPrayerSheet } from './AddPrayerSheet';
 import { CrisisResourceCard } from './CrisisResourceCard';
 import { ReportPrayerSheet } from './ReportPrayerSheet';
+import { PrayedPrayerRail } from './PrayedPrayerRail';
 import type { PrayerCardData } from './PrayerCard';
 
 const SESSION_TARGET = 3;
@@ -340,6 +341,10 @@ export function PrayerScreen() {
       ) : null}
 
       <View style={styles.heroFill}>{hero}</View>
+
+      {community?.id ? (
+        <PrayedPrayerRail communityId={community.id as Id<'communities'>} />
+      ) : null}
 
       <PraySession
         prayer={current ?? null}


### PR DESCRIPTION
## Summary

Prayed-for prayers disappear from the feed forever the moment a user prays, so members couldn't come back to remember who they prayed for or see if the author shared an update. This adds a way to keep those prayers in reach without cluttering the focused single-card feed.

- **Horizontal "Prayers you've prayed" rail** under the main feed card showing the 10 most-recent prayed prayers, with a "See all" link to a full history screen.
- **Read-only detail view** that surfaces any follow-ups the author posted since the user prayed — with a green dot indicator on rail/list cards when new content exists.
- **New `myPrayedFor` query**: newest-first, scoped to community, filters out any prayer later rejected by an admin so retroactively-removed content doesn't linger in user history. Anonymity contract preserved (no author fetch for anonymous prayers).

## Notes

- Read-only detail screen reuses the existing `getDetail` access gate (caller must be author OR have prayed for it).
- New routes: `/(user)/prayed-for` (full list) and `/(user)/prayed-for/[prayerId]` (detail).
- The "new update" dot doesn't auto-clear on view — it persists while `followUp.createdAt > prayedAt`. If we want it to dim after open, that's a small follow-up (add `lastViewedAt` on `prayerResponses` + a `markPrayerViewed` mutation).

## Test plan

- [ ] Pray for a request, confirm it leaves the feed and appears in the rail.
- [ ] Tap a rail card → opens read-only detail; verify body and any follow-ups render.
- [ ] As the prayer author, post an update; verify the rail card shows a green dot for users who prayed before it.
- [ ] Tap "See all" → confirms full history list renders with same card style.
- [ ] Anonymous prayers show eye-off icon + "Anonymous" everywhere, no author name leaks.
- [ ] If an admin upholds a report (rejected status) after someone prayed, the prayer is removed from that user's history.
- [ ] Empty state: a user who hasn't prayed for anything sees no rail and an empty-state screen on "See all".

https://claude.ai/code/session_01V67AqWm2tqbFHhGoH3JGdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01V67AqWm2tqbFHhGoH3JGdP)_