### PR TITLE
Notification settings: 2h reminder default + widen blasts/event-chat to Going + Maybe

### DIFF
--- a/apps/convex/__tests__/event-blasts.test.ts
+++ b/apps/convex/__tests__/event-blasts.test.ts
@@ -262,6 +262,30 @@ describe("Event Blasts", () => {
       expect(recipients).toContain(data.maybeId); // Maybe
       expect(recipients).not.toContain(data.cantGoId); // Can't Go excluded
     });
+
+    test("excludes stale responders whose option the host has hidden", async () => {
+      const t = convexTest(schema, modules);
+      const data = await setupTestData(t);
+
+      // Host hides Maybe (id 2) after maybeId already RSVP'd to it.
+      await t.run(async (ctx) => {
+        const meeting = await ctx.db.get(data.meetingId);
+        await ctx.db.patch(data.meetingId, {
+          rsvpOptions: (meeting!.rsvpOptions ?? []).map((o) =>
+            o.id === 2 ? { ...o, enabled: false } : o,
+          ),
+        });
+      });
+
+      const recipients: Id<"users">[] = await t.query(
+        (internal as any).functions.eventBlasts.getRsvpUserIds,
+        { meetingId: data.meetingId, optionIds: [1, 2] }
+      );
+
+      // Only the Going responder remains; the hidden-Maybe responder is
+      // excluded, matching their loss of chat access.
+      expect(recipients).toEqual([data.attendeeId]);
+    });
   });
 
   describe("blast list query", () => {

--- a/apps/convex/__tests__/event-blasts.test.ts
+++ b/apps/convex/__tests__/event-blasts.test.ts
@@ -31,6 +31,7 @@ vi.mock("jose", () => ({
 import { convexTest } from "convex-test";
 import schema from "../schema";
 import type { Id } from "../_generated/dataModel";
+import { internal } from "../_generated/api";
 import { modules } from "../test.setup";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
@@ -45,6 +46,8 @@ interface TestData {
   leaderId: Id<"users">;
   memberId: Id<"users">;
   attendeeId: Id<"users">;
+  maybeId: Id<"users">;
+  cantGoId: Id<"users">;
   meetingId: Id<"meetings">;
   leaderToken: string;
   memberToken: string;
@@ -76,9 +79,15 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
     const attendeeId = await ctx.db.insert("users", {
       firstName: "Going", lastName: "Attendee", phone: "+15559876543", createdAt: ts, updatedAt: ts,
     });
+    const maybeId = await ctx.db.insert("users", {
+      firstName: "Maybe", lastName: "Attendee", phone: "+15559876544", createdAt: ts, updatedAt: ts,
+    });
+    const cantGoId = await ctx.db.insert("users", {
+      firstName: "Cant", lastName: "Go", phone: "+15559876545", createdAt: ts, updatedAt: ts,
+    });
 
     // Community memberships
-    for (const uid of [leaderId, memberId, attendeeId]) {
+    for (const uid of [leaderId, memberId, attendeeId, maybeId, cantGoId]) {
       await ctx.db.insert("userCommunities", {
         userId: uid, communityId, roles: 1, status: 1, createdAt: ts, updatedAt: ts,
       });
@@ -88,12 +97,11 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
     await ctx.db.insert("groupMembers", {
       groupId, userId: leaderId, role: "leader", joinedAt: ts, notificationsEnabled: true,
     });
-    await ctx.db.insert("groupMembers", {
-      groupId, userId: memberId, role: "member", joinedAt: ts, notificationsEnabled: true,
-    });
-    await ctx.db.insert("groupMembers", {
-      groupId, userId: attendeeId, role: "member", joinedAt: ts, notificationsEnabled: true,
-    });
+    for (const uid of [memberId, attendeeId, maybeId, cantGoId]) {
+      await ctx.db.insert("groupMembers", {
+        groupId, userId: uid, role: "member", joinedAt: ts, notificationsEnabled: true,
+      });
+    }
 
     const meetingId = await ctx.db.insert("meetings", {
       groupId,
@@ -105,23 +113,26 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
       rsvpEnabled: true,
       rsvpOptions: [
         { id: 1, label: "Going", enabled: true },
-        { id: 2, label: "Not Going", enabled: true },
+        { id: 2, label: "Maybe", enabled: true },
+        { id: 3, label: "Can't Go", enabled: true },
       ],
       visibility: "group",
       shortId: "blast123",
     });
 
-    // Create RSVPs — attendee is "Going"
+    // Create RSVPs — attendee is "Going", maybe is "Maybe", cantGo is "Can't Go".
     await ctx.db.insert("meetingRsvps", {
       meetingId, userId: attendeeId, rsvpOptionId: 1, createdAt: ts, updatedAt: ts,
     });
-    // Member is "Not Going"
     await ctx.db.insert("meetingRsvps", {
-      meetingId, userId: memberId, rsvpOptionId: 2, createdAt: ts, updatedAt: ts,
+      meetingId, userId: maybeId, rsvpOptionId: 2, createdAt: ts, updatedAt: ts,
+    });
+    await ctx.db.insert("meetingRsvps", {
+      meetingId, userId: cantGoId, rsvpOptionId: 3, createdAt: ts, updatedAt: ts,
     });
 
     return {
-      communityId, groupId, leaderId, memberId, attendeeId, meetingId,
+      communityId, groupId, leaderId, memberId, attendeeId, maybeId, cantGoId, meetingId,
       leaderToken: `test-token-${leaderId}`,
       memberToken: `test-token-${memberId}`,
     };
@@ -236,20 +247,20 @@ describe("Event Blasts", () => {
   });
 
   describe("getRsvpUserIds helper", () => {
-    test("returns only users with matching RSVP option", async () => {
+    test("returns Going + Maybe RSVPers and excludes Can't Go", async () => {
       const t = convexTest(schema, modules);
       const data = await setupTestData(t);
 
-      const goingUsers = await t.run(async (ctx) => {
-        const rsvps = await ctx.db
-          .query("meetingRsvps")
-          .withIndex("by_meeting", (q) => q.eq("meetingId", data.meetingId))
-          .collect();
-        return rsvps.filter((r) => r.rsvpOptionId === 1).map((r) => r.userId);
-      });
+      // Blasts target the notified options (Going=1, Maybe=2).
+      const recipients: Id<"users">[] = await t.query(
+        (internal as any).functions.eventBlasts.getRsvpUserIds,
+        { meetingId: data.meetingId, optionIds: [1, 2] }
+      );
 
-      expect(goingUsers).toHaveLength(1);
-      expect(goingUsers[0]).toBe(data.attendeeId);
+      expect(recipients).toHaveLength(2);
+      expect(recipients).toContain(data.attendeeId); // Going
+      expect(recipients).toContain(data.maybeId); // Maybe
+      expect(recipients).not.toContain(data.cantGoId); // Can't Go excluded
     });
   });
 

--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -370,6 +370,39 @@ describe("ensureEventChannel", () => {
     expect(channel?.memberCount).toBe(3);
   });
 
+  test("does NOT backfill stale RSVPers whose option the host has since disabled", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    // Host hides the Maybe option (id 2) after maybeId already RSVP'd to it.
+    await t.run(async (ctx) => {
+      const meeting = await ctx.db.get(data.meetingId);
+      await ctx.db.patch(data.meetingId, {
+        rsvpOptions: (meeting!.rsvpOptions ?? []).map((o) =>
+          o.id === 2 ? { ...o, enabled: false } : o,
+        ),
+      });
+    });
+
+    const channelId = await t.mutation(
+      (internal as any).functions.messaging.eventChat.ensureEventChannel,
+      { meetingId: data.meetingId },
+    );
+
+    const userIds = await t.run(async (ctx) => {
+      const rows = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect();
+      return rows.map((r) => r.userId);
+    });
+
+    // goingId (enabled option) is seated; maybeId is not, because their
+    // option is now hidden — consistent with losing chat access.
+    expect(userIds).toContain(data.goingId);
+    expect(userIds).not.toContain(data.maybeId);
+  });
+
   test("throws when meeting has no shortId", async () => {
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);

--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -57,8 +57,8 @@ interface TestData {
   hostId: Id<"users">;
   leaderId: Id<"users">;
   goingId: Id<"users">;
-  notGoingId: Id<"users">;
-  maybeDisabledId: Id<"users">;
+  maybeId: Id<"users">;
+  cantGoDisabledId: Id<"users">;
   outsiderId: Id<"users">;
   hostToken: string;
   leaderToken: string;
@@ -118,15 +118,15 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
       createdAt: ts,
       updatedAt: ts,
     });
-    const notGoingId = await ctx.db.insert("users", {
-      firstName: "NotGoing",
+    const maybeId = await ctx.db.insert("users", {
+      firstName: "Maybe",
       lastName: "Attendee",
       phone: "+15551110004",
       createdAt: ts,
       updatedAt: ts,
     });
-    const maybeDisabledId = await ctx.db.insert("users", {
-      firstName: "MaybeDisabled",
+    const cantGoDisabledId = await ctx.db.insert("users", {
+      firstName: "CantGoDisabled",
       lastName: "Attendee",
       phone: "+15551110005",
       createdAt: ts,
@@ -141,7 +141,7 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
     });
 
     // Community memberships (everyone except outsiderId).
-    for (const uid of [hostId, leaderId, goingId, notGoingId, maybeDisabledId]) {
+    for (const uid of [hostId, leaderId, goingId, maybeId, cantGoDisabledId]) {
       await ctx.db.insert("userCommunities", {
         userId: uid,
         communityId,
@@ -152,7 +152,7 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
       });
     }
 
-    // Group memberships — host + leader as leaders, going/notGoing as members.
+    // Group memberships — host + leader as leaders, going/maybe as members.
     await ctx.db.insert("groupMembers", {
       groupId,
       userId: hostId,
@@ -176,14 +176,14 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
     });
     await ctx.db.insert("groupMembers", {
       groupId,
-      userId: notGoingId,
+      userId: maybeId,
       role: "member",
       joinedAt: ts,
       notificationsEnabled: true,
     });
     await ctx.db.insert("groupMembers", {
       groupId,
-      userId: maybeDisabledId,
+      userId: cantGoDisabledId,
       role: "member",
       joinedAt: ts,
       notificationsEnabled: true,
@@ -203,8 +203,8 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
       hostUserIds: [hostId],
       rsvpOptions: [
         { id: 1, label: "Going", enabled: true },
-        { id: 2, label: "Not Going", enabled: true },
-        { id: 3, label: "Maybe", enabled: false },
+        { id: 2, label: "Maybe", enabled: true },
+        { id: 3, label: "Can't Go", enabled: false },
       ],
       communityId,
     });
@@ -219,14 +219,14 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
     });
     await ctx.db.insert("meetingRsvps", {
       meetingId,
-      userId: notGoingId,
+      userId: maybeId,
       rsvpOptionId: 2,
       createdAt: ts,
       updatedAt: ts,
     });
     await ctx.db.insert("meetingRsvps", {
       meetingId,
-      userId: maybeDisabledId,
+      userId: cantGoDisabledId,
       rsvpOptionId: 3,
       createdAt: ts,
       updatedAt: ts,
@@ -239,8 +239,8 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestData
       hostId,
       leaderId,
       goingId,
-      notGoingId,
-      maybeDisabledId,
+      maybeId,
+      cantGoDisabledId,
       outsiderId,
       hostToken: `test-token-${hostId}`,
       leaderToken: `test-token-${leaderId}`,
@@ -325,7 +325,7 @@ describe("ensureEventChannel", () => {
     expect(hostMembership?.syncSource).toBe("event_rsvp");
   });
 
-  test("does NOT bulk-seed RSVPers — only the host is seated initially", async () => {
+  test("backfills Going/Maybe RSVPers as members; excludes Can't Go / disabled options", async () => {
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
@@ -342,15 +342,21 @@ describe("ensureEventChannel", () => {
     });
 
     const userIds = rows.map((r) => r.userId);
-    // Lazy-seed model: only the host is seated by ensureEventChannel.
-    // Non-host RSVPers become members when they call openEventChat.
-    expect(userIds).toEqual([data.hostId]);
-    expect(userIds).not.toContain(data.goingId);
-    expect(userIds).not.toContain(data.notGoingId);
-    expect(userIds).not.toContain(data.maybeDisabledId);
+    // Backfill model: the host (admin) plus every Going/Maybe RSVPer
+    // (option ids 1 & 2) are seated so they receive event updates.
+    expect(userIds).toContain(data.hostId);
+    expect(userIds).toContain(data.goingId);
+    expect(userIds).toContain(data.maybeId);
+    // The Can't Go RSVPer (disabled option id 3) is not seated.
+    expect(userIds).not.toContain(data.cantGoDisabledId);
+    expect(userIds).toHaveLength(3);
+
+    // Backfilled RSVPers are seated as members, not admins.
+    const goingRow = rows.find((r) => r.userId === data.goingId);
+    expect(goingRow?.role).toBe("member");
   });
 
-  test("memberCount starts at 1 (just the host)", async () => {
+  test("memberCount counts the host plus backfilled Going/Maybe RSVPers", async () => {
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
@@ -360,7 +366,8 @@ describe("ensureEventChannel", () => {
     );
 
     const channel = await t.run(async (ctx) => ctx.db.get(channelId));
-    expect(channel?.memberCount).toBe(1);
+    // host + goingId + maybeId = 3.
+    expect(channel?.memberCount).toBe(3);
   });
 
   test("throws when meeting has no shortId", async () => {
@@ -470,10 +477,10 @@ describe("getChannelByMeetingId", () => {
       { meetingId: data.meetingId },
     );
 
-    const maybeToken = `test-token-${data.maybeDisabledId}`;
+    const disabledToken = `test-token-${data.cantGoDisabledId}`;
     const result = await t.query(
       "functions/messaging/eventChat:getChannelByMeetingId" as any,
-      { token: maybeToken, meetingId: data.meetingId },
+      { token: disabledToken, meetingId: data.meetingId },
     );
 
     expect(result).toBeNull();
@@ -947,7 +954,7 @@ describe("openEventChat", () => {
 
     await expect(
       t.mutation("functions/messaging/eventChat:openEventChat" as any, {
-        token: `test-token-${data.maybeDisabledId}`,
+        token: `test-token-${data.cantGoDisabledId}`,
         meetingId: data.meetingId,
       }),
     ).rejects.toThrow(/access/i);
@@ -1132,13 +1139,34 @@ describe("reactions auth on event channels", () => {
     const t = convexTest(schema, modules);
     const data = await setupTestData(t);
 
-    // Host opens chat → channel created + host seated. goingId is NOT
-    // seated yet under the lazy-seed model (they have an enabled RSVP
-    // but haven't called openEventChat).
-    const channelId = await t.mutation(
-      (internal as any).functions.messaging.eventChat.ensureEventChannel,
-      { meetingId: data.meetingId },
-    );
+    // Create the channel with only the host seated (bypassing
+    // ensureEventChannel's RSVP backfill) so goingId has channel access via
+    // their enabled RSVP but no chatChannelMembers row — the case this test
+    // exercises: reaction auth is access-based, not membership-based.
+    const channelId = await t.run(async (ctx) => {
+      const cid = await ctx.db.insert("chatChannels", {
+        groupId: data.groupId,
+        slug: "event-dinner123",
+        channelType: "event",
+        name: "Dinner Party",
+        createdById: data.hostId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        isEnabled: true,
+        meetingId: data.meetingId,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: cid,
+        userId: data.hostId,
+        role: "admin",
+        syncSource: "event_rsvp",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+      return cid;
+    });
 
     // Verify goingId has no chatChannelMembers row.
     const noMembership = await t.run(async (ctx) => {

--- a/apps/convex/__tests__/messaging/event-chat.test.ts
+++ b/apps/convex/__tests__/messaging/event-chat.test.ts
@@ -983,6 +983,49 @@ describe("openEventChat", () => {
     });
     expect(channels).toHaveLength(1);
   });
+
+  test("Can't Go RSVPer can open the chat but is NOT seated as a member", async () => {
+    const t = convexTest(schema, modules);
+    const data = await setupTestData(t);
+
+    // Enable the Can't Go option (id 3) and switch goingId's RSVP to it, so
+    // they retain chat access but no longer count as attending.
+    await t.run(async (ctx) => {
+      const meeting = await ctx.db.get(data.meetingId);
+      await ctx.db.patch(data.meetingId, {
+        rsvpOptions: (meeting!.rsvpOptions ?? []).map((o) =>
+          o.id === 3 ? { ...o, enabled: true } : o,
+        ),
+      });
+      const rsvp = await ctx.db
+        .query("meetingRsvps")
+        .withIndex("by_meeting_user", (q) =>
+          q.eq("meetingId", data.meetingId).eq("userId", data.goingId),
+        )
+        .first();
+      await ctx.db.patch(rsvp!._id, { rsvpOptionId: 3 });
+    });
+
+    // Opening succeeds (access is granted for any enabled option)...
+    const result = await t.mutation(
+      "functions/messaging/eventChat:openEventChat" as any,
+      { token: data.goingToken, meetingId: data.meetingId },
+    );
+    expect(result.channelId).toBeTruthy();
+
+    // ...but the Can't Go responder is not seated, so they receive no
+    // event-chat update notifications. This guards against re-adding a user
+    // who was just removed for switching to Can't Go.
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", result.channelId).eq("userId", data.goingId),
+        )
+        .unique();
+    });
+    expect(membership).toBeNull();
+  });
 });
 
 // ============================================================================

--- a/apps/convex/functions/eventBlasts.ts
+++ b/apps/convex/functions/eventBlasts.ts
@@ -11,7 +11,7 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { requireAuth } from "../lib/auth";
 import { canEditMeeting } from "../lib/meetingPermissions";
-import { NOTIFIED_RSVP_OPTION_IDS } from "../lib/meetingConfig";
+import { NOTIFIED_RSVP_OPTION_IDS, isAttendingRsvpOption } from "../lib/meetingConfig";
 import { now, getMediaUrl } from "../lib/utils";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 
@@ -288,7 +288,10 @@ export const send = internalAction({
 // ============================================================================
 
 /**
- * Get user IDs who RSVPed with any of the given options
+ * Get user IDs who RSVPed with any of the given options AND whose option is
+ * still enabled on the meeting. The enabled check excludes stale rows for an
+ * option the host has since hidden (e.g. Maybe), mirroring chat access so a
+ * hidden option's responders don't keep receiving blasts.
  */
 export const getRsvpUserIds = internalQuery({
   args: {
@@ -296,13 +299,21 @@ export const getRsvpUserIds = internalQuery({
     optionIds: v.array(v.number()),
   },
   handler: async (ctx, args) => {
+    const meeting = await ctx.db.get(args.meetingId);
+    const rsvpOptions = meeting?.rsvpOptions;
     const allowed = new Set(args.optionIds);
     const rsvps = await ctx.db
       .query("meetingRsvps")
       .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
       .collect();
 
-    return rsvps.filter((r) => allowed.has(r.rsvpOptionId)).map((r) => r.userId);
+    return rsvps
+      .filter(
+        (r) =>
+          allowed.has(r.rsvpOptionId) &&
+          isAttendingRsvpOption(r.rsvpOptionId, rsvpOptions),
+      )
+      .map((r) => r.userId);
   },
 });
 

--- a/apps/convex/functions/eventBlasts.ts
+++ b/apps/convex/functions/eventBlasts.ts
@@ -2,7 +2,7 @@
  * Event Blast functions
  *
  * Allows leaders to send message blasts (SMS/push) to attendees who
- * RSVPed "Going" to an event. Blasts are recorded for history.
+ * RSVPed "Going" or "Maybe" to an event. Blasts are recorded for history.
  */
 
 import { v } from "convex/values";
@@ -11,6 +11,7 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { requireAuth } from "../lib/auth";
 import { canEditMeeting } from "../lib/meetingPermissions";
+import { NOTIFIED_RSVP_OPTION_IDS } from "../lib/meetingConfig";
 import { now, getMediaUrl } from "../lib/utils";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 
@@ -119,7 +120,8 @@ export const initiate = mutation({
 // ============================================================================
 
 /**
- * Send a message blast to all attendees who RSVPed "Going" (optionId 1)
+ * Send a message blast to all attendees who RSVPed "Going" or "Maybe"
+ * (NOTIFIED_RSVP_OPTION_IDS).
  */
 export const send = internalAction({
   args: {
@@ -149,10 +151,11 @@ export const send = internalAction({
       { userId: args.userId }
     );
 
-    // Get all RSVPs for this meeting (optionId 1 = "Going")
+    // Get all RSVPs for this meeting whose option counts as attending
+    // (Going + Maybe — see NOTIFIED_RSVP_OPTION_IDS).
     const rsvpUserIds: Id<"users">[] = await ctx.runQuery(
       internal.functions.eventBlasts.getRsvpUserIds,
-      { meetingId: args.meetingId, optionId: 1 }
+      { meetingId: args.meetingId, optionIds: NOTIFIED_RSVP_OPTION_IDS }
     );
 
     const communityId = groupInfo?.communityId as Id<"communities">;
@@ -285,21 +288,21 @@ export const send = internalAction({
 // ============================================================================
 
 /**
- * Get user IDs who RSVPed with a specific option
+ * Get user IDs who RSVPed with any of the given options
  */
 export const getRsvpUserIds = internalQuery({
   args: {
     meetingId: v.id("meetings"),
-    optionId: v.number(),
+    optionIds: v.array(v.number()),
   },
   handler: async (ctx, args) => {
+    const allowed = new Set(args.optionIds);
     const rsvps = await ctx.db
       .query("meetingRsvps")
       .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
-      .filter((q) => q.eq(q.field("rsvpOptionId"), args.optionId))
       .collect();
 
-    return rsvps.map((r) => r.userId);
+    return rsvps.filter((r) => allowed.has(r.rsvpOptionId)).map((r) => r.userId);
   },
 });
 

--- a/apps/convex/functions/meetingRsvps.ts
+++ b/apps/convex/functions/meetingRsvps.ts
@@ -14,7 +14,7 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { now, getMediaUrl } from "../lib/utils";
 import { requireAuth, getOptionalAuth } from "../lib/auth";
-import { PAST_EVENT_BUFFER_MS } from "../lib/meetingConfig";
+import { PAST_EVENT_BUFFER_MS, isNotifiedRsvpOptionId } from "../lib/meetingConfig";
 import {
   getMaxGuestsForMeeting,
   isGoingOption,
@@ -516,13 +516,15 @@ export const submit = mutation({
       }
 
       // Sync event chat channel membership based on whether the final
-      // option is enabled. Runs inline (same transaction) so the RSVP
-      // write and the chat-member row stay consistent — fire-and-forget
-      // via the scheduler could leave the two rows out of sync if the
-      // scheduled mutation failed, with no reconciliation path. Channels
-      // are lazy-created, so these calls are no-ops if no channel exists
-      // yet.
-      if (selectedOption.enabled) {
+      // option counts as attending (Going/Maybe — see
+      // NOTIFIED_RSVP_OPTION_IDS). Going/Maybe RSVPers are seated so they
+      // receive event updates; "Can't Go" responders are removed. Runs
+      // inline (same transaction) so the RSVP write and the chat-member row
+      // stay consistent — fire-and-forget via the scheduler could leave the
+      // two rows out of sync if the scheduled mutation failed, with no
+      // reconciliation path. Channels are lazy-created, so these calls are
+      // no-ops if no channel exists yet (backfilled on channel creation).
+      if (isNotifiedRsvpOptionId(args.optionId)) {
         await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
           meetingId: args.meetingId,
           userId,
@@ -558,14 +560,17 @@ export const submit = mutation({
       rsvpOptionLabel: selectedOption.label,
     });
 
-    // Sync event chat channel membership. Submit only allows enabled
-    // options (validated above), so new inserts always add. The channel
-    // is lazy-created, so this is a no-op if no channel exists yet.
-    // Runs inline so RSVP + chat membership stay consistent.
-    await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
-      meetingId: args.meetingId,
-      userId,
-    });
+    // Sync event chat channel membership. Only Going/Maybe responders are
+    // seated (so they receive event updates); a brand-new "Can't Go" RSVP
+    // doesn't join the chat. The channel is lazy-created, so this is a no-op
+    // if no channel exists yet (backfilled on channel creation). Runs inline
+    // so RSVP + chat membership stay consistent.
+    if (isNotifiedRsvpOptionId(args.optionId)) {
+      await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
+        meetingId: args.meetingId,
+        userId,
+      });
+    }
 
     return {
       success: true,
@@ -672,14 +677,22 @@ export const batchUpdate = mutation({
         });
       }
 
-      // Sync event chat channel membership. batchUpdate only allows
-      // enabled options (filtered via validOptionIds above), so we
-      // always add here. No-op if no channel exists yet. Runs inline so
-      // the RSVP writes and chat membership stay consistent.
-      await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
-        meetingId: args.meetingId,
-        userId: rsvpUpdate.userId,
-      });
+      // Sync event chat channel membership. Going/Maybe responders are
+      // seated so they get event updates; others (e.g. "Can't Go") are
+      // removed. No-op if no channel exists yet (backfilled on channel
+      // creation). Runs inline so the RSVP writes and chat membership stay
+      // consistent.
+      if (isNotifiedRsvpOptionId(rsvpUpdate.optionId)) {
+        await ctx.runMutation(internal.functions.messaging.eventChat.addEventChannelMember, {
+          meetingId: args.meetingId,
+          userId: rsvpUpdate.userId,
+        });
+      } else {
+        await ctx.runMutation(internal.functions.messaging.eventChat.removeEventChannelMember, {
+          meetingId: args.meetingId,
+          userId: rsvpUpdate.userId,
+        });
+      }
     }
 
     return { success: true };

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -214,7 +214,7 @@ export const create = mutation({
     // Generate a short ID for URLs (e.g., "abc123xyz")
     const shortId = generateShortId();
 
-    // Calculate reminder time (1 hour before)
+    // Calculate reminder time (2 hours before)
     const reminderAt = args.scheduledAt - DEFAULT_REMINDER_OFFSET_MS;
 
     // Calculate attendance confirmation time (30 min after end)

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -458,7 +458,9 @@ export const reconcileEventChannelAdmins = internalMutation({
  * no way to render a composer for a channel that doesn't exist yet.
  *
  * Access mirrors `canAccessEventChannel`: host OR any RSVPer whose option is
- * still enabled on the meeting.
+ * still enabled on the meeting. Note that access (can read) is broader than
+ * membership (gets update notifications): a "Can't Go" responder may open the
+ * chat but is not seated as a member.
  */
 export const openEventChat = mutation({
   args: {
@@ -497,6 +499,7 @@ export const openEventChat = mutation({
     }
 
     let hasAccess = isAdmin;
+    let callerOptionId: number | undefined;
     if (!hasAccess) {
       const rsvp = await ctx.db
         .query("meetingRsvps")
@@ -509,6 +512,7 @@ export const openEventChat = mutation({
           (opt) => opt.id === rsvp.rsvpOptionId,
         );
         hasAccess = Boolean(matched && matched.enabled);
+        callerOptionId = rsvp.rsvpOptionId;
       }
     }
     if (!hasAccess) {
@@ -520,12 +524,19 @@ export const openEventChat = mutation({
       { meetingId: args.meetingId },
     );
 
-    // Lazily seat the caller as a channel member if they aren't already.
-    // Admins (hosts / delegated-mode leaders) were seated by
-    // ensureEventChannel; RSVPers are seated only on their first
-    // openEventChat so they don't start receiving push notifications for
-    // events they haven't looked at.
-    if (!isAdmin) {
+    // Lazily seat the caller as a channel member only if their RSVP counts as
+    // attending (Going/Maybe — see NOTIFIED_RSVP_OPTION_IDS). A "Can't Go"
+    // responder can still open and read the chat (access is granted for any
+    // enabled option), but is not seated — so they don't receive event-chat
+    // update notifications, staying consistent with removeEventChannelMember
+    // dropping them when they switch to Can't Go. Admins (hosts /
+    // delegated-mode leaders) and attending RSVPers were already seated by
+    // ensureEventChannel; this covers any not-yet-seated attending caller.
+    if (
+      !isAdmin &&
+      callerOptionId !== undefined &&
+      isNotifiedRsvpOptionId(callerOptionId)
+    ) {
       const existingMembership = await ctx.db
         .query("chatChannelMembers")
         .withIndex("by_channel_user", (q) =>

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -29,7 +29,7 @@ import {
   resolveEventAdmins,
 } from "../../lib/meetingPermissions";
 import { isActiveLeader } from "../../lib/helpers";
-import { isNotifiedRsvpOptionId } from "../../lib/meetingConfig";
+import { isNotifiedRsvpOptionId, isAttendingRsvpOption } from "../../lib/meetingConfig";
 import { now } from "../../lib/utils";
 
 // ============================================================================
@@ -254,12 +254,14 @@ export const ensureEventChannel = internalMutation({
     }
 
     // Backfill existing Going/Maybe RSVPers as members so they get updates.
+    // Skip stale rows whose option the host has since hidden/disabled — those
+    // users no longer have chat access, so they must not be (re-)seated.
     const rsvps = await ctx.db
       .query("meetingRsvps")
       .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
       .collect();
     for (const rsvp of rsvps) {
-      if (!isNotifiedRsvpOptionId(rsvp.rsvpOptionId)) continue;
+      if (!isAttendingRsvpOption(rsvp.rsvpOptionId, meeting.rsvpOptions)) continue;
       if (seated.has(String(rsvp.userId))) continue; // already an admin
       await ctx.db.insert("chatChannelMembers", {
         channelId,

--- a/apps/convex/functions/messaging/eventChat.ts
+++ b/apps/convex/functions/messaging/eventChat.ts
@@ -29,6 +29,7 @@ import {
   resolveEventAdmins,
 } from "../../lib/meetingPermissions";
 import { isActiveLeader } from "../../lib/helpers";
+import { isNotifiedRsvpOptionId } from "../../lib/meetingConfig";
 import { now } from "../../lib/utils";
 
 // ============================================================================
@@ -173,17 +174,22 @@ export const getChannelStateForEditor = query({
 // ============================================================================
 
 /**
- * Idempotently create the chat channel for an event and seat its admins.
+ * Idempotently create the chat channel for an event and seat its members.
  *
  * Call this the first time we need a channel for a meeting (e.g. when an
  * admin opens the chat UI, or on the first blast). Safe to call repeatedly —
  * if a channel already exists for the meeting, the existing id is returned.
  *
  * Seating model: admins (hosts when set, otherwise the group's active
- * leaders — see `resolveEventAdmins`) are seated here. RSVPer members are
- * added lazily by `openEventChat` (they only become subscribers after
- * explicitly opening the chat), which prevents unrelated push notifications
- * and caps the write set for this mutation regardless of RSVP scale.
+ * leaders — see `resolveEventAdmins`) are seated first. We then backfill
+ * every existing Going/Maybe RSVPer (NOTIFIED_RSVP_OPTION_IDS) as a member so
+ * they receive event updates — channels are created lazily (first open/blast),
+ * so RSVPs made before the channel existed would otherwise never be seated.
+ * Forward RSVPs are kept in sync by `addEventChannelMember` /
+ * `removeEventChannelMember` from the RSVP mutations.
+ *
+ * NOTE: backfilling all RSVPers means the write set scales with RSVP count
+ * (the previous lazy model capped it). Fine for typical event sizes.
  */
 export const ensureEventChannel = internalMutation({
   args: {
@@ -229,10 +235,12 @@ export const ensureEventChannel = internalMutation({
       isArchived: false,
       isEnabled: true,
       meetingId: args.meetingId,
+      // Patched below once members are backfilled.
       memberCount: admins.length,
     });
 
-    // Seat every admin. RSVPer members are seated lazily by openEventChat.
+    // Seat every admin.
+    const seated = new Set<string>();
     for (const userId of admins) {
       await ctx.db.insert("chatChannelMembers", {
         channelId,
@@ -242,6 +250,30 @@ export const ensureEventChannel = internalMutation({
         joinedAt: ts,
         isMuted: false,
       });
+      seated.add(String(userId));
+    }
+
+    // Backfill existing Going/Maybe RSVPers as members so they get updates.
+    const rsvps = await ctx.db
+      .query("meetingRsvps")
+      .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
+      .collect();
+    for (const rsvp of rsvps) {
+      if (!isNotifiedRsvpOptionId(rsvp.rsvpOptionId)) continue;
+      if (seated.has(String(rsvp.userId))) continue; // already an admin
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: rsvp.userId,
+        role: "member",
+        syncSource: "event_rsvp",
+        joinedAt: ts,
+        isMuted: false,
+      });
+      seated.add(String(rsvp.userId));
+    }
+
+    if (seated.size !== admins.length) {
+      await ctx.db.patch(channelId, { memberCount: seated.size });
     }
 
     return channelId;

--- a/apps/convex/lib/meetingConfig.ts
+++ b/apps/convex/lib/meetingConfig.ts
@@ -60,3 +60,19 @@ export const DEFAULT_RSVP_OPTIONS: RsvpOption[] = [
   { id: 2, label: "Maybe", enabled: true },
   { id: 3, label: "Can't Go", enabled: true },
 ];
+
+/**
+ * RSVP option IDs whose responders are considered "attending enough" to:
+ *   - be seated in the event chat channel (and thus get update notifications)
+ *   - receive host text blasts
+ *
+ * 1 = "Going", 2 = "Maybe" (see DEFAULT_RSVP_OPTIONS). "Can't Go" (3) is
+ * excluded. These are matched by id, so events using custom option labels are
+ * still keyed off the conventional Going/Maybe slots.
+ */
+export const NOTIFIED_RSVP_OPTION_IDS: number[] = [1, 2];
+
+/** Whether an RSVP option id grants chat membership + blast/update delivery. */
+export function isNotifiedRsvpOptionId(optionId: number): boolean {
+  return NOTIFIED_RSVP_OPTION_IDS.includes(optionId);
+}

--- a/apps/convex/lib/meetingConfig.ts
+++ b/apps/convex/lib/meetingConfig.ts
@@ -13,10 +13,10 @@
 // ============================================================================
 
 /**
- * Default reminder time offset: 1 hour before meeting.
+ * Default reminder time offset: 2 hours before meeting.
  * Used to schedule reminder push notifications.
  */
-export const DEFAULT_REMINDER_OFFSET_MS = 60 * 60 * 1000; // 1 hour
+export const DEFAULT_REMINDER_OFFSET_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 /**
  * Default meeting duration for calculating attendance confirmation time.

--- a/apps/convex/lib/meetingConfig.ts
+++ b/apps/convex/lib/meetingConfig.ts
@@ -76,3 +76,26 @@ export const NOTIFIED_RSVP_OPTION_IDS: number[] = [1, 2];
 export function isNotifiedRsvpOptionId(optionId: number): boolean {
   return NOTIFIED_RSVP_OPTION_IDS.includes(optionId);
 }
+
+/**
+ * Whether an RSVP counts as "attending" for seating an event-chat member or
+ * picking a blast recipient: its option id is notified (Going/Maybe) AND that
+ * option is still present and enabled on the meeting.
+ *
+ * The enabled check matters for historical rows: a host can hide an option
+ * (e.g. Maybe) after people have RSVP'd — the editor drops the disabled option
+ * from `meeting.rsvpOptions`, but old `meetingRsvps` rows keep the id. Those
+ * stale responders must not keep receiving chat updates or blasts, mirroring
+ * `canAccessEventChannel`, which also keys off the currently-enabled options.
+ *
+ * (RSVP submit/batchUpdate don't need this — they can only set an option that
+ * is currently enabled, so the id check alone suffices there.)
+ */
+export function isAttendingRsvpOption(
+  optionId: number,
+  rsvpOptions: ReadonlyArray<{ id: number; enabled: boolean }> | undefined,
+): boolean {
+  if (!isNotifiedRsvpOptionId(optionId)) return false;
+  const option = (rsvpOptions ?? []).find((o) => o.id === optionId);
+  return Boolean(option && option.enabled);
+}

--- a/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
@@ -99,7 +99,7 @@ export function EventBlastSheet({
 
             <View style={styles.body}>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                Text everyone going to {eventTitle}. The message will also post to the event's Activity feed.
+                Text everyone going to or interested in {eventTitle}. The message will also post to the event's Activity feed.
               </Text>
 
               {/* Message Input */}


### PR DESCRIPTION
This branch bundles two related notification changes.

## 1. Default event reminder offset: 1h → 2h
Reminder push notifications are now scheduled 2 hours before an event instead of 1 hour. Updates the centralized `DEFAULT_REMINDER_OFFSET_MS` constant, which propagates to all event creation/edit scheduling sites.

## 2. Text blasts + event-chat updates now reach Going **and** Maybe RSVPers
Previously text blasts only reached "Going" RSVPers, and event-chat members (who receive update/comment notifications) were seated lazily — only when a user opened the chat — so most RSVPers never got updates.

- Added `NOTIFIED_RSVP_OPTION_IDS` (`[1, 2]` = Going, Maybe) + `isNotifiedRsvpOptionId()` helper in `meetingConfig` as the single source of truth for who counts as attending.
- Text blasts now target Going + Maybe (`getRsvpUserIds` takes an `optionIds` array).
- `ensureEventChannel` backfills all existing Going/Maybe RSVPers as members on channel creation, so updates reach people who RSVP'd before the (lazily-created) channel existed.
- RSVP `submit`/`batchUpdate` seat Going/Maybe responders and remove others (switching to "Can't Go" drops the chat seat).
- Updated the Text Blast sheet copy and tests; added coverage for the widened blast recipients and the channel backfill.

### Notes
- Seating/blasting is keyed off RSVP option **id** (1 = Going, 2 = Maybe), per the hardcoded-id approach chosen for this change. Default and seed events line up with these ids.
- All 1,590 Convex tests pass locally.

https://claude.ai/code/session_01CuVuhXhK9uiUJjUGgiGsAN