### PR TITLE
fix: close notifications panel when tapping a notification

### DIFF
--- a/apps/mobile/features/notifications/components/NotificationFeedScreen.tsx
+++ b/apps/mobile/features/notifications/components/NotificationFeedScreen.tsx
@@ -78,6 +78,16 @@ export function NotificationFeedScreen() {
         // Fire-and-forget — navigation shouldn't wait on the read write.
         markRead({ notificationId: item.id }).catch(() => {});
       }
+      // This feed lives inside the `(user)` route group, which is presented
+      // as a modal (`presentation: "modal"` in app/_layout.tsx). Many
+      // notifications resolve to a screen *outside* that modal — e.g. a
+      // "new prayer requests" notification opens `/(tabs)/prayer`. Pushing
+      // without dismissing first lands the destination *behind* the still-
+      // open notifications modal. Dismiss the modal stack first, then let the
+      // resolver navigate (same pattern as useStartDirectMessage).
+      if (router.canDismiss?.()) {
+        router.dismissAll();
+      }
       // DB notification rows keep the type in the `notificationType`
       // column; `data` often omits it. Surface it so the resolver can
       // route types like join_request_approved / group_creation_approved.
@@ -86,7 +96,7 @@ export function NotificationFeedScreen() {
         type: item.data?.type ?? item.notificationType,
       });
     },
-    [markRead],
+    [markRead, router],
   );
 
   const handleMarkAllRead = useCallback(() => {


### PR DESCRIPTION
## Problem

Tapping a prayer-request notification (and other notifications) in the in-app notifications feed navigates to the target page, but the **notifications panel stays open on top of it**. The destination renders *behind* the panel.

## Root cause

The in-app notifications feed (`NotificationFeedScreen`) lives inside the `(user)` route group, which `app/_layout.tsx` presents as a **modal** (`presentation: "modal"`). Many notifications resolve to a screen *outside* that modal — e.g. the `prayer.daily_digest` ("N new prayer requests") notification opens `/(tabs)/prayer`. Calling `router.push` without dismissing the modal first switches the underlying tab *behind* the still-open notifications modal, leaving the panel covering the destination.

## Fix

Dismiss the modal stack before resolving navigation in `handlePress`:

```ts
if (router.canDismiss?.()) {
  router.dismissAll();
}
await resolveNotificationNavigation({ ... });
```

This mirrors the existing, documented pattern in `features/chat/hooks/useStartDirectMessage.ts`, which dismisses the same `(user)` modal before pushing a chat for exactly this reason ("Pushing without dismissing first lands the chat *behind* the modal on iOS").

- Tabs routes (e.g. `/(tabs)/prayer`) now land in front of a dismissed panel.
- `(user)`-internal routes (e.g. `/(user)/my-prayers/[prayerId]`) cleanly re-present the modal at the new screen.

## Testing notes

- `node_modules` was not installed in the dev environment, so a full `tsc`/lint run wasn't possible here. The change uses the same `Router` API (`canDismiss`/`dismissAll`) already used elsewhere in the codebase.
- Minor behavior nuance: for an unknown/no-op notification type (the resolver's `default` case), the panel now closes and leaves the user on the underlying tab rather than staying on the feed. This only affects defensive no-op types — all real notifications navigate.

https://claude.ai/code/session_015QiiuaK4murGbDhfQMmxU4

---
_Generated by [Claude Code](https://claude.ai/code/session_015QiiuaK4murGbDhfQMmxU4)_