### PR TITLE
Route /guides to the landing site + add Guides to header nav

### DIFF
--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -89,6 +89,8 @@ function generateAppleAppSiteAssociation(hostname) {
     "/terms",
     "/contribute",
     "/issue",
+    "/guides",
+    "/guides/*",
     "/onboarding/*",
     "/admin/*",
     "/billing/*",
@@ -168,10 +170,12 @@ const DEFAULT_OG_IMAGE = "https://togather.nyc/og-image.png";
 
 // Static paths that should go to the landing page (not the app)
 // Note: /android path handling is environment-aware (see isLandingPagePath)
-const LANDING_PAGE_PATHS = ["/", "/download", "/legal", "/legal/privacy", "/legal/terms", "/contribute", "/issue"];
+const LANDING_PAGE_PATHS = ["/", "/download", "/legal", "/legal/privacy", "/legal/terms", "/contribute", "/issue", "/guides"];
 
-// Onboarding, admin, and billing flows are now handled by the Expo web app.
-const LANDING_PAGE_PREFIXES = [];
+// Multi-segment landing page routes served by the Vite site.
+// "/guides/" covers the church onboarding guide pages (e.g. /guides/branding).
+// Trailing slash keeps this from matching community slugs like /guidesxyz.
+const LANDING_PAGE_PREFIXES = ["/guides/"];
 
 // Known single-segment app routes that should NOT be redirected to /c/:slug.
 // These come from Expo Router route groups: (tabs), (auth), (user), (landing), and root-level routes.

--- a/apps/link-preview/cloudflare-worker.test.js
+++ b/apps/link-preview/cloudflare-worker.test.js
@@ -282,6 +282,8 @@ test("/.well-known/apple-app-site-association returns correct JSON for productio
   assert.ok(components.some(c => c["/"] === "*" && !c.exclude), "should include wildcard match for app routes");
   assert.ok(components.some(c => c["/"] === "/" && c.exclude === true), "should exclude root landing page");
   assert.ok(components.some(c => c["/"] === "/android" && c.exclude === true), "should exclude Android download page");
+  assert.ok(components.some(c => c["/"] === "/guides" && c.exclude === true), "should exclude guides hub");
+  assert.ok(components.some(c => c["/"] === "/guides/*" && c.exclude === true), "should exclude guides sub-pages");
 });
 
 test("/.well-known/apple-app-site-association returns correct JSON for staging domain", async () => {
@@ -486,6 +488,65 @@ test("/legal/terms passes through to landing page", async () => {
     assert.equal(res.status, 200);
 
     // Should pass through to landing page (not app)
+    assert.equal(calls.length, 1);
+    assert.ok(
+      calls[0].url.startsWith(LANDING_PAGE_URL),
+      `expected fetch to ${LANDING_PAGE_URL}, got ${calls[0].url}`
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// The guides hub and its sub-pages are served by the Vite landing site, not the
+// Expo app. Without this, /guides would be treated as a community slug and
+// redirect to /c/guides ("Community Not Found").
+test("/guides passes through to landing page", async () => {
+  const calls = [];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push({ url, init });
+    return new Response("guides hub", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/guides", {
+      headers: { "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" },
+    });
+
+    const res = await worker.fetch(req, {});
+
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 1);
+    assert.ok(
+      calls[0].url.startsWith(LANDING_PAGE_URL),
+      `expected fetch to ${LANDING_PAGE_URL}, got ${calls[0].url}`
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("/guides/:slug sub-pages pass through to landing page", async () => {
+  const calls = [];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push({ url, init });
+    return new Response("branding guide", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/guides/branding", {
+      headers: { "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" },
+    });
+
+    const res = await worker.fetch(req, {});
+
+    assert.equal(res.status, 200);
     assert.equal(calls.length, 1);
     assert.ok(
       calls[0].url.startsWith(LANDING_PAGE_URL),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -333,6 +333,12 @@ function HeroSection() {
               >
                 FAQ
               </a>
+              <Link
+                to="/guides"
+                className="text-sm font-medium text-neutral-700 hover:text-neutral-900"
+              >
+                Guides
+              </Link>
               <a
                 href="https://github.com/togathernyc/togather"
                 target="_blank"
@@ -386,6 +392,13 @@ function HeroSection() {
             >
               FAQ
             </a>
+            <Link
+              to="/guides"
+              className="block text-neutral-600 hover:text-neutral-900 py-2"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              Guides
+            </Link>
             <a
               href="https://github.com/togathernyc/togather"
               target="_blank"


### PR DESCRIPTION
Follow-up to #449 so the guides are actually reachable.

## Problem
The Cloudflare worker fronting `togather.nyc` (`apps/link-preview/cloudflare-worker.js`) didn't know about `/guides`:
- `/guides` → treated as a single-segment **community slug** → redirected to `/c/guides` → Expo app → **"Community Not Found."**
- `/guides/*` → fell through to "pass to app" → Expo 404.
- The **Apple App Site Association** didn't exclude `/guides`, so on iOS a tapped link could open the app instead of the browser.

## Fix (follows the existing `/contribute` pattern)
- Add `/guides` to `LANDING_PAGE_PATHS` and a `/guides/` entry to `LANDING_PAGE_PREFIXES` (trailing slash so it can't match a community slug like `/guidesxyz`) → both the hub and sub-pages route to the Vite landing site.
- Exclude `/guides` and `/guides/*` from the AASA so universal links open in the browser.
- New worker tests cover `/guides` + `/guides/branding` routing and the AASA exclusions (24/24 passing).

## Also
- Add a **Guides** link to the landing page header nav (desktop + mobile), matching the existing footer link.

## Deploy note
The worker is deployed separately (`apps/link-preview`, `npx wrangler deploy`) — it needs a redeploy for the routing/AASA change to take effect on `togather.nyc`.

https://claude.ai/code/session_01ADVzSB2KnkHfjZX9Qn2eYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADVzSB2KnkHfjZX9Qn2eYq)_