### PR TITLE
Availability grid — roster × events matrix (web-optimized)

### DIFF
--- a/apps/convex/__tests__/scheduling/availability.test.ts
+++ b/apps/convex/__tests__/scheduling/availability.test.ts
@@ -277,6 +277,98 @@ describe("sendAvailabilityRequest + getAvailabilityRequest (chat card)", () => {
   });
 });
 
+describe("availabilityMatrix (leader grid)", () => {
+  it("returns events as columns and members as rows with per-cell status", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const modToken = (await generateTokens(world.channelModeratorId)).accessToken;
+
+    const planA = await createPlan(
+      t,
+      leaderToken,
+      world.groupId,
+      "Week 1",
+      Date.now() + 7 * DAY,
+    );
+    const planB = await createPlan(
+      t,
+      leaderToken,
+      world.groupId,
+      "Week 2",
+      Date.now() + 14 * DAY,
+    );
+
+    // member: available wk1, unavailable wk2. moderator: available wk1 only.
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: memberToken,
+      planId: planA,
+      status: "available",
+    });
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: memberToken,
+      planId: planB,
+      status: "unavailable",
+    });
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: modToken,
+      planId: planA,
+      status: "available",
+    });
+
+    const matrix = await t.query(
+      api.functions.scheduling.availability.availabilityMatrix,
+      { token: leaderToken, groupId: world.groupId },
+    );
+
+    // Columns in date order.
+    expect(matrix.events.map((e) => e.title)).toEqual(["Week 1", "Week 2"]);
+    // Per-event tally for wk1: 2 available.
+    expect(matrix.eventCounts[planA].available).toBe(2);
+    expect(matrix.eventCounts[planB].unavailable).toBe(1);
+
+    // Most-available first → the member (2 responses, 1 available) and the
+    // moderator (1 available) lead; everyone else is all no_response.
+    const member = matrix.members.find((m) => m.userId === world.channelMemberId);
+    expect(member?.cells[planA]).toBe("available");
+    expect(member?.cells[planB]).toBe("unavailable");
+    expect(member?.availableCount).toBe(1);
+    expect(member?.hasResponded).toBe(true);
+
+    // A non-responder has all no_response and counts toward the total only.
+    const total = matrix.summary.totalMembers;
+    expect(total).toBeGreaterThanOrEqual(5);
+    expect(matrix.summary.respondedMembers).toBe(2);
+    expect(matrix.members[0].availableCount).toBeGreaterThanOrEqual(
+      matrix.members[total - 1].availableCount,
+    );
+  });
+
+  it("caps columns at 10 upcoming events", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    for (let i = 1; i <= 12; i++) {
+      await createPlan(t, leaderToken, world.groupId, `E${i}`, Date.now() + i * DAY);
+    }
+    const matrix = await t.query(
+      api.functions.scheduling.availability.availabilityMatrix,
+      { token: leaderToken, groupId: world.groupId },
+    );
+    expect(matrix.events).toHaveLength(10);
+  });
+
+  it("rejects a non-scheduler", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    await expect(
+      t.query(api.functions.scheduling.availability.availabilityMatrix, {
+        token: memberToken,
+        groupId: world.groupId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
 describe("public availability link (app-optional, OTP-verified)", () => {
   it("creates a shareable link and exposes a public read", async () => {
     const { t, world } = await setupSchedulingWorld();

--- a/apps/convex/__tests__/scheduling/availability.test.ts
+++ b/apps/convex/__tests__/scheduling/availability.test.ts
@@ -355,6 +355,14 @@ describe("availabilityMatrix (leader grid)", () => {
       { token: leaderToken, groupId: world.groupId },
     );
     expect(matrix.events).toHaveLength(10);
+
+    // A bogus negative limit must not bypass the cap (slice-from-end footgun).
+    const clamped = await t.query(
+      api.functions.scheduling.availability.availabilityMatrix,
+      { token: leaderToken, groupId: world.groupId, limit: -5 },
+    );
+    expect(clamped.events.length).toBeGreaterThanOrEqual(1);
+    expect(clamped.events.length).toBeLessThanOrEqual(10);
   });
 
   it("rejects a non-scheduler", async () => {

--- a/apps/convex/functions/scheduling/availability.ts
+++ b/apps/convex/functions/scheduling/availability.ts
@@ -310,7 +310,12 @@ export const availabilityMatrix = query({
     const userId = await requireAuth(ctx, args.token);
     await requireGroupScheduler(ctx, args.groupId, userId);
 
-    const cap = Math.min(args.limit ?? MATRIX_MAX_EVENTS, MATRIX_MAX_EVENTS);
+    // Clamp to a positive integer within the hard cap: a negative `limit`
+    // would otherwise make `slice(0, cap)` count from the end and blow past it.
+    const cap = Math.max(
+      1,
+      Math.min(Math.floor(args.limit ?? MATRIX_MAX_EVENTS), MATRIX_MAX_EVENTS),
+    );
     const cutoff = startOfTodayMs();
     const plans = (
       await ctx.db

--- a/apps/convex/functions/scheduling/availability.ts
+++ b/apps/convex/functions/scheduling/availability.ts
@@ -23,7 +23,7 @@ import { mutation, query } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
-import { requireGroupMember } from "./permissions";
+import { requireGroupMember, requireGroupScheduler } from "./permissions";
 
 /** Valid availability states a member can report. */
 const AVAILABILITY_STATUSES = new Set(["available", "unavailable"]);
@@ -278,5 +278,142 @@ export const availabilityForPlan = query({
     };
 
     return { planId: args.planId, counts, members: rows };
+  },
+});
+
+/** Cap on event-plan columns in the matrix — the grid is "up to ~10 events". */
+const MATRIX_MAX_EVENTS = 10;
+
+/**
+ * Leader matrix: every active group member (rows) × the group's upcoming event
+ * plans (columns), with each cell the member's availability for that plan
+ * (`available` / `unavailable` / `no_response`). Powers the web availability
+ * grid — built to scan a large roster against up to ~10 events at once.
+ *
+ * Each member carries an `availableCount` (how many of the listed events they
+ * can serve) so the grid can sort "most available first", and each event a
+ * tally for its column header. Members are returned sorted by availableCount
+ * desc then name; the client can re-sort.
+ *
+ * Auth: group leader or community admin — this exposes the whole roster's
+ * responses, so it's gated tighter than the per-member reads.
+ */
+export const availabilityMatrix = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    /** Max event columns (default + hard cap MATRIX_MAX_EVENTS). */
+    limit: v.optional(v.number()),
+    includePast: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupScheduler(ctx, args.groupId, userId);
+
+    const cap = Math.min(args.limit ?? MATRIX_MAX_EVENTS, MATRIX_MAX_EVENTS);
+    const cutoff = startOfTodayMs();
+    const plans = (
+      await ctx.db
+        .query("eventPlans")
+        .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+        .collect()
+    )
+      .filter((p) => args.includePast || p.eventDate >= cutoff)
+      .sort((a, b) => a.eventDate - b.eventDate)
+      .slice(0, cap);
+
+    const events = plans.map((p) => ({
+      _id: p._id,
+      title: p.title,
+      eventDate: p.eventDate,
+      times: p.times,
+    }));
+
+    // Availability rows for the listed plans, indexed by `${planId}:${userId}`.
+    const statusByPlanUser = new Map<string, "available" | "unavailable">();
+    await Promise.all(
+      plans.map(async (plan) => {
+        const rows = await ctx.db
+          .query("eventAvailability")
+          .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+          .collect();
+        for (const r of rows) {
+          statusByPlanUser.set(
+            `${plan._id}:${r.userId}`,
+            r.status as "available" | "unavailable",
+          );
+        }
+      }),
+    );
+
+    const members = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+    const activeMembers = members.filter(
+      (m) => !m.requestStatus || m.requestStatus === "accepted",
+    );
+
+    // Per-event tallies for the column headers.
+    const eventCounts: Record<
+      string,
+      { available: number; unavailable: number; noResponse: number }
+    > = {};
+    for (const plan of plans) {
+      eventCounts[plan._id] = { available: 0, unavailable: 0, noResponse: 0 };
+    }
+
+    const rows = await Promise.all(
+      activeMembers.map(async (m) => {
+        const user = await ctx.db.get(m.userId);
+        const userName =
+          `${user?.firstName ?? ""} ${user?.lastName ?? ""}`.trim() ||
+          "Someone";
+        const cells: Record<
+          string,
+          "available" | "unavailable" | "no_response"
+        > = {};
+        let availableCount = 0;
+        for (const plan of plans) {
+          const status =
+            statusByPlanUser.get(`${plan._id}:${m.userId}`) ?? "no_response";
+          cells[plan._id] = status;
+          if (status === "available") {
+            availableCount += 1;
+            eventCounts[plan._id].available += 1;
+          } else if (status === "unavailable") {
+            eventCounts[plan._id].unavailable += 1;
+          } else {
+            eventCounts[plan._id].noResponse += 1;
+          }
+        }
+        return {
+          userId: m.userId,
+          userName,
+          isLeader: isLeaderRole(m.role),
+          availableCount,
+          // Whether they've responded to ANY listed event.
+          hasResponded: Object.values(cells).some((s) => s !== "no_response"),
+          cells,
+        };
+      }),
+    );
+
+    rows.sort(
+      (a, b) =>
+        b.availableCount - a.availableCount ||
+        a.userName.localeCompare(b.userName),
+    );
+
+    return {
+      events,
+      members: rows,
+      eventCounts,
+      summary: {
+        totalMembers: rows.length,
+        respondedMembers: rows.filter((r) => r.hasResponded).length,
+      },
+    };
   },
 });

--- a/apps/mobile/app/rostering/[group_id]/availability-grid.tsx
+++ b/apps/mobile/app/rostering/[group_id]/availability-grid.tsx
@@ -1,0 +1,9 @@
+import { AvailabilityGridScreen } from "@features/scheduling";
+
+/**
+ * Leader availability grid — route `/rostering/[group_id]/availability-grid`.
+ * The roster-vs-events matrix view (see AvailabilityGridScreen).
+ */
+export default function AvailabilityGridRoute() {
+  return <AvailabilityGridScreen />;
+}

--- a/apps/mobile/features/scheduling/components/AvailabilityGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/AvailabilityGridScreen.tsx
@@ -1,0 +1,575 @@
+/**
+ * AvailabilityGridScreen
+ *
+ * Leader matrix view: every active group member (rows) against the group's
+ * upcoming event plans (columns, up to ~10), each cell showing that member's
+ * availability — available / can't / no response. Built to scan a large roster
+ * (50+) at a glance, primarily on web.
+ *
+ * UX:
+ *  - Frozen header row (events) AND frozen name column, with two-axis scroll —
+ *    the name + event labels stay put while you scan. On a wide screen the
+ *    whole matrix fits with no horizontal scroll.
+ *  - Color + icon per cell (not color alone) so it's legible for everyone.
+ *  - Sort by "most available" (default — what you want when filling slots) or
+ *    by name; optional "responded only" filter; per-event column tallies.
+ *
+ * Route: /rostering/[group_id]/availability-grid
+ * Backend: scheduling.availability.availabilityMatrix
+ */
+import React, { useMemo, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TouchableOpacity,
+  ActivityIndicator,
+  useWindowDimensions,
+  type NativeSyntheticEvent,
+  type NativeScrollEvent,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { EmptyState } from "@components/ui/EmptyState";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+type CellStatus = "available" | "unavailable" | "no_response";
+
+type MatrixEvent = {
+  _id: Id<"eventPlans">;
+  title: string;
+  eventDate: number;
+  times: Array<{ label: string; startsAt: number }>;
+};
+
+type MatrixMember = {
+  userId: Id<"users">;
+  userName: string;
+  isLeader: boolean;
+  availableCount: number;
+  hasResponded: boolean;
+  cells: Record<string, CellStatus>;
+};
+
+type Matrix = {
+  events: MatrixEvent[];
+  members: MatrixMember[];
+  eventCounts: Record<
+    string,
+    { available: number; unavailable: number; noResponse: number }
+  >;
+  summary: { totalMembers: number; respondedMembers: number };
+};
+
+type SortMode = "available" | "name";
+
+function weekday(ms: number): string {
+  return new Date(ms).toLocaleDateString("en-US", { weekday: "short" });
+}
+function monthDay(ms: number): string {
+  return new Date(ms).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function AvailabilityGridScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { width } = useWindowDimensions();
+  const { group_id } = useLocalSearchParams<{ group_id: string }>();
+  const groupId = group_id as Id<"groups">;
+
+  const isWide = width >= 700;
+  const NAME_W = isWide ? 196 : 150;
+  const CELL_W = isWide ? 84 : 76;
+  const ROW_H = 52;
+  const HEADER_H = 70;
+
+  const data = useAuthenticatedQuery(
+    api.functions.scheduling.availability.availabilityMatrix,
+    groupId ? { groupId } : "skip",
+  ) as Matrix | undefined;
+
+  const [sortMode, setSortMode] = useState<SortMode>("available");
+  const [respondedOnly, setRespondedOnly] = useState(false);
+
+  // Synced scroll: the cells area is the only user-scrollable surface; it
+  // drives the frozen header (x) and the frozen name column (y).
+  const headerScrollRef = useRef<ScrollView>(null);
+  const namesScrollRef = useRef<ScrollView>(null);
+  const [bodyH, setBodyH] = useState(0);
+
+  const members = useMemo(() => {
+    if (!data) return [];
+    let rows = data.members;
+    if (respondedOnly) rows = rows.filter((m) => m.hasResponded);
+    if (sortMode === "name") {
+      rows = [...rows].sort((a, b) => a.userName.localeCompare(b.userName));
+    }
+    // server already returns availableCount-desc, name — keep for "available".
+    return rows;
+  }, [data, respondedOnly, sortMode]);
+
+  const onCellsHScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    headerScrollRef.current?.scrollTo({
+      x: e.nativeEvent.contentOffset.x,
+      animated: false,
+    });
+  };
+  const onCellsVScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    namesScrollRef.current?.scrollTo({
+      y: e.nativeEvent.contentOffset.y,
+      animated: false,
+    });
+  };
+
+  const renderHeaderBar = () => (
+    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+      <TouchableOpacity
+        onPress={() => router.canGoBack() && router.back()}
+        hitSlop={12}
+        style={styles.back}
+      >
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <View style={styles.headerTitleWrap}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>
+          Availability
+        </Text>
+        {data && (
+          <Text style={[styles.headerSub, { color: colors.textSecondary }]}>
+            {data.summary.respondedMembers} of {data.summary.totalMembers}{" "}
+            responded
+          </Text>
+        )}
+      </View>
+      <View style={styles.back} />
+    </View>
+  );
+
+  if (data === undefined) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      </View>
+    );
+  }
+
+  if (data.events.length === 0) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <EmptyState
+            icon="calendar-outline"
+            title="No upcoming events"
+            message="Create event plans, then collect availability to see the grid."
+          />
+        </View>
+      </View>
+    );
+  }
+
+  const events = data.events;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.surface, paddingTop: insets.top },
+      ]}
+    >
+      {renderHeaderBar()}
+
+      {/* Controls */}
+      <View style={[styles.controls, { borderBottomColor: colors.border }]}>
+        <View style={styles.segmented}>
+          <SegBtn
+            label="Most available"
+            active={sortMode === "available"}
+            onPress={() => setSortMode("available")}
+            colors={colors}
+          />
+          <SegBtn
+            label="Name"
+            active={sortMode === "name"}
+            onPress={() => setSortMode("name")}
+            colors={colors}
+          />
+        </View>
+        <Pressable
+          onPress={() => setRespondedOnly((v) => !v)}
+          style={[
+            styles.filterChip,
+            {
+              borderColor: respondedOnly ? colors.link : colors.border,
+              backgroundColor: respondedOnly ? colors.link + "18" : "transparent",
+            },
+          ]}
+        >
+          <Ionicons
+            name={respondedOnly ? "checkbox" : "square-outline"}
+            size={15}
+            color={respondedOnly ? colors.link : colors.textSecondary}
+          />
+          <Text
+            style={[
+              styles.filterChipText,
+              { color: respondedOnly ? colors.link : colors.textSecondary },
+            ]}
+          >
+            Responded only
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* Legend */}
+      <View style={styles.legend}>
+        <LegendItem icon="checkmark" color={colors.success} label="Available" />
+        <LegendItem icon="close" color={colors.destructive} label="Can't" />
+        <LegendItem icon="remove" color={colors.textTertiary} label="No response" />
+      </View>
+
+      {/* ===== Matrix ===== */}
+      {/* Frozen header row */}
+      <View style={[styles.matrixHeaderRow, { borderBottomColor: colors.border }]}>
+        <View
+          style={[
+            styles.corner,
+            { width: NAME_W, height: HEADER_H, backgroundColor: colors.surface },
+          ]}
+        >
+          <Text style={[styles.cornerText, { color: colors.textSecondary }]}>
+            {members.length} {members.length === 1 ? "person" : "people"}
+          </Text>
+        </View>
+        <ScrollView
+          ref={headerScrollRef}
+          horizontal
+          scrollEnabled={false}
+          showsHorizontalScrollIndicator={false}
+        >
+          <View style={styles.row}>
+            {events.map((ev) => {
+              const c = data.eventCounts[ev._id];
+              return (
+                <View
+                  key={ev._id}
+                  style={[
+                    styles.headerCell,
+                    { width: CELL_W, height: HEADER_H, borderLeftColor: colors.border },
+                  ]}
+                >
+                  <Text
+                    style={[styles.headerCellTitle, { color: colors.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    {ev.title}
+                  </Text>
+                  <Text style={[styles.headerCellWk, { color: colors.textSecondary }]}>
+                    {weekday(ev.eventDate)}
+                  </Text>
+                  <Text style={[styles.headerCellDate, { color: colors.text }]}>
+                    {monthDay(ev.eventDate)}
+                  </Text>
+                  <View style={styles.headerCellTally}>
+                    <Ionicons name="checkmark" size={11} color={colors.success} />
+                    <Text style={[styles.headerCellTallyText, { color: colors.success }]}>
+                      {c?.available ?? 0}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
+          </View>
+        </ScrollView>
+      </View>
+
+      {/* Body: frozen name column + scrollable cells */}
+      <View
+        style={styles.matrixBody}
+        onLayout={(e) => setBodyH(e.nativeEvent.layout.height)}
+      >
+        {members.length === 0 ? (
+          <View style={styles.centered}>
+            <Text style={{ color: colors.textSecondary }}>
+              No one to show.
+            </Text>
+          </View>
+        ) : (
+          <>
+            {/* Frozen names column (driven vertically by the cells scroll) */}
+            <ScrollView
+              ref={namesScrollRef}
+              scrollEnabled={false}
+              showsVerticalScrollIndicator={false}
+              style={{ width: NAME_W }}
+            >
+              {members.map((m, i) => (
+                <View
+                  key={m.userId}
+                  style={[
+                    styles.nameCell,
+                    {
+                      width: NAME_W,
+                      height: ROW_H,
+                      backgroundColor:
+                        i % 2 === 0 ? colors.surface : colors.surfaceSecondary,
+                      borderBottomColor: colors.border,
+                    },
+                  ]}
+                >
+                  <View style={styles.nameTextWrap}>
+                    <Text
+                      style={[styles.nameText, { color: colors.text }]}
+                      numberOfLines={1}
+                    >
+                      {m.userName}
+                    </Text>
+                    {m.isLeader && (
+                      <Text style={[styles.leaderTag, { color: colors.textTertiary }]}>
+                        Leader
+                      </Text>
+                    )}
+                  </View>
+                  <Text style={[styles.nameCount, { color: colors.textSecondary }]}>
+                    {m.availableCount}/{events.length}
+                  </Text>
+                </View>
+              ))}
+            </ScrollView>
+
+            {/* Scrollable cells (the one surface the user scrolls) */}
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator
+              onScroll={onCellsHScroll}
+              scrollEventThrottle={16}
+            >
+              <ScrollView
+                style={{ height: bodyH }}
+                showsVerticalScrollIndicator
+                onScroll={onCellsVScroll}
+                scrollEventThrottle={16}
+              >
+                {members.map((m, i) => (
+                  <View key={m.userId} style={styles.row}>
+                    {events.map((ev) => (
+                      <Cell
+                        key={ev._id}
+                        status={m.cells[ev._id] ?? "no_response"}
+                        width={CELL_W}
+                        height={ROW_H}
+                        striped={i % 2 !== 0}
+                        colors={colors}
+                      />
+                    ))}
+                  </View>
+                ))}
+              </ScrollView>
+            </ScrollView>
+          </>
+        )}
+      </View>
+    </View>
+  );
+}
+
+function Cell({
+  status,
+  width,
+  height,
+  striped,
+  colors,
+}: {
+  status: CellStatus;
+  width: number;
+  height: number;
+  striped: boolean;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  const base = striped ? colors.surfaceSecondary : colors.surface;
+  let bg = base;
+  let icon: keyof typeof Ionicons.glyphMap = "remove";
+  let tint = colors.textTertiary;
+  if (status === "available") {
+    bg = colors.success + "22";
+    icon = "checkmark";
+    tint = colors.success;
+  } else if (status === "unavailable") {
+    bg = colors.destructive + "22";
+    icon = "close";
+    tint = colors.destructive;
+  }
+  return (
+    <View
+      style={[
+        styles.cell,
+        { width, height, backgroundColor: bg, borderColor: colors.border },
+      ]}
+    >
+      <Ionicons name={icon} size={status === "no_response" ? 12 : 16} color={tint} />
+    </View>
+  );
+}
+
+function SegBtn({
+  label,
+  active,
+  onPress,
+  colors,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.segBtn,
+        {
+          backgroundColor: active ? colors.surface : "transparent",
+        },
+        active && styles.segBtnActive,
+      ]}
+    >
+      <Text
+        style={[
+          styles.segBtnText,
+          { color: active ? colors.text : colors.textSecondary },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function LegendItem({
+  icon,
+  color,
+  label,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+  label: string;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.legendItem}>
+      <Ionicons name={icon} size={13} color={color} />
+      <Text style={[styles.legendText, { color: colors.textSecondary }]}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  back: { width: 36, padding: 4 },
+  headerTitleWrap: { flex: 1, alignItems: "center" },
+  headerTitle: { fontSize: 17, fontWeight: "600" },
+  headerSub: { fontSize: 12, marginTop: 1 },
+  centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  controls: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  segmented: {
+    flexDirection: "row",
+    borderRadius: 9,
+    padding: 2,
+    backgroundColor: "rgba(120,120,128,0.12)",
+  },
+  segBtn: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 7 },
+  segBtnActive: {
+    shadowColor: "#000",
+    shadowOpacity: 0.12,
+    shadowRadius: 2,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 1,
+  },
+  segBtnText: { fontSize: 13, fontWeight: "600" },
+  filterChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  filterChipText: { fontSize: 12, fontWeight: "600" },
+  legend: {
+    flexDirection: "row",
+    gap: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  legendItem: { flexDirection: "row", alignItems: "center", gap: 4 },
+  legendText: { fontSize: 11 },
+  matrixHeaderRow: {
+    flexDirection: "row",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  corner: { justifyContent: "flex-end", paddingHorizontal: 12, paddingBottom: 8 },
+  cornerText: { fontSize: 12, fontWeight: "600" },
+  row: { flexDirection: "row" },
+  headerCell: {
+    alignItems: "center",
+    justifyContent: "flex-end",
+    paddingBottom: 6,
+    paddingHorizontal: 2,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    gap: 1,
+  },
+  headerCellTitle: { fontSize: 9, maxWidth: "100%" },
+  headerCellWk: { fontSize: 10 },
+  headerCellDate: { fontSize: 13, fontWeight: "700" },
+  headerCellTally: { flexDirection: "row", alignItems: "center", gap: 2, marginTop: 1 },
+  headerCellTallyText: { fontSize: 11, fontWeight: "700" },
+  matrixBody: { flex: 1, flexDirection: "row" },
+  nameCell: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 6,
+  },
+  nameTextWrap: { flex: 1, minWidth: 0 },
+  nameText: { fontSize: 14, fontWeight: "500" },
+  leaderTag: { fontSize: 10, marginTop: 1 },
+  nameCount: { fontSize: 12, fontWeight: "600" },
+  cell: {
+    alignItems: "center",
+    justifyContent: "center",
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/apps/mobile/features/scheduling/components/EventListScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventListScreen.tsx
@@ -255,6 +255,20 @@ export function EventListScreen() {
         </Text>
       </Pressable>
 
+      <Pressable
+        onPress={() =>
+          router.push(`/rostering/${groupId}/availability-grid` as never)
+        }
+        style={styles.shareRow}
+        accessibilityRole="button"
+        accessibilityLabel="View the availability grid"
+      >
+        <Ionicons name="grid-outline" size={18} color={colors.textSecondary} />
+        <Text style={[styles.shareLabel, { color: colors.textSecondary }]}>
+          View availability grid
+        </Text>
+      </Pressable>
+
       {events.map((event) => {
         const { totalNeeded, totalFilled, totalConfirmed } = event.fillSummary;
         const confirmedPct =

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -22,6 +22,7 @@ export { EventEditorScreen } from "./components/EventEditorScreen";
 export { RunSheetScreen } from "./components/RunSheetScreen";
 export { MyScheduleScreen } from "./components/MyScheduleScreen";
 export { MyAvailabilityScreen } from "./components/MyAvailabilityScreen";
+export { AvailabilityGridScreen } from "./components/AvailabilityGridScreen";
 export { AssignmentDetailScreen } from "./components/AssignmentDetailScreen";
 
 /** Rostering hub — see ADR-024. */


### PR DESCRIPTION
## What

A leader **availability grid** — the roster-vs-events matrix from the original ask: every active group member (rows) × upcoming event plans (columns, up to 10), each cell showing that member's availability. Designed to scan a large roster (50+) at a glance, primarily on the web.

Builds on the in-app availability already shipped (#433); this is the dedicated overview view that was still missing.

## UX (built for a big roster on web)
- **Frozen header row (events) + frozen name column**, with synced two-axis scroll — the labels stay put while you scan. On a wide screen the whole matrix fits with no horizontal scroll; on a phone it scrolls horizontally.
- **Color + icon per cell** (✓ available / ✗ can't / – no response) so it's legible without relying on color alone.
- **Sort** by "most available" (default — what you want when filling slots) or by name; **"Responded only"** filter; **per-event column tallies** (✓N) and a **responded/total** summary.
- Alternating row striping, leader tag, and a per-member `available/total` count.

## Backend
- `scheduling.availability.availabilityMatrix(groupId)` — returns events (columns, capped at 10), members (rows) with per-cell status + `availableCount` + `hasResponded`, per-event tallies, and a summary. Scheduler-gated (exposes the whole roster). 3 tests; full availability suite is 13 tests, all green.

## Entry point
Rostering hub → **Schedule** tab → "View availability grid". Route: `/rostering/[group_id]/availability-grid`.

## Not done / honest caveats
- I have **not visually verified** this in a running app/web this session (no live env here) — it's typecheck-, lint-, and unit-tested, but the grid layout (synced frozen scroll on RN-web) should get a real look before relying on it.
- v1 is a **per-group matrix** (one grid, up to 10 upcoming events). Per-time-slot columns and CSV export are deferred.

https://claude.ai/code/session_01CbQRL3LCEeYM2TzAFzQh1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbQRL3LCEeYM2TzAFzQh1M)_