### PR TITLE
Rostering grid — availability → assignment (role/people toggle)

### DIFF
--- a/apps/convex/__tests__/scheduling/roster.test.ts
+++ b/apps/convex/__tests__/scheduling/roster.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the rostering matrix (roster.ts) — the joined payload behind the
+ * leader roster grid. Verifies role-centric cells (fill/open/occupants),
+ * people-centric cells (availability + assignments), double-booking, the
+ * per-event tallies, and the scheduler gate.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+async function setup() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+const DAY = 86400000;
+
+async function createPlan(
+  t: ReturnType<typeof convexTest>,
+  token: string,
+  groupId: Id<"groups">,
+  title: string,
+  eventDate: number,
+) {
+  const { planId } = await t.mutation(
+    api.functions.scheduling.events.createEvent,
+    { token, groupId, title, eventDate, times: [{ label: "9 AM", startsAt: eventDate }] },
+  );
+  return planId as Id<"eventPlans">;
+}
+
+describe("rosterMatrix", () => {
+  it("builds role + people cells, tallies, and double-booking", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const member = (await generateTokens(world.channelMemberId)).accessToken;
+    const adminTok = (await generateTokens(world.channelAdminId)).accessToken;
+
+    const sameDay = Date.now() + 7 * DAY;
+    const planA = await createPlan(t, leader, world.groupId, "Service A", sameDay);
+    const planB = await createPlan(t, leader, world.groupId, "Service B", sameDay);
+
+    // Need 2 Drums on A, 1 on B.
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: planA,
+      roles: [{ teamId: world.teamId, roleId: world.roleId, count: 2 }],
+    });
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: planB,
+      roles: [{ teamId: world.teamId, roleId: world.roleId, count: 1 }],
+    });
+
+    // channelMember serves Drums on BOTH same-day plans → double-booked.
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: planA,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: planB,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+    // channelAdmin marks available for A but isn't assigned.
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: adminTok,
+      planId: planA,
+      status: "available",
+    });
+
+    const m = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+    });
+
+    // Columns + role rows.
+    expect(m.events.map((e) => e.title)).toEqual(["Service A", "Service B"]);
+    expect(m.roles.some((r) => r.roleName === "Drums")).toBe(true);
+
+    // Role-centric cell for Drums on A: needed 2, filled 1, one open.
+    const cellA = m.roleCells[`${world.roleId}:${planA}`];
+    expect(cellA.needed).toBe(2);
+    expect(cellA.filled).toBe(1);
+    expect(cellA.open).toBe(1);
+    expect(cellA.occupants).toHaveLength(1);
+    expect(cellA.occupants[0].userId).toBe(world.channelMemberId);
+
+    // Event tally for A: 2 needed, 1 open slot, 1 available responder.
+    expect(m.eventCounts[planA].neededTotal).toBe(2);
+    expect(m.eventCounts[planA].openSlots).toBe(1);
+    expect(m.eventCounts[planA].available).toBe(1);
+
+    // People-centric: the member is assigned on both and flagged double-booked.
+    const row = m.members.find((mm) => mm.userId === world.channelMemberId);
+    expect(row?.cells[planA].assignments[0].roleName).toBe("Drums");
+    expect(row?.cells[planA].doubleBooked).toBe(true);
+    expect(row?.cells[planB].doubleBooked).toBe(true);
+    expect(row?.load).toBe(2);
+
+    // channelAdmin: available on A, no assignment.
+    const adminRow = m.members.find((mm) => mm.userId === world.channelAdminId);
+    expect(adminRow?.cells[planA].availability).toBe("available");
+    expect(adminRow?.cells[planA].assignments).toHaveLength(0);
+    expect(adminRow?.availableCount).toBe(1);
+  });
+
+  it("rejects a non-scheduler", async () => {
+    const { t, world } = await setup();
+    const member = (await generateTokens(world.channelMemberId)).accessToken;
+    await expect(
+      t.query(api.functions.scheduling.roster.rosterMatrix, {
+        token: member,
+        groupId: world.groupId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -137,6 +137,7 @@ import type * as functions_scheduling_people from "../functions/scheduling/peopl
 import type * as functions_scheduling_permissions from "../functions/scheduling/permissions.js";
 import type * as functions_scheduling_publicAvailability from "../functions/scheduling/publicAvailability.js";
 import type * as functions_scheduling_roles from "../functions/scheduling/roles.js";
+import type * as functions_scheduling_roster from "../functions/scheduling/roster.js";
 import type * as functions_scheduling_starterRoles from "../functions/scheduling/starterRoles.js";
 import type * as functions_scheduling_teamChannelSync from "../functions/scheduling/teamChannelSync.js";
 import type * as functions_scheduling_teams from "../functions/scheduling/teams.js";
@@ -336,6 +337,7 @@ declare const fullApi: ApiFromModules<{
   "functions/scheduling/permissions": typeof functions_scheduling_permissions;
   "functions/scheduling/publicAvailability": typeof functions_scheduling_publicAvailability;
   "functions/scheduling/roles": typeof functions_scheduling_roles;
+  "functions/scheduling/roster": typeof functions_scheduling_roster;
   "functions/scheduling/starterRoles": typeof functions_scheduling_starterRoles;
   "functions/scheduling/teamChannelSync": typeof functions_scheduling_teamChannelSync;
   "functions/scheduling/teams": typeof functions_scheduling_teams;

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -1,0 +1,359 @@
+/**
+ * Rostering matrix — the data spine for the leader roster grid (ADR-023
+ * follow-up). One read joins `neededRoles` + `roleAssignments` +
+ * `eventAvailability` across a group's upcoming event plans so the grid can
+ * render BOTH orientations from a single payload:
+ *
+ *   - role-centric: roles (rows) × events (columns), cell = coverage
+ *   - people-centric: members (rows) × events (columns), cell = assignment,
+ *     shaded by that member's availability
+ *
+ * It's effectively `events.getEvent` fanned across N plans, plus the
+ * `availability.availabilityMatrix` lens, shaped for the grid. Reuses the
+ * settled fill math (confirmed + unconfirmed = filled; declined reopens) and
+ * the same-UTC-day double-booking rule as the rest of scheduling.
+ *
+ * Scheduler-gated: it exposes the whole roster's assignments + availability.
+ */
+
+import { v } from "convex/values";
+import { query } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { isLeaderRole } from "../../lib/helpers";
+import { requireGroupScheduler } from "./permissions";
+
+/** Column cap — matches availabilityMatrix; a leader rosters a horizon. */
+const MAX_EVENTS = 10;
+const MS_PER_DAY = 86_400_000;
+/** Statuses that consume a slot (mirrors events.ts FILLED_STATUSES). */
+const FILLED = new Set(["confirmed", "unconfirmed"]);
+
+function startOfTodayMs(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+/** Local-day bucket for the double-booking rule (mirrors assignments.ts). */
+function utcDayBucket(eventDate: number): number {
+  return Math.floor(eventDate / MS_PER_DAY) * MS_PER_DAY;
+}
+
+type CellStatus = "confirmed" | "unconfirmed" | "declined";
+type Availability = "available" | "unavailable" | "no_response";
+
+export const rosterMatrix = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    /** Event-column cap; clamped to [1, MAX_EVENTS]. */
+    limit: v.optional(v.number()),
+    includePast: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupScheduler(ctx, args.groupId, userId);
+
+    const cap = Math.max(
+      1,
+      Math.min(Math.floor(args.limit ?? MAX_EVENTS), MAX_EVENTS),
+    );
+    const cutoff = startOfTodayMs();
+    const plans = (
+      await ctx.db
+        .query("eventPlans")
+        .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+        .collect()
+    )
+      .filter((p) => args.includePast || p.eventDate >= cutoff)
+      .sort((a, b) => a.eventDate - b.eventDate)
+      .slice(0, cap);
+
+    const events = plans.map((p) => ({
+      _id: p._id,
+      title: p.title,
+      eventDate: p.eventDate,
+      times: p.times,
+    }));
+    const planDate = new Map(plans.map((p) => [p._id as string, p.eventDate]));
+
+    // --- Fan out the three per-plan reads. ---
+    const perPlan = await Promise.all(
+      plans.map(async (plan) => {
+        const [neededRoles, assignments, availability] = await Promise.all([
+          ctx.db
+            .query("neededRoles")
+            .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+            .collect(),
+          ctx.db
+            .query("roleAssignments")
+            .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+            .collect(),
+          ctx.db
+            .query("eventAvailability")
+            .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+            .collect(),
+        ]);
+        return { plan, neededRoles, assignments, availability };
+      }),
+    );
+
+    // --- Resolve display names for every role and user referenced. ---
+    const roleIds = new Set<string>();
+    const userIds = new Set<string>();
+    for (const { neededRoles, assignments } of perPlan) {
+      for (const n of neededRoles) roleIds.add(n.roleId as string);
+      for (const a of assignments) {
+        roleIds.add(a.roleId as string);
+        userIds.add(a.userId as string);
+      }
+    }
+    const roleDocs = new Map<string, Doc<"teamRoles">>();
+    await Promise.all(
+      [...roleIds].map(async (rid) => {
+        const doc = await ctx.db.get(rid as Id<"teamRoles">);
+        if (doc) roleDocs.set(rid, doc);
+      }),
+    );
+    const teamIds = new Set<string>();
+    for (const doc of roleDocs.values()) teamIds.add(doc.teamId as string);
+    const teamDocs = new Map<string, Doc<"teams">>();
+    await Promise.all(
+      [...teamIds].map(async (tid) => {
+        const doc = await ctx.db.get(tid as Id<"teams">);
+        if (doc) teamDocs.set(tid, doc);
+      }),
+    );
+
+    const userName = (uid: string, u: Doc<"users"> | null): string =>
+      `${u?.firstName ?? ""} ${u?.lastName ?? ""}`.trim() || "Someone";
+
+    // --- Role-centric cells: keyed `${roleId}:${planId}`. ---
+    const userDocs = new Map<string, Doc<"users"> | null>();
+    await Promise.all(
+      [...userIds].map(async (uid) => {
+        userDocs.set(uid, await ctx.db.get(uid as Id<"users">));
+      }),
+    );
+
+    const roleCells: Record<
+      string,
+      {
+        needed: number;
+        filled: number;
+        confirmed: number;
+        open: number;
+        occupants: Array<{
+          userId: Id<"users">;
+          userName: string;
+          status: CellStatus;
+        }>;
+      }
+    > = {};
+    const eventCounts: Record<
+      string,
+      {
+        available: number;
+        unavailable: number;
+        noResponse: number;
+        openSlots: number;
+        neededTotal: number;
+      }
+    > = {};
+
+    for (const { plan, neededRoles, assignments, availability } of perPlan) {
+      const planKey = plan._id as string;
+      const assignsByRole = new Map<string, Doc<"roleAssignments">[]>();
+      for (const a of assignments) {
+        const arr = assignsByRole.get(a.roleId as string) ?? [];
+        arr.push(a);
+        assignsByRole.set(a.roleId as string, arr);
+      }
+      let openSlots = 0;
+      let neededTotal = 0;
+      for (const needed of neededRoles) {
+        const list = assignsByRole.get(needed.roleId as string) ?? [];
+        const filled = list.filter((a) => FILLED.has(a.status)).length;
+        const confirmed = list.filter((a) => a.status === "confirmed").length;
+        const open = Math.max(0, needed.count - filled);
+        neededTotal += needed.count;
+        openSlots += open;
+        roleCells[`${needed.roleId}:${planKey}`] = {
+          needed: needed.count,
+          filled,
+          confirmed,
+          open,
+          occupants: list.map((a) => ({
+            userId: a.userId,
+            userName: userName(a.userId as string, userDocs.get(a.userId as string) ?? null),
+            status: a.status as CellStatus,
+          })),
+        };
+      }
+      eventCounts[planKey] = {
+        available: availability.filter((r) => r.status === "available").length,
+        unavailable: availability.filter((r) => r.status === "unavailable").length,
+        noResponse: 0, // filled in once we know the active roster size
+        openSlots,
+        neededTotal,
+      };
+    }
+
+    // --- Role + team row metadata (union across plans). ---
+    const roles = [...roleDocs.values()]
+      .map((doc) => ({
+        roleId: doc._id,
+        teamId: doc.teamId,
+        roleName: doc.name,
+        roleColor: doc.color,
+        sortOrder: doc.sortOrder,
+        teamName: teamDocs.get(doc.teamId as string)?.name ?? "Team",
+      }))
+      .sort(
+        (a, b) =>
+          a.teamName.localeCompare(b.teamName) ||
+          a.sortOrder - b.sortOrder ||
+          a.roleName.localeCompare(b.roleName),
+      );
+    const teams = [...teamDocs.values()]
+      .map((t) => ({ teamId: t._id, teamName: t.name }))
+      .sort((a, b) => a.teamName.localeCompare(b.teamName));
+
+    // --- People-centric rows: active group members. ---
+    const memberRows = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+    const activeMembers = memberRows.filter(
+      (m) => !m.requestStatus || m.requestStatus === "accepted",
+    );
+
+    // Index availability + assignments by user for quick per-member assembly.
+    const availByUserPlan = new Map<string, Availability>();
+    const assignsByUser = new Map<
+      string,
+      Array<{ planId: string; roleId: string; status: string }>
+    >();
+    for (const { plan, assignments, availability } of perPlan) {
+      for (const r of availability) {
+        availByUserPlan.set(
+          `${r.userId}:${plan._id}`,
+          r.status as Availability,
+        );
+      }
+      for (const a of assignments) {
+        const arr = assignsByUser.get(a.userId as string) ?? [];
+        arr.push({
+          planId: plan._id as string,
+          roleId: a.roleId as string,
+          status: a.status,
+        });
+        assignsByUser.set(a.userId as string, arr);
+      }
+    }
+
+    const members = await Promise.all(
+      activeMembers.map(async (m) => {
+        const uid = m.userId as string;
+        const u = userDocs.get(uid) ?? (await ctx.db.get(m.userId));
+        const myAssigns = assignsByUser.get(uid) ?? [];
+
+        // Double-booking: any local day with ≥2 non-declined assignments.
+        const dayCounts = new Map<number, number>();
+        for (const a of myAssigns) {
+          if (a.status === "declined") continue;
+          const day = utcDayBucket(planDate.get(a.planId) ?? 0);
+          dayCounts.set(day, (dayCounts.get(day) ?? 0) + 1);
+        }
+
+        let availableCount = 0;
+        let load = 0;
+        const cells: Record<
+          string,
+          {
+            availability: Availability;
+            assignments: Array<{
+              roleId: Id<"teamRoles">;
+              roleName: string;
+              status: CellStatus;
+            }>;
+            doubleBooked: boolean;
+          }
+        > = {};
+        for (const plan of plans) {
+          const planKey = plan._id as string;
+          const availability =
+            availByUserPlan.get(`${uid}:${planKey}`) ?? "no_response";
+          if (availability === "available") availableCount += 1;
+          const planAssigns = myAssigns.filter((a) => a.planId === planKey);
+          for (const a of planAssigns) {
+            if (a.status !== "declined") load += 1;
+          }
+          const day = utcDayBucket(plan.eventDate);
+          cells[planKey] = {
+            availability,
+            assignments: planAssigns.map((a) => ({
+              roleId: a.roleId as Id<"teamRoles">,
+              roleName: roleDocs.get(a.roleId)?.name ?? "Role",
+              status: a.status as CellStatus,
+            })),
+            doubleBooked:
+              (dayCounts.get(day) ?? 0) >= 2 &&
+              planAssigns.some((a) => a.status !== "declined"),
+          };
+        }
+        return {
+          userId: m.userId,
+          userName: userName(uid, u),
+          isLeader: isLeaderRole(m.role),
+          availableCount,
+          load,
+          cells,
+        };
+      }),
+    );
+
+    // Now that we know the active roster size, finish each event's
+    // no-response tally (members with no availability row for that plan).
+    for (const plan of plans) {
+      const planKey = plan._id as string;
+      const responded =
+        eventCounts[planKey].available + eventCounts[planKey].unavailable;
+      eventCounts[planKey].noResponse = Math.max(
+        0,
+        members.length - responded,
+      );
+    }
+
+    // Default people order: most-available first, then name (client can re-sort).
+    members.sort(
+      (a, b) =>
+        b.availableCount - a.availableCount ||
+        a.userName.localeCompare(b.userName),
+    );
+
+    return {
+      events,
+      teams,
+      roles: roles.map((r) => ({
+        roleId: r.roleId,
+        teamId: r.teamId,
+        roleName: r.roleName,
+        roleColor: r.roleColor,
+        teamName: r.teamName,
+      })),
+      roleCells,
+      members,
+      eventCounts,
+      summary: {
+        totalMembers: members.length,
+        respondedMembers: members.filter((m) =>
+          plans.some(
+            (p) => m.cells[p._id as string]?.availability !== "no_response",
+          ),
+        ).length,
+      },
+    };
+  },
+});

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -74,6 +74,7 @@ export const rosterMatrix = query({
       title: p.title,
       eventDate: p.eventDate,
       times: p.times,
+      status: p.status, // "draft" | "published" — AssignSheet needs this
     }));
     const planDate = new Map(plans.map((p) => [p._id as string, p.eventDate]));
 
@@ -144,6 +145,7 @@ export const rosterMatrix = query({
         confirmed: number;
         open: number;
         occupants: Array<{
+          assignmentId: Id<"roleAssignments">;
           userId: Id<"users">;
           userName: string;
           status: CellStatus;
@@ -184,6 +186,7 @@ export const rosterMatrix = query({
           confirmed,
           open,
           occupants: list.map((a) => ({
+            assignmentId: a._id,
             userId: a.userId,
             userName: userName(a.userId as string, userDocs.get(a.userId as string) ?? null),
             status: a.status as CellStatus,
@@ -233,7 +236,12 @@ export const rosterMatrix = query({
     const availByUserPlan = new Map<string, Availability>();
     const assignsByUser = new Map<
       string,
-      Array<{ planId: string; roleId: string; status: string }>
+      Array<{
+        assignmentId: Id<"roleAssignments">;
+        planId: string;
+        roleId: string;
+        status: string;
+      }>
     >();
     for (const { plan, assignments, availability } of perPlan) {
       for (const r of availability) {
@@ -245,6 +253,7 @@ export const rosterMatrix = query({
       for (const a of assignments) {
         const arr = assignsByUser.get(a.userId as string) ?? [];
         arr.push({
+          assignmentId: a._id,
           planId: plan._id as string,
           roleId: a.roleId as string,
           status: a.status,
@@ -274,6 +283,7 @@ export const rosterMatrix = query({
           {
             availability: Availability;
             assignments: Array<{
+              assignmentId: Id<"roleAssignments">;
               roleId: Id<"teamRoles">;
               roleName: string;
               status: CellStatus;
@@ -294,6 +304,7 @@ export const rosterMatrix = query({
           cells[planKey] = {
             availability,
             assignments: planAssigns.map((a) => ({
+              assignmentId: a.assignmentId,
               roleId: a.roleId as Id<"teamRoles">,
               roleName: roleDocs.get(a.roleId)?.name ?? "Role",
               status: a.status as CellStatus,

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -76,7 +76,6 @@ export const rosterMatrix = query({
       times: p.times,
       status: p.status, // "draft" | "published" — AssignSheet needs this
     }));
-    const planDate = new Map(plans.map((p) => [p._id as string, p.eventDate]));
 
     // --- Fan out the three per-plan reads. ---
     const perPlan = await Promise.all(
@@ -194,9 +193,12 @@ export const rosterMatrix = query({
         };
       }
       eventCounts[planKey] = {
-        available: availability.filter((r) => r.status === "available").length,
-        unavailable: availability.filter((r) => r.status === "unavailable").length,
-        noResponse: 0, // filled in once we know the active roster size
+        // available/unavailable are filled below, counting ONLY active roster
+        // members (a left/non-accepted member's stale row must not inflate the
+        // tally or push noResponse negative).
+        available: 0,
+        unavailable: 0,
+        noResponse: 0,
         openSlots,
         neededTotal,
       };
@@ -231,6 +233,19 @@ export const rosterMatrix = query({
     const activeMembers = memberRows.filter(
       (m) => !m.requestStatus || m.requestStatus === "accepted",
     );
+    const activeUserIds = new Set(activeMembers.map((m) => m.userId as string));
+
+    // Per-event availability tallies, counting ONLY active members (stale rows
+    // from people who left must not inflate available/unavailable).
+    for (const { plan, availability } of perPlan) {
+      const planKey = plan._id as string;
+      for (const r of availability) {
+        if (!activeUserIds.has(r.userId as string)) continue;
+        if (r.status === "available") eventCounts[planKey].available += 1;
+        else if (r.status === "unavailable")
+          eventCounts[planKey].unavailable += 1;
+      }
+    }
 
     // Index availability + assignments by user for quick per-member assembly.
     const availByUserPlan = new Map<string, Availability>();
@@ -268,11 +283,18 @@ export const rosterMatrix = query({
         const u = userDocs.get(uid) ?? (await ctx.db.get(m.userId));
         const myAssigns = assignsByUser.get(uid) ?? [];
 
-        // Double-booking: any local day with ≥2 non-declined assignments.
+        // Double-booking uses the member's FULL assignment set (denormalized
+        // eventDate via by_user) — same scope as the assign mutation's check —
+        // so a same-day conflict in another event/group or beyond the column
+        // cap still flags. Counting only the matrix plans would under-report.
+        const allAssigns = await ctx.db
+          .query("roleAssignments")
+          .withIndex("by_user", (q) => q.eq("userId", m.userId))
+          .collect();
         const dayCounts = new Map<number, number>();
-        for (const a of myAssigns) {
+        for (const a of allAssigns) {
           if (a.status === "declined") continue;
-          const day = utcDayBucket(planDate.get(a.planId) ?? 0);
+          const day = utcDayBucket(a.eventDate);
           dayCounts.set(day, (dayCounts.get(day) ?? 0) + 1);
         }
 

--- a/apps/mobile/app/rostering/[group_id]/grid.tsx
+++ b/apps/mobile/app/rostering/[group_id]/grid.tsx
@@ -1,0 +1,10 @@
+import { RosterGridScreen } from "@features/scheduling";
+
+/**
+ * Leader roster grid — route `/rostering/[group_id]/grid`.
+ * The both-toggle matrix that places volunteers into roles across events
+ * (see RosterGridScreen).
+ */
+export default function RosterGridRoute() {
+  return <RosterGridScreen />;
+}

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -163,6 +163,8 @@ export function AssignSheet({
   roleName,
   timeLabel,
   assignedUserIds,
+  prioritizeAvailable = false,
+  keepOpenWhileUnfilled = false,
   onClose,
 }: {
   visible: boolean;
@@ -182,6 +184,17 @@ export function AssignSheet({
   timeLabel?: string;
   /** Users already on this role — shown as disabled. */
   assignedUserIds: Set<string>;
+  /**
+   * Sort GROUP candidates available-first (when opened from the roster grid,
+   * where availability is the primary lens). Default keeps name order.
+   */
+  prioritizeAvailable?: boolean;
+  /**
+   * Keep the sheet open after assigning instead of closing — lets a leader
+   * fill a multi-person role (e.g. "Vocals 3") without re-opening. The parent
+   * reactively updates `assignedUserIds`, so filled people grey out in place.
+   */
+  keepOpenWhileUnfilled?: boolean;
   onClose: () => void;
 }) {
   const { colors } = useTheme();
@@ -294,8 +307,20 @@ export function AssignSheet({
         communityRows.push(c);
       }
     }
+    if (prioritizeAvailable) {
+      // Available → no-response → unavailable, then existing (name) order.
+      const rank = (uid: string): number => {
+        const s = availabilityByUser.get(uid);
+        if (s === "available") return 0;
+        if (s === "unavailable") return 2;
+        return 1;
+      };
+      groupRows.sort(
+        (a, b) => rank(a.userId as string) - rank(b.userId as string),
+      );
+    }
     return { previousRows, groupRows, communityRows };
-  }, [candidates, previous, debouncedSearch]);
+  }, [candidates, previous, debouncedSearch, prioritizeAvailable, availabilityByUser]);
 
   // ---------------------------------------------------------------------------
   // Mutation handlers
@@ -328,7 +353,10 @@ export function AssignSheet({
             `${person.displayName} is already scheduled somewhere else this day. They've still been assigned — they can sort it out when they respond.`,
           );
         }
-        onClose();
+        // Multi-person roles (e.g. "Vocals 3") stay open so the leader fills
+        // the rest without re-opening; the just-assigned person greys out as
+        // the parent's reactive `assignedUserIds` updates.
+        if (!keepOpenWhileUnfilled) onClose();
       } catch (e) {
         surfaceError("Couldn't assign", e);
       } finally {
@@ -342,6 +370,7 @@ export function AssignSheet({
       teamId,
       roleId,
       timeLabel,
+      keepOpenWhileUnfilled,
       onClose,
       surfaceError,
     ],

--- a/apps/mobile/features/scheduling/components/EventListScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventListScreen.tsx
@@ -256,6 +256,22 @@ export function EventListScreen() {
       </Pressable>
 
       <Pressable
+        onPress={() => router.push(`/rostering/${groupId}/grid` as never)}
+        style={styles.shareRow}
+        accessibilityRole="button"
+        accessibilityLabel="Open the roster grid"
+      >
+        <Ionicons
+          name="git-network-outline"
+          size={18}
+          color={colors.textSecondary}
+        />
+        <Text style={[styles.shareLabel, { color: colors.textSecondary }]}>
+          Roster grid
+        </Text>
+      </Pressable>
+
+      <Pressable
         onPress={() =>
           router.push(`/rostering/${groupId}/availability-grid` as never)
         }

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -1,0 +1,1555 @@
+/**
+ * RosterGridScreen
+ *
+ * The leader's "both-toggle" rostering matrix — a generalization of the
+ * availability grid (see AvailabilityGridScreen) that turns availability into
+ * a placed roster. One screen, two lenses on the same backend matrix:
+ *
+ *  - ROLES view (default): rows = team roles, columns = events. Each cell shows
+ *    coverage (filled/needed) and lets a leader fill an open slot (AssignSheet)
+ *    or manage existing occupants (cell popover). Roles are grouped under a
+ *    small uppercase team header in the frozen first column.
+ *  - PEOPLE view: rows = members (most-available first), columns = events. Each
+ *    cell shows what a person is serving that date, or — when they're available
+ *    and unassigned — an inviting "av" tap-target that opens an *open-roles
+ *    menu* for one-tap placement. This is the availability → roster bridge.
+ *
+ * Scaffold (frozen header row + frozen first column + synced two-axis scroll,
+ * measured body height, responsive widths) is cloned from AvailabilityGridScreen.
+ * Assignment is delegated entirely to AssignSheet — we never fork that logic.
+ *
+ * Route: /rostering/[group_id]/grid
+ * Backend: scheduling.roster.rosterMatrix (reactive — mutations self-refresh),
+ *          scheduling.assignments.assignRole / .unassign
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TouchableOpacity,
+  ActivityIndicator,
+  Modal,
+  TextInput,
+  Alert,
+  useWindowDimensions,
+  type NativeSyntheticEvent,
+  type NativeScrollEvent,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { EmptyState } from "@components/ui/EmptyState";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { AssignSheet } from "./AssignSheet";
+
+// ---------------------------------------------------------------------------
+// Backend contract (mirrors scheduling.roster.rosterMatrix)
+// ---------------------------------------------------------------------------
+type Availability = "available" | "unavailable" | "no_response";
+type AssignmentStatus = "confirmed" | "unconfirmed" | "declined";
+
+type RosterEvent = {
+  _id: Id<"eventPlans">;
+  title: string;
+  eventDate: number;
+  times: Array<{ label: string; startsAt: number }>;
+  status: "draft" | "published";
+};
+
+type RosterTeam = { teamId: Id<"teams">; teamName: string };
+
+type RosterRole = {
+  roleId: Id<"teamRoles">;
+  teamId: Id<"teams">;
+  roleName: string;
+  roleColor?: string;
+  teamName: string;
+};
+
+type RoleCell = {
+  needed: number;
+  filled: number;
+  confirmed: number;
+  open: number;
+  occupants: Array<{
+    assignmentId: Id<"roleAssignments">;
+    userId: Id<"users">;
+    userName: string;
+    status: AssignmentStatus;
+  }>;
+};
+
+type MemberAssignment = {
+  assignmentId: Id<"roleAssignments">;
+  roleId: Id<"teamRoles">;
+  roleName: string;
+  status: AssignmentStatus;
+};
+
+type MemberCell = {
+  availability: Availability;
+  assignments: MemberAssignment[];
+  doubleBooked: boolean;
+};
+
+type RosterMember = {
+  userId: Id<"users">;
+  userName: string;
+  isLeader: boolean;
+  availableCount: number;
+  load: number;
+  cells: Record<string, MemberCell>;
+};
+
+type RosterMatrix = {
+  events: RosterEvent[];
+  teams: RosterTeam[];
+  roles: RosterRole[];
+  roleCells: Record<string, RoleCell>;
+  members: RosterMember[];
+  eventCounts: Record<
+    string,
+    {
+      available: number;
+      unavailable: number;
+      noResponse: number;
+      openSlots: number;
+      neededTotal: number;
+    }
+  >;
+  summary: { totalMembers: number; respondedMembers: number };
+};
+
+type ViewMode = "roles" | "people";
+
+/** A frozen-column row in the role view: a team section header or a role. */
+type RoleRow =
+  | { kind: "section"; teamId: string; teamName: string }
+  | { kind: "role"; role: RosterRole };
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+function weekday(ms: number): string {
+  return new Date(ms).toLocaleDateString("en-US", { weekday: "short" });
+}
+function monthDay(ms: number): string {
+  return new Date(ms).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** Debounce a value by `delay` ms — same pattern as AssignSheet. */
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+/** The worst (most-attention-needing) status in a set of assignments. */
+function worstStatus(items: { status: AssignmentStatus }[]): AssignmentStatus {
+  if (items.some((i) => i.status === "declined")) return "declined";
+  if (items.some((i) => i.status === "unconfirmed")) return "unconfirmed";
+  return "confirmed";
+}
+
+type Colors = ReturnType<typeof useTheme>["colors"];
+
+function statusColor(status: AssignmentStatus, colors: Colors): string {
+  if (status === "declined") return colors.destructive;
+  if (status === "unconfirmed") return colors.warning;
+  return colors.success;
+}
+
+function statusIcon(status: AssignmentStatus): keyof typeof Ionicons.glyphMap {
+  if (status === "declined") return "close";
+  if (status === "unconfirmed") return "time-outline";
+  return "checkmark";
+}
+
+// AssignSheet's required shape; used by the role-cell + open-roles flows.
+type AssignTarget = {
+  planId: Id<"eventPlans">;
+  planStatus: "draft" | "published";
+  teamId: Id<"teams">;
+  roleId: Id<"teamRoles">;
+  roleName: string;
+  timeLabel?: string;
+  assignedUserIds: Set<string>;
+  keepOpenWhileUnfilled: boolean;
+};
+
+export function RosterGridScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { width } = useWindowDimensions();
+  const { group_id } = useLocalSearchParams<{ group_id: string }>();
+  const groupId = group_id as Id<"groups">;
+
+  const isWide = width >= 700;
+  const NAME_W = isWide ? 196 : 150;
+  const CELL_W = isWide ? 84 : 76;
+  const ROW_H = 52;
+  const SECTION_H = 28;
+  const HEADER_H = 70;
+
+  const data = useAuthenticatedQuery(
+    api.functions.scheduling.roster.rosterMatrix,
+    groupId ? { groupId } : "skip",
+  ) as RosterMatrix | undefined;
+
+  const assignRole = useAuthenticatedMutation(
+    api.functions.scheduling.assignments.assignRole,
+  );
+  const unassign = useAuthenticatedMutation(
+    api.functions.scheduling.assignments.unassign,
+  );
+
+  // --- View + filter state ---
+  const [mode, setMode] = useState<ViewMode>("roles");
+  const [hiddenTeams, setHiddenTeams] = useState<Set<string>>(new Set());
+  const [openOnly, setOpenOnly] = useState(false);
+  const [availableOnly, setAvailableOnly] = useState(false);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  // --- Synced scroll scaffold (cloned from AvailabilityGridScreen) ---
+  const headerScrollRef = useRef<ScrollView>(null);
+  const frozenScrollRef = useRef<ScrollView>(null);
+  const [bodyH, setBodyH] = useState(0);
+
+  const onCellsHScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    headerScrollRef.current?.scrollTo({
+      x: e.nativeEvent.contentOffset.x,
+      animated: false,
+    });
+  };
+  const onCellsVScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    frozenScrollRef.current?.scrollTo({
+      y: e.nativeEvent.contentOffset.y,
+      animated: false,
+    });
+  };
+
+  // --- Modal state ---
+  // AssignSheet target (role-cell fill / "add someone" / open-roles handoff).
+  const [assignTarget, setAssignTarget] = useState<AssignTarget | null>(null);
+  // Role-cell occupant popover (manage existing assignments + add someone).
+  const [roleCellModal, setRoleCellModal] = useState<{
+    role: RosterRole;
+    event: RosterEvent;
+  } | null>(null);
+  // People-view: a member's assignments for an event (manage + add role).
+  const [memberCellModal, setMemberCellModal] = useState<{
+    member: RosterMember;
+    event: RosterEvent;
+  } | null>(null);
+  // People-view: open-roles menu for placing a member into a slot.
+  const [openRolesModal, setOpenRolesModal] = useState<{
+    member: RosterMember;
+    event: RosterEvent;
+    note?: string;
+  } | null>(null);
+
+  const surfaceError = useCallback((title: string, e: unknown) => {
+    const err = e as { data?: { message?: string }; message?: string };
+    Alert.alert(title, err?.data?.message ?? err?.message ?? "Something went wrong");
+  }, []);
+
+  const handleUnassign = useCallback(
+    async (assignmentId: Id<"roleAssignments">) => {
+      try {
+        await unassign({ assignmentId });
+      } catch (e) {
+        surfaceError("Couldn't remove", e);
+      }
+    },
+    [unassign, surfaceError],
+  );
+
+  /** A single time-label when the event has exactly one time, else undefined. */
+  const singleTimeLabel = useCallback(
+    (event: RosterEvent): string | undefined =>
+      event.times.length === 1 ? event.times[0].label : undefined,
+    [],
+  );
+
+  const handleQuickAssign = useCallback(
+    async (role: RosterRole, event: RosterEvent, member: RosterMember) => {
+      try {
+        await assignRole({
+          planId: event._id,
+          teamId: role.teamId,
+          roleId: role.roleId,
+          userId: member.userId,
+          timeLabel: singleTimeLabel(event),
+        });
+        setOpenRolesModal(null);
+      } catch (e) {
+        surfaceError("Couldn't assign", e);
+      }
+    },
+    [assignRole, singleTimeLabel, surfaceError],
+  );
+
+  // --- Derived filters ---
+  const events = data?.events ?? [];
+  const roleCells = data?.roleCells ?? {};
+
+  const teamVisible = useCallback(
+    (teamId: string) => !hiddenTeams.has(teamId),
+    [hiddenTeams],
+  );
+
+  const toggleTeam = useCallback((teamId: string) => {
+    setHiddenTeams((prev) => {
+      const next = new Set(prev);
+      if (next.has(teamId)) next.delete(teamId);
+      else next.add(teamId);
+      return next;
+    });
+  }, []);
+
+  /** Roles after team + "open only" filters; grouped headers are derived on render. */
+  const visibleRoles = useMemo(() => {
+    if (!data) return [];
+    return data.roles.filter((r) => {
+      if (!teamVisible(r.teamId as string)) return false;
+      if (openOnly) {
+        // Keep only roles with at least one open slot across visible events.
+        const hasOpen = events.some((ev) => {
+          const c = roleCells[`${r.roleId}:${ev._id}`];
+          return c && c.open > 0;
+        });
+        if (!hasOpen) return false;
+      }
+      return true;
+    });
+  }, [data, events, roleCells, teamVisible, openOnly]);
+
+  /**
+   * Interleave team section-header rows into the (already team-sorted) role
+   * list. Computed unconditionally (above the early returns) to respect the
+   * Rules of Hooks.
+   */
+  const roleRows = useMemo<RoleRow[]>(() => {
+    const out: RoleRow[] = [];
+    let lastTeam: string | null = null;
+    for (const role of visibleRoles) {
+      const tid = role.teamId as string;
+      if (tid !== lastTeam) {
+        out.push({ kind: "section", teamId: tid, teamName: role.teamName });
+        lastTeam = tid;
+      }
+      out.push({ kind: "role", role });
+    }
+    return out;
+  }, [visibleRoles]);
+
+  /** Members after team* + search + open/available filters. (*teams don't gate people rows.) */
+  const visibleMembers = useMemo(() => {
+    if (!data) return [];
+    const q = debouncedSearch.trim().toLowerCase();
+    return data.members.filter((m) => {
+      if (q && !m.userName.toLowerCase().includes(q)) return false;
+      if (availableOnly && m.availableCount === 0) return false;
+      if (openOnly) {
+        // Keep only people with at least one available-and-unassigned cell.
+        const hasOpenCell = events.some((ev) => {
+          const c = m.cells[ev._id as string];
+          return c && c.availability === "available" && c.assignments.length === 0;
+        });
+        if (!hasOpenCell) return false;
+      }
+      return true;
+    });
+  }, [data, events, debouncedSearch, availableOnly, openOnly]);
+
+  /** Open roles for an event, computed client-side (the placement menu). */
+  const openRolesForEvent = useCallback(
+    (event: RosterEvent): RosterRole[] => {
+      if (!data) return [];
+      return data.roles.filter((r) => {
+        const c = roleCells[`${r.roleId}:${event._id}`];
+        return c && c.open > 0;
+      });
+    },
+    [data, roleCells],
+  );
+
+  // -------------------------------------------------------------------------
+  // Header
+  // -------------------------------------------------------------------------
+  const renderHeaderBar = () => (
+    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+      <TouchableOpacity
+        onPress={() => router.canGoBack() && router.back()}
+        hitSlop={12}
+        style={styles.back}
+      >
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <View style={styles.headerTitleWrap}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Roster</Text>
+        {data && (
+          <Text style={[styles.headerSub, { color: colors.textSecondary }]}>
+            {events.length} {events.length === 1 ? "event" : "events"} ·{" "}
+            {data.summary.respondedMembers}/{data.summary.totalMembers} responded
+          </Text>
+        )}
+      </View>
+      <View style={styles.segmented}>
+        <SegBtn
+          label="Roles"
+          active={mode === "roles"}
+          onPress={() => setMode("roles")}
+          colors={colors}
+        />
+        <SegBtn
+          label="People"
+          active={mode === "people"}
+          onPress={() => setMode("people")}
+          colors={colors}
+        />
+      </View>
+    </View>
+  );
+
+  if (data === undefined) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      </View>
+    );
+  }
+
+  if (data.events.length === 0) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <EmptyState
+            icon="calendar-outline"
+            title="No upcoming events"
+            message="Create event plans and collect availability, then place volunteers here."
+          />
+        </View>
+      </View>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Filter bar
+  // -------------------------------------------------------------------------
+  const renderFilterBar = () => (
+    <View style={[styles.filterBar, { borderBottomColor: colors.border }]}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipRow}
+      >
+        <Chip
+          label="All teams"
+          active={hiddenTeams.size === 0}
+          onPress={() => setHiddenTeams(new Set())}
+          colors={colors}
+        />
+        {data.teams.map((t) => (
+          <Chip
+            key={t.teamId}
+            label={t.teamName}
+            active={teamVisible(t.teamId as string)}
+            onPress={() => toggleTeam(t.teamId as string)}
+            colors={colors}
+          />
+        ))}
+      </ScrollView>
+      <View style={styles.chipRow}>
+        <Chip
+          icon={openOnly ? "checkbox" : "square-outline"}
+          label="Open only"
+          active={openOnly}
+          onPress={() => setOpenOnly((v) => !v)}
+          colors={colors}
+        />
+        {mode === "people" && (
+          <Chip
+            icon={availableOnly ? "checkbox" : "square-outline"}
+            label="Available only"
+            active={availableOnly}
+            onPress={() => setAvailableOnly((v) => !v)}
+            colors={colors}
+          />
+        )}
+      </View>
+      {mode === "people" && (
+        <View style={[styles.searchBox, { borderColor: colors.border }]}>
+          <Ionicons name="search" size={15} color={colors.textSecondary} />
+          <TextInput
+            style={[styles.searchInput, { color: colors.text }]}
+            placeholder="Search people…"
+            placeholderTextColor={colors.textSecondary}
+            value={search}
+            onChangeText={setSearch}
+            autoCorrect={false}
+            autoCapitalize="none"
+          />
+          {search.length > 0 && (
+            <TouchableOpacity onPress={() => setSearch("")} hitSlop={8}>
+              <Ionicons name="close-circle" size={16} color={colors.textTertiary} />
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
+    </View>
+  );
+
+  const renderLegend = () => (
+    <View style={styles.legend}>
+      <LegendItem icon="checkmark" color={colors.success} label="Confirmed" colors={colors} />
+      <LegendItem icon="time-outline" color={colors.warning} label="Awaiting" colors={colors} />
+      <LegendItem icon="close" color={colors.destructive} label="Declined" colors={colors} />
+      <LegendItem icon="ellipse-outline" color={colors.textTertiary} label="Open" colors={colors} />
+      <LegendItem icon="warning" color={colors.warning} label="Double-booked" colors={colors} />
+    </View>
+  );
+
+  // -------------------------------------------------------------------------
+  // Header row of event columns (shared by both views)
+  // -------------------------------------------------------------------------
+  const renderHeaderRow = (cornerLabel: string) => (
+    <View style={[styles.matrixHeaderRow, { borderBottomColor: colors.border }]}>
+      <View
+        style={[
+          styles.corner,
+          { width: NAME_W, height: HEADER_H, backgroundColor: colors.surface },
+        ]}
+      >
+        <Text style={[styles.cornerText, { color: colors.textSecondary }]}>
+          {cornerLabel}
+        </Text>
+      </View>
+      <ScrollView
+        ref={headerScrollRef}
+        horizontal
+        scrollEnabled={false}
+        showsHorizontalScrollIndicator={false}
+      >
+        <View style={styles.row}>
+          {events.map((ev) => {
+            const c = data.eventCounts[ev._id as string];
+            const open = c?.openSlots ?? 0;
+            return (
+              <View
+                key={ev._id}
+                style={[
+                  styles.headerCell,
+                  { width: CELL_W, height: HEADER_H, borderLeftColor: colors.border },
+                ]}
+              >
+                <Text
+                  style={[styles.headerCellTitle, { color: colors.textSecondary }]}
+                  numberOfLines={1}
+                >
+                  {ev.title}
+                </Text>
+                <Text style={[styles.headerCellWk, { color: colors.textSecondary }]}>
+                  {weekday(ev.eventDate)}
+                </Text>
+                <Text style={[styles.headerCellDate, { color: colors.text }]}>
+                  {monthDay(ev.eventDate)}
+                </Text>
+                <View style={styles.headerCellTally}>
+                  {mode === "roles" ? (
+                    open > 0 ? (
+                      <>
+                        <Ionicons name="ellipse-outline" size={10} color={colors.textTertiary} />
+                        <Text style={[styles.headerCellTallyText, { color: colors.textTertiary }]}>
+                          {open}
+                        </Text>
+                      </>
+                    ) : (
+                      <Ionicons name="checkmark" size={12} color={colors.success} />
+                    )
+                  ) : (
+                    <>
+                      <Ionicons name="checkmark" size={11} color={colors.success} />
+                      <Text style={[styles.headerCellTallyText, { color: colors.success }]}>
+                        {c?.available ?? 0}
+                      </Text>
+                    </>
+                  )}
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+
+  // -------------------------------------------------------------------------
+  // ROLE VIEW — frozen column rows (team section header + role rows)
+  // -------------------------------------------------------------------------
+  const renderRoleFrozen = () => (
+    <ScrollView
+      ref={frozenScrollRef}
+      scrollEnabled={false}
+      showsVerticalScrollIndicator={false}
+      style={{ width: NAME_W }}
+    >
+      {roleRows.map((r, i) => {
+        if (r.kind === "section") {
+          return (
+            <View
+              key={`sec-${r.teamId}`}
+              style={[
+                styles.sectionCell,
+                { width: NAME_W, height: SECTION_H, backgroundColor: colors.surfaceSecondary, borderBottomColor: colors.border },
+              ]}
+            >
+              <Text style={[styles.sectionText, { color: colors.textSecondary }]} numberOfLines={1}>
+                {r.teamName.toUpperCase()}
+              </Text>
+            </View>
+          );
+        }
+        const coveredCount = events.reduce((n, ev) => {
+          const c = roleCells[`${r.role.roleId}:${ev._id}`];
+          return n + (c && c.needed > 0 && c.open === 0 ? 1 : 0);
+        }, 0);
+        return (
+          <View
+            key={r.role.roleId}
+            style={[
+              styles.nameCell,
+              {
+                width: NAME_W,
+                height: ROW_H,
+                backgroundColor: i % 2 === 0 ? colors.surface : colors.surfaceSecondary,
+                borderBottomColor: colors.border,
+              },
+            ]}
+          >
+            <View style={styles.nameTextWrap}>
+              <Text style={[styles.nameText, { color: colors.text }]} numberOfLines={1}>
+                {r.role.roleName}
+              </Text>
+              <Text style={[styles.subCount, { color: colors.textTertiary }]}>
+                covered {coveredCount}/{events.length}
+              </Text>
+            </View>
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+
+  const renderRoleCells = () => (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator
+      onScroll={onCellsHScroll}
+      scrollEventThrottle={16}
+    >
+      <ScrollView
+        style={{ height: bodyH }}
+        showsVerticalScrollIndicator
+        onScroll={onCellsVScroll}
+        scrollEventThrottle={16}
+      >
+        {roleRows.map((r, i) => {
+          if (r.kind === "section") {
+            return (
+              <View
+                key={`sec-${r.teamId}`}
+                style={[
+                  styles.row,
+                  { height: SECTION_H, backgroundColor: colors.surfaceSecondary, borderBottomColor: colors.border, borderBottomWidth: StyleSheet.hairlineWidth },
+                ]}
+              />
+            );
+          }
+          return (
+            <View key={r.role.roleId} style={styles.row}>
+              {events.map((ev) => (
+                <RoleCellView
+                  key={ev._id}
+                  cell={roleCells[`${r.role.roleId}:${ev._id}`]}
+                  width={CELL_W}
+                  height={ROW_H}
+                  striped={i % 2 !== 0}
+                  colors={colors}
+                  onPress={() => {
+                    const cell = roleCells[`${r.role.roleId}:${ev._id}`];
+                    if (!cell) return;
+                    if (cell.occupants.length === 0) {
+                      setAssignTarget({
+                        planId: ev._id,
+                        planStatus: ev.status,
+                        teamId: r.role.teamId,
+                        roleId: r.role.roleId,
+                        roleName: r.role.roleName,
+                        timeLabel: singleTimeLabel(ev),
+                        assignedUserIds: new Set(),
+                        keepOpenWhileUnfilled: cell.needed > 1,
+                      });
+                    } else {
+                      setRoleCellModal({ role: r.role, event: ev });
+                    }
+                  }}
+                />
+              ))}
+            </View>
+          );
+        })}
+      </ScrollView>
+    </ScrollView>
+  );
+
+  // -------------------------------------------------------------------------
+  // PEOPLE VIEW
+  // -------------------------------------------------------------------------
+  const renderPeopleFrozen = () => (
+    <ScrollView
+      ref={frozenScrollRef}
+      scrollEnabled={false}
+      showsVerticalScrollIndicator={false}
+      style={{ width: NAME_W }}
+    >
+      {visibleMembers.map((m, i) => {
+        const heavy = m.load >= Math.ceil(events.length / 2);
+        return (
+          <View
+            key={m.userId}
+            style={[
+              styles.nameCell,
+              {
+                width: NAME_W,
+                height: ROW_H,
+                backgroundColor: i % 2 === 0 ? colors.surface : colors.surfaceSecondary,
+                borderBottomColor: colors.border,
+              },
+            ]}
+          >
+            <View style={styles.nameTextWrap}>
+              <View style={styles.nameInline}>
+                <Text style={[styles.nameText, { color: colors.text }]} numberOfLines={1}>
+                  {m.userName}
+                </Text>
+                {m.isLeader && (
+                  <Text style={[styles.leaderTag, { color: colors.textTertiary }]}>Leader</Text>
+                )}
+              </View>
+              <View style={styles.nameInline}>
+                <Text style={[styles.subCount, { color: colors.success }]}>
+                  ✓{m.availableCount}/{events.length}
+                </Text>
+                <Text style={[styles.subCount, { color: heavy ? colors.warning : colors.textTertiary }]}>
+                  {heavy ? "⚠ " : ""}
+                  {m.load} srv
+                </Text>
+              </View>
+            </View>
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+
+  const renderPeopleCells = () => (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator
+      onScroll={onCellsHScroll}
+      scrollEventThrottle={16}
+    >
+      <ScrollView
+        style={{ height: bodyH }}
+        showsVerticalScrollIndicator
+        onScroll={onCellsVScroll}
+        scrollEventThrottle={16}
+      >
+        {visibleMembers.map((m, i) => (
+          <View key={m.userId} style={styles.row}>
+            {events.map((ev) => {
+              const cell = m.cells[ev._id as string];
+              return (
+                <PeopleCellView
+                  key={ev._id}
+                  cell={cell}
+                  width={CELL_W}
+                  height={ROW_H}
+                  striped={i % 2 !== 0}
+                  colors={colors}
+                  onPress={() => {
+                    if (cell && cell.assignments.length > 0) {
+                      setMemberCellModal({ member: m, event: ev });
+                    } else {
+                      setOpenRolesModal({
+                        member: m,
+                        event: ev,
+                        note:
+                          cell?.availability === "unavailable"
+                            ? "Marked unavailable"
+                            : undefined,
+                      });
+                    }
+                  }}
+                />
+              );
+            })}
+          </View>
+        ))}
+      </ScrollView>
+    </ScrollView>
+  );
+
+  const rows = mode === "roles" ? roleRows.length : visibleMembers.length;
+  const cornerLabel =
+    mode === "roles"
+      ? `${visibleRoles.length} ${visibleRoles.length === 1 ? "role" : "roles"}`
+      : `${visibleMembers.length} ${visibleMembers.length === 1 ? "person" : "people"}`;
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+      {renderHeaderBar()}
+      {renderFilterBar()}
+      {renderLegend()}
+
+      {renderHeaderRow(cornerLabel)}
+
+      <View style={styles.matrixBody} onLayout={(e) => setBodyH(e.nativeEvent.layout.height)}>
+        {rows === 0 ? (
+          <View style={styles.centered}>
+            <Text style={{ color: colors.textSecondary }}>
+              {mode === "roles" ? "No roles to show." : "No one to show."}
+            </Text>
+          </View>
+        ) : mode === "roles" ? (
+          <>
+            {renderRoleFrozen()}
+            {renderRoleCells()}
+          </>
+        ) : (
+          <>
+            {renderPeopleFrozen()}
+            {renderPeopleCells()}
+          </>
+        )}
+      </View>
+
+      {/* ===== Modals ===== */}
+      {assignTarget && (
+        <AssignSheet
+          visible
+          planId={assignTarget.planId}
+          planStatus={assignTarget.planStatus}
+          groupId={groupId}
+          teamId={assignTarget.teamId}
+          roleId={assignTarget.roleId}
+          roleName={assignTarget.roleName}
+          timeLabel={assignTarget.timeLabel}
+          assignedUserIds={assignTarget.assignedUserIds}
+          prioritizeAvailable
+          keepOpenWhileUnfilled={assignTarget.keepOpenWhileUnfilled}
+          onClose={() => setAssignTarget(null)}
+        />
+      )}
+
+      {roleCellModal && (
+        <RoleCellPopover
+          role={roleCellModal.role}
+          event={roleCellModal.event}
+          cell={roleCells[`${roleCellModal.role.roleId}:${roleCellModal.event._id}`]}
+          colors={colors}
+          onRemove={handleUnassign}
+          onAddSomeone={(cell) => {
+            const role = roleCellModal.role;
+            const ev = roleCellModal.event;
+            setRoleCellModal(null);
+            setAssignTarget({
+              planId: ev._id,
+              planStatus: ev.status,
+              teamId: role.teamId,
+              roleId: role.roleId,
+              roleName: role.roleName,
+              timeLabel: singleTimeLabel(ev),
+              assignedUserIds: new Set(cell.occupants.map((o) => o.userId as string)),
+              keepOpenWhileUnfilled: cell.open > 1,
+            });
+          }}
+          onClose={() => setRoleCellModal(null)}
+        />
+      )}
+
+      {memberCellModal && (
+        <MemberCellPopover
+          member={memberCellModal.member}
+          event={memberCellModal.event}
+          cell={memberCellModal.member.cells[memberCellModal.event._id as string]}
+          colors={colors}
+          onRemove={handleUnassign}
+          onAddRole={() => {
+            const m = memberCellModal.member;
+            const ev = memberCellModal.event;
+            setMemberCellModal(null);
+            setOpenRolesModal({ member: m, event: ev });
+          }}
+          onClose={() => setMemberCellModal(null)}
+        />
+      )}
+
+      {openRolesModal && (
+        <OpenRolesMenu
+          member={openRolesModal.member}
+          event={openRolesModal.event}
+          note={openRolesModal.note}
+          roles={openRolesForEvent(openRolesModal.event)}
+          roleCells={roleCells}
+          colors={colors}
+          onPick={(role) =>
+            handleQuickAssign(role, openRolesModal.event, openRolesModal.member)
+          }
+          onClose={() => setOpenRolesModal(null)}
+        />
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cell renderers
+// ---------------------------------------------------------------------------
+function RoleCellView({
+  cell,
+  width,
+  height,
+  striped,
+  colors,
+  onPress,
+}: {
+  cell: RoleCell | undefined;
+  width: number;
+  height: number;
+  striped: boolean;
+  colors: Colors;
+  onPress: () => void;
+}) {
+  const base = striped ? colors.surfaceSecondary : colors.surface;
+
+  // Role not needed this event → dim, non-interactive placeholder.
+  if (!cell || cell.needed === 0) {
+    return (
+      <View
+        style={[
+          styles.cell,
+          { width, height, backgroundColor: base, borderColor: colors.border, opacity: 0.45 },
+        ]}
+      >
+        <Text style={[styles.cellMuted, { color: colors.textTertiary }]}>·</Text>
+      </View>
+    );
+  }
+
+  const fullyConfirmed = cell.filled === cell.needed && cell.confirmed === cell.needed;
+  const fullyFilled = cell.filled === cell.needed;
+  const hasDeclined = cell.occupants.some((o) => o.status === "declined");
+
+  let bg = base;
+  const label = `${cell.filled}/${cell.needed}`;
+  let tint = colors.text;
+  let trailing: keyof typeof Ionicons.glyphMap | null = "ellipse-outline";
+  let trailingTint = colors.textTertiary;
+
+  if (cell.open > 0) {
+    bg = base;
+    tint = colors.textSecondary;
+  } else if (fullyConfirmed) {
+    bg = colors.success + "22";
+    tint = colors.success;
+    trailing = "checkmark";
+    trailingTint = colors.success;
+  } else if (fullyFilled) {
+    bg = colors.warning + "22";
+    tint = colors.warning;
+    trailing = "time-outline";
+    trailingTint = colors.warning;
+  }
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.cell, { width, height, backgroundColor: bg, borderColor: colors.border }]}
+      accessibilityRole="button"
+    >
+      <View style={styles.cellInner}>
+        <Text style={[styles.cellCount, { color: tint }]}>{label}</Text>
+        {trailing && <Ionicons name={trailing} size={12} color={trailingTint} />}
+      </View>
+      {hasDeclined && (
+        <Ionicons name="close" size={11} color={colors.destructive} style={styles.cellCorner} />
+      )}
+    </Pressable>
+  );
+}
+
+function PeopleCellView({
+  cell,
+  width,
+  height,
+  striped,
+  colors,
+  onPress,
+}: {
+  cell: MemberCell | undefined;
+  width: number;
+  height: number;
+  striped: boolean;
+  colors: Colors;
+  onPress: () => void;
+}) {
+  const base = striped ? colors.surfaceSecondary : colors.surface;
+
+  if (cell && cell.assignments.length > 0) {
+    const status = worstStatus(cell.assignments);
+    const tint = statusColor(status, colors);
+    const first = cell.assignments[0].roleName;
+    const extra = cell.assignments.length - 1;
+    return (
+      <Pressable
+        onPress={onPress}
+        style={[styles.cell, { width, height, backgroundColor: tint + "22", borderColor: colors.border }]}
+        accessibilityRole="button"
+      >
+        <Text style={[styles.cellRole, { color: tint }]} numberOfLines={1}>
+          {first}
+          {extra > 0 ? ` +${extra}` : ""}
+        </Text>
+        {cell.doubleBooked && (
+          <Ionicons name="warning" size={11} color={colors.warning} style={styles.cellCorner} />
+        )}
+      </Pressable>
+    );
+  }
+
+  const availability = cell?.availability ?? "no_response";
+  if (availability === "available") {
+    return (
+      <Pressable
+        onPress={onPress}
+        style={[styles.cell, { width, height, backgroundColor: colors.success + "12", borderColor: colors.border }]}
+        accessibilityRole="button"
+      >
+        <View style={styles.cellInner}>
+          <Ionicons name="ellipse-outline" size={11} color={colors.success} />
+          <Text style={[styles.cellAv, { color: colors.success }]}>av</Text>
+        </View>
+      </Pressable>
+    );
+  }
+  if (availability === "unavailable") {
+    return (
+      <Pressable
+        onPress={onPress}
+        style={[styles.cell, { width, height, backgroundColor: colors.destructive + "10", borderColor: colors.border }]}
+        accessibilityRole="button"
+      >
+        <Ionicons name="close" size={13} color={colors.destructive} />
+      </Pressable>
+    );
+  }
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.cell, { width, height, backgroundColor: base, borderColor: colors.border }]}
+      accessibilityRole="button"
+    >
+      <Text style={[styles.cellMuted, { color: colors.textTertiary }]}>—</Text>
+    </Pressable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Popovers / menus
+// ---------------------------------------------------------------------------
+function ModalShell({
+  title,
+  subtitle,
+  colors,
+  onClose,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  colors: Colors;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable
+          style={[styles.popover, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={styles.popoverHead}>
+            <View style={styles.popoverHeadText}>
+              <Text style={[styles.popoverTitle, { color: colors.text }]} numberOfLines={1}>
+                {title}
+              </Text>
+              {subtitle && (
+                <Text style={[styles.popoverSub, { color: colors.textSecondary }]} numberOfLines={1}>
+                  {subtitle}
+                </Text>
+              )}
+            </View>
+            <TouchableOpacity onPress={onClose} hitSlop={12}>
+              <Ionicons name="close" size={22} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+          {children}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function RoleCellPopover({
+  role,
+  event,
+  cell,
+  colors,
+  onRemove,
+  onAddSomeone,
+  onClose,
+}: {
+  role: RosterRole;
+  event: RosterEvent;
+  cell: RoleCell | undefined;
+  colors: Colors;
+  onRemove: (id: Id<"roleAssignments">) => void;
+  onAddSomeone: (cell: RoleCell) => void;
+  onClose: () => void;
+}) {
+  if (!cell) return null;
+  return (
+    <ModalShell
+      title={role.roleName}
+      subtitle={`${role.teamName} · ${monthDay(event.eventDate)} · ${cell.filled}/${cell.needed}`}
+      colors={colors}
+      onClose={onClose}
+    >
+      <ScrollView style={styles.popoverList}>
+        {cell.occupants.map((o) => (
+          <View key={o.assignmentId} style={[styles.occupantRow, { borderBottomColor: colors.border }]}>
+            <Ionicons name={statusIcon(o.status)} size={16} color={statusColor(o.status, colors)} />
+            <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+              {o.userName}
+            </Text>
+            <TouchableOpacity onPress={() => onRemove(o.assignmentId)} hitSlop={8}>
+              <Text style={[styles.removeText, { color: colors.destructive }]}>Remove</Text>
+            </TouchableOpacity>
+          </View>
+        ))}
+      </ScrollView>
+      {cell.open > 0 && (
+        <Pressable
+          onPress={() => onAddSomeone(cell)}
+          style={[styles.addBtn, { borderColor: colors.link }]}
+          accessibilityRole="button"
+        >
+          <Ionicons name="add" size={18} color={colors.link} />
+          <Text style={[styles.addBtnText, { color: colors.link }]}>Add someone</Text>
+        </Pressable>
+      )}
+    </ModalShell>
+  );
+}
+
+function MemberCellPopover({
+  member,
+  event,
+  cell,
+  colors,
+  onRemove,
+  onAddRole,
+  onClose,
+}: {
+  member: RosterMember;
+  event: RosterEvent;
+  cell: MemberCell | undefined;
+  colors: Colors;
+  onRemove: (id: Id<"roleAssignments">) => void;
+  onAddRole: () => void;
+  onClose: () => void;
+}) {
+  if (!cell) return null;
+  return (
+    <ModalShell
+      title={member.userName}
+      subtitle={`${event.title} · ${monthDay(event.eventDate)}`}
+      colors={colors}
+      onClose={onClose}
+    >
+      {cell.doubleBooked && (
+        <Text style={[styles.noteLine, { color: colors.warning }]}>
+          ⚠ Double-booked this day
+        </Text>
+      )}
+      <ScrollView style={styles.popoverList}>
+        {cell.assignments.map((a) => (
+          <View key={a.assignmentId} style={[styles.occupantRow, { borderBottomColor: colors.border }]}>
+            <Ionicons name={statusIcon(a.status)} size={16} color={statusColor(a.status, colors)} />
+            <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+              {a.roleName}
+            </Text>
+            <TouchableOpacity onPress={() => onRemove(a.assignmentId)} hitSlop={8}>
+              <Text style={[styles.removeText, { color: colors.destructive }]}>Remove</Text>
+            </TouchableOpacity>
+          </View>
+        ))}
+      </ScrollView>
+      <Pressable
+        onPress={onAddRole}
+        style={[styles.addBtn, { borderColor: colors.link }]}
+        accessibilityRole="button"
+      >
+        <Ionicons name="add" size={18} color={colors.link} />
+        <Text style={[styles.addBtnText, { color: colors.link }]}>Add role</Text>
+      </Pressable>
+    </ModalShell>
+  );
+}
+
+function OpenRolesMenu({
+  member,
+  event,
+  note,
+  roles,
+  roleCells,
+  colors,
+  onPick,
+  onClose,
+}: {
+  member: RosterMember;
+  event: RosterEvent;
+  note?: string;
+  roles: RosterRole[];
+  roleCells: Record<string, RoleCell>;
+  colors: Colors;
+  onPick: (role: RosterRole) => void;
+  onClose: () => void;
+}) {
+  return (
+    <ModalShell
+      title={`Place ${member.userName}`}
+      subtitle={`${event.title} · ${monthDay(event.eventDate)}`}
+      colors={colors}
+      onClose={onClose}
+    >
+      {note && <Text style={[styles.noteLine, { color: colors.destructive }]}>{note}</Text>}
+      {roles.length === 0 ? (
+        <Text style={[styles.menuEmpty, { color: colors.textSecondary }]}>
+          No open roles on this date.
+        </Text>
+      ) : (
+        <ScrollView style={styles.popoverList}>
+          {roles.map((role) => {
+            const c = roleCells[`${role.roleId}:${event._id}`];
+            return (
+              <Pressable
+                key={role.roleId}
+                onPress={() => onPick(role)}
+                style={[styles.menuRow, { borderBottomColor: colors.border }]}
+                accessibilityRole="button"
+              >
+                <View style={styles.menuRowText}>
+                  <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+                    {role.roleName}
+                  </Text>
+                  <Text style={[styles.menuRowSub, { color: colors.textTertiary }]} numberOfLines={1}>
+                    {role.teamName}
+                  </Text>
+                </View>
+                <Text style={[styles.menuRowCount, { color: colors.textSecondary }]}>
+                  {c ? `${c.filled}/${c.needed}` : ""}
+                </Text>
+                <Ionicons name="add-circle" size={20} color={colors.link} />
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      )}
+    </ModalShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small shared UI
+// ---------------------------------------------------------------------------
+function SegBtn({
+  label,
+  active,
+  onPress,
+  colors,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  colors: Colors;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.segBtn,
+        { backgroundColor: active ? colors.surface : "transparent" },
+        active && styles.segBtnActive,
+      ]}
+    >
+      <Text style={[styles.segBtnText, { color: active ? colors.text : colors.textSecondary }]}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function Chip({
+  icon,
+  label,
+  active,
+  onPress,
+  colors,
+}: {
+  icon?: keyof typeof Ionicons.glyphMap;
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  colors: Colors;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.chip,
+        {
+          borderColor: active ? colors.link : colors.border,
+          backgroundColor: active ? colors.link + "18" : "transparent",
+        },
+      ]}
+    >
+      {icon && (
+        <Ionicons name={icon} size={14} color={active ? colors.link : colors.textSecondary} />
+      )}
+      <Text style={[styles.chipText, { color: active ? colors.link : colors.textSecondary }]}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function LegendItem({
+  icon,
+  color,
+  label,
+  colors,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+  label: string;
+  colors: Colors;
+}) {
+  return (
+    <View style={styles.legendItem}>
+      <Ionicons name={icon} size={12} color={color} />
+      <Text style={[styles.legendText, { color: colors.textSecondary }]}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 6,
+  },
+  back: { width: 36, padding: 4 },
+  headerTitleWrap: { flex: 1 },
+  headerTitle: { fontSize: 17, fontWeight: "600" },
+  headerSub: { fontSize: 12, marginTop: 1 },
+  centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  segmented: {
+    flexDirection: "row",
+    borderRadius: 9,
+    padding: 2,
+    backgroundColor: "rgba(120,120,128,0.12)",
+  },
+  segBtn: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 7 },
+  segBtnActive: {
+    shadowColor: "#000",
+    shadowOpacity: 0.12,
+    shadowRadius: 2,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 1,
+  },
+  segBtnText: { fontSize: 13, fontWeight: "600" },
+  filterBar: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 8,
+  },
+  chipRow: { flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  chipText: { fontSize: 12, fontWeight: "600" },
+  searchBox: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  searchInput: { flex: 1, fontSize: 14, paddingVertical: 2 },
+  legend: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 14,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+  },
+  legendItem: { flexDirection: "row", alignItems: "center", gap: 4 },
+  legendText: { fontSize: 11 },
+  matrixHeaderRow: { flexDirection: "row", borderBottomWidth: StyleSheet.hairlineWidth },
+  corner: { justifyContent: "flex-end", paddingHorizontal: 12, paddingBottom: 8 },
+  cornerText: { fontSize: 12, fontWeight: "600" },
+  row: { flexDirection: "row" },
+  headerCell: {
+    alignItems: "center",
+    justifyContent: "flex-end",
+    paddingBottom: 6,
+    paddingHorizontal: 2,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    gap: 1,
+  },
+  headerCellTitle: { fontSize: 9, maxWidth: "100%" },
+  headerCellWk: { fontSize: 10 },
+  headerCellDate: { fontSize: 13, fontWeight: "700" },
+  headerCellTally: { flexDirection: "row", alignItems: "center", gap: 2, marginTop: 1 },
+  headerCellTallyText: { fontSize: 11, fontWeight: "700" },
+  matrixBody: { flex: 1, flexDirection: "row" },
+  sectionCell: {
+    justifyContent: "center",
+    paddingHorizontal: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  sectionText: { fontSize: 10, fontWeight: "700", letterSpacing: 0.6 },
+  nameCell: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 6,
+  },
+  nameTextWrap: { flex: 1, minWidth: 0 },
+  nameInline: { flexDirection: "row", alignItems: "center", gap: 6 },
+  nameText: { fontSize: 14, fontWeight: "500", flexShrink: 1 },
+  leaderTag: { fontSize: 10 },
+  subCount: { fontSize: 11, fontWeight: "600", marginTop: 1 },
+  cell: {
+    alignItems: "center",
+    justifyContent: "center",
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  cellInner: { flexDirection: "row", alignItems: "center", gap: 3 },
+  cellCount: { fontSize: 13, fontWeight: "700" },
+  cellRole: { fontSize: 11, fontWeight: "600", paddingHorizontal: 3, textAlign: "center" },
+  cellAv: { fontSize: 11, fontWeight: "700" },
+  cellMuted: { fontSize: 13 },
+  cellCorner: { position: "absolute", top: 2, right: 3 },
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  popover: {
+    width: "100%",
+    maxWidth: 420,
+    maxHeight: "80%",
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+  },
+  popoverHead: { flexDirection: "row", alignItems: "flex-start", gap: 8, marginBottom: 8 },
+  popoverHeadText: { flex: 1, minWidth: 0 },
+  popoverTitle: { fontSize: 17, fontWeight: "700" },
+  popoverSub: { fontSize: 12, marginTop: 2 },
+  popoverList: { flexGrow: 0 },
+  occupantRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  occupantName: { flex: 1, fontSize: 15, fontWeight: "500" },
+  removeText: { fontSize: 13, fontWeight: "600" },
+  noteLine: { fontSize: 12, fontWeight: "600", marginBottom: 8 },
+  addBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    marginTop: 12,
+    paddingVertical: 11,
+    borderRadius: 10,
+    borderWidth: 1,
+  },
+  addBtnText: { fontSize: 14, fontWeight: "600" },
+  menuEmpty: { fontSize: 14, paddingVertical: 20, textAlign: "center" },
+  menuRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  menuRowText: { flex: 1, minWidth: 0 },
+  menuRowSub: { fontSize: 11, marginTop: 1 },
+  menuRowCount: { fontSize: 13, fontWeight: "600" },
+});

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -23,6 +23,7 @@ export { RunSheetScreen } from "./components/RunSheetScreen";
 export { MyScheduleScreen } from "./components/MyScheduleScreen";
 export { MyAvailabilityScreen } from "./components/MyAvailabilityScreen";
 export { AvailabilityGridScreen } from "./components/AvailabilityGridScreen";
+export { RosterGridScreen } from "./components/RosterGridScreen";
 export { AssignmentDetailScreen } from "./components/AssignmentDetailScreen";
 
 /** Rostering hub — see ADR-024. */


### PR DESCRIPTION
## What

The **rostering grid** — the tool that turns *availability* into *assignments*. This is the step the product owner flagged was missing: going from "this person is available" to **placing them in a role** across many events. Implements the agreed "both-toggle" design (role-centric ↔ people-centric), reusing the existing assignment engine.

Solves the real pain: filling ~30 roles × ~10 events for ~50 volunteers without entering 10 separate event editors / ~300 modal taps.

## UX (one screen, `[ Roles | People ]` toggle)

**Roles view** — *is every role covered?* Roles (grouped by team) × event dates. Each cell = coverage: `filled/needed`, open-slot `◌`, confirmed (green ✓) / awaiting (amber …) / declined (red ✗). Tap an open cell → assign (the existing `AssignSheet`, now **available-first** and **stays open** so a "Vocals 3" fills in one go); tap a filled cell → manage/remove occupants.

**People view** — *who's free / overloaded?* Members × event dates. Cells show the role(s) someone serves, shaded by their availability, with a **serving-load count** and a **double-booked ⚠** flag. An **available-but-unassigned** cell shows an inviting `◌ av` →  **one tap → "open roles for this date" menu → placed**. That's the availability→roster bridge.

Filters: team chips, "Open only", people name search + "Available only". Frozen header + frozen first column with synced two-axis scroll (web-first; scaffold reused from the availability grid).

## Backend
- `scheduling.roster.rosterMatrix(groupId)` — one read joining `neededRoles` + `roleAssignments` + `eventAvailability` across the group's upcoming plans (capped 10), shaped for both orientations: role cells (needed/filled/confirmed/open + occupants), member cells (availability + assignments + double-booked) with availableCount + load, per-event tallies, summary. Scheduler-gated. **Reuses** `assignRole`/`unassign` for every write — no new mutation surface. 2 tests.

## Reuse / scope
- `AssignSheet` reused unchanged except two small opt-in props (`prioritizeAvailable`, `keepOpenWhileUnfilled`); the frozen-scroll scaffold is generalized from `AvailabilityGridScreen`.
- **Phase 4 (opt-in auto-suggest) is deliberately deferred** — this is the manual grid; auto-assist is a fast-follow.

## Entry point
Rostering hub → **Schedule** tab → "Roster grid". Route `/rostering/[group_id]/grid`.

## Caveats
- I have **not visually verified** this in a running app/web (no live env this session) — typecheck + lint + 2 backend tests pass, but the dense grid + frozen-scroll should get a real look before relying on it. Holding merge for review.
- v1 column = event plan (not per-service-time), matching how availability is collected.

https://claude.ai/code/session_01CbQRL3LCEeYM2TzAFzQh1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbQRL3LCEeYM2TzAFzQh1M)_