### PR TITLE
feat(chat): unify announcement channels across all groups

### DIFF
--- a/apps/convex/__tests__/migrations/unifyAnnouncementChannels.test.ts
+++ b/apps/convex/__tests__/migrations/unifyAnnouncementChannels.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { convexTest } from "convex-test";
-import { expect, test, describe } from "vitest";
+import { expect, test, describe, afterEach } from "vitest";
 import schema from "../../schema";
 import { modules } from "../../test.setup";
 import { api, internal } from "../../_generated/api";
@@ -17,6 +17,20 @@ import type { Id } from "../../_generated/dataModel";
 
 // sendMessage end-to-end coverage needs a JWT secret for token generation.
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// `sendMessage` enqueues a deferred `ctx.scheduler.runAfter(0, onMessageSent)`
+// (which itself schedules notification jobs). The `afterEach` below drains
+// them so a pending scheduled function does not fire after the test's
+// transaction closes — otherwise convex-test writes to `_scheduled_functions`
+// outside any transaction and Vitest fails the run as an unhandled rejection.
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
 
 interface Seeded {
   communityId: Id<"communities">;
@@ -151,6 +165,7 @@ async function channelsForGroup(
 describe("migrateAnnouncementGroupChannels", () => {
   test("converts general -> announcements in place and creates a fresh general", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const seeded = await seedAnnouncementGroup(t);
 
     const result = await t.mutation(
@@ -218,6 +233,7 @@ describe("migrateAnnouncementGroupChannels", () => {
 
   test("is idempotent — a second run is a no-op", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const seeded = await seedAnnouncementGroup(t);
 
     await t.mutation(
@@ -242,6 +258,7 @@ describe("migrateAnnouncementGroupChannels", () => {
 
   test("after migration: leaders-only posts in announcements, everyone in general", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const seeded = await seedAnnouncementGroup(t);
 
     await t.mutation(
@@ -289,6 +306,7 @@ describe("migrateAnnouncementGroupChannels", () => {
 
   test("dryRun reports changes without writing", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const seeded = await seedAnnouncementGroup(t);
 
     const result = await t.mutation(

--- a/apps/convex/__tests__/migrations/unifyAnnouncementChannels.test.ts
+++ b/apps/convex/__tests__/migrations/unifyAnnouncementChannels.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for the announcement-channel unification backfill.
+ *
+ * Verifies that an announcement group's legacy "general" (main) channel is
+ * converted IN PLACE into a leaders-only "announcements" channel (preserving
+ * messages + members), and a fresh, empty, everyone-can-post "general" channel
+ * is created in its place.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api, internal } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import type { Id } from "../../_generated/dataModel";
+
+// sendMessage end-to-end coverage needs a JWT secret for token generation.
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+interface Seeded {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  leaderId: Id<"users">;
+  memberId: Id<"users">;
+  oldGeneralId: Id<"chatChannels">;
+  messageIds: Id<"chatMessages">[];
+}
+
+async function seedAnnouncementGroup(
+  t: ReturnType<typeof convexTest>
+): Promise<Seeded> {
+  return await t.run(async (ctx) => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "Fount",
+      subdomain: "fount",
+      slug: "fount",
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Announcements",
+      slug: "announcements",
+      isActive: true,
+      displayOrder: 0,
+      createdAt: Date.now(),
+    });
+
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Lead",
+      lastName: "Er",
+      phone: "+15555551000",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const memberId = await ctx.db.insert("users", {
+      firstName: "Mem",
+      lastName: "Ber",
+      phone: "+15555551001",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const groupId = await ctx.db.insert("groups", {
+      name: "Fount",
+      communityId,
+      groupTypeId,
+      isAnnouncementGroup: true,
+      isPublic: true,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    await ctx.db.insert("groupMembers", {
+      userId: leaderId,
+      groupId,
+      role: "leader",
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupMembers", {
+      userId: memberId,
+      groupId,
+      role: "member",
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+
+    // Legacy general channel (leaders-only via old frontend gate) with both
+    // community members as channel members and a couple of leader posts.
+    const oldGeneralId = await ctx.db.insert("chatChannels", {
+      groupId,
+      channelType: "main",
+      name: "Fount - General",
+      slug: "general",
+      createdById: leaderId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isArchived: false,
+      memberCount: 2,
+    });
+
+    for (const userId of [leaderId, memberId]) {
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: oldGeneralId,
+        userId,
+        role: userId === leaderId ? "admin" : "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    }
+
+    const messageIds: Id<"chatMessages">[] = [];
+    for (let i = 0; i < 3; i++) {
+      const id = await ctx.db.insert("chatMessages", {
+        channelId: oldGeneralId,
+        senderId: leaderId,
+        content: `Announcement ${i}`,
+        contentType: "text",
+        createdAt: Date.now() + i,
+        isDeleted: false,
+      });
+      messageIds.push(id);
+    }
+
+    return { communityId, groupId, leaderId, memberId, oldGeneralId, messageIds };
+  });
+}
+
+async function channelsForGroup(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">
+) {
+  return await t.run(async (ctx) => {
+    return await ctx.db
+      .query("chatChannels")
+      .withIndex("by_group", (q) => q.eq("groupId", groupId))
+      .collect();
+  });
+}
+
+describe("migrateAnnouncementGroupChannels", () => {
+  test("converts general -> announcements in place and creates a fresh general", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAnnouncementGroup(t);
+
+    const result = await t.mutation(
+      internal.functions.migrations.unifyAnnouncementChannels
+        .migrateAnnouncementGroupChannels,
+      { communityId: seeded.communityId }
+    );
+
+    expect(result.groupsProcessed).toBe(1);
+    expect(result.results[0].status).toBe("migrated");
+
+    // The original channel is now the announcements channel, with messages intact.
+    const converted = await t.run((ctx) => ctx.db.get(seeded.oldGeneralId));
+    expect(converted?.channelType).toBe("announcements");
+    expect(converted?.slug).toBe("announcements");
+
+    const keptMessages = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", seeded.oldGeneralId))
+        .collect()
+    );
+    expect(keptMessages.map((m) => m._id).sort()).toEqual(
+      seeded.messageIds.sort()
+    );
+
+    // The old channel members are still attached.
+    const announcementMembers = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel", (q) => q.eq("channelId", seeded.oldGeneralId))
+        .collect()
+    );
+    expect(announcementMembers).toHaveLength(2);
+
+    // Exactly one fresh general (main) channel exists, empty of messages.
+    const channels = await channelsForGroup(t, seeded.groupId);
+    const mains = channels.filter((c) => c.channelType === "main");
+    const announcements = channels.filter(
+      (c) => c.channelType === "announcements"
+    );
+    expect(announcements).toHaveLength(1);
+    expect(mains).toHaveLength(1);
+    expect(mains[0]._id).not.toBe(seeded.oldGeneralId);
+    expect(mains[0].slug).toBe("general");
+
+    const newGeneralMessages = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", mains[0]._id))
+        .collect()
+    );
+    expect(newGeneralMessages).toHaveLength(0);
+
+    // Both active members were added to the new general channel.
+    const newGeneralMembers = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel", (q) => q.eq("channelId", mains[0]._id))
+        .collect()
+    );
+    expect(newGeneralMembers).toHaveLength(2);
+    expect(mains[0].memberCount).toBe(2);
+  });
+
+  test("is idempotent — a second run is a no-op", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAnnouncementGroup(t);
+
+    await t.mutation(
+      internal.functions.migrations.unifyAnnouncementChannels
+        .migrateAnnouncementGroupChannels,
+      { communityId: seeded.communityId }
+    );
+    const second = await t.mutation(
+      internal.functions.migrations.unifyAnnouncementChannels
+        .migrateAnnouncementGroupChannels,
+      { communityId: seeded.communityId }
+    );
+
+    expect(second.results[0].status).toBe("already_migrated");
+
+    const channels = await channelsForGroup(t, seeded.groupId);
+    expect(channels.filter((c) => c.channelType === "main")).toHaveLength(1);
+    expect(
+      channels.filter((c) => c.channelType === "announcements")
+    ).toHaveLength(1);
+  });
+
+  test("after migration: leaders-only posts in announcements, everyone in general", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAnnouncementGroup(t);
+
+    await t.mutation(
+      internal.functions.migrations.unifyAnnouncementChannels
+        .migrateAnnouncementGroupChannels,
+      { communityId: seeded.communityId }
+    );
+
+    const channels = await channelsForGroup(t, seeded.groupId);
+    const announcementsId = channels.find(
+      (c) => c.channelType === "announcements"
+    )!._id;
+    const generalId = channels.find((c) => c.channelType === "main")!._id;
+
+    const { accessToken: leaderToken } = await generateTokens(seeded.leaderId);
+    const { accessToken: memberToken } = await generateTokens(seeded.memberId);
+
+    // Leader can post in the announcements channel.
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: leaderToken,
+        channelId: announcementsId,
+        content: "Leader announcement",
+      })
+    ).resolves.toBeDefined();
+
+    // Member is blocked from the announcements channel.
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: memberToken,
+        channelId: announcementsId,
+        content: "Member trying to announce",
+      })
+    ).rejects.toThrow(/Only group leaders can post/i);
+
+    // Member CAN post in the new, open general channel.
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: memberToken,
+        channelId: generalId,
+        content: "Hello everyone",
+      })
+    ).resolves.toBeDefined();
+  });
+
+  test("dryRun reports changes without writing", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAnnouncementGroup(t);
+
+    const result = await t.mutation(
+      internal.functions.migrations.unifyAnnouncementChannels
+        .migrateAnnouncementGroupChannels,
+      { communityId: seeded.communityId, dryRun: true }
+    );
+
+    expect(result.dryRun).toBe(true);
+    expect(result.results[0].status).toBe("would_migrate");
+    expect(result.results[0].messageCount).toBe(3);
+    expect(result.results[0].memberCount).toBe(2);
+
+    // Nothing changed: still a single main channel, no announcements channel.
+    const channels = await channelsForGroup(t, seeded.groupId);
+    expect(channels.filter((c) => c.channelType === "main")).toHaveLength(1);
+    expect(
+      channels.filter((c) => c.channelType === "announcements")
+    ).toHaveLength(0);
+  });
+});

--- a/apps/convex/__tests__/scheduling/permissions.test.ts
+++ b/apps/convex/__tests__/scheduling/permissions.test.ts
@@ -6,7 +6,7 @@
  * be `ConvexError` so the client `AuthErrorBoundary` can recover.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { ConvexError } from "convex/values";
 import { convexTest } from "convex-test";
 import schema from "../../schema";
@@ -15,9 +15,22 @@ import { generateTokens } from "../../lib/auth";
 import { api } from "../../_generated/api";
 import { buildSchedulingWorld } from "./fixtures";
 
+// `respondToAssignment` enqueues a deferred team-channel reconcile via
+// `ctx.scheduler.runAfter(0, ...)`; the `afterEach` below drains it so a
+// pending scheduled function does not leak into the next test.
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
 /** Spin up a convex-test handle and seed the scheduling world into it. */
 async function setupSchedulingWorld() {
   const t = convexTest(schema, modules);
+  activeHandle = t;
   const world = await buildSchedulingWorld(t);
   return { t, world };
 }

--- a/apps/convex/functions/authInternal.ts
+++ b/apps/convex/functions/authInternal.ts
@@ -1064,7 +1064,8 @@ export const selectCommunityForUser = mutation({
         updatedAt: timestamp,
       });
 
-      // If rejoining, trigger Planning Center sync and announcement group join
+      // If rejoining, trigger Planning Center + marketing syncs.
+      // (Announcement group sync runs unconditionally below.)
       if (isRejoining) {
         console.log("[selectCommunityForUser] User rejoining community, triggering sync", {
           userId,
@@ -1088,14 +1089,16 @@ export const selectCommunityForUser = mutation({
           internal.functions.marketing.flodesk.syncUser,
           { userId, communityId: args.communityId },
         );
-
-        // Add to announcement group
-        await ctx.runMutation(internal.functions.sync.memberships.syncMemberships, {
-          userId,
-          syncAnnouncementGroup: true,
-          communityId: args.communityId,
-        });
       }
+
+      // Always reconcile announcement group membership on community-select.
+      // Cheap, idempotent, and ensures users get added to groups created
+      // after they joined (e.g. backfilled announcement groups).
+      await ctx.runMutation(internal.functions.sync.memberships.syncMemberships, {
+        userId,
+        syncAnnouncementGroup: true,
+        communityId: args.communityId,
+      });
     } else {
       // Create new membership with lastLogin
       await ctx.db.insert("userCommunities", {

--- a/apps/convex/functions/communities.ts
+++ b/apps/convex/functions/communities.ts
@@ -14,7 +14,7 @@ import { requireAuth } from "../lib/auth";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ADMIN_THRESHOLD, PRIMARY_ADMIN_ROLE } from "../lib/permissions";
 import { syncUserChannelMembershipsLogic, syncAnnouncementGroupMembership } from "./sync/memberships";
-import { ensureChannelsForGroupLogic } from "./messaging/channels";
+import { ensureChannelsForGroupLogic, ensureAnnouncementsChannelLogic } from "./messaging/channels";
 
 // ============================================================================
 // Helper Functions
@@ -107,8 +107,13 @@ export async function addUserToAnnouncementGroup(
       updatedAt: timestamp,
     });
 
-    // Create general + leaders channels for the announcement group
+    // Create general + leaders channels for the announcement group, plus the
+    // leaders-only Announcements broadcast channel. This is the same
+    // two-channel model every group uses: general = everyone posts,
+    // announcements = leaders post (enforced in sendMessage). Members are
+    // added to both via syncUserChannelMembershipsLogic below.
     await ensureChannelsForGroupLogic(ctx, announcementGroupId, userId, communityName);
+    await ensureAnnouncementsChannelLogic(ctx, announcementGroupId, userId);
 
     console.log("[addUserToAnnouncementGroup] Created announcement group with channels", {
       communityId,

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -3415,6 +3415,51 @@ export async function ensureChannelsForGroupLogic(
 }
 
 /**
+ * Ensure an enabled "announcements" channel exists for a group.
+ *
+ * Mirrors the create path in `toggleAnnouncementsChannel` but is callable
+ * directly within any mutation for atomic creation (e.g. when provisioning an
+ * announcement group). Members are NOT added here — channel-membership sync
+ * (`syncUserChannelMembershipsLogic`) adds every active group member to
+ * `announcements` channels. Posting stays leader-only, enforced in
+ * `sendMessage`.
+ *
+ * No-op (returns the existing channel id) if a channel already uses the
+ * "announcements" slug for this group.
+ */
+export async function ensureAnnouncementsChannelLogic(
+  ctx: MutationCtx,
+  groupId: Id<"groups">,
+  createdById: Id<"users">
+): Promise<Id<"chatChannels">> {
+  const existing = await ctx.db
+    .query("chatChannels")
+    .withIndex("by_group_slug", (q) =>
+      q.eq("groupId", groupId).eq("slug", "announcements")
+    )
+    .first();
+  if (existing) {
+    return existing._id;
+  }
+
+  const now = Date.now();
+  return ctx.db.insert("chatChannels", {
+    groupId,
+    slug: "announcements",
+    channelType: "announcements",
+    name: "Announcements",
+    description:
+      "Leader announcements — visible to all members; only leaders can post.",
+    createdById,
+    createdAt: now,
+    updatedAt: now,
+    isArchived: false,
+    isEnabled: true,
+    memberCount: 0,
+  });
+}
+
+/**
  * Internal mutation to ensure channels exist for a group.
  * Creates main and leaders channels if they don't exist.
  *

--- a/apps/convex/functions/migrations/unifyAnnouncementChannels.ts
+++ b/apps/convex/functions/migrations/unifyAnnouncementChannels.ts
@@ -1,0 +1,184 @@
+/**
+ * Migration: unify announcement-group channels onto the standard two-channel model
+ *
+ * Historically the community-wide announcement group's "general" channel
+ * (channelType "main") was treated as leaders-only via a frontend-only
+ * `isAnnouncementGroup` gate. We've since shipped a proper, server-enforced
+ * leaders-only "announcements" channel that every group can use. This backfill
+ * converts each announcement group onto that model:
+ *
+ *   1. Convert the existing general channel IN PLACE: channelType "main" ->
+ *      "announcements", slug "general" -> "announcements". The channel id is
+ *      unchanged, so every historical message and channel member stays attached
+ *      — the old leader announcements become the announcements-channel history.
+ *   2. Create a fresh, empty "general" channel (channelType "main") that is
+ *      open to everyone, and add all active group members to it.
+ *
+ * Idempotent: any announcement group that already has an "announcements"
+ * channel is skipped. Pass `communityId` to scope to a single community
+ * (e.g. Fount); omit to migrate every announcement group. Pass
+ * `dryRun: true` to report what would change without writing.
+ *
+ * Usage:
+ *   # dry run for one community
+ *   npx convex run functions/migrations/unifyAnnouncementChannels:migrateAnnouncementGroupChannels '{"communityId":"<id>","dryRun":true}'
+ *   # apply for one community
+ *   npx convex run functions/migrations/unifyAnnouncementChannels:migrateAnnouncementGroupChannels '{"communityId":"<id>"}'
+ */
+
+import { v } from "convex/values";
+import { internalMutation } from "../../_generated/server";
+import { getDisplayName, getMediaUrl } from "../../lib/utils";
+import { isLeaderRole } from "../../lib/permissions";
+
+export const migrateAnnouncementGroupChannels = internalMutation({
+  args: {
+    communityId: v.optional(v.id("communities")),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun ?? false;
+    const now = Date.now();
+
+    // Collect target announcement groups.
+    const announcementGroups = args.communityId
+      ? await ctx.db
+          .query("groups")
+          .withIndex("by_community", (q) =>
+            q.eq("communityId", args.communityId!)
+          )
+          .filter((q) => q.eq(q.field("isAnnouncementGroup"), true))
+          .collect()
+      : await ctx.db
+          .query("groups")
+          .filter((q) => q.eq(q.field("isAnnouncementGroup"), true))
+          .collect();
+
+    const results: Array<Record<string, unknown>> = [];
+
+    for (const group of announcementGroups) {
+      // Already migrated? An announcements channel already exists.
+      const existingAnnouncements = await ctx.db
+        .query("chatChannels")
+        .withIndex("by_group_type", (q) =>
+          q.eq("groupId", group._id).eq("channelType", "announcements")
+        )
+        .first();
+      if (existingAnnouncements) {
+        results.push({
+          groupId: group._id,
+          name: group.name,
+          status: "already_migrated",
+          announcementsChannelId: existingAnnouncements._id,
+        });
+        continue;
+      }
+
+      // Find the general/main channel to convert in place.
+      const mainChannel = await ctx.db
+        .query("chatChannels")
+        .withIndex("by_group_type", (q) =>
+          q.eq("groupId", group._id).eq("channelType", "main")
+        )
+        .filter((q) => q.eq(q.field("isArchived"), false))
+        .first();
+      if (!mainChannel) {
+        results.push({
+          groupId: group._id,
+          name: group.name,
+          status: "no_main_channel",
+        });
+        continue;
+      }
+
+      const activeMembers = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group", (q) => q.eq("groupId", group._id))
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .collect();
+
+      const messages = await ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", mainChannel._id))
+        .collect();
+
+      if (dryRun) {
+        results.push({
+          groupId: group._id,
+          name: group.name,
+          status: "would_migrate",
+          convertChannelId: mainChannel._id,
+          messageCount: messages.length,
+          memberCount: activeMembers.length,
+        });
+        continue;
+      }
+
+      // 1) Convert the existing general channel -> announcements, in place.
+      //    Messages and channel members stay attached (channel id unchanged).
+      await ctx.db.patch(mainChannel._id, {
+        channelType: "announcements",
+        slug: "announcements",
+        name: "Announcements",
+        description:
+          "Leader announcements — visible to all members; only leaders can post.",
+        isEnabled: true,
+        isArchived: false,
+        archivedAt: undefined,
+        updatedAt: now,
+      });
+
+      // 2) Create a fresh, empty general channel open to everyone.
+      const newGeneralId = await ctx.db.insert("chatChannels", {
+        groupId: group._id,
+        slug: "general",
+        channelType: "main",
+        name: `${group.name} - General`,
+        description: `General chat for ${group.name}`,
+        createdById: mainChannel.createdById,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 0,
+      });
+
+      // 3) Add every active group member to the new general channel.
+      let added = 0;
+      for (const member of activeMembers) {
+        const user = await ctx.db.get(member.userId);
+        const displayName = user
+          ? getDisplayName(user.firstName, user.lastName)
+          : undefined;
+        const profilePhoto = user ? getMediaUrl(user.profilePhoto) : undefined;
+        await ctx.db.insert("chatChannelMembers", {
+          channelId: newGeneralId,
+          userId: member.userId,
+          role: isLeaderRole(member.role) ? "admin" : "member",
+          joinedAt: now,
+          isMuted: false,
+          displayName,
+          profilePhoto,
+        });
+        added++;
+      }
+      await ctx.db.patch(newGeneralId, { memberCount: added });
+
+      results.push({
+        groupId: group._id,
+        name: group.name,
+        status: "migrated",
+        announcementsChannelId: mainChannel._id,
+        newGeneralChannelId: newGeneralId,
+        messageCount: messages.length,
+        memberCount: added,
+      });
+    }
+
+    return {
+      dryRun,
+      communityId: args.communityId ?? null,
+      groupsProcessed: announcementGroups.length,
+      results,
+    };
+  },
+});

--- a/apps/convex/functions/seed.ts
+++ b/apps/convex/functions/seed.ts
@@ -509,6 +509,9 @@ export const createChatChannels = internalMutation({
     groupId: v.id("groups"),
     groupName: v.string(),
     createdById: v.id("users"),
+    // Announcement groups also get a leaders-only "announcements" channel so
+    // dev parity matches production (general = everyone, announcements = leaders).
+    includeAnnouncements: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<{ mainChannelId: Id<"chatChannels">; leadersChannelId: Id<"chatChannels"> }> => {
     const timestamp = now();
@@ -565,6 +568,32 @@ export const createChatChannels = internalMutation({
         memberCount: 0,
       });
       console.log(`[seed] Created leaders channel for ${args.groupName}`);
+    }
+
+    if (args.includeAnnouncements) {
+      const existingAnnouncements = await ctx.db
+        .query("chatChannels")
+        .withIndex("by_group_slug", (q) =>
+          q.eq("groupId", args.groupId).eq("slug", "announcements")
+        )
+        .first();
+      if (!existingAnnouncements) {
+        await ctx.db.insert("chatChannels", {
+          groupId: args.groupId,
+          slug: "announcements",
+          channelType: "announcements",
+          name: "Announcements",
+          description:
+            "Leader announcements — visible to all members; only leaders can post.",
+          createdById: args.createdById,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          isArchived: false,
+          isEnabled: true,
+          memberCount: 0,
+        });
+        console.log(`[seed] Created announcements channel for ${args.groupName}`);
+      }
     }
 
     return { mainChannelId, leadersChannelId };
@@ -749,6 +778,7 @@ export const seedDemoData = internalAction({
           groupId: announcementGroupId,
           groupName: DEMO_COMMUNITY_NAME,
           createdById: testUserId,
+          includeAnnouncements: true,
         }
       );
     }

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -390,9 +390,11 @@ const ConvexChatRoomScreenInner: React.FC = () => {
     return activeTab?.channelType === "announcements";
   }, [channelTabs, activeSlug]);
 
-  const canSendMessages =
-    (!isAnnouncementGroup || isUserLeader) &&
-    (!isAnnouncementsChannel || isUserLeader);
+  // Leaders-only posting is now carried solely by the "announcements" channel
+  // (server-enforced in sendMessage), for every group including the
+  // community-wide announcement group. The announcement group's general
+  // channel is open to everyone, just like any other group's general channel.
+  const canSendMessages = !isAnnouncementsChannel || isUserLeader;
 
   // UI state
   const [menuVisible, setMenuVisible] = useState(false);


### PR DESCRIPTION
## What & why

There were two parallel "leaders-only posting" mechanisms doing the same thing:

1. **Announcement group** (`isAnnouncementGroup`, one per community): its `general` channel was gated leaders-only via a **frontend-only** check (`ConvexChatRoomScreen.canSendMessages`) — no server enforcement.
2. **Per-group announcements channel** (`channelType: "announcements"`): a newer, **server-enforced** leaders-only broadcast channel.

This PR collapses everything onto mechanism #2 so **every group follows one model**: an `announcements` channel where only leaders post (enforced in `sendMessage`) + a `general` channel where everyone posts.

## Changes

- **`messaging/channels.ts`** — `ensureAnnouncementsChannelLogic()` for atomic announcements-channel creation inside a mutation. Members flow in via the existing channel-membership sync (already handles `announcements`).
- **`communities.ts`** — new announcement groups get the announcements channel alongside general + leaders.
- **`ConvexChatRoomScreen.tsx`** — drop the `isAnnouncementGroup` posting gate. The announcement group's general channel is now open to everyone; leaders-only is carried solely by the announcements channel.
- **`migrations/unifyAnnouncementChannels.ts`** — idempotent backfill: converts each announcement group's legacy `general` (main) channel **in place** → `announcements` (preserving all historical leader posts + channel members), then creates a fresh, empty, open `general`. Supports `communityId` scoping and `dryRun`.
- **`seed.ts`** — dev parity: announcement group also gets an announcements channel.

## Migration / rollout

The backfill is scoped to run for the **Fount** community in Togather prod:

```bash
# dry run
npx convex run functions/migrations/unifyAnnouncementChannels:migrateAnnouncementGroupChannels '{"communityId":"<fount-id>","dryRun":true}'
# apply
npx convex run functions/migrations/unifyAnnouncementChannels:migrateAnnouncementGroupChannels '{"communityId":"<fount-id>"}'
```

It will be run against prod **after** this lands and is deployed there. Idempotent + `dryRun` make it safe to re-run.

## Tests

`__tests__/migrations/unifyAnnouncementChannels.test.ts`:
- convert-in-place (messages + members preserved, fresh empty general created)
- idempotency (second run is a no-op)
- dryRun (reports without writing)
- end-to-end `sendMessage` enforcement: leader posts in announcements ✅, member blocked ❌, member posts in general ✅

Existing `membershipSync` / `permissions` / `community-membership` suites still green. Full `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)