### PR TITLE
feat(chat): make the General channel optional

### DIFF
--- a/apps/convex/__tests__/messaging/postToChat-fallback.test.ts
+++ b/apps/convex/__tests__/messaging/postToChat-fallback.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for meetings.postToChat with the optional General channel.
+ *
+ * postToChat used to require the group's `main` channel and throw if it was
+ * missing. With General optional, it now resolves the group's best active
+ * channel via resolveGroupDefaultChannel — posting to announcements when
+ * General is disabled, and throwing only when nothing active remains.
+ *
+ * postToChat enqueues `ctx.scheduler.runAfter(0, onMessageSent)`, so the
+ * scheduled-function drain pattern is required.
+ */
+
+import { vi, expect, test, describe, afterEach } from "vitest";
+
+vi.mock("jose", () => ({
+  jwtVerify: vi.fn(async (token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) throw new Error("Invalid token");
+    return { payload: { userId: match[1], type: "access" } };
+  }),
+  SignJWT: vi.fn(() => ({
+    setProtectedHeader: vi.fn().mockReturnThis(),
+    setIssuedAt: vi.fn().mockReturnThis(),
+    setExpirationTime: vi.fn().mockReturnThis(),
+    sign: vi.fn().mockResolvedValue("mock-signed-token"),
+  })),
+  decodeJwt: vi.fn((token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) return null;
+    return { userId: match[1], type: "access" };
+  }),
+}));
+
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import type { Id } from "../../_generated/dataModel";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// Drain scheduled functions enqueued by postToChat (onMessageSent).
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+  vi.useRealTimers();
+});
+
+interface Seed {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  meetingId: Id<"meetings">;
+  leaderId: Id<"users">;
+  leaderToken: string;
+}
+
+async function seed(t: ReturnType<typeof convexTest>): Promise<Seed> {
+  return await t.run(async (ctx) => {
+    const ts = Date.now();
+    const future = ts + 86_400_000;
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug: "test-post-to-chat",
+      isPublic: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "General",
+      slug: "general",
+      isActive: true,
+      displayOrder: 0,
+      createdAt: ts,
+    });
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      name: "Dinner Club",
+      groupTypeId,
+      isArchived: false,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Lead",
+      lastName: "Er",
+      phone: "+15551110002",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: leaderId,
+      role: "leader",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+    const meetingId = await ctx.db.insert("meetings", {
+      groupId,
+      title: "Dinner Party",
+      scheduledAt: future,
+      status: "scheduled",
+      meetingType: 1,
+      createdAt: ts,
+      rsvpEnabled: true,
+      visibility: "public",
+      shortId: "dinner123",
+      createdById: leaderId,
+      hostUserIds: [leaderId],
+      communityId,
+    });
+
+    return {
+      communityId,
+      groupId,
+      meetingId,
+      leaderId,
+      leaderToken: `test-token-${leaderId}`,
+    };
+  });
+}
+
+async function addChannel(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  leaderId: Id<"users">,
+  channelType: string,
+  opts: { slug?: string; name?: string; isArchived?: boolean } = {},
+): Promise<Id<"chatChannels">> {
+  const ts = Date.now();
+  return await t.run((ctx) =>
+    ctx.db.insert("chatChannels", {
+      groupId,
+      slug: opts.slug ?? channelType,
+      channelType,
+      name: opts.name ?? channelType,
+      createdById: leaderId,
+      createdAt: ts,
+      updatedAt: ts,
+      isArchived: opts.isArchived ?? false,
+      memberCount: 1,
+    }),
+  );
+}
+
+async function addChannelMember(
+  t: ReturnType<typeof convexTest>,
+  channelId: Id<"chatChannels">,
+  userId: Id<"users">,
+) {
+  const ts = Date.now();
+  await t.run((ctx) =>
+    ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId,
+      role: "member",
+      joinedAt: ts,
+      isMuted: false,
+    }),
+  );
+}
+
+describe("meetings.postToChat fallback", () => {
+  test("posts to announcements when General is disabled", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { groupId, meetingId, leaderId, leaderToken } = await seed(t);
+
+    // General disabled (archived); announcements active.
+    await addChannel(t, groupId, leaderId, "main", {
+      slug: "general",
+      name: "General",
+      isArchived: true,
+    });
+    const annId = await addChannel(t, groupId, leaderId, "announcements", {
+      name: "Announcements",
+    });
+    await addChannelMember(t, annId, leaderId);
+
+    const messageId = await t.mutation(api.functions.meetings.index.postToChat, {
+      token: leaderToken,
+      meetingId,
+      message: "Join us!",
+    });
+
+    const message = await t.run((ctx) => ctx.db.get(messageId));
+    expect(message?.channelId).toBe(annId);
+  });
+
+  test("throws when the group has no active channel to share to", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { groupId, meetingId, leaderId, leaderToken } = await seed(t);
+
+    // Only an archived General — nothing active.
+    await addChannel(t, groupId, leaderId, "main", {
+      slug: "general",
+      name: "General",
+      isArchived: true,
+    });
+
+    await expect(
+      t.mutation(api.functions.meetings.index.postToChat, {
+        token: leaderToken,
+        meetingId,
+        message: "Join us!",
+      }),
+    ).rejects.toThrow("This group has no active channel to share to");
+  });
+});

--- a/apps/convex/__tests__/messaging/postToChat-fallback.test.ts
+++ b/apps/convex/__tests__/messaging/postToChat-fallback.test.ts
@@ -3,8 +3,10 @@
  *
  * postToChat used to require the group's `main` channel and throw if it was
  * missing. With General optional, it now resolves the group's best active
- * channel via resolveGroupDefaultChannel — posting to announcements when
- * General is disabled, and throwing only when nothing active remains.
+ * channel the SENDER can post to (resolveGroupDefaultChannelForUser) — posting
+ * to announcements when General is disabled, falling through past channels the
+ * sender isn't in (so the membership gate doesn't reject them) to e.g. Leaders,
+ * and throwing only when nothing active+accessible remains.
  *
  * postToChat enqueues `ctx.scheduler.runAfter(0, onMessageSent)`, so the
  * scheduled-function drain pattern is required.
@@ -189,6 +191,38 @@ describe("meetings.postToChat fallback", () => {
 
     const message = await t.run((ctx) => ctx.db.get(messageId));
     expect(message?.channelId).toBe(annId);
+  });
+
+  test("falls through to a postable channel (Leaders), skipping a custom channel the sender isn't in", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { groupId, meetingId, leaderId, leaderToken } = await seed(t);
+
+    // General disabled; an active custom channel the leader is NOT a member of;
+    // a Leaders channel the leader IS in. The resolver must skip the custom
+    // channel (membership gate would reject it) and post to Leaders.
+    await addChannel(t, groupId, leaderId, "main", {
+      slug: "general",
+      name: "General",
+      isArchived: true,
+    });
+    await addChannel(t, groupId, leaderId, "custom", {
+      slug: "secret",
+      name: "Secret",
+    });
+    const leadersId = await addChannel(t, groupId, leaderId, "leaders", {
+      name: "Leaders",
+    });
+    await addChannelMember(t, leadersId, leaderId);
+
+    const messageId = await t.mutation(api.functions.meetings.index.postToChat, {
+      token: leaderToken,
+      meetingId,
+      message: "Join us!",
+    });
+
+    const message = await t.run((ctx) => ctx.db.get(messageId));
+    expect(message?.channelId).toBe(leadersId);
   });
 
   test("throws when the group has no active channel to share to", async () => {

--- a/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
+++ b/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
@@ -314,6 +314,59 @@ describe("getGroupDefaultChannel query", () => {
     expect(result?.channelId).toBe(sharedChannelId);
   });
 
+  test("excludes a shared channel hidden from this group (hiddenFromNavigation)", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId, userId, accessToken } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+
+    // Shared channel the caller is a member of, but the linked group hid it.
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      const ownerGroupId = await ctx.db.insert("groups", {
+        name: "Owner Group",
+        communityId,
+        groupTypeId: (await ctx.db.query("groupTypes").first())!._id,
+        isArchived: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const channelId = await ctx.db.insert("chatChannels", {
+        groupId: ownerGroupId,
+        slug: "hidden-room",
+        channelType: "custom",
+        name: "Hidden Room",
+        createdById: userId,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 1,
+        isShared: true,
+        sharedGroups: [
+          {
+            groupId,
+            status: "accepted",
+            invitedById: userId,
+            invitedAt: now,
+            hiddenFromNavigation: true,
+          },
+        ],
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId,
+        role: "member",
+        joinedAt: now,
+        isMuted: false,
+      });
+    });
+
+    const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
+      token: accessToken,
+      groupId,
+    });
+    expect(result).toBeNull();
+  });
+
   test("returns null when the only active channels are ones the caller isn't in", async () => {
     const t = convexTest(schema, modules);
     const { groupId, accessToken } = await seed(t);

--- a/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
+++ b/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
@@ -18,7 +18,10 @@ import schema from "../../schema";
 import { modules } from "../../test.setup";
 import { api } from "../../_generated/api";
 import { generateTokens } from "../../lib/auth";
-import { resolveGroupDefaultChannel } from "../../functions/messaging/channels";
+import {
+  resolveGroupDefaultChannel,
+  ensureChannelsForGroupLogic,
+} from "../../functions/messaging/channels";
 import type { Id } from "../../_generated/dataModel";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
@@ -307,5 +310,57 @@ describe("getGroupDefaultChannel query", () => {
       groupId,
     });
     expect(result).toBeNull();
+  });
+});
+
+describe("ensureChannelsForGroupLogic — disabled General", () => {
+  test("does NOT recreate an archived (intentionally disabled) main channel", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, userId } = await seed(t);
+    // General was disabled (archived); leaders remains active.
+    const archivedMainId = await addChannel(t, groupId, "main", {
+      slug: "general",
+      name: "General",
+      isArchived: true,
+    });
+    await addChannel(t, groupId, "leaders", { name: "Leaders" });
+
+    const result = await t.run((ctx) =>
+      ensureChannelsForGroupLogic(ctx, groupId, userId, "Test Group"),
+    );
+
+    // Nothing should be created — the archived main is intentional, not missing.
+    expect(result.created).toBe(false);
+
+    const mains = await t.run((ctx) =>
+      ctx.db
+        .query("chatChannels")
+        .withIndex("by_group", (q) => q.eq("groupId", groupId))
+        .filter((q) => q.eq(q.field("channelType"), "main"))
+        .collect(),
+    );
+    // Still exactly one main channel, still archived (no duplicate, not resurrected).
+    expect(mains).toHaveLength(1);
+    expect(mains[0]._id).toBe(archivedMainId);
+    expect(mains[0].isArchived).toBe(true);
+  });
+
+  test("still provisions main + leaders for a brand-new group", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, userId } = await seed(t);
+
+    const result = await t.run((ctx) =>
+      ensureChannelsForGroupLogic(ctx, groupId, userId, "Test Group"),
+    );
+
+    expect(result.created).toBe(true);
+    const channels = await t.run((ctx) =>
+      ctx.db
+        .query("chatChannels")
+        .withIndex("by_group", (q) => q.eq("groupId", groupId))
+        .collect(),
+    );
+    expect(channels.some((c) => c.channelType === "main")).toBe(true);
+    expect(channels.some((c) => c.channelType === "leaders")).toBe(true);
   });
 });

--- a/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
+++ b/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
@@ -264,6 +264,56 @@ describe("getGroupDefaultChannel query", () => {
     expect(result?.channelId).toBe(annId);
   });
 
+  test("includes a shared channel the caller is in (linked group, General disabled)", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId, userId, accessToken } = await seed(t);
+    // This (linked) group's General is disabled and it owns no other channel.
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+
+    // A channel OWNED by another group, shared into this group (accepted),
+    // with the caller as an active member.
+    const sharedChannelId = await t.run(async (ctx) => {
+      const now = Date.now();
+      const ownerGroupId = await ctx.db.insert("groups", {
+        name: "Owner Group",
+        communityId,
+        groupTypeId: (await ctx.db.query("groupTypes").first())!._id,
+        isArchived: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const channelId = await ctx.db.insert("chatChannels", {
+        groupId: ownerGroupId,
+        slug: "shared-room",
+        channelType: "custom",
+        name: "Shared Room",
+        createdById: userId,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 1,
+        isShared: true,
+        sharedGroups: [
+          { groupId, status: "accepted", invitedById: userId, invitedAt: now },
+        ],
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId,
+        role: "member",
+        joinedAt: now,
+        isMuted: false,
+      });
+      return channelId;
+    });
+
+    const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
+      token: accessToken,
+      groupId,
+    });
+    expect(result?.channelId).toBe(sharedChannelId);
+  });
+
   test("returns null when the only active channels are ones the caller isn't in", async () => {
     const t = convexTest(schema, modules);
     const { groupId, accessToken } = await seed(t);

--- a/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
+++ b/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
@@ -124,6 +124,22 @@ async function addChannel(
   );
 }
 
+async function addMembership(
+  t: ReturnType<typeof convexTest>,
+  channelId: Id<"chatChannels">,
+  userId: Id<"users">,
+): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId,
+      role: "member",
+      joinedAt: Date.now(),
+      isMuted: false,
+    }),
+  );
+}
+
 describe("resolveGroupDefaultChannel", () => {
   test("main active -> main", async () => {
     const t = convexTest(schema, modules);
@@ -206,9 +222,10 @@ describe("resolveGroupDefaultChannel", () => {
 describe("getGroupDefaultChannel query", () => {
   test("returns the resolved channel for an active member", async () => {
     const t = convexTest(schema, modules);
-    const { groupId, accessToken } = await seed(t);
+    const { groupId, userId, accessToken } = await seed(t);
     await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
     const annId = await addChannel(t, groupId, "announcements", { name: "Announcements" });
+    await addMembership(t, annId, userId);
 
     const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
       token: accessToken,
@@ -219,6 +236,40 @@ describe("getGroupDefaultChannel query", () => {
       slug: "announcements",
       channelType: "announcements",
     });
+  });
+
+  test("skips channels the caller isn't a member of (leaders/custom)", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, userId, accessToken } = await seed(t);
+    // General disabled. A leaders channel and a custom channel exist but the
+    // member belongs to neither; they ARE in announcements.
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+    await addChannel(t, groupId, "leaders", { name: "Leaders" });
+    await addChannel(t, groupId, "custom", { slug: "secret", name: "Secret" });
+    const annId = await addChannel(t, groupId, "announcements", { name: "Announcements" });
+    await addMembership(t, annId, userId);
+
+    const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
+      token: accessToken,
+      groupId,
+    });
+    // Must NOT route the member to leaders/custom they can't see.
+    expect(result?.channelType).toBe("announcements");
+    expect(result?.channelId).toBe(annId);
+  });
+
+  test("returns null when the only active channels are ones the caller isn't in", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, accessToken } = await seed(t);
+    // General disabled; only a leaders channel remains and the member isn't in it.
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+    await addChannel(t, groupId, "leaders", { name: "Leaders" });
+
+    const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
+      token: accessToken,
+      groupId,
+    });
+    expect(result).toBeNull();
   });
 
   test("returns null when caller is not a group member", async () => {

--- a/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
+++ b/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for resolveGroupDefaultChannel + getGroupDefaultChannel.
+ *
+ * General (the `main` channel) is now optional. resolveGroupDefaultChannel
+ * picks the highest-priority ACTIVE channel for a group so backend sites that
+ * used to assume a main channel exists have a deterministic fallback.
+ *
+ * "Active" means `isArchived !== true && isEnabled !== false`.
+ *
+ * Priority:
+ *   1. main  2. announcements  3. reach_out, then custom/pco_services/cross_team
+ *   (by lastMessageAt desc, then name)  4. leaders  5. null
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import { resolveGroupDefaultChannel } from "../../functions/messaging/channels";
+import type { Id } from "../../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+vi.useFakeTimers();
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+interface Seed {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  userId: Id<"users">;
+  accessToken: string;
+}
+
+let createdByUserId: Id<"users">;
+
+async function seed(t: ReturnType<typeof convexTest>): Promise<Seed> {
+  const now = Date.now();
+  const communityId = await t.run((ctx) =>
+    ctx.db.insert("communities", {
+      name: "Test Community",
+      subdomain: "test",
+      slug: "test",
+      timezone: "America/New_York",
+      createdAt: now,
+      updatedAt: now,
+    }),
+  );
+  const groupTypeId = await t.run((ctx) =>
+    ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Groups",
+      slug: "small-groups",
+      isActive: true,
+      displayOrder: 1,
+      createdAt: now,
+    }),
+  );
+  const userId = await t.run((ctx) =>
+    ctx.db.insert("users", {
+      firstName: "Test",
+      lastName: "User",
+      phone: "+15555550001",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: now,
+      updatedAt: now,
+    }),
+  );
+  const groupId = await t.run((ctx) =>
+    ctx.db.insert("groups", {
+      name: "Test Group",
+      communityId,
+      groupTypeId,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    }),
+  );
+  await t.run((ctx) =>
+    ctx.db.insert("groupMembers", {
+      userId,
+      groupId,
+      role: "member",
+      joinedAt: now,
+      notificationsEnabled: true,
+    }),
+  );
+  const { accessToken } = await generateTokens(userId);
+  createdByUserId = userId;
+  return { communityId, groupId, userId, accessToken };
+}
+
+async function addChannel(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  channelType: string,
+  opts: {
+    slug?: string;
+    name?: string;
+    isArchived?: boolean;
+    isEnabled?: boolean;
+    lastMessageAt?: number;
+  } = {},
+): Promise<Id<"chatChannels">> {
+  const now = Date.now();
+  return await t.run((ctx) =>
+    ctx.db.insert("chatChannels", {
+      groupId,
+      slug: opts.slug ?? channelType,
+      channelType,
+      name: opts.name ?? channelType,
+      createdById: createdByUserId,
+      createdAt: now,
+      updatedAt: now,
+      isArchived: opts.isArchived ?? false,
+      isEnabled: opts.isEnabled,
+      lastMessageAt: opts.lastMessageAt,
+      memberCount: 0,
+    }),
+  );
+}
+
+describe("resolveGroupDefaultChannel", () => {
+  test("main active -> main", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId } = await seed(t);
+    const mainId = await addChannel(t, groupId, "main", { slug: "general", name: "General" });
+    await addChannel(t, groupId, "announcements", { name: "Announcements" });
+    await addChannel(t, groupId, "leaders", { name: "Leaders" });
+
+    const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
+    expect(resolved?._id).toBe(mainId);
+  });
+
+  test("main disabled + announcements active -> announcements", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+    const annId = await addChannel(t, groupId, "announcements", { name: "Announcements" });
+    await addChannel(t, groupId, "leaders", { name: "Leaders" });
+
+    const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
+    expect(resolved?._id).toBe(annId);
+  });
+
+  test("main + announcements disabled + reach_out active -> reach_out", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+    await addChannel(t, groupId, "announcements", { name: "Announcements", isEnabled: false });
+    const reachId = await addChannel(t, groupId, "reach_out", { name: "Reach Out" });
+    await addChannel(t, groupId, "leaders", { name: "Leaders" });
+
+    const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
+    expect(resolved?._id).toBe(reachId);
+  });
+
+  test("custom channels chosen by lastMessageAt desc, tie-break by name", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId } = await seed(t);
+    await addChannel(t, groupId, "custom", { slug: "old", name: "Alpha", lastMessageAt: 1000 });
+    const recentId = await addChannel(t, groupId, "custom", { slug: "new", name: "Zulu", lastMessageAt: 5000 });
+
+    const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
+    expect(resolved?._id).toBe(recentId);
+  });
+
+  test("only leaders active -> leaders", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+    await addChannel(t, groupId, "announcements", { name: "Announcements", isArchived: true });
+    await addChannel(t, groupId, "reach_out", { name: "Reach Out", isEnabled: false });
+    const leadersId = await addChannel(t, groupId, "leaders", { name: "Leaders" });
+
+    const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
+    expect(resolved?._id).toBe(leadersId);
+  });
+
+  test("all disabled -> null", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+    await addChannel(t, groupId, "leaders", { name: "Leaders", isEnabled: false });
+
+    const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
+    expect(resolved).toBeNull();
+  });
+
+  test("dm / group_dm / event channel types are excluded", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId } = await seed(t);
+    await addChannel(t, groupId, "dm", { name: "DM" });
+    await addChannel(t, groupId, "group_dm", { name: "Group DM" });
+    await addChannel(t, groupId, "event", { name: "Event" });
+
+    const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
+    expect(resolved).toBeNull();
+  });
+});
+
+describe("getGroupDefaultChannel query", () => {
+  test("returns the resolved channel for an active member", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, accessToken } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+    const annId = await addChannel(t, groupId, "announcements", { name: "Announcements" });
+
+    const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
+      token: accessToken,
+      groupId,
+    });
+    expect(result).toEqual({
+      channelId: annId,
+      slug: "announcements",
+      channelType: "announcements",
+    });
+  });
+
+  test("returns null when caller is not a group member", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General" });
+
+    const outsiderId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Out",
+        lastName: "Sider",
+        phone: "+15555559999",
+        phoneVerified: true,
+        activeCommunityId: communityId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const { accessToken: outsiderToken } = await generateTokens(outsiderId);
+
+    const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
+      token: outsiderToken,
+      groupId,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the group has no active channel", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, accessToken } = await seed(t);
+    await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
+
+    const result = await t.query(api.functions.messaging.channels.getGroupDefaultChannel, {
+      token: accessToken,
+      groupId,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
+++ b/apps/convex/__tests__/messaging/resolveGroupDefaultChannel.test.ts
@@ -8,8 +8,9 @@
  * "Active" means `isArchived !== true && isEnabled !== false`.
  *
  * Priority:
- *   1. main  2. announcements  3. reach_out, then custom/pco_services/cross_team
+ *   1. main  2. announcements  3. custom/pco_services/cross_team
  *   (by lastMessageAt desc, then name)  4. leaders  5. null
+ *   (reach_out is excluded — it renders ReachOutScreen, not a message list.)
  */
 
 import { convexTest } from "convex-test";
@@ -166,16 +167,18 @@ describe("resolveGroupDefaultChannel", () => {
     expect(resolved?._id).toBe(annId);
   });
 
-  test("main + announcements disabled + reach_out active -> reach_out", async () => {
+  test("reach_out is skipped (special UI, not a message list) -> leaders", async () => {
     const t = convexTest(schema, modules);
     const { groupId } = await seed(t);
     await addChannel(t, groupId, "main", { slug: "general", name: "General", isArchived: true });
     await addChannel(t, groupId, "announcements", { name: "Announcements", isEnabled: false });
-    const reachId = await addChannel(t, groupId, "reach_out", { name: "Reach Out" });
-    await addChannel(t, groupId, "leaders", { name: "Leaders" });
+    // reach_out is active but renders ReachOutScreen, not a message list, so a
+    // posted message would be invisible there — it must NOT be chosen.
+    await addChannel(t, groupId, "reach_out", { name: "Reach Out" });
+    const leadersId = await addChannel(t, groupId, "leaders", { name: "Leaders" });
 
     const resolved = await t.run((ctx) => resolveGroupDefaultChannel(ctx, groupId));
-    expect(resolved?._id).toBe(reachId);
+    expect(resolved?._id).toBe(leadersId);
   });
 
   test("custom channels chosen by lastMessageAt desc, tie-break by name", async () => {

--- a/apps/convex/__tests__/sendBotMessage-suppression.test.ts
+++ b/apps/convex/__tests__/sendBotMessage-suppression.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for scheduledJobs.sendBotMessage suppression when General is disabled.
+ *
+ * General (the `main`/"general" channel) is now optional. When a bot/scheduled
+ * message targets a channel that is missing or inactive (archived or
+ * leader-disabled), sendBotMessage SUPPRESSES it silently — returning
+ * `{ success: false, skipped: true, reason: "target channel inactive" }`
+ * and inserting NO message — instead of erroring (which callers would log as a
+ * failure).
+ *
+ * The happy path enqueues `ctx.scheduler.runAfter(0, onMessageSent)`, so the
+ * scheduled-function drain pattern is required.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+vi.useFakeTimers();
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+  vi.clearAllTimers();
+});
+
+async function seedGroup(t: ReturnType<typeof convexTest>): Promise<{
+  groupId: Id<"groups">;
+  userId: Id<"users">;
+}> {
+  const now = Date.now();
+  return await t.run(async (ctx) => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug: "test-bot-suppression",
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "General",
+      slug: "general",
+      isActive: true,
+      displayOrder: 0,
+      createdAt: now,
+    });
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      name: "Test Group",
+      groupTypeId,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const userId = await ctx.db.insert("users", {
+      firstName: "Test",
+      lastName: "User",
+      phone: "+15555550001",
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { groupId, userId };
+  });
+}
+
+async function addGeneral(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  userId: Id<"users">,
+  opts: { isArchived?: boolean; isEnabled?: boolean } = {},
+): Promise<Id<"chatChannels">> {
+  const now = Date.now();
+  return await t.run((ctx) =>
+    ctx.db.insert("chatChannels", {
+      groupId,
+      slug: "general",
+      channelType: "main",
+      name: "General",
+      createdById: userId,
+      createdAt: now,
+      updatedAt: now,
+      isArchived: opts.isArchived ?? false,
+      isEnabled: opts.isEnabled,
+      memberCount: 1,
+    }),
+  );
+}
+
+describe("sendBotMessage suppression", () => {
+  test("skips (no error, no message) when General is archived", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { groupId, userId } = await seedGroup(t);
+    const channelId = await addGeneral(t, groupId, userId, { isArchived: true });
+
+    const result = await t.action(internal.functions.scheduledJobs.sendBotMessage, {
+      groupId,
+      message: "Happy birthday!",
+      targetChannelSlug: "general",
+      botType: "birthday",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      skipped: true,
+      reason: "target channel inactive",
+    });
+
+    // No message inserted into the archived channel.
+    const messages = await t.run((ctx) =>
+      ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect(),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  test("skips when General is leader-disabled (isEnabled false)", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { groupId, userId } = await seedGroup(t);
+    const channelId = await addGeneral(t, groupId, userId, { isEnabled: false });
+
+    const result = await t.action(internal.functions.scheduledJobs.sendBotMessage, {
+      groupId,
+      message: "Reminder",
+      targetChannelSlug: "general",
+      botType: "task_reminder",
+    });
+
+    expect(result).toMatchObject({ success: false, skipped: true });
+    const messages = await t.run((ctx) =>
+      ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect(),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  test("happy path still posts when General is active", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { groupId, userId } = await seedGroup(t);
+    const channelId = await addGeneral(t, groupId, userId);
+
+    const result = await t.action(internal.functions.scheduledJobs.sendBotMessage, {
+      groupId,
+      message: "Welcome!",
+      targetChannelSlug: "general",
+      botType: "welcome",
+    });
+
+    expect(result.success).toBe(true);
+    const messages = await t.run((ctx) =>
+      ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect(),
+    );
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -94,6 +94,7 @@ import type * as functions_messaging_sharedChannels from "../functions/messaging
 import type * as functions_messaging_typing from "../functions/messaging/typing.js";
 import type * as functions_migrations from "../functions/migrations.js";
 import type * as functions_migrations_migrateToCommunityPeople from "../functions/migrations/migrateToCommunityPeople.js";
+import type * as functions_migrations_unifyAnnouncementChannels from "../functions/migrations/unifyAnnouncementChannels.js";
 import type * as functions_notifications_actions from "../functions/notifications/actions.js";
 import type * as functions_notifications_dailyEnabledSnapshot from "../functions/notifications/dailyEnabledSnapshot.js";
 import type * as functions_notifications_debug from "../functions/notifications/debug.js";
@@ -288,6 +289,7 @@ declare const fullApi: ApiFromModules<{
   "functions/messaging/typing": typeof functions_messaging_typing;
   "functions/migrations": typeof functions_migrations;
   "functions/migrations/migrateToCommunityPeople": typeof functions_migrations_migrateToCommunityPeople;
+  "functions/migrations/unifyAnnouncementChannels": typeof functions_migrations_unifyAnnouncementChannels;
   "functions/notifications/actions": typeof functions_notifications_actions;
   "functions/notifications/dailyEnabledSnapshot": typeof functions_notifications_dailyEnabledSnapshot;
   "functions/notifications/debug": typeof functions_notifications_debug;

--- a/apps/convex/functions/groupBots.ts
+++ b/apps/convex/functions/groupBots.ts
@@ -737,6 +737,11 @@ export const testTaskReminder = action({
         messageId: result.messageId as string,
       };
     }
+    // A suppressed (skipped) send — e.g. the target channel was disabled —
+    // surfaces as a graceful failure with a reason for this user-triggered path.
+    if ("skipped" in result) {
+      return { success: false, error: result.reason };
+    }
     return result;
   },
 });
@@ -814,6 +819,11 @@ export const sendCommunicationNow = action({
         channelId: result.channelId as string,
         messageId: result.messageId as string,
       };
+    }
+    // A suppressed (skipped) send — e.g. the target channel was disabled —
+    // surfaces as a graceful failure with a reason for this user-triggered path.
+    if ("skipped" in result) {
+      return { success: false, error: result.reason };
     }
     return result;
   },

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -26,7 +26,7 @@ import {
 } from "../../lib/meetingConfig";
 import { buildMeetingSearchText } from "../../lib/meetingSearchText";
 import { findSeriesByGroupAndName } from "../eventSeries";
-import { resolveGroupDefaultChannel } from "../messaging/channels";
+import { resolveGroupDefaultChannelForUser } from "../messaging/channels";
 
 // Re-export meeting config for consumers that import from this module
 export {
@@ -961,9 +961,15 @@ export const postToChat = mutation({
     }
 
     // Find the group's default channel to post to. General (main) is now
-    // optional, so fall back to the next-best active channel (announcements,
-    // reach out, etc.) when it's disabled.
-    const targetChannel = await resolveGroupDefaultChannel(ctx, meeting.groupId);
+    // optional, so fall back to the next-best active channel when it's
+    // disabled. Resolve among channels THIS sender can post to, so the
+    // membership gate below doesn't reject a fallback they aren't in (e.g. a
+    // custom channel) instead of falling through to Leaders.
+    const targetChannel = await resolveGroupDefaultChannelForUser(
+      ctx,
+      meeting.groupId,
+      userId
+    );
 
     if (!targetChannel) {
       throw new Error("This group has no active channel to share to");

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -26,6 +26,7 @@ import {
 } from "../../lib/meetingConfig";
 import { buildMeetingSearchText } from "../../lib/meetingSearchText";
 import { findSeriesByGroupAndName } from "../eventSeries";
+import { resolveGroupDefaultChannel } from "../messaging/channels";
 
 // Re-export meeting config for consumers that import from this module
 export {
@@ -959,23 +960,20 @@ export const postToChat = mutation({
       throw new Error("Only group leaders can share events to chat");
     }
 
-    // Find the group's main channel
-    const mainChannel = await ctx.db
-      .query("chatChannels")
-      .withIndex("by_group_type", (q) =>
-        q.eq("groupId", meeting.groupId).eq("channelType", "main")
-      )
-      .first();
+    // Find the group's default channel to post to. General (main) is now
+    // optional, so fall back to the next-best active channel (announcements,
+    // reach out, etc.) when it's disabled.
+    const targetChannel = await resolveGroupDefaultChannel(ctx, meeting.groupId);
 
-    if (!mainChannel) {
-      throw new Error("Group chat channel not found");
+    if (!targetChannel) {
+      throw new Error("This group has no active channel to share to");
     }
 
     // Check user is a member of the channel
     const channelMembership = await ctx.db
       .query("chatChannelMembers")
       .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", mainChannel._id).eq("userId", userId)
+        q.eq("channelId", targetChannel._id).eq("userId", userId)
       )
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
@@ -1004,7 +1002,7 @@ export const postToChat = mutation({
 
     // Insert the chat message
     const messageId = await ctx.db.insert("chatMessages", {
-      channelId: mainChannel._id,
+      channelId: targetChannel._id,
       senderId: userId,
       content,
       contentType: "text",
@@ -1017,7 +1015,7 @@ export const postToChat = mutation({
 
     // Update channel with last message info
     const preview = content.slice(0, 100);
-    await ctx.db.patch(mainChannel._id, {
+    await ctx.db.patch(targetChannel._id, {
       lastMessageAt: timestamp,
       lastMessagePreview: preview,
       lastMessageSenderId: userId,
@@ -1028,7 +1026,7 @@ export const postToChat = mutation({
     // Trigger notification logic
     await ctx.scheduler.runAfter(0, internal.functions.messaging.events.onMessageSent, {
       messageId,
-      channelId: mainChannel._id,
+      channelId: targetChannel._id,
       senderId: userId,
     });
 

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -110,6 +110,75 @@ function sortChannelsByPinOrder<T extends {
   });
 }
 
+/**
+ * Resolve a group's best "default landing / post" channel.
+ *
+ * With General (the `main` channel) now optional, several backend sites that
+ * used to assume a main channel exists need a deterministic fallback. This
+ * picks the highest-priority ACTIVE channel for the group, where "active" means
+ * `isArchived !== true && isEnabled !== false`.
+ *
+ * Strict priority (only ACTIVE channels considered):
+ *   1. `main` (preserves today's default landing/post target)
+ *   2. `announcements`
+ *   3. first active member-facing channel: `reach_out`, then
+ *      `custom`/`pco_services`/`cross_team` sorted by `lastMessageAt` desc
+ *      (most recent first), tie-break by name
+ *   4. `leaders`
+ *   5. `null` if none active
+ *
+ * `dm` / `group_dm` / `event` channel types are excluded entirely.
+ */
+export async function resolveGroupDefaultChannel(
+  ctx: QueryCtx,
+  groupId: Id<"groups">,
+): Promise<Doc<"chatChannels"> | null> {
+  const channels = await ctx.db
+    .query("chatChannels")
+    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+    .collect();
+
+  const isActive = (c: Doc<"chatChannels">) =>
+    c.isArchived !== true && c.isEnabled !== false;
+
+  const active = channels.filter(isActive);
+
+  // 1. main
+  const main = active.find((c) => c.channelType === "main");
+  if (main) return main;
+
+  // 2. announcements
+  const announcements = active.find((c) => c.channelType === "announcements");
+  if (announcements) return announcements;
+
+  // 3a. reach_out
+  const reachOut = active.find((c) => c.channelType === "reach_out");
+  if (reachOut) return reachOut;
+
+  // 3b. custom / pco_services / cross_team, most recently active first
+  const memberFacing = active
+    .filter(
+      (c) =>
+        c.channelType === "custom" ||
+        c.channelType === "pco_services" ||
+        c.channelType === "cross_team",
+    )
+    .sort((a, b) => {
+      const aTime = a.lastMessageAt ?? 0;
+      const bTime = b.lastMessageAt ?? 0;
+      if (aTime !== bTime) return bTime - aTime;
+      return a.name.localeCompare(b.name);
+    });
+  if (memberFacing.length > 0) return memberFacing[0];
+
+  // 4. leaders
+  const leaders = active.find((c) => c.channelType === "leaders");
+  if (leaders) return leaders;
+
+  // 5. nothing active
+  return null;
+}
+
 type LinkedGroupToggleResult =
   | { handled: false }
   | { handled: true; result: { channelId: Id<"chatChannels">; status: "already_disabled" | "already_enabled" | "disabled" | "enabled" | "linked_unhidden_but_globally_disabled" } };
@@ -619,6 +688,48 @@ export const getChannelsByGroup = query({
       ...channel,
       slug: getChannelSlug(channel),
     }));
+  },
+});
+
+/**
+ * Get the group's best "default landing / post" channel for the caller.
+ *
+ * Mobile calls this to know where to land when General (the main channel) is
+ * disabled. Mirrors the membership gate used by `getChannelsByGroup`: the
+ * caller must be an active group member. Returns `null` when the group has no
+ * active member-facing channel.
+ */
+export const getGroupDefaultChannel = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    // Check group membership (same gate as getChannelsByGroup)
+    const groupMembership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", args.groupId).eq("userId", userId)
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+
+    if (!groupMembership) {
+      return null;
+    }
+
+    const channel = await resolveGroupDefaultChannel(ctx, args.groupId);
+    if (!channel) {
+      return null;
+    }
+
+    return {
+      channelId: channel._id,
+      slug: getChannelSlug(channel),
+      channelType: channel.channelType,
+    };
   },
 });
 

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -184,6 +184,44 @@ export async function resolveGroupDefaultChannel(
   return pickDefaultChannelByPriority(channels);
 }
 
+/**
+ * Like `resolveGroupDefaultChannel`, but only considers channels the given user
+ * can actually post to / see — those with an active `chatChannelMembers` row.
+ *
+ * Use this anywhere the result is scoped to a specific user (mobile landing
+ * fallback; the event-share posting fallback in `meetings.postToChat`). The
+ * group-wide resolver can otherwise return a `leaders`/custom/PCO/cross-team
+ * channel the user isn't in — landing them on an invisible channel, or making
+ * `postToChat`'s membership gate throw instead of falling through to a channel
+ * the sender can post to. Members are auto-added to main/announcements;
+ * leaders/custom only have rows for their actual participants.
+ */
+export async function resolveGroupDefaultChannelForUser(
+  ctx: QueryCtx,
+  groupId: Id<"groups">,
+  userId: Id<"users">,
+): Promise<Doc<"chatChannels"> | null> {
+  const channels = await ctx.db
+    .query("chatChannels")
+    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+    .collect();
+
+  const accessible: Doc<"chatChannels">[] = [];
+  for (const c of channels) {
+    const membership = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", c._id).eq("userId", userId)
+      )
+      .first();
+    if (membership && membership.leftAt === undefined) {
+      accessible.push(c);
+    }
+  }
+
+  return pickDefaultChannelByPriority(accessible);
+}
+
 type LinkedGroupToggleResult =
   | { handled: false }
   | { handled: true; result: { channelId: Id<"chatChannels">; status: "already_disabled" | "already_enabled" | "disabled" | "enabled" | "linked_unhidden_but_globally_disabled" } };
@@ -726,32 +764,12 @@ export const getGroupDefaultChannel = query({
     }
 
     // Resolve among channels the CALLER can actually access, not the
-    // group-wide set. The global resolver could otherwise return a `leaders`
-    // or custom/PCO/cross-team channel a regular member isn't in — those are
-    // hidden by `listGroupChannels` and return empty pages, so routing
-    // /general there would land the user on an invisible channel. Restrict
-    // to channels with an active membership row for this user (members are
-    // auto-added to main/announcements; leaders/custom only have rows for
-    // their actual participants).
-    const groupChannels = await ctx.db
-      .query("chatChannels")
-      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
-      .collect();
-
-    const accessible: Doc<"chatChannels">[] = [];
-    for (const c of groupChannels) {
-      const membership = await ctx.db
-        .query("chatChannelMembers")
-        .withIndex("by_channel_user", (q) =>
-          q.eq("channelId", c._id).eq("userId", userId)
-        )
-        .first();
-      if (membership && membership.leftAt === undefined) {
-        accessible.push(c);
-      }
-    }
-
-    const channel = pickDefaultChannelByPriority(accessible);
+    // group-wide set — see resolveGroupDefaultChannelForUser.
+    const channel = await resolveGroupDefaultChannelForUser(
+      ctx,
+      args.groupId,
+      userId
+    );
     if (!channel) {
       return null;
     }

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -3504,11 +3504,16 @@ export async function ensureChannelsForGroupLogic(
   createdById: Id<"users">,
   groupName: string
 ): Promise<{ created: boolean; createdChannelIds: Id<"chatChannels">[] }> {
-  // Check if channels already exist
+  // Check if channels already exist — including ARCHIVED ones. With General
+  // now optional, a leader can disable (archive) the main channel; an archived
+  // main/leaders means it existed and was intentionally turned off, NOT that it
+  // needs provisioning. Filtering to unarchived here would let this self-heal
+  // path (called from useConvexChannelFromGroup when a member's visible channel
+  // list is empty) resurrect a disabled General and create a duplicate
+  // (groupId, "general") row. Re-enabling is the toggle's job, not this one.
   const existingChannels = await ctx.db
     .query("chatChannels")
     .withIndex("by_group", (q) => q.eq("groupId", groupId))
-    .filter((q) => q.eq(q.field("isArchived"), false))
     .collect();
 
   const hasMain = existingChannels.some((ch) => ch.channelType === "main");

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -121,13 +121,15 @@ function sortChannelsByPinOrder<T extends {
  * Strict priority (only ACTIVE channels considered):
  *   1. `main` (preserves today's default landing/post target)
  *   2. `announcements`
- *   3. first active member-facing channel: `reach_out`, then
- *      `custom`/`pco_services`/`cross_team` sorted by `lastMessageAt` desc
- *      (most recent first), tie-break by name
+ *   3. first active `custom`/`pco_services`/`cross_team` channel, sorted by
+ *      `lastMessageAt` desc (most recent first), tie-break by name
  *   4. `leaders`
  *   5. `null` if none active
  *
- * `dm` / `group_dm` / `event` channel types are excluded entirely.
+ * `dm` / `group_dm` / `event` are excluded entirely. `reach_out` is also
+ * excluded: it renders with `ReachOutScreen` (leader 1:1 outreach), not the
+ * normal message list, so a posted message/event-share would be invisible
+ * there and it's not a sensible chat-landing target.
  */
 function pickDefaultChannelByPriority(
   channels: Doc<"chatChannels">[],
@@ -145,11 +147,8 @@ function pickDefaultChannelByPriority(
   const announcements = active.find((c) => c.channelType === "announcements");
   if (announcements) return announcements;
 
-  // 3a. reach_out
-  const reachOut = active.find((c) => c.channelType === "reach_out");
-  if (reachOut) return reachOut;
-
-  // 3b. custom / pco_services / cross_team, most recently active first
+  // 3. custom / pco_services / cross_team, most recently active first.
+  //    (reach_out is intentionally NOT here — see doc comment above.)
   const memberFacing = active
     .filter(
       (c) =>

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -201,20 +201,29 @@ export async function resolveGroupDefaultChannelForUser(
   groupId: Id<"groups">,
   userId: Id<"users">,
 ): Promise<Doc<"chatChannels"> | null> {
-  const channels = await ctx.db
-    .query("chatChannels")
-    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+  // Start from the user's active channel memberships rather than the group's
+  // owned channels: this naturally includes SHARED channels (owned by another
+  // group but shared into `groupId`), which `listGroupChannels` also surfaces.
+  // Keep channels that are either owned by this group or shared into it with an
+  // accepted entry — i.e. the set this user can actually see/post to here.
+  const memberships = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
     .collect();
 
   const accessible: Doc<"chatChannels">[] = [];
-  for (const c of channels) {
-    const membership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q) =>
-        q.eq("channelId", c._id).eq("userId", userId)
-      )
-      .first();
-    if (membership && membership.leftAt === undefined) {
+  for (const membership of memberships) {
+    const c = await ctx.db.get(membership.channelId);
+    if (!c) continue;
+    const ownedByGroup = c.groupId === groupId;
+    const sharedIntoGroup =
+      c.isShared === true &&
+      (c.sharedGroups?.some(
+        (sg) => sg.groupId === groupId && sg.status === "accepted",
+      ) ??
+        false);
+    if (ownedByGroup || sharedIntoGroup) {
       accessible.push(c);
     }
   }

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -129,15 +129,9 @@ function sortChannelsByPinOrder<T extends {
  *
  * `dm` / `group_dm` / `event` channel types are excluded entirely.
  */
-export async function resolveGroupDefaultChannel(
-  ctx: QueryCtx,
-  groupId: Id<"groups">,
-): Promise<Doc<"chatChannels"> | null> {
-  const channels = await ctx.db
-    .query("chatChannels")
-    .withIndex("by_group", (q) => q.eq("groupId", groupId))
-    .collect();
-
+function pickDefaultChannelByPriority(
+  channels: Doc<"chatChannels">[],
+): Doc<"chatChannels"> | null {
   const isActive = (c: Doc<"chatChannels">) =>
     c.isArchived !== true && c.isEnabled !== false;
 
@@ -177,6 +171,18 @@ export async function resolveGroupDefaultChannel(
 
   // 5. nothing active
   return null;
+}
+
+export async function resolveGroupDefaultChannel(
+  ctx: QueryCtx,
+  groupId: Id<"groups">,
+): Promise<Doc<"chatChannels"> | null> {
+  const channels = await ctx.db
+    .query("chatChannels")
+    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+    .collect();
+
+  return pickDefaultChannelByPriority(channels);
 }
 
 type LinkedGroupToggleResult =
@@ -720,7 +726,33 @@ export const getGroupDefaultChannel = query({
       return null;
     }
 
-    const channel = await resolveGroupDefaultChannel(ctx, args.groupId);
+    // Resolve among channels the CALLER can actually access, not the
+    // group-wide set. The global resolver could otherwise return a `leaders`
+    // or custom/PCO/cross-team channel a regular member isn't in — those are
+    // hidden by `listGroupChannels` and return empty pages, so routing
+    // /general there would land the user on an invisible channel. Restrict
+    // to channels with an active membership row for this user (members are
+    // auto-added to main/announcements; leaders/custom only have rows for
+    // their actual participants).
+    const groupChannels = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .collect();
+
+    const accessible: Doc<"chatChannels">[] = [];
+    for (const c of groupChannels) {
+      const membership = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", c._id).eq("userId", userId)
+        )
+        .first();
+      if (membership && membership.leftAt === undefined) {
+        accessible.push(c);
+      }
+    }
+
+    const channel = pickDefaultChannelByPriority(accessible);
     if (!channel) {
       return null;
     }

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -216,14 +216,21 @@ export async function resolveGroupDefaultChannelForUser(
   for (const membership of memberships) {
     const c = await ctx.db.get(membership.channelId);
     if (!c) continue;
-    const ownedByGroup = c.groupId === groupId;
+    if (c.groupId === groupId) {
+      accessible.push(c);
+      continue;
+    }
+    // Shared channel: include only if shared into this group AND not hidden
+    // from this group's navigation (a linked-group leader can hide it). This
+    // mirrors listGroupChannels' channelEffectiveEnabledForGroup gate so we
+    // don't land members on a channel that's hidden for their group.
     const sharedIntoGroup =
       c.isShared === true &&
       (c.sharedGroups?.some(
         (sg) => sg.groupId === groupId && sg.status === "accepted",
       ) ??
         false);
-    if (ownedByGroup || sharedIntoGroup) {
+    if (sharedIntoGroup && channelEffectiveEnabledForGroup(c, groupId)) {
       accessible.push(c);
     }
   }

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -1234,6 +1234,10 @@ export const runTaskReminderBot = internalAction({
 
           if (result.success) {
             messagesSent++;
+          } else if ("skipped" in result) {
+            console.info(
+              `[TaskReminder] Skipped task-card post for task ${assignment.taskId} to ${targetChannelSlug}: ${result.reason}`,
+            );
           } else {
             console.error(
               `[TaskReminder] Failed task-card post for task ${assignment.taskId} to ${targetChannelSlug}: ${result.error}`,
@@ -1507,6 +1511,7 @@ export const sendBotMessage = internalAction({
         channelId: Id<"chatChannels">;
         messageId: Id<"chatMessages">;
       }
+    | { success: false; skipped: true; reason: string }
     | { success: false; error: string }
   > => {
     // Determine target slug with backwards compatibility
@@ -1541,16 +1546,14 @@ export const sendBotMessage = internalAction({
       );
     }
 
-    if (!channel) {
-      console.error(`[sendBotMessage] No channel found for group ${groupId}`);
-      return { success: false, error: "Channel not found" };
-    }
-
-    // Check if channel is archived
-    if (channel.isArchived) {
-      const errorMsg = `Bot cannot post to archived channel "${channel.name}". Please update bot settings to target an active channel.`;
-      console.error(`[sendBotMessage] ${errorMsg}`);
-      return { success: false, error: errorMsg };
+    // When the target channel is missing or inactive (e.g. a leader disabled
+    // the General channel), suppress the bot message silently. This is a no-op
+    // skip — NOT an error — so callers don't retry, log a failure, or throw.
+    if (!channel || channel.isArchived || channel.isEnabled === false) {
+      console.info(
+        `[sendBotMessage] Skipping bot message for group ${groupId}: target channel "${targetSlug}" is inactive.`,
+      );
+      return { success: false, skipped: true, reason: "target channel inactive" };
     }
 
     // Insert the bot message
@@ -2206,6 +2209,16 @@ export const processCommunicationBotBucket = internalAction({
                 );
 
                 if (sendResult.success) {
+                  results.push({
+                    groupId: config.groupId,
+                    messageId: msg.id,
+                    success: true,
+                  });
+                } else if ("skipped" in sendResult) {
+                  // Target channel inactive (e.g. General disabled) — silent no-op.
+                  console.info(
+                    `[CommunicationBot] Skipped message ${msg.id}: ${sendResult.reason}`,
+                  );
                   results.push({
                     groupId: config.groupId,
                     messageId: msg.id,

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/index.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/index.tsx
@@ -3,14 +3,11 @@
  *
  * Route: /inbox/[groupId]/[channelSlug]/info
  *
- * Mounts `ChannelInfoScreen` for non-General channels. For General
- * (channelType === "main") the group page IS the channel info, so we
- * redirect there on mount.
- *
- * The "general" slug always maps to channelType "main", so the redirect
- * fires synchronously without a flash of the info screen.
+ * Mounts `ChannelInfoScreen` for every channel, including General
+ * (channelType === "main"). General's info page is where a leader reaches
+ * the Active state control to disable/re-enable it.
  */
-import { Redirect, useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams } from "expo-router";
 import { ChannelInfoScreen } from "@features/chat/components/ChannelInfoScreen";
 
 export default function ChannelInfoRoute() {
@@ -20,11 +17,6 @@ export default function ChannelInfoRoute() {
   }>();
 
   if (!groupId || !channelSlug) return null;
-
-  // General -> the group page IS the info surface for the main channel.
-  if (channelSlug === "general") {
-    return <Redirect href={`/groups/${groupId}` as any} />;
-  }
 
   return <ChannelInfoScreen groupId={groupId} channelSlug={channelSlug} />;
 }

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -2,14 +2,14 @@
  * ChannelInfoScreen
  *
  * Mirror of `ChatInfoScreen` (the DM info surface) but for group channels
- * — Leaders, Reach Out, PCO synced, and custom channels. Reached via the
- * (i) icon in the chat header on non-General channels and via the
- * CHANNELS card on the group page.
+ * — General, Leaders, Reach Out, PCO synced, and custom channels. Reached
+ * via the (i) icon in the chat header and via the CHANNELS card on the
+ * group page.
  *
- * General (channelType === "main") does NOT mount this screen — the
- * group page IS the channel info for General. The route shim
- * `/inbox/[groupId]/[channelSlug]/info/index.tsx` redirects in that
- * case.
+ * General (channelType === "main") mounts this screen like every other
+ * channel, but only renders the hero, Open chat, Members, and the
+ * leader-only Active state control — General can't be renamed, archived,
+ * shared, left, or have people added (its membership is the group itself).
  *
  * Layout (DM-sleek):
  *   - "Channel info" centered title + back chevron
@@ -547,26 +547,6 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
     );
   }
 
-  // Main channel never reaches the rendered body — the route shim
-  // redirects to the group page. This is a defensive fallback.
-  if (isMain) {
-    return (
-      <View
-        style={[
-          styles.container,
-          { paddingTop: insets.top, backgroundColor: colors.surface },
-        ]}
-      >
-        <Header onBack={handleBack} colors={colors} />
-        <View style={styles.centered}>
-          <Text style={[styles.errorText, { color: colors.textSecondary }]}>
-            The General channel uses the group page for info.
-          </Text>
-        </View>
-      </View>
-    );
-  }
-
   const memberRows = channelMembers?.members ?? [];
   const totalMemberCount = channelMembers?.totalCount ?? channel.memberCount ?? 0;
   const ownerId = (channel as { createdById?: Id<"users"> }).createdById;
@@ -963,8 +943,9 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
         {/* Add people — for now this routes to the existing manage-members
             sub-route. TODO: fold the in-screen picker (mirror of DM
             ChatInfoScreen.AddPeopleModal) inline once we have a
-            channel-scoped search query. */}
-        {isLeader && (
+            channel-scoped search query. General's membership is the group
+            itself, so there's nothing to add here. */}
+        {isLeader && !isMain && (
           <Pressable
             onPress={handleManageMembers}
             style={({ pressed }) => [
@@ -983,40 +964,45 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
           </Pressable>
         )}
 
-        {/* CHANNEL ACTIONS */}
-        <SectionHeader colors={colors} label="Channel actions" />
-        <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
-          {isLeader && isCustom && (
-            <Pressable
-              onPress={handleShareInvite}
-              style={({ pressed }) => [
-                styles.actionRowFlat,
-                pressed && { backgroundColor: colors.selectedBackground },
-              ]}
-            >
-              <Ionicons name="share-outline" size={20} color={colors.icon} />
-              <Text style={[styles.actionLabel, { color: colors.text }]}>
-                Share invite link
-              </Text>
-            </Pressable>
-          )}
-          <Pressable
-            onPress={() => setLeaveVisible(true)}
-            style={({ pressed }) => [
-              styles.actionRowFlat,
-              isLeader && isCustom && {
-                borderTopWidth: StyleSheet.hairlineWidth,
-                borderTopColor: colors.border,
-              },
-              pressed && { backgroundColor: colors.selectedBackground },
-            ]}
-          >
-            <Ionicons name="exit-outline" size={20} color={colors.destructive} />
-            <Text style={[styles.actionLabel, { color: colors.destructive }]}>
-              Leave channel
-            </Text>
-          </Pressable>
-        </View>
+        {/* CHANNEL ACTIONS — General has no invite link and can't be left
+            (its membership is the group itself), so hide the whole section. */}
+        {!isMain && (
+          <>
+            <SectionHeader colors={colors} label="Channel actions" />
+            <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
+              {isLeader && isCustom && (
+                <Pressable
+                  onPress={handleShareInvite}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons name="share-outline" size={20} color={colors.icon} />
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>
+                    Share invite link
+                  </Text>
+                </Pressable>
+              )}
+              <Pressable
+                onPress={() => setLeaveVisible(true)}
+                style={({ pressed }) => [
+                  styles.actionRowFlat,
+                  isLeader && isCustom && {
+                    borderTopWidth: StyleSheet.hairlineWidth,
+                    borderTopColor: colors.border,
+                  },
+                  pressed && { backgroundColor: colors.selectedBackground },
+                ]}
+              >
+                <Ionicons name="exit-outline" size={20} color={colors.destructive} />
+                <Text style={[styles.actionLabel, { color: colors.destructive }]}>
+                  Leave channel
+                </Text>
+              </Pressable>
+            </View>
+          </>
+        )}
 
         {/* LEADER CONTROLS */}
         {isLeader && (
@@ -1025,7 +1011,9 @@ export function ChannelInfoScreen({ groupId, channelSlug }: Props) {
             <View
               style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}
             >
-              {/* Active state — common to leaders/reach_out/custom/pco */}
+              {/* Active state — common to main/leaders/reach_out/custom/pco.
+                  For General this is the only leader control: it's how a
+                  leader disables and (from the disabled row) re-enables it. */}
               <Pressable
                 onPress={handleActiveState}
                 style={({ pressed }) => [

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -1017,6 +1017,31 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const isEssentialDataReady =
     (resolvedGroupId || isAdHocChannel) && activeChannelId != null;
 
+  // General was disabled and there's no fallback channel this user can open
+  // (getGroupDefaultChannel resolved to null — distinct from `undefined`, which
+  // means still loading). Show an unavailable message instead of spinning
+  // forever, since activeChannelId will never become non-null here.
+  const hasNoAvailableChannel =
+    isGeneralUnavailable && defaultChannelFallback === null;
+
+  if (hasNoAvailableChannel) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surface }]}>
+        <ChatHeaderPlaceholder
+          displayName={displayName}
+          onBack={handleBack}
+          topInset={insets.top}
+        />
+        <View style={[styles.centered, { backgroundColor: colors.surface }]}>
+          <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+            This channel isn't available. The General channel has been turned
+            off for this group.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
   // Loading state: show placeholder while essential data resolves
   if (!isEssentialDataReady) {
     return (

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -165,7 +165,10 @@ const ConvexChatRoomScreenInner: React.FC = () => {
 
   // Derive active slug from route parameter (URL-based routing)
   // Priority: resolvedChannelSlug > parsedChannel type > default "general"
-  const activeSlug: string = useMemo(() => {
+  // This is the slug the URL asked for. The slug actually displayed
+  // (`activeSlug`, derived further below) may differ when General is disabled
+  // and we fall back to the group's default channel.
+  const routeActiveSlug: string = useMemo(() => {
     // If we have a channel slug from the URL, use it directly
     if (resolvedChannelSlug) return resolvedChannelSlug;
     // Fallback to parsed channel type if available (legacy Stream URLs)
@@ -265,6 +268,24 @@ const ConvexChatRoomScreenInner: React.FC = () => {
       : "skip"
   );
 
+  // General (main) channel can be disabled (archived) by a leader. When it is,
+  // `useConvexChannelFromGroup(groupId, "main")` resolves to null (the backend
+  // filters archived channels), which would leave the user on an empty chat.
+  // Detect that case and fall back to the group's best default channel.
+  //
+  // Gated to ONLY run when General is the target AND no active main channel
+  // exists — passing "skip" otherwise avoids an extra round-trip in the common
+  // (General available) path. `mainChannelId === null` (not `undefined`) means
+  // the lookup completed and found no active main channel.
+  const isGeneralUnavailable =
+    routeActiveSlug === "general" && mainChannelId === null && !!resolvedGroupId;
+  const defaultChannelFallback = useQuery(
+    api.functions.messaging.channels.getGroupDefaultChannel,
+    isGeneralUnavailable && resolvedGroupId && token
+      ? { token, groupId: resolvedGroupId }
+      : "skip"
+  );
+
   // Active channel: derive from URL-based routing
   // With URL-based routing, the slug is the source of truth
   // If user doesn't have access to leaders channel, fallback to general
@@ -280,17 +301,35 @@ const ConvexChatRoomScreenInner: React.FC = () => {
       return channelBySlug._id;
     }
 
-    // Use slug-based selection for standard channels - activeSlug is derived from URL
-    let channelId = activeSlug === "general" ? mainChannelId : leadersChannelId;
+    // Use slug-based selection for standard channels - routeActiveSlug is derived from URL
+    let channelId = routeActiveSlug === "general" ? mainChannelId : leadersChannelId;
 
     // Fallback: if leaders slug is requested but user doesn't have access,
     // use main channel instead to prevent infinite loading
-    if (activeSlug === "leaders" && leadersChannelId === null && mainChannelId) {
+    if (routeActiveSlug === "leaders" && leadersChannelId === null && mainChannelId) {
       channelId = mainChannelId;
     }
 
+    // Fallback: General was requested but the main channel is disabled
+    // (archived). Land on the group's default channel instead of an empty
+    // chat. `getGroupDefaultChannel` returns null when the group has no active
+    // member-facing channel — leave `channelId` null so the no-channel handling
+    // below applies as before.
+    if (isGeneralUnavailable && defaultChannelFallback) {
+      channelId = defaultChannelFallback.channelId;
+    }
+
     return channelId;
-  }, [activeSlug, resolvedChannelSlug, isCustomChannel, mainChannelId, leadersChannelId, channelBySlug, isConvexChannelId, directChannelId]);
+  }, [routeActiveSlug, resolvedChannelSlug, isCustomChannel, mainChannelId, leadersChannelId, channelBySlug, isConvexChannelId, directChannelId, isGeneralUnavailable, defaultChannelFallback]);
+
+  // Slug actually displayed. When General is disabled and we've fallen back to
+  // the group's default channel, reflect the fallback's slug so the tab bar
+  // highlights the correct tab and the header / channel-type checks line up
+  // with the channel the user is really viewing.
+  const activeSlug =
+    isGeneralUnavailable && defaultChannelFallback
+      ? defaultChannelFallback.slug
+      : routeActiveSlug;
 
   // Fetch group details for display (with token to get user's role)
   const groupDetailsRaw = useQuery(
@@ -455,15 +494,15 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // 3. Main channel exists (we have somewhere to redirect to)
   // Reset guard when the group or slug changes (component instance may be reused)
   const hasRedirectedFromLeaders = useRef(false);
-  const prevLeadersKey = useRef(`${resolvedGroupId}:${activeSlug}`);
-  if (prevLeadersKey.current !== `${resolvedGroupId}:${activeSlug}`) {
-    prevLeadersKey.current = `${resolvedGroupId}:${activeSlug}`;
+  const prevLeadersKey = useRef(`${resolvedGroupId}:${routeActiveSlug}`);
+  if (prevLeadersKey.current !== `${resolvedGroupId}:${routeActiveSlug}`) {
+    prevLeadersKey.current = `${resolvedGroupId}:${routeActiveSlug}`;
     hasRedirectedFromLeaders.current = false;
   }
   useEffect(() => {
     if (hasRedirectedFromLeaders.current) return;
     if (
-      activeSlug === "leaders" &&
+      routeActiveSlug === "leaders" &&
       leadersChannelId === null && // null = query completed, channel not found (not undefined = still loading)
       mainChannelId &&
       resolvedGroupId
@@ -483,7 +522,7 @@ const ConvexChatRoomScreenInner: React.FC = () => {
         },
       });
     }
-  }, [activeSlug, leadersChannelId, mainChannelId, resolvedGroupId, router, displayName, displayType, groupTypeIdSource, displayImage, isUserLeader, isAnnouncementGroup, externalChatLink]);
+  }, [routeActiveSlug, leadersChannelId, mainChannelId, resolvedGroupId, router, displayName, displayType, groupTypeIdSource, displayImage, isUserLeader, isAnnouncementGroup, externalChatLink]);
 
   // Track active channel for notification suppression
   // When viewing a channel, suppress push notification banners for that channel

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -13,8 +13,8 @@
  *   3. SHARED CHANNEL INVITATIONS card (leaders only, when present)
  *
  * Navigation:
- *   - General (channelType === "main"): → /inbox/{groupId}/{slug} (chat)
- *   - Everything else: → /inbox/{groupId}/{slug}/info
+ *   - Every channel (including General / channelType === "main"):
+ *     → /inbox/{groupId}/{slug}/info
  *
  * The Pin Channels / Toolbar Settings buttons that used to float at the
  * bottom of this section now live in GROUP ACTIONS on
@@ -134,11 +134,6 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
     }
   }, [enablingAnnouncements, groupId, toggleAnnouncementsChannelMutation]);
 
-  const navigateToChannelChat = useCallback(
-    (slug: string) => router.push(`/inbox/${groupId}/${slug}` as any),
-    [router, groupId]
-  );
-
   const navigateToChannelInfo = useCallback(
     (slug: string) => router.push(`/inbox/${groupId}/${slug}/info` as any),
     [router, groupId]
@@ -195,8 +190,9 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
       name: "General",
       subtitle: mainEnabled ? "All members" : "Disabled",
       enabled: mainEnabled,
-      // General opens the chat directly. The group page IS its info screen.
-      onPress: () => navigateToChannelChat(mainChannel.slug),
+      // General opens its info page like every other channel — that's where
+      // a leader reaches Active state to disable/re-enable it.
+      onPress: () => navigateToChannelInfo(mainChannel.slug),
       unreadCount: mainChannel.unreadCount,
       pinned: mainChannel.isPinned,
     });

--- a/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
@@ -255,7 +255,7 @@ describe("ChannelsSection (redesigned)", () => {
   });
 
   describe("Navigation", () => {
-    it("navigates to General chat (not info) on tap", () => {
+    it("navigates to General /info on tap (where Active state lives)", () => {
       const { getByText } = render(
         <ChannelsSection groupId="test-group" userRole="member" />
       );
@@ -264,7 +264,7 @@ describe("ChannelsSection (redesigned)", () => {
         fireEvent.press(getByText("General").parent!.parent!.parent!);
       });
 
-      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/general");
+      expect(mockPush).toHaveBeenCalledWith("/inbox/test-group/general/info");
     });
 
     it("navigates to Leaders /info on tap", () => {


### PR DESCRIPTION
## Summary

Lets a group leader **disable the General (main) channel**, and makes the rest of the app behave correctly when it's off. The disable mechanism (`toggleMainChannel`) and the Active-state screen already existed from the announcement-channel unification (#424) — this wires up the missing entry point and the fallbacks.

### Backend
- **`resolveGroupDefaultChannel(ctx, groupId)`** — highest-priority *active* channel: `main → announcements → reach_out/custom/pco/cross_team (by recency) → leaders → null` (excludes dm/group_dm/event).
- **`getGroupDefaultChannel`** query (member-gated) so mobile can resolve where to land when General is off.
- **Event-chat sharing** (`meetings.postToChat`) now falls back to the default channel instead of throwing `"Group chat channel not found"`.
- **Bot/scheduled messages** (`sendBotMessage`) **silently skip** (no-op, not an error/retry) when the target channel is inactive — e.g. General disabled. Per product decision: reminders are suppressed, not rerouted. Callers treat the skip as benign.

### Mobile
- The **General row** on the group page now opens its **info page** (like every other channel) instead of the chat directly — that's where a leader reaches **Active state** to disable/re-enable General. `ChannelInfoScreen` is un-gated for `main` (hero + Open chat + Members + Active state; rename/archive/share/leave hidden). Archived General still loads so re-enabling works.
- **`ConvexChatRoomScreen`**: when routed to General but it's disabled, fall back to the group's default channel (`getGroupDefaultChannel`) instead of an empty chat. Active-General and explicit non-general slugs are unchanged.

### Decisions baked in
- Fallback order: announcements → other active member-facing → leaders.
- **No** last-channel guard (disabling is always allowed; the fallback chain covers it).
- Bots **suppress** when General is off (don't reroute reminders).

### Tests
- Convex: resolver tiers + exclusions, event-chat fallback, bot suppression (full suite 96 files / 1579 pass).
- Mobile: updated `ChannelsSection` nav test (General → `/info`); mobile suite green.

### Note
The branch's backend changes are already live on the shared **dev/staging** backend (`hushed-lemur-239`) from a `convex codegen` push during development. Prod is unaffected (manual deploy gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)