### PR TITLE
Import church-uploaded chart files from Planning Center (ADR-027)

### DIFF
--- a/apps/convex/__tests__/pco/songFileImport.test.ts
+++ b/apps/convex/__tests__/pco/songFileImport.test.ts
@@ -124,6 +124,7 @@ function attachment(
       url: "https://files.pco/chart.pdf",
       content_type: "application/pdf",
       linked_url: null,
+      remote_link: null,
       pco_type: "AttachmentTypes::S3",
       downloadable: true,
       licenses_purchased: null,
@@ -190,6 +191,19 @@ describe("isChurchUploadedChart", () => {
         attachment("a", {
           linked_url: "https://docs.google.com/x",
           pco_type: "AttachmentTypes::GoogleDrive",
+          content_type: "application/pdf",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("skips remote_link attachments even with an upload-like pco_type", () => {
+    // PCO's other link attribute: an external link-out, not a church upload.
+    // License counts null + S3-ish pco_type + PDF MIME must NOT slip through.
+    expect(
+      isChurchUploadedChart(
+        attachment("a", {
+          remote_link: "https://example.com/chart.pdf",
           content_type: "application/pdf",
         }),
       ),

--- a/apps/convex/__tests__/pco/songFileImport.test.ts
+++ b/apps/convex/__tests__/pco/songFileImport.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for copying church-uploaded chart/audio FILES from PCO into songs'
+ * `charts` (ADR-027 Phase 2, the song-file import follow-up).
+ *
+ * Covers:
+ *  - `isChurchUploadedChart` — the licensing/type guardrail that decides which
+ *    PCO arrangement attachments may be re-hosted (church-uploaded PDF → import;
+ *    SongSelect/CCLI-licensed chart → skip; link/unsupported type → skip).
+ *  - `importSongsFromPco` with `includeFiles` — the download → R2 → attach flow,
+ *    with the PCO HTTP layer and the R2 put helper mocked. Asserts charts get
+ *    attached, idempotent re-runs add nothing, and SongSelect attachments are
+ *    skipped with correct counts.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import { buildSchedulingWorld } from "../scheduling/fixtures";
+import { isChurchUploadedChart } from "../../functions/pcoServices/songImport";
+import type {
+  PcoArrangement,
+  PcoSong,
+  PcoSongAttachment,
+} from "../../lib/pcoServicesApi";
+
+// Mock the PCO HTTP layer (token + fetchers + attachment download) and the
+// server-side R2 put helper. Everything else (auth, permissions, the upsert &
+// attach mutations) runs for real inside convexTest.
+vi.mock("../../lib/pcoServicesApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../lib/pcoServicesApi")>();
+  return {
+    ...actual,
+    getValidAccessToken: vi.fn().mockResolvedValue("mock-access-token"),
+    fetchAllSongs: vi.fn().mockResolvedValue([]),
+    fetchSongArrangements: vi.fn().mockResolvedValue([]),
+    fetchArrangementAttachments: vi.fn().mockResolvedValue([]),
+    openAttachmentUrl: vi.fn().mockResolvedValue(null),
+    downloadAttachmentBytes: vi
+      .fn()
+      .mockResolvedValue(new ArrayBuffer(8)),
+  };
+});
+
+vi.mock("../../lib/r2", () => ({
+  putR2Object: vi.fn(async (args: { fileName: string }) => ({
+    key: `uploads/mock-${args.fileName}`,
+    storagePath: `r2:uploads/mock-${args.fileName}`,
+  })),
+}));
+
+import {
+  fetchAllSongs,
+  fetchSongArrangements,
+  fetchArrangementAttachments,
+  openAttachmentUrl,
+  downloadAttachmentBytes,
+} from "../../lib/pcoServicesApi";
+import { putR2Object } from "../../lib/r2";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+  vi.clearAllMocks();
+});
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+function pcoSong(
+  id: string,
+  title: string,
+  attributes?: Partial<PcoSong["attributes"]>,
+): PcoSong {
+  return {
+    id,
+    type: "Song",
+    attributes: { title, ccli_number: null, author: null, ...attributes },
+  };
+}
+
+function pcoArrangement(
+  id: string,
+  attributes?: Partial<PcoArrangement["attributes"]>,
+): PcoArrangement {
+  return {
+    id,
+    type: "Arrangement",
+    attributes: {
+      name: "Default",
+      bpm: null,
+      length: null,
+      meter: null,
+      chord_chart_key: null,
+      ...attributes,
+    },
+  };
+}
+
+function attachment(
+  id: string,
+  attributes?: Partial<PcoSongAttachment["attributes"]>,
+): PcoSongAttachment {
+  return {
+    id,
+    type: "Attachment",
+    attributes: {
+      filename: "chart.pdf",
+      url: "https://files.pco/chart.pdf",
+      content_type: "application/pdf",
+      linked_url: null,
+      pco_type: "AttachmentTypes::S3",
+      downloadable: true,
+      licenses_purchased: null,
+      licenses_used: null,
+      licenses_remaining: null,
+      ...attributes,
+    },
+  };
+}
+
+async function connectPco(t: ReturnType<typeof convexTest>, communityId: any) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("communityIntegrations", {
+      communityId,
+      integrationType: "planning_center",
+      credentials: { access_token: "x" },
+      config: {},
+      status: "connected",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+// ============================================================================
+// isChurchUploadedChart (pure licensing/type guardrail)
+// ============================================================================
+
+describe("isChurchUploadedChart", () => {
+  it("imports a plain church-uploaded PDF", () => {
+    expect(isChurchUploadedChart(attachment("a"))).toBe(true);
+  });
+
+  it("imports a church-uploaded image and audio reference", () => {
+    expect(
+      isChurchUploadedChart(
+        attachment("a", { filename: "chart.png", content_type: "image/png" }),
+      ),
+    ).toBe(true);
+    expect(
+      isChurchUploadedChart(
+        attachment("a", { filename: "ref.mp3", content_type: "audio/mpeg" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips SongSelect/CCLI-licensed charts (license tracking present)", () => {
+    expect(
+      isChurchUploadedChart(
+        attachment("a", { licenses_purchased: 5, licenses_used: 1 }),
+      ),
+    ).toBe(false);
+    // Or marked by pco_type even when license counts happen to be null.
+    expect(
+      isChurchUploadedChart(
+        attachment("a", { pco_type: "AttachmentTypes::SongSelect" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("skips linked files (Google Docs / remote links)", () => {
+    expect(
+      isChurchUploadedChart(
+        attachment("a", {
+          linked_url: "https://docs.google.com/x",
+          pco_type: "AttachmentTypes::GoogleDrive",
+          content_type: "application/pdf",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("skips unsupported file types and non-downloadable files", () => {
+    expect(
+      isChurchUploadedChart(
+        attachment("a", {
+          filename: "clip.mp4",
+          content_type: "video/mp4",
+        }),
+      ),
+    ).toBe(false);
+    expect(isChurchUploadedChart(attachment("a", { downloadable: false }))).toBe(
+      false,
+    );
+  });
+});
+
+// ============================================================================
+// importSongsFromPco — file import phase
+// ============================================================================
+
+describe("importSongsFromPco (includeFiles)", () => {
+  function mockLibrary(attachments: PcoSongAttachment[]) {
+    (fetchAllSongs as any).mockResolvedValue([
+      pcoSong("s1", "Goodness of God", { ccli_number: "7117726" }),
+    ]);
+    (fetchSongArrangements as any).mockResolvedValue([
+      pcoArrangement("arr1", { chord_chart_key: "Ab" }),
+    ]);
+    (fetchArrangementAttachments as any).mockResolvedValue(attachments);
+  }
+
+  it("downloads a church chart, stores it in R2, and attaches it", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+    mockLibrary([attachment("a1", { filename: "leadsheet.pdf" })]);
+
+    const result = await t.action(
+      api.functions.pcoServices.songImport.importSongsFromPco,
+      { token, communityId: world.communityId },
+    );
+
+    expect(result.imported).toBe(1);
+    expect(result.filesImported).toBe(1);
+    expect(result.filesSkipped).toBe(0);
+    expect(putR2Object).toHaveBeenCalledTimes(1);
+    expect(downloadAttachmentBytes).toHaveBeenCalledTimes(1);
+
+    const songs = await t.run(async (ctx) =>
+      ctx.db
+        .query("songs")
+        .withIndex("by_community", (q) => q.eq("communityId", world.communityId))
+        .collect(),
+    );
+    const charts = songs[0].charts ?? [];
+    expect(charts).toHaveLength(1);
+    expect(charts[0].label).toBe("leadsheet.pdf (Ab)");
+    expect(charts[0].key).toBe("Ab");
+    expect(charts[0].fileKey).toBe("r2:uploads/mock-leadsheet.pdf");
+    expect(charts[0].mimeType).toBe("application/pdf");
+  });
+
+  it("skips SongSelect attachments and counts them", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+    mockLibrary([
+      attachment("a1", { filename: "church.pdf" }),
+      attachment("a2", {
+        filename: "songselect.pdf",
+        licenses_purchased: 10,
+        pco_type: "AttachmentTypes::SongSelect",
+      }),
+    ]);
+
+    const result = await t.action(
+      api.functions.pcoServices.songImport.importSongsFromPco,
+      { token, communityId: world.communityId },
+    );
+
+    expect(result.filesImported).toBe(1);
+    expect(result.filesSkipped).toBe(1);
+    // Only the church file was downloaded/stored.
+    expect(putR2Object).toHaveBeenCalledTimes(1);
+
+    const songs = await t.run(async (ctx) =>
+      ctx.db
+        .query("songs")
+        .withIndex("by_community", (q) => q.eq("communityId", world.communityId))
+        .collect(),
+    );
+    expect((songs[0].charts ?? []).map((c) => c.label)).toEqual([
+      "church.pdf (Ab)",
+    ]);
+  });
+
+  it("is idempotent: a re-run adds no new charts and no PCO downloads", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+    mockLibrary([attachment("a1", { filename: "leadsheet.pdf" })]);
+
+    await t.action(api.functions.pcoServices.songImport.importSongsFromPco, {
+      token,
+      communityId: world.communityId,
+    });
+    vi.clearAllMocks();
+    // Re-establish the library mocks cleared above.
+    mockLibrary([attachment("a1", { filename: "leadsheet.pdf" })]);
+
+    const second = await t.action(
+      api.functions.pcoServices.songImport.importSongsFromPco,
+      { token, communityId: world.communityId },
+    );
+
+    expect(second.filesImported).toBe(0);
+    // Already-present label → we don't even download the file again.
+    expect(downloadAttachmentBytes).not.toHaveBeenCalled();
+    expect(putR2Object).not.toHaveBeenCalled();
+
+    const songs = await t.run(async (ctx) =>
+      ctx.db
+        .query("songs")
+        .withIndex("by_community", (q) => q.eq("communityId", world.communityId))
+        .collect(),
+    );
+    expect(songs[0].charts ?? []).toHaveLength(1);
+  });
+
+  it("resolves the download URL via the open action when url is empty", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+    mockLibrary([attachment("a1", { filename: "leadsheet.pdf", url: null })]);
+    (openAttachmentUrl as any).mockResolvedValue("https://signed.pco/leadsheet.pdf");
+
+    const result = await t.action(
+      api.functions.pcoServices.songImport.importSongsFromPco,
+      { token, communityId: world.communityId },
+    );
+
+    expect(openAttachmentUrl).toHaveBeenCalledWith(
+      "mock-access-token",
+      "s1",
+      "arr1",
+      "a1",
+    );
+    expect(result.filesImported).toBe(1);
+  });
+
+  it("does not fetch attachments when includeFiles is false", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+    mockLibrary([attachment("a1")]);
+
+    const result = await t.action(
+      api.functions.pcoServices.songImport.importSongsFromPco,
+      { token, communityId: world.communityId, includeFiles: false },
+    );
+
+    expect(result.imported).toBe(1);
+    expect(result.filesImported).toBe(0);
+    expect(result.filesSkipped).toBe(0);
+    expect(fetchArrangementAttachments).not.toHaveBeenCalled();
+  });
+});

--- a/apps/convex/__tests__/pco/songImport.test.ts
+++ b/apps/convex/__tests__/pco/songImport.test.ts
@@ -32,6 +32,11 @@ vi.mock("../../lib/pcoServicesApi", async (importOriginal) => {
     getValidAccessToken: vi.fn().mockResolvedValue("mock-access-token"),
     fetchAllSongs: vi.fn().mockResolvedValue([]),
     fetchSongArrangements: vi.fn().mockResolvedValue([]),
+    // File-import phase: default to no attachments so these metadata-focused
+    // tests don't exercise the download/R2 path (covered in songFileImport).
+    fetchArrangementAttachments: vi.fn().mockResolvedValue([]),
+    openAttachmentUrl: vi.fn().mockResolvedValue(null),
+    downloadAttachmentBytes: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
   };
 });
 
@@ -467,7 +472,14 @@ describe("importSongsFromPco", () => {
       { token, communityId: world.communityId },
     );
 
-    expect(result).toEqual({ imported: 2, updated: 0, skipped: 0, total: 2 });
+    expect(result).toEqual({
+      imported: 2,
+      updated: 0,
+      skipped: 0,
+      total: 2,
+      filesImported: 0,
+      filesSkipped: 0,
+    });
 
     const songs = await t.run(async (ctx) =>
       ctx.db

--- a/apps/convex/functions/pcoServices/songImport.ts
+++ b/apps/convex/functions/pcoServices/songImport.ts
@@ -172,7 +172,7 @@ const BLOCKED_PCO_TYPE_SUBSTRINGS = [
  *  - it is `downloadable` (PCO itself permits download);
  *  - it carries NO CCLI/SongSelect license tracking (`licenses_purchased` etc.
  *    are null/0 — licensed content always tracks these);
- *  - it has NO `linked_url` (a link-out, not an uploaded file);
+ *  - it has NO `linked_url` or `remote_link` (a link-out, not an uploaded file);
  *  - its `pco_type` contains none of the blocked provider/link markers;
  *  - its `content_type` is a chart/audio format we support.
  *
@@ -191,8 +191,10 @@ export function isChurchUploadedChart(
   if ((a.licenses_used ?? 0) > 0) return false;
   if ((a.licenses_remaining ?? 0) > 0) return false;
 
-  // A linked file is not an upload we own.
+  // A linked/remote file is not an upload we own. PCO exposes link-outs via
+  // either `linked_url` or `remote_link`; reject both.
   if (a.linked_url) return false;
+  if (a.remote_link) return false;
 
   // Provider / link markers in pco_type are off-limits.
   const pcoType = (a.pco_type ?? "").toLowerCase();

--- a/apps/convex/functions/pcoServices/songImport.ts
+++ b/apps/convex/functions/pcoServices/songImport.ts
@@ -16,7 +16,12 @@
  */
 
 import { ConvexError, v } from "convex/values";
-import { action, internalMutation } from "../../_generated/server";
+import {
+  action,
+  internalMutation,
+  internalQuery,
+  type ActionCtx,
+} from "../../_generated/server";
 import { api, internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuthFromTokenAction } from "../../lib/auth";
@@ -24,9 +29,14 @@ import {
   getValidAccessToken,
   fetchAllSongs,
   fetchSongArrangements,
+  fetchArrangementAttachments,
+  openAttachmentUrl,
+  downloadAttachmentBytes,
   type PcoArrangement,
   type PcoSong,
+  type PcoSongAttachment,
 } from "../../lib/pcoServicesApi";
+import { putR2Object } from "../../lib/r2";
 
 // ============================================================================
 // Pure transform
@@ -98,6 +108,100 @@ export function mapPcoSongs(
   }
 
   return rows;
+}
+
+// ============================================================================
+// Church-uploaded chart filter (licensing guardrail, ADR-027)
+// ============================================================================
+
+/**
+ * Content types we can store as a chart. PDFs and images are the chart formats
+ * the rest of the song library already accepts (`uploads.ts` / SongLibrary
+ * screen's document picker). Audio is allowed too — a church's own recorded
+ * reference track is bring-your-own media it holds the rights to. Anything else
+ * (Google Docs, video, octet-stream links) is skipped.
+ */
+const SUPPORTED_CHART_CONTENT_TYPES = new Set<string>([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/mp4",
+]);
+
+/**
+ * Lower-cased substrings in `pco_type` that mark third-party / licensed sources
+ * we must NOT re-host: SongSelect/CCLI (the church's license does not grant us
+ * API re-hosting rights), PraiseCharts and MultiTracks (paid catalog content),
+ * and pure link types (Spotify/Drive/Dropbox/YouTube/Vimeo) which are not files
+ * we own anyway. A plain church upload's `pco_type` (e.g. "AttachmentTypes::S3"
+ * / file upload) matches none of these.
+ */
+const BLOCKED_PCO_TYPE_SUBSTRINGS = [
+  "songselect",
+  "ccli",
+  "praisecharts",
+  "multitracks",
+  "spotify",
+  "youtube",
+  "vimeo",
+  "googledrive",
+  "google_drive",
+  "dropbox",
+  "url",
+  "link",
+];
+
+/**
+ * Decide whether a PCO arrangement attachment is a church-uploaded chart we may
+ * copy. CONSERVATIVE by design (the licensing guardrail): an attachment is
+ * imported only when it is positively identifiable as the church's own file —
+ * every ambiguous or third-party-sourced one is rejected (and counted as
+ * skipped by the caller).
+ *
+ * An attachment is imported only if ALL hold:
+ *  - it is `downloadable` (PCO itself permits download);
+ *  - it carries NO CCLI/SongSelect license tracking (`licenses_purchased` etc.
+ *    are null/0 — licensed content always tracks these);
+ *  - it has NO `linked_url` (a link-out, not an uploaded file);
+ *  - its `pco_type` contains none of the blocked provider/link markers;
+ *  - its `content_type` is a chart/audio format we support.
+ *
+ * The license-tracking + `pco_type` provider check is the primary signal that
+ * distinguishes a SongSelect/CCLI chart from a file the church uploaded itself.
+ */
+export function isChurchUploadedChart(
+  attachment: PcoSongAttachment,
+): boolean {
+  const a = attachment.attributes;
+
+  if (!a.downloadable) return false;
+
+  // Any CCLI/SongSelect license tracking → licensed content, never re-hosted.
+  if ((a.licenses_purchased ?? 0) > 0) return false;
+  if ((a.licenses_used ?? 0) > 0) return false;
+  if ((a.licenses_remaining ?? 0) > 0) return false;
+
+  // A linked file is not an upload we own.
+  if (a.linked_url) return false;
+
+  // Provider / link markers in pco_type are off-limits.
+  const pcoType = (a.pco_type ?? "").toLowerCase();
+  if (BLOCKED_PCO_TYPE_SUBSTRINGS.some((s) => pcoType.includes(s))) return false;
+
+  // Only file types we can serve as charts.
+  if (!SUPPORTED_CHART_CONTENT_TYPES.has(a.content_type)) return false;
+
+  return true;
 }
 
 // ============================================================================
@@ -223,6 +327,72 @@ export const upsertImportedSongs = internalMutation({
 });
 
 // ============================================================================
+// Chart attach mutation + matching query (file import, ADR-027 Phase 2)
+// ============================================================================
+
+const importedChartValidator = v.object({
+  key: v.optional(v.string()),
+  label: v.string(),
+  fileKey: v.string(),
+  mimeType: v.string(),
+});
+
+/**
+ * Minimal projection of a community's songs for matching imported PCO files
+ * back to native song docs in the action. Returns each song's id, title, ccli,
+ * and the labels of charts it already has (so the action skips re-downloading a
+ * file it already imported — idempotent re-runs).
+ *
+ * Internal-only: the public action authenticates/permission-checks first.
+ */
+export const listCommunitySongsForMatching = internalQuery({
+  args: { communityId: v.id("communities") },
+  handler: async (ctx, args) => {
+    const songs = await ctx.db
+      .query("songs")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    return songs.map((s) => ({
+      _id: s._id,
+      title: s.title,
+      ccliNumber: s.ccliNumber,
+      chartLabels: (s.charts ?? []).map((c) => c.label),
+    }));
+  },
+});
+
+/**
+ * Append charts to a song, skipping any whose `label` the song already has.
+ * Idempotent: re-running the import never duplicates a chart. The label encodes
+ * the PCO filename (+ key), so the same source file maps to the same label.
+ *
+ * Returns how many charts were actually added.
+ *
+ * Internal-only: the public action authenticates/permission-checks first.
+ */
+export const attachImportedCharts = internalMutation({
+  args: {
+    songId: v.id("songs"),
+    charts: v.array(importedChartValidator),
+  },
+  handler: async (ctx, args): Promise<{ added: number }> => {
+    const song = await ctx.db.get(args.songId);
+    if (!song) return { added: 0 };
+
+    const existing = song.charts ?? [];
+    const existingLabels = new Set(existing.map((c) => c.label));
+    const toAdd = args.charts.filter((c) => !existingLabels.has(c.label));
+    if (toAdd.length === 0) return { added: 0 };
+
+    await ctx.db.patch(args.songId, {
+      charts: [...existing, ...toAdd],
+      updatedAt: Date.now(),
+    });
+    return { added: toAdd.length };
+  },
+});
+
+// ============================================================================
 // Public action
 // ============================================================================
 
@@ -233,6 +403,25 @@ export const upsertImportedSongs = internalMutation({
 const BATCH_SIZE = 15;
 const MIN_BATCH_INTERVAL_MS = 3500;
 
+/** A native chart row resolved from a church-uploaded PCO attachment. */
+interface ResolvedChart {
+  key?: string;
+  label: string;
+  fileKey: string;
+  mimeType: string;
+}
+
+/**
+ * Build the chart `label` for an imported attachment. The label is the
+ * idempotency key (re-runs skip a song's existing labels), so it must be stable
+ * for the same source file: PCO's filename, suffixed with the arrangement key
+ * when known (charts are key-specific in worship).
+ */
+function chartLabel(filename: string, key: string | undefined): string {
+  const name = filename.trim() || "Chart";
+  return key ? `${name} (${key})` : name;
+}
+
 /**
  * One-time import of the community's PCO Services song library into the
  * native `songs` table.
@@ -240,13 +429,19 @@ const MIN_BATCH_INTERVAL_MS = 3500;
  * Auth: community admin or group leader (`canManageSongs`); the community
  * must have a connected Planning Center integration.
  *
- * Returns `{ imported, updated, skipped, total }` — `total` is the number of
- * library rows processed (imported + updated + skipped).
+ * When `includeFiles` is true (the default), also copies each matched song's
+ * CHURCH-UPLOADED chart/audio attachments out of PCO into R2 and attaches them
+ * to the song (see `isChurchUploadedChart` for the licensing guardrail).
+ *
+ * Returns `{ imported, updated, skipped, total, filesImported, filesSkipped }`
+ * — `total` is the number of library rows processed; `filesSkipped` counts
+ * attachments rejected by the licensing/type guardrail.
  */
 export const importSongsFromPco = action({
   args: {
     token: v.string(),
     communityId: v.id("communities"),
+    includeFiles: v.optional(v.boolean()),
   },
   handler: async (
     ctx,
@@ -256,6 +451,8 @@ export const importSongsFromPco = action({
     updated: number;
     skipped: number;
     total: number;
+    filesImported: number;
+    filesSkipped: number;
   }> => {
     // 1. Authenticate and check song-library permission. Guards like
     //    requireCommunitySongEditor need query/mutation ctx, so the action
@@ -315,7 +512,7 @@ export const importSongsFromPco = action({
       }
     }
 
-    // 4. Transform and upsert.
+    // 4. Transform and upsert metadata.
     const songs = mapPcoSongs(pcoSongs, arrangementsBySongId);
     const counts: { imported: number; updated: number; skipped: number } =
       await ctx.runMutation(
@@ -323,6 +520,177 @@ export const importSongsFromPco = action({
         { communityId: args.communityId, userId, songs },
       );
 
-    return { ...counts, total: songs.length };
+    // 5. Optionally copy church-uploaded chart files into R2 and attach them.
+    let filesImported = 0;
+    let filesSkipped = 0;
+    if (args.includeFiles ?? true) {
+      const fileResult = await importSongFiles(ctx, {
+        communityId: args.communityId,
+        accessToken,
+        pcoSongs,
+        arrangementsBySongId,
+      });
+      filesImported = fileResult.filesImported;
+      filesSkipped = fileResult.filesSkipped;
+    }
+
+    return {
+      ...counts,
+      total: songs.length,
+      filesImported,
+      filesSkipped,
+    };
   },
 });
+
+/**
+ * Copy each matched song's church-uploaded chart attachments from PCO into R2
+ * and attach them to the native song. Shared by the action; pulled out to keep
+ * the handler readable.
+ *
+ * Matching mirrors the metadata upsert: a PCO song maps to a native song by
+ * CCLI number, else case-insensitive title. Attachments live on the song's
+ * arrangements; we fetch them in the same paced batches and apply the
+ * `isChurchUploadedChart` guardrail. Re-runs are idempotent — the attach
+ * mutation skips charts whose label already exists, and we skip whole songs
+ * whose existing chart labels already cover the source file.
+ */
+async function importSongFiles(
+  ctx: ActionCtx,
+  params: {
+    communityId: Id<"communities">;
+    accessToken: string;
+    pcoSongs: PcoSong[];
+    arrangementsBySongId: Map<string, PcoArrangement[]>;
+  },
+): Promise<{ filesImported: number; filesSkipped: number }> {
+  const { communityId, accessToken, pcoSongs, arrangementsBySongId } = params;
+
+  // Build CCLI/title → native song lookup so we can attach to the right doc.
+  const nativeSongs = await ctx.runQuery(
+    internal.functions.pcoServices.songImport.listCommunitySongsForMatching,
+    { communityId },
+  );
+  const byCcli = new Map<string, (typeof nativeSongs)[number]>();
+  const byTitle = new Map<string, (typeof nativeSongs)[number]>();
+  for (const s of nativeSongs) {
+    if (s.ccliNumber) byCcli.set(s.ccliNumber, s);
+    if (!byTitle.has(s.title.toLowerCase())) byTitle.set(s.title.toLowerCase(), s);
+  }
+
+  // Existing chart labels per native song id — to skip already-imported files
+  // before doing any network work (idempotent re-runs make no PCO requests).
+  const existingLabels = new Map<string, Set<string>>(
+    nativeSongs.map((s) => [s._id, new Set(s.chartLabels)]),
+  );
+
+  let filesImported = 0;
+  let filesSkipped = 0;
+
+  for (let i = 0; i < pcoSongs.length; i += BATCH_SIZE) {
+    const batchStart = Date.now();
+    const batch = pcoSongs.slice(i, i + BATCH_SIZE);
+
+    await Promise.all(
+      batch.map(async (pcoSong) => {
+        // Resolve which native song this maps to (CCLI first, else title).
+        const ccli =
+          pcoSong.attributes.ccli_number == null
+            ? undefined
+            : String(pcoSong.attributes.ccli_number).trim() || undefined;
+        const title = pcoSong.attributes.title?.trim();
+        const native =
+          (ccli ? byCcli.get(ccli) : undefined) ??
+          (title ? byTitle.get(title.toLowerCase()) : undefined);
+        if (!native) return;
+
+        const arrangement = arrangementsBySongId.get(pcoSong.id)?.[0];
+        if (!arrangement) return;
+
+        let attachments: PcoSongAttachment[];
+        try {
+          attachments = await fetchArrangementAttachments(
+            accessToken,
+            pcoSong.id,
+            arrangement.id,
+          );
+        } catch {
+          // A single song's attachment fetch failing must not abort the import.
+          return;
+        }
+
+        const labels = existingLabels.get(native._id) ?? new Set<string>();
+        const charts: ResolvedChart[] = [];
+
+        for (const attachment of attachments) {
+          if (!isChurchUploadedChart(attachment)) {
+            filesSkipped++;
+            continue;
+          }
+          const key = arrangement.attributes.chord_chart_key?.trim() || undefined;
+          const label = chartLabel(attachment.attributes.filename, key);
+          // Idempotency: skip a file we already imported for this song.
+          if (labels.has(label)) continue;
+
+          let url = attachment.attributes.url;
+          if (!url) {
+            url = await openAttachmentUrl(
+              accessToken,
+              pcoSong.id,
+              arrangement.id,
+              attachment.id,
+            );
+          }
+          if (!url) {
+            filesSkipped++;
+            continue;
+          }
+
+          let bytes: ArrayBuffer;
+          try {
+            bytes = await downloadAttachmentBytes(url);
+          } catch {
+            filesSkipped++;
+            continue;
+          }
+
+          const { storagePath } = await putR2Object({
+            folder: "uploads",
+            fileName: attachment.attributes.filename,
+            contentType: attachment.attributes.content_type,
+            body: bytes,
+          });
+
+          charts.push({
+            ...(key ? { key } : {}),
+            label,
+            fileKey: storagePath,
+            mimeType: attachment.attributes.content_type,
+          });
+          labels.add(label);
+        }
+
+        if (charts.length > 0) {
+          const { added } = await ctx.runMutation(
+            internal.functions.pcoServices.songImport.attachImportedCharts,
+            { songId: native._id, charts },
+          );
+          filesImported += added;
+        }
+      }),
+    );
+
+    // Same pacing as the arrangement fetch — stay under 100 req/20s.
+    const isLastBatch = i + BATCH_SIZE >= pcoSongs.length;
+    if (!isLastBatch) {
+      const elapsed = Date.now() - batchStart;
+      if (elapsed < MIN_BATCH_INTERVAL_MS) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, MIN_BATCH_INTERVAL_MS - elapsed),
+        );
+      }
+    }
+  }
+
+  return { filesImported, filesSkipped };
+}

--- a/apps/convex/lib/pcoServicesApi.ts
+++ b/apps/convex/lib/pcoServicesApi.ts
@@ -916,3 +916,114 @@ export async function fetchSongArrangements(
   );
   return response.data;
 }
+
+// ============================================================================
+// Song / Arrangement Attachments (ADR-027 Phase 2 — church-uploaded charts)
+// ============================================================================
+
+/**
+ * A song/arrangement-level attachment in PCO.
+ *
+ * In PCO Services, chord charts and other files hang off a song's *arrangement*
+ * (`/songs/{id}/arrangements/{id}/attachments`). The attributes below are the
+ * ones we need to (a) tell a church-uploaded file from SongSelect/CCLI-sourced
+ * content we may not re-host, and (b) decide whether it is a file type we can
+ * store as a chart.
+ *
+ * Licensing signal (see classifyChurchUploadedChart): SongSelect/CCLI/
+ * PraiseCharts content carries license tracking (`licenses_purchased` etc.) and
+ * a provider `pco_type`; remote/linked files carry a `linked_url`. A file the
+ * church uploaded itself is a plain upload with none of these.
+ */
+export interface PcoSongAttachment {
+  id: string;
+  type: "Attachment";
+  attributes: {
+    filename: string;
+    /** Direct URL PCO exposes; may be empty until the `open` action is called. */
+    url: string | null;
+    content_type: string;
+    /** Non-null for links (Spotify/Drive/Dropbox/remote SongSelect), not uploads. */
+    linked_url: string | null;
+    /** e.g. "AttachmentTypes::SongSelect", "AttachmentTypes::S3". */
+    pco_type: string | null;
+    downloadable: boolean;
+    /** CCLI/SongSelect license tracking — present on licensed content only. */
+    licenses_purchased: number | null;
+    licenses_used: number | null;
+    licenses_remaining: number | null;
+  };
+}
+
+interface PcoAttachmentsPageResponse {
+  data: PcoSongAttachment[];
+  links?: { next?: string };
+}
+
+/**
+ * Fetch all attachments on a song's arrangement.
+ * GET /services/v2/songs/{songId}/arrangements/{arrangementId}/attachments
+ *
+ * Uses `pcoFetchWithRetry` (429-aware) and follows pagination. Callers must
+ * batch these per-arrangement calls to respect the 100-req/20s rate limit.
+ */
+export async function fetchArrangementAttachments(
+  accessToken: string,
+  songId: string,
+  arrangementId: string
+): Promise<PcoSongAttachment[]> {
+  const attachments: PcoSongAttachment[] = [];
+  let nextUrl: string | undefined = `${PCO_SERVICES_BASE}/songs/${songId}/arrangements/${arrangementId}/attachments?per_page=100`;
+
+  while (nextUrl) {
+    const response: PcoAttachmentsPageResponse =
+      await pcoFetchWithRetry<PcoAttachmentsPageResponse>(accessToken, nextUrl);
+    attachments.push(...response.data);
+    nextUrl = response.links?.next;
+  }
+
+  return attachments;
+}
+
+/**
+ * Resolve an attachment's temporary, downloadable URL.
+ *
+ * PCO does not expose a stable download URL on the attachment itself; you must
+ * POST to `.../attachments/{id}/open`, which returns an `AttachmentActivity`
+ * whose `attachment_url` is a short-lived signed URL. (Confirmed against PCO's
+ * Services API — the Attachment vertex's `open` action.)
+ */
+export async function openAttachmentUrl(
+  accessToken: string,
+  songId: string,
+  arrangementId: string,
+  attachmentId: string
+): Promise<string | null> {
+  const response = await pcoFetchWithRetry<{
+    data?: { attributes?: { attachment_url?: string | null } };
+  }>(
+    accessToken,
+    `${PCO_SERVICES_BASE}/songs/${songId}/arrangements/${arrangementId}/attachments/${attachmentId}/open`,
+    { method: "POST" }
+  );
+  return response.data?.attributes?.attachment_url ?? null;
+}
+
+/**
+ * Download an attachment's bytes from a (temporary) URL.
+ *
+ * The signed `attachment_url` is not a PCO API endpoint — it points straight at
+ * the file store — so this is a plain `fetch`, NOT `pcoFetch` (no bearer auth).
+ */
+export async function downloadAttachmentBytes(
+  url: string
+): Promise<ArrayBuffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new PcoApiError(
+      response.status,
+      `Failed to download attachment (${response.status})`
+    );
+  }
+  return response.arrayBuffer();
+}

--- a/apps/convex/lib/pcoServicesApi.ts
+++ b/apps/convex/lib/pcoServicesApi.ts
@@ -945,6 +945,8 @@ export interface PcoSongAttachment {
     content_type: string;
     /** Non-null for links (Spotify/Drive/Dropbox/remote SongSelect), not uploads. */
     linked_url: string | null;
+    /** PCO's other link attribute for external/linked files; also not an upload. */
+    remote_link: string | null;
     /** e.g. "AttachmentTypes::SongSelect", "AttachmentTypes::S3". */
     pco_type: string | null;
     downloadable: boolean;

--- a/apps/convex/lib/r2.ts
+++ b/apps/convex/lib/r2.ts
@@ -1,0 +1,62 @@
+/**
+ * Server-side Cloudflare R2 object storage.
+ *
+ * The client upload pipeline (`functions/uploads.ts`) is presigned-URL only:
+ * the *client* PUTs the bytes. Server-side flows that already hold the bytes
+ * (e.g. copying a church's chart out of Planning Center, ADR-027 Phase 2) need
+ * to PUT directly. This is the lowest-level R2 helper for that — it reuses the
+ * same S3-compatible client, env vars, and `r2:<key>` storage-path convention
+ * that `getR2FileUploadUrl` and `getMediaUrl` use, so files land in the same
+ * bucket and resolve through the same URL resolver.
+ */
+
+/** Generate an R2 object key under `folder`, sanitizing the file name. */
+function buildObjectKey(folder: string, fileName: string): string {
+  const uuid = crypto.randomUUID();
+  const sanitized = fileName
+    .replace(/[^a-zA-Z0-9.-]/g, "_")
+    .slice(0, 50);
+  return `${folder}/${uuid}-${sanitized}`;
+}
+
+/**
+ * Upload bytes to R2 and return the database storage path (`r2:<key>`),
+ * resolvable to a public URL via `getMediaUrl`.
+ *
+ * @throws Error if R2 env vars are not configured.
+ */
+export async function putR2Object(args: {
+  folder: string;
+  fileName: string;
+  contentType: string;
+  body: ArrayBuffer;
+}): Promise<{ key: string; storagePath: string }> {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+  const bucketName = process.env.R2_BUCKET_NAME;
+
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
+    throw new Error("R2 not configured. Missing environment variables.");
+  }
+
+  const key = buildObjectKey(args.folder, args.fileName);
+
+  const { S3Client, PutObjectCommand } = await import("@aws-sdk/client-s3");
+  const r2Client = new S3Client({
+    region: "auto",
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+  });
+
+  await r2Client.send(
+    new PutObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+      Body: new Uint8Array(args.body),
+      ContentType: args.contentType,
+    })
+  );
+
+  return { key, storagePath: `r2:${key}` };
+}

--- a/apps/mobile/features/songs/components/SongLibraryScreen.tsx
+++ b/apps/mobile/features/songs/components/SongLibraryScreen.tsx
@@ -111,7 +111,7 @@ export function SongLibraryScreen() {
       });
       notify(
         "Import complete",
-        `Imported ${result.imported} songs, updated ${result.updated}, skipped ${result.skipped}.`,
+        `Imported ${result.imported} songs and ${result.filesImported} charts, updated ${result.updated}, skipped ${result.skipped}.`,
       );
     } catch (e: any) {
       // ConvexError carries its message in `data`.

--- a/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
+++ b/apps/mobile/features/songs/components/__tests__/SongLibraryScreen.test.tsx
@@ -299,6 +299,8 @@ describe("SongLibraryScreen", () => {
         updated: 3,
         skipped: 12,
         total: 57,
+        filesImported: 18,
+        filesSkipped: 5,
       });
       (useAuthenticatedAction as jest.Mock).mockReturnValue(importFromPco);
       const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
@@ -312,7 +314,7 @@ describe("SongLibraryScreen", () => {
         });
         expect(alertSpy).toHaveBeenCalledWith(
           "Import complete",
-          "Imported 42 songs, updated 3, skipped 12.",
+          "Imported 42 songs and 18 charts, updated 3, skipped 12.",
         );
       });
       alertSpy.mockRestore();


### PR DESCRIPTION
## Summary

Follow-up to #445 (greenlit). The PCO import now also copies the church's **own uploaded chart/audio files** from Planning Center into each song's `charts` (stored in R2), so a migrating church gets its chart binder, not just metadata.

## Licensing guardrail (the important part)
Only files the church uploaded itself are copied — **never SongSelect/CCLI/PraiseCharts/MultiTracks content**, which we have no right to re-host. `isChurchUploadedChart` is conservative/fail-safe: an attachment is imported only if **all** hold —
- `downloadable === true`;
- **no license tracking** (`licenses_purchased/used/remaining` all null/0 — CCLI/SongSelect/PraiseCharts content always tracks these) ← the primary discriminator;
- no `linked_url` (link-out, not an upload);
- `pco_type` not in a provider denylist (songselect/ccli/praisecharts/multitracks/drive/dropbox/spotify/youtube/…);
- a supported chart/audio MIME (PDF, images, mp3/m4a/wav).

Anything ambiguous is **skipped** and counted. Worst case: we over-skip a legit church file; we can never re-host a licensed one. ⚠️ One follow-up: the exact SongSelect `pco_type` string couldn't be verified against live PCO data, so the `pco_type` list is a *secondary* guard — worth a spot-check against a real church library before relying on it in production (no rush given the fail-safe design + admin gating).

## How it works
- `importSongsFromPco({ token, communityId, includeFiles? })` (default `true`) now returns `{ imported, updated, skipped, total, filesImported, filesSkipped }`.
- Per song's first arrangement: fetch attachments, filter via the guardrail, get a download URL (PCO's `…/attachments/{id}/open` signed-URL step when needed), download bytes, store in R2 via a new server-side `putR2Object` (reuses the existing `@aws-sdk/client-s3` + `r2:` convention from `uploads.ts`), and attach to the song.
- **Idempotent**: charts dedupe by label (filename + key); re-runs skip already-imported files *before* any PCO download. Rate limiting reuses the existing pacing + 429 retry.

## Testing
- Convex: pco + scheduling song suites **217 passed** (new `songFileImport` classifier + flow tests 10; updated `songImport` 14). 
- Mobile: SongLibraryScreen **12 passed** (import toast now reports charts).
- tsc clean on changed files; lint 0 errors.

https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo)_