### PR TITLE
Fix update banner layout push and hidden image-viewer close button

### DIFF
--- a/apps/mobile/components/ui/ImageViewer.tsx
+++ b/apps/mobile/components/ui/ImageViewer.tsx
@@ -32,17 +32,24 @@ import { useTheme } from '@hooks/useTheme';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
+// Reserved vertical space (added to safe-area insets) so the contained
+// image stays clear of the close button and the Done/Save footer buttons.
+const HEADER_HEIGHT = 60;
+const FOOTER_HEIGHT = 80;
+
 // Separate component for rendering individual images
 interface ImageSlideProps {
   imageUrl: string;
   onZoomStateChange?: (zoomed: boolean) => void;
+  topReserve: number;
+  bottomReserve: number;
 }
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 5;
 const DOUBLE_TAP_SCALE = 2.5;
 
-function ImageSlide({ imageUrl, onZoomStateChange }: ImageSlideProps) {
+function ImageSlide({ imageUrl, onZoomStateChange, topReserve, bottomReserve }: ImageSlideProps) {
   const { colors } = useTheme();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -130,7 +137,7 @@ function ImageSlide({ imageUrl, onZoomStateChange }: ImageSlideProps) {
   }));
 
   return (
-    <View style={styles.imageSlide}>
+    <View style={[styles.imageSlide, { paddingTop: topReserve, paddingBottom: bottomReserve }]}>
       {loading && (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#fff" />
@@ -275,8 +282,22 @@ export function ImageViewer({
     }
   };
 
+  // Reserve space so the contained image doesn't render behind the
+  // close button (header) or Done/Save buttons (footer). Without this,
+  // portrait images extend edge-to-edge and the close-X visually blends
+  // into the image content / iOS dynamic island area.
+  const topReserve = insets.top + HEADER_HEIGHT;
+  const bottomReserve = insets.bottom + FOOTER_HEIGHT;
+
   const renderImage = ({ item }: { item: string }) => {
-    return <ImageSlide imageUrl={item} onZoomStateChange={setIsZoomed} />;
+    return (
+      <ImageSlide
+        imageUrl={item}
+        onZoomStateChange={setIsZoomed}
+        topReserve={topReserve}
+        bottomReserve={bottomReserve}
+      />
+    );
   };
 
   const renderDotIndicators = () => {

--- a/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
+++ b/apps/mobile/components/ui/PostUpdateRecoveryBanner.tsx
@@ -28,7 +28,7 @@ import * as Updates from 'expo-updates';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const STORAGE_KEY = '@togather/last_seen_update_id';
-export const AUTO_DISMISS_MS = 60_000;
+export const AUTO_DISMISS_MS = 5_000;
 
 export function PostUpdateRecoveryBanner() {
   const [isVisible, setIsVisible] = useState(false);
@@ -123,6 +123,15 @@ export function PostUpdateRecoveryBanner() {
 
 const styles = StyleSheet.create({
   container: {
+    // Absolutely positioned so the banner overlays the screen's empty top
+    // safe-area instead of pushing every screen's content down by ~85pt
+    // for the entire time it's visible.
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1000,
+    elevation: 1000,
     flexDirection: 'row',
     alignItems: 'center',
     // paddingTop is applied inline together with the top safe-area inset.


### PR DESCRIPTION
## Summary
- Absolutely position `PostUpdateRecoveryBanner` so it overlays the empty top safe-area instead of pushing every screen's content down by ~85pt while it's visible. Cut auto-dismiss from 60s to 5s per request.
- In `ImageViewer`, reserve vertical space (safe-area inset + 60pt top / 80pt bottom) inside each slide so portrait images don't render behind the close X or Done/Save buttons.

## Test plan
- [ ] Trigger an OTA update; confirm the banner appears at the top of Inbox / chat / other screens without shifting the content below, and auto-dismisses after ~5s.
- [ ] Open a portrait image in the fullscreen viewer; confirm the close X is fully visible above the image and the Done/Save buttons are not obscured.
- [ ] Verify with multiple images (carousel) and after zooming/panning that the close button remains visible.

https://claude.ai/code/session_015xmCWfJnLdgrQZ4gVbwqfk

---
_Generated by [Claude Code](https://claude.ai/code/session_015xmCWfJnLdgrQZ4gVbwqfk)_