### PR TITLE
fix(chat): use surrogate-safe slicing for message previews

### DIFF
--- a/apps/convex/__tests__/messaging/messagePreview.test.ts
+++ b/apps/convex/__tests__/messaging/messagePreview.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { generateMessagePreview } from "../../functions/messaging/messages";
+
+/**
+ * Regression: a paste that landed a non-BMP emoji's surrogate pair at the
+ * 100-unit slice boundary used to produce a `lastMessagePreview` ending in a
+ * lone high surrogate. Writing that string to the DB threw an unclassified
+ * error, leaving the optimistic message stuck on "Tap to retry" in chat.
+ */
+describe("generateMessagePreview surrogate safety", () => {
+  function hasLoneSurrogate(s: string): boolean {
+    for (let i = 0; i < s.length; i++) {
+      const c = s.charCodeAt(i);
+      if (c >= 0xd800 && c <= 0xdbff) {
+        const next = s.charCodeAt(i + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+        i++;
+      } else if (c >= 0xdc00 && c <= 0xdfff) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  test("does not leave a lone surrogate when emoji straddles the 100-unit boundary", () => {
+    const content =
+      "🎉 Dinner Party May 27\n🚨Note: Location Change!\n📍Meeting Place: Prospect Park\n⏰Meeting Time: 7PM\n\n🍽️ MENU: Bring your own!";
+    const preview = generateMessagePreview({ content });
+    expect(hasLoneSurrogate(preview)).toBe(false);
+    expect(() => JSON.parse(JSON.stringify({ preview }))).not.toThrow();
+  });
+
+  test("preview round-trips through JSON for emoji-at-boundary content", () => {
+    const content = "A".repeat(99) + "🍽️ rest";
+    const preview = generateMessagePreview({ content });
+    const round = JSON.parse(JSON.stringify({ preview }));
+    expect(round.preview).toBe(preview);
+    expect(hasLoneSurrogate(preview)).toBe(false);
+  });
+
+  test("preview for image+text caption stays surrogate-safe", () => {
+    const content = "A".repeat(99) + "🎂 cake";
+    const preview = generateMessagePreview({
+      content,
+      attachments: [{ type: "image", url: "https://example.com/x.jpg" }],
+    });
+    expect(hasLoneSurrogate(preview)).toBe(false);
+  });
+
+  test("short text content passes through unchanged", () => {
+    expect(generateMessagePreview({ content: "Hello!" })).toBe("Hello!");
+  });
+
+  test("attachment-only messages still use canned previews", () => {
+    expect(
+      generateMessagePreview({
+        content: "",
+        attachments: [{ type: "image", url: "https://example.com/x.jpg" }],
+      }),
+    ).toBe("Sent a photo");
+  });
+});

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -15,6 +15,7 @@ import type { ActionCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { getChannelSlug } from "../../lib/slugs";
+import { safeSliceForJson } from "../../lib/utils";
 import { notifyBatch } from "../../lib/notifications/send";
 import { chatRequestEmail } from "../../lib/notifications/emailTemplates";
 
@@ -47,7 +48,7 @@ export const onMessageSent = internalMutation({
 
     // Generate preview for notifications (but don't update channel - sendMessage already does it
     // with smart previews like "Sent a photo" or "Sent X files")
-    const preview = message.content.slice(0, MAX_PREVIEW_LENGTH);
+    const preview = safeSliceForJson(message.content, MAX_PREVIEW_LENGTH);
 
     // Get all channel members (except sender if there is one)
     // For bot messages (no sender), all non-muted members are included
@@ -404,10 +405,12 @@ export const sendMessageNotifications = internalAction({
 
 /**
  * Truncate a string to `max` chars, suffixing "…" if truncation occurred.
+ * Uses surrogate-safe slicing so emoji at the cut boundary don't leave a
+ * lone surrogate that breaks downstream JSON serialization.
  */
 function truncateForBody(text: string, max: number): string {
   if (text.length <= max) return text;
-  return text.slice(0, Math.max(0, max - 1)) + "…";
+  return safeSliceForJson(text, Math.max(0, max - 1)) + "…";
 }
 
 /**

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -17,7 +17,7 @@ import {
   channelEffectiveEnabledForGroup,
   isLeaderRole,
 } from "../../lib/helpers";
-import { getDisplayName, getMediaUrl } from "../../lib/utils";
+import { getDisplayName, getMediaUrl, safeSliceForJson } from "../../lib/utils";
 import { isCommunityAdmin } from "../../lib/permissions";
 import {
   getHostUserIds,
@@ -176,7 +176,7 @@ export function generateMessagePreview(message: MessageForPreview): string {
 
     if (imageCount > 0 && content.trim()) {
       // Has both images and text - show text
-      return content.slice(0, MAX_PREVIEW_LENGTH);
+      return safeSliceForJson(content, MAX_PREVIEW_LENGTH);
     } else if (imageCount > 0) {
       // Only images
       return imageCount === 1 ? "Sent a photo" : `Sent ${imageCount} photos`;
@@ -190,25 +190,25 @@ export function generateMessagePreview(message: MessageForPreview): string {
       // Documents and other files
       return fileCount === 1 ? "Sent a file" : `Sent ${fileCount} files`;
     } else {
-      return content.slice(0, MAX_PREVIEW_LENGTH);
+      return safeSliceForJson(content, MAX_PREVIEW_LENGTH);
     }
   } else if (DOMAIN_CONFIG.eventLinkRegexSingle().test(content)) {
     // Event link shared
     return content.trim() === content.match(DOMAIN_CONFIG.eventLinkRegexSingle())?.[0]
       ? "Shared an event"
-      : content.slice(0, MAX_PREVIEW_LENGTH);
+      : safeSliceForJson(content, MAX_PREVIEW_LENGTH);
   } else if (DOMAIN_CONFIG.toolLinkRegexSingle().test(content)) {
     // Tool link shared (Run Sheet, Resource)
     return content.trim() === content.match(DOMAIN_CONFIG.toolLinkRegexSingle())?.[0]
       ? "Shared a tool"
-      : content.slice(0, MAX_PREVIEW_LENGTH);
+      : safeSliceForJson(content, MAX_PREVIEW_LENGTH);
   } else if (DOMAIN_CONFIG.groupLinkRegexSingle().test(content)) {
     // Group link shared
     return content.trim() === content.match(DOMAIN_CONFIG.groupLinkRegexSingle())?.[0]
       ? "Shared a group"
-      : content.slice(0, MAX_PREVIEW_LENGTH);
+      : safeSliceForJson(content, MAX_PREVIEW_LENGTH);
   } else {
-    return content.slice(0, MAX_PREVIEW_LENGTH);
+    return safeSliceForJson(content, MAX_PREVIEW_LENGTH);
   }
 }
 
@@ -1089,7 +1089,7 @@ export const sendSystemMessage = internalMutation({
     // Update channel metadata
     await ctx.db.patch(args.channelId, {
       lastMessageAt: now,
-      lastMessagePreview: args.content.substring(0, MAX_PREVIEW_LENGTH),
+      lastMessagePreview: safeSliceForJson(args.content, MAX_PREVIEW_LENGTH),
       updatedAt: now,
     });
 

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -24,7 +24,7 @@ import {
   isCustomChannel,
   isLeaderRole,
 } from "../../lib/helpers";
-import { getDisplayName, getMediaUrl } from "../../lib/utils";
+import { getDisplayName, getMediaUrl, safeSliceForJson } from "../../lib/utils";
 import { canAccessEventChannel } from "./eventChat";
 import { generateMessagePreview } from "./messages";
 import { checkRateLimit } from "../../lib/rateLimit";
@@ -305,7 +305,7 @@ export const createPoll = mutation({
     const previewBase = `📊 ${trimmedQuestion}`;
     const preview =
       previewBase.length > 100
-        ? previewBase.slice(0, 97) + "…"
+        ? safeSliceForJson(previewBase, 97) + "…"
         : previewBase;
     await ctx.db.patch(args.channelId, {
       lastMessageAt: now,
@@ -625,7 +625,7 @@ export const editPoll = mutation({
       ) {
         const previewBase = `📊 ${newQuestion.trim()}`;
         const preview =
-          previewBase.length > 100 ? previewBase.slice(0, 97) + "…" : previewBase;
+          previewBase.length > 100 ? safeSliceForJson(previewBase, 97) + "…" : previewBase;
         await ctx.db.patch(poll.channelId, {
           lastMessagePreview: preview,
           updatedAt: now,

--- a/apps/convex/functions/messaging/reachOut.ts
+++ b/apps/convex/functions/messaging/reachOut.ts
@@ -11,7 +11,7 @@ import { query, mutation } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
-import { getDisplayName, getMediaUrl } from "../../lib/utils";
+import { getDisplayName, getMediaUrl, safeSliceForJson } from "../../lib/utils";
 import { isLeaderRole, isActiveMembership } from "../../lib/helpers";
 
 type ReachOutMemberStatus = "pending" | "assigned" | "resolved" | "revoked";
@@ -138,7 +138,7 @@ export const submitTaskRequest = mutation({
       },
     );
 
-    const preview = content.length > 100 ? content.substring(0, 97) + "..." : content;
+    const preview = content.length > 100 ? safeSliceForJson(content, 97) + "..." : content;
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: leadersChannel._id,
       senderId: userId,
@@ -168,7 +168,7 @@ export const submitTaskRequest = mutation({
       groupMemberId: membership._id,
       createdById: userId,
       type: "reach_out",
-      content: `Reach out: ${content.substring(0, 100)}`,
+      content: `Reach out: ${safeSliceForJson(content, 100)}`,
       createdAt: now,
     });
 
@@ -511,7 +511,7 @@ export const submitRequest = mutation({
     );
 
     // Post a card message to the leaders channel
-    const preview = content.length > 100 ? content.substring(0, 97) + "..." : content;
+    const preview = content.length > 100 ? safeSliceForJson(content, 97) + "..." : content;
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: leadersChannel._id,
       senderId: userId,
@@ -547,7 +547,7 @@ export const submitRequest = mutation({
       groupMemberId: membership._id,
       createdById: userId,
       type: "reach_out",
-      content: `Reach out: ${content.substring(0, 100)}`,
+      content: `Reach out: ${safeSliceForJson(content, 100)}`,
       reachOutRequestId: requestId,
       createdAt: now,
     });


### PR DESCRIPTION
## Summary

Fixes a chat send failure where pasting certain emoji-containing messages produced a "Tap to retry" error with no surfaced reason.

### The bug

When a message's 100th UTF-16 code unit lands inside a non-BMP emoji's surrogate pair, `generateMessagePreview` would slice through the pair and leave a lone high surrogate at the end of `lastMessagePreview`. Writing that malformed string to the DB raised an unclassified error (the same "unexpected end of hex escape" failure mode the codebase already has a regression test for in `__tests__/utils-safeSliceForJson.test.ts:46`). Because the error doesn't match any pattern in `apps/mobile/features/chat/utils/chatSendErrors.ts`, it fell into the `unknown` (hard-fail) bucket and the optimistic message got stuck on "Tap to retry".

Concretely, this paste hit it because slicing at unit 100 landed mid-🍽 (U+1F37D):

```
🎉 Dinner Party May 27\n🚨Note: Location Change!\n📍Meeting Place: Prospect Park\n⏰Meeting Time: 7PM\n\n🍽…
                                                                                                  ^ unit 99 = lone 0xD83C
```

### The fix

Route every preview-style truncation in the messaging functions through the existing `safeSliceForJson` helper (`apps/convex/lib/utils.ts:94`) — introduced for the same class of bug in user notes but never applied here. Replaces seven naive `.slice(0, MAX_PREVIEW_LENGTH)` / `.substring(0, 97)` call sites across:

- `functions/messaging/messages.ts` (`generateMessagePreview` × 6, `sendSystemMessage`'s preview write)
- `functions/messaging/events.ts` (`onMessageSent` preview, `truncateForBody` notification helper)
- `functions/messaging/polls.ts` (poll preview in `createPoll` and `editPoll`)
- `functions/messaging/reachOut.ts` (task-card preview and follow-up content in both submit paths)

## Test plan

- [x] New regression test `__tests__/messaging/messagePreview.test.ts` covering emoji at the slice boundary, JSON round-trip, image+caption path, and short-content passthrough — 5 tests pass
- [x] Existing `__tests__/utils-safeSliceForJson.test.ts` still passes — 7 tests
- [x] Full `__tests__/messaging/` suite passes — 414 tests across 17 files
- [x] Type check clean (only pre-existing `@togather/shared/config` module-resolution errors in the sandbox, unrelated)
- [ ] Manual: paste the original failing message into a chat and confirm it sends

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAAWKZTUS7Lf3op4bWTTTk)_