### PR TITLE
fix(rostering): run sheet delete (X) confirm works on web

### DIFF
--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -58,6 +58,19 @@ const SEGMENT_OPTIONS: Array<{ key: Segment; label: string }> = [
   { key: "after", label: "After event" },
 ];
 
+/**
+ * Show a one-button error. React Native's Alert.alert is a no-op on web in this
+ * codebase, so fall back to window.alert there — otherwise a failed save /
+ * delete / reorder would fail silently for web users.
+ */
+function notifyError(title: string, message: string) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);
+    return;
+  }
+  Alert.alert(title, message);
+}
+
 type ItemAssignment = {
   roleId: Id<"teamRoles">;
   roleName: string;
@@ -218,7 +231,7 @@ export function RunSheetScreen() {
   const patchItem = useCallback(
     (itemId: Id<"eventItems">, patch: ItemPatch) =>
       updateItem({ itemId, ...patch }).catch((e: any) =>
-        Alert.alert("Couldn't save", e?.data?.message ?? e?.message ?? "Please try again."),
+        notifyError("Couldn't save", e?.data?.message ?? e?.message ?? "Please try again."),
       ),
     [updateItem],
   );
@@ -234,7 +247,7 @@ export function RunSheetScreen() {
         });
         setFocusId(itemId as string);
       } catch (e: any) {
-        Alert.alert("Couldn't add item", e?.message ?? "Please try again.");
+        notifyError("Couldn't add item", e?.message ?? "Please try again.");
       }
     },
     [createItem, planId, addSegment],
@@ -243,7 +256,7 @@ export function RunSheetScreen() {
   const handleDuplicate = useCallback(
     (itemId: Id<"eventItems">) =>
       duplicateItem({ itemId }).catch((e: any) =>
-        Alert.alert("Couldn't duplicate", e?.message ?? "Please try again."),
+        notifyError("Couldn't duplicate", e?.message ?? "Please try again."),
       ),
     [duplicateItem],
   );
@@ -252,7 +265,7 @@ export function RunSheetScreen() {
     (item: RunSheetItem) => {
       const doDelete = () =>
         deleteItem({ itemId: item._id }).catch((e: any) =>
-          Alert.alert("Couldn't delete", e?.message ?? "Please try again."),
+          notifyError("Couldn't delete", e?.message ?? "Please try again."),
         );
       const prompt = `Remove "${item.title}" from the run sheet?`;
       // React Native's Alert.alert is a no-op on web in this codebase, so the
@@ -288,7 +301,7 @@ export function RunSheetScreen() {
         }
       }
       return reorderItems({ planId, orderedItems }).catch((e: any) =>
-        Alert.alert("Couldn't reorder", e?.message ?? "Please try again."),
+        notifyError("Couldn't reorder", e?.message ?? "Please try again."),
       );
     },
     [reorderItems, planId],

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -26,6 +26,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Alert,
+  Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -249,16 +250,23 @@ export function RunSheetScreen() {
 
   const handleDelete = useCallback(
     (item: RunSheetItem) => {
-      Alert.alert("Delete item?", `Remove "${item.title}" from the run sheet?`, [
+      const doDelete = () =>
+        deleteItem({ itemId: item._id }).catch((e: any) =>
+          Alert.alert("Couldn't delete", e?.message ?? "Please try again."),
+        );
+      const prompt = `Remove "${item.title}" from the run sheet?`;
+      // React Native's Alert.alert is a no-op on web in this codebase, so the
+      // delete (X) confirm never resolved there — fall back to window.confirm
+      // (same pattern as HostsPicker / EventPageClient).
+      if (Platform.OS === "web") {
+        if (typeof window !== "undefined" && window.confirm(prompt)) {
+          void doDelete();
+        }
+        return;
+      }
+      Alert.alert("Delete item?", prompt, [
         { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: () =>
-            deleteItem({ itemId: item._id }).catch((e: any) =>
-              Alert.alert("Couldn't delete", e?.message ?? "Please try again."),
-            ),
-        },
+        { text: "Delete", style: "destructive", onPress: () => void doDelete() },
       ]);
     },
     [deleteItem],


### PR DESCRIPTION
## Summary

The run sheet row's delete (**X**) did nothing on web. It called `Alert.alert` with a Cancel/Delete confirm, but React Native's `Alert.alert` is a no-op on web in this codebase, so the destructive callback never fired.

Fix: on web, use `window.confirm` (the same pattern already used in `HostsPicker` / `EventPageClient`); native keeps the `Alert.alert` two-button sheet.

## Testing
- Verified on web: clicking the X now shows a "Remove "…" from the run sheet?" confirm; accepting removes the item (the phase went from two items to one). Typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)