### PR TITLE
fix(auth): reconcile announcement group on every community-select

### DIFF
--- a/apps/convex/functions/authInternal.ts
+++ b/apps/convex/functions/authInternal.ts
@@ -1064,7 +1064,8 @@ export const selectCommunityForUser = mutation({
         updatedAt: timestamp,
       });
 
-      // If rejoining, trigger Planning Center sync and announcement group join
+      // If rejoining, trigger Planning Center + marketing syncs.
+      // (Announcement group sync runs unconditionally below.)
       if (isRejoining) {
         console.log("[selectCommunityForUser] User rejoining community, triggering sync", {
           userId,
@@ -1088,14 +1089,16 @@ export const selectCommunityForUser = mutation({
           internal.functions.marketing.flodesk.syncUser,
           { userId, communityId: args.communityId },
         );
-
-        // Add to announcement group
-        await ctx.runMutation(internal.functions.sync.memberships.syncMemberships, {
-          userId,
-          syncAnnouncementGroup: true,
-          communityId: args.communityId,
-        });
       }
+
+      // Always reconcile announcement group membership on community-select.
+      // Cheap, idempotent, and ensures users get added to groups created
+      // after they joined (e.g. backfilled announcement groups).
+      await ctx.runMutation(internal.functions.sync.memberships.syncMemberships, {
+        userId,
+        syncAnnouncementGroup: true,
+        communityId: args.communityId,
+      });
     } else {
       // Create new membership with lastLogin
       await ctx.db.insert("userCommunities", {


### PR DESCRIPTION
## Summary

Follow-up to #422. After backfilling the missing announcement group for Union church, the proposer was in it but the other community member was not. Opening the app didn't reconcile them, which was unexpected — there's already a sync wired into `selectCommunityForUser` that should handle exactly this.

The sync was gated on `isRejoining` (`status === 2`), so active members never triggered it. Lift the `syncMemberships` call out of that branch so it runs on every community-select. Cheap and idempotent (the helper looks up current state and no-ops if already in sync).

Planning Center + marketing syncs stay gated on `isRejoining` — those hit external APIs.

## Why this matters

- Backfilled groups (like Union church's announcement group) get picked up on next app open.
- Future code paths that create new groups for existing members will be reconciled automatically.
- Matches user expectation: "opening the app should reconcile me into groups I should be in."

## Test plan

- [x] Convex typecheck passes
- [ ] After deploy, open Union church as `joseph.o.olujide@gmail.com` and verify the announcement group + general channel appear.
- [ ] Verify no extra Planning Center or marketing API calls are triggered for non-rejoining users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)