### PR TITLE
feat(rostering): run sheet before/during/after event phases + cross-phase drag

### DIFF
--- a/apps/convex/__tests__/scheduling/eventItems.test.ts
+++ b/apps/convex/__tests__/scheduling/eventItems.test.ts
@@ -180,7 +180,10 @@ describe("reorderItems", () => {
     await t.mutation(api.functions.scheduling.eventItems.reorderItems, {
       token,
       planId,
-      orderedIds: [ids[2], ids[0], ids[1]],
+      orderedItems: [ids[2], ids[0], ids[1]].map((id) => ({
+        id,
+        segment: "during",
+      })),
     });
 
     const items = await t.query(api.functions.scheduling.eventItems.listItems, {
@@ -210,7 +213,7 @@ describe("reorderItems", () => {
       t.mutation(api.functions.scheduling.eventItems.reorderItems, {
         token,
         planId,
-        orderedIds: [a], // only one id; plan has two
+        orderedItems: [{ id: a, segment: "during" }], // only one; plan has two
       }),
     ).rejects.toThrow(ConvexError);
   });
@@ -234,7 +237,7 @@ describe("reorderItems", () => {
       t.mutation(api.functions.scheduling.eventItems.reorderItems, {
         token,
         planId: planA,
-        orderedIds: [onA, onB], // onB belongs to planB
+        orderedItems: [onA, onB].map((id) => ({ id, segment: "during" })), // onB ∈ planB
       }),
     ).rejects.toThrow(ConvexError);
   });
@@ -473,5 +476,180 @@ describe("plan lifecycle integration", () => {
     // Role-only links are structural (they point at shared teamRoles), so they
     // are copied — they resolve to the new plan's (empty) roster.
     expect(items?.[0].assignments.map((a) => a.roleName)).toEqual(["Drums"]);
+  });
+});
+
+describe("run sheet segments (before / during / after)", () => {
+  const create = (
+    t: ReturnType<typeof convexTest>,
+    token: string,
+    planId: Id<"eventPlans">,
+    title: string,
+    segment?: string,
+  ) =>
+    t.mutation(api.functions.scheduling.eventItems.createItem, {
+      token,
+      planId,
+      type: "item",
+      title,
+      segment,
+    });
+
+  it("defaults to 'during' and groups items before → during → after", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    // Created out of phase order; listItems must regroup them.
+    await create(t, token, planId, "Teardown", "after");
+    await create(t, token, planId, "Welcome"); // defaults to during
+    await create(t, token, planId, "Call time", "before");
+    await create(t, token, planId, "Worship"); // during
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    expect(items?.map((i) => i.title)).toEqual([
+      "Call time",
+      "Welcome",
+      "Worship",
+      "Teardown",
+    ]);
+    expect(items?.map((i) => i.segment)).toEqual([
+      "before",
+      "during",
+      "during",
+      "after",
+    ]);
+  });
+
+  it("sequence is per-segment (independent ordering within each phase)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    await create(t, token, planId, "Before 1", "before");
+    await create(t, token, planId, "During 1", "during");
+    await create(t, token, planId, "Before 2", "before");
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    const byTitle = Object.fromEntries(
+      (items ?? []).map((i) => [i.title, i]),
+    );
+    // Each phase counts from 0 independently.
+    expect(byTitle["Before 1"].sequence).toBe(0);
+    expect(byTitle["Before 2"].sequence).toBe(1);
+    expect(byTitle["During 1"].sequence).toBe(0);
+  });
+
+  it("moving an item to another phase appends it there", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    await create(t, token, planId, "Before A", "before");
+    const { itemId: moved } = await create(t, token, planId, "Welcome"); // during
+
+    await t.mutation(api.functions.scheduling.eventItems.updateItem, {
+      token,
+      itemId: moved,
+      segment: "before",
+    });
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    const moveItem = (items ?? []).find((i) => i._id === moved);
+    expect(moveItem?.segment).toBe("before");
+    // Appended after the existing "Before A" (sequence 0) → sequence 1.
+    expect(moveItem?.sequence).toBe(1);
+    expect(items?.map((i) => i.title)).toEqual(["Before A", "Welcome"]);
+  });
+
+  it("reorderItems can drag an item across phases", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    const { itemId: b1 } = await create(t, token, planId, "Before 1", "before");
+    const { itemId: b2 } = await create(t, token, planId, "Before 2", "before");
+    const { itemId: d1 } = await create(t, token, planId, "During 1", "during");
+
+    // Drag "Before 2" into the during phase, ahead of "During 1", and leave
+    // "Before 1" in before — the whole plan is sent with each item's new phase.
+    await t.mutation(api.functions.scheduling.eventItems.reorderItems, {
+      token,
+      planId,
+      orderedItems: [
+        { id: b1, segment: "before" },
+        { id: b2, segment: "during" },
+        { id: d1, segment: "during" },
+      ],
+    });
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    expect(items?.map((i) => i.title)).toEqual([
+      "Before 1",
+      "Before 2",
+      "During 1",
+    ]);
+    const byTitle = Object.fromEntries((items ?? []).map((i) => [i.title, i]));
+    expect(byTitle["Before 2"].segment).toBe("during");
+    expect(byTitle["Before 2"].sequence).toBe(0); // first in during now
+    expect(byTitle["During 1"].sequence).toBe(1);
+    expect(byTitle["Before 1"].segment).toBe("before");
+
+    // A stale/incomplete list (missing an item) is rejected.
+    await expect(
+      t.mutation(api.functions.scheduling.eventItems.reorderItems, {
+        token,
+        planId,
+        orderedItems: [{ id: b1, segment: "before" }],
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("duplicateItem keeps the source's segment", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    const { itemId: src } = await create(t, token, planId, "Call time", "before");
+    await create(t, token, planId, "Welcome"); // during
+
+    await t.mutation(api.functions.scheduling.eventItems.duplicateItem, {
+      token,
+      itemId: src,
+    });
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    const before = (items ?? []).filter((i) => i.segment === "before");
+    expect(before.map((i) => i.title)).toEqual(["Call time", "Call time"]);
+    // The copy stays in the before phase; the during item is untouched.
+    expect(items?.map((i) => i.title)).toEqual([
+      "Call time",
+      "Call time",
+      "Welcome",
+    ]);
+  });
+
+  it("rejects an unknown segment", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+    await expect(
+      create(t, token, planId, "Oops", "midway"),
+    ).rejects.toThrow(ConvexError);
   });
 });

--- a/apps/convex/__tests__/scheduling/eventItems.test.ts
+++ b/apps/convex/__tests__/scheduling/eventItems.test.ts
@@ -617,6 +617,34 @@ describe("run sheet segments (before / during / after)", () => {
     ).rejects.toThrow(ConvexError);
   });
 
+  it("reorderItems accepts the legacy orderedIds shape, preserving phases", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    const { itemId: b1 } = await create(t, token, planId, "Before 1", "before");
+    const { itemId: d1 } = await create(t, token, planId, "During 1", "during");
+    const { itemId: d2 } = await create(t, token, planId, "During 2", "during");
+
+    // An old client sends a flat id order with no phase — phases are preserved.
+    await t.mutation(api.functions.scheduling.eventItems.reorderItems, {
+      token,
+      planId,
+      orderedIds: [b1, d2, d1],
+    });
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    expect(items?.map((i) => i.title)).toEqual(["Before 1", "During 2", "During 1"]);
+    const byTitle = Object.fromEntries((items ?? []).map((i) => [i.title, i]));
+    expect(byTitle["Before 1"].segment).toBe("before");
+    expect(byTitle["During 2"].segment).toBe("during");
+    expect(byTitle["During 2"].sequence).toBe(0);
+    expect(byTitle["During 1"].sequence).toBe(1);
+  });
+
   it("duplicateItem keeps the source's segment", async () => {
     const { t, world } = await setupSchedulingWorld();
     const token = (await generateTokens(world.groupLeaderId)).accessToken;

--- a/apps/convex/functions/scheduling/eventItems.ts
+++ b/apps/convex/functions/scheduling/eventItems.ts
@@ -412,9 +412,16 @@ export const reorderItems = mutation({
     token: v.string(),
     planId: v.id("eventPlans"),
     /** Every item in new display order, each tagged with its phase. */
-    orderedItems: v.array(
-      v.object({ id: v.id("eventItems"), segment: v.string() }),
+    orderedItems: v.optional(
+      v.array(v.object({ id: v.id("eventItems"), segment: v.string() })),
     ),
+    /**
+     * Legacy shape (pre-phases clients): a flat id order with no phase. Convex
+     * deploys ahead of native app updates, so an older bundle may still send
+     * this — we honour it, preserving each item's current phase. New clients
+     * send `orderedItems`.
+     */
+    orderedIds: v.optional(v.array(v.id("eventItems"))),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -425,9 +432,25 @@ export const reorderItems = mutation({
       .withIndex("by_plan", (q) => q.eq("planId", args.planId))
       .collect();
 
+    // Normalize legacy `orderedIds` into `orderedItems` by keeping each item's
+    // stored phase, so an old client's reorder doesn't drop items out of phase.
+    let orderedItems = args.orderedItems;
+    if (!orderedItems) {
+      if (!args.orderedIds) {
+        throw new ConvexError("Reorder requires orderedItems or orderedIds");
+      }
+      const segById = new Map(
+        existing.map((i) => [i._id as string, itemSegment(i)]),
+      );
+      orderedItems = args.orderedIds.map((id) => ({
+        id,
+        segment: segById.get(id as string) ?? "during",
+      }));
+    }
+
     const existingIds = new Set(existing.map((i) => i._id as string));
     const seen = new Set<string>();
-    for (const entry of args.orderedItems) {
+    for (const entry of orderedItems) {
       assertSegment(entry.segment);
       if (!existingIds.has(entry.id as string)) {
         throw new ConvexError("Reorder list references an item not on this plan");
@@ -437,7 +460,7 @@ export const reorderItems = mutation({
       }
       seen.add(entry.id as string);
     }
-    if (args.orderedItems.length !== existing.length) {
+    if (orderedItems.length !== existing.length) {
       throw new ConvexError(
         "Reorder list is stale — it does not match the plan's current items",
       );
@@ -448,13 +471,13 @@ export const reorderItems = mutation({
     const counters: Record<Segment, number> = { before: 0, during: 0, after: 0 };
     const nowMs = Date.now();
     await Promise.all(
-      args.orderedItems.map((entry) => {
+      orderedItems.map((entry) => {
         const segment = entry.segment as Segment;
         const sequence = counters[segment]++;
         return ctx.db.patch(entry.id, { segment, sequence, updatedAt: nowMs });
       }),
     );
 
-    return { reordered: args.orderedItems.length };
+    return { reordered: orderedItems.length };
   },
 });

--- a/apps/convex/functions/scheduling/eventItems.ts
+++ b/apps/convex/functions/scheduling/eventItems.ts
@@ -23,6 +23,39 @@ import { requireGroupMember, requirePlanScheduler } from "./permissions";
 /** Run sheet item types — mirrors PCO vocabulary. */
 const ITEM_TYPES = new Set(["song", "header", "media", "item"]);
 
+/**
+ * When an item happens relative to the event's service times. Items group into
+ * these three phases (like PCO's "Before All" / "After All"). Legacy rows with
+ * no `segment` are treated as "during".
+ */
+const SEGMENTS = ["before", "during", "after"] as const;
+type Segment = (typeof SEGMENTS)[number];
+const SEGMENT_SET = new Set<string>(SEGMENTS);
+
+/** An item's segment, defaulting legacy rows to "during". */
+function itemSegment(item: Doc<"eventItems">): Segment {
+  const s = item.segment;
+  return s && SEGMENT_SET.has(s) ? (s as Segment) : "during";
+}
+
+/** Validate a run sheet segment, throwing on an unknown value. */
+function assertSegment(segment: string): void {
+  if (!SEGMENT_SET.has(segment)) {
+    throw new ConvexError(`Unknown run sheet segment: ${segment}`);
+  }
+}
+
+/** Highest `sequence` among a plan's items in `segment`, or -1 if none. */
+function lastSequenceInSegment(
+  items: Doc<"eventItems">[],
+  segment: Segment,
+): number {
+  return items.reduce(
+    (max, i) => (itemSegment(i) === segment ? Math.max(max, i.sequence) : max),
+    -1,
+  );
+}
+
 const noteValidator = v.object({
   category: v.string(),
   content: v.string(),
@@ -113,7 +146,9 @@ export const listItems = query({
       .query("eventItems")
       .withIndex("by_plan", (q) => q.eq("planId", args.planId))
       .collect();
-    items.sort((a, b) => a.sequence - b.sequence);
+    // Group by segment (before → during → after), then by sequence within it.
+    const segRank = (i: Doc<"eventItems">) => SEGMENTS.indexOf(itemSegment(i));
+    items.sort((a, b) => segRank(a) - segRank(b) || a.sequence - b.sequence);
 
     return Promise.all(items.map((item) => hydrateItem(ctx, item)));
   },
@@ -138,6 +173,7 @@ async function hydrateItem(ctx: QueryCtx, item: Doc<"eventItems">) {
   return {
     _id: item._id,
     planId: item.planId,
+    segment: itemSegment(item),
     sequence: item.sequence,
     type: item.type,
     title: item.title,
@@ -160,6 +196,8 @@ export const createItem = mutation({
     planId: v.id("eventPlans"),
     type: v.string(),
     title: v.string(),
+    /** "before" | "during" | "after" — defaults to "during". */
+    segment: v.optional(v.string()),
     durationSec: v.optional(v.number()),
     description: v.optional(v.string()),
     notes: v.optional(v.array(noteValidator)),
@@ -171,6 +209,8 @@ export const createItem = mutation({
     const { plan } = await requirePlanScheduler(ctx, args.planId, userId);
 
     assertItemType(args.type);
+    const segment: Segment = (args.segment as Segment) ?? "during";
+    assertSegment(segment);
     const title = args.title.trim();
     if (!title) {
       throw new ConvexError("Run sheet item title cannot be empty");
@@ -179,18 +219,18 @@ export const createItem = mutation({
       await validateItemAssignments(ctx, plan, args.assignments);
     }
 
-    // Append after the current last item.
+    // Append after the current last item in the same segment.
     const existing = await ctx.db
       .query("eventItems")
       .withIndex("by_plan", (q) => q.eq("planId", args.planId))
       .collect();
-    const nextSequence =
-      existing.reduce((max, i) => Math.max(max, i.sequence), -1) + 1;
+    const nextSequence = lastSequenceInSegment(existing, segment) + 1;
 
     const nowMs = Date.now();
     const itemId = await ctx.db.insert("eventItems", {
       planId: args.planId,
       communityId: plan.communityId,
+      segment,
       sequence: nextSequence,
       type: args.type,
       title,
@@ -220,6 +260,8 @@ export const updateItem = mutation({
     itemId: v.id("eventItems"),
     type: v.optional(v.string()),
     title: v.optional(v.string()),
+    /** Move the item to "before" | "during" | "after"; appended to that phase. */
+    segment: v.optional(v.string()),
     durationSec: v.optional(v.number()),
     description: v.optional(v.string()),
     notes: v.optional(v.array(noteValidator)),
@@ -228,9 +270,22 @@ export const updateItem = mutation({
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
-    const { plan } = await requireItemScheduler(ctx, args.itemId, userId);
+    const { item, plan } = await requireItemScheduler(ctx, args.itemId, userId);
 
     const patch: Partial<Doc<"eventItems">> = { updatedAt: Date.now() };
+    if (args.segment !== undefined) {
+      assertSegment(args.segment);
+      // Moving to another phase appends the item to the end of it, so its
+      // sequence doesn't collide with that phase's existing items.
+      if (args.segment !== itemSegment(item)) {
+        const siblings = await ctx.db
+          .query("eventItems")
+          .withIndex("by_plan", (q) => q.eq("planId", item.planId))
+          .collect();
+        patch.segment = args.segment;
+        patch.sequence = lastSequenceInSegment(siblings, args.segment as Segment) + 1;
+      }
+    }
     if (args.type !== undefined) {
       assertItemType(args.type);
       patch.type = args.type;
@@ -298,10 +353,12 @@ export const duplicateItem = mutation({
     const userId = await requireAuth(ctx, args.token);
     const { item, plan } = await requireItemScheduler(ctx, args.itemId, userId);
 
+    const segment = itemSegment(item);
     const nowMs = Date.now();
     const newItemId = await ctx.db.insert("eventItems", {
       planId: item.planId,
       communityId: plan.communityId,
+      segment,
       sequence: item.sequence, // provisional; resequenced below
       type: item.type,
       title: item.title,
@@ -315,20 +372,21 @@ export const duplicateItem = mutation({
       updatedAt: nowMs,
     });
 
-    // Rebuild contiguous sequences with the copy directly after the source.
+    // Rebuild contiguous sequences WITHIN the source's segment, with the copy
+    // directly after the source. Other segments are untouched.
     const all = await ctx.db
       .query("eventItems")
       .withIndex("by_plan", (q) => q.eq("planId", item.planId))
       .collect();
-    const existingOrder = all
-      .filter((i) => i._id !== newItemId)
+    const segmentOrder = all
+      .filter((i) => i._id !== newItemId && itemSegment(i) === segment)
       .sort((a, b) => a.sequence - b.sequence)
       .map((i) => i._id);
-    const sourceIndex = existingOrder.findIndex((id) => id === item._id);
-    existingOrder.splice(sourceIndex + 1, 0, newItemId);
+    const sourceIndex = segmentOrder.findIndex((id) => id === item._id);
+    segmentOrder.splice(sourceIndex + 1, 0, newItemId);
 
     await Promise.all(
-      existingOrder.map((id, index) =>
+      segmentOrder.map((id, index) =>
         ctx.db.patch(id, { sequence: index, updatedAt: nowMs }),
       ),
     );
@@ -338,10 +396,14 @@ export const duplicateItem = mutation({
 });
 
 /**
- * Reorder a plan's run sheet by rewriting each item's `sequence` to its index
- * in `orderedIds`. Every id must belong to the plan, and the set must be
- * complete — this rejects a stale client list rather than silently dropping or
- * stranding items.
+ * Reorder a plan's whole run sheet, carrying each item's (possibly changed)
+ * `segment`. This is what powers drag-and-drop, including dragging an item from
+ * one phase (before / during / after) into another: the client sends every item
+ * in its new display order, each tagged with the phase it landed in, and this
+ * rewrites `segment` + a per-phase `sequence` for all of them in one atomic pass.
+ *
+ * Every id must belong to the plan and the set must be complete — this rejects a
+ * stale client list rather than silently dropping or stranding items.
  *
  * Auth: scheduler for the plan's group.
  */
@@ -349,7 +411,10 @@ export const reorderItems = mutation({
   args: {
     token: v.string(),
     planId: v.id("eventPlans"),
-    orderedIds: v.array(v.id("eventItems")),
+    /** Every item in new display order, each tagged with its phase. */
+    orderedItems: v.array(
+      v.object({ id: v.id("eventItems"), segment: v.string() }),
+    ),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -362,28 +427,34 @@ export const reorderItems = mutation({
 
     const existingIds = new Set(existing.map((i) => i._id as string));
     const seen = new Set<string>();
-    for (const id of args.orderedIds) {
-      if (!existingIds.has(id as string)) {
+    for (const entry of args.orderedItems) {
+      assertSegment(entry.segment);
+      if (!existingIds.has(entry.id as string)) {
         throw new ConvexError("Reorder list references an item not on this plan");
       }
-      if (seen.has(id as string)) {
+      if (seen.has(entry.id as string)) {
         throw new ConvexError("Reorder list contains a duplicate item");
       }
-      seen.add(id as string);
+      seen.add(entry.id as string);
     }
-    if (args.orderedIds.length !== existing.length) {
+    if (args.orderedItems.length !== existing.length) {
       throw new ConvexError(
         "Reorder list is stale — it does not match the plan's current items",
       );
     }
 
+    // Sequence counts up independently within each phase, in the order items
+    // appear in the client's list.
+    const counters: Record<Segment, number> = { before: 0, during: 0, after: 0 };
     const nowMs = Date.now();
     await Promise.all(
-      args.orderedIds.map((id, index) =>
-        ctx.db.patch(id, { sequence: index, updatedAt: nowMs }),
-      ),
+      args.orderedItems.map((entry) => {
+        const segment = entry.segment as Segment;
+        const sequence = counters[segment]++;
+        return ctx.db.patch(entry.id, { segment, sequence, updatedAt: nowMs });
+      }),
     );
 
-    return { reordered: args.orderedIds.length };
+    return { reordered: args.orderedItems.length };
   },
 });

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -189,6 +189,7 @@ export const duplicateEvent = mutation({
         ctx.db.insert("eventItems", {
           planId: newPlanId,
           communityId: item.communityId,
+          segment: item.segment,
           sequence: item.sequence,
           type: item.type,
           title: item.title,

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2626,7 +2626,14 @@ export default defineSchema({
   eventItems: defineTable({
     planId: v.id("eventPlans"),
     communityId: v.id("communities"),
-    /** Ordering within the run sheet; reordering rewrites these. */
+    /**
+     * When this item happens relative to the event's service times:
+     * "before" | "during" | "after". Items group into these three phases
+     * (PCO's "Before All" / "After All"). Optional for legacy rows, which are
+     * treated as "during". `sequence` orders items WITHIN a segment.
+     */
+    segment: v.optional(v.string()),
+    /** Ordering within the run sheet segment; reordering rewrites these. */
     sequence: v.number(),
     /** "song" | "header" | "media" | "item" (mirrors PCO vocabulary). */
     type: v.string(),

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -28,11 +28,20 @@ import { useAuthenticatedQuery, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { DEFAULT_ROLE_COLOR, formatEventDate } from "@features/scheduling/utils/format";
 import {
-  computeItemClockTimes,
+  computeSegmentedClockTimes,
   formatClockTime,
   formatDuration,
   formatServiceRanges,
+  totalDurationSec,
 } from "@features/scheduling/utils/runSheetTiming";
+
+/** When an item happens relative to the event's service times. */
+type Segment = "before" | "during" | "after";
+const SEGMENT_OPTIONS: Array<{ key: Segment; label: string }> = [
+  { key: "before", label: "Before event" },
+  { key: "during", label: "During event" },
+  { key: "after", label: "After event" },
+];
 
 type PlanSummary = {
   _id: Id<"eventPlans">;
@@ -43,6 +52,7 @@ type PlanSummary = {
 
 type RunSheetItem = {
   _id: Id<"eventItems">;
+  segment: string;
   type: string;
   title: string;
   description: string | null;
@@ -196,13 +206,36 @@ function PlanRunSheet({
     () => (times.length > 0 ? Math.min(...times.map((t) => t.startsAt)) : Date.now()),
     [times],
   );
+  // Group into before / during / after phases (listItems returns them sorted
+  // by (segment, sequence)), then time each phase: during from the event start,
+  // before backward to it, after from the event end. Keeps clocks consistent
+  // with the editor's segmented timing.
+  const itemsBySegment = useMemo(() => {
+    const groups: Record<Segment, RunSheetItem[]> = {
+      before: [],
+      during: [],
+      after: [],
+    };
+    for (const it of items ?? []) {
+      const seg = (it.segment as Segment) ?? "during";
+      (groups[seg] ?? groups.during).push(it);
+    }
+    return groups;
+  }, [items]);
   const clockTimes = useMemo(
-    () => computeItemClockTimes(items ?? [], earliestStart),
-    [items, earliestStart],
+    () =>
+      computeSegmentedClockTimes(
+        itemsBySegment.before,
+        itemsBySegment.during,
+        itemsBySegment.after,
+        earliestStart,
+      ),
+    [itemsBySegment, earliestStart],
   );
-  const totalSec = useMemo(
-    () => (items ?? []).reduce((s, i) => s + i.durationSec, 0),
-    [items],
+  // The service window is the "during" phase — before/after bracket it.
+  const duringTotalSec = useMemo(
+    () => totalDurationSec(itemsBySegment.during),
+    [itemsBySegment.during],
   );
   const peopleByRole = useMemo(() => {
     const map: Record<string, string[]> = {};
@@ -240,7 +273,7 @@ function PlanRunSheet({
           </Text>
           {times.length > 0 ? (
             <Text style={[styles.ranges, { color: colors.textSecondary }]}>
-              {formatServiceRanges(times, totalSec)}
+              {formatServiceRanges(times, duringTotalSec)}
             </Text>
           ) : null}
         </View>
@@ -259,15 +292,26 @@ function PlanRunSheet({
           This event plan's run sheet is empty.
         </Text>
       ) : (
-        items.map((item) => (
-          <ReadOnlyRow
-            key={item._id}
-            item={item}
-            clockMs={clockTimes[item._id]}
-            peopleByRole={peopleByRole}
-            colors={colors}
-          />
-        ))
+        SEGMENT_OPTIONS.map((seg) => {
+          const segItems = itemsBySegment[seg.key];
+          if (segItems.length === 0) return null;
+          return (
+            <View key={seg.key}>
+              <Text style={[styles.segmentLabel, { color: colors.textSecondary }]}>
+                {seg.label.toUpperCase()}
+              </Text>
+              {segItems.map((item) => (
+                <ReadOnlyRow
+                  key={item._id}
+                  item={item}
+                  clockMs={clockTimes[item._id]}
+                  peopleByRole={peopleByRole}
+                  colors={colors}
+                />
+              ))}
+            </View>
+          );
+        })
       )}
     </ScrollView>
   );
@@ -371,6 +415,13 @@ const styles = StyleSheet.create({
   sheetHeaderText: { flex: 1 },
   planTitle: { fontSize: 20, fontWeight: "700" },
   ranges: { fontSize: 13, fontWeight: "600", marginTop: 4 },
+  segmentLabel: {
+    fontSize: 12,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    marginTop: 14,
+    marginBottom: 6,
+  },
   editRow: { flexDirection: "row", alignItems: "center", gap: 4, paddingTop: 4 },
   editText: { fontSize: 14, fontWeight: "600" },
   row: { flexDirection: "row", gap: 10, borderRadius: 12, padding: 12, marginTop: 4 },

--- a/apps/mobile/features/scheduling/components/RunSheetDragList.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetDragList.tsx
@@ -17,7 +17,7 @@
  * Reorder math (`moveKey`) is shared; the platforms only differ in how a drag
  * is driven and how the drop target is detected.
  */
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { View, StyleSheet, Platform } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -62,12 +62,21 @@ export function RunSheetDragList<T>({
 }) {
   const { colors } = useTheme();
   const keys = data.map(keyExtractor);
+  const keysSignature = keys.join("|");
 
   const [activeKey, setActiveKey] = useState<string | null>(null);
   // Insertion slot the dragged row would drop into (0..length), or null.
   const [overSlot, setOverSlot] = useState<number | null>(null);
   // Measured row heights (native offset math only).
   const heights = useRef<Record<string, number>>({});
+
+  // Latest key order in a ref so `commit` (and the Handles built from it) can
+  // stay identity-stable across renders. If they were rebuilt every render, the
+  // re-render triggered by `setActiveKey` / `setOverSlot` mid-drag would give
+  // each row a NEW Handle type, making React remount the dragged element — which
+  // cancels an in-progress HTML5 drag. That was the "have to drag twice" bug.
+  const keysRef = useRef(keys);
+  keysRef.current = keys;
 
   const reset = useCallback(() => {
     setActiveKey(null);
@@ -76,14 +85,47 @@ export function RunSheetDragList<T>({
 
   const commit = useCallback(
     (key: string, toSlot: number) => {
-      const from = keys.indexOf(key);
+      const ks = keysRef.current;
+      const from = ks.indexOf(key);
       if (from !== -1 && toSlot !== from && toSlot !== from + 1) {
-        onReorder(moveKey(keys, key, toSlot));
+        onReorder(moveKey(ks, key, toSlot));
       }
       reset();
     },
-    [keys, onReorder, reset],
+    [onReorder, reset],
   );
+
+  // Stable per-key Handle components. Recomputed only when the row set/order
+  // changes — never on `activeKey` / `overSlot` updates during a drag — so the
+  // dragged element is not remounted while the user is dragging it.
+  const handlesByKey = useMemo(() => {
+    const map: Record<string, HandleComponent> = {};
+    keysRef.current.forEach((k, i) => {
+      map[k] =
+        Platform.OS === "web"
+          ? ({ children }) => (
+              <WebHandle dragKey={k} setActiveKey={setActiveKey} reset={reset}>
+                {children}
+              </WebHandle>
+            )
+          : ({ children }) => (
+              <NativeHandle
+                dragKey={k}
+                index={i}
+                keys={keysRef.current}
+                heights={heights}
+                setActiveKey={setActiveKey}
+                setOverSlot={setOverSlot}
+                commit={commit}
+                reset={reset}
+              >
+                {children}
+              </NativeHandle>
+            );
+    });
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keysSignature, commit, reset]);
 
   const line = (
     <View style={[styles.insertLine, { backgroundColor: colors.buttonPrimary }]} />
@@ -94,27 +136,7 @@ export function RunSheetDragList<T>({
       {data.map((item, index) => {
         const key = keyExtractor(item);
         const isActive = key === activeKey;
-
-        const Handle: HandleComponent =
-          Platform.OS === "web"
-            ? ({ children }) => (
-                <WebHandle dragKey={key} setActiveKey={setActiveKey}>
-                  {children}
-                </WebHandle>
-              )
-            : ({ children }) => (
-                <NativeHandle
-                  dragKey={key}
-                  index={index}
-                  keys={keys}
-                  heights={heights}
-                  setActiveKey={setActiveKey}
-                  setOverSlot={setOverSlot}
-                  commit={commit}
-                >
-                  {children}
-                </NativeHandle>
-              );
+        const Handle = handlesByKey[key];
 
         const rowBody = (
           <>
@@ -131,7 +153,12 @@ export function RunSheetDragList<T>({
               key,
               "data-runsheet-row": "true",
               onDragOver: (e: any) => {
-                if (!activeKey) return;
+                // Always preventDefault so the row is a valid drop target from
+                // the very first dragover frame — even before React has
+                // re-rendered with `activeKey` set. Guarding on `activeKey`
+                // here skipped preventDefault on the opening frames of a drag,
+                // so the browser refused the drop and the item only moved on a
+                // second attempt.
                 e.preventDefault();
                 const rect = e.currentTarget?.getBoundingClientRect?.();
                 const after =
@@ -170,10 +197,12 @@ export function RunSheetDragList<T>({
 function WebHandle({
   dragKey,
   setActiveKey,
+  reset,
   children,
 }: {
   dragKey: string;
   setActiveKey: (k: string | null) => void;
+  reset: () => void;
   children: React.ReactNode;
 }) {
   return React.createElement(
@@ -190,6 +219,10 @@ function WebHandle({
         }
         setActiveKey(dragKey);
       },
+      // Always clear the active/insert state when the drag ends — including a
+      // cancelled drop (released outside any row). Without this the row stays
+      // "lifted" and a stale activeKey forces a second drag before it moves.
+      onDragEnd: () => reset(),
     },
     children,
   );
@@ -204,6 +237,7 @@ function NativeHandle({
   setActiveKey,
   setOverSlot,
   commit,
+  reset,
   children,
 }: {
   dragKey: string;
@@ -213,6 +247,7 @@ function NativeHandle({
   setActiveKey: (k: string | null) => void;
   setOverSlot: (i: number | null) => void;
   commit: (key: string, toSlot: number) => void;
+  reset: () => void;
   children: React.ReactNode;
 }) {
   const translateY = useSharedValue(0);
@@ -250,7 +285,10 @@ function NativeHandle({
 
   const pan = Gesture.Pan()
     .activateAfterLongPress(150)
-    .onBegin(() => runOnJS(setActiveKey)(dragKey))
+    // Mark the row active only once the drag actually starts (after the
+    // long-press activates) — not on mere touch-down — so a quick tap/flick
+    // doesn't leave it "lifted".
+    .onStart(() => runOnJS(setActiveKey)(dragKey))
     .onUpdate((e) => {
       translateY.value = e.translationY;
       runOnJS(onMove)(e.translationY);
@@ -259,8 +297,11 @@ function NativeHandle({
       runOnJS(onDrop)(e.translationY);
       translateY.value = 0;
     })
+    // Always runs (commit or cancel): drop the lift and clear active/insert
+    // state so the next drag starts clean.
     .onFinalize(() => {
       translateY.value = 0;
+      runOnJS(reset)();
     });
 
   const animatedStyle = useAnimatedStyle(() => ({

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -40,13 +40,22 @@ import {
 import type { Id } from "@services/api/convex";
 import { DEFAULT_ROLE_COLOR, formatEventDateLong } from "../utils/format";
 import {
-  computeItemClockTimes,
+  computeSegmentedClockTimes,
   formatClockTime,
   formatDuration,
   formatServiceRanges,
+  totalDurationSec,
 } from "../utils/runSheetTiming";
 import { InlineText } from "./InlineText";
 import { RunSheetDragList } from "./RunSheetDragList";
+
+/** When an item happens relative to the event's service times. */
+type Segment = "before" | "during" | "after";
+const SEGMENT_OPTIONS: Array<{ key: Segment; label: string }> = [
+  { key: "before", label: "Before event" },
+  { key: "during", label: "During event" },
+  { key: "after", label: "After event" },
+];
 
 type ItemAssignment = {
   roleId: Id<"teamRoles">;
@@ -57,6 +66,7 @@ type ItemAssignment = {
 type RunSheetItem = {
   _id: Id<"eventItems">;
   planId: Id<"eventPlans">;
+  segment: string;
   sequence: number;
   type: string;
   title: string;
@@ -93,6 +103,7 @@ type RoleOption = {
 type ItemPatch = {
   type?: string;
   title?: string;
+  segment?: Segment;
   durationSec?: number;
   description?: string;
   notes?: Array<{ category: string; content: string }>;
@@ -136,6 +147,8 @@ export function RunSheetScreen() {
 
   // The just-created item to autofocus its title for immediate editing.
   const [focusId, setFocusId] = useState<string | null>(null);
+  // Which phase the "Add" buttons create into.
+  const [addSegment, setAddSegment] = useState<Segment>("during");
 
   const handleBack = useCallback(() => {
     if (router.canGoBack()) router.back();
@@ -151,14 +164,36 @@ export function RunSheetScreen() {
     [times, event?.eventDate],
   );
 
+  // Group items into before / during / after phases. `listItems` already
+  // returns them sorted by (segment, sequence), so each group stays ordered.
+  const itemsBySegment = useMemo(() => {
+    const groups: Record<Segment, RunSheetItem[]> = {
+      before: [],
+      during: [],
+      after: [],
+    };
+    for (const it of items ?? []) {
+      const seg = (it.segment as Segment) ?? "during";
+      (groups[seg] ?? groups.during).push(it);
+    }
+    return groups;
+  }, [items]);
+
   const clockTimes = useMemo(
-    () => computeItemClockTimes(items ?? [], earliestStart),
-    [items, earliestStart],
+    () =>
+      computeSegmentedClockTimes(
+        itemsBySegment.before,
+        itemsBySegment.during,
+        itemsBySegment.after,
+        earliestStart,
+      ),
+    [itemsBySegment, earliestStart],
   );
 
-  const totalSec = useMemo(
-    () => (items ?? []).reduce((sum, i) => sum + i.durationSec, 0),
-    [items],
+  // The service window is the "during" phase — before/after bracket it.
+  const duringTotalSec = useMemo(
+    () => totalDurationSec(itemsBySegment.during),
+    [itemsBySegment.during],
   );
 
   const roleOptions: RoleOption[] = useMemo(
@@ -194,13 +229,14 @@ export function RunSheetScreen() {
           planId,
           type,
           title: type === "header" ? "New section" : "New item",
+          segment: addSegment,
         });
         setFocusId(itemId as string);
       } catch (e: any) {
         Alert.alert("Couldn't add item", e?.message ?? "Please try again.");
       }
     },
-    [createItem, planId],
+    [createItem, planId, addSegment],
   );
 
   const handleDuplicate = useCallback(
@@ -228,16 +264,44 @@ export function RunSheetScreen() {
     [deleteItem],
   );
 
+  // The unified list interleaves phase-header rows (keyed `seg:<phase>`) with
+  // item rows. After a drag, walk the new key order: each header switches the
+  // running phase, and every item that follows takes it — so dragging an item
+  // past a header moves it into that phase.
   const handleReorder = useCallback(
-    (orderedKeys: string[]) =>
-      reorderItems({
-        planId,
-        orderedIds: orderedKeys as Id<"eventItems">[],
-      }).catch((e: any) =>
+    (orderedKeys: string[]) => {
+      const orderedItems: Array<{ id: Id<"eventItems">; segment: Segment }> = [];
+      let current: Segment = "before";
+      for (const key of orderedKeys) {
+        if (key.startsWith("seg:")) {
+          current = key.slice(4) as Segment;
+        } else {
+          orderedItems.push({ id: key as Id<"eventItems">, segment: current });
+        }
+      }
+      return reorderItems({ planId, orderedItems }).catch((e: any) =>
         Alert.alert("Couldn't reorder", e?.message ?? "Please try again."),
-      ),
+      );
+    },
     [reorderItems, planId],
   );
+
+  // Flat rows for the single drag list: each phase's header followed by its
+  // items. Phase headers are always present so an empty phase is still a drop
+  // target — you can drag the first item into it.
+  const rows = useMemo(() => {
+    type Row =
+      | { kind: "header"; segment: Segment; key: string }
+      | { kind: "item"; item: RunSheetItem; key: string };
+    const out: Row[] = [];
+    for (const seg of SEGMENT_OPTIONS) {
+      out.push({ kind: "header", segment: seg.key, key: `seg:${seg.key}` });
+      for (const it of itemsBySegment[seg.key]) {
+        out.push({ kind: "item", item: it, key: it._id as string });
+      }
+    }
+    return out;
+  }, [itemsBySegment]);
 
   const loading = event === undefined || items === undefined;
 
@@ -285,43 +349,93 @@ export function RunSheetScreen() {
           <Text style={[styles.planDate, { color: colors.textSecondary }]}>
             {formatEventDateLong(event.eventDate)}
           </Text>
-          {/* Each service as a start–end range; grows with items/durations. */}
+          {/* The "during" phase is the event window; before/after bracket it. */}
           {times.length > 0 ? (
             <Text style={[styles.ranges, { color: colors.text }]}>
-              {formatServiceRanges(times, totalSec)}
+              {formatServiceRanges(times, duringTotalSec)}
             </Text>
           ) : null}
 
           {items.length === 0 ? (
             <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              No items yet. Add songs, headers, media, and other moments — drag
-              the grip to reorder, tap a field to edit it inline.
+              No items yet. Pick a phase under "Add to" below, then add songs,
+              headers, and other moments. Drag the grip to reorder — drag across
+              a phase heading to move an item before, during, or after the event.
             </Text>
           ) : (
             <View style={styles.list}>
+              {/* One drag list over all phases. Phase headings are drop zones:
+                  drag an item past one to change its phase. */}
               <RunSheetDragList
-                data={items}
-                keyExtractor={(i) => i._id as string}
+                data={rows}
+                keyExtractor={(r) => r.key}
                 onReorder={handleReorder}
-                renderRow={({ item, Handle, isActive }) => (
-                  <EditableRow
-                    item={item}
-                    clockMs={clockTimes[item._id]}
-                    roleOptions={roleOptions}
-                    peopleByRole={peopleByRole}
-                    autoFocus={focusId === (item._id as string)}
-                    isActive={isActive}
-                    Handle={Handle}
-                    onPatch={(patch) => patchItem(item._id, patch)}
-                    onDuplicate={() => handleDuplicate(item._id)}
-                    onDelete={() => handleDelete(item)}
-                  />
-                )}
+                renderRow={({ item: row, Handle, isActive }) =>
+                  row.kind === "header" ? (
+                    <Text
+                      style={[
+                        styles.segmentLabel,
+                        { color: colors.textSecondary },
+                      ]}
+                    >
+                      {SEGMENT_OPTIONS.find((s) => s.key === row.segment)?.label.toUpperCase()}
+                    </Text>
+                  ) : (
+                    <EditableRow
+                      item={row.item}
+                      clockMs={clockTimes[row.item._id]}
+                      roleOptions={roleOptions}
+                      peopleByRole={peopleByRole}
+                      autoFocus={focusId === (row.item._id as string)}
+                      isActive={isActive}
+                      Handle={Handle}
+                      onPatch={(patch) => patchItem(row.item._id, patch)}
+                      onDuplicate={() => handleDuplicate(row.item._id)}
+                      onDelete={() => handleDelete(row.item)}
+                    />
+                  )
+                }
               />
             </View>
           )}
 
-          {/* Add controls */}
+          {/* Add controls — choose the phase, then add. */}
+          <View style={styles.addToRow}>
+            <Text style={[styles.addToLabel, { color: colors.textSecondary }]}>
+              Add to:
+            </Text>
+            {SEGMENT_OPTIONS.map((seg) => {
+              const active = addSegment === seg.key;
+              return (
+                <Pressable
+                  key={seg.key}
+                  onPress={() => setAddSegment(seg.key)}
+                  style={styles.addToChipPressable}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                >
+                  <View
+                    style={[
+                      styles.addToChip,
+                      {
+                        borderColor: active ? primaryColor : colors.border,
+                        backgroundColor: active ? primaryColor + "18" : "transparent",
+                      },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.addToChipText,
+                        { color: active ? primaryColor : colors.textSecondary },
+                      ]}
+                    >
+                      {seg.label}
+                    </Text>
+                  </View>
+                </Pressable>
+              );
+            })}
+          </View>
           <View style={styles.addBar}>
             <AddButton label="Add item" icon="add" onPress={() => handleAdd("item")} primaryColor={primaryColor} colors={colors} />
             <AddButton label="Song" icon="musical-notes" onPress={() => handleAdd("song")} primaryColor={primaryColor} colors={colors} />
@@ -515,6 +629,46 @@ function EditableRow({
       {/* Expanded inline editors */}
       {expanded && !isHeader ? (
         <View style={styles.expanded}>
+          {/* Timing phase — before / during / after the event (PCO's position). */}
+          <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+            Timing
+          </Text>
+          <View style={styles.timingToggle}>
+            {SEGMENT_OPTIONS.map((seg) => {
+              const active = (item.segment as Segment) === seg.key;
+              return (
+                <Pressable
+                  key={seg.key}
+                  onPress={() => onPatch({ segment: seg.key })}
+                  style={styles.timingPressable}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                >
+                  <View
+                    style={[
+                      styles.timingChip,
+                      {
+                        borderColor: active ? colors.buttonPrimary : colors.border,
+                        backgroundColor: active
+                          ? colors.buttonPrimary + "1F"
+                          : "transparent",
+                      },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.timingChipText,
+                        { color: active ? colors.buttonPrimary : colors.textSecondary },
+                      ]}
+                    >
+                      {seg.label}
+                    </Text>
+                  </View>
+                </Pressable>
+              );
+            })}
+          </View>
+
           {isSong ? (
             <View style={styles.songRow}>
               <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Key</Text>
@@ -715,7 +869,39 @@ const styles = StyleSheet.create({
   planDate: { fontSize: 13, marginTop: 4 },
   ranges: { fontSize: 14, fontWeight: "600", marginTop: 8 },
   emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
-  list: { marginTop: 16 },
+  segmentLabel: {
+    fontSize: 12,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    marginTop: 14,
+    marginBottom: 8,
+  },
+  list: { marginTop: 10 },
+  addToRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 8,
+    marginTop: 24,
+  },
+  addToLabel: { fontSize: 13, fontWeight: "600" },
+  addToChipPressable: { borderRadius: 999 },
+  addToChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  addToChipText: { fontSize: 13, fontWeight: "600" },
+  timingToggle: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 4 },
+  timingPressable: { borderRadius: 999 },
+  timingChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  timingChipText: { fontSize: 12, fontWeight: "600" },
   row: {
     borderRadius: 12,
     padding: 10,

--- a/apps/mobile/features/scheduling/utils/runSheetTiming.ts
+++ b/apps/mobile/features/scheduling/utils/runSheetTiming.ts
@@ -55,6 +55,39 @@ export function computeItemClockTimes(
   return times;
 }
 
+/** Sum of item durations (seconds), ignoring negatives. */
+export function totalDurationSec(items: TimingItem[]): number {
+  return items.reduce((sum, i) => sum + Math.max(0, i.durationSec), 0);
+}
+
+/**
+ * Clock times for a run sheet split into before / during / after phases:
+ *
+ *  - **during** cascades forward from the event start (`serviceStartMs`).
+ *  - **before** counts BACKWARD so its items lead up to the start — the last
+ *    "before" item ends exactly at `serviceStartMs`.
+ *  - **after** cascades forward from the event end (start + total "during").
+ *
+ * Returns one merged map of item id → start time, so a single lookup works
+ * regardless of an item's phase.
+ */
+export function computeSegmentedClockTimes(
+  before: TimingItem[],
+  during: TimingItem[],
+  after: TimingItem[],
+  serviceStartMs: number,
+): Record<string, number | null> {
+  const duringTotalMs = totalDurationSec(during) * 1000;
+  const beforeTotalMs = totalDurationSec(before) * 1000;
+  const eventEndMs = serviceStartMs + duringTotalMs;
+  const beforeStartMs = serviceStartMs - beforeTotalMs;
+  return {
+    ...computeItemClockTimes(before, beforeStartMs),
+    ...computeItemClockTimes(during, serviceStartMs),
+    ...computeItemClockTimes(after, eventEndMs),
+  };
+}
+
 /** "10:04 AM" — clock label for a run sheet row. */
 export function formatClockTime(ms: number): string {
   return new Date(ms).toLocaleTimeString("en-US", {


### PR DESCRIPTION
## Summary

Adds PCO-style phasing to the native run sheet: items now happen **before**, **during**, or **after** the event's service times (PCO's "Before All" / "After All"), with auto-computed clocks per phase and drag-and-drop across phases.

### Phases
- New optional `eventItems.segment` (`before` | `during` | `after`); legacy rows default to `during`. `sequence` orders items *within* a phase.
- The run sheet groups into three sections. Clocks auto-compute per phase:
  - **during** cascades forward from the event start,
  - **before** counts **backward** so its items lead up to the start,
  - **after** cascades forward from the event end.
- "Add to:" chooses the phase for new items; each item's editor has a phase selector.
- `createItem`/`updateItem` take a segment (a move appends to the target phase); `duplicateItem` and `duplicateEvent` carry the phase over; `reorderItems` now sends every item with its new phase so a single atomic pass handles reorder **and** cross-phase moves.

### Drag-and-drop
- Drag an item across the Before/During/After headings to change its phase (one unified, drop-zone'd list).
- Fixed a "have to drag twice" bug: a new `Handle` identity was created every render, so re-rendering mid-drag remounted the dragged element and the browser cancelled the HTML5 drag. The Handle and `commit` are now identity-stable; web always `preventDefault`s a row's dragover and clears state on dragend; native marks active on real drag start and always resets on finalize.

## Testing
- Convex scheduling suite green, incl. new tests: phase grouping, per-phase sequence, cross-phase move, duplicate keeps phase, unknown-segment rejection (34 tests in the two affected files).
- Mobile typecheck clean; eslint passes via pre-commit hook.
- Verified on web: three phases render with correct per-phase clocks (e.g. a 15-min "before" item shows 5:45 ahead of a 6:00 start; "after" starts at the event end), add-to phase chooser, editor phase selector, and single-drag reordering within and across phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)