### PR TITLE
fix(convex): accept legacy runSheetConfig.source to unblock deploy

### DIFF
--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -430,6 +430,11 @@ export default defineSchema({
             order: v.array(v.string()), // ordered visible category names
           }),
         ),
+        // Legacy drift: some existing `groups` docs carry `source: "native"`
+        // here. Nothing in the codebase reads or writes it anymore, but the
+        // deploy-time schema validation rejects the extra field. Accept it so
+        // deploys pass. TODO: backfill-strip this field, then remove.
+        source: v.optional(v.string()),
       }),
     ),
 


### PR DESCRIPTION
## Problem

The post-merge **Deploy to Convex** job on `main` is failing at schema validation:

```
Schema validation failed.
Document ... in table "groups" does not match the schema:
Object contains extra field `source` that is not in the validator.
Path: .runSheetConfig
Object: {chipConfig: {...}, defaultServiceTypeIds: [], source: "native"}
```

Convex validates every existing document against the schema at deploy time. One or more `groups` docs carry a legacy `runSheetConfig.source = "native"` field. **Nothing in the codebase reads or writes it** (`updateRunSheetConfig` never set it; no reader references it) — it's orphaned drift from an older shape. This blocks **all** deploys to `main`, not just the change that happened to land first.

## Fix

Widen the `runSheetConfig` validator with `source: v.optional(v.string())` so existing data validates and the deploy passes. Additive and non-destructive — it rejects nothing that was previously valid.

Data cleanup (stripping the field) would require two deploys because of the deploy-time-validation chicken-and-egg, so this unblocks now; left a `TODO` to backfill-strip and remove the field later.

## Verified
- Convex typecheck clean.

https://claude.ai/code/session_01CbQRL3LCEeYM2TzAFzQh1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbQRL3LCEeYM2TzAFzQh1M)_