### PR TITLE
Actionable error when Planning Center song import is forbidden (403)

### DIFF
--- a/apps/convex/__tests__/pco/songImport.test.ts
+++ b/apps/convex/__tests__/pco/songImport.test.ts
@@ -20,6 +20,7 @@ import { generateTokens } from "../../lib/auth";
 import { api, internal } from "../../_generated/api";
 import { buildSchedulingWorld } from "../scheduling/fixtures";
 import { mapPcoSongs } from "../../functions/pcoServices/songImport";
+import { PcoApiError } from "../../lib/pcoServicesApi";
 import type { PcoArrangement, PcoSong } from "../../lib/pcoServicesApi";
 
 // Mock only the PCO HTTP layer — token + fetch helpers. Everything else
@@ -518,5 +519,22 @@ describe("importSongsFromPco", () => {
         communityId: world.communityId,
       }),
     ).rejects.toThrow(/group leader or community admin/);
+  });
+
+  it("maps a PCO 403 to an actionable permission message", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+
+    (fetchAllSongs as any).mockRejectedValue(
+      new PcoApiError(403, "PCO API error: Forbidden", "forbidden"),
+    );
+
+    await expect(
+      t.action(api.functions.pcoServices.songImport.importSongsFromPco, {
+        token,
+        communityId: world.communityId,
+      }),
+    ).rejects.toThrow(/Editor or Administrator access to Services/);
   });
 });

--- a/apps/convex/__tests__/pco/songImport.test.ts
+++ b/apps/convex/__tests__/pco/songImport.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../lib/pcoServicesApi", async (importOriginal) => {
 import {
   fetchAllSongs,
   fetchSongArrangements,
+  getValidAccessToken,
 } from "../../lib/pcoServicesApi";
 
 let activeHandle: ReturnType<typeof convexTest> | null = null;
@@ -536,5 +537,23 @@ describe("importSongsFromPco", () => {
         communityId: world.communityId,
       }),
     ).rejects.toThrow(/Editor or Administrator access to Services/);
+  });
+
+  it("maps a token refresh failure to the reconnect message", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await connectPco(t, world.communityId);
+
+    // A revoked refresh token surfaces from getValidAccessToken (often 400).
+    (getValidAccessToken as any).mockRejectedValueOnce(
+      new PcoApiError(400, "Failed to refresh Planning Center access token"),
+    );
+
+    await expect(
+      t.action(api.functions.pcoServices.songImport.importSongsFromPco, {
+        token,
+        communityId: world.communityId,
+      }),
+    ).rejects.toThrow(/expired or was revoked/);
   });
 });

--- a/apps/convex/functions/pcoServices/songImport.ts
+++ b/apps/convex/functions/pcoServices/songImport.ts
@@ -32,11 +32,50 @@ import {
   fetchArrangementAttachments,
   openAttachmentUrl,
   downloadAttachmentBytes,
+  PcoApiError,
   type PcoArrangement,
   type PcoSong,
   type PcoSongAttachment,
 } from "../../lib/pcoServicesApi";
 import { putR2Object } from "../../lib/r2";
+
+/**
+ * Map a PCO API failure to an actionable, user-facing message. A bare
+ * `PcoApiError` would otherwise surface its raw status/stack in the client
+ * dialog. 403 in particular is common here: the OAuth token is valid (it has
+ * the `services` scope) but the connected Planning Center account lacks
+ * permission to read the org's Services song library.
+ */
+function pcoImportError(err: unknown): ConvexError<string> {
+  if (err instanceof PcoApiError) {
+    if (err.status === 403) {
+      return new ConvexError(
+        "Planning Center denied access to your song library. The connected " +
+          "Planning Center account needs Editor or Administrator access to " +
+          "Services. Reconnect Planning Center with an account that has those " +
+          "permissions, then try again.",
+      );
+    }
+    if (err.status === 401) {
+      return new ConvexError(
+        "Your Planning Center connection has expired or was revoked. " +
+          "Reconnect Planning Center and try again.",
+      );
+    }
+    if (err.status === 429) {
+      return new ConvexError(
+        "Planning Center is rate-limiting the import. Wait a minute and try again.",
+      );
+    }
+    return new ConvexError(
+      `Planning Center returned an error (${err.status}). Please try again, or ` +
+        "reconnect Planning Center if this persists.",
+    );
+  }
+  return new ConvexError(
+    "Something went wrong importing from Planning Center. Please try again.",
+  );
+}
 
 // ============================================================================
 // Pure transform
@@ -486,32 +525,39 @@ export const importSongsFromPco = action({
 
     // 3. Fetch the whole library, then each song's arrangements in batches
     //    (the songs endpoint has no `include=arrangements`; see
-    //    fetchSongArrangements).
-    const pcoSongs = await fetchAllSongs(accessToken);
-
+    //    fetchSongArrangements). PCO API failures (e.g. a 403 when the
+    //    connected account can't read the song library) are mapped to a clear,
+    //    actionable message rather than surfacing a raw stack trace.
+    let pcoSongs: PcoSong[];
     const arrangementsBySongId = new Map<string, PcoArrangement[]>();
-    for (let i = 0; i < pcoSongs.length; i += BATCH_SIZE) {
-      const batchStart = Date.now();
-      const batch = pcoSongs.slice(i, i + BATCH_SIZE);
-      const results = await Promise.all(
-        batch.map(
-          async (song) =>
-            [song.id, await fetchSongArrangements(accessToken, song.id)] as const,
-        ),
-      );
-      for (const [songId, arrangements] of results) {
-        arrangementsBySongId.set(songId, arrangements);
-      }
-      // Pace to stay under PCO's 100/20s rate limit; no wait after the last batch.
-      const isLastBatch = i + BATCH_SIZE >= pcoSongs.length;
-      if (!isLastBatch) {
-        const elapsed = Date.now() - batchStart;
-        if (elapsed < MIN_BATCH_INTERVAL_MS) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, MIN_BATCH_INTERVAL_MS - elapsed),
-          );
+    try {
+      pcoSongs = await fetchAllSongs(accessToken);
+
+      for (let i = 0; i < pcoSongs.length; i += BATCH_SIZE) {
+        const batchStart = Date.now();
+        const batch = pcoSongs.slice(i, i + BATCH_SIZE);
+        const results = await Promise.all(
+          batch.map(
+            async (song) =>
+              [song.id, await fetchSongArrangements(accessToken, song.id)] as const,
+          ),
+        );
+        for (const [songId, arrangements] of results) {
+          arrangementsBySongId.set(songId, arrangements);
+        }
+        // Pace to stay under PCO's 100/20s rate limit; no wait after the last batch.
+        const isLastBatch = i + BATCH_SIZE >= pcoSongs.length;
+        if (!isLastBatch) {
+          const elapsed = Date.now() - batchStart;
+          if (elapsed < MIN_BATCH_INTERVAL_MS) {
+            await new Promise((resolve) =>
+              setTimeout(resolve, MIN_BATCH_INTERVAL_MS - elapsed),
+            );
+          }
         }
       }
+    } catch (err) {
+      throw pcoImportError(err);
     }
 
     // 4. Transform and upsert metadata.
@@ -526,14 +572,21 @@ export const importSongsFromPco = action({
     let filesImported = 0;
     let filesSkipped = 0;
     if (args.includeFiles ?? true) {
-      const fileResult = await importSongFiles(ctx, {
-        communityId: args.communityId,
-        accessToken,
-        pcoSongs,
-        arrangementsBySongId,
-      });
-      filesImported = fileResult.filesImported;
-      filesSkipped = fileResult.filesSkipped;
+      // Best-effort: metadata is already committed above, so a permission or
+      // network failure while copying files must not fail the whole import.
+      // Re-running is idempotent and will retry the files.
+      try {
+        const fileResult = await importSongFiles(ctx, {
+          communityId: args.communityId,
+          accessToken,
+          pcoSongs,
+          arrangementsBySongId,
+        });
+        filesImported = fileResult.filesImported;
+        filesSkipped = fileResult.filesSkipped;
+      } catch {
+        // Swallow — songs imported; files can be retried on the next run.
+      }
     }
 
     return {

--- a/apps/convex/functions/pcoServices/songImport.ts
+++ b/apps/convex/functions/pcoServices/songImport.ts
@@ -521,7 +521,18 @@ export const importSongsFromPco = action({
     if (!integration || integration.status !== "connected") {
       throw new ConvexError("Planning Center is not connected");
     }
-    const accessToken = await getValidAccessToken(ctx, args.communityId);
+    // Acquiring/refreshing the token can fail if it's expired or revoked (a
+    // revoked refresh token returns 400, not 401), so map any failure here to
+    // the reconnect guidance regardless of status — it always means reconnect.
+    let accessToken: string;
+    try {
+      accessToken = await getValidAccessToken(ctx, args.communityId);
+    } catch {
+      throw new ConvexError(
+        "Your Planning Center connection has expired or was revoked. " +
+          "Reconnect Planning Center and try again.",
+      );
+    }
 
     // 3. Fetch the whole library, then each song's arrangements in batches
     //    (the songs endpoint has no `include=arrangements`; see


### PR DESCRIPTION
## Summary

A church hit **`Import failed — Uncaught PcoApiError: PCO API error: Forbidden`** (a raw stack trace) when importing from Planning Center. The import got a **403** from `GET /services/v2/songs`.

## Diagnosis (not a code bug — a PCO permissions issue, but our UX was bad)
The OAuth token is valid and *does* carry the `services` scope, so this isn't a missing-scope bug. PCO mirrors the user's in-app permissions on the API: a **403 on the song library** means the **connected Planning Center account doesn't have permission to read the org's Services song library** (or the connection predates song access and needs reconnecting). The PCO API never even returned data, so there was nothing to import.

The real defect on our side: we surfaced the raw `PcoApiError` (a plain `Error`, so Convex rendered "Server Error" + a stack) instead of telling the user what to do.

## Fix
- Map `PcoApiError` → `ConvexError` with an actionable message (the Song Library import dialog already renders `e.data`):
  - **403** → "Planning Center denied access to your song library. The connected account needs Editor or Administrator access to Services. Reconnect with an account that has those permissions, then try again."
  - **401** → reconnect; **429** → wait and retry; other → status + reconnect hint.
- Make the **file-copy phase best-effort**: metadata is committed before files are fetched, so a late permission/network failure there no longer discards an otherwise-successful metadata import (re-runs are idempotent).
- Test for the 403 → friendly-message mapping.

## What the affected church should do
Reconnect Planning Center using an account that can view the song library in PCO Services (Editor/Administrator), then retry. (No data was imported, so nothing to clean up.)

## Testing
- `songImport.test.ts`: **15 passed** (added the 403 mapping case). tsc clean; lint 0 errors.

https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrKRCrxgksLBhNpCmPcPo)_