### PR TITLE
Native song library & worship media for run sheets (ADR-027)

### DIFF
--- a/apps/convex/__tests__/scheduling/songs.test.ts
+++ b/apps/convex/__tests__/scheduling/songs.test.ts
@@ -433,4 +433,73 @@ describe("eventItems ⇄ song integration", () => {
       }),
     ).rejects.toThrow(ConvexError);
   });
+
+  it("duplicateItem preserves the song link", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+    const planId = await createPlan(t, leaderToken, world.groupId);
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token: adminToken,
+      communityId: world.communityId,
+      input: { title: "Build My Life", defaultKey: "G" },
+    });
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.eventItems.createItem,
+      { token: leaderToken, planId, type: "song", title: "Opener" },
+    );
+    await t.mutation(api.functions.scheduling.eventItems.updateItem, {
+      token: leaderToken,
+      itemId,
+      songId,
+    });
+
+    const { itemId: copyId } = await t.mutation(
+      api.functions.scheduling.eventItems.duplicateItem,
+      { token: leaderToken, itemId },
+    );
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token: leaderToken,
+      planId,
+    });
+    const copy = items?.find((i) => i._id === copyId);
+    expect(copy?.songId).toBe(songId);
+    expect(copy?.song?.title).toBe("Build My Life");
+  });
+
+  it("duplicateEvent preserves song links on copied items", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+    const planId = await createPlan(t, leaderToken, world.groupId);
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token: adminToken,
+      communityId: world.communityId,
+      input: { title: "Great Are You Lord" },
+    });
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.eventItems.createItem,
+      { token: leaderToken, planId, type: "song", title: "Worship 1" },
+    );
+    await t.mutation(api.functions.scheduling.eventItems.updateItem, {
+      token: leaderToken,
+      itemId,
+      songId,
+    });
+
+    const { planId: newPlanId } = await t.mutation(
+      api.functions.scheduling.events.duplicateEvent,
+      { token: leaderToken, planId },
+    );
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token: leaderToken,
+      planId: newPlanId,
+    });
+    expect(items?.[0]?.songId).toBe(songId);
+    expect(items?.[0]?.song?.title).toBe("Great Are You Lord");
+  });
 });

--- a/apps/convex/__tests__/scheduling/songs.test.ts
+++ b/apps/convex/__tests__/scheduling/songs.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Tests for the native song library — `songs` CRUD, search, chart attach/remove,
+ * the deleteSong → null-out-referencing-`eventItems` cascade, and the
+ * `eventItems` ⇄ song integration (updateItem sets/clears `songId`,
+ * listItems/getEvent join `item.song`). Permissions reuse existing guards
+ * (community admin for edits, community membership for reads). (ADR-027)
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+const DAY = 86400000;
+
+/** Create a draft event plan and return its id. */
+async function createPlan(
+  t: ReturnType<typeof convexTest>,
+  token: string,
+  groupId: Id<"groups">,
+): Promise<Id<"eventPlans">> {
+  const eventDate = Date.now() + 7 * DAY;
+  const { planId } = await t.mutation(
+    api.functions.scheduling.events.createEvent,
+    {
+      token,
+      groupId,
+      title: "Sunday",
+      eventDate,
+      times: [{ label: "10 AM", startsAt: eventDate }],
+    },
+  );
+  return planId;
+}
+
+describe("songs CRUD", () => {
+  it("creates a song and reads it back", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: {
+        title: "Amazing Grace",
+        author: "John Newton",
+        ccliNumber: "22025",
+        defaultKey: "G",
+        bpm: 72,
+        meter: "3/4",
+        arrangementName: "Standard",
+        structure: ["Verse 1", "Chorus"],
+        multitracksUrl: "https://multitracks.com/x",
+        notes: "Capo 3",
+      },
+    });
+
+    const song = await t.query(api.functions.scheduling.songs.getSong, {
+      token,
+      songId,
+    });
+    expect(song?.title).toBe("Amazing Grace");
+    expect(song?.author).toBe("John Newton");
+    expect(song?.ccliNumber).toBe("22025");
+    expect(song?.defaultKey).toBe("G");
+    expect(song?.bpm).toBe(72);
+    expect(song?.structure).toEqual(["Verse 1", "Chorus"]);
+    expect(song?.charts).toEqual([]);
+    expect(typeof song?.createdAt).toBe("number");
+    expect(song?.createdById).toBe(world.communityAdminId);
+  });
+
+  it("lists songs sorted by title (case-insensitive)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    for (const title of ["zebra", "Apple", "mango"]) {
+      await t.mutation(api.functions.scheduling.songs.createSong, {
+        token,
+        communityId: world.communityId,
+        input: { title },
+      });
+    }
+
+    const songs = await t.query(api.functions.scheduling.songs.listSongs, {
+      token,
+      communityId: world.communityId,
+    });
+    expect(songs.map((s) => s.title)).toEqual(["Apple", "mango", "zebra"]);
+  });
+
+  it("filters by title or ccliNumber via search (case-insensitive)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Build My Life", ccliNumber: "7070345" },
+    });
+    await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Goodness of God", ccliNumber: "7117726" },
+    });
+
+    const byTitle = await t.query(api.functions.scheduling.songs.listSongs, {
+      token,
+      communityId: world.communityId,
+      search: "build",
+    });
+    expect(byTitle.map((s) => s.title)).toEqual(["Build My Life"]);
+
+    const byCcli = await t.query(api.functions.scheduling.songs.listSongs, {
+      token,
+      communityId: world.communityId,
+      search: "7117726",
+    });
+    expect(byCcli.map((s) => s.title)).toEqual(["Goodness of God"]);
+  });
+
+  it("updates a song's fields and bumps updatedAt", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Old Title", defaultKey: "C" },
+    });
+    const before = await t.query(api.functions.scheduling.songs.getSong, {
+      token,
+      songId,
+    });
+
+    await t.mutation(api.functions.scheduling.songs.updateSong, {
+      token,
+      songId,
+      patch: { title: "New Title", defaultKey: "D" },
+    });
+
+    const after = await t.query(api.functions.scheduling.songs.getSong, {
+      token,
+      songId,
+    });
+    expect(after?.title).toBe("New Title");
+    expect(after?.defaultKey).toBe("D");
+    expect(after!.updatedAt).toBeGreaterThanOrEqual(before!.updatedAt);
+  });
+
+  it("deletes a song", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Temp" },
+    });
+    await t.mutation(api.functions.scheduling.songs.deleteSong, {
+      token,
+      songId,
+    });
+
+    const song = await t.query(api.functions.scheduling.songs.getSong, {
+      token,
+      songId,
+    });
+    expect(song).toBeNull();
+  });
+
+  it("rejects an empty title on create", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+    await expect(
+      t.mutation(api.functions.scheduling.songs.createSong, {
+        token,
+        communityId: world.communityId,
+        input: { title: "   " },
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("song charts", () => {
+  it("attaches and removes charts, resolving a url for each", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Charted" },
+    });
+
+    await t.mutation(api.functions.scheduling.songs.attachChart, {
+      token,
+      songId,
+      chart: {
+        key: "G",
+        label: "Lead Sheet (G)",
+        fileKey: "https://example.com/chart-g.pdf",
+        mimeType: "application/pdf",
+      },
+    });
+    await t.mutation(api.functions.scheduling.songs.attachChart, {
+      token,
+      songId,
+      chart: {
+        key: "A",
+        label: "Lead Sheet (A)",
+        fileKey: "https://example.com/chart-a.pdf",
+        mimeType: "application/pdf",
+      },
+    });
+
+    let song = await t.query(api.functions.scheduling.songs.getSong, {
+      token,
+      songId,
+    });
+    expect(song?.charts.map((c) => c.label)).toEqual([
+      "Lead Sheet (G)",
+      "Lead Sheet (A)",
+    ]);
+    // Each chart carries a resolved url alongside its stored fileKey.
+    expect(song?.charts[0].url).toBe("https://example.com/chart-g.pdf");
+
+    await t.mutation(api.functions.scheduling.songs.removeChart, {
+      token,
+      songId,
+      fileKey: "https://example.com/chart-g.pdf",
+    });
+
+    song = await t.query(api.functions.scheduling.songs.getSong, {
+      token,
+      songId,
+    });
+    expect(song?.charts.map((c) => c.label)).toEqual(["Lead Sheet (A)"]);
+  });
+});
+
+describe("songs permissions", () => {
+  it("lets a community member list/get but not edit", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token: adminToken,
+      communityId: world.communityId,
+      input: { title: "Members can read" },
+    });
+
+    // A plain group member is an active community member.
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const songs = await t.query(api.functions.scheduling.songs.listSongs, {
+      token: memberToken,
+      communityId: world.communityId,
+    });
+    expect(songs.length).toBe(1);
+
+    await expect(
+      t.mutation(api.functions.scheduling.songs.createSong, {
+        token: memberToken,
+        communityId: world.communityId,
+        input: { title: "Sneaky" },
+      }),
+    ).rejects.toThrow(ConvexError);
+    await expect(
+      t.mutation(api.functions.scheduling.songs.updateSong, {
+        token: memberToken,
+        songId,
+        patch: { title: "Hijacked" },
+      }),
+    ).rejects.toThrow(ConvexError);
+    await expect(
+      t.mutation(api.functions.scheduling.songs.deleteSong, {
+        token: memberToken,
+        songId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("forbids an outsider from listing the library", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const outsiderToken = (await generateTokens(world.outsiderId)).accessToken;
+    await expect(
+      t.query(api.functions.scheduling.songs.listSongs, {
+        token: outsiderToken,
+        communityId: world.communityId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("eventItems ⇄ song integration", () => {
+  it("updateItem sets and clears songId, and listItems joins the song", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token: adminToken,
+      communityId: world.communityId,
+      input: { title: "Opener Song", defaultKey: "E" },
+    });
+
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.eventItems.createItem,
+      { token, planId, type: "song", title: "Opener" },
+    );
+
+    // No song yet.
+    let items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    expect(items?.[0].song ?? null).toBeNull();
+
+    // Link the song.
+    await t.mutation(api.functions.scheduling.eventItems.updateItem, {
+      token,
+      itemId,
+      songId,
+    });
+    items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    expect(items?.[0].songId).toBe(songId);
+    expect(items?.[0].song?.title).toBe("Opener Song");
+    expect(items?.[0].song?.defaultKey).toBe("E");
+
+    // getEvent also joins the song onto its items.
+    const event = await t.query(api.functions.scheduling.events.getEvent, {
+      token,
+      planId,
+    });
+    expect(event?.items?.[0].song?.title).toBe("Opener Song");
+
+    // Clear the link with null.
+    await t.mutation(api.functions.scheduling.eventItems.updateItem, {
+      token,
+      itemId,
+      songId: null,
+    });
+    items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    expect(items?.[0].songId ?? null).toBeNull();
+    expect(items?.[0].song ?? null).toBeNull();
+  });
+
+  it("deleteSong nulls out songId on referencing eventItems", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token: adminToken,
+      communityId: world.communityId,
+      input: { title: "Doomed" },
+    });
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.eventItems.createItem,
+      { token, planId, type: "song", title: "Row" },
+    );
+    await t.mutation(api.functions.scheduling.eventItems.updateItem, {
+      token,
+      itemId,
+      songId,
+    });
+
+    await t.mutation(api.functions.scheduling.songs.deleteSong, {
+      token: adminToken,
+      songId,
+    });
+
+    const items = await t.query(api.functions.scheduling.eventItems.listItems, {
+      token,
+      planId,
+    });
+    // The item survives, falling back to its free-typed row; the link is gone.
+    expect(items?.length).toBe(1);
+    expect(items?.[0].songId ?? null).toBeNull();
+    expect(items?.[0].song ?? null).toBeNull();
+  });
+
+  it("linking a song reuses requirePlanScheduler (member cannot link)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+    const planId = await createPlan(t, leaderToken, world.groupId);
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token: adminToken,
+      communityId: world.communityId,
+      input: { title: "Locked" },
+    });
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.eventItems.createItem,
+      { token: leaderToken, planId, type: "song", title: "Row" },
+    );
+
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    await expect(
+      t.mutation(api.functions.scheduling.eventItems.updateItem, {
+        token: memberToken,
+        itemId,
+        songId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -138,6 +138,7 @@ import type * as functions_scheduling_permissions from "../functions/scheduling/
 import type * as functions_scheduling_publicAvailability from "../functions/scheduling/publicAvailability.js";
 import type * as functions_scheduling_roles from "../functions/scheduling/roles.js";
 import type * as functions_scheduling_roster from "../functions/scheduling/roster.js";
+import type * as functions_scheduling_songs from "../functions/scheduling/songs.js";
 import type * as functions_scheduling_starterRoles from "../functions/scheduling/starterRoles.js";
 import type * as functions_scheduling_teamChannelSync from "../functions/scheduling/teamChannelSync.js";
 import type * as functions_scheduling_teams from "../functions/scheduling/teams.js";
@@ -338,6 +339,7 @@ declare const fullApi: ApiFromModules<{
   "functions/scheduling/publicAvailability": typeof functions_scheduling_publicAvailability;
   "functions/scheduling/roles": typeof functions_scheduling_roles;
   "functions/scheduling/roster": typeof functions_scheduling_roster;
+  "functions/scheduling/songs": typeof functions_scheduling_songs;
   "functions/scheduling/starterRoles": typeof functions_scheduling_starterRoles;
   "functions/scheduling/teamChannelSync": typeof functions_scheduling_teamChannelSync;
   "functions/scheduling/teams": typeof functions_scheduling_teams;

--- a/apps/convex/functions/scheduling/eventItems.ts
+++ b/apps/convex/functions/scheduling/eventItems.ts
@@ -393,6 +393,7 @@ export const duplicateItem = mutation({
       notes: item.notes,
       assignments: item.assignments,
       songDetails: item.songDetails,
+      songId: item.songId,
       createdAt: nowMs,
       createdById: userId,
       updatedAt: nowMs,

--- a/apps/convex/functions/scheduling/eventItems.ts
+++ b/apps/convex/functions/scheduling/eventItems.ts
@@ -19,6 +19,7 @@ import type { MutationCtx, QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { requireGroupMember, requirePlanScheduler } from "./permissions";
+import { getHydratedSongForJoin } from "./songs";
 
 /** Run sheet item types — mirrors PCO vocabulary. */
 const ITEM_TYPES = new Set(["song", "header", "media", "item"]);
@@ -158,7 +159,7 @@ export const listItems = query({
  * Join an item's linked assignments with role + user display info. Kept small
  * and shared so the shape stays consistent across mutations that echo an item.
  */
-async function hydrateItem(ctx: QueryCtx, item: Doc<"eventItems">) {
+export async function hydrateItem(ctx: QueryCtx, item: Doc<"eventItems">) {
   const assignments = await Promise.all(
     (item.assignments ?? []).map(async (link) => {
       const role = await ctx.db.get(link.roleId);
@@ -169,6 +170,10 @@ async function hydrateItem(ctx: QueryCtx, item: Doc<"eventItems">) {
       };
     }),
   );
+
+  // Join the linked library song (ADR-027). `songDetails` overrides the song's
+  // defaults; the frontend resolves `songDetails.key ?? song.defaultKey`.
+  const song = await getHydratedSongForJoin(ctx, item.songId);
 
   return {
     _id: item._id,
@@ -181,6 +186,8 @@ async function hydrateItem(ctx: QueryCtx, item: Doc<"eventItems">) {
     durationSec: item.durationSec,
     notes: item.notes ?? [],
     songDetails: item.songDetails ?? null,
+    songId: item.songId ?? null,
+    song,
     assignments,
   };
 }
@@ -267,6 +274,12 @@ export const updateItem = mutation({
     notes: v.optional(v.array(noteValidator)),
     assignments: v.optional(v.array(itemAssignmentValidator)),
     songDetails: v.optional(songDetailsValidator),
+    /**
+     * Link this item to a library song, or clear the link (ADR-027). An id sets
+     * `songId`; `null` clears it; omitted leaves it unchanged. Reuses the same
+     * `requirePlanScheduler` gate as the rest of `updateItem`.
+     */
+    songId: v.optional(v.union(v.id("songs"), v.null())),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -311,6 +324,19 @@ export const updateItem = mutation({
       patch.assignments = args.assignments;
     }
     if (args.songDetails !== undefined) patch.songDetails = args.songDetails;
+    if (args.songId !== undefined) {
+      if (args.songId === null) {
+        patch.songId = undefined;
+      } else {
+        // The song must belong to the same community as the plan — an item
+        // cannot link a foreign community's song.
+        const song = await ctx.db.get(args.songId);
+        if (!song || song.communityId !== plan.communityId) {
+          throw new ConvexError("Linked song does not belong to this community");
+        }
+        patch.songId = args.songId;
+      }
+    }
 
     await ctx.db.patch(args.itemId, patch);
     return { itemId: args.itemId };

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -199,6 +199,7 @@ export const duplicateEvent = mutation({
           notes: item.notes,
           assignments: item.assignments,
           songDetails: item.songDetails,
+          songId: item.songId,
           createdAt: nowMs,
           createdById: userId,
           updatedAt: nowMs,

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -23,6 +23,7 @@ import {
   requireGroupScheduler,
   requirePlanScheduler,
 } from "./permissions";
+import { hydrateItem } from "./eventItems";
 
 /** Statuses that consume a slot in fill-summary math (ADR-023). */
 const FILLED_STATUSES = new Set(["confirmed", "unconfirmed"]);
@@ -571,7 +572,7 @@ export const getEvent = query({
 
     await requireGroupMember(ctx, plan.groupId, userId);
 
-    const [neededRoles, assignments] = await Promise.all([
+    const [neededRoles, assignments, rawItems] = await Promise.all([
       ctx.db
         .query("neededRoles")
         .withIndex("by_plan", (q) => q.eq("planId", args.planId))
@@ -580,7 +581,20 @@ export const getEvent = query({
         .query("roleAssignments")
         .withIndex("by_plan", (q) => q.eq("planId", args.planId))
         .collect(),
+      ctx.db
+        .query("eventItems")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
     ]);
+
+    // Run sheet items with their linked library song joined (ADR-027), in the
+    // same before → during → after, then sequence, order as `listItems`.
+    const SEGMENT_RANK: Record<string, number> = { before: 0, during: 1, after: 2 };
+    const segRank = (s: string | undefined) => SEGMENT_RANK[s ?? "during"] ?? 1;
+    rawItems.sort(
+      (a, b) => segRank(a.segment) - segRank(b.segment) || a.sequence - b.sequence,
+    );
+    const items = await Promise.all(rawItems.map((item) => hydrateItem(ctx, item)));
 
     const fill = buildFillSummary(neededRoles, assignments);
     const fillByRole = new Map(fill.roles.map((r) => [r.roleId as string, r]));
@@ -641,6 +655,7 @@ export const getEvent = query({
       meetingIds: plan.meetingIds,
       fillSummary: { totalNeeded: fill.totalNeeded, totalFilled: fill.totalFilled },
       roles,
+      items,
     };
   },
 });

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -212,6 +212,49 @@ export async function requireTeamGroupMember(
 }
 
 /**
+ * Require that `userId` is an active member of `communityId`. Community-scoped
+ * read gate for library resources (ADR-027 song library) that are not tied to a
+ * single group. Throws `ConvexError` (not a plain `Error`) so the mobile
+ * `AuthErrorBoundary` can recover, unlike `lib/permissions.requireCommunityAdmin`.
+ *
+ * @throws ConvexError if the caller is not an active community member.
+ */
+export async function requireCommunityMember(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+): Promise<void> {
+  const membership = await ctx.db
+    .query("userCommunities")
+    .withIndex("by_user_community", (q) =>
+      q.eq("userId", userId).eq("communityId", communityId),
+    )
+    .first();
+  if (!membership || membership.status !== 1) {
+    throw new ConvexError("You must be a member of this community");
+  }
+}
+
+/**
+ * Require that `userId` is an admin of `communityId`. Community-scoped edit gate
+ * for the song library (ADR-027) — the closest existing community-admin concept
+ * (`isCommunityAdmin`), wrapped to throw `ConvexError` for the mobile client.
+ *
+ * @throws ConvexError if the caller is not a community admin.
+ */
+export async function requireCommunityAdmin(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+): Promise<void> {
+  if (!(await isCommunityAdmin(ctx, communityId, userId))) {
+    throw new ConvexError(
+      "You must be a community admin to manage the song library",
+    );
+  }
+}
+
+/**
  * Resolve the campus-group scheduler used by an event plan, asserting the
  * caller may manage it. Returns both the plan and its owning group.
  *

--- a/apps/convex/functions/scheduling/songs.ts
+++ b/apps/convex/functions/scheduling/songs.ts
@@ -1,0 +1,307 @@
+/**
+ * Scheduling — native song library (ADR-027)
+ *
+ * A per-community library of songs that run sheet `eventItems` reference by
+ * `songId`. A song lives once; editing it updates every plan that uses it.
+ * `ccliNumber` is the worship world's universal song ID, stored as plain
+ * metadata (no live CCLI/MultiTracks integration). Charts are key-specific
+ * files in the existing R2 upload pipeline (`functions/uploads.ts`) — we store
+ * the `fileKey` and resolve the served `url` on read via `getMediaUrl`, the same
+ * helper other media features use. `multitracksUrl` is a link-out, never audio.
+ *
+ * Permissions reuse existing guards: editing the library is a community-admin
+ * action (`requireCommunityAdmin`); listing/viewing requires an active
+ * community member (`requireCommunityMember`). Linking a song to a run sheet
+ * item lives in `eventItems.updateItem` and reuses `requirePlanScheduler`.
+ */
+
+import { ConvexError, v } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { getMediaUrl } from "../../lib/utils";
+import { requireCommunityAdmin, requireCommunityMember } from "./permissions";
+
+/** Editable song fields shared by create (`input`) and update (`patch`). */
+const songInputValidator = v.object({
+  title: v.optional(v.string()),
+  author: v.optional(v.string()),
+  ccliNumber: v.optional(v.string()),
+  defaultKey: v.optional(v.string()),
+  bpm: v.optional(v.number()),
+  meter: v.optional(v.string()),
+  arrangementName: v.optional(v.string()),
+  structure: v.optional(v.array(v.string())),
+  multitracksUrl: v.optional(v.string()),
+  notes: v.optional(v.string()),
+});
+
+const chartValidator = v.object({
+  key: v.optional(v.string()),
+  label: v.string(),
+  fileKey: v.string(),
+  mimeType: v.string(),
+});
+
+/**
+ * The client-facing Song shape: the stored doc with each chart's served `url`
+ * resolved from its `fileKey`. Charts default to `[]` so the client never has
+ * to null-check the array.
+ */
+function hydrateSong(song: Doc<"songs">) {
+  return {
+    ...song,
+    charts: (song.charts ?? []).map((chart) => ({
+      ...chart,
+      url: getMediaUrl(chart.fileKey) ?? null,
+    })),
+  };
+}
+
+/**
+ * Resolve a song and assert the caller may edit its community library.
+ *
+ * @throws ConvexError if the song is missing or the caller is not an admin.
+ */
+async function requireSongAdmin(
+  ctx: MutationCtx,
+  songId: Id<"songs">,
+  userId: Id<"users">,
+): Promise<Doc<"songs">> {
+  const song = await ctx.db.get(songId);
+  if (!song) {
+    throw new ConvexError("Song not found");
+  }
+  await requireCommunityAdmin(ctx, song.communityId, userId);
+  return song;
+}
+
+/**
+ * List a community's songs, sorted by title (case-insensitive). When `search`
+ * is given, keep only songs whose title or `ccliNumber` contains it.
+ *
+ * Auth: active community member.
+ */
+export const listSongs = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    search: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireCommunityMember(ctx, args.communityId, userId);
+
+    let songs = await ctx.db
+      .query("songs")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+
+    const search = args.search?.trim().toLowerCase();
+    if (search) {
+      songs = songs.filter(
+        (s) =>
+          s.title.toLowerCase().includes(search) ||
+          (s.ccliNumber ?? "").toLowerCase().includes(search),
+      );
+    }
+
+    songs.sort((a, b) =>
+      a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
+    );
+
+    return songs.map(hydrateSong);
+  },
+});
+
+/**
+ * Get a single song with its chart urls resolved, or null if it does not exist.
+ *
+ * Auth: active member of the song's community.
+ */
+export const getSong = query({
+  args: {
+    token: v.string(),
+    songId: v.id("songs"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const song = await ctx.db.get(args.songId);
+    if (!song) return null;
+    await requireCommunityMember(ctx, song.communityId, userId);
+    return hydrateSong(song);
+  },
+});
+
+/**
+ * Create a library song. Charts are attached separately via `attachChart`.
+ *
+ * Auth: community admin.
+ */
+export const createSong = mutation({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    input: songInputValidator,
+  },
+  handler: async (ctx, args): Promise<Id<"songs">> => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireCommunityAdmin(ctx, args.communityId, userId);
+
+    const title = (args.input.title ?? "").trim();
+    if (!title) {
+      throw new ConvexError("Song title cannot be empty");
+    }
+
+    const nowMs = Date.now();
+    return ctx.db.insert("songs", {
+      communityId: args.communityId,
+      title,
+      author: args.input.author?.trim() || undefined,
+      ccliNumber: args.input.ccliNumber?.trim() || undefined,
+      defaultKey: args.input.defaultKey?.trim() || undefined,
+      bpm: args.input.bpm,
+      meter: args.input.meter?.trim() || undefined,
+      arrangementName: args.input.arrangementName?.trim() || undefined,
+      structure: args.input.structure,
+      multitracksUrl: args.input.multitracksUrl?.trim() || undefined,
+      notes: args.input.notes?.trim() || undefined,
+      createdAt: nowMs,
+      createdById: userId,
+      updatedAt: nowMs,
+    });
+  },
+});
+
+/**
+ * Update a song's metadata. Only provided fields change; `updatedAt` bumps.
+ *
+ * Auth: community admin for the song's community.
+ */
+export const updateSong = mutation({
+  args: {
+    token: v.string(),
+    songId: v.id("songs"),
+    patch: songInputValidator,
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireSongAdmin(ctx, args.songId, userId);
+
+    const patch: Partial<Doc<"songs">> = { updatedAt: Date.now() };
+    const p = args.patch;
+    if (p.title !== undefined) {
+      const title = p.title.trim();
+      if (!title) {
+        throw new ConvexError("Song title cannot be empty");
+      }
+      patch.title = title;
+    }
+    if (p.author !== undefined) patch.author = p.author.trim() || undefined;
+    if (p.ccliNumber !== undefined)
+      patch.ccliNumber = p.ccliNumber.trim() || undefined;
+    if (p.defaultKey !== undefined)
+      patch.defaultKey = p.defaultKey.trim() || undefined;
+    if (p.bpm !== undefined) patch.bpm = p.bpm;
+    if (p.meter !== undefined) patch.meter = p.meter.trim() || undefined;
+    if (p.arrangementName !== undefined)
+      patch.arrangementName = p.arrangementName.trim() || undefined;
+    if (p.structure !== undefined) patch.structure = p.structure;
+    if (p.multitracksUrl !== undefined)
+      patch.multitracksUrl = p.multitracksUrl.trim() || undefined;
+    if (p.notes !== undefined) patch.notes = p.notes.trim() || undefined;
+
+    await ctx.db.patch(args.songId, patch);
+    return { songId: args.songId };
+  },
+});
+
+/**
+ * Delete a song. First null out `songId` on every run sheet item that
+ * references it — the item survives, falling back to its `songDetails`/title —
+ * then delete the song (ADR-027). Uses the `eventItems.by_song` index.
+ *
+ * Auth: community admin for the song's community.
+ */
+export const deleteSong = mutation({
+  args: {
+    token: v.string(),
+    songId: v.id("songs"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireSongAdmin(ctx, args.songId, userId);
+
+    const referencing = await ctx.db
+      .query("eventItems")
+      .withIndex("by_song", (q) => q.eq("songId", args.songId))
+      .collect();
+    await Promise.all(
+      referencing.map((item) =>
+        ctx.db.patch(item._id, { songId: undefined, updatedAt: Date.now() }),
+      ),
+    );
+
+    await ctx.db.delete(args.songId);
+    return { deleted: true, unlinkedItems: referencing.length };
+  },
+});
+
+/**
+ * Append a chart to a song's `charts` array. The `fileKey` is the R2 stored
+ * path from the upload pipeline; its served url is resolved on read.
+ *
+ * Auth: community admin for the song's community.
+ */
+export const attachChart = mutation({
+  args: {
+    token: v.string(),
+    songId: v.id("songs"),
+    chart: chartValidator,
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const song = await requireSongAdmin(ctx, args.songId, userId);
+
+    const charts = [...(song.charts ?? []), args.chart];
+    await ctx.db.patch(args.songId, { charts, updatedAt: Date.now() });
+    return { songId: args.songId };
+  },
+});
+
+/**
+ * Remove the chart with the given `fileKey` from a song's `charts` array.
+ *
+ * Auth: community admin for the song's community.
+ */
+export const removeChart = mutation({
+  args: {
+    token: v.string(),
+    songId: v.id("songs"),
+    fileKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const song = await requireSongAdmin(ctx, args.songId, userId);
+
+    const charts = (song.charts ?? []).filter((c) => c.fileKey !== args.fileKey);
+    await ctx.db.patch(args.songId, { charts, updatedAt: Date.now() });
+    return { songId: args.songId };
+  },
+});
+
+/**
+ * Internal: resolve a song to the client-facing Song shape (charts with urls),
+ * or null. Shared by `eventItems`/`events` so a run sheet item can join its
+ * linked song without a client round-trip. Skips the membership guard — callers
+ * have already gated on the plan's group, which is scoped to the community.
+ */
+export async function getHydratedSongForJoin(
+  ctx: QueryCtx,
+  songId: Id<"songs"> | undefined,
+) {
+  if (!songId) return null;
+  const song = await ctx.db.get(songId);
+  return song ? hydrateSong(song) : null;
+}

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2654,7 +2654,11 @@ export default defineSchema({
     assignments: v.optional(
       v.array(v.object({ roleId: v.id("teamRoles") })),
     ),
-    /** Lightweight song metadata. No CCLI / library (ADR-023 Phase 3). */
+    /**
+     * Lightweight per-occurrence song metadata, retained as an OVERRIDE of the
+     * linked library song's defaults (ADR-027). Display resolves
+     * `songDetails.key ?? song.defaultKey`.
+     */
     songDetails: v.optional(
       v.object({
         key: v.optional(v.string()),
@@ -2662,10 +2666,68 @@ export default defineSchema({
         author: v.optional(v.string()),
       }),
     ),
+    /**
+     * Optional link to a library song (ADR-027). When set, the run sheet row
+     * renders the joined song's title/charts/links; `songDetails` overrides its
+     * defaults. Cleared (nulled) when the referenced song is deleted.
+     */
+    songId: v.optional(v.id("songs")),
     createdAt: v.number(),
     createdById: v.id("users"),
     updatedAt: v.number(),
-  }).index("by_plan", ["planId"]),
+  })
+    .index("by_plan", ["planId"])
+    // Scan items referencing a song so deleteSong can null them out (ADR-027).
+    .index("by_song", ["songId"]),
+
+  /**
+   * Per-community song library (ADR-027). A song lives once and is referenced
+   * by run sheet `eventItems` via `songId`, so editing its charts/metadata
+   * updates every plan that uses it (no copied-string drift). `ccliNumber` is
+   * the worship world's universal song ID, stored as plain metadata — there is
+   * no live CCLI/MultiTracks integration. Charts are key-specific files in the
+   * existing R2 document pipeline (`functions/uploads.ts`); `multitracksUrl` is
+   * a link-out, never re-hosted audio.
+   *
+   * TODO: cascade songs on community delete — there is no central
+   * community-deletion cascade in the codebase today (eventPlans/eventItems
+   * aren't cascaded either), so `songs` follows the same (absent) pattern. Add
+   * `songs` to that cascade if/when one lands.
+   */
+  songs: defineTable({
+    communityId: v.id("communities"),
+    title: v.string(),
+    author: v.optional(v.string()),
+    /** Universal song ID; the join key for a future Phase-3 integration. */
+    ccliNumber: v.optional(v.string()),
+    defaultKey: v.optional(v.string()),
+    bpm: v.optional(v.number()),
+    meter: v.optional(v.string()),
+    arrangementName: v.optional(v.string()),
+    structure: v.optional(v.array(v.string())),
+    /**
+     * Bring-your-own charts (Phase 2). One file per key. `fileKey` is the R2
+     * stored path (e.g. `r2:...`) from the upload pipeline; the served `url` is
+     * resolved on read, never stored.
+     */
+    charts: v.optional(
+      v.array(
+        v.object({
+          key: v.optional(v.string()),
+          label: v.string(),
+          fileKey: v.string(),
+          mimeType: v.string(),
+        }),
+      ),
+    ),
+    multitracksUrl: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    createdAt: v.number(),
+    createdById: v.id("users"),
+    updatedAt: v.number(),
+  })
+    .index("by_community", ["communityId"])
+    .index("by_community_ccli", ["communityId", "ccliNumber"]),
 
   /**
    * A member's self-reported availability for a single event plan (ADR-023

--- a/apps/mobile/app/rostering/[group_id]/run-sheet/rehearse/[plan_id].tsx
+++ b/apps/mobile/app/rostering/[group_id]/run-sheet/rehearse/[plan_id].tsx
@@ -1,0 +1,9 @@
+import { MusicianRehearsalScreen } from "@features/scheduling";
+
+/**
+ * Read-only musician rehearsal view for an event plan's run sheet songs.
+ * See ADR-027.
+ */
+export default function RehearsePage() {
+  return <MusicianRehearsalScreen />;
+}

--- a/apps/mobile/app/rostering/[group_id]/songs.tsx
+++ b/apps/mobile/app/rostering/[group_id]/songs.tsx
@@ -1,0 +1,6 @@
+import { SongLibraryScreen } from "@features/songs";
+
+/** Per-community song library management screen. See ADR-027. */
+export default function SongLibraryPage() {
+  return <SongLibraryScreen />;
+}

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -164,6 +164,11 @@ export function NativeRunSheetView({
               `/rostering/${groupId}/run-sheet/${activePlanId}` as never,
             )
           }
+          onRehearse={() =>
+            router.push(
+              `/rostering/${groupId}/run-sheet/rehearse/${activePlanId}` as never,
+            )
+          }
         />
       ) : null}
     </View>
@@ -174,11 +179,14 @@ function PlanRunSheet({
   planId,
   canEdit,
   onEdit,
+  onRehearse,
 }: {
   planId: Id<"eventPlans">;
   groupId: Id<"groups">;
   canEdit: boolean;
   onEdit: () => void;
+  /** Open the read-only musician rehearsal view for this plan (all members). */
+  onRehearse: () => void;
 }) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
@@ -246,6 +254,11 @@ function PlanRunSheet({
     }
     return map;
   }, [event?.roles]);
+  // Only surface the rehearsal shortcut when the sheet actually has songs.
+  const hasSongs = useMemo(
+    () => (items ?? []).some((it) => it.type === "song"),
+    [items],
+  );
 
   if (event === undefined || items === undefined) {
     return (
@@ -277,14 +290,37 @@ function PlanRunSheet({
             </Text>
           ) : null}
         </View>
-        {canEdit ? (
-          <Pressable onPress={onEdit} hitSlop={8} accessibilityRole="button">
-            <View style={styles.editRow}>
-              <Ionicons name="create-outline" size={16} color={primaryColor} />
-              <Text style={[styles.editText, { color: primaryColor }]}>Edit</Text>
-            </View>
-          </Pressable>
-        ) : null}
+        <View style={styles.sheetHeaderActions}>
+          {hasSongs ? (
+            <Pressable
+              onPress={onRehearse}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Rehearse songs"
+            >
+              <View style={styles.editRow}>
+                <Ionicons
+                  name="musical-notes-outline"
+                  size={16}
+                  color={primaryColor}
+                />
+                <Text style={[styles.editText, { color: primaryColor }]}>
+                  Rehearse
+                </Text>
+              </View>
+            </Pressable>
+          ) : null}
+          {canEdit ? (
+            <Pressable onPress={onEdit} hitSlop={8} accessibilityRole="button">
+              <View style={styles.editRow}>
+                <Ionicons name="create-outline" size={16} color={primaryColor} />
+                <Text style={[styles.editText, { color: primaryColor }]}>
+                  Edit
+                </Text>
+              </View>
+            </Pressable>
+          ) : null}
+        </View>
       </View>
 
       {items.length === 0 ? (
@@ -413,6 +449,7 @@ const styles = StyleSheet.create({
   sheet: { padding: 16, gap: 8 },
   sheetHeader: { flexDirection: "row", alignItems: "flex-start", justifyContent: "space-between", gap: 12 },
   sheetHeaderText: { flex: 1 },
+  sheetHeaderActions: { flexDirection: "row", alignItems: "flex-start", gap: 12 },
   planTitle: { fontSize: 20, fontWeight: "700" },
   ranges: { fontSize: 13, fontWeight: "600", marginTop: 4 },
   segmentLabel: {

--- a/apps/mobile/features/scheduling/components/AssignmentDetailScreen.tsx
+++ b/apps/mobile/features/scheduling/components/AssignmentDetailScreen.tsx
@@ -51,6 +51,7 @@ type MyAssignment = {
 };
 
 type EventDoc = {
+  groupId: Id<"groups">;
   roles: Array<{
     roleId: Id<"teamRoles">;
     teamId: Id<"teams">;
@@ -61,6 +62,7 @@ type EventDoc = {
       status: string;
     }>;
   }>;
+  items: Array<{ _id: string; type: string; title: string }>;
 };
 
 export function AssignmentDetailScreen() {
@@ -112,6 +114,18 @@ export function AssignmentDetailScreen() {
   }, [event, assignment, assignmentId]);
 
   const busy = busyId === (assignmentId as string);
+
+  // Musician rehearsal entry (ADR-027): only when the plan's run sheet has songs.
+  const hasSongs = useMemo(
+    () => (event?.items ?? []).some((it) => it.type === "song"),
+    [event?.items],
+  );
+  const openRehearsal = useCallback(() => {
+    if (!event || !assignment) return;
+    router.push(
+      `/rostering/${event.groupId}/run-sheet/rehearse/${assignment.planId}` as any,
+    );
+  }, [router, event, assignment]);
 
   return (
     <View
@@ -236,6 +250,34 @@ export function AssignmentDetailScreen() {
                 {assignment.declineNote ? ` — "${assignment.declineNote}"` : ""}
               </Text>
             </View>
+          )}
+
+          {/* Rehearse songs (ADR-027) */}
+          {hasSongs && (
+            <Pressable
+              onPress={openRehearsal}
+              accessibilityRole="button"
+              style={({ pressed }) => [
+                styles.group,
+                styles.rehearseRow,
+                { backgroundColor: colors.surfaceSecondary },
+                pressed && { opacity: 0.7 },
+              ]}
+            >
+              <Ionicons
+                name="musical-notes-outline"
+                size={20}
+                color={colors.text}
+              />
+              <Text style={[styles.rehearseText, { color: colors.text }]}>
+                Rehearse songs
+              </Text>
+              <Ionicons
+                name="chevron-forward"
+                size={18}
+                color={colors.textTertiary}
+              />
+            </Pressable>
           )}
 
           {/* Teammates */}
@@ -447,6 +489,14 @@ const styles = StyleSheet.create({
     overflow: "hidden",
     marginTop: 16,
   },
+  rehearseRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  rehearseText: { flex: 1, fontSize: 16, fontWeight: "500" },
   detailRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/features/scheduling/components/MusicianRehearsalScreen.tsx
+++ b/apps/mobile/features/scheduling/components/MusicianRehearsalScreen.tsx
@@ -1,0 +1,349 @@
+/**
+ * MusicianRehearsalScreen
+ *
+ * A read-only, per-person view of ONE event plan's run sheet songs (ADR-027),
+ * so an assigned volunteer/musician can rehearse ahead of time. It reuses the
+ * existing `getEvent` / `listItems` queries (ADR-026) — each `song`-type item
+ * now carries an optional joined `item.song` (the library song) and may have a
+ * per-occurrence `item.songDetails` override.
+ *
+ * For each song it shows: title, effective key/BPM (override → song default),
+ * meter, arrangement, and structure. Each chart opens its file externally; the
+ * multitracks link opens the provider (MultiTracks / Loop Community) — we never
+ * host audio or stems, only link out to where the musician's own subscription
+ * and RehearsalMix live.
+ *
+ * Read-only: no editing affordances. Items without a linked song still render
+ * their free-typed title (backwards compatible with ADR-026 song rows).
+ *
+ * Route: /rostering/[group_id]/run-sheet/rehearse/[plan_id]
+ */
+import React, { useCallback, useMemo } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { formatEventDateLong } from "../utils/format";
+import {
+  effectiveBpm,
+  effectiveKey,
+  type Song,
+  type SongChart,
+} from "../utils/songRehearsal";
+
+// TODO(integration): the joined `item.song` is typed locally via
+// `../utils/songRehearsal` until `features/songs/types` lands and the orchestrator
+// unifies the two. `getEvent` / `listItems` will return these shapes per ADR-027.
+
+type RehearsalItem = {
+  _id: Id<"eventItems">;
+  type: string;
+  title: string;
+  songDetails?: { key?: string; bpm?: number; author?: string } | null;
+  song?: Song | null;
+};
+
+type EventDoc = {
+  _id: Id<"eventPlans">;
+  title: string;
+  eventDate: number;
+};
+
+/** Open a URL externally, surfacing a friendly error if the device can't. */
+async function openExternal(url: string) {
+  try {
+    await Linking.openURL(url);
+  } catch {
+    const message = "Couldn't open the link. Please try again.";
+    if (Platform.OS === "web") {
+      if (typeof window !== "undefined") window.alert(message);
+      return;
+    }
+    Alert.alert("Couldn't open", message);
+  }
+}
+
+export function MusicianRehearsalScreen() {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { plan_id } = useLocalSearchParams<{ plan_id: string }>();
+  const planId = plan_id as Id<"eventPlans">;
+
+  const event = useAuthenticatedQuery(
+    api.functions.scheduling.events.getEvent,
+    planId ? { planId } : "skip",
+  ) as EventDoc | null | undefined;
+
+  const items = useAuthenticatedQuery(
+    api.functions.scheduling.eventItems.listItems,
+    planId ? { planId } : "skip",
+  ) as RehearsalItem[] | null | undefined;
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+  }, [router]);
+
+  // Only song rows are relevant to a musician rehearsing — headers, media, and
+  // generic items are part of the run flow, not the song set.
+  const songs = useMemo(
+    () => (items ?? []).filter((it) => it.type === "song"),
+    [items],
+  );
+
+  const loading = event === undefined || items === undefined;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      <View
+        style={[
+          styles.header,
+          { backgroundColor: colors.surface, borderBottomColor: colors.border },
+        ]}
+      >
+        <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBtn}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Rehearse</Text>
+        <View style={styles.headerBtn} />
+      </View>
+
+      {loading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      ) : !event || !items ? (
+        <View style={styles.centered}>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+            This run sheet is no longer available.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          contentContainerStyle={[
+            styles.scrollContent,
+            { paddingBottom: insets.bottom + 32 },
+          ]}
+        >
+          <Text style={[styles.planTitle, { color: colors.text }]}>
+            {event.title}
+          </Text>
+          <Text style={[styles.planDate, { color: colors.textSecondary }]}>
+            {formatEventDateLong(event.eventDate)}
+          </Text>
+
+          {songs.length === 0 ? (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              No songs on this run sheet yet. Check back once the worship leader
+              has added them.
+            </Text>
+          ) : (
+            <View style={styles.list}>
+              {songs.map((item) => (
+                <SongCard
+                  key={item._id}
+                  item={item}
+                  colors={colors}
+                  primaryColor={primaryColor}
+                />
+              ))}
+            </View>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+/** One read-only song card with its charts and multitracks link. */
+function SongCard({
+  item,
+  colors,
+  primaryColor,
+}: {
+  item: RehearsalItem;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+}) {
+  const song = item.song ?? null;
+  const key = effectiveKey(item);
+  const bpm = effectiveBpm(item);
+  const meter = song?.meter;
+  const arrangement = song?.arrangementName;
+  const author = song?.author ?? item.songDetails?.author;
+  const structure = song?.structure ?? [];
+  const charts: SongChart[] = song?.charts ?? [];
+  const multitracksUrl = song?.multitracksUrl;
+
+  // Compact metadata line: "Key A · 120 BPM · 4/4".
+  const meta = [
+    key ? `Key ${key}` : null,
+    bpm ? `${bpm} BPM` : null,
+    meter ?? null,
+  ].filter(Boolean) as string[];
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
+      <Text style={[styles.songTitle, { color: colors.text }]}>
+        {song?.title ?? item.title}
+      </Text>
+      {author ? (
+        <Text style={[styles.songAuthor, { color: colors.textSecondary }]}>
+          {author}
+        </Text>
+      ) : null}
+
+      {meta.length > 0 ? (
+        <Text style={[styles.metaLine, { color: colors.text }]}>
+          {meta.join("  ·  ")}
+        </Text>
+      ) : null}
+
+      {arrangement ? (
+        <Text style={[styles.arrangement, { color: colors.textSecondary }]}>
+          {arrangement}
+        </Text>
+      ) : null}
+
+      {structure.length > 0 ? (
+        <View style={styles.structureWrap}>
+          {structure.map((section, idx) => (
+            <View
+              key={`${section}-${idx}`}
+              style={[styles.sectionChip, { backgroundColor: primaryColor + "14" }]}
+            >
+              <Text style={[styles.sectionText, { color: colors.text }]} numberOfLines={1}>
+                {section}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {charts.length > 0 ? (
+        <View style={styles.chartsWrap}>
+          {charts.map((chart, idx) => {
+            const label = chart.key ? `${chart.label} (${chart.key})` : chart.label;
+            const disabled = !chart.url;
+            return (
+              <Pressable
+                key={`${chart.fileKey}-${idx}`}
+                onPress={() => chart.url && void openExternal(chart.url)}
+                disabled={disabled}
+                accessibilityRole="button"
+                accessibilityLabel={`Open chart: ${label}`}
+                style={[
+                  styles.chartBtn,
+                  { borderColor: colors.border, opacity: disabled ? 0.5 : 1 },
+                ]}
+              >
+                <Ionicons name="document-text-outline" size={16} color={primaryColor} />
+                <Text style={[styles.chartText, { color: colors.text }]} numberOfLines={1}>
+                  {label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
+
+      {multitracksUrl ? (
+        <Pressable
+          onPress={() => void openExternal(multitracksUrl)}
+          accessibilityRole="button"
+          accessibilityLabel="Rehearse multitracks"
+          style={[styles.multitracksBtn, { backgroundColor: primaryColor }]}
+        >
+          <Ionicons name="musical-notes" size={16} color="#fff" />
+          <Text style={styles.multitracksText}>Rehearse multitracks</Text>
+          <Ionicons name="open-outline" size={15} color="#fff" />
+        </Pressable>
+      ) : null}
+      {multitracksUrl ? (
+        <Text style={[styles.multitracksHint, { color: colors.textTertiary }]}>
+          Opens your provider (MultiTracks, etc.) — Togather doesn't host audio.
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBtn: { width: 36, padding: 4, alignItems: "center" },
+  headerTitle: { flex: 1, fontSize: 17, fontWeight: "600", textAlign: "center" },
+  centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  errorText: { fontSize: 14 },
+  scrollContent: { padding: 16 },
+  planTitle: { fontSize: 22, fontWeight: "700" },
+  planDate: { fontSize: 13, marginTop: 4 },
+  emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
+  list: { marginTop: 16, gap: 12 },
+  card: {
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  songTitle: { fontSize: 17, fontWeight: "700" },
+  songAuthor: { fontSize: 13, marginTop: 2 },
+  metaLine: { fontSize: 14, fontWeight: "600", marginTop: 8 },
+  arrangement: { fontSize: 13, marginTop: 4, fontStyle: "italic" },
+  structureWrap: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginTop: 10 },
+  sectionChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  sectionText: { fontSize: 12, fontWeight: "600" },
+  chartsWrap: { gap: 8, marginTop: 12 },
+  chartBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  chartText: { fontSize: 14, fontWeight: "600", flexShrink: 1 },
+  multitracksBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 11,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    marginTop: 12,
+  },
+  multitracksText: { fontSize: 14, fontWeight: "700", color: "#fff" },
+  multitracksHint: { fontSize: 11, marginTop: 6, lineHeight: 15 },
+});

--- a/apps/mobile/features/scheduling/components/MusicianRehearsalScreen.tsx
+++ b/apps/mobile/features/scheduling/components/MusicianRehearsalScreen.tsx
@@ -46,9 +46,8 @@ import {
   type SongChart,
 } from "../utils/songRehearsal";
 
-// TODO(integration): the joined `item.song` is typed locally via
-// `../utils/songRehearsal` until `features/songs/types` lands and the orchestrator
-// unifies the two. `getEvent` / `listItems` will return these shapes per ADR-027.
+// The joined `item.song` shape (returned by `getEvent` / `listItems` per
+// ADR-027) is typed via `Song` re-exported from `features/songs/types`.
 
 type RehearsalItem = {
   _id: Id<"eventItems">;

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -47,8 +47,11 @@ import {
   formatServiceRanges,
   totalDurationSec,
 } from "../utils/runSheetTiming";
+import { useAuth } from "@providers/AuthProvider";
 import { InlineText } from "./InlineText";
 import { RunSheetDragList } from "./RunSheetDragList";
+import { SongPicker } from "./SongPicker";
+import type { Song } from "@features/songs/types";
 
 /** When an item happens relative to the event's service times. */
 type Segment = "before" | "during" | "after";
@@ -88,6 +91,10 @@ type RunSheetItem = {
   durationSec: number;
   notes: Array<{ category: string; content: string }>;
   songDetails: { key?: string; bpm?: number; author?: string } | null;
+  // Link to a library song (ADR-027). When set, the joined `song` carries the
+  // defaults; `songDetails.key`/`.bpm` become per-service overrides of them.
+  songId: Id<"songs"> | null;
+  song: Song | null;
   assignments: ItemAssignment[];
 };
 
@@ -123,6 +130,8 @@ type ItemPatch = {
   notes?: Array<{ category: string; content: string }>;
   assignments?: Array<{ roleId: Id<"teamRoles"> }>;
   songDetails?: { key?: string; bpm?: number };
+  // Link / unlink a library song. `null` clears the link (ADR-027).
+  songId?: Id<"songs"> | null;
 };
 
 export function RunSheetScreen() {
@@ -130,8 +139,13 @@ export function RunSheetScreen() {
   const { primaryColor } = useCommunityTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { plan_id } = useLocalSearchParams<{ plan_id: string }>();
+  const { community } = useAuth();
+  const { plan_id, group_id } = useLocalSearchParams<{
+    plan_id: string;
+    group_id: string;
+  }>();
   const planId = plan_id as Id<"eventPlans">;
+  const communityId = community?.id ?? "";
 
   const event = useAuthenticatedQuery(
     api.functions.scheduling.events.getEvent,
@@ -405,6 +419,8 @@ export function RunSheetScreen() {
                     <EditableRow
                       item={row.item}
                       clockMs={clockTimes[row.item._id]}
+                      communityId={communityId}
+                      groupId={group_id ?? ""}
                       roleOptions={roleOptions}
                       peopleByRole={peopleByRole}
                       autoFocus={focusId === (row.item._id as string)}
@@ -495,6 +511,8 @@ function AddButton({
 function EditableRow({
   item,
   clockMs,
+  communityId,
+  groupId,
   roleOptions,
   peopleByRole,
   autoFocus,
@@ -506,6 +524,8 @@ function EditableRow({
 }: {
   item: RunSheetItem;
   clockMs: number | null;
+  communityId: string;
+  groupId: string;
   roleOptions: RoleOption[];
   peopleByRole: Record<string, string[]>;
   autoFocus: boolean;
@@ -691,38 +711,57 @@ function EditableRow({
           </View>
 
           {isSong ? (
-            <View style={styles.songRow}>
-              <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Key</Text>
-              <InlineText
-                value={item.songDetails?.key ?? ""}
-                onSave={(key) =>
-                  onPatch({
-                    songDetails: { key: key.trim() || undefined, bpm: item.songDetails?.bpm },
-                  })
+            <>
+              {/* Link this row to a library song (ADR-027). Free-typed rows
+                  (no songId) keep working — the picker just stays unlinked. */}
+              <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Song</Text>
+              <SongPicker
+                communityId={communityId}
+                groupId={groupId}
+                songId={item.songId}
+                song={item.song}
+                onSelect={(songId) =>
+                  onPatch({ songId: songId as Id<"songs"> | null })
                 }
-                placeholder="—"
-                maxLength={8}
-                accessibilityLabel="Song key"
-                style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
               />
-              <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>BPM</Text>
-              <InlineText
-                value={item.songDetails?.bpm ? String(item.songDetails.bpm) : ""}
-                onSave={(bpm) =>
-                  onPatch({
-                    songDetails: {
-                      key: item.songDetails?.key,
-                      bpm: parseInt(bpm, 10) || undefined,
-                    },
-                  })
-                }
-                placeholder="—"
-                keyboardType="number-pad"
-                maxLength={3}
-                accessibilityLabel="Song BPM"
-                style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
-              />
-            </View>
+
+              {/* Key / BPM. When a song is linked these are PER-SERVICE
+                  OVERRIDES: the value is only the override (blank if none),
+                  the placeholder is the song's default, and saving writes
+                  songDetails. Display elsewhere resolves override ?? default. */}
+              <View style={styles.songRow}>
+                <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Key</Text>
+                <InlineText
+                  value={item.songDetails?.key ?? ""}
+                  onSave={(key) =>
+                    onPatch({
+                      songDetails: { key: key.trim() || undefined, bpm: item.songDetails?.bpm },
+                    })
+                  }
+                  placeholder={item.song?.defaultKey ?? "—"}
+                  maxLength={8}
+                  accessibilityLabel="Song key"
+                  style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
+                />
+                <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>BPM</Text>
+                <InlineText
+                  value={item.songDetails?.bpm ? String(item.songDetails.bpm) : ""}
+                  onSave={(bpm) =>
+                    onPatch({
+                      songDetails: {
+                        key: item.songDetails?.key,
+                        bpm: parseInt(bpm, 10) || undefined,
+                      },
+                    })
+                  }
+                  placeholder={item.song?.bpm ? String(item.song.bpm) : "—"}
+                  keyboardType="number-pad"
+                  maxLength={3}
+                  accessibilityLabel="Song BPM"
+                  style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
+                />
+              </View>
+            </>
           ) : null}
 
           <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Description</Text>

--- a/apps/mobile/features/scheduling/components/SongPicker.tsx
+++ b/apps/mobile/features/scheduling/components/SongPicker.tsx
@@ -19,6 +19,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useAuth } from "@providers/AuthProvider";
 import {
   useAuthenticatedQuery,
   useAuthenticatedMutation,
@@ -26,6 +27,7 @@ import {
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import type { Song } from "@features/songs/types";
+import { notify } from "@/utils/platformAlert";
 
 export interface SongPickerProps {
   /** Community the song library belongs to. */
@@ -53,6 +55,11 @@ export function SongPicker({
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const router = useRouter();
+  const { user } = useAuth();
+  // Creating a library song is community-admin-only (backend `requireCommunityAdmin`).
+  // Plan schedulers who aren't admins can still link existing songs, but the
+  // inline Create affordance is hidden so it can't reject under them.
+  const canCreate = !!user?.is_admin;
   const [query, setQuery] = useState("");
 
   const songs = useAuthenticatedQuery(
@@ -90,12 +97,19 @@ export function SongPicker({
 
   const handleCreate = async () => {
     if (!trimmed) return;
-    const newId = await createSong({
-      communityId: communityId as Id<"communities">,
-      input: { title: trimmed },
-    });
-    setQuery("");
-    onSelect(newId as unknown as string);
+    try {
+      const newId = await createSong({
+        communityId: communityId as Id<"communities">,
+        input: { title: trimmed },
+      });
+      setQuery("");
+      onSelect(newId as unknown as string);
+    } catch (e: any) {
+      notify(
+        "Couldn't create song",
+        e?.data?.message ?? e?.message ?? "Please try again.",
+      );
+    }
   };
 
   // Linked state: show the song + clear / change controls.
@@ -166,7 +180,7 @@ export function SongPicker({
             </Text>
           </Pressable>
         ))}
-        {trimmed && !exactExists ? (
+        {trimmed && !exactExists && canCreate ? (
           <Pressable
             onPress={handleCreate}
             style={[styles.createRow, { borderColor: primaryColor }]}

--- a/apps/mobile/features/scheduling/components/SongPicker.tsx
+++ b/apps/mobile/features/scheduling/components/SongPicker.tsx
@@ -1,0 +1,250 @@
+/**
+ * SongPicker (ADR-027)
+ *
+ * Mounted in the run sheet song-item editor (RunSheetScreen). Lets a scheduler
+ * link a run sheet song row to a library `Song`:
+ *  - search the community library by title / author / CCLI#
+ *  - tap a result to link it (calls `onSelect(songId)` → updateItem)
+ *  - "Create" a new song inline from the typed query, then link it
+ *  - "Clear" to unlink (`onSelect(null)`)
+ *  - "Manage song library" jumps to the full library screen
+ *
+ * The picker stays presentational about the item itself — it owns library
+ * search + create, but delegates the actual `updateItem({ songId })` write to
+ * `onSelect` so RunSheetScreen keeps a single mutation wiring point.
+ */
+import React, { useMemo, useState } from "react";
+import { View, Text, StyleSheet, Pressable, TextInput } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Song } from "@features/songs/types";
+
+export interface SongPickerProps {
+  /** Community the song library belongs to. */
+  communityId: string;
+  /** Group context, used to route to the library screen. */
+  groupId: string;
+  /** Currently linked song id, if any. */
+  songId: string | null | undefined;
+  /** The joined song doc for the linked id, if any. */
+  song: Song | null | undefined;
+  /**
+   * Link / unlink the item. Receives the chosen song id, or `null` to clear.
+   * RunSheetScreen wires this to `updateItem({ songId })`.
+   */
+  onSelect: (songId: string | null) => void;
+}
+
+export function SongPicker({
+  communityId,
+  groupId,
+  songId,
+  song,
+  onSelect,
+}: SongPickerProps) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+
+  const songs = useAuthenticatedQuery(
+    api.functions.scheduling.songs.listSongs,
+    communityId ? { communityId } : "skip",
+  ) as Song[] | null | undefined;
+
+  const createSong = useAuthenticatedMutation(
+    api.functions.scheduling.songs.createSong,
+  );
+
+  const trimmed = query.trim();
+  const results = useMemo(() => {
+    const all = songs ?? [];
+    if (!trimmed) return all;
+    const q = trimmed.toLowerCase();
+    return all.filter(
+      (s) =>
+        s.title.toLowerCase().includes(q) ||
+        (s.author ?? "").toLowerCase().includes(q) ||
+        (s.ccliNumber ?? "").toLowerCase().includes(q),
+    );
+  }, [songs, trimmed]);
+
+  // Offer "create" when the typed title doesn't already exist verbatim.
+  const exactExists = useMemo(
+    () =>
+      (songs ?? []).some(
+        (s) => s.title.toLowerCase() === trimmed.toLowerCase(),
+      ),
+    [songs, trimmed],
+  );
+
+  const handleCreate = async () => {
+    if (!trimmed) return;
+    const newId = await createSong({
+      communityId,
+      input: { title: trimmed },
+    });
+    setQuery("");
+    onSelect(newId as unknown as string);
+  };
+
+  // Linked state: show the song + clear / change controls.
+  if (songId && song) {
+    return (
+      <View style={styles.container}>
+        <View
+          style={[
+            styles.linkedRow,
+            { backgroundColor: colors.surface, borderColor: colors.border },
+          ]}
+        >
+          <Ionicons name="musical-notes" size={16} color={primaryColor} />
+          <Text style={[styles.linkedTitle, { color: colors.text }]} numberOfLines={1}>
+            {song.title}
+          </Text>
+          {song.defaultKey ? (
+            <Text style={[styles.linkedMeta, { color: colors.textSecondary }]}>
+              {song.defaultKey}
+            </Text>
+          ) : null}
+          <Pressable
+            onPress={() => onSelect(null)}
+            hitSlop={8}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.clearText, { color: colors.textSecondary }]}>
+              Clear
+            </Text>
+          </Pressable>
+        </View>
+        <ManageLibraryLink
+          colors={colors}
+          primaryColor={primaryColor}
+          onPress={() => router.push(`/rostering/${groupId}/songs`)}
+        />
+      </View>
+    );
+  }
+
+  // Unlinked: search + pick / create.
+  return (
+    <View style={styles.container}>
+      <TextInput
+        value={query}
+        onChangeText={setQuery}
+        placeholder="Search songs…"
+        placeholderTextColor={colors.inputPlaceholder}
+        accessibilityLabel="Search songs"
+        style={[
+          styles.search,
+          { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
+        ]}
+      />
+      <View style={styles.results}>
+        {results.map((s) => (
+          <Pressable
+            key={s._id}
+            onPress={() => onSelect(s._id)}
+            style={[styles.resultRow, { borderColor: colors.border }]}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.resultTitle, { color: colors.text }]} numberOfLines={1}>
+              {s.title}
+            </Text>
+            <Text style={[styles.resultMeta, { color: colors.textSecondary }]} numberOfLines={1}>
+              {[s.author, s.defaultKey].filter(Boolean).join(" · ")}
+            </Text>
+          </Pressable>
+        ))}
+        {trimmed && !exactExists ? (
+          <Pressable
+            onPress={handleCreate}
+            style={[styles.createRow, { borderColor: primaryColor }]}
+            accessibilityRole="button"
+          >
+            <Ionicons name="add" size={16} color={primaryColor} />
+            <Text style={[styles.createText, { color: primaryColor }]} numberOfLines={1}>
+              Create "{trimmed}"
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+      <ManageLibraryLink
+        colors={colors}
+        primaryColor={primaryColor}
+        onPress={() => router.push(`/rostering/${groupId}/songs`)}
+      />
+    </View>
+  );
+}
+
+function ManageLibraryLink({
+  colors,
+  primaryColor,
+  onPress,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable onPress={onPress} style={styles.manageRow} accessibilityRole="button">
+      <Ionicons name="library-outline" size={14} color={primaryColor} />
+      <Text style={[styles.manageText, { color: primaryColor }]}>
+        Manage song library
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: 6 },
+  linkedRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+  },
+  linkedTitle: { flex: 1, fontSize: 14, fontWeight: "600" },
+  linkedMeta: { fontSize: 13, fontWeight: "600" },
+  clearText: { fontSize: 13, fontWeight: "600" },
+  search: {
+    fontSize: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+  },
+  results: { gap: 4 },
+  resultRow: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+  },
+  resultTitle: { fontSize: 14, fontWeight: "600" },
+  resultMeta: { fontSize: 12, marginTop: 1 },
+  createRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+  },
+  createText: { fontSize: 14, fontWeight: "600", flexShrink: 1 },
+  manageRow: { flexDirection: "row", alignItems: "center", gap: 4, paddingVertical: 4 },
+  manageText: { fontSize: 13, fontWeight: "600" },
+});

--- a/apps/mobile/features/scheduling/components/SongPicker.tsx
+++ b/apps/mobile/features/scheduling/components/SongPicker.tsx
@@ -24,6 +24,7 @@ import {
   useAuthenticatedMutation,
   api,
 } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
 import type { Song } from "@features/songs/types";
 
 export interface SongPickerProps {
@@ -56,7 +57,9 @@ export function SongPicker({
 
   const songs = useAuthenticatedQuery(
     api.functions.scheduling.songs.listSongs,
-    communityId ? { communityId } : "skip",
+    communityId
+      ? { communityId: communityId as Id<"communities"> }
+      : "skip",
   ) as Song[] | null | undefined;
 
   const createSong = useAuthenticatedMutation(
@@ -88,7 +91,7 @@ export function SongPicker({
   const handleCreate = async () => {
     if (!trimmed) return;
     const newId = await createSong({
-      communityId,
+      communityId: communityId as Id<"communities">,
       input: { title: trimmed },
     });
     setQuery("");

--- a/apps/mobile/features/scheduling/components/__tests__/AssignmentDetailScreen.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/AssignmentDetailScreen.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { AssignmentDetailScreen } from "../AssignmentDetailScreen";
+import { useAuthenticatedQuery } from "@services/api/convex";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    canGoBack: () => true,
+    back: jest.fn(),
+    push: mockPush,
+    replace: jest.fn(),
+  }),
+  useLocalSearchParams: () => ({ id: "assignment-1" }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      surface: "#fff",
+      surfaceSecondary: "#f5f5f5",
+      text: "#000",
+      textSecondary: "#666",
+      textTertiary: "#999",
+      border: "#e5e5e5",
+      success: "#16a34a",
+      destructive: "#dc2626",
+      primary: "#2563EB",
+    },
+    isDark: false,
+  }),
+}));
+
+jest.mock("../../hooks/useRespondToAssignment", () => ({
+  useRespondToAssignment: () => ({
+    respond: jest.fn(),
+    declineWith: jest.fn(),
+    busyId: null,
+  }),
+}));
+
+jest.mock("../DeclineNoteModal", () => ({
+  DeclineNoteModal: () => null,
+}));
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      scheduling: {
+        mySchedule: {
+          myAssignments: "api.functions.scheduling.mySchedule.myAssignments",
+        },
+        events: { getEvent: "api.functions.scheduling.events.getEvent" },
+      },
+    },
+  },
+  useAuthenticatedQuery: jest.fn(),
+}));
+
+const mockQuery = useAuthenticatedQuery as jest.Mock;
+
+const ASSIGNMENT = {
+  _id: "assignment-1",
+  planId: "plan-1",
+  eventTitle: "Sunday Gathering",
+  eventDate: new Date("2026-06-14T10:00:00").getTime(),
+  roleName: "Acoustic Guitar",
+  teamName: "Worship",
+  status: "confirmed",
+};
+
+function mockQueries(event: unknown) {
+  mockQuery.mockImplementation((ref: string) => {
+    if (ref === "api.functions.scheduling.mySchedule.myAssignments") {
+      return [ASSIGNMENT];
+    }
+    if (ref === "api.functions.scheduling.events.getEvent") return event;
+    return undefined;
+  });
+}
+
+describe("AssignmentDetailScreen — rehearse entry point", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows a 'Rehearse songs' row when the plan's run sheet has songs", () => {
+    mockQueries({
+      groupId: "group-1",
+      roles: [],
+      items: [
+        { _id: "item-1", type: "song", title: "Build My Life" },
+        { _id: "item-2", type: "item", title: "Announcements" },
+      ],
+    });
+
+    const { getByText } = render(<AssignmentDetailScreen />);
+
+    fireEvent.press(getByText("Rehearse songs"));
+    expect(mockPush).toHaveBeenCalledWith(
+      "/rostering/group-1/run-sheet/rehearse/plan-1",
+    );
+  });
+
+  it("hides the row when the run sheet has no songs", () => {
+    mockQueries({
+      groupId: "group-1",
+      roles: [],
+      items: [{ _id: "item-2", type: "item", title: "Announcements" }],
+    });
+
+    const { queryByText } = render(<AssignmentDetailScreen />);
+    expect(queryByText("Rehearse songs")).toBeNull();
+  });
+
+  it("hides the row while the event is still loading", () => {
+    mockQueries(undefined);
+
+    const { queryByText } = render(<AssignmentDetailScreen />);
+    expect(queryByText("Rehearse songs")).toBeNull();
+  });
+});

--- a/apps/mobile/features/scheduling/components/__tests__/MusicianRehearsalScreen.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/MusicianRehearsalScreen.test.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { Linking } from "react-native";
+import { fireEvent, render } from "@testing-library/react-native";
+import { MusicianRehearsalScreen } from "../MusicianRehearsalScreen";
+import { useAuthenticatedQuery } from "@services/api/convex";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    canGoBack: () => true,
+    back: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+  useLocalSearchParams: () => ({ plan_id: "plan-1", group_id: "group-1" }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      surface: "#fff",
+      surfaceSecondary: "#f5f5f5",
+      text: "#000",
+      textSecondary: "#666",
+      textTertiary: "#999",
+      border: "#e5e5e5",
+    },
+    isDark: false,
+  }),
+}));
+
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
+}));
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      scheduling: {
+        events: { getEvent: "api.functions.scheduling.events.getEvent" },
+        eventItems: {
+          listItems: "api.functions.scheduling.eventItems.listItems",
+        },
+      },
+    },
+  },
+  useAuthenticatedQuery: jest.fn(),
+}));
+
+const mockQuery = useAuthenticatedQuery as jest.Mock;
+
+const EVENT = {
+  _id: "plan-1",
+  title: "Sunday Gathering",
+  eventDate: new Date("2026-06-14T10:00:00").getTime(),
+};
+
+/** Wire getEvent + listItems based on the query reference passed. */
+function mockQueries(items: unknown) {
+  mockQuery.mockImplementation((ref: string) => {
+    if (ref === "api.functions.scheduling.events.getEvent") return EVENT;
+    if (ref === "api.functions.scheduling.eventItems.listItems") return items;
+    return undefined;
+  });
+}
+
+describe("MusicianRehearsalScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(true as never);
+  });
+
+  it("renders each song with its effective key and BPM", () => {
+    mockQueries([
+      {
+        _id: "item-1",
+        type: "song",
+        title: "Free-typed title",
+        // Override key present; BPM falls back to the library song default.
+        songDetails: { key: "A" },
+        song: {
+          _id: "song-1",
+          title: "Build My Life",
+          defaultKey: "G",
+          bpm: 68,
+          meter: "4/4",
+          arrangementName: "Acoustic",
+          structure: ["Intro", "Verse 1", "Chorus"],
+          charts: [],
+        },
+      },
+    ]);
+
+    const { getByText, queryByText } = render(<MusicianRehearsalScreen />);
+
+    // Library title wins over the free-typed item title.
+    expect(getByText("Build My Life")).toBeTruthy();
+    expect(queryByText("Free-typed title")).toBeNull();
+    // Effective key = override "A"; effective BPM = song default 68; meter 4/4.
+    expect(getByText("Key A  ·  68 BPM  ·  4/4")).toBeTruthy();
+    expect(getByText("Acoustic")).toBeTruthy();
+    expect(getByText("Intro")).toBeTruthy();
+    expect(getByText("Chorus")).toBeTruthy();
+  });
+
+  it("opens a chart file when its button is pressed", () => {
+    mockQueries([
+      {
+        _id: "item-1",
+        type: "song",
+        title: "Song",
+        song: {
+          _id: "song-1",
+          title: "Build My Life",
+          charts: [
+            {
+              key: "G",
+              label: "Chord Chart",
+              fileKey: "r2:charts/abc.pdf",
+              mimeType: "application/pdf",
+              url: "https://cdn.example.com/abc.pdf",
+            },
+          ],
+        },
+      },
+    ]);
+
+    const { getByText } = render(<MusicianRehearsalScreen />);
+    fireEvent.press(getByText("Chord Chart (G)"));
+    expect(Linking.openURL).toHaveBeenCalledWith("https://cdn.example.com/abc.pdf");
+  });
+
+  it("opens the multitracks provider link externally", () => {
+    mockQueries([
+      {
+        _id: "item-1",
+        type: "song",
+        title: "Song",
+        song: {
+          _id: "song-1",
+          title: "Build My Life",
+          multitracksUrl: "https://www.multitracks.com/songs/build-my-life",
+        },
+      },
+    ]);
+
+    const { getByText } = render(<MusicianRehearsalScreen />);
+    fireEvent.press(getByText("Rehearse multitracks"));
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      "https://www.multitracks.com/songs/build-my-life",
+    );
+  });
+
+  it("renders a free-typed song row that has no linked library song", () => {
+    mockQueries([
+      {
+        _id: "item-1",
+        type: "song",
+        title: "Spontaneous Worship",
+        songDetails: { key: "D" },
+        song: null,
+      },
+    ]);
+
+    const { getByText } = render(<MusicianRehearsalScreen />);
+    expect(getByText("Spontaneous Worship")).toBeTruthy();
+    expect(getByText("Key D")).toBeTruthy();
+  });
+
+  it("only lists song-type items, ignoring headers and generic items", () => {
+    mockQueries([
+      { _id: "h", type: "header", title: "Welcome" },
+      { _id: "i", type: "item", title: "Announcements" },
+      {
+        _id: "s",
+        type: "song",
+        title: "Opener",
+        song: { _id: "song-1", title: "Opener" },
+      },
+    ]);
+
+    const { getByText, queryByText } = render(<MusicianRehearsalScreen />);
+    expect(getByText("Opener")).toBeTruthy();
+    expect(queryByText("Welcome")).toBeNull();
+    expect(queryByText("Announcements")).toBeNull();
+  });
+
+  it("shows an empty state when there are no songs", () => {
+    mockQueries([{ _id: "h", type: "header", title: "Welcome" }]);
+    const { getByText } = render(<MusicianRehearsalScreen />);
+    expect(getByText(/No songs on this run sheet/i)).toBeTruthy();
+  });
+});

--- a/apps/mobile/features/scheduling/components/__tests__/SongPicker.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/SongPicker.test.tsx
@@ -31,6 +31,16 @@ jest.mock("@hooks/useCommunityTheme", () => ({
   useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
 }));
 
+let mockIsAdmin = true;
+jest.mock("@providers/AuthProvider", () => ({
+  useAuth: () => ({ user: { is_admin: mockIsAdmin } }),
+}));
+
+const mockNotify = jest.fn();
+jest.mock("@/utils/platformAlert", () => ({
+  notify: (...args: unknown[]) => mockNotify(...args),
+}));
+
 jest.mock("@services/api/convex", () => ({
   api: {
     functions: {
@@ -68,6 +78,7 @@ describe("SongPicker", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsAdmin = true;
     onSelect = jest.fn();
     (useAuthenticatedQuery as jest.Mock).mockImplementation(
       (fn: string, args: unknown) => {
@@ -169,6 +180,48 @@ describe("SongPicker", () => {
       });
       expect(onSelect).toHaveBeenCalledWith("song-new");
     });
+  });
+
+  it("hides the inline Create action for non-admins (createSong is admin-only)", () => {
+    mockIsAdmin = false;
+    const { getByPlaceholderText, queryByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId={null}
+        song={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    // A non-admin can still search/link existing songs…
+    fireEvent.changeText(getByPlaceholderText("Search songs…"), "Brand New Song");
+    // …but the inline Create affordance (which would hit the admin-only
+    // createSong guard) is not offered.
+    expect(queryByText('Create "Brand New Song"')).toBeNull();
+  });
+
+  it("surfaces an error instead of failing silently when createSong rejects", async () => {
+    const createSong = jest
+      .fn()
+      .mockRejectedValue(new Error("Only community admins can do that"));
+    (useAuthenticatedMutation as jest.Mock).mockReturnValue(createSong);
+
+    const { getByPlaceholderText, getByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId={null}
+        song={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText("Search songs…"), "Brand New Song");
+    fireEvent.press(getByText('Create "Brand New Song"'));
+
+    await waitFor(() => expect(mockNotify).toHaveBeenCalled());
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it("navigates to the song library when Manage song library is pressed", () => {

--- a/apps/mobile/features/scheduling/components/__tests__/SongPicker.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/SongPicker.test.tsx
@@ -1,0 +1,187 @@
+import React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { SongPicker } from "../SongPicker";
+import {
+  useAuthenticatedMutation,
+  useAuthenticatedQuery,
+} from "@services/api/convex";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      text: "#000",
+      textSecondary: "#555",
+      textTertiary: "#999",
+      surface: "#fff",
+      surfaceSecondary: "#eee",
+      border: "#ccc",
+      buttonPrimary: "#2563EB",
+      inputPlaceholder: "#aaa",
+    },
+  }),
+}));
+
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
+}));
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      scheduling: {
+        songs: {
+          listSongs: "api.functions.scheduling.songs.listSongs",
+          createSong: "api.functions.scheduling.songs.createSong",
+        },
+      },
+    },
+  },
+  useAuthenticatedQuery: jest.fn(),
+  useAuthenticatedMutation: jest.fn(),
+}));
+
+const SONGS = [
+  {
+    _id: "song-1",
+    communityId: "community-1",
+    title: "Amazing Grace",
+    author: "John Newton",
+    defaultKey: "G",
+    bpm: 72,
+  },
+  {
+    _id: "song-2",
+    communityId: "community-1",
+    title: "How Great Thou Art",
+    defaultKey: "C",
+  },
+];
+
+describe("SongPicker", () => {
+  let onSelect: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onSelect = jest.fn();
+    (useAuthenticatedQuery as jest.Mock).mockImplementation(
+      (fn: string, args: unknown) => {
+        if (args === "skip") return undefined;
+        if (fn === "api.functions.scheduling.songs.listSongs") return SONGS;
+        return undefined;
+      },
+    );
+    (useAuthenticatedMutation as jest.Mock).mockReturnValue(jest.fn());
+  });
+
+  it("shows the linked song's title when a song is selected", () => {
+    const { getByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId="song-1"
+        song={SONGS[0] as any}
+        onSelect={onSelect}
+      />,
+    );
+    expect(getByText("Amazing Grace")).toBeTruthy();
+  });
+
+  it("lists and filters library songs when searching", async () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId={null}
+        song={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    // Both songs available from the library query.
+    expect(getByText("Amazing Grace")).toBeTruthy();
+    expect(getByText("How Great Thou Art")).toBeTruthy();
+
+    // Typing narrows the list to client-side matches.
+    const search = getByPlaceholderText("Search songs…");
+    fireEvent.changeText(search, "Amazing");
+    await waitFor(() => {
+      expect(getByText("Amazing Grace")).toBeTruthy();
+      expect(queryByText("How Great Thou Art")).toBeNull();
+    });
+  });
+
+  it("calls onSelect with the song id when a result is tapped", () => {
+    const { getByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId={null}
+        song={null}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.press(getByText("How Great Thou Art"));
+    expect(onSelect).toHaveBeenCalledWith("song-2");
+  });
+
+  it("calls onSelect with null when Clear is pressed on a linked song", () => {
+    const { getByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId="song-1"
+        song={SONGS[0] as any}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.press(getByText("Clear"));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("creates a new song then links it", async () => {
+    const createSong = jest.fn().mockResolvedValue("song-new");
+    (useAuthenticatedMutation as jest.Mock).mockReturnValue(createSong);
+
+    const { getByPlaceholderText, getByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId={null}
+        song={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    // Type a query that doesn't match, then create from it.
+    fireEvent.changeText(getByPlaceholderText("Search songs…"), "Brand New Song");
+    fireEvent.press(getByText('Create "Brand New Song"'));
+
+    await waitFor(() => {
+      expect(createSong).toHaveBeenCalledWith({
+        communityId: "community-1",
+        input: { title: "Brand New Song" },
+      });
+      expect(onSelect).toHaveBeenCalledWith("song-new");
+    });
+  });
+
+  it("navigates to the song library when Manage song library is pressed", () => {
+    const { getByText } = render(
+      <SongPicker
+        communityId="community-1"
+        groupId="group-1"
+        songId={null}
+        song={null}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.press(getByText("Manage song library"));
+    expect(mockPush).toHaveBeenCalledWith("/rostering/group-1/songs");
+  });
+});

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -20,6 +20,7 @@ export {
 export { EventListScreen } from "./components/EventListScreen";
 export { EventEditorScreen } from "./components/EventEditorScreen";
 export { RunSheetScreen } from "./components/RunSheetScreen";
+export { MusicianRehearsalScreen } from "./components/MusicianRehearsalScreen";
 export { MyScheduleScreen } from "./components/MyScheduleScreen";
 export { MyAvailabilityScreen } from "./components/MyAvailabilityScreen";
 export { RosterGridScreen } from "./components/RosterGridScreen";

--- a/apps/mobile/features/scheduling/utils/__tests__/songRehearsal.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/songRehearsal.test.ts
@@ -1,0 +1,79 @@
+import { effectiveKey, effectiveBpm } from "../songRehearsal";
+
+describe("effectiveKey", () => {
+  it("prefers the per-occurrence override over the song default", () => {
+    const item = {
+      songDetails: { key: "G" },
+      song: { _id: "s1", title: "Song", defaultKey: "C" },
+    };
+    expect(effectiveKey(item)).toBe("G");
+  });
+
+  it("falls back to the song's default key when no override", () => {
+    const item = {
+      songDetails: { bpm: 72 },
+      song: { _id: "s1", title: "Song", defaultKey: "C" },
+    };
+    expect(effectiveKey(item)).toBe("C");
+  });
+
+  it("falls back to the default when songDetails is null", () => {
+    const item = {
+      songDetails: null,
+      song: { _id: "s1", title: "Song", defaultKey: "C" },
+    };
+    expect(effectiveKey(item)).toBe("C");
+  });
+
+  it("returns undefined when neither override nor default is present", () => {
+    const item = {
+      songDetails: { bpm: 72 },
+      song: { _id: "s1", title: "Song" },
+    };
+    expect(effectiveKey(item)).toBeUndefined();
+  });
+
+  it("returns undefined for a free-typed item with no song", () => {
+    const item = { songDetails: null };
+    expect(effectiveKey(item)).toBeUndefined();
+  });
+});
+
+describe("effectiveBpm", () => {
+  it("prefers the per-occurrence override over the song default", () => {
+    const item = {
+      songDetails: { bpm: 80 },
+      song: { _id: "s1", title: "Song", bpm: 72 },
+    };
+    expect(effectiveBpm(item)).toBe(80);
+  });
+
+  it("falls back to the song's default bpm when no override", () => {
+    const item = {
+      songDetails: { key: "G" },
+      song: { _id: "s1", title: "Song", bpm: 72 },
+    };
+    expect(effectiveBpm(item)).toBe(72);
+  });
+
+  it("falls back to the default when songDetails is null", () => {
+    const item = {
+      songDetails: null,
+      song: { _id: "s1", title: "Song", bpm: 72 },
+    };
+    expect(effectiveBpm(item)).toBe(72);
+  });
+
+  it("returns undefined when neither override nor default is present", () => {
+    const item = {
+      songDetails: { key: "G" },
+      song: { _id: "s1", title: "Song" },
+    };
+    expect(effectiveBpm(item)).toBeUndefined();
+  });
+
+  it("returns undefined for a free-typed item with no song", () => {
+    const item = { songDetails: null };
+    expect(effectiveBpm(item)).toBeUndefined();
+  });
+});

--- a/apps/mobile/features/scheduling/utils/songRehearsal.ts
+++ b/apps/mobile/features/scheduling/utils/songRehearsal.ts
@@ -6,46 +6,34 @@
  * (`item.song`). Worship teams routinely transpose the same song week to week,
  * so the override always wins when present; otherwise the library default shows.
  *
- * These are pure so the rehearsal view (and tests) can resolve values without
- * touching Convex.
+ * The resolution itself lives once in `features/songs/utils/songOverride`; these
+ * are thin item-shaped adapters so the rehearsal view can resolve values from a
+ * whole run sheet item without touching Convex.
  */
+import type { Song, SongChart } from "@features/songs/types";
+import {
+  resolveSongBpm,
+  resolveSongKey,
+} from "@features/songs/utils/songOverride";
 
-// TODO(integration): import { Song } from "features/songs/types" once the shared
-// types file lands. Until then this minimal local fallback mirrors that shape.
-export interface SongChart {
-  key?: string;
-  label: string;
-  fileKey: string;
-  mimeType: string;
-  url?: string;
-}
+export type { Song, SongChart };
 
-export interface Song {
-  _id: string;
-  title: string;
-  author?: string;
-  ccliNumber?: string;
-  defaultKey?: string;
-  bpm?: number;
-  meter?: string;
-  arrangementName?: string;
-  structure?: string[];
-  charts?: SongChart[];
-  multitracksUrl?: string;
-}
-
-/** The slice of a run sheet item this module reads. */
+/**
+ * The slice of a run sheet item this module reads. `song` is widened to a
+ * partial of the library `Song` because the resolvers only touch `defaultKey` /
+ * `bpm`, and callers (and tests) supply just the joined fields they have.
+ */
 export interface SongRehearsalItem {
   songDetails?: { key?: string; bpm?: number; author?: string } | null;
-  song?: Song | null;
+  song?: Partial<Song> | null;
 }
 
 /** Effective display key: per-occurrence override, else the song's default. */
 export function effectiveKey(item: SongRehearsalItem): string | undefined {
-  return item.songDetails?.key ?? item.song?.defaultKey;
+  return resolveSongKey(item.songDetails, item.song);
 }
 
 /** Effective display BPM: per-occurrence override, else the song's default. */
 export function effectiveBpm(item: SongRehearsalItem): number | undefined {
-  return item.songDetails?.bpm ?? item.song?.bpm;
+  return resolveSongBpm(item.songDetails, item.song);
 }

--- a/apps/mobile/features/scheduling/utils/songRehearsal.ts
+++ b/apps/mobile/features/scheduling/utils/songRehearsal.ts
@@ -1,0 +1,51 @@
+/**
+ * Musician rehearsal helpers (ADR-027).
+ *
+ * A run sheet `song` item resolves its display key/BPM by layering a
+ * per-occurrence override (`item.songDetails`) over the library song's defaults
+ * (`item.song`). Worship teams routinely transpose the same song week to week,
+ * so the override always wins when present; otherwise the library default shows.
+ *
+ * These are pure so the rehearsal view (and tests) can resolve values without
+ * touching Convex.
+ */
+
+// TODO(integration): import { Song } from "features/songs/types" once the shared
+// types file lands. Until then this minimal local fallback mirrors that shape.
+export interface SongChart {
+  key?: string;
+  label: string;
+  fileKey: string;
+  mimeType: string;
+  url?: string;
+}
+
+export interface Song {
+  _id: string;
+  title: string;
+  author?: string;
+  ccliNumber?: string;
+  defaultKey?: string;
+  bpm?: number;
+  meter?: string;
+  arrangementName?: string;
+  structure?: string[];
+  charts?: SongChart[];
+  multitracksUrl?: string;
+}
+
+/** The slice of a run sheet item this module reads. */
+export interface SongRehearsalItem {
+  songDetails?: { key?: string; bpm?: number; author?: string } | null;
+  song?: Song | null;
+}
+
+/** Effective display key: per-occurrence override, else the song's default. */
+export function effectiveKey(item: SongRehearsalItem): string | undefined {
+  return item.songDetails?.key ?? item.song?.defaultKey;
+}
+
+/** Effective display BPM: per-occurrence override, else the song's default. */
+export function effectiveBpm(item: SongRehearsalItem): number | undefined {
+  return item.songDetails?.bpm ?? item.song?.bpm;
+}

--- a/apps/mobile/features/songs/__tests__/songOverride.test.ts
+++ b/apps/mobile/features/songs/__tests__/songOverride.test.ts
@@ -1,0 +1,28 @@
+import { resolveSongKey, resolveSongBpm } from "../utils/songOverride";
+
+describe("song per-service override resolution (ADR-027)", () => {
+  it("prefers the per-item override key over the library default", () => {
+    expect(
+      resolveSongKey({ key: "A" }, { defaultKey: "G" } as any),
+    ).toBe("A");
+  });
+
+  it("falls back to the library default key when no override", () => {
+    expect(resolveSongKey(null, { defaultKey: "G" } as any)).toBe("G");
+    expect(resolveSongKey({}, { defaultKey: "G" } as any)).toBe("G");
+  });
+
+  it("returns undefined when neither override nor song default is set", () => {
+    expect(resolveSongKey(null, null)).toBeUndefined();
+    expect(resolveSongKey({}, {} as any)).toBeUndefined();
+  });
+
+  it("prefers the per-item override bpm over the library default", () => {
+    expect(resolveSongBpm({ bpm: 80 }, { bpm: 72 } as any)).toBe(80);
+  });
+
+  it("falls back to the library default bpm when no override", () => {
+    expect(resolveSongBpm(null, { bpm: 72 } as any)).toBe(72);
+    expect(resolveSongBpm({}, { bpm: 72 } as any)).toBe(72);
+  });
+});

--- a/apps/mobile/features/songs/components/SongLibraryScreen.tsx
+++ b/apps/mobile/features/songs/components/SongLibraryScreen.tsx
@@ -26,7 +26,7 @@ import {
   Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
@@ -36,6 +36,7 @@ import {
   useAuthenticatedMutation,
   api,
 } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
 import {
   useFileUpload,
   type SelectedFile,
@@ -81,7 +82,10 @@ export function SongLibraryScreen() {
   const songs = useAuthenticatedQuery(
     api.functions.scheduling.songs.listSongs,
     communityId
-      ? { communityId, ...(search.trim() ? { search: search.trim() } : {}) }
+      ? {
+          communityId: communityId as Id<"communities">,
+          ...(search.trim() ? { search: search.trim() } : {}),
+        }
       : "skip",
   ) as Song[] | null | undefined;
 
@@ -281,9 +285,12 @@ function SongEditor({
     setSaving(true);
     try {
       if (song) {
-        await updateSong({ songId: song._id, patch: input });
+        await updateSong({ songId: song._id as Id<"songs">, patch: input });
       } else {
-        await createSong({ communityId, input });
+        await createSong({
+          communityId: communityId as Id<"communities">,
+          input,
+        });
       }
       onClose();
     } catch (e: any) {
@@ -296,7 +303,7 @@ function SongEditor({
   const handleDelete = useCallback(() => {
     if (!song) return;
     confirmDestructive(`Delete "${song.title}" from the library?`, () => {
-      void deleteSong({ songId: song._id })
+      void deleteSong({ songId: song._id as Id<"songs"> })
         .then(onClose)
         .catch((e: any) =>
           notifyError("Couldn't delete", e?.message ?? "Please try again."),
@@ -333,7 +340,7 @@ function SongEditor({
         return;
       }
       await attachChart({
-        songId: song._id,
+        songId: song._id as Id<"songs">,
         chart: {
           label: defaultKey.trim()
             ? `${file.name} (${defaultKey.trim()})`
@@ -351,7 +358,7 @@ function SongEditor({
   const handleRemoveChart = useCallback(
     (fileKey: string) => {
       if (!song) return;
-      void removeChart({ songId: song._id, fileKey }).catch((e: any) =>
+      void removeChart({ songId: song._id as Id<"songs">, fileKey }).catch((e: any) =>
         notifyError("Couldn't remove chart", e?.message ?? "Please try again."),
       );
     },

--- a/apps/mobile/features/songs/components/SongLibraryScreen.tsx
+++ b/apps/mobile/features/songs/components/SongLibraryScreen.tsx
@@ -1,0 +1,639 @@
+/**
+ * SongLibraryScreen (ADR-027)
+ *
+ * The per-community song library management screen. Lists the community's songs
+ * (searchable), and lets leaders / community admins create, edit, and delete
+ * songs, upload key-specific charts (reusing the existing R2 document-upload
+ * pipeline), and paste a multitracks link.
+ *
+ * Songs are community-scoped; the screen resolves the community from the active
+ * auth context. It is reached from the run sheet's SongPicker ("Manage song
+ * library") at `/rostering/[group_id]/songs`. Editing affordances are gated to
+ * community admins client-side; the backend enforces the real guard
+ * (`requireGroupLeaderOrCommunityAdmin`).
+ */
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useAuth } from "@providers/AuthProvider";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import {
+  useFileUpload,
+  type SelectedFile,
+} from "@features/chat/hooks/useFileUpload";
+import type { Song, SongInput } from "../types";
+
+/** One-button error that works on web (Alert.alert is a no-op on web here). */
+function notifyError(title: string, message: string) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);
+    return;
+  }
+  Alert.alert(title, message);
+}
+
+/** Confirm dialog that works on web (Alert.alert is a no-op on web here). */
+function confirmDestructive(prompt: string, onConfirm: () => void) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined" && window.confirm(prompt)) onConfirm();
+    return;
+  }
+  Alert.alert("Are you sure?", prompt, [
+    { text: "Cancel", style: "cancel" },
+    { text: "Delete", style: "destructive", onPress: onConfirm },
+  ]);
+}
+
+export function SongLibraryScreen() {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { user, community } = useAuth();
+  const communityId = community?.id as string | undefined;
+  // Community admins manage the library; leaders are also allowed by the
+  // backend guard, but `is_admin` is the signal available client-side here.
+  const canEdit = !!user?.is_admin;
+
+  const [search, setSearch] = useState("");
+  // The song currently open in the editor: `null` = closed, "new" = create.
+  const [editing, setEditing] = useState<Song | "new" | null>(null);
+
+  const songs = useAuthenticatedQuery(
+    api.functions.scheduling.songs.listSongs,
+    communityId
+      ? { communityId, ...(search.trim() ? { search: search.trim() } : {}) }
+      : "skip",
+  ) as Song[] | null | undefined;
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+  }, [router]);
+
+  const loading = songs === undefined;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      <View
+        style={[
+          styles.header,
+          { backgroundColor: colors.surface, borderBottomColor: colors.border },
+        ]}
+      >
+        <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBtn}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Song library</Text>
+        <View style={styles.headerBtn} />
+      </View>
+
+      {editing ? (
+        <SongEditor
+          song={editing === "new" ? null : editing}
+          communityId={communityId ?? ""}
+          onClose={() => setEditing(null)}
+        />
+      ) : (
+        <ScrollView
+          contentContainerStyle={[
+            styles.scrollContent,
+            { paddingBottom: insets.bottom + 96 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          <TextInput
+            value={search}
+            onChangeText={setSearch}
+            placeholder="Search songs…"
+            placeholderTextColor={colors.inputPlaceholder}
+            accessibilityLabel="Search songs"
+            style={[
+              styles.search,
+              { color: colors.text, borderColor: colors.border, backgroundColor: colors.surfaceSecondary },
+            ]}
+          />
+
+          {canEdit ? (
+            <Pressable
+              onPress={() => setEditing("new")}
+              style={[styles.addRow, { borderColor: primaryColor }]}
+              accessibilityRole="button"
+            >
+              <Ionicons name="add" size={18} color={primaryColor} />
+              <Text style={[styles.addText, { color: primaryColor }]}>Add song</Text>
+            </Pressable>
+          ) : null}
+
+          {loading ? (
+            <View style={styles.centered}>
+              <ActivityIndicator size="small" color={colors.text} />
+            </View>
+          ) : (songs ?? []).length === 0 ? (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              {search.trim()
+                ? "No songs match your search."
+                : "No songs yet. Add your worship songs here so run sheets can link to them."}
+            </Text>
+          ) : (
+            <View style={styles.list}>
+              {(songs ?? []).map((s) => (
+                <View
+                  key={s._id}
+                  style={[
+                    styles.songRow,
+                    { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                  ]}
+                >
+                  <View style={styles.songInfo}>
+                    <Text style={[styles.songTitle, { color: colors.text }]} numberOfLines={1}>
+                      {s.title}
+                    </Text>
+                    <Text style={[styles.songMeta, { color: colors.textSecondary }]} numberOfLines={1}>
+                      {[
+                        s.author,
+                        s.defaultKey ? `Key ${s.defaultKey}` : null,
+                        s.bpm ? `${s.bpm} BPM` : null,
+                        s.ccliNumber ? `CCLI ${s.ccliNumber}` : null,
+                      ]
+                        .filter(Boolean)
+                        .join(" · ") || "No details yet"}
+                    </Text>
+                    {s.charts && s.charts.length > 0 ? (
+                      <Text style={[styles.songCharts, { color: colors.textTertiary }]}>
+                        {s.charts.length} chart{s.charts.length === 1 ? "" : "s"}
+                      </Text>
+                    ) : null}
+                  </View>
+                  {canEdit ? (
+                    <Pressable
+                      onPress={() => setEditing(s)}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                    >
+                      <Text style={[styles.editText, { color: primaryColor }]}>Edit</Text>
+                    </Pressable>
+                  ) : null}
+                </View>
+              ))}
+            </View>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+/** Create / edit form for a single song. */
+function SongEditor({
+  song,
+  communityId,
+  onClose,
+}: {
+  song: Song | null;
+  communityId: string;
+  onClose: () => void;
+}) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+
+  const createSong = useAuthenticatedMutation(api.functions.scheduling.songs.createSong);
+  const updateSong = useAuthenticatedMutation(api.functions.scheduling.songs.updateSong);
+  const deleteSong = useAuthenticatedMutation(api.functions.scheduling.songs.deleteSong);
+  const attachChart = useAuthenticatedMutation(api.functions.scheduling.songs.attachChart);
+  const removeChart = useAuthenticatedMutation(api.functions.scheduling.songs.removeChart);
+  const { uploadFile, uploading, isAvailable: uploadAvailable } = useFileUpload();
+
+  const [title, setTitle] = useState(song?.title ?? "");
+  const [author, setAuthor] = useState(song?.author ?? "");
+  const [ccliNumber, setCcliNumber] = useState(song?.ccliNumber ?? "");
+  const [defaultKey, setDefaultKey] = useState(song?.defaultKey ?? "");
+  const [bpm, setBpm] = useState(song?.bpm ? String(song.bpm) : "");
+  const [meter, setMeter] = useState(song?.meter ?? "");
+  const [arrangementName, setArrangementName] = useState(song?.arrangementName ?? "");
+  const [structureText, setStructureText] = useState(
+    (song?.structure ?? []).join(", "),
+  );
+  const [multitracksUrl, setMultitracksUrl] = useState(song?.multitracksUrl ?? "");
+  const [notes, setNotes] = useState(song?.notes ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const buildInput = useCallback((): SongInput => {
+    const structure = structureText
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return {
+      title: title.trim(),
+      author: author.trim() || undefined,
+      ccliNumber: ccliNumber.trim() || undefined,
+      defaultKey: defaultKey.trim() || undefined,
+      bpm: bpm.trim() ? parseInt(bpm, 10) || undefined : undefined,
+      meter: meter.trim() || undefined,
+      arrangementName: arrangementName.trim() || undefined,
+      structure: structure.length > 0 ? structure : undefined,
+      multitracksUrl: multitracksUrl.trim() || undefined,
+      notes: notes.trim() || undefined,
+    };
+  }, [
+    title,
+    author,
+    ccliNumber,
+    defaultKey,
+    bpm,
+    meter,
+    arrangementName,
+    structureText,
+    multitracksUrl,
+    notes,
+  ]);
+
+  const handleSave = useCallback(async () => {
+    const input = buildInput();
+    if (!input.title) {
+      notifyError("Title required", "Give the song a title before saving.");
+      return;
+    }
+    setSaving(true);
+    try {
+      if (song) {
+        await updateSong({ songId: song._id, patch: input });
+      } else {
+        await createSong({ communityId, input });
+      }
+      onClose();
+    } catch (e: any) {
+      notifyError("Couldn't save", e?.data?.message ?? e?.message ?? "Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }, [buildInput, song, updateSong, createSong, communityId, onClose]);
+
+  const handleDelete = useCallback(() => {
+    if (!song) return;
+    confirmDestructive(`Delete "${song.title}" from the library?`, () => {
+      void deleteSong({ songId: song._id })
+        .then(onClose)
+        .catch((e: any) =>
+          notifyError("Couldn't delete", e?.message ?? "Please try again."),
+        );
+    });
+  }, [song, deleteSong, onClose]);
+
+  const handleUploadChart = useCallback(async () => {
+    if (!song) return;
+    if (!uploadAvailable) {
+      notifyError(
+        "Update required",
+        "Chart uploads require the latest version of the app.",
+      );
+      return;
+    }
+    try {
+      const DocumentPicker = require("expo-document-picker");
+      const result = await DocumentPicker.getDocumentAsync({
+        type: ["application/pdf", "image/*"],
+        copyToCacheDirectory: true,
+      });
+      if (result.canceled || !result.assets?.[0]) return;
+      const asset = result.assets[0];
+      const file: SelectedFile = {
+        uri: asset.uri,
+        name: asset.name || "chart",
+        size: asset.size || 0,
+        mimeType: asset.mimeType || "application/octet-stream",
+      };
+      const upload = await uploadFile(file);
+      if (upload.error || !upload.storagePath) {
+        notifyError("Upload failed", upload.error ?? "Please try again.");
+        return;
+      }
+      await attachChart({
+        songId: song._id,
+        chart: {
+          label: defaultKey.trim()
+            ? `${file.name} (${defaultKey.trim()})`
+            : file.name,
+          ...(defaultKey.trim() ? { key: defaultKey.trim() } : {}),
+          fileKey: upload.storagePath,
+          mimeType: file.mimeType,
+        },
+      });
+    } catch (e: any) {
+      notifyError("Upload failed", e?.message ?? "Please try again.");
+    }
+  }, [song, uploadAvailable, uploadFile, attachChart, defaultKey]);
+
+  const handleRemoveChart = useCallback(
+    (fileKey: string) => {
+      if (!song) return;
+      void removeChart({ songId: song._id, fileKey }).catch((e: any) =>
+        notifyError("Couldn't remove chart", e?.message ?? "Please try again."),
+      );
+    },
+    [song, removeChart],
+  );
+
+  return (
+    <ScrollView
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 48 }]}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={[styles.editorTitle, { color: colors.text }]}>
+        {song ? "Edit song" : "New song"}
+      </Text>
+
+      <Field label="Title" value={title} onChange={setTitle} colors={colors} />
+      <Field label="Author" value={author} onChange={setAuthor} colors={colors} />
+      <Field
+        label="CCLI number"
+        value={ccliNumber}
+        onChange={setCcliNumber}
+        keyboardType="number-pad"
+        colors={colors}
+      />
+      <Field label="Default key" value={defaultKey} onChange={setDefaultKey} colors={colors} />
+      <Field
+        label="BPM"
+        value={bpm}
+        onChange={setBpm}
+        keyboardType="number-pad"
+        colors={colors}
+      />
+      <Field label="Meter" value={meter} onChange={setMeter} colors={colors} placeholder="e.g. 4/4" />
+      <Field
+        label="Arrangement name"
+        value={arrangementName}
+        onChange={setArrangementName}
+        colors={colors}
+      />
+      <Field
+        label="Structure"
+        value={structureText}
+        onChange={setStructureText}
+        colors={colors}
+        placeholder="Intro, Verse 1, Chorus, …"
+      />
+      <Field
+        label="Multitracks URL"
+        value={multitracksUrl}
+        onChange={setMultitracksUrl}
+        colors={colors}
+        keyboardType="url"
+        placeholder="https://…"
+      />
+      <Field
+        label="Notes"
+        value={notes}
+        onChange={setNotes}
+        colors={colors}
+        multiline
+      />
+
+      {/* Charts — only available once the song exists (attach needs its id). */}
+      {song ? (
+        <View style={styles.chartsSection}>
+          <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Charts</Text>
+          {(song.charts ?? []).map((c) => (
+            <View
+              key={c.fileKey}
+              style={[styles.chartRow, { borderColor: colors.border }]}
+            >
+              <Ionicons name="document-text-outline" size={16} color={colors.textSecondary} />
+              <Text style={[styles.chartLabel, { color: colors.text }]} numberOfLines={1}>
+                {c.label}
+              </Text>
+              <Pressable
+                onPress={() => handleRemoveChart(c.fileKey)}
+                hitSlop={8}
+                accessibilityLabel={`Remove chart ${c.label}`}
+              >
+                <Ionicons name="close" size={16} color={colors.textTertiary} />
+              </Pressable>
+            </View>
+          ))}
+          <Pressable
+            onPress={handleUploadChart}
+            disabled={uploading}
+            style={[styles.uploadRow, { borderColor: primaryColor }]}
+            accessibilityRole="button"
+          >
+            {uploading ? (
+              <ActivityIndicator size="small" color={primaryColor} />
+            ) : (
+              <Ionicons name="cloud-upload-outline" size={16} color={primaryColor} />
+            )}
+            <Text style={[styles.uploadText, { color: primaryColor }]}>Upload chart</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <Text style={[styles.hint, { color: colors.textTertiary }]}>
+          Save the song first to attach charts.
+        </Text>
+      )}
+
+      <View style={styles.actions}>
+        <Pressable
+          onPress={onClose}
+          style={[styles.secondaryBtn, { borderColor: colors.border }]}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.secondaryBtnText, { color: colors.text }]}>Cancel</Text>
+        </Pressable>
+        <Pressable
+          onPress={handleSave}
+          disabled={saving}
+          style={[styles.primaryBtn, { backgroundColor: primaryColor, opacity: saving ? 0.6 : 1 }]}
+          accessibilityRole="button"
+        >
+          <Text style={styles.primaryBtnText}>Save</Text>
+        </Pressable>
+      </View>
+
+      {song ? (
+        <Pressable onPress={handleDelete} style={styles.deleteRow} accessibilityRole="button">
+          <Ionicons name="trash-outline" size={16} color={colors.error ?? "#C4564A"} />
+          <Text style={[styles.deleteText, { color: colors.error ?? "#C4564A" }]}>
+            Delete song
+          </Text>
+        </Pressable>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  colors,
+  keyboardType,
+  multiline,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+  keyboardType?: React.ComponentProps<typeof TextInput>["keyboardType"];
+  multiline?: boolean;
+  placeholder?: string;
+}) {
+  return (
+    <View style={styles.field}>
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChange}
+        accessibilityLabel={label}
+        keyboardType={keyboardType}
+        multiline={multiline}
+        placeholder={placeholder}
+        placeholderTextColor={colors.inputPlaceholder}
+        style={[
+          styles.input,
+          multiline && styles.inputMultiline,
+          { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBtn: { width: 36, padding: 4, alignItems: "center" },
+  headerTitle: { flex: 1, fontSize: 17, fontWeight: "600", textAlign: "center" },
+  centered: { alignItems: "center", justifyContent: "center", padding: 24 },
+  scrollContent: { padding: 16 },
+  search: {
+    fontSize: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+  },
+  addRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderRadius: 10,
+    paddingVertical: 12,
+    marginTop: 12,
+  },
+  addText: { fontSize: 14, fontWeight: "600" },
+  emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
+  list: { marginTop: 12, gap: 8 },
+  songRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    padding: 12,
+  },
+  songInfo: { flex: 1 },
+  songTitle: { fontSize: 15, fontWeight: "600" },
+  songMeta: { fontSize: 12, marginTop: 2 },
+  songCharts: { fontSize: 11, marginTop: 2 },
+  editText: { fontSize: 14, fontWeight: "600" },
+  editorTitle: { fontSize: 20, fontWeight: "700", marginBottom: 8 },
+  field: { marginTop: 10 },
+  fieldLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    marginBottom: 4,
+  },
+  input: {
+    fontSize: 15,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+  },
+  inputMultiline: { minHeight: 64, textAlignVertical: "top" },
+  chartsSection: { marginTop: 16 },
+  chartRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    marginBottom: 6,
+  },
+  chartLabel: { flex: 1, fontSize: 13 },
+  uploadRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderRadius: 8,
+    paddingVertical: 10,
+  },
+  uploadText: { fontSize: 14, fontWeight: "600" },
+  hint: { fontSize: 12, marginTop: 16, fontStyle: "italic" },
+  actions: { flexDirection: "row", gap: 10, marginTop: 24 },
+  secondaryBtn: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  secondaryBtnText: { fontSize: 15, fontWeight: "600" },
+  primaryBtn: {
+    flex: 1,
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  primaryBtnText: { fontSize: 15, fontWeight: "700", color: "#fff" },
+  deleteRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    marginTop: 20,
+  },
+  deleteText: { fontSize: 14, fontWeight: "600" },
+});

--- a/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
+++ b/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
@@ -1,0 +1,259 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { SongLibraryScreen } from "../SongLibraryScreen";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+} from "@services/api/convex";
+import { useFileUpload } from "@features/chat/hooks/useFileUpload";
+
+const mockBack = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ canGoBack: () => true, back: mockBack }),
+  useLocalSearchParams: () => ({ group_id: "group-1" }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      text: "#000",
+      textSecondary: "#555",
+      textTertiary: "#999",
+      surface: "#fff",
+      surfaceSecondary: "#eee",
+      border: "#ccc",
+      buttonPrimary: "#2563EB",
+      inputPlaceholder: "#aaa",
+    },
+  }),
+}));
+
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
+}));
+
+let mockUser: { is_admin?: boolean } = { is_admin: true };
+jest.mock("@providers/AuthProvider", () => ({
+  useAuth: () => ({ community: { id: "community-1" }, user: mockUser }),
+}));
+
+jest.mock("@features/chat/hooks/useFileUpload", () => ({
+  useFileUpload: jest.fn(),
+}));
+
+jest.mock(
+  "expo-document-picker",
+  () => ({
+    getDocumentAsync: jest.fn().mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: "file://chart.pdf",
+          name: "chart.pdf",
+          size: 1000,
+          mimeType: "application/pdf",
+        },
+      ],
+    }),
+  }),
+  { virtual: true },
+);
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      scheduling: {
+        songs: {
+          listSongs: "api.functions.scheduling.songs.listSongs",
+          createSong: "api.functions.scheduling.songs.createSong",
+          updateSong: "api.functions.scheduling.songs.updateSong",
+          deleteSong: "api.functions.scheduling.songs.deleteSong",
+          attachChart: "api.functions.scheduling.songs.attachChart",
+          removeChart: "api.functions.scheduling.songs.removeChart",
+        },
+      },
+    },
+  },
+  useAuthenticatedQuery: jest.fn(),
+  useAuthenticatedMutation: jest.fn(),
+}));
+
+const SONGS = [
+  {
+    _id: "song-1",
+    communityId: "community-1",
+    title: "Amazing Grace",
+    author: "John Newton",
+    defaultKey: "G",
+    bpm: 72,
+    charts: [
+      { label: "Lead sheet (G)", key: "G", fileKey: "r2:abc", mimeType: "application/pdf" },
+    ],
+  },
+  {
+    _id: "song-2",
+    communityId: "community-1",
+    title: "How Great Thou Art",
+    defaultKey: "C",
+  },
+];
+
+function setMutations(map: Record<string, jest.Mock>) {
+  (useAuthenticatedMutation as jest.Mock).mockImplementation((fn: string) => {
+    return map[fn] ?? jest.fn();
+  });
+}
+
+describe("SongLibraryScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = { is_admin: true };
+    (useAuthenticatedQuery as jest.Mock).mockImplementation(
+      (fn: string, args: unknown) => {
+        if (args === "skip") return undefined;
+        if (fn === "api.functions.scheduling.songs.listSongs") return SONGS;
+        return undefined;
+      },
+    );
+    setMutations({});
+    (useFileUpload as jest.Mock).mockReturnValue({
+      uploadFile: jest.fn(),
+      uploading: false,
+      progress: 0,
+      reset: jest.fn(),
+      isAvailable: true,
+    });
+  });
+
+  it("renders the community song list", () => {
+    const { getByText } = render(<SongLibraryScreen />);
+    expect(getByText("Amazing Grace")).toBeTruthy();
+    expect(getByText("How Great Thou Art")).toBeTruthy();
+  });
+
+  it("passes the search term to the query", () => {
+    const { getByPlaceholderText } = render(<SongLibraryScreen />);
+    fireEvent.changeText(getByPlaceholderText("Search songs…"), "grace");
+    const calls = (useAuthenticatedQuery as jest.Mock).mock.calls.filter(
+      (c) => c[0] === "api.functions.scheduling.songs.listSongs",
+    );
+    const last = calls[calls.length - 1];
+    expect(last[1]).toMatchObject({ communityId: "community-1", search: "grace" });
+  });
+
+  it("creates a song with the entered fields", async () => {
+    const createSong = jest.fn().mockResolvedValue("song-new");
+    setMutations({ "api.functions.scheduling.songs.createSong": createSong });
+
+    const { getByText, getByLabelText } = render(<SongLibraryScreen />);
+    fireEvent.press(getByText("Add song"));
+    fireEvent.changeText(getByLabelText("Title"), "New Song");
+    fireEvent.changeText(getByLabelText("Default key"), "D");
+    fireEvent.press(getByText("Save"));
+
+    await waitFor(() => {
+      expect(createSong).toHaveBeenCalledWith({
+        communityId: "community-1",
+        input: expect.objectContaining({ title: "New Song", defaultKey: "D" }),
+      });
+    });
+  });
+
+  it("updates a song when editing", async () => {
+    const updateSong = jest.fn().mockResolvedValue(undefined);
+    setMutations({ "api.functions.scheduling.songs.updateSong": updateSong });
+
+    const { getByText, getByLabelText, getAllByText } = render(<SongLibraryScreen />);
+    fireEvent.press(getAllByText("Edit")[0]);
+    fireEvent.changeText(getByLabelText("Author"), "J. Newton");
+    fireEvent.press(getByText("Save"));
+
+    await waitFor(() => {
+      expect(updateSong).toHaveBeenCalledWith({
+        songId: "song-1",
+        patch: expect.objectContaining({ author: "J. Newton" }),
+      });
+    });
+  });
+
+  it("deletes a song with confirmation", async () => {
+    const deleteSong = jest.fn().mockResolvedValue(undefined);
+    setMutations({ "api.functions.scheduling.songs.deleteSong": deleteSong });
+    // On native, the confirm uses Alert.alert; press its destructive button.
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_t, _m, buttons) => {
+        const destructive = (buttons ?? []).find((b) => b.style === "destructive");
+        destructive?.onPress?.();
+      });
+
+    const { getByText, getAllByText } = render(<SongLibraryScreen />);
+    fireEvent.press(getAllByText("Edit")[0]);
+    fireEvent.press(getByText("Delete song"));
+
+    await waitFor(() => {
+      expect(deleteSong).toHaveBeenCalledWith({ songId: "song-1" });
+    });
+    alertSpy.mockRestore();
+  });
+
+  it("uploads a chart and attaches it", async () => {
+    const attachChart = jest.fn().mockResolvedValue(undefined);
+    setMutations({ "api.functions.scheduling.songs.attachChart": attachChart });
+    const uploadFile = jest.fn().mockResolvedValue({
+      storagePath: "r2:newchart",
+      name: "chart.pdf",
+      category: "document",
+    });
+    (useFileUpload as jest.Mock).mockReturnValue({
+      uploadFile,
+      uploading: false,
+      progress: 0,
+      reset: jest.fn(),
+      isAvailable: true,
+    });
+
+    const { getByText, getAllByText } = render(<SongLibraryScreen />);
+    fireEvent.press(getAllByText("Edit")[0]);
+    fireEvent.press(getByText("Upload chart"));
+
+    await waitFor(() => {
+      expect(uploadFile).toHaveBeenCalled();
+      expect(attachChart).toHaveBeenCalledWith({
+        songId: "song-1",
+        chart: expect.objectContaining({
+          fileKey: "r2:newchart",
+          mimeType: "application/pdf",
+        }),
+      });
+    });
+  });
+
+  it("removes a chart", async () => {
+    const removeChart = jest.fn().mockResolvedValue(undefined);
+    setMutations({ "api.functions.scheduling.songs.removeChart": removeChart });
+
+    const { getByText, getByLabelText, getAllByText } = render(<SongLibraryScreen />);
+    fireEvent.press(getAllByText("Edit")[0]);
+    fireEvent.press(getByLabelText("Remove chart Lead sheet (G)"));
+
+    await waitFor(() => {
+      expect(removeChart).toHaveBeenCalledWith({
+        songId: "song-1",
+        fileKey: "r2:abc",
+      });
+    });
+  });
+
+  it("hides editing controls for non-admin members", () => {
+    mockUser = { is_admin: false };
+    const { queryByText } = render(<SongLibraryScreen />);
+    expect(queryByText("Add song")).toBeNull();
+    expect(queryByText("Edit")).toBeNull();
+  });
+});

--- a/apps/mobile/features/songs/index.ts
+++ b/apps/mobile/features/songs/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Songs feature — the native, per-community song library (ADR-027).
+ *
+ * @see /docs/architecture/ADR-027-native-song-library-and-worship-media.md
+ */
+export { SongLibraryScreen } from "./components/SongLibraryScreen";
+export type { Song, SongChart, SongInput } from "./types";
+export { resolveSongKey, resolveSongBpm } from "./utils/songOverride";

--- a/apps/mobile/features/songs/types.ts
+++ b/apps/mobile/features/songs/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared frontend types for the native Song Library (ADR-027).
+ *
+ * These mirror the backend `songs` table contract. The rehearsal view imports
+ * `Song` / `SongChart` from here, and the run sheet editor consumes the joined
+ * `item.song` shape. Keep these in sync with `functions/scheduling/songs.ts`.
+ */
+
+/** A key-specific chart file attached to a song (PDF/image in R2). */
+export interface SongChart {
+  /** Musical key this chart is for (e.g. "G"); optional if key-agnostic. */
+  key?: string;
+  /** Human label shown in the UI (e.g. "Lead sheet (G)"). */
+  label: string;
+  /** R2 object key from the document-upload pipeline. */
+  fileKey: string;
+  /** MIME type of the uploaded file. */
+  mimeType: string;
+  /** Resolved view URL, populated by the backend on read. */
+  url?: string;
+}
+
+/** A library song. Lives once per community; referenced by run sheet items. */
+export interface Song {
+  _id: string;
+  communityId: string;
+  title: string;
+  author?: string;
+  /** CCLI number — the universal worship-song ID; plain metadata for now. */
+  ccliNumber?: string;
+  defaultKey?: string;
+  bpm?: number;
+  meter?: string;
+  arrangementName?: string;
+  /** Section labels, e.g. ["Intro", "Verse 1", "Chorus"]. */
+  structure?: string[];
+  charts?: SongChart[];
+  /** Link-out to where the multitrack stems live; never re-hosted audio. */
+  multitracksUrl?: string;
+  notes?: string;
+}
+
+/** Editable fields for create/update (charts are managed separately). */
+export interface SongInput {
+  title: string;
+  author?: string;
+  ccliNumber?: string;
+  defaultKey?: string;
+  bpm?: number;
+  meter?: string;
+  arrangementName?: string;
+  structure?: string[];
+  multitracksUrl?: string;
+  notes?: string;
+}

--- a/apps/mobile/features/songs/utils/songOverride.ts
+++ b/apps/mobile/features/songs/utils/songOverride.ts
@@ -1,0 +1,27 @@
+/**
+ * Per-service override resolution for library-linked run sheet songs (ADR-027).
+ *
+ * A library `Song` carries the *defaults* (defaultKey, bpm); a run sheet item
+ * may override them for a specific service via its `songDetails` blob — worship
+ * teams routinely transpose the same song week to week. Display resolves the
+ * override first, then the library default.
+ */
+import type { Song } from "../types";
+
+type SongDetails = { key?: string; bpm?: number } | null | undefined;
+
+/** Resolved key for display: per-item override, else the song's default. */
+export function resolveSongKey(
+  songDetails: SongDetails,
+  song: Pick<Song, "defaultKey"> | null | undefined,
+): string | undefined {
+  return songDetails?.key ?? song?.defaultKey ?? undefined;
+}
+
+/** Resolved BPM for display: per-item override, else the song's default. */
+export function resolveSongBpm(
+  songDetails: SongDetails,
+  song: Pick<Song, "bpm"> | null | undefined,
+): number | undefined {
+  return songDetails?.bpm ?? song?.bpm ?? undefined;
+}

--- a/docs/architecture/ADR-027-native-song-library-and-worship-media.md
+++ b/docs/architecture/ADR-027-native-song-library-and-worship-media.md
@@ -1,0 +1,220 @@
+# ADR-027: Native Song Library & Worship Media
+
+> **Terminology.** Follows ADR-023/026. **Event Plan** is the dated rostering
+> entity (`eventPlans`); a **run sheet** is the ordered order-of-items for an
+> event plan; **run sheet items** are `eventItems`. PCO's product is "PCO
+> Services". A **song** here is a library entry in Togather, identified where
+> possible by its **CCLI number** (the worship world's universal song ID).
+
+## Status
+Accepted
+
+## Date
+2026-06-09
+
+## Context
+
+ADR-026 shipped the native run sheet (`eventItems`) and deliberately kept songs
+thin — a `songDetails: { key?, bpm?, author? }` blob on each item — explicitly
+deferring "Song library / CCLI / chord charts / arrangements" to "ADR-023
+Phase 3". Feedback from worship leaders is that this thinness misses the point
+of how worship teams actually run: songs are connected via **CCLI** and
+**multitracks** to Planning Center, which surfaces title/key/BPM/arrangement for
+the worship leader and audio engineers, and lets each musician open a song and
+rehearse *their specific part* from its multitrack stems. The run sheet's "song"
+row is the tip of a music workflow, not a label.
+
+The product goal (per the maintainer) is to **stop depending on Planning Center
+for anything** — including this. The critical reframe, confirmed by research
+(see "Licensing reality" below), is that **the music content was never PCO's to
+begin with**. PCO is an aggregator: it holds its *own* CCLI SongSelect Partner
+API agreement and a MultiTracks account-link integration, and surfaces what the
+*church's own* CCLI/MultiTracks subscriptions entitle it to. The songs,
+copyrighted charts, and multitrack stems originate at **CCLI** and
+**MultiTracks.com**, not Planning Center.
+
+### Licensing reality (why this shapes the design)
+
+Research into the CCLI and MultiTracks integration landscape (2025–2026)
+established three load-bearing facts:
+
+1. **Automated CCLI content requires two separate relationships, both
+   mandatory:** (a) a **vendor-held** CCLI SongSelect Partner API agreement
+   (Togather's own subscription key on every request — NDA-bound,
+   community-reported ~$1k/yr, and *possibly closed to new partners*), and
+   (b) the **church's own** SongSelect subscription connected via OAuth, which
+   governs which content may be surfaced. A church's license alone does **not**
+   grant a third party API access — you cannot "ride on the user's license" to
+   pull content programmatically.
+2. **MultiTracks has no open API or partner program.** All integrations (PCO,
+   ProPresenter) are privately negotiated. Stem audio is **never re-hosted** —
+   it stays in MultiTracks' player and requires the user's MultiTracks
+   subscription. "RehearsalMix" (the per-part rehearsal product) is delivered
+   only inside MultiTracks' own surfaces and host integrations.
+3. **The church already holds the rights.** A church with a CCLI Copyright
+   License + SongSelect subscription + Streaming Plus (or MultiTracks' Church
+   Streaming License) is licensed to download its own charts and use its own
+   purchased stems. Letting *them* import content *they* are licensed for keeps
+   the legal burden on the license holder and needs **no vendor agreement at
+   all**. This "bring-your-own" model is dramatically cheaper, faster, and
+   legally cleaner than an official API integration.
+
+**Consequence for "PCO independence":** a native song library plus
+bring-your-own media achieves the goal **completely** — none of it needs PCO.
+The only thing we cannot *natively own* is automated, always-fresh CCLI/​
+MultiTracks content, and that is not a PCO dependency: it is the church's own
+licensed content, brought in by the church.
+
+## Decision
+
+Add a **native, per-community song library** and let run sheet song items
+reference it, plus **bring-your-own** charts and multitrack links so musicians
+can rehearse. No CCLI/MultiTracks API integration; no re-hosting of copyrighted
+stems. The official-API path is documented but deferred indefinitely (Phase 3),
+gated on a business agreement rather than engineering.
+
+### Data model: a new `songs` table, referenced by `eventItems`
+
+A song lives once in the community's library and is referenced by run sheet
+items, so editing a song's charts/metadata updates every plan that uses it (no
+copied-string drift — the same principle ADR-026 applied to role assignments).
+
+```ts
+songs: defineTable({
+  communityId: v.id("communities"),
+  title: v.string(),
+  author: v.optional(v.string()),
+  ccliNumber: v.optional(v.string()),     // universal song ID; the join key
+  defaultKey: v.optional(v.string()),
+  bpm: v.optional(v.number()),
+  meter: v.optional(v.string()),          // e.g. "4/4"
+  arrangementName: v.optional(v.string()),
+  structure: v.optional(v.array(v.string())), // ["Intro","Verse 1","Chorus",...]
+  // --- Bring-your-own media (Phase 2) ---
+  // Charts are key-specific in worship; store one file per key. fileKey is the
+  // R2 object key from the existing document-upload pipeline (functions/uploads.ts).
+  charts: v.optional(v.array(v.object({
+    key: v.optional(v.string()),
+    label: v.string(),
+    fileKey: v.string(),
+    mimeType: v.string(),
+  }))),
+  // A link-out to where the stems live (MultiTracks/Loop Community). We store a
+  // URL, never the audio. Audio stays in the provider's ecosystem (licensing).
+  multitracksUrl: v.optional(v.string()),
+  notes: v.optional(v.string()),
+  createdAt: v.number(),
+  createdById: v.id("users"),
+  updatedAt: v.number(),
+})
+  .index("by_community", ["communityId"])
+  .index("by_community_ccli", ["communityId", "ccliNumber"]),
+```
+
+`eventItems` gains an optional link to the library:
+
+```ts
+// added to eventItems (ADR-026)
+songId: v.optional(v.id("songs")),
+```
+
+The existing `eventItems.songDetails` blob is **retained as a per-occurrence
+override**, not replaced. A library song carries the *defaults* (default key,
+BPM); a run sheet item may override them for a specific service — worship teams
+routinely transpose the same song week to week. Display resolves
+`item.songDetails.key ?? song.defaultKey` (and likewise BPM). An item with a
+`songId` but no `songDetails` simply shows the library defaults. An item with
+neither remains a free-typed song row (backwards compatible — nothing migrates).
+
+### CCLI number is the join key, not a foreign integration
+
+`ccliNumber` is stored as a plain string the leader enters (or leaves blank). It
+is the stable identity that a *future* Phase-3 CCLI/MultiTracks integration would
+match on, but it has **no live dependency** today — it is metadata. This keeps
+the universal ID in our data now without coupling us to any external service.
+
+### Bring-your-own media (Phase 2)
+
+- **Charts:** uploaded through the existing R2 document pipeline
+  (`functions/uploads.ts` already allows `.pdf`/images) and attached per key on
+  the song. The church holds the SongSelect license that lets it download these;
+  Togather only stores the church's own file. Copyright lines are the church's
+  responsibility and are shown alongside the chart.
+- **Multitracks:** a **link-out** field per song (and an optional per-item
+  override). We deep-link to the church's MultiTracks/Loop Community song; we do
+  **not** embed a player or host audio. Tapping it opens the provider, where the
+  musician's own subscription and RehearsalMix live.
+- **Musician rehearsal view:** a read-only, per-person view of an event plan's
+  run sheet that lists the songs (key, structure, chart to view, multitracks
+  link), so a volunteer assigned to a plan can open it and rehearse ahead of
+  time. "Solo my part" is **not** rebuilt — that is RehearsalMix, reached via the
+  multitracks link. This resolves ADR-026's open question #1 (volunteers seeing
+  the run sheet read-only) for the song dimension.
+
+### Permissions reuse existing guards
+
+No new permission concept. **Editing the song library** requires
+`requireGroupLeaderOrCommunityAdmin` (the guard `uploads.ts`/`groups` already
+use). **Linking a song to a run sheet item** reuses ADR-026's
+`requirePlanScheduler`. **Viewing** songs/charts/links in a run sheet requires
+`requireGroupMember`; the musician rehearsal view is available to members
+assigned to the plan (read-only).
+
+### Backend surface
+
+A small `functions/scheduling/songs.ts` (queries: `listSongs`, `getSong`;
+mutations: `createSong`, `updateSong`, `deleteSong`, plus `attachChart` /
+`removeChart` building on the existing upload mutations). `eventItems.updateItem`
+gains `songId` in its patch. `listItems`/`getEvent` join the referenced song so
+the run sheet renders title/charts/links without extra round-trips.
+
+### Frontend surface
+
+- A **song picker** in the run sheet item editor (`RunSheetScreen`): search the
+  community library by title/CCLI#, or "create new song". Selecting sets
+  `songId`; key/BPM fields become per-service overrides of the song's defaults.
+- A **Song Library** management screen (community/leader scope) to add songs,
+  edit metadata, upload charts, and paste a multitracks link.
+- The **musician rehearsal view**, reachable from a volunteer's plan/run sheet.
+
+## Deliberately out of scope (v1)
+
+- **Official CCLI SongSelect Partner API integration** — deferred to Phase 3,
+  gated on a business/NDA agreement that may not be available to new partners.
+  Engineering would be moderate (OAuth + sync, like the existing PCO path); the
+  blocker is commercial, not technical.
+- **Official MultiTracks integration / account-connect / embedded RehearsalMix**
+  — no open program exists; deferred indefinitely. We link out only.
+- **Re-hosting stem audio or copyrighted charts we don't own** — never; a
+  licensing non-starter.
+- **Transposition / chord-chart rendering** — we display the church's uploaded
+  key-specific files; we do not transpose ChordPro.
+- **Cross-community shared/global song catalog** — songs are per-community.
+
+## Consequences
+
+- A church can build its order-of-items **and** its song library entirely in
+  Togather, fully independent of Planning Center, including the worship-leader/
+  audio-engineer metadata and a path for musicians to rehearse.
+- The remaining reliance for charts/stems is on the **church's own** licensed
+  files and provider accounts — not on PCO — satisfying the independence goal
+  with the cleanest available legal posture.
+- `songs` is a child of `communities`; deleting a community cascades to it.
+  Deleting a song must null out (`songId`) referencing `eventItems` rather than
+  orphan them — the item falls back to its `songDetails`/title.
+- The CCLI number is captured now, so a future Phase-3 integration has a join key
+  to match on without a data backfill.
+- Two song representations coexist briefly (free-typed `songDetails`-only items
+  and library-linked items); the picker nudges toward the library, and nothing
+  is force-migrated (ADR-024).
+
+## Open questions
+
+1. Should charts be viewable by **all** assigned volunteers, or gated further
+   (some churches restrict sheet music)? Default to plan-assigned members;
+   revisit if a church needs tighter control.
+2. Should the song library be seedable/importable from an existing PCO plan
+   (one-time map of a plan's songs → `songs`, carrying CCLI#s) to ease the
+   switch? Likely a useful migration aid; deferred to a follow-up.
+3. Per-item multitracks override vs. song-level only — start song-level; add the
+   per-item override if a real "different mix this week" need appears.


### PR DESCRIPTION
## Summary

Implements **ADR-027** (included in this PR): a native, per-community song library plus bring-your-own worship media, so churches can run their full worship workflow in Togather with **no Planning Center dependency**. Follows worship-leader feedback that run sheet songs need CCLI/key/BPM metadata and a way for musicians to rehearse their parts.

### Backend (Convex)
- New `songs` table (per-community, keyed on CCLI number) with key/BPM/meter/arrangement/structure, chart attachments (R2), and a multitracks link-out (audio is never re-hosted — licensing).
- `eventItems.songId` links run sheet song items to the library; `songDetails` is retained as a **per-service override** (`songDetails.key ?? song.defaultKey`).
- `functions/scheduling/songs.ts`: `listSongs` / `getSong` / `createSong` / `updateSong` / `deleteSong` (nulls referencing items via new `by_song` index) / `attachChart` / `removeChart`.
- `listItems` / `getEvent` join the linked song (with resolved chart URLs).
- Permissions reuse existing guards: community-admin for library edits, community-member for reads, `requirePlanScheduler` for linking.

### Frontend (mobile)
- **Song Library** screen at `/rostering/[group_id]/songs` — search, create/edit/delete, chart upload via the existing R2 pipeline, multitracks URL.
- **SongPicker** in the run sheet editor — link/unlink/create songs; key & BPM fields become per-service overrides. Free-typed song rows unchanged.
- **Musician rehearsal view** at `/rostering/[group_id]/run-sheet/rehearse/[plan_id]` — read-only per-plan song list with effective key/BPM, chart open, multitracks link-out.
- Entry points: "Rehearse" on the member-facing native run sheet, and "Rehearse songs" on the My Schedule assignment detail.

### Docs
- `docs/architecture/ADR-027-native-song-library-and-worship-media.md` — records the decision, the CCLI/MultiTracks licensing findings (vendor API agreements required; stems can't be re-hosted), and why bring-your-own achieves PCO independence. Official CCLI/MultiTracks integrations deferred to Phase 3 (business-gated).

## Testing
- Convex: 12 new `songs` tests; full scheduling suite 178/178 ✅
- Mobile: 38 new tests (SongLibraryScreen, SongPicker, MusicianRehearsalScreen, AssignmentDetailScreen, override/rehearsal utils) ✅; existing RunSheetScreen 45/45 ✅
- Typecheck & lint clean on all new code

**Note:** `_generated/api.d.ts` was hand-registered for the new `songs` module (codegen needs a live deployment, unavailable in the sandbox); deploy-time codegen will regenerate it.

https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo)_