### PR TITLE
feat(prayer): comprehensive notifications + user controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ When testing the app (Playwright, iOS Simulator, etc.), use the seeded test cred
 - **Always create a PR** - Even for small changes
 - PRs require passing CI and **all conversations resolved** before merge
 - The workflow is: `feature branch` -> PR -> `main`
+- **Code review is by @codex** — after opening a PR, post a `@codex please review` comment to trigger the review. The review doesn't run automatically.
 
 ## Code Philosophy
 

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -120,6 +120,7 @@ import type * as functions_pcoServices_servingHistory from "../functions/pcoServ
 import type * as functions_peopleSavedViews from "../functions/peopleSavedViews.js";
 import type * as functions_posters from "../functions/posters.js";
 import type * as functions_prayers from "../functions/prayers.js";
+import type * as functions_prayers_notifications from "../functions/prayers/notifications.js";
 import type * as functions_proposals from "../functions/proposals.js";
 import type * as functions_resources from "../functions/resources.js";
 import type * as functions_scheduledJobs from "../functions/scheduledJobs.js";
@@ -313,6 +314,7 @@ declare const fullApi: ApiFromModules<{
   "functions/peopleSavedViews": typeof functions_peopleSavedViews;
   "functions/posters": typeof functions_posters;
   "functions/prayers": typeof functions_prayers;
+  "functions/prayers/notifications": typeof functions_prayers_notifications;
   "functions/proposals": typeof functions_proposals;
   "functions/resources": typeof functions_resources;
   "functions/scheduledJobs": typeof functions_scheduledJobs;

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -235,4 +235,46 @@ crons.daily(
   {}
 );
 
+// =============================================================================
+// PRAYER DAILY DIGEST
+// =============================================================================
+// Runs daily at 14:00 UTC (9am ET / 6am PT). For each prayer-enabled
+// community, sends one push to eligible members summarizing how many new
+// approved prayers landed in the last 24 hours.
+
+crons.daily(
+  "prayer-daily-digest",
+  { hourUTC: 14, minuteUTC: 0 },
+  internal.functions.prayers.notifications.cronDailyDigest,
+  {}
+);
+
+// =============================================================================
+// PRAYER MONDAY NUDGE
+// =============================================================================
+// Runs daily at 14:15 UTC; the handler bails when the UTC weekday isn't
+// Monday. Sent to community members who don't currently have an active
+// prayer, nudging them to share a request to start the week.
+
+crons.daily(
+  "prayer-monday-nudge",
+  { hourUTC: 14, minuteUTC: 15 },
+  internal.functions.prayers.notifications.cronMondayNudge,
+  {}
+);
+
+// =============================================================================
+// PRAYER UPDATE NUDGE
+// =============================================================================
+// Runs daily at 14:30 UTC. Sends a single push to authors of prayers that
+// are still `status: "active"` ~14 days after creation, asking for an
+// update or praise report. One-shot per prayer.
+
+crons.daily(
+  "prayer-update-nudge",
+  { hourUTC: 14, minuteUTC: 30 },
+  internal.functions.prayers.notifications.cronUpdateNudge,
+  {}
+);
+
 export default crons;

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -735,6 +735,7 @@ export const _applyModerationResult = internalMutation({
         : args.severity === "yellow"
           ? "pending_review"
           : "rejected";
+    const ts = now();
     await ctx.db.patch(args.prayerId, {
       moderationStatus: status,
       crisisFlag: args.crisis,
@@ -743,7 +744,10 @@ export const _applyModerationResult = internalMutation({
         category: args.category,
         note: args.note,
       },
-      updatedAt: now(),
+      // Stamped on first transition to approved so the digest cron can
+      // count "new since last digest" by publish time.
+      ...(status === "approved" ? { approvedAt: ts } : {}),
+      updatedAt: ts,
     });
 
     if (status === "pending_review") {
@@ -951,9 +955,11 @@ export const approvePending = mutation({
     if (prayer.moderationStatus !== "pending_review") {
       throw new ConvexError("prayer_not_pending");
     }
+    const ts = now();
     await ctx.db.patch(args.prayerId, {
       moderationStatus: "approved",
-      updatedAt: now(),
+      approvedAt: ts,
+      updatedAt: ts,
     });
     return { ok: true };
   },

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -790,6 +790,15 @@ export const notifyAuthor = internalAction({
       { prayerId: args.prayerId },
     );
     if (!data) return;
+    const allowed = await ctx.runQuery(
+      internal.functions.prayers.notifications._shouldSendPrayerNotification,
+      {
+        userId: data.prayer.authorUserId,
+        communityId: data.prayer.communityId,
+        notificationType: "prayer.prayed_for",
+      },
+    );
+    if (!allowed) return;
     await notify(ctx, {
       type: "prayer.prayed_for",
       userId: data.prayer.authorUserId,
@@ -831,9 +840,27 @@ export const notifyPrayedUsers = internalAction({
     const notificationType =
       followUp.kind === "praise_report" ? "prayer.praise_report" : "prayer.update";
 
+    // Filter through the per-user prefs gate before fanning out. A user who
+    // muted prayer notifications (master toggle off) or turned off this
+    // specific type should never see the push, even though they once prayed
+    // for this prayer.
+    const allowedRecipients: Id<"users">[] = [];
+    for (const userId of responderIds) {
+      const allowed = await ctx.runQuery(
+        internal.functions.prayers.notifications._shouldSendPrayerNotification,
+        {
+          userId,
+          communityId: data.prayer.communityId,
+          notificationType,
+        },
+      );
+      if (allowed) allowedRecipients.push(userId);
+    }
+    if (allowedRecipients.length === 0) return;
+
     await notifyBatch(ctx, {
       type: notificationType,
-      userIds: responderIds,
+      userIds: allowedRecipients,
       communityId: data.prayer.communityId,
       data: {
         prayerId: String(args.prayerId),

--- a/apps/convex/functions/prayers/notifications.ts
+++ b/apps/convex/functions/prayers/notifications.ts
@@ -274,18 +274,22 @@ export const _getCommunityMemberIds = internalQuery({
 });
 
 /**
- * Returns the createdAt timestamps of all currently active+approved prayers
- * in a community. Loaded once per community, then filtered per user in the
- * cron based on each user's `dailyDigestLastSentAt`.
+ * Returns the active+approved prayers in a community, with the effective
+ * "published-at" timestamp (`approvedAt`, falling back to `createdAt` for
+ * pre-migration rows). Per-user filtering happens in the cron.
  *
- * Including the full set (not capped to "last 24h") lets first-time
- * recipients get a digest that reflects ALL prayers in their community,
- * not just yesterday's. After the first send, each user's per-user cutoff
- * naturally narrows the window to "since I was last digested".
+ * Returning author id + prayer id lets the cron exclude per-recipient:
+ *   - prayers the recipient authored (they can't pray for themselves)
+ *   - prayers the recipient has already prayed for
+ * — so the digest count matches what the recipient would actually see in
+ * their feed when they tap the push.
  */
-export const _getApprovedPrayerTimestamps = internalQuery({
+export const _getApprovedPrayers = internalQuery({
   args: { communityId: v.id("communities") },
-  handler: async (ctx, args): Promise<number[]> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<Array<{ id: Id<"prayers">; authorUserId: Id<"users">; effectiveTime: number }>> => {
     const rows = await ctx.db
       .query("prayers")
       .withIndex("by_community_status_modStatus_count", (q) =>
@@ -295,7 +299,32 @@ export const _getApprovedPrayerTimestamps = internalQuery({
           .eq("moderationStatus", "approved"),
       )
       .collect();
-    return rows.map((p) => p.createdAt);
+    return rows.map((p) => ({
+      id: p._id,
+      authorUserId: p.authorUserId,
+      effectiveTime: p.approvedAt ?? p.createdAt,
+    }));
+  },
+});
+
+/**
+ * IDs of the prayers this user has already prayed for in a given community,
+ * used by the daily-digest cron to subtract them from the new-prayer count.
+ */
+export const _getUserPrayedForIds = internalQuery({
+  args: { userId: v.id("users"), communityId: v.id("communities") },
+  handler: async (ctx, args): Promise<Id<"prayers">[]> => {
+    // Use the per-user index; filter by community in memory. The
+    // `by_user_community` index exists but communityId is optional on
+    // pre-migration responses, so scanning by_user is the safer bet
+    // (matches the same approach used by `myPrayedFor`).
+    const responses = await ctx.db
+      .query("prayerResponses")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .collect();
+    return responses
+      .filter((r) => r.communityId === args.communityId)
+      .map((r) => r.prayerId);
   },
 });
 
@@ -306,8 +335,15 @@ export const _userHasActivePrayer = internalQuery({
       .query("prayers")
       .withIndex("by_author", (q) => q.eq("authorUserId", args.userId))
       .collect();
+    // Rejected prayers keep `status: "active"` (only moderationStatus
+    // changes), so without the moderation filter a user whose only
+    // submission was rejected would never get the Monday nudge until the
+    // 30-day archive cron rotated the prayer out.
     return mine.some(
-      (p) => p.communityId === args.communityId && p.status === "active",
+      (p) =>
+        p.communityId === args.communityId &&
+        p.status === "active" &&
+        p.moderationStatus !== "rejected",
     );
   },
 });
@@ -389,15 +425,18 @@ export const _markMondayNudgeSent = internalMutation({
  * pushes one notification per eligible member summarizing how many new
  * approved prayers have landed since the user's last digest.
  *
- * The cutoff is per-user: `state.dailyDigestLastSentAt`. First-time
- * recipients (no state row yet) get a digest covering every approved prayer
- * in the community — the count reflects everything they could pray for
- * right now, not just the last 24h. After that, the cutoff naturally
- * narrows to ~24h since the cron runs daily.
+ * Per-user filtering keeps the count honest: we subtract prayers the
+ * recipient authored (they can't pray for themselves) and ones they've
+ * already prayed for, so tapping the push lands on a feed that actually
+ * has that many prayers in it.
  *
- * Eligibility: master enabled, dailyDigest toggle on (default ON), and
- * today's digest hasn't already been sent (defensive — guards against the
- * cron being invoked twice).
+ * "New since" uses each prayer's `approvedAt` timestamp, not `createdAt` —
+ * a prayer held in `pending_review` across a digest boundary surfaces to
+ * members on the digest immediately after the admin approves it.
+ *
+ * First-time recipients (no state row yet) have `since = 0`, so their
+ * digest reflects every approved prayer in the community right now, not
+ * just the last 24h. After that the cutoff naturally narrows.
  */
 export const cronDailyDigest = internalAction({
   args: {},
@@ -411,11 +450,11 @@ export const cronDailyDigest = internalAction({
     );
 
     for (const community of communities) {
-      const timestamps = await ctx.runQuery(
-        internal.functions.prayers.notifications._getApprovedPrayerTimestamps,
+      const prayers = await ctx.runQuery(
+        internal.functions.prayers.notifications._getApprovedPrayers,
         { communityId: community.id },
       );
-      if (timestamps.length === 0) continue;
+      if (prayers.length === 0) continue;
 
       const memberIds = await ctx.runQuery(
         internal.functions.prayers.notifications._getCommunityMemberIds,
@@ -439,11 +478,19 @@ export const cronDailyDigest = internalAction({
         );
         if (state?.dailyDigestLastSentDateKey === dateKey) continue;
 
-        // First-ever digest for this user → since = 0 means "include
-        // every approved prayer in the community". Subsequent digests
-        // count only what's been posted since their last send.
         const since = state?.dailyDigestLastSentAt ?? 0;
-        const count = timestamps.filter((t) => t >= since).length;
+        const prayedForIds = await ctx.runQuery(
+          internal.functions.prayers.notifications._getUserPrayedForIds,
+          { userId, communityId: community.id },
+        );
+        const prayedForSet = new Set(prayedForIds.map((id) => String(id)));
+
+        const count = prayers.filter(
+          (p) =>
+            p.effectiveTime >= since &&
+            p.authorUserId !== userId &&
+            !prayedForSet.has(String(p.id)),
+        ).length;
         if (count === 0) continue;
 
         await notify(ctx, {

--- a/apps/convex/functions/prayers/notifications.ts
+++ b/apps/convex/functions/prayers/notifications.ts
@@ -1,0 +1,670 @@
+/**
+ * Prayer notifications — preferences API + cron handlers.
+ *
+ * The chokepoint is `shouldSendPrayerNotification`: every prayer notification
+ * path (existing `notifyAuthor` / `notifyPrayedUsers` in ../prayers.ts and the
+ * crons here) must consult it before calling notify(). It enforces:
+ *   - master kill switch (the bell-off toggle on the prayer page)
+ *   - per-type defaults (all ON in v1) and overrides
+ *
+ * Crons:
+ *   - cronDailyDigest:  daily 14:00 UTC. One push per community member who
+ *                       has the toggle on, counting prayers approved since
+ *                       their last digest.
+ *   - cronMondayNudge:  Monday 14:00 UTC. To users without an active prayer.
+ *   - cronUpdateNudge:  daily 14:30 UTC. To authors whose prayer is ~14 days
+ *                       old and still `status: "active"`, one-shot per prayer.
+ */
+
+import { v, ConvexError } from "convex/values";
+import {
+  query,
+  mutation,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  type QueryCtx,
+  type MutationCtx,
+} from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { now } from "../../lib/utils";
+import { notify } from "../../lib/notifications/send";
+
+// ============================================================================
+// Per-type defaults
+// ============================================================================
+
+/**
+ * Default ON/OFF for each toggleable prayer notification type. All ON in v1.
+ * Reading code applies these when the user's prefs row has `undefined` for
+ * the field — we never eagerly backfill, so flipping the default later
+ * doesn't require a migration.
+ */
+export const PRAYER_NOTIFICATION_DEFAULTS = {
+  prayedFor: true,
+  update: true,
+  praiseReport: true,
+  dailyDigest: true,
+  mondayNudge: true,
+  updateNudge: true,
+} as const;
+
+export type PrayerNotificationToggleKey = keyof typeof PRAYER_NOTIFICATION_DEFAULTS;
+
+// Maps a notification `type` string (matches definitions.ts) to its toggle key.
+const TYPE_TO_TOGGLE: Record<string, PrayerNotificationToggleKey> = {
+  "prayer.prayed_for": "prayedFor",
+  "prayer.update": "update",
+  "prayer.praise_report": "praiseReport",
+  "prayer.daily_digest": "dailyDigest",
+  "prayer.monday_nudge": "mondayNudge",
+  "prayer.update_nudge": "updateNudge",
+};
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+async function getPrefs(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+  communityId: Id<"communities">,
+): Promise<Doc<"userPrayerNotificationPreferences"> | null> {
+  return ctx.db
+    .query("userPrayerNotificationPreferences")
+    .withIndex("by_user_community", (q) =>
+      q.eq("userId", userId).eq("communityId", communityId),
+    )
+    .first();
+}
+
+/**
+ * Returns whether a given prayer notification should fire for this user.
+ * Falls back to defaults when no prefs row exists.
+ */
+export const _shouldSendPrayerNotification = internalQuery({
+  args: {
+    userId: v.id("users"),
+    communityId: v.id("communities"),
+    notificationType: v.string(),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    const toggleKey = TYPE_TO_TOGGLE[args.notificationType];
+    if (!toggleKey) {
+      // Unknown type — admin types (admin_review_needed, member_reported)
+      // are not user-toggleable; let them through.
+      return true;
+    }
+    const prefs = await getPrefs(ctx, args.userId, args.communityId);
+    if (!prefs) return PRAYER_NOTIFICATION_DEFAULTS[toggleKey];
+    if (prefs.masterEnabled === false) return false;
+    const value = prefs[toggleKey];
+    return value ?? PRAYER_NOTIFICATION_DEFAULTS[toggleKey];
+  },
+});
+
+// ============================================================================
+// Public queries + mutations (settings UI)
+// ============================================================================
+
+interface ResolvedPrefs {
+  masterEnabled: boolean;
+  prayedFor: boolean;
+  update: boolean;
+  praiseReport: boolean;
+  dailyDigest: boolean;
+  mondayNudge: boolean;
+  updateNudge: boolean;
+}
+
+function resolve(prefs: Doc<"userPrayerNotificationPreferences"> | null): ResolvedPrefs {
+  return {
+    masterEnabled: prefs?.masterEnabled ?? true,
+    prayedFor: prefs?.prayedFor ?? PRAYER_NOTIFICATION_DEFAULTS.prayedFor,
+    update: prefs?.update ?? PRAYER_NOTIFICATION_DEFAULTS.update,
+    praiseReport: prefs?.praiseReport ?? PRAYER_NOTIFICATION_DEFAULTS.praiseReport,
+    dailyDigest: prefs?.dailyDigest ?? PRAYER_NOTIFICATION_DEFAULTS.dailyDigest,
+    mondayNudge: prefs?.mondayNudge ?? PRAYER_NOTIFICATION_DEFAULTS.mondayNudge,
+    updateNudge: prefs?.updateNudge ?? PRAYER_NOTIFICATION_DEFAULTS.updateNudge,
+  };
+}
+
+/**
+ * Get the caller's prayer notification preferences for a community,
+ * with all defaults resolved. Returns null-safe defaults if no row exists.
+ */
+export const getPrayerNotificationPreferences = query({
+  args: { token: v.string(), communityId: v.id("communities") },
+  handler: async (ctx, args): Promise<ResolvedPrefs> => {
+    const userId = await requireAuth(ctx, args.token);
+    const prefs = await getPrefs(ctx, userId, args.communityId);
+    return resolve(prefs);
+  },
+});
+
+async function upsertPrefs(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+  communityId: Id<"communities">,
+  patch: Partial<Omit<Doc<"userPrayerNotificationPreferences">, "_id" | "_creationTime" | "userId" | "communityId">>,
+): Promise<void> {
+  const existing = await getPrefs(ctx, userId, communityId);
+  const ts = now();
+  if (existing) {
+    await ctx.db.patch(existing._id, { ...patch, updatedAt: ts });
+  } else {
+    await ctx.db.insert("userPrayerNotificationPreferences", {
+      userId,
+      communityId,
+      masterEnabled: patch.masterEnabled ?? true,
+      prayedFor: patch.prayedFor,
+      update: patch.update,
+      praiseReport: patch.praiseReport,
+      dailyDigest: patch.dailyDigest,
+      mondayNudge: patch.mondayNudge,
+      updateNudge: patch.updateNudge,
+      updatedAt: ts,
+    });
+  }
+}
+
+/**
+ * Flip the master kill switch. `false` silences ALL prayer notifications for
+ * this user in this community, regardless of per-type toggles. The prayer
+ * page bell icon calls this.
+ */
+export const setMasterPrayerNotifications = mutation({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    enabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await upsertPrefs(ctx, userId, args.communityId, {
+      masterEnabled: args.enabled,
+    });
+    return { ok: true };
+  },
+});
+
+/**
+ * Toggle one per-type preference. The settings sheet uses this.
+ */
+export const setPrayerNotificationToggle = mutation({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    toggle: v.union(
+      v.literal("prayedFor"),
+      v.literal("update"),
+      v.literal("praiseReport"),
+      v.literal("dailyDigest"),
+      v.literal("mondayNudge"),
+      v.literal("updateNudge"),
+    ),
+    enabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const patch: Record<string, boolean> = {};
+    patch[args.toggle] = args.enabled;
+    await upsertPrefs(
+      ctx,
+      userId,
+      args.communityId,
+      patch as Partial<Doc<"userPrayerNotificationPreferences">>,
+    );
+    return { ok: true };
+  },
+});
+
+// ============================================================================
+// Cron: Daily digest
+// ============================================================================
+
+function utcDateKey(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function isoWeekKey(ts: number): string {
+  // ISO week: Thursday-anchored. Good enough for "did we send this Monday".
+  const d = new Date(ts);
+  d.setUTCHours(0, 0, 0, 0);
+  // Move to Thursday in current week (Mon=1, Sun=0 → 4)
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, "0")}`;
+}
+
+/**
+ * Returns IDs of all communities that have the prayer feature enabled.
+ * Used to bound the cron scans.
+ */
+export const _getPrayerEnabledCommunities = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<Array<{ id: Id<"communities">; name: string }>> => {
+    // No index on churchFeatures (it's a nested object). Acceptable: this
+    // is at most ~hundreds of rows and runs once per cron tick.
+    const all = await ctx.db.query("communities").collect();
+    return all
+      .filter((c) => c.churchFeatures?.prayerEnabled === true)
+      .map((c) => ({ id: c._id, name: c.name ?? "" }));
+  },
+});
+
+export const _getCommunityMemberIds = internalQuery({
+  args: { communityId: v.id("communities") },
+  handler: async (ctx, args): Promise<Id<"users">[]> => {
+    const memberships = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .filter((q) => q.eq(q.field("status"), 1))
+      .collect();
+    return memberships.map((m) => m.userId);
+  },
+});
+
+/**
+ * Returns the createdAt timestamps of all currently active+approved prayers
+ * in a community. Loaded once per community, then filtered per user in the
+ * cron based on each user's `dailyDigestLastSentAt`.
+ *
+ * Including the full set (not capped to "last 24h") lets first-time
+ * recipients get a digest that reflects ALL prayers in their community,
+ * not just yesterday's. After the first send, each user's per-user cutoff
+ * naturally narrows the window to "since I was last digested".
+ */
+export const _getApprovedPrayerTimestamps = internalQuery({
+  args: { communityId: v.id("communities") },
+  handler: async (ctx, args): Promise<number[]> => {
+    const rows = await ctx.db
+      .query("prayers")
+      .withIndex("by_community_status_modStatus_count", (q) =>
+        q
+          .eq("communityId", args.communityId)
+          .eq("status", "active")
+          .eq("moderationStatus", "approved"),
+      )
+      .collect();
+    return rows.map((p) => p.createdAt);
+  },
+});
+
+export const _userHasActivePrayer = internalQuery({
+  args: { userId: v.id("users"), communityId: v.id("communities") },
+  handler: async (ctx, args): Promise<boolean> => {
+    const mine = await ctx.db
+      .query("prayers")
+      .withIndex("by_author", (q) => q.eq("authorUserId", args.userId))
+      .collect();
+    return mine.some(
+      (p) => p.communityId === args.communityId && p.status === "active",
+    );
+  },
+});
+
+export const _getOrInitState = internalQuery({
+  args: { userId: v.id("users"), communityId: v.id("communities") },
+  handler: async (ctx, args) => {
+    return ctx.db
+      .query("userPrayerNotificationState")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", args.userId).eq("communityId", args.communityId),
+      )
+      .first();
+  },
+});
+
+export const _markDailyDigestSent = internalMutation({
+  args: {
+    userId: v.id("users"),
+    communityId: v.id("communities"),
+    dateKey: v.string(),
+    ts: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("userPrayerNotificationState")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", args.userId).eq("communityId", args.communityId),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        dailyDigestLastSentDateKey: args.dateKey,
+        dailyDigestLastSentAt: args.ts,
+      });
+    } else {
+      await ctx.db.insert("userPrayerNotificationState", {
+        userId: args.userId,
+        communityId: args.communityId,
+        dailyDigestLastSentDateKey: args.dateKey,
+        dailyDigestLastSentAt: args.ts,
+      });
+    }
+  },
+});
+
+export const _markMondayNudgeSent = internalMutation({
+  args: {
+    userId: v.id("users"),
+    communityId: v.id("communities"),
+    weekKey: v.string(),
+    ts: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("userPrayerNotificationState")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", args.userId).eq("communityId", args.communityId),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        mondayNudgeLastSentWeekKey: args.weekKey,
+        mondayNudgeLastSentAt: args.ts,
+      });
+    } else {
+      await ctx.db.insert("userPrayerNotificationState", {
+        userId: args.userId,
+        communityId: args.communityId,
+        mondayNudgeLastSentWeekKey: args.weekKey,
+        mondayNudgeLastSentAt: args.ts,
+      });
+    }
+  },
+});
+
+/**
+ * Daily digest. Runs daily at 14:00 UTC. For each prayer-enabled community,
+ * pushes one notification per eligible member summarizing how many new
+ * approved prayers have landed since the user's last digest.
+ *
+ * The cutoff is per-user: `state.dailyDigestLastSentAt`. First-time
+ * recipients (no state row yet) get a digest covering every approved prayer
+ * in the community — the count reflects everything they could pray for
+ * right now, not just the last 24h. After that, the cutoff naturally
+ * narrows to ~24h since the cron runs daily.
+ *
+ * Eligibility: master enabled, dailyDigest toggle on (default ON), and
+ * today's digest hasn't already been sent (defensive — guards against the
+ * cron being invoked twice).
+ */
+export const cronDailyDigest = internalAction({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const ts = now();
+    const dateKey = utcDateKey(ts);
+
+    const communities = await ctx.runQuery(
+      internal.functions.prayers.notifications._getPrayerEnabledCommunities,
+      {},
+    );
+
+    for (const community of communities) {
+      const timestamps = await ctx.runQuery(
+        internal.functions.prayers.notifications._getApprovedPrayerTimestamps,
+        { communityId: community.id },
+      );
+      if (timestamps.length === 0) continue;
+
+      const memberIds = await ctx.runQuery(
+        internal.functions.prayers.notifications._getCommunityMemberIds,
+        { communityId: community.id },
+      );
+
+      for (const userId of memberIds) {
+        const allowed = await ctx.runQuery(
+          internal.functions.prayers.notifications._shouldSendPrayerNotification,
+          {
+            userId,
+            communityId: community.id,
+            notificationType: "prayer.daily_digest",
+          },
+        );
+        if (!allowed) continue;
+
+        const state = await ctx.runQuery(
+          internal.functions.prayers.notifications._getOrInitState,
+          { userId, communityId: community.id },
+        );
+        if (state?.dailyDigestLastSentDateKey === dateKey) continue;
+
+        // First-ever digest for this user → since = 0 means "include
+        // every approved prayer in the community". Subsequent digests
+        // count only what's been posted since their last send.
+        const since = state?.dailyDigestLastSentAt ?? 0;
+        const count = timestamps.filter((t) => t >= since).length;
+        if (count === 0) continue;
+
+        await notify(ctx, {
+          type: "prayer.daily_digest",
+          userId,
+          communityId: community.id,
+          data: {
+            communityId: String(community.id),
+            communityName: community.name,
+            count,
+          },
+        });
+        await ctx.runMutation(
+          internal.functions.prayers.notifications._markDailyDigestSent,
+          { userId, communityId: community.id, dateKey, ts },
+        );
+      }
+    }
+  },
+});
+
+/**
+ * Monday nudge. Runs Monday at 14:00 UTC. Sent to community members in
+ * prayer-enabled communities who do NOT currently have an active prayer.
+ *
+ * "Active" = status === "active" — answered or archived prayers don't count.
+ */
+export const cronMondayNudge = internalAction({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const ts = now();
+    const dayOfWeek = new Date(ts).getUTCDay(); // 0=Sunday, 1=Monday
+    // Defensive: the cron schedule already only runs Monday, but if anyone
+    // wires it differently in dev, skip non-Monday invocations.
+    if (dayOfWeek !== 1) return;
+    const weekKey = isoWeekKey(ts);
+
+    const communities = await ctx.runQuery(
+      internal.functions.prayers.notifications._getPrayerEnabledCommunities,
+      {},
+    );
+
+    for (const community of communities) {
+      const memberIds = await ctx.runQuery(
+        internal.functions.prayers.notifications._getCommunityMemberIds,
+        { communityId: community.id },
+      );
+
+      for (const userId of memberIds) {
+        const allowed = await ctx.runQuery(
+          internal.functions.prayers.notifications._shouldSendPrayerNotification,
+          {
+            userId,
+            communityId: community.id,
+            notificationType: "prayer.monday_nudge",
+          },
+        );
+        if (!allowed) continue;
+
+        const state = await ctx.runQuery(
+          internal.functions.prayers.notifications._getOrInitState,
+          { userId, communityId: community.id },
+        );
+        if (state?.mondayNudgeLastSentWeekKey === weekKey) continue;
+
+        const hasActive = await ctx.runQuery(
+          internal.functions.prayers.notifications._userHasActivePrayer,
+          { userId, communityId: community.id },
+        );
+        if (hasActive) continue;
+
+        await notify(ctx, {
+          type: "prayer.monday_nudge",
+          userId,
+          communityId: community.id,
+          data: {
+            communityId: String(community.id),
+            communityName: community.name,
+          },
+        });
+        await ctx.runMutation(
+          internal.functions.prayers.notifications._markMondayNudgeSent,
+          { userId, communityId: community.id, weekKey, ts },
+        );
+      }
+    }
+  },
+});
+
+// ============================================================================
+// Cron: Update nudge (T+14d to author of still-active prayers)
+// ============================================================================
+
+const UPDATE_NUDGE_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+const UPDATE_NUDGE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const UPDATE_NUDGE_EVENT_TYPE = "update_nudge_sent";
+
+/**
+ * Find prayers eligible for the update nudge: active, between 14 and 30 days
+ * old (capped so very stale prayers don't all fire at once on initial
+ * rollout), and missing a `prayerNotificationEvents` row marking the nudge
+ * as already sent.
+ *
+ * The 30-day cap also lets the existing `archiveStalePrayers` cron handle
+ * 30d+ prayers — we don't want to nudge then immediately archive.
+ */
+export const _getUpdateNudgeCandidates = internalQuery({
+  args: { now: v.number() },
+  handler: async (ctx, args) => {
+    const minCreated = args.now - UPDATE_NUDGE_MAX_AGE_MS;
+    const maxCreated = args.now - UPDATE_NUDGE_AGE_MS;
+
+    const candidates: Array<{
+      prayerId: Id<"prayers">;
+      authorUserId: Id<"users">;
+      communityId: Id<"communities">;
+    }> = [];
+
+    // No compound index covers (status, createdAt) — scan all active
+    // prayers via the existing index and filter by age. Bounded by status:
+    // active, which is small (answered/archived rotate out).
+    //
+    // We page so a community with thousands of active prayers doesn't blow
+    // the transaction limit.
+    const PAGE = 200;
+    const MAX_PAGES = 25;
+    let cursor: string | null = null;
+    for (let i = 0; i < MAX_PAGES; i++) {
+      const result = await ctx.db
+        .query("prayers")
+        .filter((q) =>
+          q.and(
+            q.eq(q.field("status"), "active"),
+            q.eq(q.field("moderationStatus"), "approved"),
+            q.lt(q.field("createdAt"), maxCreated),
+            q.gte(q.field("createdAt"), minCreated),
+          ),
+        )
+        .paginate({ numItems: PAGE, cursor });
+      for (const p of result.page) {
+        const sent = await ctx.db
+          .query("prayerNotificationEvents")
+          .withIndex("by_prayer_type", (q) =>
+            q.eq("prayerId", p._id).eq("type", UPDATE_NUDGE_EVENT_TYPE),
+          )
+          .first();
+        if (sent) continue;
+        candidates.push({
+          prayerId: p._id,
+          authorUserId: p.authorUserId,
+          communityId: p.communityId,
+        });
+      }
+      if (result.isDone) break;
+      cursor = result.continueCursor;
+    }
+    return candidates;
+  },
+});
+
+export const _markUpdateNudgeSent = internalMutation({
+  args: { prayerId: v.id("prayers"), ts: v.number() },
+  handler: async (ctx, args) => {
+    // Double-check inside the mutation in case two cron ticks raced (the
+    // cron is idempotent per prayer thanks to this guard).
+    const existing = await ctx.db
+      .query("prayerNotificationEvents")
+      .withIndex("by_prayer_type", (q) =>
+        q.eq("prayerId", args.prayerId).eq("type", UPDATE_NUDGE_EVENT_TYPE),
+      )
+      .first();
+    if (existing) return { alreadySent: true };
+    await ctx.db.insert("prayerNotificationEvents", {
+      prayerId: args.prayerId,
+      type: UPDATE_NUDGE_EVENT_TYPE,
+      sentAt: args.ts,
+    });
+    return { alreadySent: false };
+  },
+});
+
+export const cronUpdateNudge = internalAction({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const ts = now();
+    const candidates = await ctx.runQuery(
+      internal.functions.prayers.notifications._getUpdateNudgeCandidates,
+      { now: ts },
+    );
+
+    for (const c of candidates) {
+      const allowed = await ctx.runQuery(
+        internal.functions.prayers.notifications._shouldSendPrayerNotification,
+        {
+          userId: c.authorUserId,
+          communityId: c.communityId,
+          notificationType: "prayer.update_nudge",
+        },
+      );
+      if (!allowed) continue;
+
+      // Reserve before sending so a partial failure (push fails mid-fan-out)
+      // still records the attempt and we don't re-nudge tomorrow.
+      const reserve = await ctx.runMutation(
+        internal.functions.prayers.notifications._markUpdateNudgeSent,
+        { prayerId: c.prayerId, ts },
+      );
+      if (reserve.alreadySent) continue;
+
+      await notify(ctx, {
+        type: "prayer.update_nudge",
+        userId: c.authorUserId,
+        communityId: c.communityId,
+        data: {
+          prayerId: String(c.prayerId),
+          communityId: String(c.communityId),
+        },
+      });
+    }
+  },
+});
+
+// Suppress unused-import warnings for symbols the types pull in indirectly.
+void ConvexError;

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -848,6 +848,92 @@ export const prayerAdminReviewNeeded: NotificationDefinition<PrayerAdminReviewDa
   defaultChannels: ['push'],
 };
 
+interface PrayerDailyDigestData {
+  communityId: string;
+  communityName?: string;
+  count: number;
+}
+
+export const prayerDailyDigest: NotificationDefinition<PrayerDailyDigestData> = {
+  type: 'prayer.daily_digest',
+  description:
+    'Sent once per day summarizing how many new prayer requests landed in the community',
+  formatters: {
+    push: (ctx) => {
+      const { count, communityName } = ctx.data;
+      const where = communityName ? ` in ${communityName}` : '';
+      const title =
+        count === 1
+          ? `1 new prayer request${where}`
+          : `${count} new prayer requests${where}`;
+      return {
+        title,
+        body:
+          count === 1
+            ? 'Take a few minutes to pray for someone in your community.'
+            : 'Take a few minutes to lift them up.',
+        data: {
+          type: 'prayer.daily_digest',
+          communityId: ctx.data.communityId,
+          url: '/(tabs)/prayer',
+        },
+      };
+    },
+  },
+  defaultChannels: ['push'],
+};
+
+interface PrayerMondayNudgeData {
+  communityId: string;
+  communityName?: string;
+}
+
+export const prayerMondayNudge: NotificationDefinition<PrayerMondayNudgeData> = {
+  type: 'prayer.monday_nudge',
+  description:
+    "Monday-morning nudge inviting users who don't have an active prayer request to share one",
+  formatters: {
+    push: (ctx) => ({
+      title: 'Is there something on your heart?',
+      body: ctx.data.communityName
+        ? `Your community in ${ctx.data.communityName} would love to pray for you this week.`
+        : 'Your community would love to pray for you this week.',
+      data: {
+        type: 'prayer.monday_nudge',
+        communityId: ctx.data.communityId,
+        // The PrayerScreen reads this query param on mount and auto-opens
+        // the AddPrayerSheet — one-tap from notification to the compose UI.
+        url: '/(tabs)/prayer?openAdd=1',
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
+interface PrayerUpdateNudgeData {
+  prayerId: string;
+  communityId: string;
+}
+
+export const prayerUpdateNudge: NotificationDefinition<PrayerUpdateNudgeData> = {
+  type: 'prayer.update_nudge',
+  description:
+    "Sent to the author of an active prayer ~14 days after posting, encouraging an update or praise report",
+  formatters: {
+    push: (ctx) => ({
+      title: 'Any update on your prayer?',
+      body: "If God's been working, share a praise report — it encourages everyone who prayed.",
+      data: {
+        type: 'prayer.update_nudge',
+        prayerId: ctx.data.prayerId,
+        communityId: ctx.data.communityId,
+        url: `/(user)/my-prayers/${ctx.data.prayerId}`,
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
 interface PrayerMemberReportedData {
   prayerId: string;
   communityId?: string;

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2658,6 +2658,13 @@ export default defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
     archivedAt: v.optional(v.number()),
+    // When the prayer's moderationStatus most recently flipped to "approved".
+    // Used by the daily-digest cron to count "new since last digest" by
+    // publish time rather than creation time — a prayer held in
+    // pending_review across a digest boundary still surfaces to members
+    // once an admin approves it. Falls back to createdAt for any pre-
+    // migration row that has no approvedAt yet.
+    approvedAt: v.optional(v.number()),
   })
     .index("by_community", ["communityId"])
     .index("by_author", ["authorUserId"])

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2745,4 +2745,62 @@ export default defineSchema({
     .index("by_community_status", ["communityId", "status"])
     // Uniqueness check inside reportPrayer.
     .index("by_prayer_reporter", ["prayerId", "reporterUserId"]),
+
+  // =============================================================================
+  // PRAYER NOTIFICATION PREFERENCES + CRON STATE
+  // =============================================================================
+
+  /**
+   * Per-(user, community) prayer notification preferences.
+   *
+   * `masterEnabled: false` short-circuits every prayer notification path for
+   * this user — it's the bell-off toggle surfaced on the prayer page.
+   *
+   * Per-type fields are optional; `undefined` means "use the type's default"
+   * (every prayer type defaults to ON in v1). Reading code applies the
+   * default — we never write defaults eagerly so flipping the global
+   * default later doesn't require a backfill.
+   */
+  userPrayerNotificationPreferences: defineTable({
+    userId: v.id("users"),
+    communityId: v.id("communities"),
+    masterEnabled: v.boolean(),
+    prayedFor: v.optional(v.boolean()),
+    update: v.optional(v.boolean()),
+    praiseReport: v.optional(v.boolean()),
+    dailyDigest: v.optional(v.boolean()),
+    mondayNudge: v.optional(v.boolean()),
+    updateNudge: v.optional(v.boolean()),
+    updatedAt: v.number(),
+  }).index("by_user_community", ["userId", "communityId"]),
+
+  /**
+   * Per-(user, community) cron scheduling state for prayer notifications.
+   * Separated from the prefs table because it's high-write — keeping it on
+   * the prefs row would churn its `_creationTime` and invalidate any cache
+   * on every cron send.
+   *
+   * Dedup keys:
+   *   - dailyDigestLastSentDateKey: UTC YYYY-MM-DD of last digest sent
+   *   - mondayNudgeLastSentWeekKey: ISO year+week of last Monday nudge sent
+   */
+  userPrayerNotificationState: defineTable({
+    userId: v.id("users"),
+    communityId: v.id("communities"),
+    dailyDigestLastSentDateKey: v.optional(v.string()),
+    dailyDigestLastSentAt: v.optional(v.number()),
+    mondayNudgeLastSentWeekKey: v.optional(v.string()),
+    mondayNudgeLastSentAt: v.optional(v.number()),
+  }).index("by_user_community", ["userId", "communityId"]),
+
+  /**
+   * Per-prayer one-shot tracking for notification events that fire at most
+   * once per prayer (e.g. T+14d update nudge). Insertion is the "lock" —
+   * the cron looks up `by_prayer_type` before sending and inserts on send.
+   */
+  prayerNotificationEvents: defineTable({
+    prayerId: v.id("prayers"),
+    type: v.string(),
+    sentAt: v.number(),
+  }).index("by_prayer_type", ["prayerId", "type"]),
 });

--- a/apps/mobile/features/prayer/components/PrayerNotificationsSheet.tsx
+++ b/apps/mobile/features/prayer/components/PrayerNotificationsSheet.tsx
@@ -1,0 +1,228 @@
+/**
+ * PrayerNotificationsSheet — per-type prayer notification toggles.
+ *
+ * Surfaced from Settings → Notifications → "Prayer notifications" row.
+ * The prayer page itself uses a simpler bell icon + confirmation popup for
+ * the master kill switch (the most common action); this sheet is for users
+ * who want fine-grained control per notification type.
+ */
+
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Switch,
+  ScrollView,
+  Pressable,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from '@services/api/convex';
+import type { Id } from '@services/api/convex';
+
+type ToggleKey =
+  | 'prayedFor'
+  | 'update'
+  | 'praiseReport'
+  | 'dailyDigest'
+  | 'mondayNudge'
+  | 'updateNudge';
+
+type ToggleRow = {
+  key: ToggleKey;
+  label: string;
+  description: string;
+};
+
+const ROWS: ToggleRow[] = [
+  {
+    key: 'prayedFor',
+    label: 'Someone prayed for you',
+    description: 'When another member finishes praying for your request.',
+  },
+  {
+    key: 'update',
+    label: 'Prayer updates',
+    description: "Updates from someone whose prayer you've prayed for.",
+  },
+  {
+    key: 'praiseReport',
+    label: 'Praise reports',
+    description: 'When a prayer you prayed for is marked answered.',
+  },
+  {
+    key: 'dailyDigest',
+    label: 'Daily community digest',
+    description: 'A daily summary of new prayer requests in your community.',
+  },
+  {
+    key: 'mondayNudge',
+    label: 'Monday morning reminders',
+    description: 'A start-of-week nudge to share a prayer request.',
+  },
+  {
+    key: 'updateNudge',
+    label: 'Update reminders for your prayers',
+    description: 'A nudge ~2 weeks after posting to share an update.',
+  },
+];
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  communityId: Id<'communities'>;
+}
+
+export function PrayerNotificationsSheet({ visible, onClose, communityId }: Props) {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const prefs = useAuthenticatedQuery(
+    api.functions.prayers.notifications.getPrayerNotificationPreferences,
+    visible ? { communityId } : 'skip',
+  );
+  const setMaster = useAuthenticatedMutation(
+    api.functions.prayers.notifications.setMasterPrayerNotifications,
+  );
+  const setToggle = useAuthenticatedMutation(
+    api.functions.prayers.notifications.setPrayerNotificationToggle,
+  );
+
+  const masterEnabled = prefs?.masterEnabled ?? true;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}>
+        <View style={[styles.header, { paddingTop: insets.top + 8 }]}>
+          <Text style={[styles.title, { color: colors.text }]}>Prayer notifications</Text>
+          <Pressable onPress={onClose} hitSlop={12} accessibilityLabel="Close">
+            <Ionicons name="close" size={26} color={colors.iconSecondary} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+        >
+          <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+            <View style={styles.rowText}>
+              <Text style={[styles.rowLabel, { color: colors.text }]}>
+                Prayer notifications
+              </Text>
+              <Text style={[styles.rowDescription, { color: colors.textSecondary }]}>
+                When off, you won't receive any prayer-related notifications.
+              </Text>
+            </View>
+            <Switch
+              value={masterEnabled}
+              onValueChange={(value) => {
+                void setMaster({ communityId, enabled: value });
+              }}
+              trackColor={{ false: colors.border, true: primaryColor }}
+              thumbColor={colors.textInverse}
+            />
+          </View>
+
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+            Choose specific notifications
+          </Text>
+
+          <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border, padding: 0 }]}>
+            {ROWS.map((row, i) => {
+              const value = (prefs?.[row.key] ?? true) as boolean;
+              const isLast = i === ROWS.length - 1;
+              return (
+                <View
+                  key={row.key}
+                  style={[
+                    styles.toggleRow,
+                    !isLast && { borderBottomColor: colors.borderLight, borderBottomWidth: StyleSheet.hairlineWidth },
+                  ]}
+                >
+                  <View style={styles.rowText}>
+                    <Text
+                      style={[
+                        styles.rowLabel,
+                        { color: masterEnabled ? colors.text : colors.textTertiary },
+                      ]}
+                    >
+                      {row.label}
+                    </Text>
+                    <Text style={[styles.rowDescription, { color: colors.textSecondary }]}>
+                      {row.description}
+                    </Text>
+                  </View>
+                  <Switch
+                    value={masterEnabled && value}
+                    disabled={!masterEnabled}
+                    onValueChange={(next) => {
+                      void setToggle({
+                        communityId,
+                        toggle: row.key,
+                        enabled: next,
+                      });
+                    }}
+                    trackColor={{ false: colors.border, true: primaryColor }}
+                    thumbColor={colors.textInverse}
+                  />
+                </View>
+              );
+            })}
+          </View>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingBottom: 12,
+  },
+  title: { fontSize: 20, fontWeight: '700' },
+  scroll: { flex: 1 },
+  scrollContent: { padding: 16, paddingBottom: 48 },
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 24,
+    marginBottom: 8,
+    marginLeft: 4,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+  },
+  rowText: { flex: 1, marginRight: 12 },
+  rowLabel: { fontSize: 16, fontWeight: '600' },
+  rowDescription: { fontSize: 13, marginTop: 2, lineHeight: 18 },
+});

--- a/apps/mobile/features/prayer/components/PrayerScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayerScreen.tsx
@@ -18,21 +18,26 @@
  * for. See `apps/convex/functions/prayers.ts:feed`.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@providers/AuthProvider';
 import { useTheme } from '@hooks/useTheme';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
-import { useAuthenticatedQuery, api } from '@services/api/convex';
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from '@services/api/convex';
 import type { Id } from '@services/api/convex';
 import { PraySession } from './PraySession';
 import { AddPrayerSheet } from './AddPrayerSheet';
@@ -93,9 +98,22 @@ export function PrayerScreen() {
   const { community } = useAuth();
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
+  // `openAdd=1` is set by the `prayer.monday_nudge` deep link — one-tap from
+  // the notification straight into the AddPrayerSheet. We guard with a ref-
+  // style flag to ensure we only auto-open on first mount of this query
+  // param, not every time the user dismisses and the param lingers.
+  const params = useLocalSearchParams<{ openAdd?: string }>();
   const [praySessionOpen, setPraySessionOpen] = useState(false);
-  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [isAddOpen, setIsAddOpen] = useState(params.openAdd === '1');
   const [reportOpen, setReportOpen] = useState(false);
+  const [autoOpenedAdd, setAutoOpenedAdd] = useState(false);
+
+  useEffect(() => {
+    if (params.openAdd === '1' && !autoOpenedAdd) {
+      setIsAddOpen(true);
+      setAutoOpenedAdd(true);
+    }
+  }, [params.openAdd, autoOpenedAdd]);
   // Whether the user has dismissed today's "you prayed for 3" celebration.
   // Local + session-scoped: a fresh app open *does* re-show the celebration
   // if they cross 3 again, but tapping "Pray for more" hides it for the rest
@@ -114,6 +132,47 @@ export function PrayerScreen() {
       ? { communityId: community.id as Id<'communities'> }
       : 'skip',
   );
+  const prayerNotifPrefs = useAuthenticatedQuery(
+    api.functions.prayers.notifications.getPrayerNotificationPreferences,
+    community?.id
+      ? { communityId: community.id as Id<'communities'> }
+      : 'skip',
+  );
+  const setMasterPrayerNotifications = useAuthenticatedMutation(
+    api.functions.prayers.notifications.setMasterPrayerNotifications,
+  );
+  const notifsMasterEnabled = prayerNotifPrefs?.masterEnabled ?? true;
+
+  const handleToggleNotifications = useCallback(() => {
+    if (!community?.id) return;
+    if (notifsMasterEnabled) {
+      // Turning OFF — confirm because this silences everything (the user
+      // won't be reminded to pray or notified when someone prays for them).
+      Alert.alert(
+        'Turn off prayer notifications?',
+        "You won't be reminded to pray or notified when someone prays for you. You can turn this back on anytime.",
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Turn off',
+            style: 'destructive',
+            onPress: () => {
+              void setMasterPrayerNotifications({
+                communityId: community.id as Id<'communities'>,
+                enabled: false,
+              });
+            },
+          },
+        ],
+      );
+    } else {
+      // Turning ON — no confirmation needed, it's the safe direction.
+      void setMasterPrayerNotifications({
+        communityId: community.id as Id<'communities'>,
+        enabled: true,
+      });
+    }
+  }, [community?.id, notifsMasterEnabled, setMasterPrayerNotifications]);
   const todayCount = counts?.today ?? 0;
   const weekCount = counts?.week ?? 0;
 
@@ -299,6 +358,23 @@ export function PrayerScreen() {
       <View style={styles.topBar}>
         <Text style={[styles.heading, { color: colors.text }]}>Pray for your community</Text>
         <View style={styles.topRightRow}>
+          <TouchableOpacity
+            style={styles.topAction}
+            onPress={handleToggleNotifications}
+            hitSlop={8}
+            accessibilityLabel={
+              notifsMasterEnabled
+                ? 'Turn off prayer notifications'
+                : 'Turn on prayer notifications'
+            }
+            accessibilityRole="button"
+          >
+            <Ionicons
+              name={notifsMasterEnabled ? 'notifications-outline' : 'notifications-off-outline'}
+              size={22}
+              color={notifsMasterEnabled ? primaryColor : colors.iconSecondary}
+            />
+          </TouchableOpacity>
           <TouchableOpacity
             style={styles.topAction}
             onPress={() => setIsAddOpen(true)}

--- a/apps/mobile/features/settings/components/NotificationPreferencesSection.tsx
+++ b/apps/mobile/features/settings/components/NotificationPreferencesSection.tsx
@@ -15,12 +15,14 @@ import {
   TouchableOpacity,
   Alert,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useNotifications } from '@providers/NotificationProvider';
 import { useQuery, useAuthenticatedMutation, api } from '@services/api/convex';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useTheme } from '@hooks/useTheme';
 import { useAuth } from '@providers/AuthProvider';
 import { useEnableNotificationsFlow } from '@features/notifications/hooks/useEnableNotificationsFlow';
+import { PrayerNotificationsSheet } from '@features/prayer/components/PrayerNotificationsSheet';
 import type { Id } from '@services/api/convex';
 
 type GroupNotificationToggleProps = {
@@ -89,12 +91,14 @@ const GroupNotificationToggle: React.FC<GroupNotificationToggleProps> = ({
 };
 
 export const NotificationPreferencesSection: React.FC = () => {
-  const { user, token } = useAuth();
+  const { user, token, community } = useAuth();
   const { isEnabled, expoPushToken } = useNotifications();
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
   const userId = user?.id as Id<"users"> | undefined;
   const [isUpdating, setIsUpdating] = useState(false);
+  const [prayerSheetOpen, setPrayerSheetOpen] = useState(false);
+  const prayerEnabled = community?.churchFeatures?.prayerEnabled === true;
 
   // Fetch preferences using Convex
   const preferences = useQuery(
@@ -254,6 +258,34 @@ export const NotificationPreferencesSection: React.FC = () => {
         </View>
       )}
 
+      {prayerEnabled && community?.id && (
+        <>
+          <TouchableOpacity
+            style={[
+              styles.linkRow,
+              { borderTopColor: colors.borderLight, borderBottomColor: colors.borderLight },
+            ]}
+            onPress={() => setPrayerSheetOpen(true)}
+            accessibilityRole="button"
+          >
+            <View style={styles.linkRowText}>
+              <Text style={[styles.linkRowLabel, { color: colors.text }]}>
+                Prayer notifications
+              </Text>
+              <Text style={[styles.linkRowDescription, { color: colors.textSecondary }]}>
+                Per-type controls for prayer requests, digests, and reminders.
+              </Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={colors.iconSecondary} />
+          </TouchableOpacity>
+          <PrayerNotificationsSheet
+            visible={prayerSheetOpen}
+            onClose={() => setPrayerSheetOpen(false)}
+            communityId={community.id as Id<'communities'>}
+          />
+        </>
+      )}
+
       {isUpdating && (
         <View style={styles.savingIndicator}>
           <ActivityIndicator size="small" color={colors.textSecondary} />
@@ -378,4 +410,15 @@ const styles = StyleSheet.create({
     marginLeft: 8,
     fontSize: 12,
   },
+  linkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    marginTop: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  linkRowText: { flex: 1, marginRight: 12 },
+  linkRowLabel: { fontSize: 16, fontWeight: '600' },
+  linkRowDescription: { fontSize: 13, marginTop: 2 },
 });


### PR DESCRIPTION
## Summary

Turns prayer from a tap-in-app-to-see-it feature into something that reaches back out to community members — and gives users one-tap control to turn it off.

**New notification types (all push, default ON):**
- `prayer.daily_digest` — "N new prayer requests in your community" once per day. First send to a user includes every approved prayer ever posted in their community; subsequent sends use the user's own `lastSentAt` cutoff so the count is "since I last heard from you."
- `prayer.monday_nudge` — Monday morning encouragement to share a request, sent only to members who don't currently have an active prayer.
- `prayer.update_nudge` — ~14 days after a prayer is posted, ping the author to share an update or praise report. One-shot per prayer.

**User controls:**
- Bell icon on the prayer page is the master kill switch. Tap to confirm → all prayer notifications stop for that user in that community (existing `prayer.prayed_for` / `.update` / `.praise_report` types too).
- Settings → Notifications gains a "Prayer notifications" row that opens a sheet with per-type toggles for power users who want fine control instead of all-or-nothing.

The `prayer.monday_nudge` deep link includes `?openAdd=1` so tapping the push opens the AddPrayerSheet on the prayer tab in one step.

**Schema additions:**
- `userPrayerNotificationPreferences` (master + per-type, per user × community)
- `userPrayerNotificationState` (cron dedup keys + lastSentAt timestamps)
- `prayerNotificationEvents` (per-prayer one-shot tracking for update nudge)

## Test plan

- [ ] Bell icon on prayer page: ON → tap → confirmation popup → confirm → all prayer notifications suppressed
- [ ] Bell icon: OFF → tap → instantly re-enables (no confirmation)
- [ ] Master kill switch off → existing "someone prayed for you" push is suppressed
- [ ] Settings → Notifications → "Prayer notifications" opens the per-type sheet (only on prayer-enabled communities)
- [ ] Per-type toggle off → only that notification type is suppressed
- [ ] Daily digest cron (`prayer-daily-digest`) fires once per user per day; first send counts all approved prayers in their community, second send counts only those since `lastSentAt`
- [ ] Monday-nudge cron (`prayer-monday-nudge`) only sends to users without an active prayer
- [ ] Update-nudge cron (`prayer-update-nudge`) fires exactly once per prayer at T+14d
- [ ] Tapping a Monday nudge push opens `/(tabs)/prayer?openAdd=1` and the AddPrayerSheet auto-opens

https://claude.ai/code/session_01JQ2r3NXS9tHT8vNuVQnhCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ2r3NXS9tHT8vNuVQnhCn)_