### PR TITLE
Let group leaders manage the song library (ADR-027 follow-up)

### DIFF
--- a/apps/convex/__tests__/scheduling/songs.test.ts
+++ b/apps/convex/__tests__/scheduling/songs.test.ts
@@ -310,6 +310,46 @@ describe("songs permissions", () => {
       }),
     ).rejects.toThrow(ConvexError);
   });
+
+  it("lets a group leader (not a community admin) manage the library", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token: leaderToken,
+      communityId: world.communityId,
+      input: { title: "Leader's pick" },
+    });
+    expect(songId).toBeTruthy();
+    await t.mutation(api.functions.scheduling.songs.updateSong, {
+      token: leaderToken,
+      songId,
+      patch: { defaultKey: "A" },
+    });
+    await t.mutation(api.functions.scheduling.songs.deleteSong, {
+      token: leaderToken,
+      songId,
+    });
+  });
+
+  it("canManageSongs reflects admin/leader vs plain member", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const outsiderToken = (await generateTokens(world.outsiderId)).accessToken;
+
+    const call = (token: string) =>
+      t.query(api.functions.scheduling.songs.canManageSongs, {
+        token,
+        communityId: world.communityId,
+      });
+
+    expect(await call(adminToken)).toBe(true);
+    expect(await call(leaderToken)).toBe(true);
+    expect(await call(memberToken)).toBe(false);
+    expect(await call(outsiderToken)).toBe(false);
+  });
 });
 
 describe("eventItems ⇄ song integration", () => {

--- a/apps/convex/__tests__/scheduling/songs.test.ts
+++ b/apps/convex/__tests__/scheduling/songs.test.ts
@@ -332,6 +332,33 @@ describe("songs permissions", () => {
     });
   });
 
+  it("does not grant edit rights from a leader role on an archived group", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Archive the only group the user leads; their membership is retained.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(world.groupId, {
+        isArchived: true,
+        archivedAt: Date.now(),
+      });
+    });
+
+    expect(
+      await t.query(api.functions.scheduling.songs.canManageSongs, {
+        token: leaderToken,
+        communityId: world.communityId,
+      }),
+    ).toBe(false);
+    await expect(
+      t.mutation(api.functions.scheduling.songs.createSong, {
+        token: leaderToken,
+        communityId: world.communityId,
+        input: { title: "From an archived group" },
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
   it("canManageSongs reflects admin/leader vs plain member", async () => {
     const { t, world } = await setupSchedulingWorld();
     const adminToken = (await generateTokens(world.communityAdminId)).accessToken;

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -253,7 +253,11 @@ export async function isCommunityGroupLeader(
   for (const m of memberships) {
     if (!isLeaderRole(m.role)) continue;
     const group = await ctx.db.get(m.groupId);
-    if (group && group.communityId === communityId) return true;
+    // Archived groups don't confer active leader status (memberships are
+    // retained on archive), matching how leader status is derived elsewhere.
+    if (group && group.communityId === communityId && !group.isArchived) {
+      return true;
+    }
   }
   return false;
 }

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -236,20 +236,57 @@ export async function requireCommunityMember(
 }
 
 /**
- * Require that `userId` is an admin of `communityId`. Community-scoped edit gate
- * for the song library (ADR-027) — the closest existing community-admin concept
- * (`isCommunityAdmin`), wrapped to throw `ConvexError` for the mobile client.
- *
- * @throws ConvexError if the caller is not a community admin.
+ * Whether `userId` leads at least one group in `communityId`. The worship /
+ * ministry leader who builds run sheets is a group leader (ADR-027), so song
+ * library management is open to them, not only community admins.
  */
-export async function requireCommunityAdmin(
+export async function isCommunityGroupLeader(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const memberships = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .collect();
+  for (const m of memberships) {
+    if (!isLeaderRole(m.role)) continue;
+    const group = await ctx.db.get(m.groupId);
+    if (group && group.communityId === communityId) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether `userId` may edit the community song library (ADR-027): a community
+ * admin OR a leader of any group in the community. Used both to gate mutations
+ * (`requireCommunitySongEditor`) and to drive UI affordances (`canManageSongs`).
+ */
+export async function canEditCommunitySongs(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  if (await isCommunityAdmin(ctx, communityId, userId)) return true;
+  return isCommunityGroupLeader(ctx, communityId, userId);
+}
+
+/**
+ * Require that `userId` may edit the community song library (ADR-027): a
+ * community admin or a group leader in the community. Throws `ConvexError`
+ * (not a plain `Error`) so the mobile `AuthErrorBoundary` can recover.
+ *
+ * @throws ConvexError if the caller is neither.
+ */
+export async function requireCommunitySongEditor(
   ctx: QueryCtx | MutationCtx,
   communityId: Id<"communities">,
   userId: Id<"users">,
 ): Promise<void> {
-  if (!(await isCommunityAdmin(ctx, communityId, userId))) {
+  if (!(await canEditCommunitySongs(ctx, communityId, userId))) {
     throw new ConvexError(
-      "You must be a community admin to manage the song library",
+      "You must be a group leader or community admin to manage the song library",
     );
   }
 }

--- a/apps/convex/functions/scheduling/songs.ts
+++ b/apps/convex/functions/scheduling/songs.ts
@@ -9,8 +9,9 @@
  * the `fileKey` and resolve the served `url` on read via `getMediaUrl`, the same
  * helper other media features use. `multitracksUrl` is a link-out, never audio.
  *
- * Permissions reuse existing guards: editing the library is a community-admin
- * action (`requireCommunityAdmin`); listing/viewing requires an active
+ * Permissions reuse existing guards: editing the library is open to community
+ * admins and group leaders (`requireCommunitySongEditor`) — the worship leader
+ * who builds run sheets is a group leader; listing/viewing requires an active
  * community member (`requireCommunityMember`). Linking a song to a run sheet
  * item lives in `eventItems.updateItem` and reuses `requirePlanScheduler`.
  */
@@ -21,7 +22,11 @@ import type { MutationCtx, QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getMediaUrl } from "../../lib/utils";
-import { requireCommunityAdmin, requireCommunityMember } from "./permissions";
+import {
+  canEditCommunitySongs,
+  requireCommunityMember,
+  requireCommunitySongEditor,
+} from "./permissions";
 
 /** Editable song fields shared by create (`input`) and update (`patch`). */
 const songInputValidator = v.object({
@@ -73,9 +78,28 @@ async function requireSongAdmin(
   if (!song) {
     throw new ConvexError("Song not found");
   }
-  await requireCommunityAdmin(ctx, song.communityId, userId);
+  await requireCommunitySongEditor(ctx, song.communityId, userId);
   return song;
 }
+
+/**
+ * Whether the caller may manage (create/edit/delete) the community song
+ * library — a community admin or a leader of any group in the community. Drives
+ * UI affordances; the mutations enforce the same rule server-side. Returns
+ * `false` (rather than throwing) for non-editors so callers can gate cleanly.
+ *
+ * Auth: any authenticated user.
+ */
+export const canManageSongs = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    return canEditCommunitySongs(ctx, args.communityId, userId);
+  },
+});
 
 /**
  * List a community's songs, sorted by title (case-insensitive). When `search`
@@ -147,7 +171,7 @@ export const createSong = mutation({
   },
   handler: async (ctx, args): Promise<Id<"songs">> => {
     const userId = await requireAuth(ctx, args.token);
-    await requireCommunityAdmin(ctx, args.communityId, userId);
+    await requireCommunitySongEditor(ctx, args.communityId, userId);
 
     const title = (args.input.title ?? "").trim();
     if (!title) {

--- a/apps/mobile/features/scheduling/components/SongPicker.tsx
+++ b/apps/mobile/features/scheduling/components/SongPicker.tsx
@@ -19,7 +19,6 @@ import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
-import { useAuth } from "@providers/AuthProvider";
 import {
   useAuthenticatedQuery,
   useAuthenticatedMutation,
@@ -55,11 +54,17 @@ export function SongPicker({
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const router = useRouter();
-  const { user } = useAuth();
-  // Creating a library song is community-admin-only (backend `requireCommunityAdmin`).
-  // Plan schedulers who aren't admins can still link existing songs, but the
-  // inline Create affordance is hidden so it can't reject under them.
-  const canCreate = !!user?.is_admin;
+  // Creating a library song is open to community admins and group leaders
+  // (backend `requireCommunitySongEditor`). Gate the inline Create affordance on
+  // the authoritative check so a scheduler who can't edit the library (e.g. a
+  // team moderator who isn't a leader) links existing songs without a dead tap.
+  const canCreate =
+    useAuthenticatedQuery(
+      api.functions.scheduling.songs.canManageSongs,
+      communityId
+        ? { communityId: communityId as Id<"communities"> }
+        : "skip",
+    ) ?? false;
   const [query, setQuery] = useState("");
 
   const songs = useAuthenticatedQuery(

--- a/apps/mobile/features/scheduling/components/__tests__/SongPicker.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/SongPicker.test.tsx
@@ -31,10 +31,9 @@ jest.mock("@hooks/useCommunityTheme", () => ({
   useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
 }));
 
-let mockIsAdmin = true;
-jest.mock("@providers/AuthProvider", () => ({
-  useAuth: () => ({ user: { is_admin: mockIsAdmin } }),
-}));
+// Whether the current user may manage songs (admin or group leader), surfaced
+// by the canManageSongs query.
+let mockCanManage = true;
 
 const mockNotify = jest.fn();
 jest.mock("@/utils/platformAlert", () => ({
@@ -48,6 +47,7 @@ jest.mock("@services/api/convex", () => ({
         songs: {
           listSongs: "api.functions.scheduling.songs.listSongs",
           createSong: "api.functions.scheduling.songs.createSong",
+          canManageSongs: "api.functions.scheduling.songs.canManageSongs",
         },
       },
     },
@@ -78,12 +78,14 @@ describe("SongPicker", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsAdmin = true;
+    mockCanManage = true;
     onSelect = jest.fn();
     (useAuthenticatedQuery as jest.Mock).mockImplementation(
       (fn: string, args: unknown) => {
         if (args === "skip") return undefined;
         if (fn === "api.functions.scheduling.songs.listSongs") return SONGS;
+        if (fn === "api.functions.scheduling.songs.canManageSongs")
+          return mockCanManage;
         return undefined;
       },
     );
@@ -182,8 +184,8 @@ describe("SongPicker", () => {
     });
   });
 
-  it("hides the inline Create action for non-admins (createSong is admin-only)", () => {
-    mockIsAdmin = false;
+  it("hides the inline Create action for users who can't manage songs", () => {
+    mockCanManage = false;
     const { getByPlaceholderText, queryByText } = render(
       <SongPicker
         communityId="community-1"
@@ -194,10 +196,10 @@ describe("SongPicker", () => {
       />,
     );
 
-    // A non-admin can still search/link existing songs…
+    // A non-editor (e.g. a team moderator who isn't a group leader) can still
+    // search/link existing songs…
     fireEvent.changeText(getByPlaceholderText("Search songs…"), "Brand New Song");
-    // …but the inline Create affordance (which would hit the admin-only
-    // createSong guard) is not offered.
+    // …but the inline Create affordance is not offered.
     expect(queryByText('Create "Brand New Song"')).toBeNull();
   });
 

--- a/apps/mobile/features/songs/components/SongLibraryScreen.tsx
+++ b/apps/mobile/features/songs/components/SongLibraryScreen.tsx
@@ -8,11 +8,11 @@
  *
  * Songs are community-scoped; the screen resolves the community from the active
  * auth context. It is reached from the run sheet's SongPicker ("Manage song
- * library") at `/rostering/[group_id]/songs`. Editing affordances are gated to
- * community admins client-side; the backend enforces the real guard
- * (`requireGroupLeaderOrCommunityAdmin`).
+ * library") at `/rostering/[group_id]/songs`. Editing affordances are gated on
+ * the `canManageSongs` query (community admin or group leader); the backend
+ * enforces the same rule via `requireCommunitySongEditor`.
  */
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useState } from "react";
 import {
   View,
   Text,
@@ -69,11 +69,17 @@ export function SongLibraryScreen() {
   const { primaryColor } = useCommunityTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { user, community } = useAuth();
+  const { community } = useAuth();
   const communityId = community?.id as string | undefined;
-  // Community admins manage the library; leaders are also allowed by the
-  // backend guard, but `is_admin` is the signal available client-side here.
-  const canEdit = !!user?.is_admin;
+  // Community admins and group leaders manage the library (backend
+  // `requireCommunitySongEditor`); ask the server which applies to this user.
+  const canEdit =
+    useAuthenticatedQuery(
+      api.functions.scheduling.songs.canManageSongs,
+      communityId
+        ? { communityId: communityId as Id<"communities"> }
+        : "skip",
+    ) ?? false;
 
   const [search, setSearch] = useState("");
   // The song currently open in the editor: `null` = closed, "new" = create.

--- a/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
+++ b/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
@@ -37,9 +37,11 @@ jest.mock("@hooks/useCommunityTheme", () => ({
   useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
 }));
 
-let mockUser: { is_admin?: boolean } = { is_admin: true };
+// Whether the current user may manage songs (admin or group leader), surfaced
+// by the canManageSongs query.
+let mockCanManage = true;
 jest.mock("@providers/AuthProvider", () => ({
-  useAuth: () => ({ community: { id: "community-1" }, user: mockUser }),
+  useAuth: () => ({ community: { id: "community-1" } }),
 }));
 
 jest.mock("@features/chat/hooks/useFileUpload", () => ({
@@ -75,6 +77,7 @@ jest.mock("@services/api/convex", () => ({
           deleteSong: "api.functions.scheduling.songs.deleteSong",
           attachChart: "api.functions.scheduling.songs.attachChart",
           removeChart: "api.functions.scheduling.songs.removeChart",
+          canManageSongs: "api.functions.scheduling.songs.canManageSongs",
         },
       },
     },
@@ -112,11 +115,13 @@ function setMutations(map: Record<string, jest.Mock>) {
 describe("SongLibraryScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUser = { is_admin: true };
+    mockCanManage = true;
     (useAuthenticatedQuery as jest.Mock).mockImplementation(
       (fn: string, args: unknown) => {
         if (args === "skip") return undefined;
         if (fn === "api.functions.scheduling.songs.listSongs") return SONGS;
+        if (fn === "api.functions.scheduling.songs.canManageSongs")
+          return mockCanManage;
         return undefined;
       },
     );
@@ -250,8 +255,8 @@ describe("SongLibraryScreen", () => {
     });
   });
 
-  it("hides editing controls for non-admin members", () => {
-    mockUser = { is_admin: false };
+  it("hides editing controls for members who can't manage songs", () => {
+    mockCanManage = false;
     const { queryByText } = render(<SongLibraryScreen />);
     expect(queryByText("Add song")).toBeNull();
     expect(queryByText("Edit")).toBeNull();

--- a/docs/architecture/ADR-027-native-song-library-and-worship-media.md
+++ b/docs/architecture/ADR-027-native-song-library-and-worship-media.md
@@ -153,12 +153,15 @@ the universal ID in our data now without coupling us to any external service.
 
 ### Permissions reuse existing guards
 
-No new permission concept. **Editing the song library** requires
-`requireGroupLeaderOrCommunityAdmin` (the guard `uploads.ts`/`groups` already
-use). **Linking a song to a run sheet item** reuses ADR-026's
-`requirePlanScheduler`. **Viewing** songs/charts/links in a run sheet requires
-`requireGroupMember`; the musician rehearsal view is available to members
-assigned to the plan (read-only).
+No new role field. **Editing the song library** (`requireCommunitySongEditor`)
+is open to a **community admin or a leader of any group in the community** — the
+worship/ministry leader who builds run sheets is a group leader, so the library
+isn't admin-gated. A `canManageSongs` query exposes the same check to the client
+so it can show/hide edit affordances authoritatively (rather than guessing from
+`is_admin`). **Linking a song to a run sheet item** reuses ADR-026's
+`requirePlanScheduler`. **Viewing** songs/charts/links in a run sheet requires an
+active community member (`requireCommunityMember`); the musician rehearsal view
+is available to members assigned to the plan (read-only).
 
 ### Backend surface
 


### PR DESCRIPTION
## Summary

Follow-up to #443. Lets **group leaders** (not only community admins) manage the song library — the worship/ministry leader who builds run sheets is a group leader, so admin-only edits were too restrictive and made the SongPicker's inline "Create song" reject under them.

## Changes
- **Backend:** new `requireCommunitySongEditor` guard = **community admin OR leader of any group in the community**, applied to `createSong`/`updateSong`/`deleteSong`/`attachChart`/`removeChart`. Removed the now-unused admin-only `requireCommunityAdmin` wrapper in `scheduling/permissions.ts`. Added a `canManageSongs` query exposing the same check.
- **Frontend:** `SongPicker` and `SongLibraryScreen` now gate their edit affordances on the authoritative `canManageSongs` query instead of `is_admin` (which wrongly hid edits from group leaders).
- **Docs:** updated ADR-027's permissions section.

## Why a query instead of client-side role logic
Group-leader status isn't readily available client-side, and the library screen is reachable by any community member — so an accurate gate needs the server. `canManageSongs` returns the same boolean the mutations enforce, keeping UI and enforcement in sync.

## Testing
- Convex scheduling suite: **182/182** ✅ — added: group leader (non-admin) can create/update/delete; member/outsider cannot; `canManageSongs` returns true for admin/leader, false for member/outsider.
- Mobile: SongPicker + SongLibraryScreen **16/16** ✅ (mocks updated to the `canManageSongs` query; non-editor still has create/edit hidden).
- Typecheck & lint clean on changed files.

https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo)_