### PR TITLE
fix(proposals): create announcement group on accept, not just Stripe checkout

### DIFF
--- a/apps/convex/functions/ee/proposals.ts
+++ b/apps/convex/functions/ee/proposals.ts
@@ -14,6 +14,8 @@ import { v } from "convex/values";
 import { mutation, query } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import { requireAuth } from "../../lib/auth";
+import { PRIMARY_ADMIN_ROLE } from "../../lib/permissions";
+import { addUserToAnnouncementGroup } from "../communities";
 // Reserved slugs inlined to avoid importing @togather/shared (which pulls in react-native via storage.ts)
 const RESERVED_COMMUNITY_SLUGS = new Set([
   "api", "www", "app", "staging", "dev",
@@ -215,14 +217,36 @@ export const accept = mutation({
     const now = Date.now();
     const setupToken = crypto.randomUUID();
 
-    // Create the community (proposer is NOT added as member yet — that
-    // happens in handleCheckoutCompleted after payment is confirmed)
+    // Create the community. Stripe checkout still gates `isPublic` and the
+    // subscription fields — see handleCheckoutCompleted — but the proposer
+    // gets primary-admin access and an announcement group at acceptance so
+    // they can configure the community before/while paying.
     const communityId = await ctx.db.insert("communities", {
       name: proposal.communityName,
       isPublic: false,
       createdAt: now,
       updatedAt: now,
     });
+
+    // Make proposer the primary admin
+    await ctx.db.insert("userCommunities", {
+      userId: proposal.proposerId,
+      communityId,
+      roles: PRIMARY_ADMIN_ROLE,
+      status: 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Create the announcement group and add proposer as leader.
+    // handleCheckoutCompleted keeps its defensive call as a safety net
+    // (idempotent — reuses existing group/membership).
+    await addUserToAnnouncementGroup(
+      ctx,
+      communityId,
+      proposal.proposerId,
+      PRIMARY_ADMIN_ROLE,
+    );
 
     // Update the proposal with acceptance details
     await ctx.db.patch(args.proposalId, {

--- a/apps/convex/functions/ee/proposals.ts
+++ b/apps/convex/functions/ee/proposals.ts
@@ -434,6 +434,46 @@ export const completeSetup = mutation({
       updatedAt: now,
     });
 
+    // Sync announcement group + channel names so they reflect any rename
+    // during setup. The group is created at proposal.accept using
+    // proposal.communityName, which may differ from the final name chosen
+    // here.
+    const announcementGroup = await ctx.db
+      .query("groups")
+      .withIndex("by_community", (q) =>
+        q.eq("communityId", proposal.communityId!)
+      )
+      .filter((q) => q.eq(q.field("isAnnouncementGroup"), true))
+      .first();
+
+    if (announcementGroup && announcementGroup.name !== args.name) {
+      await ctx.db.patch(announcementGroup._id, {
+        name: args.name,
+        updatedAt: now,
+      });
+
+      const channels = await ctx.db
+        .query("chatChannels")
+        .withIndex("by_group", (q) => q.eq("groupId", announcementGroup._id))
+        .collect();
+
+      for (const channel of channels) {
+        if (channel.channelType === "main") {
+          await ctx.db.patch(channel._id, {
+            name: `${args.name} - General`,
+            description: `General chat for ${args.name}`,
+            updatedAt: now,
+          });
+        } else if (channel.channelType === "leaders") {
+          await ctx.db.patch(channel._id, {
+            name: `${args.name} - Leaders Hub`,
+            description: `Leaders-only chat for ${args.name}`,
+            updatedAt: now,
+          });
+        }
+      }
+    }
+
     // Mark setup as completed and persist the description on the proposal
     await ctx.db.patch(proposal._id, {
       setupCompletedAt: now,

--- a/apps/convex/functions/migrations.ts
+++ b/apps/convex/functions/migrations.ts
@@ -10,6 +10,9 @@ import { internalQuery, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
+import { addUserToAnnouncementGroup } from "./communities";
+import { PRIMARY_ADMIN_ROLE } from "../lib/permissions";
+import { now } from "../lib/utils";
 
 const NYC_METRO_ZIP_CODES = [
   "10001", "10002", "10003", "10009", "10010", "10011", "10012", "10013",
@@ -458,5 +461,68 @@ export const updateMeetingCoverImage = internalMutation({
   },
   handler: async (ctx, args) => {
     await ctx.db.patch(args.meetingId, { coverImage: args.newPath });
+  },
+});
+
+/**
+ * One-off backfill: ensure a community's proposer has a primary-admin
+ * userCommunities row and an announcement group with them as leader.
+ *
+ * Needed for communities created via `proposals.accept` before that mutation
+ * was patched to create the announcement group inline. The Stripe checkout
+ * webhook was the only path that did so, leaving accepted-but-unpaid
+ * communities (e.g. Union church in prod) without one.
+ *
+ * Idempotent: announcement-group creation already has defensive checks; this
+ * skips the membership insert if the row already exists. Safe to re-run.
+ */
+export const backfillProposerAnnouncementGroup = internalMutation({
+  args: { proposalId: v.id("communityProposals") },
+  handler: async (ctx, args) => {
+    const proposal = await ctx.db.get(args.proposalId);
+    if (!proposal) {
+      throw new Error(`Proposal not found: ${args.proposalId}`);
+    }
+    if (!proposal.communityId) {
+      throw new Error(
+        `Proposal ${args.proposalId} has no associated community`
+      );
+    }
+    if (proposal.status !== "accepted") {
+      throw new Error(
+        `Proposal ${args.proposalId} is not accepted (status: ${proposal.status})`
+      );
+    }
+
+    const communityId = proposal.communityId;
+    const proposerId = proposal.proposerId;
+    const timestamp = now();
+
+    const existing = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", proposerId).eq("communityId", communityId)
+      )
+      .first();
+
+    if (!existing) {
+      await ctx.db.insert("userCommunities", {
+        userId: proposerId,
+        communityId,
+        roles: PRIMARY_ADMIN_ROLE,
+        status: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    }
+
+    await addUserToAnnouncementGroup(
+      ctx,
+      communityId,
+      proposerId,
+      PRIMARY_ADMIN_ROLE,
+    );
+
+    return { communityId, proposerId, insertedMembership: !existing };
   },
 });

--- a/apps/convex/functions/proposals.ts
+++ b/apps/convex/functions/proposals.ts
@@ -10,6 +10,8 @@ import { v } from "convex/values";
 import { mutation, query } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { requireAuth } from "../lib/auth";
+import { PRIMARY_ADMIN_ROLE } from "../lib/permissions";
+import { addUserToAnnouncementGroup } from "./communities";
 
 // ============================================================================
 // Submit a Proposal
@@ -202,11 +204,21 @@ export const accept = mutation({
     await ctx.db.insert("userCommunities", {
       userId: proposal.proposerId,
       communityId,
-      roles: 4, // PRIMARY_ADMIN
+      roles: PRIMARY_ADMIN_ROLE,
       status: 1, // Active
       createdAt: now,
       updatedAt: now,
     });
+
+    // Create the announcement group and add the proposer as leader.
+    // Previously this only happened in the Stripe checkout webhook, leaving
+    // accepted-but-unpaid communities without an announcement group.
+    await addUserToAnnouncementGroup(
+      ctx,
+      communityId,
+      proposal.proposerId,
+      PRIMARY_ADMIN_ROLE,
+    );
 
     // Update the proposal with acceptance details
     await ctx.db.patch(args.proposalId, {


### PR DESCRIPTION
## Summary

- Move announcement-group creation from the Stripe checkout webhook into `proposals.accept`. Accepted-but-unpaid communities (e.g. **Union church** in prod) were ending up with no announcement group because creation was gated on the webhook firing.
- `handleCheckoutCompleted` keeps its defensive `addUserToAnnouncementGroup` call as a safety net (it's idempotent — finds and reuses an existing group).
- Add a one-off internal mutation `backfillProposerAnnouncementGroup` to repair existing accepted proposals: inserts the missing primary-admin `userCommunities` row (if absent) and triggers announcement group creation. Idempotent.

## Why this happened

`communities.create`, `proposals.accept`, and `proposals.completeSetup` all create or finalize community records, but none of them created an announcement group. Only `ee/billing.ts → handleCheckoutCompleted` did. Union church was accepted but the proposer never completed Stripe checkout, so it had no announcement group and (separately) no primary-admin membership for the proposer.

## Test plan

- [ ] Typecheck (already passing locally)
- [ ] After prod deploy, run:
  ```
  npx convex run --prod functions/migrations:backfillProposerAnnouncementGroup '{"proposalId":"rx770xzpre3jhabg6ehgry0e1987hdsh"}'
  ```
  to repair Union church.
- [ ] Verify in prod that `groups` for that community contains an `isAnnouncementGroup: true` row and the proposer is a `leader` group member.
- [ ] Accept a fresh test proposal and confirm the announcement group + leader membership are created in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)