### PR TITLE
Import songs from Planning Center into the native library (ADR-027)

### DIFF
--- a/apps/convex/__tests__/pco/pcoFetchRetry.test.ts
+++ b/apps/convex/__tests__/pco/pcoFetchRetry.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for `pcoFetchWithRetry` — the 429-aware retry used by the song-library
+ * import's bulk fetches. Mocks global `fetch` (the real fetcher runs) to assert
+ * it backs off on 429 honoring Retry-After and gives up after maxRetries.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  pcoFetchWithRetry,
+  PcoApiError,
+} from "../../lib/pcoServicesApi";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function rateLimited(retryAfterSeconds = 0): Response {
+  return new Response("rate limited", {
+    status: 429,
+    headers: { "Retry-After": String(retryAfterSeconds) },
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("pcoFetchWithRetry", () => {
+  it("retries on 429 (honoring Retry-After) then succeeds", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(rateLimited(0))
+      .mockResolvedValueOnce(rateLimited(0))
+      .mockResolvedValueOnce(jsonResponse({ data: ["ok"] }));
+
+    const result = await pcoFetchWithRetry<{ data: string[] }>(
+      "token",
+      "https://api.planningcenteronline.com/services/v2/songs",
+    );
+
+    expect(result).toEqual({ data: ["ok"] });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up after maxRetries and rethrows the 429", async () => {
+    // Fresh Response per call — a Response body can only be read once.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      rateLimited(0),
+    );
+
+    await expect(
+      pcoFetchWithRetry("token", "https://example.test", {}, 2),
+    ).rejects.toMatchObject({ status: 429 });
+  });
+
+  it("does not retry non-429 errors", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("nope", { status: 500 }));
+
+    await expect(
+      pcoFetchWithRetry("token", "https://example.test"),
+    ).rejects.toBeInstanceOf(PcoApiError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/convex/__tests__/pco/songImport.test.ts
+++ b/apps/convex/__tests__/pco/songImport.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Tests for the one-time PCO song library import (ADR-027 open question #2).
+ *
+ * Covers:
+ *  - `mapPcoSongs` — pure transform of PCO songs + arrangements into
+ *    `ImportedSongInput` rows (first arrangement wins, blank titles skipped,
+ *    null attributes omitted).
+ *  - `upsertImportedSongs` — internalMutation dedupe/upsert into the native
+ *    `songs` table (match by ccli, else case-insensitive title; fill only
+ *    missing fields; imported/updated/skipped counts).
+ *  - `importSongsFromPco` — the public action's permission gate, "not
+ *    connected" error, and happy path (PCO HTTP layer mocked).
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api, internal } from "../../_generated/api";
+import { buildSchedulingWorld } from "../scheduling/fixtures";
+import { mapPcoSongs } from "../../functions/pcoServices/songImport";
+import type { PcoArrangement, PcoSong } from "../../lib/pcoServicesApi";
+
+// Mock only the PCO HTTP layer — token + fetch helpers. Everything else
+// (auth, permissions, the upsert mutation) runs for real inside convexTest.
+vi.mock("../../lib/pcoServicesApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../lib/pcoServicesApi")>();
+  return {
+    ...actual,
+    getValidAccessToken: vi.fn().mockResolvedValue("mock-access-token"),
+    fetchAllSongs: vi.fn().mockResolvedValue([]),
+    fetchSongArrangements: vi.fn().mockResolvedValue([]),
+  };
+});
+
+import {
+  fetchAllSongs,
+  fetchSongArrangements,
+} from "../../lib/pcoServicesApi";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+  vi.clearAllMocks();
+});
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+function pcoSong(
+  id: string,
+  title: string,
+  attributes?: Partial<PcoSong["attributes"]>,
+): PcoSong {
+  return {
+    id,
+    type: "Song",
+    attributes: {
+      title,
+      ccli_number: null,
+      author: null,
+      ...attributes,
+    },
+  };
+}
+
+function pcoArrangement(
+  id: string,
+  attributes?: Partial<PcoArrangement["attributes"]>,
+): PcoArrangement {
+  return {
+    id,
+    type: "Arrangement",
+    attributes: {
+      name: "Default Arrangement",
+      bpm: null,
+      length: null,
+      meter: null,
+      chord_chart_key: null,
+      ...attributes,
+    },
+  };
+}
+
+// ============================================================================
+// mapPcoSongs (pure transform)
+// ============================================================================
+
+describe("mapPcoSongs", () => {
+  it("merges song attributes with the first arrangement", () => {
+    const songs = [
+      pcoSong("s1", "Goodness of God", {
+        author: "Jenn Johnson",
+        ccli_number: "7117726",
+      }),
+    ];
+    const arrangements = new Map([
+      [
+        "s1",
+        [
+          pcoArrangement("a1", {
+            name: "Standard",
+            bpm: 126,
+            meter: "4/4",
+            chord_chart_key: "Ab",
+          }),
+        ],
+      ],
+    ]);
+
+    expect(mapPcoSongs(songs, arrangements)).toEqual([
+      {
+        title: "Goodness of God",
+        author: "Jenn Johnson",
+        ccliNumber: "7117726",
+        defaultKey: "Ab",
+        bpm: 126,
+        meter: "4/4",
+        arrangementName: "Standard",
+      },
+    ]);
+  });
+
+  it("uses the FIRST arrangement when a song has several", () => {
+    const songs = [pcoSong("s1", "Way Maker")];
+    const arrangements = new Map([
+      [
+        "s1",
+        [
+          pcoArrangement("a1", { name: "Live", chord_chart_key: "E", bpm: 68 }),
+          pcoArrangement("a2", { name: "Acoustic", chord_chart_key: "D", bpm: 60 }),
+        ],
+      ],
+    ]);
+
+    const [row] = mapPcoSongs(songs, arrangements);
+    expect(row.defaultKey).toBe("E");
+    expect(row.bpm).toBe(68);
+    expect(row.arrangementName).toBe("Live");
+  });
+
+  it("skips songs with blank or whitespace-only titles", () => {
+    const songs = [
+      pcoSong("s1", ""),
+      pcoSong("s2", "   "),
+      pcoSong("s3", "Real Song"),
+    ];
+
+    const rows = mapPcoSongs(songs, new Map());
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe("Real Song");
+  });
+
+  it("omits fields that are null or missing", () => {
+    const songs = [pcoSong("s1", "Bare Song")];
+
+    // No arrangements at all; author/ccli are null.
+    expect(mapPcoSongs(songs, new Map())).toEqual([{ title: "Bare Song" }]);
+  });
+});
+
+// ============================================================================
+// upsertImportedSongs (internalMutation)
+// ============================================================================
+
+describe("upsertImportedSongs", () => {
+  it("inserts new songs with the importing user as creator", async () => {
+    const { t, world } = await setupSchedulingWorld();
+
+    const counts = await t.mutation(
+      internal.functions.pcoServices.songImport.upsertImportedSongs,
+      {
+        communityId: world.communityId,
+        userId: world.groupLeaderId,
+        songs: [
+          {
+            title: "Goodness of God",
+            author: "Jenn Johnson",
+            ccliNumber: "7117726",
+            defaultKey: "Ab",
+            bpm: 126,
+            meter: "4/4",
+            arrangementName: "Standard",
+          },
+          { title: "Way Maker" },
+        ],
+      },
+    );
+
+    expect(counts).toEqual({ imported: 2, updated: 0, skipped: 0 });
+
+    const songs = await t.run(async (ctx) =>
+      ctx.db
+        .query("songs")
+        .withIndex("by_community", (q) => q.eq("communityId", world.communityId))
+        .collect(),
+    );
+    expect(songs).toHaveLength(2);
+    const goodness = songs.find((s) => s.title === "Goodness of God");
+    expect(goodness?.ccliNumber).toBe("7117726");
+    expect(goodness?.defaultKey).toBe("Ab");
+    expect(goodness?.bpm).toBe(126);
+    expect(goodness?.createdById).toBe(world.groupLeaderId);
+    expect(typeof goodness?.createdAt).toBe("number");
+  });
+
+  it("matches by ccli number and fills ONLY missing fields", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    // Existing song with a user-set bpm; no author/key yet.
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Goodness of God", ccliNumber: "7117726", bpm: 120 },
+    });
+
+    const counts = await t.mutation(
+      internal.functions.pcoServices.songImport.upsertImportedSongs,
+      {
+        communityId: world.communityId,
+        userId: world.groupLeaderId,
+        songs: [
+          {
+            // Different title casing — ccli is the match key.
+            title: "GOODNESS OF GOD",
+            author: "Jenn Johnson",
+            ccliNumber: "7117726",
+            defaultKey: "Ab",
+            bpm: 126,
+          },
+        ],
+      },
+    );
+
+    expect(counts).toEqual({ imported: 0, updated: 1, skipped: 0 });
+
+    const song = await t.run(async (ctx) => ctx.db.get(songId));
+    // User's edits are never clobbered.
+    expect(song?.bpm).toBe(120);
+    expect(song?.title).toBe("Goodness of God");
+    // Missing fields are filled.
+    expect(song?.author).toBe("Jenn Johnson");
+    expect(song?.defaultKey).toBe("Ab");
+  });
+
+  it("counts a ccli match with nothing to fill as skipped", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: {
+        title: "Way Maker",
+        ccliNumber: "7115744",
+        author: "Sinach",
+        defaultKey: "E",
+        bpm: 68,
+        meter: "4/4",
+        arrangementName: "Live",
+      },
+    });
+
+    const counts = await t.mutation(
+      internal.functions.pcoServices.songImport.upsertImportedSongs,
+      {
+        communityId: world.communityId,
+        userId: world.groupLeaderId,
+        songs: [
+          {
+            title: "Way Maker",
+            ccliNumber: "7115744",
+            author: "Different Author",
+            defaultKey: "D",
+          },
+        ],
+      },
+    );
+
+    expect(counts).toEqual({ imported: 0, updated: 0, skipped: 1 });
+  });
+
+  it("matches rows without a ccli number by case-insensitive title", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    const songId = await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Way Maker" },
+    });
+
+    const counts = await t.mutation(
+      internal.functions.pcoServices.songImport.upsertImportedSongs,
+      {
+        communityId: world.communityId,
+        userId: world.groupLeaderId,
+        songs: [{ title: "WAY MAKER", defaultKey: "E", bpm: 68 }],
+      },
+    );
+
+    expect(counts).toEqual({ imported: 0, updated: 1, skipped: 0 });
+    const song = await t.run(async (ctx) => ctx.db.get(songId));
+    expect(song?.defaultKey).toBe("E");
+    expect(song?.bpm).toBe(68);
+
+    const all = await t.run(async (ctx) =>
+      ctx.db
+        .query("songs")
+        .withIndex("by_community", (q) => q.eq("communityId", world.communityId))
+        .collect(),
+    );
+    expect(all).toHaveLength(1);
+  });
+
+  it("inserts a row whose ccli matches nothing (ccli rows do not fall back to title)", async () => {
+    // Per the import spec: rows carrying a ccli number match by ccli only.
+    // A same-title song without that ccli is treated as a different song.
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Way Maker" },
+    });
+
+    const counts = await t.mutation(
+      internal.functions.pcoServices.songImport.upsertImportedSongs,
+      {
+        communityId: world.communityId,
+        userId: world.groupLeaderId,
+        songs: [{ title: "Way Maker", ccliNumber: "7115744" }],
+      },
+    );
+
+    expect(counts).toEqual({ imported: 1, updated: 0, skipped: 0 });
+  });
+
+  it("dedupes repeated rows within a single import batch", async () => {
+    const { t, world } = await setupSchedulingWorld();
+
+    const counts = await t.mutation(
+      internal.functions.pcoServices.songImport.upsertImportedSongs,
+      {
+        communityId: world.communityId,
+        userId: world.groupLeaderId,
+        songs: [
+          { title: "Amazing Grace", ccliNumber: "22025", bpm: 72 },
+          { title: "Amazing Grace", ccliNumber: "22025", author: "John Newton" },
+        ],
+      },
+    );
+
+    // First row inserts; second matches it and fills the missing author.
+    expect(counts).toEqual({ imported: 1, updated: 1, skipped: 0 });
+
+    const all = await t.run(async (ctx) =>
+      ctx.db
+        .query("songs")
+        .withIndex("by_community", (q) => q.eq("communityId", world.communityId))
+        .collect(),
+    );
+    expect(all).toHaveLength(1);
+    expect(all[0].bpm).toBe(72);
+    expect(all[0].author).toBe("John Newton");
+  });
+});
+
+// ============================================================================
+// importSongsFromPco (action)
+// ============================================================================
+
+async function connectPco(t: ReturnType<typeof convexTest>, communityId: any) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("communityIntegrations", {
+      communityId,
+      integrationType: "planning_center",
+      credentials: { access_token: "x" },
+      config: {},
+      status: "connected",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+describe("importSongsFromPco", () => {
+  it("imports the PCO library end-to-end and returns counts", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+
+    (fetchAllSongs as any).mockResolvedValue([
+      pcoSong("s1", "Goodness of God", {
+        author: "Jenn Johnson",
+        ccli_number: "7117726",
+      }),
+      pcoSong("s2", "Way Maker"),
+    ]);
+    (fetchSongArrangements as any).mockImplementation(
+      async (_token: string, songId: string) =>
+        songId === "s1"
+          ? [
+              pcoArrangement("a1", {
+                name: "Standard",
+                bpm: 126,
+                meter: "4/4",
+                chord_chart_key: "Ab",
+              }),
+            ]
+          : [],
+    );
+
+    const result = await t.action(
+      api.functions.pcoServices.songImport.importSongsFromPco,
+      { token, communityId: world.communityId },
+    );
+
+    expect(result).toEqual({ imported: 2, updated: 0, skipped: 0, total: 2 });
+
+    const songs = await t.run(async (ctx) =>
+      ctx.db
+        .query("songs")
+        .withIndex("by_community", (q) => q.eq("communityId", world.communityId))
+        .collect(),
+    );
+    expect(songs).toHaveLength(2);
+    const goodness = songs.find((s) => s.title === "Goodness of God");
+    expect(goodness?.defaultKey).toBe("Ab");
+    expect(goodness?.bpm).toBe(126);
+    expect(goodness?.arrangementName).toBe("Standard");
+    expect(goodness?.createdById).toBe(world.groupLeaderId);
+  });
+
+  it("rejects when Planning Center is not connected", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await expect(
+      t.action(api.functions.pcoServices.songImport.importSongsFromPco, {
+        token,
+        communityId: world.communityId,
+      }),
+    ).rejects.toThrow("Planning Center is not connected");
+  });
+
+  it("rejects callers who may not manage the song library", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.channelMemberId)).accessToken;
+    await connectPco(t, world.communityId);
+
+    await expect(
+      t.action(api.functions.pcoServices.songImport.importSongsFromPco, {
+        token,
+        communityId: world.communityId,
+      }),
+    ).rejects.toThrow(/group leader or community admin/);
+  });
+});

--- a/apps/convex/__tests__/pco/songImport.test.ts
+++ b/apps/convex/__tests__/pco/songImport.test.ts
@@ -328,9 +328,9 @@ describe("upsertImportedSongs", () => {
     expect(all).toHaveLength(1);
   });
 
-  it("inserts a row whose ccli matches nothing (ccli rows do not fall back to title)", async () => {
-    // Per the import spec: rows carrying a ccli number match by ccli only.
-    // A same-title song without that ccli is treated as a different song.
+  it("enriches a manually-entered (ccli-less) song instead of duplicating it", async () => {
+    // A leader hand-added "Way Maker" without a CCLI; the import row carries one.
+    // It should fill the CCLI into the existing row, not create a second song.
     const { t, world } = await setupSchedulingWorld();
     const token = (await generateTokens(world.communityAdminId)).accessToken;
 
@@ -345,11 +345,46 @@ describe("upsertImportedSongs", () => {
       {
         communityId: world.communityId,
         userId: world.groupLeaderId,
-        songs: [{ title: "Way Maker", ccliNumber: "7115744" }],
+        songs: [{ title: "Way Maker", ccliNumber: "7115744", bpm: 68 }],
+      },
+    );
+
+    expect(counts).toEqual({ imported: 0, updated: 1, skipped: 0 });
+    const songs = await t.query(api.functions.scheduling.songs.listSongs, {
+      token,
+      communityId: world.communityId,
+    });
+    expect(songs.length).toBe(1);
+    expect(songs[0].ccliNumber).toBe("7115744");
+    expect(songs[0].bpm).toBe(68);
+  });
+
+  it("does not merge two distinct songs that share a title but differ in ccli", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.communityAdminId)).accessToken;
+
+    await t.mutation(api.functions.scheduling.songs.createSong, {
+      token,
+      communityId: world.communityId,
+      input: { title: "Glory", ccliNumber: "111" },
+    });
+
+    const counts = await t.mutation(
+      internal.functions.pcoServices.songImport.upsertImportedSongs,
+      {
+        communityId: world.communityId,
+        userId: world.groupLeaderId,
+        // Same title, different CCLI → a genuinely different song → insert.
+        songs: [{ title: "Glory", ccliNumber: "222" }],
       },
     );
 
     expect(counts).toEqual({ imported: 1, updated: 0, skipped: 0 });
+    const songs = await t.query(api.functions.scheduling.songs.listSongs, {
+      token,
+      communityId: world.communityId,
+    });
+    expect(songs.length).toBe(2);
   });
 
   it("dedupes repeated rows within a single import batch", async () => {

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -119,6 +119,7 @@ import type * as functions_pcoServices_queries from "../functions/pcoServices/qu
 import type * as functions_pcoServices_rotation from "../functions/pcoServices/rotation.js";
 import type * as functions_pcoServices_runSheet from "../functions/pcoServices/runSheet.js";
 import type * as functions_pcoServices_servingHistory from "../functions/pcoServices/servingHistory.js";
+import type * as functions_pcoServices_songImport from "../functions/pcoServices/songImport.js";
 import type * as functions_peopleSavedViews from "../functions/peopleSavedViews.js";
 import type * as functions_posters from "../functions/posters.js";
 import type * as functions_prayers from "../functions/prayers.js";
@@ -320,6 +321,7 @@ declare const fullApi: ApiFromModules<{
   "functions/pcoServices/rotation": typeof functions_pcoServices_rotation;
   "functions/pcoServices/runSheet": typeof functions_pcoServices_runSheet;
   "functions/pcoServices/servingHistory": typeof functions_pcoServices_servingHistory;
+  "functions/pcoServices/songImport": typeof functions_pcoServices_songImport;
   "functions/peopleSavedViews": typeof functions_peopleSavedViews;
   "functions/posters": typeof functions_posters;
   "functions/prayers": typeof functions_prayers;

--- a/apps/convex/functions/pcoServices/songImport.ts
+++ b/apps/convex/functions/pcoServices/songImport.ts
@@ -226,9 +226,12 @@ export const upsertImportedSongs = internalMutation({
 // Public action
 // ============================================================================
 
-// PCO rate limit is 100 requests per 20 seconds; 15 concurrent arrangement
-// fetches per batch is the established safe convention (see actions.ts).
+// PCO rate limit is 100 requests per 20 seconds. We fetch arrangements 15 at a
+// time AND pace the batches so the request *rate* stays under the limit (concur-
+// rency alone doesn't bound rate): ~15 requests per 3.5s ≈ 86 req/20s. The
+// fetchers also retry 429s honoring Retry-After, so this is belt-and-suspenders.
 const BATCH_SIZE = 15;
+const MIN_BATCH_INTERVAL_MS = 3500;
 
 /**
  * One-time import of the community's PCO Services song library into the
@@ -289,6 +292,7 @@ export const importSongsFromPco = action({
 
     const arrangementsBySongId = new Map<string, PcoArrangement[]>();
     for (let i = 0; i < pcoSongs.length; i += BATCH_SIZE) {
+      const batchStart = Date.now();
       const batch = pcoSongs.slice(i, i + BATCH_SIZE);
       const results = await Promise.all(
         batch.map(
@@ -298,6 +302,16 @@ export const importSongsFromPco = action({
       );
       for (const [songId, arrangements] of results) {
         arrangementsBySongId.set(songId, arrangements);
+      }
+      // Pace to stay under PCO's 100/20s rate limit; no wait after the last batch.
+      const isLastBatch = i + BATCH_SIZE >= pcoSongs.length;
+      if (!isLastBatch) {
+        const elapsed = Date.now() - batchStart;
+        if (elapsed < MIN_BATCH_INTERVAL_MS) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, MIN_BATCH_INTERVAL_MS - elapsed),
+          );
+        }
       }
     }
 

--- a/apps/convex/functions/pcoServices/songImport.ts
+++ b/apps/convex/functions/pcoServices/songImport.ts
@@ -7,9 +7,11 @@
  * native `songs` table. Import is additive and never clobbers user edits —
  * matched songs only have their *missing* fields filled.
  *
- * Dedupe rules: rows carrying a CCLI number match existing songs by
+ * Dedupe rules: a row carrying a CCLI number matches an existing song by
  * `ccliNumber` (the worship world's universal song ID, via the
- * `by_community_ccli` index); rows without one match by case-insensitive
+ * `by_community_ccli` index); failing that, it enriches a same-title song that
+ * has no CCLI yet (rather than create a duplicate), but never one that already
+ * carries a different CCLI. A row without a CCLI matches by case-insensitive
  * title within the community.
  */
 
@@ -160,11 +162,22 @@ export const upsertImportedSongs = internalMutation({
     let skipped = 0;
 
     for (const row of args.songs) {
-      // Rows with a CCLI number match by it alone — same title without that
-      // CCLI is treated as a different song. CCLI-less rows match by title.
-      const match = row.ccliNumber
-        ? byCcli.get(row.ccliNumber)
-        : byTitle.get(row.title.toLowerCase());
+      // Match priority:
+      //   - row has a CCLI → match that CCLI; if none, fall back to a title
+      //     match that has NO CCLI yet (enrich a manually-entered song rather
+      //     than create a duplicate), but never a title match that already
+      //     carries a *different* CCLI (those are distinct songs).
+      //   - row has no CCLI → match by title.
+      let match: Doc<"songs"> | undefined;
+      if (row.ccliNumber) {
+        match = byCcli.get(row.ccliNumber);
+        if (!match) {
+          const titleMatch = byTitle.get(row.title.toLowerCase());
+          if (titleMatch && !titleMatch.ccliNumber) match = titleMatch;
+        }
+      } else {
+        match = byTitle.get(row.title.toLowerCase());
+      }
 
       if (!match) {
         const nowMs = Date.now();

--- a/apps/convex/functions/pcoServices/songImport.ts
+++ b/apps/convex/functions/pcoServices/songImport.ts
@@ -1,0 +1,301 @@
+/**
+ * One-time PCO song library import (ADR-027 open question #2)
+ *
+ * A migration aid for churches moving off Planning Center: fetches the
+ * community's entire PCO Services song library (title, author, CCLI number,
+ * and the first arrangement's key/BPM/meter/name) and upserts it into the
+ * native `songs` table. Import is additive and never clobbers user edits —
+ * matched songs only have their *missing* fields filled.
+ *
+ * Dedupe rules: rows carrying a CCLI number match existing songs by
+ * `ccliNumber` (the worship world's universal song ID, via the
+ * `by_community_ccli` index); rows without one match by case-insensitive
+ * title within the community.
+ */
+
+import { ConvexError, v } from "convex/values";
+import { action, internalMutation } from "../../_generated/server";
+import { api, internal } from "../../_generated/api";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuthFromTokenAction } from "../../lib/auth";
+import {
+  getValidAccessToken,
+  fetchAllSongs,
+  fetchSongArrangements,
+  type PcoArrangement,
+  type PcoSong,
+} from "../../lib/pcoServicesApi";
+
+// ============================================================================
+// Pure transform
+// ============================================================================
+
+/** One import row — the subset of `songs` fields PCO can provide. */
+export interface ImportedSongInput {
+  title: string;
+  author?: string;
+  ccliNumber?: string;
+  defaultKey?: string;
+  bpm?: number;
+  meter?: string;
+  arrangementName?: string;
+}
+
+/** Trimmed string, or undefined when null/blank. */
+function cleanString(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Map PCO songs (plus each song's arrangements) to `ImportedSongInput` rows.
+ *
+ * Key/BPM/meter/arrangement-name come from the FIRST arrangement — PCO songs
+ * can have several, and the first is the default. Songs with blank titles are
+ * skipped. Null/blank attributes are omitted (not set to undefined) so the
+ * rows serialize cleanly as Convex values.
+ */
+export function mapPcoSongs(
+  songs: PcoSong[],
+  arrangementsBySongId: Map<string, PcoArrangement[]>,
+): ImportedSongInput[] {
+  const rows: ImportedSongInput[] = [];
+
+  for (const song of songs) {
+    const title = cleanString(song.attributes.title);
+    if (!title) continue;
+
+    const row: ImportedSongInput = { title };
+
+    const author = cleanString(song.attributes.author);
+    if (author) row.author = author;
+
+    // PCO types ccli_number as a string but has been seen returning numbers;
+    // normalize defensively since it's our dedupe key.
+    const ccliNumber = cleanString(
+      song.attributes.ccli_number == null
+        ? undefined
+        : String(song.attributes.ccli_number),
+    );
+    if (ccliNumber) row.ccliNumber = ccliNumber;
+
+    const arrangement = arrangementsBySongId.get(song.id)?.[0];
+    if (arrangement) {
+      const defaultKey = cleanString(arrangement.attributes.chord_chart_key);
+      if (defaultKey) row.defaultKey = defaultKey;
+      if (arrangement.attributes.bpm != null) {
+        row.bpm = arrangement.attributes.bpm;
+      }
+      const meter = cleanString(arrangement.attributes.meter);
+      if (meter) row.meter = meter;
+      const arrangementName = cleanString(arrangement.attributes.name);
+      if (arrangementName) row.arrangementName = arrangementName;
+    }
+
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+// ============================================================================
+// Upsert mutation
+// ============================================================================
+
+const importedSongValidator = v.object({
+  title: v.string(),
+  author: v.optional(v.string()),
+  ccliNumber: v.optional(v.string()),
+  defaultKey: v.optional(v.string()),
+  bpm: v.optional(v.number()),
+  meter: v.optional(v.string()),
+  arrangementName: v.optional(v.string()),
+});
+
+/** The import-fillable metadata fields, shared by the fill loop below. */
+const FILLABLE_FIELDS = [
+  "author",
+  "ccliNumber",
+  "defaultKey",
+  "bpm",
+  "meter",
+  "arrangementName",
+] as const;
+
+/**
+ * Upsert imported rows into the community's `songs` table.
+ *
+ * - No match → insert (`createdById` = the importing user).
+ * - Match → fill ONLY fields the existing song is missing; never overwrite.
+ *   Something filled counts as `updated`, nothing to fill counts as `skipped`.
+ *
+ * Internal-only: the public `importSongsFromPco` action authenticates and
+ * permission-checks before calling this.
+ */
+export const upsertImportedSongs = internalMutation({
+  args: {
+    communityId: v.id("communities"),
+    userId: v.id("users"),
+    songs: v.array(importedSongValidator),
+  },
+  handler: async (ctx, args) => {
+    // One indexed read, then in-memory lookup maps. Both maps are kept
+    // current as we insert/patch so duplicate rows within the same import
+    // batch dedupe against each other too.
+    const existing = await ctx.db
+      .query("songs")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    const byCcli = new Map<string, Doc<"songs">>();
+    const byTitle = new Map<string, Doc<"songs">>();
+    for (const song of existing) {
+      if (song.ccliNumber) byCcli.set(song.ccliNumber, song);
+      if (!byTitle.has(song.title.toLowerCase())) {
+        byTitle.set(song.title.toLowerCase(), song);
+      }
+    }
+
+    let imported = 0;
+    let updated = 0;
+    let skipped = 0;
+
+    for (const row of args.songs) {
+      // Rows with a CCLI number match by it alone — same title without that
+      // CCLI is treated as a different song. CCLI-less rows match by title.
+      const match = row.ccliNumber
+        ? byCcli.get(row.ccliNumber)
+        : byTitle.get(row.title.toLowerCase());
+
+      if (!match) {
+        const nowMs = Date.now();
+        const songId = await ctx.db.insert("songs", {
+          communityId: args.communityId,
+          ...row,
+          createdAt: nowMs,
+          createdById: args.userId,
+          updatedAt: nowMs,
+        });
+        const inserted = (await ctx.db.get(songId))!;
+        if (inserted.ccliNumber) byCcli.set(inserted.ccliNumber, inserted);
+        if (!byTitle.has(inserted.title.toLowerCase())) {
+          byTitle.set(inserted.title.toLowerCase(), inserted);
+        }
+        imported++;
+        continue;
+      }
+
+      // Fill only the fields the existing song is missing.
+      const patch: Partial<Doc<"songs">> = {};
+      for (const field of FILLABLE_FIELDS) {
+        if (match[field] === undefined && row[field] !== undefined) {
+          patch[field] = row[field] as never;
+        }
+      }
+
+      if (Object.keys(patch).length === 0) {
+        skipped++;
+        continue;
+      }
+
+      patch.updatedAt = Date.now();
+      await ctx.db.patch(match._id, patch);
+      const patched = (await ctx.db.get(match._id))!;
+      if (patched.ccliNumber) byCcli.set(patched.ccliNumber, patched);
+      byTitle.set(patched.title.toLowerCase(), patched);
+      updated++;
+    }
+
+    return { imported, updated, skipped };
+  },
+});
+
+// ============================================================================
+// Public action
+// ============================================================================
+
+// PCO rate limit is 100 requests per 20 seconds; 15 concurrent arrangement
+// fetches per batch is the established safe convention (see actions.ts).
+const BATCH_SIZE = 15;
+
+/**
+ * One-time import of the community's PCO Services song library into the
+ * native `songs` table.
+ *
+ * Auth: community admin or group leader (`canManageSongs`); the community
+ * must have a connected Planning Center integration.
+ *
+ * Returns `{ imported, updated, skipped, total }` — `total` is the number of
+ * library rows processed (imported + updated + skipped).
+ */
+export const importSongsFromPco = action({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    imported: number;
+    updated: number;
+    skipped: number;
+    total: number;
+  }> => {
+    // 1. Authenticate and check song-library permission. Guards like
+    //    requireCommunitySongEditor need query/mutation ctx, so the action
+    //    delegates to the canManageSongs query.
+    const userId = (await requireAuthFromTokenAction(
+      ctx,
+      args.token,
+    )) as Id<"users">;
+    const allowed = await ctx.runQuery(
+      api.functions.scheduling.songs.canManageSongs,
+      { token: args.token, communityId: args.communityId },
+    );
+    if (!allowed) {
+      throw new ConvexError(
+        "You must be a group leader or community admin to import songs",
+      );
+    }
+
+    // 2. Require a connected PCO integration (clear error before we try to
+    //    use its tokens).
+    const integration = await ctx.runQuery(
+      internal.functions.pcoServices.queries.getIntegration,
+      { communityId: args.communityId },
+    );
+    if (!integration || integration.status !== "connected") {
+      throw new ConvexError("Planning Center is not connected");
+    }
+    const accessToken = await getValidAccessToken(ctx, args.communityId);
+
+    // 3. Fetch the whole library, then each song's arrangements in batches
+    //    (the songs endpoint has no `include=arrangements`; see
+    //    fetchSongArrangements).
+    const pcoSongs = await fetchAllSongs(accessToken);
+
+    const arrangementsBySongId = new Map<string, PcoArrangement[]>();
+    for (let i = 0; i < pcoSongs.length; i += BATCH_SIZE) {
+      const batch = pcoSongs.slice(i, i + BATCH_SIZE);
+      const results = await Promise.all(
+        batch.map(
+          async (song) =>
+            [song.id, await fetchSongArrangements(accessToken, song.id)] as const,
+        ),
+      );
+      for (const [songId, arrangements] of results) {
+        arrangementsBySongId.set(songId, arrangements);
+      }
+    }
+
+    // 4. Transform and upsert.
+    const songs = mapPcoSongs(pcoSongs, arrangementsBySongId);
+    const counts: { imported: number; updated: number; skipped: number } =
+      await ctx.runMutation(
+        internal.functions.pcoServices.songImport.upsertImportedSongs,
+        { communityId: args.communityId, userId, songs },
+      );
+
+    return { ...counts, total: songs.length };
+  },
+});

--- a/apps/convex/lib/pcoServicesApi.ts
+++ b/apps/convex/lib/pcoServicesApi.ts
@@ -823,3 +823,54 @@ export async function fetchPlanTeamMembersForItems(
       : null,
   }));
 }
+
+// ============================================================================
+// Song Library API (one-time import — ADR-027 open question #2)
+// ============================================================================
+
+interface PcoSongsPageResponse {
+  data: PcoSong[];
+  links?: { next?: string };
+}
+
+/**
+ * Fetch ALL songs in the organization's PCO Services song library.
+ * GET /services/v2/songs?per_page=100
+ *
+ * Follows `links.next` until exhausted (same pagination convention as
+ * fetchPlanItems). One request per 100 songs keeps us far under the
+ * 100-requests/20s rate limit.
+ */
+export async function fetchAllSongs(accessToken: string): Promise<PcoSong[]> {
+  const songs: PcoSong[] = [];
+  let nextUrl: string | undefined = `${PCO_SERVICES_BASE}/songs?per_page=100`;
+
+  while (nextUrl) {
+    const response: PcoSongsPageResponse =
+      await pcoFetch<PcoSongsPageResponse>(accessToken, nextUrl);
+    songs.push(...response.data);
+    nextUrl = response.links?.next;
+  }
+
+  return songs;
+}
+
+/**
+ * Fetch a song's arrangements (first is PCO's default).
+ * GET /services/v2/songs/{id}/arrangements
+ *
+ * NOTE: This is a per-song call because the songs list endpoint does not
+ * support `?include=arrangements` — PCO's Song vertex documents no includes.
+ * Callers must batch these requests (BATCH_SIZE=15, see actions.ts) to
+ * respect the 100-requests/20s rate limit.
+ */
+export async function fetchSongArrangements(
+  accessToken: string,
+  songId: string
+): Promise<PcoArrangement[]> {
+  const response = await pcoFetch<{ data: PcoArrangement[] }>(
+    accessToken,
+    `${PCO_SERVICES_BASE}/songs/${songId}/arrangements?per_page=100`
+  );
+  return response.data;
+}

--- a/apps/convex/lib/pcoServicesApi.ts
+++ b/apps/convex/lib/pcoServicesApi.ts
@@ -27,16 +27,20 @@ const PCO_OAUTH_TOKEN_URL = "https://api.planningcenteronline.com/oauth/token";
 export class PcoApiError extends Error {
   status: number;
   response?: unknown;
+  /** Parsed `Retry-After` (ms) when PCO returns 429; used to back off. */
+  retryAfterMs?: number;
 
   constructor(
     status: number,
     message: string,
-    response?: unknown
+    response?: unknown,
+    retryAfterMs?: number
   ) {
     super(message);
     this.name = "PcoApiError";
     this.status = status;
     this.response = response;
+    this.retryAfterMs = retryAfterMs;
   }
 }
 
@@ -186,10 +190,19 @@ export async function pcoFetch<T>(
 
   if (!response.ok) {
     const errorBody = await response.text();
+    // PCO returns 429 + `Retry-After` (seconds) when its 100-req/20s limit is
+    // exceeded; surface it so callers can back off precisely.
+    let retryAfterMs: number | undefined;
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      if (!Number.isNaN(seconds)) retryAfterMs = seconds * 1000;
+    }
     throw new PcoApiError(
       response.status,
       `PCO API error: ${response.statusText}`,
-      errorBody
+      errorBody,
+      retryAfterMs
     );
   }
 
@@ -199,6 +212,35 @@ export async function pcoFetch<T>(
   }
 
   return response.json();
+}
+
+/**
+ * `pcoFetch` with bounded retry on 429 (rate limit), honoring PCO's
+ * `Retry-After` header. PCO enforces 100 requests / 20s and returns 429 when
+ * exceeded; without retry a large bulk operation (e.g. the song-library
+ * import's per-song arrangement fetches) would hard-fail mid-run. Non-429
+ * errors and exhausted retries rethrow unchanged.
+ */
+export async function pcoFetchWithRetry<T>(
+  accessToken: string,
+  url: string,
+  options: RequestInit = {},
+  maxRetries = 4
+): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await pcoFetch<T>(accessToken, url, options);
+    } catch (err) {
+      const rateLimited = err instanceof PcoApiError && err.status === 429;
+      if (!rateLimited || attempt >= maxRetries) throw err;
+      // Honor Retry-After when present; otherwise exponential backoff capped at
+      // the 20s window.
+      const waitMs =
+        (err as PcoApiError).retryAfterMs ??
+        Math.min(20000, 1000 * 2 ** attempt);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
 }
 
 // ============================================================================
@@ -847,7 +889,7 @@ export async function fetchAllSongs(accessToken: string): Promise<PcoSong[]> {
 
   while (nextUrl) {
     const response: PcoSongsPageResponse =
-      await pcoFetch<PcoSongsPageResponse>(accessToken, nextUrl);
+      await pcoFetchWithRetry<PcoSongsPageResponse>(accessToken, nextUrl);
     songs.push(...response.data);
     nextUrl = response.links?.next;
   }
@@ -868,7 +910,7 @@ export async function fetchSongArrangements(
   accessToken: string,
   songId: string
 ): Promise<PcoArrangement[]> {
-  const response = await pcoFetch<{ data: PcoArrangement[] }>(
+  const response = await pcoFetchWithRetry<{ data: PcoArrangement[] }>(
     accessToken,
     `${PCO_SERVICES_BASE}/songs/${songId}/arrangements?per_page=100`
   );

--- a/apps/mobile/features/songs/components/SongLibraryScreen.tsx
+++ b/apps/mobile/features/songs/components/SongLibraryScreen.tsx
@@ -34,6 +34,7 @@ import { useAuth } from "@providers/AuthProvider";
 import {
   useAuthenticatedQuery,
   useAuthenticatedMutation,
+  useAuthenticatedAction,
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
@@ -43,14 +44,17 @@ import {
 } from "@features/chat/hooks/useFileUpload";
 import type { Song, SongInput } from "../types";
 
-/** One-button error that works on web (Alert.alert is a no-op on web here). */
-function notifyError(title: string, message: string) {
+/** One-button notice that works on web (Alert.alert is a no-op on web here). */
+function notify(title: string, message: string) {
   if (Platform.OS === "web") {
     if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);
     return;
   }
   Alert.alert(title, message);
 }
+
+/** Alias for error notices — same dialog, kept for call-site readability. */
+const notifyError = notify;
 
 /** Confirm dialog that works on web (Alert.alert is a no-op on web here). */
 function confirmDestructive(prompt: string, onConfirm: () => void) {
@@ -84,6 +88,41 @@ export function SongLibraryScreen() {
   const [search, setSearch] = useState("");
   // The song currently open in the editor: `null` = closed, "new" = create.
   const [editing, setEditing] = useState<Song | "new" | null>(null);
+
+  // One-time PCO library import (ADR-027 open question #2): offered only when
+  // the community's Planning Center integration is connected. The action
+  // re-checks both permission and connection server-side.
+  const pcoStatus = useAuthenticatedQuery(
+    api.functions.integrations.planningCenterStatus,
+    communityId ? { communityId: communityId as Id<"communities"> } : "skip",
+  );
+  const pcoConnected = pcoStatus?.isConnected ?? false;
+  const importFromPco = useAuthenticatedAction(
+    api.functions.pcoServices.songImport.importSongsFromPco,
+  );
+  const [importing, setImporting] = useState(false);
+
+  const handleImport = useCallback(async () => {
+    if (!communityId || importing) return;
+    setImporting(true);
+    try {
+      const result = await importFromPco({
+        communityId: communityId as Id<"communities">,
+      });
+      notify(
+        "Import complete",
+        `Imported ${result.imported} songs, updated ${result.updated}, skipped ${result.skipped}.`,
+      );
+    } catch (e: any) {
+      // ConvexError carries its message in `data`.
+      notifyError(
+        "Import failed",
+        typeof e?.data === "string" ? e.data : e?.message ?? "Please try again.",
+      );
+    } finally {
+      setImporting(false);
+    }
+  }, [communityId, importing, importFromPco]);
 
   const songs = useAuthenticatedQuery(
     api.functions.scheduling.songs.listSongs,
@@ -155,6 +194,31 @@ export function SongLibraryScreen() {
             >
               <Ionicons name="add" size={18} color={primaryColor} />
               <Text style={[styles.addText, { color: primaryColor }]}>Add song</Text>
+            </Pressable>
+          ) : null}
+
+          {canEdit && pcoConnected ? (
+            <Pressable
+              onPress={handleImport}
+              disabled={importing}
+              style={[
+                styles.addRow,
+                { borderColor: primaryColor, opacity: importing ? 0.6 : 1 },
+              ]}
+              accessibilityRole="button"
+            >
+              {importing ? (
+                <ActivityIndicator size="small" color={primaryColor} />
+              ) : (
+                <Ionicons
+                  name="cloud-download-outline"
+                  size={18}
+                  color={primaryColor}
+                />
+              )}
+              <Text style={[styles.addText, { color: primaryColor }]}>
+                {importing ? "Importing…" : "Import from Planning Center"}
+              </Text>
             </Pressable>
           ) : null}
 

--- a/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
+++ b/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
@@ -5,6 +5,7 @@ import { SongLibraryScreen } from "../SongLibraryScreen";
 import {
   useAuthenticatedQuery,
   useAuthenticatedMutation,
+  useAuthenticatedAction,
 } from "@services/api/convex";
 import { useFileUpload } from "@features/chat/hooks/useFileUpload";
 
@@ -40,6 +41,9 @@ jest.mock("@hooks/useCommunityTheme", () => ({
 // Whether the current user may manage songs (admin or group leader), surfaced
 // by the canManageSongs query.
 let mockCanManage = true;
+// Whether the community has a connected PCO integration, surfaced by the
+// integrations.planningCenterStatus query (gates the import button).
+let mockPcoConnected = true;
 jest.mock("@providers/AuthProvider", () => ({
   useAuth: () => ({ community: { id: "community-1" } }),
 }));
@@ -80,10 +84,20 @@ jest.mock("@services/api/convex", () => ({
           canManageSongs: "api.functions.scheduling.songs.canManageSongs",
         },
       },
+      integrations: {
+        planningCenterStatus: "api.functions.integrations.planningCenterStatus",
+      },
+      pcoServices: {
+        songImport: {
+          importSongsFromPco:
+            "api.functions.pcoServices.songImport.importSongsFromPco",
+        },
+      },
     },
   },
   useAuthenticatedQuery: jest.fn(),
   useAuthenticatedMutation: jest.fn(),
+  useAuthenticatedAction: jest.fn(),
 }));
 
 const SONGS = [
@@ -116,16 +130,20 @@ describe("SongLibraryScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCanManage = true;
+    mockPcoConnected = true;
     (useAuthenticatedQuery as jest.Mock).mockImplementation(
       (fn: string, args: unknown) => {
         if (args === "skip") return undefined;
         if (fn === "api.functions.scheduling.songs.listSongs") return SONGS;
         if (fn === "api.functions.scheduling.songs.canManageSongs")
           return mockCanManage;
+        if (fn === "api.functions.integrations.planningCenterStatus")
+          return { isConnected: mockPcoConnected };
         return undefined;
       },
     );
     setMutations({});
+    (useAuthenticatedAction as jest.Mock).mockReturnValue(jest.fn());
     (useFileUpload as jest.Mock).mockReturnValue({
       uploadFile: jest.fn(),
       uploading: false,
@@ -260,5 +278,67 @@ describe("SongLibraryScreen", () => {
     const { queryByText } = render(<SongLibraryScreen />);
     expect(queryByText("Add song")).toBeNull();
     expect(queryByText("Edit")).toBeNull();
+    expect(queryByText("Import from Planning Center")).toBeNull();
+  });
+
+  describe("Import from Planning Center", () => {
+    it("shows the import button for editors when PCO is connected", () => {
+      const { getByText } = render(<SongLibraryScreen />);
+      expect(getByText("Import from Planning Center")).toBeTruthy();
+    });
+
+    it("hides the import button when PCO is not connected", () => {
+      mockPcoConnected = false;
+      const { queryByText } = render(<SongLibraryScreen />);
+      expect(queryByText("Import from Planning Center")).toBeNull();
+    });
+
+    it("calls the import action and shows the result counts", async () => {
+      const importFromPco = jest.fn().mockResolvedValue({
+        imported: 42,
+        updated: 3,
+        skipped: 12,
+        total: 57,
+      });
+      (useAuthenticatedAction as jest.Mock).mockReturnValue(importFromPco);
+      const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+      const { getByText } = render(<SongLibraryScreen />);
+      fireEvent.press(getByText("Import from Planning Center"));
+
+      await waitFor(() => {
+        expect(importFromPco).toHaveBeenCalledWith({
+          communityId: "community-1",
+        });
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Import complete",
+          "Imported 42 songs, updated 3, skipped 12.",
+        );
+      });
+      alertSpy.mockRestore();
+    });
+
+    it("notifies when the import fails", async () => {
+      const importFromPco = jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error("ConvexError"), {
+            data: "Planning Center is not connected",
+          }),
+        );
+      (useAuthenticatedAction as jest.Mock).mockReturnValue(importFromPco);
+      const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+      const { getByText } = render(<SongLibraryScreen />);
+      fireEvent.press(getByText("Import from Planning Center"));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Import failed",
+          "Planning Center is not connected",
+        );
+      });
+      alertSpy.mockRestore();
+    });
   });
 });

--- a/docs/architecture/ADR-027-native-song-library-and-worship-media.md
+++ b/docs/architecture/ADR-027-native-song-library-and-worship-media.md
@@ -219,5 +219,10 @@ the run sheet renders title/charts/links without extra round-trips.
 2. Should the song library be seedable/importable from an existing PCO plan
    (one-time map of a plan's songs → `songs`, carrying CCLI#s) to ease the
    switch? Likely a useful migration aid; deferred to a follow-up.
+   **Resolved:** implemented as a one-time import of the *whole* PCO song
+   library (not a single plan) — `functions/pcoServices/songImport.ts`
+   (`importSongsFromPco`), surfaced as "Import from Planning Center" in the
+   Song Library screen. Matches by CCLI# (else case-insensitive title) and
+   fills only missing fields, so re-running never clobbers user edits.
 3. Per-item multitracks override vs. song-level only — start song-level; add the
    per-item override if a real "different mix this week" need appears.


### PR DESCRIPTION
## Summary

A one-tap **"Import from Planning Center"** for the Song Library (implements ADR-027 open question #2). Churches migrating off PCO get their whole song library — titles, authors, CCLI numbers, keys, BPMs, meters, arrangement names — pulled into the native `songs` table instead of typing it all in by hand.

Metadata only for now; importing the church's own uploaded **files** (charts/audio) is a planned fast-follow.

## Backend
- `importSongsFromPco({ token, communityId })` action → `{ imported, updated, skipped, total }`. Authenticates, checks the caller can manage songs (reuses `canManageSongs`), verifies the `planning_center` integration is connected, then fetches the full PCO song library.
- PCO's `/services/v2/songs` doesn't support `?include=arrangements`, so arrangements are fetched per-song (key/BPM/meter/arrangement name from the first arrangement), batched at the repo's standard 15-concurrency to respect the 100 req/20s rate limit. Songs list paginates via `links.next`.
- **Upsert is additive and never clobbers edits:** matched songs only get their *missing* fields filled. Dedupe is by CCLI number; failing that it **enriches a same-title song that has no CCLI yet** (rather than duplicating a hand-entered song), but never merges two distinct songs that share a title with different CCLIs.

## Frontend
- "Import from Planning Center" button on the Song Library screen, shown to editors when PCO is connected (`planningCenterStatus`). Shows a spinner while importing, then a summary: *"Imported 42 songs, updated 3, skipped 12."*

## Testing
- Convex: **204/204** across the pco + scheduling song suites — `mapPcoSongs` (arrangement merge, blank-title skip, missing fields), `upsertImportedSongs` (insert, ccli-fill-missing, ccli-less enrichment, distinct-ccli guard, batch dedupe), and the action (happy path with mocked PCO HTTP, not-connected, permission-denied).
- Mobile: SongLibraryScreen **12/12** (button gating, success counts, error path).
- Typecheck clean on all new code; lint 0 errors.

**Note:** `_generated/api.d.ts` hand-registers the new `pcoServices/songImport` module (codegen needs a live deployment); deploy-time codegen regenerates it.

https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo)_