### PR TITLE
fix(ui): keyboard dismissal on Log Past Contact + drop crisis card from prayer feed

### DIFF
--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
   Modal,
   Pressable,
   Image,
+  Keyboard,
   KeyboardAvoidingView,
   Platform,
 } from "react-native";
@@ -1471,13 +1472,17 @@ export function FollowupDetailContent({
         animationType="fade"
         onRequestClose={() => !addFollowupMutation.isPending && setShowLogPastModal(false)}
       >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={{ flex: 1 }}
+        >
         <Pressable
           style={[styles.modalOverlay, { backgroundColor: colors.overlay }]}
           onPress={() => !addFollowupMutation.isPending && setShowLogPastModal(false)}
         >
           <Pressable
             style={[styles.modalContent, { backgroundColor: colors.modalBackground }]}
-            onPress={(e) => e.stopPropagation()}
+            onPress={Keyboard.dismiss}
           >
             <Text style={[styles.modalTitle, { color: colors.text }]}>Log Past Contact</Text>
             <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]}>
@@ -1615,6 +1620,7 @@ export function FollowupDetailContent({
             </TouchableOpacity>
           </Pressable>
         </Pressable>
+        </KeyboardAvoidingView>
       </Modal>
 
       {/* Snooze Modal */}

--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -1482,7 +1482,10 @@ export function FollowupDetailContent({
         >
           <Pressable
             style={[styles.modalContent, { backgroundColor: colors.modalBackground }]}
-            onPress={Keyboard.dismiss}
+            onPress={(e) => {
+              e.stopPropagation();
+              Keyboard.dismiss();
+            }}
           >
             <Text style={[styles.modalTitle, { color: colors.text }]}>Log Past Contact</Text>
             <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]}>

--- a/apps/mobile/features/prayer/components/PrayerScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayerScreen.tsx
@@ -41,7 +41,6 @@ import {
 import type { Id } from '@services/api/convex';
 import { PraySession } from './PraySession';
 import { AddPrayerSheet } from './AddPrayerSheet';
-import { CrisisResourceCard } from './CrisisResourceCard';
 import { ReportPrayerSheet } from './ReportPrayerSheet';
 import { PrayedPrayerRail } from './PrayedPrayerRail';
 import type { PrayerCardData } from './PrayerCard';
@@ -281,7 +280,6 @@ export function PrayerScreen() {
             },
           ]}
         >
-          {current.crisisFlag ? <CrisisResourceCard /> : null}
           <View style={styles.cardHeader}>
             {/*
              * Initials-only on purpose — NEVER swap in a profile photo here.


### PR DESCRIPTION
- Wrap Log Past Contact modal in KeyboardAvoidingView and dismiss the
  keyboard on tap inside the modal so the submit/cancel buttons stay
  reachable when the note field is focused.
- Stop rendering CrisisResourceCard above prayers in the main feed; the
  card still appears on the prayer detail/pray-session screens where the
  context is more focused.

https://claude.ai/code/session_01BJhXada4X69SfcjQgua8FT