### PR TITLE
fix(people): Connection score 0 with recent attendance + Quick Actions UX

### DIFF
--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -2210,6 +2210,26 @@ export const addFollowup = mutation({
           content: args.content,
           createdAt: timestamp,
         });
+
+        // Recompute scores so the new (or back-dated) follow-up reflects
+        // immediately on the People view. Without this, score3 (Connection)
+        // stays stale until the next batch run.
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.followupScoreComputation.computeSingleMemberScore,
+          {
+            groupId: announcementGroup._id,
+            groupMemberId: groupMember._id,
+          },
+        );
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.communityScoreComputation.recomputeForGroupMember,
+          {
+            groupId: announcementGroup._id,
+            userId: cpRecord.userId,
+          },
+        );
       }
     }
 

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -1896,6 +1896,10 @@ export const history = query({
           } else if (v.variableId === "attended_weeks_in_window" || v.variableId === "total_weeks_in_window" || v.variableId === "meeting_weeks_in_window") {
             // For week counts, normalize relative to max window (approx 9 weeks in 60 days)
             normalizedValue = Math.min(100, Math.round((raw / 9) * 100));
+          } else if (v.variableId === "consecutive_missed") {
+            // Mirror the attendance-portion formula: 0 misses → 100%, 7+ → 0%.
+            // Bar fills from the "good" end, so more misses = shorter bar.
+            normalizedValue = Math.max(0, Math.round(100 - raw * (100 / 7)));
           }
           return {
             id: v.variableId,
@@ -2132,10 +2136,24 @@ export const addFollowup = mutation({
       v.literal("followed_up"),
     ),
     content: v.optional(v.string()),
+    // Optional back-dated timestamp for logging past contact. Must be in the past
+    // and not earlier than 1 year ago.
+    occurredAt: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
-    const timestamp = Date.now();
+    const now = Date.now();
+    let timestamp = now;
+    if (args.occurredAt !== undefined) {
+      const oneYearAgo = now - 365 * 24 * 60 * 60 * 1000;
+      if (args.occurredAt > now) {
+        throw new ConvexError("Past contact date cannot be in the future");
+      }
+      if (args.occurredAt < oneYearAgo) {
+        throw new ConvexError("Past contact date cannot be more than a year ago");
+      }
+      timestamp = args.occurredAt;
+    }
 
     const cpRecord = await ctx.db.get(args.communityPeopleId);
     if (!cpRecord) {
@@ -2144,14 +2162,22 @@ export const addFollowup = mutation({
 
     await requireCommunityLeader(ctx, cpRecord.communityId, userId);
 
-    // Update lastFollowupAt and latestNote on communityPeople when adding a note
+    // Update lastFollowupAt and latestNote on communityPeople when adding a note.
+    // For back-dated entries, only advance lastFollowupAt if it's actually newer
+    // than the existing one — a logged-past call shouldn't overwrite a fresh note.
     const patchFields: Record<string, any> = {
-      lastFollowupAt: timestamp,
-      updatedAt: timestamp,
+      updatedAt: now,
     };
+    const existingLastFollowupAt = (cpRecord as any).lastFollowupAt ?? 0;
+    if (timestamp > existingLastFollowupAt) {
+      patchFields.lastFollowupAt = timestamp;
+    }
     if (args.type === "note" && args.content) {
-      patchFields.latestNote = safeSliceForJson(args.content, 200);
-      patchFields.latestNoteAt = timestamp;
+      const existingLatestNoteAt = (cpRecord as any).latestNoteAt ?? 0;
+      if (timestamp >= existingLatestNoteAt) {
+        patchFields.latestNote = safeSliceForJson(args.content, 200);
+        patchFields.latestNoteAt = timestamp;
+      }
     }
     await ctx.db.patch(args.communityPeopleId, patchFields);
 

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -2211,25 +2211,36 @@ export const addFollowup = mutation({
           createdAt: timestamp,
         });
 
-        // Recompute scores so the new (or back-dated) follow-up reflects
+        // Recompute scores so the new (or back-dated) contact reflects
         // immediately on the People view. Without this, score3 (Connection)
         // stays stale until the next batch run.
-        await ctx.scheduler.runAfter(
-          0,
-          internal.functions.followupScoreComputation.computeSingleMemberScore,
-          {
-            groupId: announcementGroup._id,
-            groupMemberId: groupMember._id,
-          },
-        );
-        await ctx.scheduler.runAfter(
-          0,
-          internal.functions.communityScoreComputation.recomputeForGroupMember,
-          {
-            groupId: announcementGroup._id,
-            userId: cpRecord.userId,
-          },
-        );
+        //
+        // Skip recompute for `note` because:
+        //  1. The Connection-score formula doesn't read `daysSinceLastNote` —
+        //     only call/text/followed_up factor in — so notes can't change
+        //     the score.
+        //  2. We just patched `lastFollowupAt` to the note timestamp above;
+        //     `computeCommunityScoresBatch` re-derives that field from only
+        //     contact-type rows, which would clobber the just-set note time
+        //     and visually erase the note from the People table.
+        if (args.type !== "note") {
+          await ctx.scheduler.runAfter(
+            0,
+            internal.functions.followupScoreComputation.computeSingleMemberScore,
+            {
+              groupId: announcementGroup._id,
+              groupMemberId: groupMember._id,
+            },
+          );
+          await ctx.scheduler.runAfter(
+            0,
+            internal.functions.communityScoreComputation.recomputeForGroupMember,
+            {
+              groupId: announcementGroup._id,
+              userId: cpRecord.userId,
+            },
+          );
+        }
       }
     }
 

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -228,11 +228,15 @@ export const computeCommunityScoresBatch = internalQuery({
             .filter((q) => q.eq(q.field("type"), type))
             .first();
 
-        const [lastInPerson, lastCall, lastText] = await Promise.all([
+        const [lastInPersonRaw, lastCallRaw, lastTextRaw] = await Promise.all([
           latestByType("followed_up"),
           latestByType("call"),
           latestByType("text"),
         ]);
+        // .first() returns T | null; `daysSince` consumes T | undefined.
+        const lastInPerson = lastInPersonRaw ?? undefined;
+        const lastCall = lastCallRaw ?? undefined;
+        const lastText = lastTextRaw ?? undefined;
         const contactCandidates = [lastInPerson, lastCall, lastText].filter(
           (f): f is NonNullable<typeof f> => f != null,
         );

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -283,14 +283,33 @@ export const computeCommunityScoresBatch = internalQuery({
             1,
             Math.round((lastWeek - firstWeek) / WEEK_MS) + 1,
           );
-          // Filter attended weeks to only those within the member's window
-          attendedWeeksInWindow = crossGroupData.attendedWeekStarts.filter(
-            (ws) => ws >= firstWeek,
-          ).length;
-          // Weeks that actually had meetings (within member's window)
-          meetingWeeksInWindow = crossGroupData.meetingWeekStarts
-            ? crossGroupData.meetingWeekStarts.filter((ws) => ws >= firstWeek).length
-            : totalWeeksInWindow; // fallback: assume all weeks had meetings
+          // Derive attended/meeting weeks from meetingEntries filtered by full
+          // `scheduledAt >= member.joinedAt` — a week-start cutoff alone would
+          // keep a meeting that ran earlier in the same ISO week the member
+          // joined, even though they couldn't have attended it.
+          if (crossGroupData.meetingEntries) {
+            const eligible = crossGroupData.meetingEntries.filter(
+              (e: any) => e.scheduledAt >= member.joinedAt,
+            );
+            const meetingWeeks = new Set<number>();
+            const attendedWeeks = new Set<number>();
+            for (const e of eligible) {
+              const ws = getWeekStart(e.scheduledAt);
+              meetingWeeks.add(ws);
+              if (e.attended) attendedWeeks.add(ws);
+            }
+            meetingWeeksInWindow = meetingWeeks.size;
+            attendedWeeksInWindow = attendedWeeks.size;
+          } else {
+            // Pre-meetingEntries fallback (kept for safety; current
+            // internalCrossGroupAttendance always returns entries).
+            attendedWeeksInWindow = crossGroupData.attendedWeekStarts.filter(
+              (ws) => ws >= firstWeek,
+            ).length;
+            meetingWeeksInWindow = crossGroupData.meetingWeekStarts
+              ? crossGroupData.meetingWeekStarts.filter((ws) => ws >= firstWeek).length
+              : totalWeeksInWindow;
+          }
         } else {
           // Legacy fallback: plain number percentage
           crossGroupPct = (crossGroupData as number) ?? 0;

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -230,15 +230,19 @@ export const computeCommunityScoresBatch = internalQuery({
             .order("desc")
             .first();
 
-        const [lastInPersonRaw, lastCallRaw, lastTextRaw] = await Promise.all([
+        const [lastInPersonRaw, lastCallRaw, lastTextRaw, lastNoteRaw] = await Promise.all([
           latestByType("followed_up"),
           latestByType("call"),
           latestByType("text"),
+          latestByType("note"),
         ]);
         // .first() returns T | null; `daysSince` consumes T | undefined.
         const lastInPerson = lastInPersonRaw ?? undefined;
         const lastCall = lastCallRaw ?? undefined;
         const lastText = lastTextRaw ?? undefined;
+        const lastNote = lastNoteRaw ?? undefined;
+        // "Last contact" for the days-since-contact score signal: only the
+        // three contact types (call / text / followed_up) — notes don't count.
         const contactCandidates = [lastInPerson, lastCall, lastText].filter(
           (f): f is NonNullable<typeof f> => f != null,
         );
@@ -247,6 +251,23 @@ export const computeCommunityScoresBatch = internalQuery({
             ? contactCandidates.reduce((a, b) =>
                 a.createdAt >= b.createdAt ? a : b,
               )
+            : undefined;
+        // `lastFollowupAt` (the displayed "Last Contact" column) tracks the
+        // most recent touch of ANY kind, including notes — matches the
+        // addFollowup mutation's monotonic patch. Without including notes,
+        // a recompute right after a back-dated contact insert would roll
+        // back lastFollowupAt and erase a newer note's timestamp.
+        const lastTouchCandidates = [
+          lastInPerson,
+          lastCall,
+          lastText,
+          lastNote,
+        ].filter((f): f is NonNullable<typeof f> => f != null);
+        const lastTouchAt =
+          lastTouchCandidates.length > 0
+            ? lastTouchCandidates.reduce((a, b) =>
+                a.createdAt >= b.createdAt ? a : b,
+              ).createdAt
             : undefined;
 
         const daysSince = (entry: { createdAt: number } | undefined): number =>
@@ -270,14 +291,12 @@ export const computeCommunityScoresBatch = internalQuery({
           }
         }
 
-        // Latest note for display in notes cell
-        const latestNoteEntry = followups.find(
-          (f) => f.type === "note" && f.content,
-        );
-        const latestNote = latestNoteEntry?.content
-          ? safeSliceForJson(latestNoteEntry.content, 200)
+        // Latest note for display in notes cell — use the per-type indexed
+        // lookup (same back-dated-row reasoning as contacts).
+        const latestNote = lastNote?.content
+          ? safeSliceForJson(lastNote.content, 200)
           : undefined;
-        const latestNoteAt = latestNoteEntry?.createdAt ?? undefined;
+        const latestNoteAt = lastNote?.createdAt ?? undefined;
 
         // Cross-group attendance data
         const crossGroupData = args.crossGroupAttendanceMap?.[
@@ -437,7 +456,7 @@ export const computeCommunityScoresBatch = internalQuery({
           isSnoozed: !!snoozedUntil,
           snoozedUntil,
           rawValues,
-          lastFollowupAt: lastFollowup?.createdAt,
+          lastFollowupAt: lastTouchAt,
           lastActiveAt: member.lastActiveAt,
           lastAttendedAt,
           addedAt: member.joinedAt,

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -309,25 +309,39 @@ export const computeCommunityScoresBatch = internalQuery({
         // (not raw meeting entries) keeps the unit consistent with the displayed
         // "Weeks with meetings" so a member in multiple groups isn't penalized
         // multiple times for the same week.
+        //
+        // We derive both meeting-week and attended-week sets from `meetingEntries`
+        // filtered by `scheduledAt >= member.joinedAt`. A week-start cutoff alone
+        // would count a meeting that happened earlier in the same ISO week the
+        // member joined — they had no chance to attend it.
         let consecutiveMissed = 0;
-        if (crossGroupData && typeof crossGroupData === "object") {
-          const memberJoinWeek = getWeekStart(member.joinedAt);
-          const attendedSet = new Set(crossGroupData.attendedWeekStarts ?? []);
-          const meetingWeeksDesc = [...(crossGroupData.meetingWeekStarts ?? [])]
-            .filter((ws) => ws >= memberJoinWeek)
-            .sort((a, b) => b - a);
+        if (
+          crossGroupData &&
+          typeof crossGroupData === "object" &&
+          crossGroupData.meetingEntries
+        ) {
+          const eligibleEntries = crossGroupData.meetingEntries.filter(
+            (e: any) => e.scheduledAt >= member.joinedAt,
+          );
+          const eligibleMeetingWeeks = new Set<number>();
+          const eligibleAttendedWeeks = new Set<number>();
+          for (const e of eligibleEntries) {
+            const ws = getWeekStart(e.scheduledAt);
+            eligibleMeetingWeeks.add(ws);
+            if (e.attended) eligibleAttendedWeeks.add(ws);
+          }
+          const meetingWeeksDesc = [...eligibleMeetingWeeks].sort(
+            (a, b) => b - a,
+          );
           for (const ws of meetingWeeksDesc) {
-            if (attendedSet.has(ws)) break;
+            if (eligibleAttendedWeeks.has(ws)) break;
             consecutiveMissed++;
           }
-          // Last attended date — actual meeting timestamp (not week start)
-          if (crossGroupData.meetingEntries) {
-            const lastAttendedEntry = crossGroupData.meetingEntries.find(
-              (e: any) => e.scheduledAt >= member.joinedAt && e.attended,
-            );
-            if (lastAttendedEntry) {
-              lastAttendedAt = lastAttendedEntry.scheduledAt;
-            }
+          // Last attended date — actual meeting timestamp (not week start).
+          // `meetingEntries` is sorted desc, so .find returns the most recent.
+          const lastAttendedEntry = eligibleEntries.find((e: any) => e.attended);
+          if (lastAttendedEntry) {
+            lastAttendedAt = lastAttendedEntry.scheduledAt;
           }
         }
 

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -304,21 +304,30 @@ export const computeCommunityScoresBatch = internalQuery({
           meetingWeeksInWindow = totalWeeksInWindow;
         }
 
-        // Consecutive missed meetings — from cross-group meeting entries, filtered by join date
+        // Consecutive missed weeks — walk back week-by-week through weeks that had
+        // meetings (post-join) until we find one the member attended. Counting weeks
+        // (not raw meeting entries) keeps the unit consistent with the displayed
+        // "Weeks with meetings" so a member in multiple groups isn't penalized
+        // multiple times for the same week.
         let consecutiveMissed = 0;
-        if (crossGroupData && typeof crossGroupData === "object" && crossGroupData.meetingEntries) {
-          // Filter to meetings after member joined, already sorted desc by scheduledAt
-          const memberMeetings = crossGroupData.meetingEntries.filter(
-            (e: any) => e.scheduledAt >= member.joinedAt,
-          );
-          for (const entry of memberMeetings) {
-            if (entry.attended) break;
+        if (crossGroupData && typeof crossGroupData === "object") {
+          const memberJoinWeek = getWeekStart(member.joinedAt);
+          const attendedSet = new Set(crossGroupData.attendedWeekStarts ?? []);
+          const meetingWeeksDesc = [...(crossGroupData.meetingWeekStarts ?? [])]
+            .filter((ws) => ws >= memberJoinWeek)
+            .sort((a, b) => b - a);
+          for (const ws of meetingWeeksDesc) {
+            if (attendedSet.has(ws)) break;
             consecutiveMissed++;
           }
           // Last attended date — actual meeting timestamp (not week start)
-          const lastAttendedEntry = memberMeetings.find((e: any) => e.attended);
-          if (lastAttendedEntry) {
-            lastAttendedAt = lastAttendedEntry.scheduledAt;
+          if (crossGroupData.meetingEntries) {
+            const lastAttendedEntry = crossGroupData.meetingEntries.find(
+              (e: any) => e.scheduledAt >= member.joinedAt && e.attended,
+            );
+            if (lastAttendedEntry) {
+              lastAttendedAt = lastAttendedEntry.scheduledAt;
+            }
           }
         }
 

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -204,7 +204,9 @@ export const computeCommunityScoresBatch = internalQuery({
 
     const results = await Promise.all(
       args.members.map(async (member) => {
-        // Fetch followups for this member in the announcement group
+        // Fetch followups for this member in the announcement group.
+        // The top-20 window is used only for snooze/note state, both of which
+        // are always written at `now` — so back-dating doesn't affect them.
         const followups = await ctx.db
           .query("memberFollowups")
           .withIndex("by_groupMember_createdAt", (q) =>
@@ -213,16 +215,33 @@ export const computeCommunityScoresBatch = internalQuery({
           .order("desc")
           .take(20);
 
-        // Compute days since each followup type
-        const lastFollowup = followups.find(
-          (f) =>
-            f.type === "followed_up" ||
-            f.type === "call" ||
-            f.type === "text"
+        // Contact-type recency must query per-type so a back-dated Log Past
+        // contact (createdAt set to its occurrence time) is still picked up
+        // even if there are 20+ newer rows of other types in between.
+        const latestByType = (type: string) =>
+          ctx.db
+            .query("memberFollowups")
+            .withIndex("by_groupMember_createdAt", (q) =>
+              q.eq("groupMemberId", member.groupMemberId)
+            )
+            .order("desc")
+            .filter((q) => q.eq(q.field("type"), type))
+            .first();
+
+        const [lastInPerson, lastCall, lastText] = await Promise.all([
+          latestByType("followed_up"),
+          latestByType("call"),
+          latestByType("text"),
+        ]);
+        const contactCandidates = [lastInPerson, lastCall, lastText].filter(
+          (f): f is NonNullable<typeof f> => f != null,
         );
-        const lastInPerson = followups.find((f) => f.type === "followed_up");
-        const lastCall = followups.find((f) => f.type === "call");
-        const lastText = followups.find((f) => f.type === "text");
+        const lastFollowup =
+          contactCandidates.length > 0
+            ? contactCandidates.reduce((a, b) =>
+                a.createdAt >= b.createdAt ? a : b,
+              )
+            : undefined;
 
         const daysSince = (entry: { createdAt: number } | undefined): number =>
           entry

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -217,15 +217,17 @@ export const computeCommunityScoresBatch = internalQuery({
 
         // Contact-type recency must query per-type so a back-dated Log Past
         // contact (createdAt set to its occurrence time) is still picked up
-        // even if there are 20+ newer rows of other types in between.
+        // even if there are 20+ newer rows of other types in between. Use
+        // the (groupMember, type, createdAt) compound index so the lookup is
+        // bounded to rows of that type — a filtered scan would walk the
+        // whole history for members with no matching row.
         const latestByType = (type: string) =>
           ctx.db
             .query("memberFollowups")
-            .withIndex("by_groupMember_createdAt", (q) =>
-              q.eq("groupMemberId", member.groupMemberId)
+            .withIndex("by_groupMember_type_createdAt", (q) =>
+              q.eq("groupMemberId", member.groupMemberId).eq("type", type),
             )
             .order("desc")
-            .filter((q) => q.eq(q.field("type"), type))
             .first();
 
         const [lastInPersonRaw, lastCallRaw, lastTextRaw] = await Promise.all([

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -474,11 +474,10 @@ export const internalScoreBatch = internalQuery({
         ) =>
           ctx.db
             .query("memberFollowups")
-            .withIndex("by_groupMember_createdAt", (q) =>
-              q.eq("groupMemberId", member._id),
+            .withIndex("by_groupMember_type_createdAt", (q) =>
+              q.eq("groupMemberId", member._id).eq("type", type),
             )
             .order("desc")
-            .filter((q) => q.eq(q.field("type"), type))
             .first();
 
         const [lastInPerson, lastCall, lastText] = await Promise.all([

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -456,14 +456,47 @@ export const internalScoreBatch = internalQuery({
           };
         });
 
-        // Fetch followups for this member
-        const followups = await ctx.db
+        // Fetch followups for this member. We take(20) for the active-snooze
+        // probe, then prepend any back-dated contact rows (call/text/in-person
+        // inserted with an older createdAt) so calculateFollowupPriority's
+        // `followups[0]` and history sweep still reflect them. Without this a
+        // logged-past contact would sit behind the top 20 and be ignored.
+        const recentFollowups = await ctx.db
           .query("memberFollowups")
           .withIndex("by_groupMember_createdAt", (q) =>
             q.eq("groupMemberId", member._id)
           )
           .order("desc")
           .take(20);
+
+        const findMostRecentOfType = async (
+          type: "followed_up" | "call" | "text",
+        ) =>
+          ctx.db
+            .query("memberFollowups")
+            .withIndex("by_groupMember_createdAt", (q) =>
+              q.eq("groupMemberId", member._id),
+            )
+            .order("desc")
+            .filter((q) => q.eq(q.field("type"), type))
+            .first();
+
+        const [lastInPerson, lastCall, lastText] = await Promise.all([
+          findMostRecentOfType("followed_up"),
+          findMostRecentOfType("call"),
+          findMostRecentOfType("text"),
+        ]);
+
+        // Merge: keep recent batch, union with type-specific most-recents,
+        // de-dupe by _id, re-sort desc by createdAt.
+        const merged = new Map<string, typeof recentFollowups[number]>();
+        for (const f of recentFollowups) merged.set(f._id.toString(), f);
+        for (const f of [lastInPerson, lastCall, lastText]) {
+          if (f) merged.set(f._id.toString(), f);
+        }
+        const followups = [...merged.values()].sort(
+          (a, b) => b.createdAt - a.createdAt,
+        );
 
         const followupData: FollowupAction[] = followups.map((f) => ({
           type: f.type,

--- a/apps/convex/functions/systemScoring.ts
+++ b/apps/convex/functions/systemScoring.ts
@@ -128,6 +128,12 @@ export const SYSTEM_SCORES: SystemScoreDefinition[] = [
         weight: 1,
       },
       {
+        variableId: "consecutive_missed",
+        label: "Consecutive missed weeks",
+        normHint: "Weeks in a row with no attendance since the last attended meeting. Caps the attendance portion: −15 pts per miss, 0 at 7+",
+        weight: 1,
+      },
+      {
         variableId: "days_since_last_in_person",
         label: "Days since in-person",
         normHint: "In-person follow-up: fills 100% of remaining, decays over ~100 days (~50 if no attendance)",

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1071,6 +1071,10 @@ export default defineSchema({
     .index("by_legacyId", ["legacyId"])
     .index("by_groupMember", ["groupMemberId"])
     .index("by_groupMember_createdAt", ["groupMemberId", "createdAt"])
+    // For "most recent of type X for member" lookups in score recomputes —
+    // back-dated rows can sit far behind newer entries, so we need to
+    // resolve them via an index rather than a filtered scan.
+    .index("by_groupMember_type_createdAt", ["groupMemberId", "type", "createdAt"])
     .index("by_createdBy", ["createdById"])
     .index("by_snoozeUntil", ["snoozeUntil"]),
 

--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -12,7 +12,10 @@ import {
   Modal,
   Pressable,
   Image,
+  KeyboardAvoidingView,
+  Platform,
 } from "react-native";
+import DateTimePicker from "@react-native-community/datetimepicker";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -94,6 +97,13 @@ export function FollowupDetailContent({
   } | null>(null);
   const [isConvertingFollowup, setIsConvertingFollowup] = useState(false);
 
+  // Log Past Contact modal
+  const [showLogPastModal, setShowLogPastModal] = useState(false);
+  const [logPastType, setLogPastType] = useState<"call" | "text" | "followed_up">("followed_up");
+  const [logPastDate, setLogPastDate] = useState<Date>(() => new Date());
+  const [logPastNote, setLogPastNote] = useState("");
+  const [showLogPastDatePicker, setShowLogPastDatePicker] = useState(false);
+
   // Reset local state when switching between members (desktop side-sheet reuses component)
   useEffect(() => {
     setNoteText("");
@@ -116,6 +126,11 @@ export function FollowupDetailContent({
     setTagInput("");
     setConvertEntry(null);
     setIsConvertingFollowup(false);
+    setShowLogPastModal(false);
+    setLogPastType("followed_up");
+    setLogPastDate(new Date());
+    setLogPastNote("");
+    setShowLogPastDatePicker(false);
   }, [memberId]);
 
   const group_id = groupId;
@@ -266,13 +281,14 @@ export function FollowupDetailContent({
 
   // Mutation wrapper objects for backward compatibility
   const addFollowupMutation = {
-    mutate: async (args: { communityPeopleId: string; type: string; content?: string }) => {
+    mutate: async (args: { communityPeopleId: string; type: string; content?: string; occurredAt?: number }) => {
       setIsAddingFollowup(true);
       try {
         await addFollowup({
           communityPeopleId: args.communityPeopleId as Id<"communityPeople">,
           type: args.type as "note" | "call" | "text" | "followed_up",
           content: args.content,
+          occurredAt: args.occurredAt,
         });
         setNoteText("");
         // Convex auto-updates reactive queries
@@ -370,6 +386,25 @@ export function FollowupDetailContent({
       type: "note",
       content: noteText.trim(),
     });
+  };
+
+  const handleSubmitLogPast = async () => {
+    if (!communityPeopleId) return;
+    const occurredAt = logPastDate.getTime();
+    if (occurredAt > Date.now()) {
+      Alert.alert("Invalid date", "Past contact date cannot be in the future.");
+      return;
+    }
+    await addFollowupMutation.mutate({
+      communityPeopleId,
+      type: logPastType,
+      content: logPastNote.trim() || undefined,
+      occurredAt,
+    });
+    setShowLogPastModal(false);
+    setLogPastNote("");
+    setLogPastDate(new Date());
+    setLogPastType("followed_up");
   };
 
   const handleSnooze = (duration: SnoozeDuration) => {
@@ -476,7 +511,7 @@ export function FollowupDetailContent({
       case "attendance_all_groups_pct":
         return `${rawValue}%`;
       case "consecutive_missed":
-        return `${rawValue} missed`;
+        return rawValue === 1 ? "1 week" : `${rawValue} weeks`;
       case "days_since_last_followup":
       case "days_since_last_text":
       case "days_since_last_call":
@@ -643,7 +678,17 @@ export function FollowupDetailContent({
         <View style={styles.headerSpacer} />
       </View>
 
-      <ScrollView ref={scrollViewRef} style={styles.content}>
+      <KeyboardAvoidingView
+        style={styles.flex1}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? (onClose ? 56 : insets.top + 56) : 0}
+      >
+      <ScrollView
+        ref={scrollViewRef}
+        style={styles.content}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="interactive"
+      >
         {/* Profile Section */}
         <View style={[styles.profileSection, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
           <TouchableOpacity
@@ -829,6 +874,21 @@ export function FollowupDetailContent({
               <Text style={[styles.quickActionText, { color: colors.text }]}>Snooze</Text>
             </TouchableOpacity>
           </View>
+
+          <TouchableOpacity
+            style={styles.logPastButton}
+            onPress={() => {
+              setLogPastType("followed_up");
+              setLogPastDate(new Date());
+              setLogPastNote("");
+              setShowLogPastModal(true);
+            }}
+          >
+            <Ionicons name="time-outline" size={18} color={primaryColor} />
+            <Text style={[styles.logPastButtonText, { color: primaryColor }]}>
+              Log past contact
+            </Text>
+          </TouchableOpacity>
         </View>
 
         {/* Contact Info */}
@@ -1200,6 +1260,7 @@ export function FollowupDetailContent({
 
         <View style={{ height: 100 }} />
       </ScrollView>
+      </KeyboardAvoidingView>
 
       {/* Convert history entry (e.g. note → text/call/in-person) */}
       <Modal
@@ -1276,6 +1337,135 @@ export function FollowupDetailContent({
             <TouchableOpacity
               style={styles.modalCancelButton}
               onPress={() => !isConvertingFollowup && setConvertEntry(null)}
+            >
+              <Text style={[styles.modalCancelText, { color: colors.textSecondary }]}>Cancel</Text>
+            </TouchableOpacity>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* Log Past Contact Modal */}
+      <Modal
+        visible={showLogPastModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => !addFollowupMutation.isPending && setShowLogPastModal(false)}
+      >
+        <Pressable
+          style={[styles.modalOverlay, { backgroundColor: colors.overlay }]}
+          onPress={() => !addFollowupMutation.isPending && setShowLogPastModal(false)}
+        >
+          <Pressable
+            style={[styles.modalContent, { backgroundColor: colors.modalBackground }]}
+            onPress={(e) => e.stopPropagation()}
+          >
+            <Text style={[styles.modalTitle, { color: colors.text }]}>Log Past Contact</Text>
+            <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]}>
+              Record a call, text, or in-person contact that already happened.
+            </Text>
+
+            <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>Type</Text>
+            <View style={styles.logPastTypeRow}>
+              {[
+                { value: "followed_up" as const, label: "In-person", icon: "checkmark-circle-outline" },
+                { value: "call" as const, label: "Call", icon: "call-outline" },
+                { value: "text" as const, label: "Text", icon: "chatbubble-outline" },
+              ].map((option) => {
+                const selected = logPastType === option.value;
+                return (
+                  <TouchableOpacity
+                    key={option.value}
+                    style={[
+                      styles.logPastTypeOption,
+                      {
+                        backgroundColor: selected ? primaryColor : colors.surfaceSecondary,
+                        borderColor: selected ? primaryColor : colors.border,
+                      },
+                    ]}
+                    onPress={() => setLogPastType(option.value)}
+                    disabled={addFollowupMutation.isPending}
+                  >
+                    <Ionicons
+                      name={option.icon as any}
+                      size={18}
+                      color={selected ? colors.textInverse : colors.text}
+                    />
+                    <Text
+                      style={[
+                        styles.logPastTypeText,
+                        { color: selected ? colors.textInverse : colors.text },
+                      ]}
+                    >
+                      {option.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>When</Text>
+            <TouchableOpacity
+              style={[styles.logPastDateButton, { borderColor: colors.inputBorder, backgroundColor: colors.inputBackground }]}
+              onPress={() => setShowLogPastDatePicker(true)}
+              disabled={addFollowupMutation.isPending}
+            >
+              <Ionicons name="calendar-outline" size={18} color={colors.textSecondary} />
+              <Text style={[styles.logPastDateText, { color: colors.text }]}>
+                {logPastDate.toLocaleDateString("en-US", {
+                  weekday: "short",
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </Text>
+            </TouchableOpacity>
+
+            {showLogPastDatePicker && (
+              <DateTimePicker
+                value={logPastDate}
+                mode="date"
+                display={Platform.OS === "ios" ? "inline" : "default"}
+                maximumDate={new Date()}
+                minimumDate={new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)}
+                onChange={(event, selected) => {
+                  if (Platform.OS !== "ios") setShowLogPastDatePicker(false);
+                  if (event.type === "dismissed") return;
+                  if (selected) setLogPastDate(selected);
+                }}
+              />
+            )}
+
+            <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>Note (optional)</Text>
+            <TextInput
+              style={[styles.snoozeNoteInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+              placeholder="What happened?"
+              placeholderTextColor={colors.inputPlaceholder}
+              value={logPastNote}
+              onChangeText={setLogPastNote}
+              multiline
+            />
+
+            <TouchableOpacity
+              style={[
+                styles.logPastSubmitButton,
+                { backgroundColor: primaryColor },
+                addFollowupMutation.isPending && { opacity: 0.6 },
+              ]}
+              onPress={handleSubmitLogPast}
+              disabled={addFollowupMutation.isPending}
+            >
+              {addFollowupMutation.isPending ? (
+                <ActivityIndicator size="small" color={colors.textInverse} />
+              ) : (
+                <Text style={[styles.logPastSubmitText, { color: colors.textInverse }]}>
+                  Log Contact
+                </Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.modalCancelButton}
+              onPress={() => !addFollowupMutation.isPending && setShowLogPastModal(false)}
             >
               <Text style={[styles.modalCancelText, { color: colors.textSecondary }]}>Cancel</Text>
             </TouchableOpacity>
@@ -1595,6 +1785,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  flex1: {
+    flex: 1,
+  },
   loadingContainer: {
     flex: 1,
     justifyContent: "center",
@@ -1728,6 +1921,67 @@ const styles = StyleSheet.create({
   },
   quickActionTextDisabled: {
     opacity: 0.5,
+  },
+  logPastButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    marginTop: 8,
+    paddingVertical: 8,
+  },
+  logPastButtonText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  logPastFieldLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginTop: 12,
+    marginBottom: 6,
+  },
+  logPastTypeRow: {
+    flexDirection: "row",
+    gap: 8,
+    marginBottom: 4,
+  },
+  logPastTypeOption: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  logPastTypeText: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  logPastDateButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  logPastDateText: {
+    fontSize: 14,
+  },
+  logPastSubmitButton: {
+    marginTop: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  logPastSubmitText: {
+    fontSize: 15,
+    fontWeight: "700",
   },
   contactText: {
     fontSize: 14,

--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -140,6 +140,8 @@ export function FollowupDetailContent({
     setLogPastDate(new Date());
     setLogPastNote("");
     setShowLogPastDatePicker(false);
+    setQuickActionType(null);
+    setQuickActionNote("");
   }, [memberId]);
 
   const group_id = groupId;

--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -16,6 +16,7 @@ import {
   Platform,
 } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
+import * as Clipboard from "expo-clipboard";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -103,6 +104,14 @@ export function FollowupDetailContent({
   const [logPastDate, setLogPastDate] = useState<Date>(() => new Date());
   const [logPastNote, setLogPastNote] = useState("");
   const [showLogPastDatePicker, setShowLogPastDatePicker] = useState(false);
+
+  // Quick-action note modal — captures an optional note before logging an
+  // in-person / call / text follow-up. `quickActionType` doubles as the
+  // visibility flag (null = closed).
+  const [quickActionType, setQuickActionType] = useState<
+    "followed_up" | "call" | "text" | null
+  >(null);
+  const [quickActionNote, setQuickActionNote] = useState("");
 
   // Reset local state when switching between members (desktop side-sheet reuses component)
   useEffect(() => {
@@ -270,12 +279,11 @@ export function FollowupDetailContent({
   // Confirmation hook — logs action only after user confirms they completed it
   const { setPendingAction } = useContactConfirmation({
     onConfirm: (type) => {
-      if (!communityPeopleId) return;
-      addFollowupMutation.mutate({
-        communityPeopleId,
-        type,
-        content: type === "call" ? "Made a phone call" : "Sent a text message",
-      });
+      // Instead of logging immediately on "Yes", open the note modal so the
+      // leader can capture what came of the call / text.
+      if (type === "email") return;
+      setQuickActionNote("");
+      setQuickActionType(type);
     },
   });
 
@@ -372,11 +380,19 @@ export function FollowupDetailContent({
 
   const handleMarkFollowedUp = () => {
     if (!communityPeopleId) return;
+    setQuickActionNote("");
+    setQuickActionType("followed_up");
+  };
+
+  const handleSubmitQuickAction = () => {
+    if (!communityPeopleId || !quickActionType) return;
     addFollowupMutation.mutate({
       communityPeopleId,
-      type: "followed_up",
-      content: "Marked as followed up",
+      type: quickActionType,
+      content: quickActionNote.trim() || undefined,
     });
+    setQuickActionType(null);
+    setQuickActionNote("");
   };
 
   const handleAddNote = () => {
@@ -903,10 +919,26 @@ export function FollowupDetailContent({
           <View style={[styles.section, { backgroundColor: colors.surface }]}>
             <Text style={[styles.sectionTitle, { color: colors.text }]}>Contact</Text>
             {member.phone && (
-              <Text style={[styles.contactText, { color: colors.textSecondary }]}>{member.phone}</Text>
+              <TouchableOpacity
+                onPress={async () => {
+                  await Clipboard.setStringAsync(member.phone!);
+                  Alert.alert("Copied", `${member.phone} copied to clipboard.`);
+                }}
+                activeOpacity={0.6}
+              >
+                <Text style={[styles.contactText, { color: colors.textSecondary }]}>{member.phone}</Text>
+              </TouchableOpacity>
             )}
             {member.email && (
-              <Text style={[styles.contactText, { color: colors.textSecondary }]}>{member.email}</Text>
+              <TouchableOpacity
+                onPress={async () => {
+                  await Clipboard.setStringAsync(member.email!);
+                  Alert.alert("Copied", `${member.email} copied to clipboard.`);
+                }}
+                activeOpacity={0.6}
+              >
+                <Text style={[styles.contactText, { color: colors.textSecondary }]}>{member.email}</Text>
+              </TouchableOpacity>
             )}
           </View>
         )}
@@ -1351,6 +1383,79 @@ export function FollowupDetailContent({
         </Pressable>
       </Modal>
 
+      {/* Quick-Action Note Modal — captures an optional note before logging
+          an in-person / call / text follow-up triggered from Quick Actions
+          (or the post-call/text "Did you ___?" confirmation flow). */}
+      <Modal
+        visible={quickActionType !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => !addFollowupMutation.isPending && setQuickActionType(null)}
+      >
+        <Pressable
+          style={[styles.modalOverlay, { backgroundColor: colors.overlay }]}
+          onPress={() => !addFollowupMutation.isPending && setQuickActionType(null)}
+        >
+          <Pressable
+            style={[styles.modalContent, { backgroundColor: colors.modalBackground }]}
+            onPress={(e) => e.stopPropagation()}
+          >
+            <Text style={[styles.modalTitle, { color: colors.text }]}>
+              {quickActionType === "followed_up"
+                ? "Log in-person follow-up"
+                : quickActionType === "call"
+                  ? "Log call"
+                  : "Log text"}
+            </Text>
+            <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]}>
+              Add a quick note if you want — what came of it, what they shared, anything to remember.
+            </Text>
+
+            <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>Note (optional)</Text>
+            <TextInput
+              style={[styles.logPastNoteInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+              placeholder={
+                quickActionType === "followed_up"
+                  ? "e.g. Caught up after service, talked through their week"
+                  : quickActionType === "call"
+                    ? "e.g. Chatted for 15 min, they're settling in fine"
+                    : "e.g. Sent a check-in, waiting to hear back"
+              }
+              placeholderTextColor={colors.inputPlaceholder}
+              value={quickActionNote}
+              onChangeText={setQuickActionNote}
+              multiline
+              numberOfLines={3}
+              textAlignVertical="top"
+              autoFocus
+            />
+
+            <TouchableOpacity
+              style={[
+                styles.logPastSubmitButton,
+                { backgroundColor: primaryColor },
+                addFollowupMutation.isPending && { opacity: 0.6 },
+              ]}
+              onPress={handleSubmitQuickAction}
+              disabled={addFollowupMutation.isPending}
+            >
+              {addFollowupMutation.isPending ? (
+                <ActivityIndicator size="small" color={colors.textInverse} />
+              ) : (
+                <Text style={[styles.logPastSubmitText, { color: colors.textInverse }]}>Log follow-up</Text>
+              )}
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.modalCancelButton}
+              onPress={() => setQuickActionType(null)}
+              disabled={addFollowupMutation.isPending}
+            >
+              <Text style={[styles.modalCancelText, { color: colors.textSecondary }]}>Cancel</Text>
+            </TouchableOpacity>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
       {/* Log Past Contact Modal */}
       <Modal
         visible={showLogPastModal}
@@ -1412,35 +1517,56 @@ export function FollowupDetailContent({
             </View>
 
             <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>When</Text>
-            <TouchableOpacity
-              style={[styles.logPastDateButton, { borderColor: colors.inputBorder, backgroundColor: colors.inputBackground }]}
-              onPress={() => setShowLogPastDatePicker(true)}
-              disabled={addFollowupMutation.isPending}
-            >
-              <Ionicons name="calendar-outline" size={18} color={colors.textSecondary} />
-              <Text style={[styles.logPastDateText, { color: colors.text }]}>
-                {logPastDate.toLocaleDateString("en-US", {
-                  weekday: "short",
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-              </Text>
-            </TouchableOpacity>
-
-            {showLogPastDatePicker && (
-              <DateTimePicker
-                value={logPastDate}
-                mode="date"
-                display={Platform.OS === "ios" ? "inline" : "default"}
-                maximumDate={new Date()}
-                minimumDate={new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)}
-                onChange={(event, selected) => {
-                  if (Platform.OS !== "ios") setShowLogPastDatePicker(false);
-                  if (event.type === "dismissed") return;
-                  if (selected) setLogPastDate(selected);
-                }}
-              />
+            {Platform.OS === "ios" ? (
+              // Compact picker is itself the tappable date — pops a native
+              // calendar overlay so we don't have to embed (and theme) one
+              // inside this modal.
+              <View style={styles.logPastDateRow}>
+                <DateTimePicker
+                  value={logPastDate}
+                  mode="date"
+                  display="compact"
+                  themeVariant="light"
+                  maximumDate={new Date()}
+                  minimumDate={new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)}
+                  onChange={(event, selected) => {
+                    if (event.type === "dismissed") return;
+                    if (selected) setLogPastDate(selected);
+                  }}
+                />
+              </View>
+            ) : (
+              <>
+                <TouchableOpacity
+                  style={[styles.logPastDateButton, { borderColor: colors.inputBorder, backgroundColor: colors.inputBackground }]}
+                  onPress={() => setShowLogPastDatePicker(true)}
+                  disabled={addFollowupMutation.isPending}
+                >
+                  <Ionicons name="calendar-outline" size={18} color={colors.textSecondary} />
+                  <Text style={[styles.logPastDateText, { color: colors.text }]}>
+                    {logPastDate.toLocaleDateString("en-US", {
+                      weekday: "short",
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </Text>
+                </TouchableOpacity>
+                {showLogPastDatePicker && (
+                  <DateTimePicker
+                    value={logPastDate}
+                    mode="date"
+                    display="default"
+                    maximumDate={new Date()}
+                    minimumDate={new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)}
+                    onChange={(event, selected) => {
+                      setShowLogPastDatePicker(false);
+                      if (event.type === "dismissed") return;
+                      if (selected) setLogPastDate(selected);
+                    }}
+                  />
+                )}
+              </>
             )}
 
             <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>Note (optional)</Text>
@@ -1970,6 +2096,11 @@ const styles = StyleSheet.create({
   },
   logPastDateText: {
     fontSize: 14,
+  },
+  logPastDateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 4,
   },
   logPastNoteInput: {
     minHeight: 72,

--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -862,33 +862,40 @@ export function FollowupDetailContent({
               onPress={handleMarkFollowedUp}
               disabled={addFollowupMutation.isPending}
             >
-              <Ionicons name="checkmark-circle" size={24} color={colors.success} />
-              <Text style={[styles.quickActionText, { color: colors.text }]}>Done</Text>
+              <Ionicons name="hand-left" size={24} color={colors.success} />
+              <Text style={[styles.quickActionText, { color: colors.text }]}>In-person</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
               style={styles.quickAction}
-              onPress={() => setShowSnoozeModal(true)}
+              onPress={() => {
+                setLogPastType("followed_up");
+                setLogPastDate(new Date());
+                setLogPastNote("");
+                setShowLogPastModal(true);
+              }}
+              disabled={addFollowupMutation.isPending}
             >
-              <Ionicons name="time" size={24} color={colors.warning} />
-              <Text style={[styles.quickActionText, { color: colors.text }]}>Snooze</Text>
+              <Ionicons name="time-outline" size={24} color={colors.warning} />
+              <Text style={[styles.quickActionText, { color: colors.text }]}>Log past</Text>
             </TouchableOpacity>
-          </View>
 
-          <TouchableOpacity
-            style={styles.logPastButton}
-            onPress={() => {
-              setLogPastType("followed_up");
-              setLogPastDate(new Date());
-              setLogPastNote("");
-              setShowLogPastModal(true);
-            }}
-          >
-            <Ionicons name="time-outline" size={18} color={primaryColor} />
-            <Text style={[styles.logPastButtonText, { color: primaryColor }]}>
-              Log past contact
-            </Text>
-          </TouchableOpacity>
+            {/*
+              SNOOZE — temporarily hidden from the UI per UX feedback 2026-05-28.
+              All wiring is preserved (`handleSnooze`, `snoozeMutation`,
+              `showSnoozeModal` state, snooze Modal further down in this file,
+              and the `snooze` mutation in apps/convex/functions/communityPeople.ts).
+              To re-enable: paste the TouchableOpacity below back into this row.
+
+              <TouchableOpacity
+                style={styles.quickAction}
+                onPress={() => setShowSnoozeModal(true)}
+              >
+                <Ionicons name="time" size={24} color={colors.warning} />
+                <Text style={[styles.quickActionText, { color: colors.text }]}>Skip for…</Text>
+              </TouchableOpacity>
+            */}
+          </View>
         </View>
 
         {/* Contact Info */}
@@ -1362,6 +1369,7 @@ export function FollowupDetailContent({
             <Text style={[styles.modalTitle, { color: colors.text }]}>Log Past Contact</Text>
             <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]}>
               Record a call, text, or in-person contact that already happened.
+              Add a note so you remember what came of it.
             </Text>
 
             <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>Type</Text>
@@ -1437,12 +1445,14 @@ export function FollowupDetailContent({
 
             <Text style={[styles.logPastFieldLabel, { color: colors.textSecondary }]}>Note (optional)</Text>
             <TextInput
-              style={[styles.snoozeNoteInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
-              placeholder="What happened?"
+              style={[styles.logPastNoteInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBackground }]}
+              placeholder="e.g. Texted a while back, didn't get back to me — will try again later"
               placeholderTextColor={colors.inputPlaceholder}
               value={logPastNote}
               onChangeText={setLogPastNote}
               multiline
+              numberOfLines={3}
+              textAlignVertical="top"
             />
 
             <TouchableOpacity
@@ -1922,18 +1932,6 @@ const styles = StyleSheet.create({
   quickActionTextDisabled: {
     opacity: 0.5,
   },
-  logPastButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 6,
-    marginTop: 8,
-    paddingVertical: 8,
-  },
-  logPastButtonText: {
-    fontSize: 14,
-    fontWeight: "600",
-  },
   logPastFieldLabel: {
     fontSize: 12,
     fontWeight: "600",
@@ -1972,6 +1970,15 @@ const styles = StyleSheet.create({
   },
   logPastDateText: {
     fontSize: 14,
+  },
+  logPastNoteInput: {
+    minHeight: 72,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    fontSize: 14,
+    lineHeight: 20,
   },
   logPastSubmitButton: {
     marginTop: 16,

--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -287,9 +287,11 @@ export function FollowupDetailContent({
     },
   });
 
-  // Mutation wrapper objects for backward compatibility
+  // Mutation wrapper objects for backward compatibility.
+  // Returns true on success / false on failure so callers can decide whether
+  // to close a modal or preserve the user's typed input.
   const addFollowupMutation = {
-    mutate: async (args: { communityPeopleId: string; type: string; content?: string; occurredAt?: number }) => {
+    mutate: async (args: { communityPeopleId: string; type: string; content?: string; occurredAt?: number }): Promise<boolean> => {
       setIsAddingFollowup(true);
       try {
         await addFollowup({
@@ -300,8 +302,10 @@ export function FollowupDetailContent({
         });
         setNoteText("");
         // Convex auto-updates reactive queries
+        return true;
       } catch (err: any) {
         Alert.alert("Error", err.message || "Failed to add note");
+        return false;
       } finally {
         setIsAddingFollowup(false);
       }
@@ -384,13 +388,14 @@ export function FollowupDetailContent({
     setQuickActionType("followed_up");
   };
 
-  const handleSubmitQuickAction = () => {
+  const handleSubmitQuickAction = async () => {
     if (!communityPeopleId || !quickActionType) return;
-    addFollowupMutation.mutate({
+    const ok = await addFollowupMutation.mutate({
       communityPeopleId,
       type: quickActionType,
       content: quickActionNote.trim() || undefined,
     });
+    if (!ok) return; // keep the modal + typed note so the user can retry
     setQuickActionType(null);
     setQuickActionNote("");
   };
@@ -411,12 +416,13 @@ export function FollowupDetailContent({
       Alert.alert("Invalid date", "Past contact date cannot be in the future.");
       return;
     }
-    await addFollowupMutation.mutate({
+    const ok = await addFollowupMutation.mutate({
       communityPeopleId,
       type: logPastType,
       content: logPastNote.trim() || undefined,
       occurredAt,
     });
+    if (!ok) return; // keep the modal + typed note so the user can retry
     setShowLogPastModal(false);
     setLogPastNote("");
     setLogPastDate(new Date());


### PR DESCRIPTION
## Summary

A member who attended a meeting 3 weeks ago was still showing a Connection score of 0, with no visible reason. Root cause: `consecutive_missed` counted individual meeting entries across every group the member belonged to, while the displayed "Weeks with meetings" is week-deduped. A leader in 2+ weekly groups could rack up 7+ raw misses since the last attended meeting in only 3 calendar weeks — capping the attendance portion to 0 — and the variable driving the collapse wasn't shown anywhere.

This PR fixes the unit mismatch, surfaces the driving variable, and tightens the Quick Actions UX so leaders can actually log the kind of contact the score is asking about.

### Score fixes
- Count `consecutive_missed` in **weeks** (using `meetingWeekStarts` + `attendedWeekStarts`) so it matches the unit displayed in the breakdown.
- Add `consecutive_missed` as a visible row in the Connection breakdown with a normalized bar (0 misses → 100%, 7+ → 0%), so a leader can see why the attendance portion is what it is.
- Add an optional `occurredAt` arg to `addFollowup` so a leader can back-date a Call/Text/In-person contact (clamped: not future, not >1y ago). `lastFollowupAt` / `latestNote` only advance if the new timestamp is actually newer.

### UX changes (FollowupDetailScreen)
- Quick Actions row is now **Call · Text · In-person · Log past** (replaces Call/Text/Done/Snooze).
  - "Done" → "In-person" (handshake icon) — parallel with Call/Text, names a contact type rather than a task state.
  - "Snooze" removed from the visible row; mutation, modal, handlers, and state are preserved with an inline comment showing exactly how to restore the button if needed.
- New "Log past contact" modal: type picker (In-person/Call/Text), date picker (today by default, back to 1y), multiline note with a concrete placeholder example.
- Wrap detail screen in `KeyboardAvoidingView` so Add Note isn't hidden when the keyboard opens.

## Test plan

- [ ] Open a member's People detail. Confirm the Connection breakdown now shows a "Consecutive missed weeks" row.
- [ ] For a member who attended a meeting in the past 2 weeks: verify `consecutive_missed` reflects calendar weeks since that meeting (not raw meeting count across groups).
- [ ] Tap Quick Actions → In-person → confirm a `followed_up` entry appears in People History with today's timestamp.
- [ ] Tap Log past → pick "Text" + date a week ago + note "Texted, no reply yet" → submit → verify the history entry uses the back-dated timestamp and the note text.
- [ ] Tap Add Note → keyboard opens → confirm the input and Add Note button remain visible above the keyboard.
- [ ] Cross-check the Connection score before/after attendance is recorded for a member who previously had 7+ raw missed meetings but only 1-2 missed weeks.

https://claude.ai/code/session_01UM6PTZpiBqVwa1E7LT9268

---
_Generated by [Claude Code](https://claude.ai/code/session_01UM6PTZpiBqVwa1E7LT9268)_