### PR TITLE
fix(rostering): make confirms & the event-plan menu work on web

### DIFF
--- a/apps/mobile/components/ui/ActionMenuSheet.tsx
+++ b/apps/mobile/components/ui/ActionMenuSheet.tsx
@@ -1,0 +1,107 @@
+/**
+ * ActionMenuSheet
+ *
+ * A small cross-platform action menu (a list of buttons over a dim backdrop).
+ * Used as the web fallback for `ActionSheetIOS` menus, which are iOS-only — on
+ * web the native action sheet never shows, so an imperative ⋯ menu silently
+ * does nothing. Callers own the `visible` state and pass the actions.
+ */
+import React from "react";
+import { Modal, View, Text, Pressable, StyleSheet } from "react-native";
+import { useTheme } from "@hooks/useTheme";
+
+export type MenuAction = {
+  label: string;
+  onPress: () => void;
+  destructive?: boolean;
+};
+
+export function ActionMenuSheet({
+  visible,
+  title,
+  actions,
+  onClose,
+}: {
+  visible: boolean;
+  title?: string;
+  actions: MenuAction[];
+  onClose: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable
+          style={[styles.sheet, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          {title ? (
+            <Text style={[styles.title, { color: colors.textSecondary }]} numberOfLines={2}>
+              {title}
+            </Text>
+          ) : null}
+          {actions.map((action, i) => (
+            <Pressable
+              key={i}
+              onPress={() => {
+                onClose();
+                action.onPress();
+              }}
+              style={[styles.action, { borderTopColor: colors.border }]}
+              accessibilityRole="button"
+            >
+              <Text
+                style={[
+                  styles.actionText,
+                  { color: action.destructive ? colors.destructive : colors.text },
+                ]}
+              >
+                {action.label}
+              </Text>
+            </Pressable>
+          ))}
+          <Pressable
+            onPress={onClose}
+            style={[styles.action, styles.cancel, { borderTopColor: colors.border }]}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.actionText, { color: colors.textSecondary }]}>Cancel</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  sheet: {
+    width: "100%",
+    maxWidth: 360,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: "hidden",
+  },
+  title: {
+    fontSize: 13,
+    fontWeight: "600",
+    textAlign: "center",
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 12,
+  },
+  action: {
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    alignItems: "center",
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  cancel: { marginTop: 0 },
+  actionText: { fontSize: 16, fontWeight: "600" },
+});

--- a/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
@@ -23,7 +23,6 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   TextInput,
-  Alert,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -37,6 +36,7 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { confirmAsync, notify } from "@/utils/platformAlert";
 import { DEFAULT_ROLE_COLOR } from "../utils/format";
 import { NeededRolesModal } from "./NeededRolesModal";
 import { AssignSheet } from "./AssignSheet";
@@ -174,7 +174,7 @@ export function EventEditorScreen() {
     try {
       await updateEvent({ planId, title: trimmed });
     } catch (e: any) {
-      Alert.alert("Couldn't rename", e?.message ?? "Please try again.");
+      notify("Couldn't rename", e?.message ?? "Please try again.");
     }
   }, [event?.title, updateEvent, planId]);
 
@@ -206,7 +206,7 @@ export function EventEditorScreen() {
       try {
         await updateEvent({ planId, eventDate: date.getTime() });
       } catch (e: any) {
-        Alert.alert("Couldn't update date", e?.message ?? "Please try again.");
+        notify("Couldn't update date", e?.message ?? "Please try again.");
       }
     },
     [updateEvent, planId],
@@ -218,7 +218,7 @@ export function EventEditorScreen() {
       try {
         await updateEvent({ planId, times });
       } catch (e: any) {
-        Alert.alert("Couldn't update times", e?.message ?? "Please try again.");
+        notify("Couldn't update times", e?.message ?? "Please try again.");
       }
     },
     [updateEvent, planId],
@@ -265,59 +265,52 @@ export function EventEditorScreen() {
   const handleUnassign = useCallback(
     (assignmentId: Id<"roleAssignments">) => {
       unassign({ assignmentId }).catch((e: any) =>
-        Alert.alert("Couldn't remove", e?.message ?? "Please try again."),
+        notify("Couldn't remove", e?.message ?? "Please try again."),
       );
     },
     [unassign],
   );
 
-  const handleDelete = useCallback(() => {
-    Alert.alert("Delete event plan?", "This removes the event plan and all its assignments.", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: async () => {
-          try {
-            await deleteEvent({ planId });
-            if (router.canGoBack()) router.back();
-          } catch (e: any) {
-            Alert.alert("Couldn't delete", e?.message ?? "Please try again.");
-          }
-        },
-      },
-    ]);
+  const handleDelete = useCallback(async () => {
+    const ok = await confirmAsync({
+      title: "Delete event plan?",
+      message: "This removes the event plan and all its assignments.",
+      confirmText: "Delete",
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await deleteEvent({ planId });
+      if (router.canGoBack()) router.back();
+    } catch (e: any) {
+      notify("Couldn't delete", e?.message ?? "Please try again.");
+    }
   }, [deleteEvent, planId, router]);
 
-  const handlePublish = useCallback(() => {
-    Alert.alert(
-      "Publish & send requests?",
-      "Volunteers with an open request will get a push and SMS asking them to accept or decline.",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Publish",
-          onPress: async () => {
-            setPublishing(true);
-            try {
-              const result = await publishEvent({ planId });
-              Alert.alert(
-                "Event plan published",
-                result.requestCount > 0
-                  ? `Sent ${result.requestCount} request${
-                      result.requestCount === 1 ? "" : "s"
-                    }.`
-                  : "No pending requests to send.",
-              );
-            } catch (e: any) {
-              Alert.alert("Couldn't publish", e?.message ?? "Please try again.");
-            } finally {
-              setPublishing(false);
-            }
-          },
-        },
-      ],
-    );
+  const handlePublish = useCallback(async () => {
+    const ok = await confirmAsync({
+      title: "Publish & send requests?",
+      message:
+        "Volunteers with an open request will get a push and SMS asking them to accept or decline.",
+      confirmText: "Publish",
+    });
+    if (!ok) return;
+    setPublishing(true);
+    try {
+      const result = await publishEvent({ planId });
+      notify(
+        "Event plan published",
+        result.requestCount > 0
+          ? `Sent ${result.requestCount} request${
+              result.requestCount === 1 ? "" : "s"
+            }.`
+          : "No pending requests to send.",
+      );
+    } catch (e: any) {
+      notify("Couldn't publish", e?.message ?? "Please try again.");
+    } finally {
+      setPublishing(false);
+    }
   }, [publishEvent, planId]);
 
   if (event === undefined) {

--- a/apps/mobile/features/scheduling/components/EventListScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventListScreen.tsx
@@ -37,6 +37,8 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { ActionMenuSheet } from "@components/ui/ActionMenuSheet";
+import { confirmAsync } from "@/utils/platformAlert";
 import { formatEventDate } from "../utils/format";
 
 type EventRow = {
@@ -83,6 +85,8 @@ export function EventListScreen() {
   const [creating, setCreating] = useState(false);
   const [sharingLink, setSharingLink] = useState(false);
   const [showPast, setShowPast] = useState(false);
+  // Web ⋯ menu target (ActionSheetIOS/Alert don't work on web).
+  const [menuEvent, setMenuEvent] = useState<EventRow | null>(null);
 
   // Generate a public, app-optional availability link and hand it to the OS
   // share sheet. People can open it in a browser (no app needed) and their
@@ -137,26 +141,20 @@ export function EventListScreen() {
   );
 
   const handleDelete = useCallback(
-    (event: EventRow) => {
-      Alert.alert(
-        "Delete event plan?",
-        `"${event.title}" and its roster will be permanently deleted.`,
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Delete",
-            style: "destructive",
-            onPress: () => {
-              void deleteEvent({ planId: event._id });
-            },
-          },
-        ],
-      );
+    async (event: EventRow) => {
+      const ok = await confirmAsync({
+        title: "Delete event plan?",
+        message: `"${event.title}" and its roster will be permanently deleted.`,
+        confirmText: "Delete",
+        destructive: true,
+      });
+      if (ok) void deleteEvent({ planId: event._id });
     },
     [deleteEvent],
   );
 
-  // Contextual ⋯ menu for an event card — Duplicate / Delete.
+  // Contextual ⋯ menu for an event card — Duplicate / Delete. ActionSheetIOS is
+  // iOS-only and Alert.alert is a no-op on web, so web uses ActionMenuSheet.
   const handleEventMenu = useCallback(
     (event: EventRow) => {
       if (Platform.OS === "ios") {
@@ -169,24 +167,21 @@ export function EventListScreen() {
           },
           (buttonIndex) => {
             if (buttonIndex === 1) void handleDuplicate(event);
-            else if (buttonIndex === 2) handleDelete(event);
+            else if (buttonIndex === 2) void handleDelete(event);
           },
         );
-      } else {
+      } else if (Platform.OS === "android") {
         Alert.alert(event.title, undefined, [
           { text: "Cancel", style: "cancel" },
-          {
-            text: "Duplicate",
-            onPress: () => {
-              void handleDuplicate(event);
-            },
-          },
+          { text: "Duplicate", onPress: () => void handleDuplicate(event) },
           {
             text: "Delete",
             style: "destructive",
-            onPress: () => handleDelete(event),
+            onPress: () => void handleDelete(event),
           },
         ]);
+      } else {
+        setMenuEvent(event);
       }
     },
     [handleDuplicate, handleDelete],
@@ -306,6 +301,7 @@ export function EventListScreen() {
   const past = events.filter((e) => e.eventDate < cutoff).reverse();
 
   return (
+    <>
     <ScrollView
       style={{ backgroundColor: colors.surface }}
       contentContainerStyle={[
@@ -397,6 +393,24 @@ export function EventListScreen() {
         </>
       )}
     </ScrollView>
+    <ActionMenuSheet
+      visible={menuEvent !== null}
+      title={menuEvent?.title}
+      actions={
+        menuEvent
+          ? [
+              { label: "Duplicate", onPress: () => void handleDuplicate(menuEvent) },
+              {
+                label: "Delete",
+                destructive: true,
+                onPress: () => void handleDelete(menuEvent),
+              },
+            ]
+          : []
+      }
+      onClose={() => setMenuEvent(null)}
+    />
+    </>
   );
 }
 

--- a/apps/mobile/features/scheduling/components/RolesEditor.tsx
+++ b/apps/mobile/features/scheduling/components/RolesEditor.tsx
@@ -16,7 +16,6 @@ import {
   Pressable,
   TextInput,
   ActivityIndicator,
-  Alert,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { CustomModal } from "@components/ui/Modal";
@@ -27,6 +26,7 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { confirmAsync, notify } from "@/utils/platformAlert";
 import { ROLE_COLORS, DEFAULT_ROLE_COLOR } from "../utils/format";
 
 type Role = {
@@ -89,7 +89,7 @@ export function RolesEditor({ teamId }: { teamId: Id<"teams"> }) {
         setEditorVisible(false);
         setEditing(null);
       } catch (e: any) {
-        Alert.alert("Couldn't save role", e?.message ?? "Please try again.");
+        notify("Couldn't save role", e?.message ?? "Please try again.");
       } finally {
         setBusy(false);
       }
@@ -98,28 +98,19 @@ export function RolesEditor({ teamId }: { teamId: Id<"teams"> }) {
   );
 
   const handleArchive = useCallback(
-    (role: Role) => {
-      Alert.alert(
-        "Archive role?",
-        `"${role.name}" stays on past event plans but won't appear on new ones.`,
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Archive",
-            style: "destructive",
-            onPress: async () => {
-              try {
-                await archiveRole({ roleId: role._id });
-              } catch (e: any) {
-                Alert.alert(
-                  "Couldn't archive",
-                  e?.message ?? "Please try again.",
-                );
-              }
-            },
-          },
-        ],
-      );
+    async (role: Role) => {
+      const ok = await confirmAsync({
+        title: "Archive role?",
+        message: `"${role.name}" stays on past event plans but won't appear on new ones.`,
+        confirmText: "Archive",
+        destructive: true,
+      });
+      if (!ok) return;
+      try {
+        await archiveRole({ roleId: role._id });
+      } catch (e: any) {
+        notify("Couldn't archive", e?.message ?? "Please try again.");
+      }
     },
     [archiveRole],
   );
@@ -134,7 +125,7 @@ export function RolesEditor({ teamId }: { teamId: Id<"teams"> }) {
       try {
         await reorderRoles({ teamId, orderedRoleIds: ordered });
       } catch (e: any) {
-        Alert.alert("Couldn't reorder", e?.message ?? "Please try again.");
+        notify("Couldn't reorder", e?.message ?? "Please try again.");
       }
     },
     [roles, reorderRoles, teamId],

--- a/apps/mobile/features/scheduling/components/TeamChannelToggle.tsx
+++ b/apps/mobile/features/scheduling/components/TeamChannelToggle.tsx
@@ -16,11 +16,12 @@
  * Backend: scheduling.teams.linkChannel / unlinkChannel.
  */
 import React, { useCallback, useState } from "react";
-import { View, Text, Pressable, Alert, ActivityIndicator, StyleSheet } from "react-native";
+import { View, Text, Pressable, ActivityIndicator, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import { useAuthenticatedMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { confirmAsync, notify } from "@/utils/platformAlert";
 
 export function TeamChannelToggle({
   teamId,
@@ -57,7 +58,7 @@ export function TeamChannelToggle({
         }
         // Convex queries re-fetch reactively — no manual refresh needed.
       } catch (e: any) {
-        Alert.alert(
+        notify(
           turningOn ? "Couldn't turn on chat" : "Couldn't turn off chat",
           e?.data?.message ?? e?.message ?? "Couldn't update the team's chat channel",
         );
@@ -68,35 +69,26 @@ export function TeamChannelToggle({
     [linkChannel, unlinkChannel, teamId],
   );
 
-  const handlePress = useCallback(() => {
+  const handlePress = useCallback(async () => {
     if (busy) return;
     if (hasChannel) {
-      Alert.alert(
-        `Turn off chat for ${teamName}?`,
-        `The team's chat channel will be unlinked. ${channelMemberCount} auto-synced ${
+      const ok = await confirmAsync({
+        title: `Turn off chat for ${teamName}?`,
+        message: `The team's chat channel will be unlinked. ${channelMemberCount} auto-synced ${
           channelMemberCount === 1 ? "member is" : "members are"
         } removed from it; the channel itself stays in the inbox as a regular custom channel. You can turn chat back on later. This affects every event this team is on.`,
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Turn off",
-            style: "destructive",
-            onPress: () => void performToggle(false),
-          },
-        ],
-      );
+        confirmText: "Turn off",
+        destructive: true,
+      });
+      if (ok) void performToggle(false);
     } else {
-      Alert.alert(
-        `Turn on chat for ${teamName}?`,
-        "A new chat channel will be created in the inbox. Membership auto-syncs from the team's event-plan assignments. This affects every event this team is on.",
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Turn on",
-            onPress: () => void performToggle(true),
-          },
-        ],
-      );
+      const ok = await confirmAsync({
+        title: `Turn on chat for ${teamName}?`,
+        message:
+          "A new chat channel will be created in the inbox. Membership auto-syncs from the team's event-plan assignments. This affects every event this team is on.",
+        confirmText: "Turn on",
+      });
+      if (ok) void performToggle(true);
     }
   }, [busy, hasChannel, teamName, channelMemberCount, performToggle]);
 

--- a/apps/mobile/features/scheduling/components/TeamSetupScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TeamSetupScreen.tsx
@@ -35,6 +35,7 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { confirmAsync, notify } from "@/utils/platformAlert";
 import { RolesEditor } from "./RolesEditor";
 import { ROLE_COLORS } from "../utils/format";
 
@@ -376,31 +377,22 @@ function PermanentMembersSection({
   const [removing, setRemoving] = useState<string | null>(null);
 
   const handleRemove = useCallback(
-    (member: PermanentMember) => {
-      Alert.alert(
-        "Remove member?",
-        `${member.displayName} will be removed from this channel.`,
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Remove",
-            style: "destructive",
-            onPress: async () => {
-              setRemoving(member.userId as string);
-              try {
-                await removeMember({ teamId, userId: member.userId });
-              } catch (e: any) {
-                Alert.alert(
-                  "Couldn't remove",
-                  e?.message ?? "Please try again.",
-                );
-              } finally {
-                setRemoving(null);
-              }
-            },
-          },
-        ],
-      );
+    async (member: PermanentMember) => {
+      const ok = await confirmAsync({
+        title: "Remove member?",
+        message: `${member.displayName} will be removed from this channel.`,
+        confirmText: "Remove",
+        destructive: true,
+      });
+      if (!ok) return;
+      setRemoving(member.userId as string);
+      try {
+        await removeMember({ teamId, userId: member.userId });
+      } catch (e: any) {
+        notify("Couldn't remove", e?.message ?? "Please try again.");
+      } finally {
+        setRemoving(null);
+      }
     },
     [removeMember, teamId],
   );

--- a/apps/mobile/utils/platformAlert.ts
+++ b/apps/mobile/utils/platformAlert.ts
@@ -1,0 +1,68 @@
+/**
+ * Cross-platform confirm / notice helpers.
+ *
+ * React Native's `Alert.alert` is a **no-op on web** in this codebase, so any
+ * confirm built on it (Cancel/Delete buttons) silently does nothing on web —
+ * the action never runs. These helpers fall back to `window.confirm` /
+ * `window.alert` on web and use `Alert.alert` on native, matching the inline
+ * pattern already used in `HostsPicker` / `EventPageClient`.
+ */
+import { Alert, Platform } from "react-native";
+
+/**
+ * Imperative confirm. Resolves `true` if the user confirms, `false` if they
+ * cancel or dismiss. Works on web (window.confirm) and native (Alert.alert).
+ */
+export function confirmAsync(opts: {
+  title: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+  /** iOS shows the confirm button in red; ignored on web. */
+  destructive?: boolean;
+}): Promise<boolean> {
+  const {
+    title,
+    message = "",
+    confirmText = "OK",
+    cancelText = "Cancel",
+    destructive = false,
+  } = opts;
+
+  if (Platform.OS === "web") {
+    if (typeof window === "undefined" || !window.confirm) {
+      return Promise.resolve(false);
+    }
+    return Promise.resolve(window.confirm(message ? `${title}\n\n${message}` : title));
+  }
+
+  return new Promise((resolve) => {
+    Alert.alert(
+      title,
+      message || undefined,
+      [
+        { text: cancelText, style: "cancel", onPress: () => resolve(false) },
+        {
+          text: confirmText,
+          style: destructive ? "destructive" : "default",
+          onPress: () => resolve(true),
+        },
+      ],
+      { onDismiss: () => resolve(false) },
+    );
+  });
+}
+
+/**
+ * One-button informational / error notice. Web uses window.alert (Alert.alert
+ * is a no-op there), so a failure message isn't swallowed silently.
+ */
+export function notify(title: string, message?: string): void {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined" && window.alert) {
+      window.alert(message ? `${title}\n\n${message}` : title);
+    }
+    return;
+  }
+  Alert.alert(title, message);
+}


### PR DESCRIPTION
## Summary

Same web bug class you hit with the run sheet X, swept across the rostering flow. React Native's `Alert.alert` is a **no-op on web** and `ActionSheetIOS` is iOS-only, so every confirm / action menu silently did nothing on web — most notably **duplicating and deleting event plans** (the ⋯ menu never opened).

### Shared helpers (new)
- `utils/platformAlert.ts` — `confirmAsync` (window.confirm on web / Alert.alert on native, returns a Promise<boolean>) and `notify` (window.alert on web).
- `components/ui/ActionMenuSheet.tsx` — a small cross-platform action menu, used as the web fallback for `ActionSheetIOS`.

### Fixes (scheduling feature)
- **EventListScreen**: the ⋯ event-plan menu (**Duplicate / Delete**) now opens an `ActionMenuSheet` on web; delete confirms via `confirmAsync`.
- **EventEditorScreen**: delete + publish confirms.
- **RolesEditor**: archive role.
- **TeamSetupScreen**: remove member.
- **TeamChannelToggle**: turn chat on/off.
- Their error/info toasts now route through `notify` so failures aren't swallowed on web.

iOS keeps `ActionSheetIOS`; Android keeps `Alert.alert`. Only the broken web path changed.

Out of scope (separate surface, follow-up): leader-tools `EventDetails` / `RunSheetScreen` share + location menus.

## Testing
- Verified on web: the ⋯ menu opens with Duplicate/Delete; **Duplicate** creates the copy and opens its editor; **Delete** shows the confirm and removes the plan. Typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)