### PR TITLE
fix(guides): rewrite onboarding guides for accuracy + add event-plans & check-in

### DIFF
--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -174,8 +174,12 @@ const LANDING_PAGE_PATHS = ["/", "/download", "/legal", "/legal/privacy", "/lega
 
 // Multi-segment landing page routes served by the Vite site.
 // "/guides/" covers the church onboarding guide pages (e.g. /guides/branding).
-// Trailing slash keeps this from matching community slugs like /guidesxyz.
-const LANDING_PAGE_PREFIXES = ["/guides/"];
+// "/demo/" covers the guide live-preview pages (e.g. /demo/settings.html) —
+// Vite entry points built into the landing deployment. Note the EXACT path
+// /demo (no trailing segment) is an Expo app route (KNOWN_APP_ROUTES) and
+// still goes to the app because prefix matching requires the trailing slash.
+// Trailing slash keeps these from matching community slugs like /guidesxyz.
+const LANDING_PAGE_PREFIXES = ["/guides/", "/demo/"];
 
 // Known single-segment app routes that should NOT be redirected to /c/:slug.
 // These come from Expo Router route groups: (tabs), (auth), (user), (landing), and root-level routes.

--- a/apps/link-preview/cloudflare-worker.test.js
+++ b/apps/link-preview/cloudflare-worker.test.js
@@ -557,6 +557,67 @@ test("/guides/:slug sub-pages pass through to landing page", async () => {
   }
 });
 
+// The guide live-preview demo pages (/demo/*.html) are Vite entry points built
+// into the landing deployment. Without the "/demo/" prefix they fell through
+// to the Expo app origin and 404'd inside the guide iframes.
+test("/demo/settings.html passes through to landing page", async () => {
+  const calls = [];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push({ url, init });
+    return new Response("settings demo", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/demo/settings.html", {
+      headers: { "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" },
+    });
+
+    const res = await worker.fetch(req, {});
+
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 1);
+    assert.ok(
+      calls[0].url.startsWith(LANDING_PAGE_URL),
+      `expected fetch to ${LANDING_PAGE_URL}, got ${calls[0].url}`
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// The exact path /demo (no trailing segment) is an Expo app route and must
+// keep going to the app — only /demo/* belongs to the landing site.
+test("/demo (exact, no trailing segment) passes through to EAS Hosting (app)", async () => {
+  const calls = [];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push({ url, init });
+    return new Response("app demo route", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/demo", {
+      headers: { "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" },
+    });
+
+    const res = await worker.fetch(req, {});
+
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 1);
+    assert.ok(
+      calls[0].url.startsWith(APP_ORIGIN_URL),
+      `expected fetch to ${APP_ORIGIN_URL}, got ${calls[0].url}`
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 // Channel invite link preview tests (/ch/:shortId)
 test("bot /ch/:shortId fetches from Convex and returns OG tags", async () => {
   const calls = [];

--- a/apps/web/demo/harness/togather-shared.ts
+++ b/apps/web/demo/harness/togather-shared.ts
@@ -1,7 +1,7 @@
 /** Stub of @togather/shared for the demo bundle (only what screens reference). */
 export const DOMAIN_CONFIG = {
   landingUrl: "https://togather.nyc",
-  appUrl: "https://app.togather.nyc",
+  appUrl: "https://togather.nyc",
   baseDomain: "togather.nyc",
 };
 

--- a/apps/web/src/components/guide/DesktopFrame.tsx
+++ b/apps/web/src/components/guide/DesktopFrame.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+/**
+ * A lightweight desktop-browser frame, the wide-screen sibling of PhoneFrame.
+ * Purely presentational — it draws a rounded bezel, a top chrome bar with three
+ * traffic-light dots and a centered pill URL field, and a wide content area.
+ * Used to wrap code-reconstructed desktop app screens (e.g. the roster grid)
+ * so they read as "in the app on a big screen".
+ */
+export function DesktopFrame({
+  children,
+  url = "togather.nyc",
+}: {
+  children: ReactNode;
+  /** URL shown in the centered address pill, e.g. "togather.nyc/rostering". */
+  url?: string;
+}) {
+  return (
+    <div className="w-full bg-neutral-900 rounded-[1.25rem] p-2.5 shadow-xl shadow-neutral-900/15">
+      {/* Top chrome bar */}
+      <div className="relative flex items-center px-3 py-2.5">
+        {/* Traffic-light dots */}
+        <div className="flex items-center gap-1.5">
+          <span className="h-3 w-3 rounded-full bg-red-400" />
+          <span className="h-3 w-3 rounded-full bg-amber-400" />
+          <span className="h-3 w-3 rounded-full bg-green-400" />
+        </div>
+        {/* Centered URL pill */}
+        <div className="absolute left-1/2 -translate-x-1/2 flex w-1/2 max-w-xs items-center justify-center gap-1.5 rounded-md bg-neutral-700/70 px-3 py-1 text-[11px] font-medium text-neutral-200">
+          <svg
+            className="h-3 w-3 flex-shrink-0 text-neutral-400"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+          <span className="truncate">{url}</span>
+        </div>
+      </div>
+      {/* Content area — wide 16:10-ish aspect. */}
+      <div
+        className="bg-white rounded-[0.9rem] overflow-hidden"
+        style={{ aspectRatio: "16 / 10" }}
+      >
+        <div className="h-full w-full overflow-auto no-scrollbar">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/guides/appLinks.ts
+++ b/apps/web/src/guides/appLinks.ts
@@ -11,7 +11,11 @@
  * route changes in the app, update it here and every guide picks up the value.
  */
 export const APP_BASE =
-  (import.meta.env.VITE_APP_BASE_URL as string | undefined) ?? "https://app.togather.nyc";
+  (import.meta.env.VITE_APP_BASE_URL as string | undefined) ??
+  // The marketing site and the Expo app share the same domain (the Cloudflare
+  // worker splits traffic), so deep links are same-origin. The string fallback
+  // only applies in non-browser contexts (SSR/build-time evaluation).
+  (typeof window !== "undefined" ? window.location.origin : "https://togather.nyc");
 
 /** Custom URL scheme registered by the mobile apps (apps/mobile/app.json). */
 export const APP_SCHEME = "togather://";
@@ -31,8 +35,13 @@ export const appLinks = {
   groupTypes: `${APP_BASE}/admin`,
   /** Community-wide events (`(user)/admin/community-wide-events`). */
   communityWideEvents: `${APP_BASE}/admin/community-wide-events`,
-  /** Church feature flags incl. prayer (`(user)/admin/features`). */
-  features: `${APP_BASE}/admin/features`,
+  /**
+   * Church features (incl. the prayer toggle) live in the admin Settings tab's
+   * "Church Features" section. Do NOT link to /admin/features — that route is
+   * the staff-only Feature Flags screen and shows "You don't have access" to
+   * community admins.
+   */
+  features: `${APP_BASE}/admin`,
   /** Groups tab (`(tabs)/groups`). */
   groups: `${APP_BASE}/groups`,
 } as const;

--- a/apps/web/src/guides/registry.ts
+++ b/apps/web/src/guides/registry.ts
@@ -63,12 +63,30 @@ export const guides: Guide[] = [
   },
   {
     slug: "events",
-    title: "Create event plans & community-wide events",
+    title: "Events, series & community-wide events",
     summary:
-      "Schedule events for a single group, or roll out a community-wide event that spawns a meeting for every group of a type at once.",
+      "Schedule events with invitations and RSVPs, repeat them as a series, or roll out a community-wide event that spawns a meeting for every group of a type at once.",
     series: CHURCH_ONBOARDING_SERIES,
     readMinutes: 7,
     emoji: "📅",
+  },
+  {
+    slug: "event-plans",
+    title: "Event plans: teams, rostering & run sheets",
+    summary:
+      "Plan services the way you would in Planning Center: define teams and roles, collect availability, schedule volunteers in a roster grid, and run the day from a shared run sheet.",
+    series: CHURCH_ONBOARDING_SERIES,
+    readMinutes: 9,
+    emoji: "📋",
+  },
+  {
+    slug: "check-in",
+    title: "Check-ins & follow-up",
+    summary:
+      "Make sure every member gets cared for: follow-up scores that surface who needs attention, assigning people to leaders, and logging every reach-out.",
+    series: CHURCH_ONBOARDING_SERIES,
+    readMinutes: 6,
+    emoji: "🤝",
   },
   {
     slug: "prayer",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -15,6 +15,8 @@ import { Branding } from './pages/guides/Branding.tsx'
 import { GroupTypes } from './pages/guides/GroupTypes.tsx'
 import { GroupsAndChannels } from './pages/guides/GroupsAndChannels.tsx'
 import { Events } from './pages/guides/Events.tsx'
+import { EventPlans } from './pages/guides/EventPlans.tsx'
+import { CheckIn } from './pages/guides/CheckIn.tsx'
 import { Prayer } from './pages/guides/Prayer.tsx'
 import { ScrollToTop } from './components/ScrollToTop.tsx'
 // Onboarding, billing, admin, and sign-in pages have been moved to the Expo web app.
@@ -35,6 +37,8 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/guides/group-types" element={<GroupTypes />} />
         <Route path="/guides/groups-and-channels" element={<GroupsAndChannels />} />
         <Route path="/guides/events" element={<Events />} />
+        <Route path="/guides/event-plans" element={<EventPlans />} />
+        <Route path="/guides/check-in" element={<CheckIn />} />
         <Route path="/guides/prayer" element={<Prayer />} />
         <Route path="/legal/privacy" element={<PrivacyPolicy />} />
         <Route path="/legal/terms" element={<TermsOfService />} />

--- a/apps/web/src/pages/guides/Branding.tsx
+++ b/apps/web/src/pages/guides/Branding.tsx
@@ -1,16 +1,15 @@
+import { useMemo, useState } from "react";
 import { GuideLayout, type TocItem } from "../../components/guide/GuideLayout";
 import {
   Lead,
   Section,
   P,
   Callout,
-  Steps,
-  Step,
   Term,
   DeepLink,
   Figure,
 } from "../../components/guide/primitives";
-import { PhoneFrame, Avatar } from "../../components/guide/PhoneFrame";
+import { PhoneFrame } from "../../components/guide/PhoneFrame";
 import { appLinks } from "../../guides/appLinks";
 
 /**
@@ -21,14 +20,18 @@ import { appLinks } from "../../guides/appLinks";
  * (apps/mobile/features/admin/components/SettingsContent.tsx) and the
  * `updateCommunitySettings` mutation (apps/convex/functions/admin/settings.ts):
  * Community Name, Logo, Subdomain, Primary Color, Secondary Color.
+ *
+ * The "Subdomain" field is labeled that way in the app, but it really sets the
+ * community's path-based link (togather.nyc/your-church) that leads to the
+ * public landing page. We're honest about the label while explaining what it
+ * does.
  */
 
 const toc: TocItem[] = [
   { id: "where", label: "Where to find branding" },
-  { id: "name", label: "Name & subdomain" },
-  { id: "logo", label: "Logo & app icon" },
-  { id: "colors", label: "Brand colors" },
-  { id: "preview", label: "Preview & save" },
+  { id: "name", label: "Name & your link" },
+  { id: "logo", label: "Logo" },
+  { id: "color", label: "Brand color" },
 ];
 
 export function Branding() {
@@ -36,148 +39,122 @@ export function Branding() {
     <GuideLayout slug="branding" toc={toc}>
       <Lead>
         A few minutes in your settings is all it takes to make Togather feel like
-        home for your congregation. Add your church's name, drop in your logo,
-        and pick your colors — so the moment someone opens the app, they know
-        they're in the right place.
+        home for your congregation. Set your community's name, give out a link
+        people can remember, add your logo, and pick a brand color — so the
+        moment someone opens the app, they know they're in the right place.
       </Lead>
 
       <Section id="where" title="Where to find branding">
         <P>
-          Branding lives in your admin settings. Open the{" "}
-          <Term>Settings</Term> area for your community and look for the section
-          that controls how the app looks — your name, logo, and{" "}
-          <Term>Branding Colors</Term> all live together here.
+          Branding lives in your admin settings. Open <Term>Admin</Term>, then
+          tap the <Term>Settings</Term> tab. Everything that controls how your
+          community looks — name, logo, link, and{" "}
+          <Term>Branding Colors</Term> — lives in the cards on that screen.
         </P>
         <P>
-          <DeepLink href={appLinks.branding}>Open branding settings</DeepLink>
+          <DeepLink href={appLinks.branding}>Open admin settings</DeepLink>
         </P>
-        <Figure caption="The admin settings menu — branding and appearance are grouped together.">
-          {/* swap-in: <img src="/images/guides/branding-settings.png" /> */}
-          <SettingsMenuMock />
+        <Figure caption="Admin → Settings. The Basic Information card holds your name, logo, and link.">
+          <BasicInfoMock />
         </Figure>
       </Section>
 
-      <Section id="name" title="Name & subdomain">
+      <Section id="name" title="Name & your link">
         <P>
-          Two fields set your church's identity. <Term>Community Name</Term> is
-          the friendly display name your members see throughout the app — for
-          example, "Grace Community Church." Set it to whatever your congregation
-          calls you.
+          The <Term>Basic Information</Term> card sets your community's identity.{" "}
+          <Term>Community Name</Term> is the friendly display name members see
+          throughout the app — for example, "Grace Community Church." Set it to
+          whatever your congregation calls you.
         </P>
         <P>
-          <Term>Subdomain</Term> is your short, unique web address — the handle
-          in your community's link (think <Term>your-church</Term> in{" "}
-          <Term>your-church.togather.nyc</Term>). Keep it short, lowercase, and
-          easy to share on a bulletin or text message.
+          The field labeled <Term>Subdomain</Term> is more important than its
+          name suggests. Whatever you type here becomes your community's link:{" "}
+          <Term>togather.nyc/your-church</Term>. That link is the front door —
+          it opens your <strong>landing page</strong>, the first thing a
+          newcomer sees.
         </P>
-        <Callout tone="warn" title="Subdomains are one-of-a-kind">
+        <P>
+          Your landing page is a simple welcome form. A visitor enters their
+          first name, last name, and phone number (you can also turn on email
+          and add your own custom fields), and each person who fills it out
+          becomes a row in your community's <Term>People</Term>. It's the
+          easiest way to capture someone the moment they're interested, before
+          they've even downloaded anything.
+        </P>
+        <Callout tone="warn" title="Your link has to be one-of-a-kind">
           <P>
-            Every church needs its own subdomain, so yours has to be unique. If
-            you see a message that it's already in use, try a small variation
-            until it's available.
+            Every community needs its own link, so yours must be unique. A
+            handful of names are also reserved because the app already uses them
+            as web addresses — words like <Term>admin</Term>, <Term>chat</Term>,{" "}
+            <Term>groups</Term>, <Term>search</Term>, and <Term>signup</Term>{" "}
+            can't be used. If a name is taken or reserved, just try a small
+            variation. Lowercase letters, numbers, and hyphens only.
           </P>
         </Callout>
-        <Figure caption="Your display name and subdomain — the two fields that name your church.">
-          {/* swap-in: <img src="/images/guides/branding-name.png" /> */}
-          <NameFieldsMock />
+        <Callout tone="tip" title="Customize the landing page">
+          <P>
+            Want to change the welcome message, the form fields, or the look of
+            your landing page? In <Term>Admin Settings</Term>, open{" "}
+            <Term>Quick Links</Term> and choose <Term>Landing Page</Term>.
+          </P>
+        </Callout>
+        <Figure caption="The Subdomain field becomes your link, togather.nyc/your-church — the door to your landing page.">
+          <NameLinkMock />
         </Figure>
       </Section>
 
-      <Section id="logo" title="Logo & app icon">
+      <Section id="logo" title="Logo">
         <P>
           Your <Term>Logo</Term> appears in headers across the app, so it's the
-          first visual cue members recognize. You can also set an app icon — the
-          little rounded square members tap to open Togather on their phone. A
-          few simple choices make both look sharp.
+          first visual cue members recognize. Tap <Term>Select Logo</Term> and
+          pick an image from your device.
         </P>
-        <Steps>
-          <Step n={1}>
-            In the branding settings, tap <Term>Select Logo</Term> and choose an
-            image from your device.
-          </Step>
-          <Step n={2}>
-            Use a <strong>square</strong> image so nothing gets cropped or
-            stretched.
-          </Step>
-          <Step n={3}>
-            Prefer a <strong>transparent PNG</strong> so your logo sits cleanly
-            on any background, light or dark.
-          </Step>
-          <Step n={4}>
-            Keep it <strong>simple and readable when small</strong> — fine print
-            and thin lines disappear at icon size. A clean mark or your initials
-            works best.
-          </Step>
-        </Steps>
-        <Callout tone="tip">
-          <P>
-            If you only have one image, your full logo can double as both the
-            header logo and the app icon — just make sure it still reads clearly
-            shrunk down to a thumbnail.
-          </P>
-        </Callout>
+        <P>
+          Two quick tips: a <strong>square</strong> image works best so nothing
+          gets cropped, and a logo with a <strong>transparent background</strong>{" "}
+          sits cleanly on both light and dark screens.
+        </P>
       </Section>
 
-      <Section id="colors" title="Brand colors">
+      <Section id="color" title="Brand color">
         <P>
-          Colors are what make the app feel like yours. You'll set two:{" "}
-          <Term>Primary Color</Term> and <Term>Secondary Color</Term>. As the
-          app describes it, these are your community's accent colors, used for
-          buttons, links, and other interactive elements.
+          The <Term>Branding Colors</Term> card has pickers for a primary and a
+          secondary color, but in practice only one matters: your{" "}
+          <strong>primary color</strong>. It's the accent the live app actually
+          uses — for buttons, active tabs, links, and highlights. Don't worry
+          about the secondary color; you can leave it as-is.
         </P>
         <P>
-          <strong>Primary</strong> is your main accent — it shows up on buttons
-          and highlights all over the app, so pick the color your church is most
-          known for. <strong>Secondary</strong> is a supporting color that pairs
-          with it for accents and details.
+          The one thing to get right: pick a color that looks good in{" "}
+          <strong>both light mode and dark mode</strong>. Togather renders both,
+          and members choose whichever they prefer, so your color needs to read
+          well on a white screen and a near-black one. Very pale colors wash out
+          on white; very dark colors disappear on black. Aim for the middle.
         </P>
         <P>
-          Each color is entered as a <Term>hex</Term> value (a code like{" "}
-          <Term>#6B4423</Term>). If you have a brand kit, use the exact codes
-          from there; otherwise the color picker lets you choose visually.
+          Try it below — pick a color and see exactly where it shows up, side by
+          side in both modes.
         </P>
-        <Callout tone="tip" title="Choose colors people can read">
-          <P>
-            Your primary color often sits behind white text on buttons, so go
-            for a deeper, richer shade rather than a pale one — light colors make
-            white text hard to read. When in doubt, pick a color with enough
-            contrast that text stays crisp and legible for everyone.
-          </P>
-        </Callout>
-        <Figure caption="Set your primary and secondary colors and see them update live.">
-          {/* swap-in: <img src="/images/guides/branding-colors.png" /> */}
-          <ColorFormMock />
+
+        <ColorPreviewWidget />
+
+        <P>
+          When you make a change, a <Term>Save Changes</Term> bar slides up
+          pinned to the bottom of the screen. Tap it and your branding applies
+          to your whole community immediately.
+        </P>
+        <Figure caption="The Branding Colors card — focus on Primary Color. Save Changes applies it everywhere.">
+          <BrandingColorsMock />
         </Figure>
 
         <Callout tone="note" title="Live preview">
           This is the real admin settings screen running in your browser with
           sample data. Scroll to <Term>Basic Information</Term> for the name,
-          logo, and subdomain, then to <Term>Branding Colors</Term> to edit your
-          primary and secondary colors.
+          logo, and link, then to <Term>Branding Colors</Term> to edit your
+          colors.
         </Callout>
         <Figure caption="The live admin settings screen — branding fields running on mock data.">
           <SettingsLiveDemo />
-        </Figure>
-      </Section>
-
-      <Section id="preview" title="Preview & save">
-        <P>
-          Before you finish, take a quick look at the live preview to see how
-          your name, logo, and colors come together. Adjust anything that feels
-          off, then save — your changes apply across your whole community at
-          once.
-        </P>
-        <Callout tone="note">
-          <P>
-            Saving updates the app for everyone in your church, so what you see
-            in the preview is what your members will see. You can come back and
-            tweak your branding any time as your church grows or refreshes its
-            look.
-          </P>
-        </Callout>
-        <Figure caption="A live preview of your branding before you save.">
-          {/* swap-in: <img src="/images/guides/branding-preview.png" /> */}
-          <PreviewMock />
         </Figure>
       </Section>
     </GuideLayout>
@@ -186,7 +163,7 @@ export function Branding() {
 
 /* ------------------------------------------------------------------ */
 /* Page-local UI mockups — reconstructions of the in-app screens.      */
-/* These are swapped for real screenshots via <Figure src=...>.        */
+/* Match apps/mobile/features/admin/components/SettingsContent.tsx.     */
 /* ------------------------------------------------------------------ */
 
 /**
@@ -206,180 +183,476 @@ function SettingsLiveDemo() {
   );
 }
 
-/** Settings menu with the Branding / Appearance row highlighted. */
-function SettingsMenuMock() {
-  const rows = [
-    { icon: "🎨", label: "Branding & Appearance", active: true },
-    { icon: "📍", label: "Address & location" },
-    { icon: "🔭", label: "Explore page settings" },
-    { icon: "🧩", label: "Group types" },
-  ];
+/** App default green — matches the in-app primary color default. */
+const APP_DEFAULT_PRIMARY = "#1E8449";
+
+/** Real theme tokens from the app, used by the color preview widget. */
+const LIGHT_THEME = {
+  surface: "#ffffff",
+  secondarySurface: "#f5f5f5",
+  text: "#1a1a1a",
+  secondaryText: "#666666",
+} as const;
+
+const DARK_THEME = {
+  background: "#0b141a",
+  surface: "#1f2c34",
+  secondarySurface: "#1a2730",
+  text: "#e9edef",
+  secondaryText: "#8696a0",
+} as const;
+
+/**
+ * The iOS-style segmented control header at the top of the Admin screen.
+ * Active segment is a white pill with a subtle shadow.
+ */
+function AdminHeaderMock() {
+  const tabs = ["Requests", "People", "Stats", "Notify", "Settings"];
+  const active = "Settings";
   return (
-    <PhoneFrame title="Settings">
-      <div className="p-4 space-y-2.5 bg-neutral-50">
-        {rows.map((row) => (
-          <div
-            key={row.label}
-            className={`flex items-center gap-3 rounded-xl border p-3 ${
-              row.active
-                ? "border-primary-300 bg-primary-50 ring-2 ring-primary-200"
-                : "border-neutral-200 bg-white"
+    <div className="bg-[#f5f5f5] px-4 pt-3 pb-2">
+      <p className="text-xl font-bold text-[#1a1a1a] mb-3">Admin</p>
+      <div className="flex rounded-lg bg-neutral-200/80 p-0.5">
+        {tabs.map((t) => (
+          <span
+            key={t}
+            className={`flex-1 text-center text-[10px] font-medium rounded-md py-1 ${
+              t === active
+                ? "bg-white text-[#1a1a1a] shadow-sm"
+                : "text-neutral-500"
             }`}
           >
-            <span className="text-lg" aria-hidden>
-              {row.icon}
-            </span>
-            <span
-              className={`text-sm font-medium ${
-                row.active ? "text-primary-800" : "text-neutral-700"
-              }`}
-            >
-              {row.label}
-            </span>
-            <span className="ml-auto text-neutral-300">›</span>
-          </div>
+            {t}
+          </span>
         ))}
-      </div>
-    </PhoneFrame>
-  );
-}
-
-/** Name + subdomain text fields. */
-function NameFieldsMock() {
-  return (
-    <PhoneFrame title="Branding">
-      <div className="p-4 space-y-4 bg-neutral-50">
-        <Field label="Community Name" value="Grace Community Church" />
-        <div>
-          <FieldLabel>Subdomain</FieldLabel>
-          <div className="flex items-stretch rounded-xl border border-neutral-200 bg-white overflow-hidden">
-            <span className="px-3 py-2.5 text-sm text-neutral-800 font-medium">
-              grace-community
-            </span>
-            <span className="ml-auto flex items-center px-3 bg-neutral-100 text-xs text-neutral-400 border-l border-neutral-200">
-              .togather.nyc
-            </span>
-          </div>
-          <p className="mt-1.5 text-[11px] text-neutral-400">
-            Must be unique. Lowercase letters, numbers and hyphens.
-          </p>
-        </div>
-      </div>
-    </PhoneFrame>
-  );
-}
-
-/** Brand color form with two swatches, hex inputs, and a live preview chip. */
-function ColorFormMock() {
-  return (
-    <PhoneFrame title="Branding Colors">
-      <div className="p-4 space-y-4 bg-neutral-50">
-        <p className="text-[11px] leading-snug text-neutral-500">
-          Customize your community's accent colors. Used for buttons, links, and
-          other interactive elements.
-        </p>
-
-        <ColorRow label="Primary Color" hex="#6B4423" swatch="bg-primary-700" />
-        <ColorRow label="Secondary Color" hex="#C2884E" swatch="bg-accent-500" />
-
-        {/* Live preview chip */}
-        <div className="rounded-xl border border-neutral-200 bg-white p-3">
-          <p className="text-[11px] font-semibold uppercase tracking-wide text-neutral-400 mb-2">
-            Live preview
-          </p>
-          <div className="flex items-center gap-2">
-            <button className="rounded-lg bg-primary-700 px-3 py-1.5 text-xs font-semibold text-white">
-              Join group
-            </button>
-            <span className="rounded-lg border border-accent-500 px-3 py-1.5 text-xs font-semibold text-accent-600">
-              Learn more
-            </span>
-          </div>
-        </div>
-      </div>
-    </PhoneFrame>
-  );
-}
-
-/** Final preview: logo, name, and a themed action button. */
-function PreviewMock() {
-  return (
-    <PhoneFrame title="Preview">
-      <div className="bg-neutral-50">
-        {/* Themed header */}
-        <div className="bg-primary-700 px-4 py-4 flex items-center gap-3">
-          <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-white/90 text-primary-800 text-sm font-bold">
-            GC
-          </span>
-          <span className="text-sm font-semibold text-white">
-            Grace Community Church
-          </span>
-        </div>
-        <div className="p-4 space-y-3">
-          <div className="rounded-xl border border-neutral-200 bg-white p-3">
-            <div className="flex items-center gap-2 mb-2">
-              <Avatar label="AM" />
-              <div className="text-xs">
-                <p className="font-semibold text-neutral-800">
-                  Young Adults Group
-                </p>
-                <p className="text-neutral-400">Wednesdays · 7:00 PM</p>
-              </div>
-            </div>
-            <button className="w-full rounded-lg bg-primary-700 py-2 text-xs font-semibold text-white">
-              RSVP
-            </button>
-          </div>
-          <p className="text-center text-[11px] text-neutral-400">
-            Looks good? Save to apply across your community.
-          </p>
-        </div>
-      </div>
-    </PhoneFrame>
-  );
-}
-
-/* --- tiny shared field helpers for the mocks --- */
-
-function FieldLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <label className="mb-1 block text-xs font-medium text-neutral-500">
-      {children}
-    </label>
-  );
-}
-
-function Field({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <FieldLabel>{label}</FieldLabel>
-      <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2.5 text-sm text-neutral-800">
-        {value}
       </div>
     </div>
   );
 }
 
-function ColorRow({
+/** A settings card: white, radius 12, padding 16, 18px/600 title. */
+function SettingsCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl bg-white p-4">
+      <p className="text-[18px] font-semibold text-[#1a1a1a] mb-3">{title}</p>
+      <div className="space-y-3.5">{children}</div>
+    </div>
+  );
+}
+
+/** 14px/500 gray label above an input. */
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <label className="mb-1.5 block text-[14px] font-medium text-[#666666]">
+      {children}
+    </label>
+  );
+}
+
+/** Rounded-8, 1px #ecedf0 border, white bg text input mock. */
+function TextField({
   label,
-  hex,
-  swatch,
+  value,
+  placeholder,
+  helper,
 }: {
   label: string;
-  hex: string;
-  swatch: string;
+  value?: string;
+  placeholder?: string;
+  helper?: string;
 }) {
   return (
     <div>
       <FieldLabel>{label}</FieldLabel>
-      <div className="flex items-center gap-2">
+      <div className="rounded-lg border border-[#ecedf0] bg-white px-3 py-2.5 text-sm">
+        {value ? (
+          <span className="text-[#1a1a1a]">{value}</span>
+        ) : (
+          <span className="text-neutral-400">{placeholder}</span>
+        )}
+      </div>
+      {helper && <p className="mt-1.5 text-[11px] text-[#666666]">{helper}</p>}
+    </div>
+  );
+}
+
+/** The Logo field empty state: dashed button, image icon, primary-tinted text. */
+function LogoField() {
+  return (
+    <div>
+      <FieldLabel>Logo</FieldLabel>
+      <div
+        className="flex items-center justify-center gap-2 rounded-lg border-2 border-dashed py-4"
+        style={{ borderColor: APP_DEFAULT_PRIMARY }}
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={APP_DEFAULT_PRIMARY}
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+          <circle cx="8.5" cy="8.5" r="1.5" />
+          <polyline points="21 15 16 10 5 21" />
+        </svg>
         <span
-          className={`h-9 w-9 flex-shrink-0 rounded-lg border border-neutral-200 ${swatch}`}
-        />
-        <div className="flex-1 rounded-xl border border-neutral-200 bg-white px-3 py-2.5 text-sm font-mono text-neutral-700">
-          {hex}
+          className="text-sm font-medium"
+          style={{ color: APP_DEFAULT_PRIMARY }}
+        >
+          Select Logo
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** The Basic Information card mock (name + logo + subdomain). */
+function BasicInfoMock() {
+  return (
+    <PhoneFrame title="Settings">
+      <div className="min-h-full bg-[#f5f5f5]">
+        <AdminHeaderMock />
+        <div className="p-4">
+          <SettingsCard title="Basic Information">
+            <TextField
+              label="Community Name"
+              placeholder="Enter community name"
+            />
+            <LogoField />
+            <TextField
+              label="Subdomain"
+              placeholder="your-community"
+              helper="Lowercase letters, numbers, and hyphens only"
+            />
+          </SettingsCard>
         </div>
       </div>
+    </PhoneFrame>
+  );
+}
+
+/** Focused on the Subdomain field with a filled value to show the link. */
+function NameLinkMock() {
+  return (
+    <PhoneFrame title="Settings">
+      <div className="min-h-full bg-[#f5f5f5]">
+        <AdminHeaderMock />
+        <div className="p-4 space-y-3">
+          <SettingsCard title="Basic Information">
+            <TextField
+              label="Community Name"
+              value="Grace Community Church"
+            />
+            <TextField
+              label="Subdomain"
+              value="grace-community"
+              helper="Lowercase letters, numbers, and hyphens only"
+            />
+          </SettingsCard>
+          <div className="rounded-xl border border-[#ecedf0] bg-white p-3">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-[#666666] mb-1">
+              Your link
+            </p>
+            <p className="text-sm font-medium text-[#1a1a1a]">
+              togather.nyc/<span style={{ color: APP_DEFAULT_PRIMARY }}>grace-community</span>
+            </p>
+            <p className="mt-1 text-[11px] text-[#666666]">
+              Opens your landing page — the welcome form newcomers fill out.
+            </p>
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/** A color row: bordered, 32×32 rounded-6 swatch, monospace hex, chevron. */
+function ColorRow({ label, hex }: { label: string; hex: string }) {
+  return (
+    <div>
+      <FieldLabel>{label}</FieldLabel>
+      <div className="flex items-center gap-2.5 rounded-lg border border-[#ecedf0] bg-white px-3 py-2.5">
+        <span
+          className="h-8 w-8 flex-shrink-0 rounded-md"
+          style={{ backgroundColor: hex }}
+        />
+        <span className="flex-1 text-sm font-mono text-[#1a1a1a]">{hex}</span>
+        <span className="text-neutral-300">›</span>
+      </div>
+    </div>
+  );
+}
+
+/** The Branding Colors card mock with a pinned Save Changes bar. */
+function BrandingColorsMock() {
+  return (
+    <PhoneFrame title="Settings">
+      <div className="relative flex min-h-full flex-col bg-[#f5f5f5]">
+        <AdminHeaderMock />
+        <div className="flex-1 p-4">
+          <SettingsCard title="Branding Colors">
+            <p className="text-[12px] leading-snug text-[#666666]">
+              Customize your community's accent colors. These colors will be used
+              for buttons, links, and other interactive elements.
+            </p>
+            <ColorRow label="Primary Color" hex={APP_DEFAULT_PRIMARY} />
+            <ColorRow label="Secondary Color" hex="#34495E" />
+            <div className="rounded-lg border border-[#ecedf0] bg-white p-3">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-[#666666] mb-2">
+                Preview
+              </p>
+              <button
+                className="w-full rounded-lg py-2 text-xs font-semibold text-white"
+                style={{ backgroundColor: APP_DEFAULT_PRIMARY }}
+              >
+                Example button
+              </button>
+            </div>
+          </SettingsCard>
+        </div>
+        {/* Pinned Save Changes bar */}
+        <div className="border-t border-[#ecedf0] bg-white p-3">
+          <button
+            className="w-full rounded-lg py-2.5 text-sm font-semibold text-white"
+            style={{ backgroundColor: APP_DEFAULT_PRIMARY }}
+          >
+            Save Changes
+          </button>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Interactive color preview widget.                                   */
+/* Shows where the primary color appears in both light and dark mode.  */
+/* ------------------------------------------------------------------ */
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/** Mix a hex color with a base color at the given alpha (0–1). */
+function tint(hex: string, baseHex: string, alpha: number): string {
+  const c = parseHex(hex);
+  const b = parseHex(baseHex);
+  if (!c || !b) return hex;
+  const mix = (x: number, y: number) => Math.round(x * alpha + y * (1 - alpha));
+  return `rgb(${mix(c.r, b.r)}, ${mix(c.g, b.g)}, ${mix(c.b, b.b)})`;
+}
+
+function parseHex(hex: string): { r: number; g: number; b: number } | null {
+  if (!HEX_RE.test(hex)) return null;
+  return {
+    r: parseInt(hex.slice(1, 3), 16),
+    g: parseInt(hex.slice(3, 5), 16),
+    b: parseInt(hex.slice(5, 7), 16),
+  };
+}
+
+/** One mini phone-surface preview (light or dark) using real theme tokens. */
+function ModePreview({
+  mode,
+  color,
+}: {
+  mode: "light" | "dark";
+  color: string;
+}) {
+  const isDark = mode === "dark";
+  const bg = isDark ? DARK_THEME.background : LIGHT_THEME.surface;
+  const surface = isDark ? DARK_THEME.surface : LIGHT_THEME.secondarySurface;
+  const text = isDark ? DARK_THEME.text : LIGHT_THEME.text;
+  const subText = isDark ? DARK_THEME.secondaryText : LIGHT_THEME.secondaryText;
+  // Accent chip: color at ~10% over the surface, color as foreground.
+  const chipBg = tint(color, surface, 0.12);
+
+  return (
+    <div className="flex-1">
+      <p className="mb-1.5 text-center text-[11px] font-medium text-neutral-500">
+        {isDark ? "Dark mode" : "Light mode"}
+      </p>
+      <div
+        className="overflow-hidden rounded-xl border"
+        style={{
+          backgroundColor: bg,
+          borderColor: isDark ? "#0b141a" : "#e5e5e5",
+        }}
+      >
+        <div className="p-3 space-y-3">
+          {/* Accent chip */}
+          <div
+            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold"
+            style={{ backgroundColor: chipBg, color }}
+          >
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            New
+          </div>
+
+          {/* A small card */}
+          <div className="rounded-lg p-2.5" style={{ backgroundColor: surface }}>
+            <p className="text-[12px] font-semibold" style={{ color: text }}>
+              Young Adults
+            </p>
+            <p className="text-[10px]" style={{ color: subText }}>
+              Wednesdays · 7:00 PM
+            </p>
+          </div>
+
+          {/* Filled primary button */}
+          <button
+            className="w-full rounded-lg py-2 text-[12px] font-semibold text-white"
+            style={{ backgroundColor: color }}
+          >
+            Save Changes
+          </button>
+        </div>
+
+        {/* Tab bar with an active (tinted) tab */}
+        <div
+          className="flex items-center justify-around border-t px-2 py-2"
+          style={{
+            backgroundColor: surface,
+            borderColor: isDark
+              ? DARK_THEME.secondarySurface
+              : LIGHT_THEME.surface,
+          }}
+        >
+          <TabItem label="Home" color={color} active />
+          <TabItem label="Groups" color={subText} />
+          <TabItem label="Chat" color={subText} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** A single tab-bar item (icon dot + label) tinted with the given color. */
+function TabItem({
+  label,
+  color,
+  active = false,
+}: {
+  label: string;
+  color: string;
+  active?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span
+        className="h-3.5 w-3.5 rounded-md"
+        style={{ backgroundColor: color, opacity: active ? 1 : 0.7 }}
+      />
+      <span
+        className="text-[8px]"
+        style={{ color, fontWeight: active ? 600 : 400 }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+const EXAMPLE_SWATCHES = [
+  { hex: "#1E8449", name: "Green" },
+  { hex: "#2563EB", name: "Blue" },
+  { hex: "#9333EA", name: "Purple" },
+  { hex: "#D97706", name: "Amber" },
+];
+
+/** Interactive widget: pick a color, preview it live in light + dark mode. */
+function ColorPreviewWidget() {
+  const [color, setColor] = useState(APP_DEFAULT_PRIMARY);
+  const [hexInput, setHexInput] = useState(APP_DEFAULT_PRIMARY);
+
+  const valid = useMemo(() => HEX_RE.test(color), [color]);
+
+  function applyHex(next: string) {
+    setHexInput(next);
+    const normalized = next.startsWith("#") ? next : `#${next}`;
+    if (HEX_RE.test(normalized)) setColor(normalized);
+  }
+
+  function pickColor(next: string) {
+    setColor(next);
+    setHexInput(next);
+  }
+
+  return (
+    <div className="my-8 rounded-2xl border border-neutral-200 bg-white p-5 sm:p-6">
+      {/* Picker row */}
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2">
+          <span className="text-sm font-medium text-neutral-700">
+            Your color
+          </span>
+          <input
+            type="color"
+            value={valid ? color : APP_DEFAULT_PRIMARY}
+            onChange={(e) => pickColor(e.target.value)}
+            className="h-9 w-9 cursor-pointer rounded-lg border border-neutral-200 bg-white p-0.5"
+            aria-label="Pick brand color"
+          />
+        </label>
+        <input
+          type="text"
+          value={hexInput}
+          onChange={(e) => applyHex(e.target.value.trim())}
+          spellCheck={false}
+          className="w-28 rounded-lg border border-neutral-200 bg-white px-3 py-2 font-mono text-sm text-neutral-800 focus:border-primary-400 focus:outline-none"
+          aria-label="Hex color value"
+        />
+        {!valid && (
+          <span className="text-xs text-amber-600">
+            Enter a 6-digit hex, e.g. #1E8449
+          </span>
+        )}
+      </div>
+
+      {/* Example swatches */}
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="text-xs text-neutral-500">Looks good in both:</span>
+        {EXAMPLE_SWATCHES.map((s) => (
+          <button
+            key={s.hex}
+            type="button"
+            onClick={() => pickColor(s.hex)}
+            className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors ${
+              color.toLowerCase() === s.hex.toLowerCase()
+                ? "border-neutral-400 bg-neutral-50"
+                : "border-neutral-200 hover:bg-neutral-50"
+            }`}
+          >
+            <span
+              className="h-3 w-3 rounded-full"
+              style={{ backgroundColor: s.hex }}
+            />
+            {s.name}
+          </button>
+        ))}
+      </div>
+
+      {/* Side-by-side previews */}
+      <div className="mt-5 flex gap-4">
+        <ModePreview mode="light" color={valid ? color : APP_DEFAULT_PRIMARY} />
+        <ModePreview mode="dark" color={valid ? color : APP_DEFAULT_PRIMARY} />
+      </div>
+      <p className="mt-3 text-center text-xs text-neutral-500">
+        Your primary color appears on the active tab, filled buttons, and accent
+        chips — in both modes.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/pages/guides/Branding.tsx
+++ b/apps/web/src/pages/guides/Branding.tsx
@@ -577,7 +577,12 @@ function ColorPreviewWidget() {
   const [color, setColor] = useState(APP_DEFAULT_PRIMARY);
   const [hexInput, setHexInput] = useState(APP_DEFAULT_PRIMARY);
 
-  const valid = useMemo(() => HEX_RE.test(color), [color]);
+  // Validity tracks what's typed, not the last-applied color, so invalid
+  // entries surface the warning instead of silently keeping the old preview.
+  const valid = useMemo(() => {
+    const normalized = hexInput.startsWith("#") ? hexInput : `#${hexInput}`;
+    return HEX_RE.test(normalized);
+  }, [hexInput]);
 
   function applyHex(next: string) {
     setHexInput(next);
@@ -600,7 +605,7 @@ function ColorPreviewWidget() {
           </span>
           <input
             type="color"
-            value={valid ? color : APP_DEFAULT_PRIMARY}
+            value={color}
             onChange={(e) => pickColor(e.target.value)}
             className="h-9 w-9 cursor-pointer rounded-lg border border-neutral-200 bg-white p-0.5"
             aria-label="Pick brand color"

--- a/apps/web/src/pages/guides/CheckIn.tsx
+++ b/apps/web/src/pages/guides/CheckIn.tsx
@@ -1,0 +1,416 @@
+import { GuideLayout, type TocItem } from "../../components/guide/GuideLayout";
+import {
+  Lead,
+  Section,
+  P,
+  Callout,
+  Term,
+  Figure,
+} from "../../components/guide/primitives";
+import { PhoneFrame, Avatar } from "../../components/guide/PhoneFrame";
+
+const toc: TocItem[] = [
+  { id: "heart", label: "The heart of check-in" },
+  { id: "screen", label: "The Check-in screen" },
+  { id: "scores", label: "Scores" },
+  { id: "assign", label: "Assigning people" },
+  { id: "reach", label: "Reaching out" },
+];
+
+/**
+ * Guide post: "Check-ins & follow-up."
+ *
+ * Reconstructs the leader-facing Check-in screen — the triaged people list, the
+ * three-score member cards, the assign sheet, and the reach-out sheet — as code
+ * mockups. Labels and score bands are kept in sync with the check-in feature
+ * (apps/mobile features/check-in + apps/convex check-in functions).
+ */
+export function CheckIn() {
+  return (
+    <GuideLayout slug="check-in" toc={toc}>
+      <Lead>
+        You can't control how often people show up — but you can control how well
+        you follow up. Check-in is about leaving the ninety-nine for the one:
+        making sure that as your community grows, nobody slips through
+        unnoticed.
+      </Lead>
+
+      <Section id="heart" title="The heart of check-in">
+        <P>
+          Every leader knows the feeling of realizing, weeks too late, that
+          someone quietly stopped coming. Check-in exists to catch that earlier.
+          It surfaces the people who need a touch right now and gives you a
+          simple way to reach out and remember that you did.
+        </P>
+        <Callout tone="note">
+          This isn't about chasing attendance numbers. It's about care — making
+          sure the people God has put in front of you actually get seen.
+        </Callout>
+      </Section>
+
+      <Section id="screen" title="The Check-in screen">
+        <P>
+          Open Check-in for a group and you get a searchable list of its people,
+          triaged into three collapsible sections so the most urgent rise to the
+          top:
+        </P>
+        <P>
+          <Term>NEEDS ATTENTION</Term> (red) for people slipping away,{" "}
+          <Term>WATCH</Term> (amber) for those to keep an eye on, and{" "}
+          <Term>HEALTHY</Term> (green, collapsed by default) for everyone who's
+          doing well. Within each section, people are ordered lowest score
+          first, so whoever needs you most is always right at the top.
+        </P>
+
+        <Figure caption="The Check-in screen — people triaged by how they're doing.">
+          <PeopleListMock />
+        </Figure>
+      </Section>
+
+      <Section id="scores" title="Scores">
+        <P>
+          Each member card carries three scores. <Term>Connection</Term> is the
+          headline follow-up score — a composite of recent attendance and how
+          recently someone reached out, decaying over time so it cools off if no
+          one's been in touch. <Term>Attendance</Term> is the percentage of
+          meetings attended, and <Term>Service</Term> reflects how they're
+          serving.
+        </P>
+        <P>
+          The bands are simple: <Term>needs attention</Term> below 40,{" "}
+          <Term>watch</Term> from 40 to 69, and <Term>healthy</Term> at 70 and
+          above. A one-line reason always explains the number — something like{" "}
+          <Term>14d since contact · missed last 3</Term> — so the score is never
+          a mystery.
+        </P>
+      </Section>
+
+      <Section id="assign" title="Assigning people to leaders">
+        <P>
+          Care works best when someone owns it. Tap a member's assignee line —{" "}
+          <Term>Unassigned · tap to assign</Term> — and a sheet titled{" "}
+          <Term>Assign {"{name}"}</Term> opens. You can tap{" "}
+          <Term>Assign to me</Term>, or pick from searchable, multi-select lists
+          under <Term>GROUP LEADERS</Term> and{" "}
+          <Term>OTHER COMMUNITY LEADERS</Term>, then <Term>Save</Term>.
+        </P>
+        <P>
+          Assigned members show up on that leader's plate, and the leader gets a
+          notification so they know someone's now in their care.
+        </P>
+
+        <Figure caption="Assigning a member to a leader.">
+          <AssignSheetMock />
+        </Figure>
+      </Section>
+
+      <Section id="reach" title="Reaching out">
+        <P>
+          When you're ready to make contact, tap <Term>Reach out →</Term>. A
+          sheet offers three ways to connect: <Term>Text</Term> (opens Messages
+          and logs as a text), <Term>Call</Term> (opens the dialer and logs as a
+          call), and <Term>Log in-person</Term> (for when you've already seen
+          them — no message is sent). You can add an optional note to any of
+          them.
+        </P>
+        <P>
+          Every logged touch immediately lifts that person's Connection score.
+          The system rewards actual care, not streaks — what counts is that you
+          reached out.
+        </P>
+
+        <Figure caption="The Reach out sheet — three ways to make contact.">
+          <ReachOutSheetMock />
+        </Figure>
+
+        <Callout tone="tip">
+          Logged a quick hallway chat with <Term>Log in-person</Term>? That
+          counts too. The point is to capture care wherever it happens, so the
+          next leader to look knows this person's been seen.
+        </Callout>
+      </Section>
+    </GuideLayout>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Page-local UI mockups                                              */
+/* ------------------------------------------------------------------ */
+
+type Member = {
+  name: string;
+  initials: string;
+  assignee: string;
+  connection: number;
+  attendance: number;
+  service: number;
+  reason: string;
+};
+
+function bandColor(score: number) {
+  if (score < 40) return { dot: "bg-red-500", text: "text-red-600" };
+  if (score < 70) return { dot: "bg-amber-500", text: "text-amber-600" };
+  return { dot: "bg-green-500", text: "text-green-600" };
+}
+
+function MemberCard({ m }: { m: Member }) {
+  const band = bandColor(m.connection);
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-3">
+      <div className="flex items-center gap-3">
+        <Avatar label={m.initials} />
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold text-neutral-900">{m.name}</div>
+          <div className="truncate text-[11px] text-neutral-400">
+            {m.assignee}
+          </div>
+        </div>
+      </div>
+
+      {/* Three-score row */}
+      <div className="mt-3 flex items-stretch gap-2 text-center">
+        <div className="flex-1 rounded-lg bg-neutral-50 px-2 py-1.5">
+          <div className="flex items-center justify-center gap-1">
+            <span className={`h-2 w-2 rounded-full ${band.dot}`} />
+            <span className={`text-base font-bold ${band.text}`}>
+              {m.connection}
+            </span>
+          </div>
+          <div className="text-[9px] uppercase tracking-wide text-neutral-400">
+            Connection
+          </div>
+        </div>
+        <div className="flex-1 rounded-lg bg-neutral-50 px-2 py-1.5">
+          <div className="text-sm font-semibold text-neutral-700">
+            {m.attendance}%
+          </div>
+          <div className="text-[9px] uppercase tracking-wide text-neutral-400">
+            Attendance
+          </div>
+        </div>
+        <div className="flex-1 rounded-lg bg-neutral-50 px-2 py-1.5">
+          <div className="text-sm font-semibold text-neutral-700">
+            {m.service}%
+          </div>
+          <div className="text-[9px] uppercase tracking-wide text-neutral-400">
+            Service
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-2 text-[11px] text-neutral-500">{m.reason}</div>
+
+      <div className="mt-2 flex justify-end">
+        <span className="rounded-full bg-primary-600 px-3 py-1 text-[11px] font-semibold text-white">
+          Reach out →
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** (a) The triaged people list. */
+function PeopleListMock() {
+  const needsAttention: Member[] = [
+    {
+      name: "Marcus Bell",
+      initials: "MB",
+      assignee: "Unassigned · tap to assign",
+      connection: 28,
+      attendance: 35,
+      service: 0,
+      reason: "14d since contact · missed last 3",
+    },
+    {
+      name: "Priya Shah",
+      initials: "PS",
+      assignee: "Assigned to you",
+      connection: 36,
+      attendance: 50,
+      service: 20,
+      reason: "21d since contact · attendance falling",
+    },
+  ];
+  const watch: Member[] = [
+    {
+      name: "Daniel Okoye",
+      initials: "DO",
+      assignee: "Assigned to Sarah L.",
+      connection: 58,
+      attendance: 70,
+      service: 40,
+      reason: "8d since contact",
+    },
+  ];
+
+  return (
+    <PhoneFrame title="Check-in">
+      <div className="bg-neutral-50">
+        {/* Search */}
+        <div className="px-3 pt-3">
+          <div className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-white px-3 py-2 text-[11px] text-neutral-400">
+            <span>🔍</span>
+            Search people
+          </div>
+        </div>
+
+        {/* Needs attention */}
+        <div className="px-3 pt-3">
+          <div className="mb-2 flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-red-600">
+            <span className="h-2 w-2 rounded-full bg-red-500" />
+            Needs attention
+            <span className="text-neutral-400">{needsAttention.length}</span>
+          </div>
+          <div className="space-y-2">
+            {needsAttention.map((m) => (
+              <MemberCard key={m.name} m={m} />
+            ))}
+          </div>
+        </div>
+
+        {/* Watch */}
+        <div className="px-3 pt-4">
+          <div className="mb-2 flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-amber-600">
+            <span className="h-2 w-2 rounded-full bg-amber-500" />
+            Watch
+            <span className="text-neutral-400">{watch.length}</span>
+          </div>
+          <div className="space-y-2">
+            {watch.map((m) => (
+              <MemberCard key={m.name} m={m} />
+            ))}
+          </div>
+        </div>
+
+        {/* Healthy (collapsed) */}
+        <div className="px-3 py-4">
+          <div className="flex items-center justify-between rounded-lg border border-neutral-200 bg-white px-3 py-2">
+            <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-green-600">
+              <span className="h-2 w-2 rounded-full bg-green-500" />
+              Healthy
+              <span className="text-neutral-400">31</span>
+            </div>
+            <span className="text-neutral-400">▾</span>
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/** (b) The assign-to-leader sheet. */
+function AssignSheetMock() {
+  const groupLeaders = [
+    { name: "Sarah Lewis", initials: "SL", selected: true },
+    { name: "James Park", initials: "JP", selected: false },
+  ];
+  const communityLeaders = [
+    { name: "Grace Nwosu", initials: "GN", selected: false },
+    { name: "Tomas Rivera", initials: "TR", selected: false },
+  ];
+  return (
+    <PhoneFrame title="Assign Marcus Bell">
+      <div className="space-y-4 bg-white p-3">
+        <button className="w-full rounded-xl bg-primary-600 py-2.5 text-sm font-semibold text-white">
+          Assign to me
+        </button>
+
+        <div>
+          <div className="mb-2 text-[10px] font-bold uppercase tracking-wider text-neutral-400">
+            Group leaders
+          </div>
+          <div className="space-y-2">
+            {groupLeaders.map((l) => (
+              <LeaderRow key={l.name} {...l} />
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div className="mb-2 text-[10px] font-bold uppercase tracking-wider text-neutral-400">
+            Other community leaders
+          </div>
+          <div className="space-y-2">
+            {communityLeaders.map((l) => (
+              <LeaderRow key={l.name} {...l} />
+            ))}
+          </div>
+        </div>
+
+        <button className="w-full rounded-xl bg-neutral-900 py-2.5 text-sm font-semibold text-white">
+          Save
+        </button>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function LeaderRow({
+  name,
+  initials,
+  selected,
+}: {
+  name: string;
+  initials: string;
+  selected: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-white p-2.5">
+      <Avatar label={initials} />
+      <div className="flex-1 text-sm font-medium text-neutral-900">{name}</div>
+      <span
+        className={`flex h-5 w-5 items-center justify-center rounded-full border text-[11px] ${
+          selected
+            ? "border-primary-600 bg-primary-600 text-white"
+            : "border-neutral-300 text-transparent"
+        }`}
+      >
+        ✓
+      </span>
+    </div>
+  );
+}
+
+/** (c) The reach-out sheet. */
+function ReachOutSheetMock() {
+  const options = [
+    { label: "Text", sub: "Opens Messages · logs as text", icon: "💬" },
+    { label: "Call", sub: "Opens dialer · logs as call", icon: "📞" },
+    { label: "Log in-person", sub: "Already saw them · no message sent", icon: "🤝" },
+  ];
+  return (
+    <PhoneFrame title="Reach out">
+      <div className="space-y-3 bg-white p-3">
+        <div className="text-[11px] text-neutral-500">
+          Marcus Bell · every logged touch lifts their Connection score.
+        </div>
+        {options.map((o) => (
+          <div
+            key={o.label}
+            className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-white p-3"
+          >
+            <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-50 text-base">
+              {o.icon}
+            </span>
+            <div className="flex-1">
+              <div className="text-sm font-semibold text-neutral-900">
+                {o.label}
+              </div>
+              <div className="text-[11px] text-neutral-500">{o.sub}</div>
+            </div>
+            <span className="text-neutral-300">›</span>
+          </div>
+        ))}
+
+        <div>
+          <div className="mb-1 text-[11px] font-medium text-neutral-500">
+            Note (optional)
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-[11px] text-neutral-400">
+            Add a note about this reach-out…
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}

--- a/apps/web/src/pages/guides/CreateCommunity.tsx
+++ b/apps/web/src/pages/guides/CreateCommunity.tsx
@@ -11,7 +11,7 @@ import {
   DeepLink,
   Figure,
 } from "../../components/guide/primitives";
-import { PhoneFrame, Avatar } from "../../components/guide/PhoneFrame";
+import { PhoneFrame } from "../../components/guide/PhoneFrame";
 import { appLinks } from "../../guides/appLinks";
 
 const toc: TocItem[] = [
@@ -39,14 +39,16 @@ export function CreateCommunity() {
           church isn't on Togather yet, this is your starting point.
         </P>
         <P>
-          Open the switcher, look past the communities you can already see, and
-          choose <Term>Propose a Community</Term>.
+          Open the switcher, scroll past the communities you can already see,
+          and tap the <Term>Create a Community</Term> button at the bottom of
+          the screen. It opens the <Term>Propose a Community</Term> form in
+          your browser.
         </P>
         <DeepLink href={appLinks.communitySwitcher}>
           Open the community switcher
         </DeepLink>
 
-        <Figure caption="The community switcher: search for an existing community, or propose a new one for your church.">
+        <Figure caption="The Select Community screen: pick a community you belong to, search for another, or create your own.">
           {/* swap-in: <img src="/images/guides/community-switcher.png" /> */}
           <CommunitySwitcherMock />
         </Figure>
@@ -93,8 +95,8 @@ export function CreateCommunity() {
           </Step>
           <Step n={6}>
             <Term>Contact Email</Term> — where we'll send updates about your
-            request. (You'll only see this field if we don't already have an
-            email on file for you.)
+            request. (It appears at the top of the form, and only if we don't
+            already have an email on file for you.)
           </Step>
         </Steps>
         <P>
@@ -117,6 +119,14 @@ export function CreateCommunity() {
           sustainably pay each month. A small congregation and a large one will
           land in very different places, and that's by design.
         </P>
+        <Callout tone="tip" title="Not sure what to propose?">
+          Add up what you're paying today. Togather replaces several tools at
+          once — Planning Center for service planning and rostering, Slack or
+          GroupMe for team chat, texting tools like Clearstream, and
+          event/RSVP tools. The combined monthly total of whatever you
+          currently pay for those is a fair starting point: you're
+          consolidating, not adding a line item.
+        </Callout>
         <P>
           Every request is reviewed by hand. Our admins look at your proposal
           and decide whether we can responsibly support a congregation of your
@@ -202,113 +212,184 @@ function LiveCommunitySwitcherDemo() {
 
 function CommunitySwitcherMock() {
   return (
-    <PhoneFrame title="Select Community">
-      <div className="p-4 space-y-4">
-        <div>
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-neutral-400 mb-2">
+    <PhoneFrame>
+      <div className="p-4 pb-2 bg-white min-h-full flex flex-col">
+        <div className="text-center text-xl font-bold text-neutral-900 mt-3 mb-1">
+          Select Community
+        </div>
+        <div className="text-center text-xs text-neutral-500 mb-5 px-2 leading-snug">
+          Choose a community to continue or search for a new one
+        </div>
+
+        <div className="mb-5">
+          <div className="text-sm font-semibold text-neutral-900 mb-2">
             Your Communities
           </div>
-          <div className="space-y-2">
-            <CommunityRow label="GP" name="Grace Park Fellowship" sub="Member" />
-            <CommunityRow label="HC" name="Hope City Church" sub="Member" color="bg-accent-500" />
+          <CommunityRow initials="GP" name="Grace Park Fellowship" slug="gracepark" />
+          <CommunityRow
+            initials="HC"
+            name="Hope City Church"
+            slug="hopecity"
+            color="bg-accent-500"
+          />
+        </div>
+
+        <div className="mb-5">
+          <div className="text-sm font-semibold text-neutral-900 mb-2">
+            Or Join Another
+          </div>
+          <div className="flex items-center gap-2 rounded-xl bg-neutral-100 px-3 py-2.5">
+            <SearchIcon />
+            <span className="text-sm text-neutral-400">
+              Search communities...
+            </span>
           </div>
         </div>
 
-        <div>
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-neutral-400 mb-2">
-            Find a community
+        <div className="mt-auto border-t border-neutral-100 pt-4 space-y-3">
+          <div className="text-center text-[11px] text-neutral-500">
+            Can't find your community?{" "}
+            <span className="font-medium text-primary-700">Contact support</span>
           </div>
-          <div className="flex items-center gap-2 rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2">
-            <span className="w-3.5 h-3.5 rounded-full border-2 border-neutral-400" />
-            <span className="text-sm text-neutral-400">Search communities…</span>
+          <button className="w-full rounded-xl bg-neutral-100 px-4 py-3 text-center text-sm font-semibold text-neutral-900">
+            Create a Community
+          </button>
+          <div className="text-center text-xs text-neutral-400 underline pb-1">
+            Continue without community
           </div>
         </div>
-
-        <button className="w-full rounded-xl border border-dashed border-primary-300 bg-primary-50 px-4 py-3 text-left">
-          <div className="text-sm font-semibold text-primary-800">
-            + Propose a Community
-          </div>
-          <div className="text-xs text-primary-700/80 mt-0.5">
-            Request a new community for your church
-          </div>
-        </button>
       </div>
     </PhoneFrame>
   );
 }
 
 function CommunityRow({
-  label,
+  initials,
   name,
-  sub,
-  color,
+  slug,
+  color = "bg-primary-400",
 }: {
-  label: string;
+  initials: string;
   name: string;
-  sub: string;
+  slug: string;
   color?: string;
 }) {
   return (
-    <div className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-white px-3 py-2.5">
-      <Avatar label={label} color={color} />
-      <div className="min-w-0">
+    <div className="flex items-center gap-3 rounded-2xl bg-white p-3.5 mb-2 shadow-[0_1px_4px_rgba(0,0,0,0.08)]">
+      <span
+        className={`inline-flex items-center justify-center w-11 h-11 rounded-full ${color} text-white text-sm font-semibold flex-shrink-0`}
+      >
+        {initials}
+      </span>
+      <div className="min-w-0 flex-1">
         <div className="text-sm font-semibold text-neutral-900 truncate">
           {name}
         </div>
-        <div className="text-xs text-neutral-500">{sub}</div>
+        <div className="text-xs text-neutral-500 truncate">{slug}</div>
       </div>
+      <span className="text-neutral-300 text-lg leading-none">›</span>
     </div>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="w-4 h-4 text-neutral-400 flex-shrink-0"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m20 20-3.5-3.5" />
+    </svg>
   );
 }
 
 function RequestFormMock() {
   return (
-    <PhoneFrame title="Propose a Community">
-      <div className="p-4 space-y-3.5">
-        <MockField label="Community Name" value="Grace Church NYC" />
-        <MockField label="Estimated Number of People" value="150" />
-
-        <div>
-          <div className="text-xs font-semibold text-neutral-700 mb-1">
-            Proposed Monthly Price
-          </div>
-          <div className="flex items-center rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2">
-            <span className="text-sm text-neutral-500 mr-1">$</span>
-            <span className="text-sm text-neutral-900">200</span>
-          </div>
+    <PhoneFrame>
+      <div className="p-4 bg-neutral-100 min-h-full">
+        <div className="text-base font-bold tracking-tight text-neutral-900 mb-3">
+          togather
+        </div>
+        <div className="text-lg font-bold text-neutral-900 mb-1">
+          Propose a Community
+        </div>
+        <div className="text-xs text-neutral-500 leading-snug mb-4">
+          Tell us about your community and we'll get you set up on Togather.
         </div>
 
-        <div className="flex items-center justify-between rounded-xl border border-neutral-200 bg-white px-3 py-2.5">
-          <span className="text-sm font-semibold text-neutral-700">
-            Need Help Migrating?
-          </span>
-          <span className="inline-flex h-5 w-9 items-center rounded-full bg-neutral-200 p-0.5">
-            <span className="h-4 w-4 rounded-full bg-white shadow" />
-          </span>
-        </div>
+        <div className="rounded-2xl bg-white p-4 space-y-3.5 shadow-[0_1px_3px_rgba(0,0,0,0.08)]">
+          <MockField label="Community Name" required value="Grace Church NYC" />
+          <MockField
+            label="Estimated Number of People"
+            required
+            value="150"
+          />
 
-        <div>
-          <div className="text-xs font-semibold text-neutral-700 mb-1">
-            Additional Notes{" "}
-            <span className="font-normal text-neutral-400">(optional)</span>
+          <div>
+            <div className="text-xs font-semibold text-neutral-900 mb-1">
+              Proposed Monthly Price <span className="text-red-500">*</span>
+            </div>
+            <div className="flex items-center rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2">
+              <span className="text-sm font-medium text-neutral-500 mr-1">
+                $
+              </span>
+              <span className="text-sm text-neutral-900">200</span>
+            </div>
           </div>
-          <div className="rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-400 leading-snug min-h-[3rem]">
-            Anything else you'd like us to know…
-          </div>
-        </div>
 
-        <button className="w-full rounded-xl bg-primary-600 px-4 py-2.5 text-sm font-semibold text-white">
-          Submit Proposal
-        </button>
+          <div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold text-neutral-900">
+                Need Help Migrating?
+              </span>
+              <span className="inline-flex h-5 w-9 items-center justify-end rounded-full bg-primary-600 p-0.5">
+                <span className="h-4 w-4 rounded-full bg-white shadow" />
+              </span>
+            </div>
+            <div className="mt-2 flex items-start gap-1.5 rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-2 text-[11px] leading-snug text-amber-800">
+              <span className="font-semibold">ⓘ</span>
+              <span>Migration assistance is a one-time $500 flat fee.</span>
+            </div>
+          </div>
+
+          <div>
+            <div className="text-xs font-semibold text-neutral-900 mb-1">
+              Additional Notes{" "}
+              <span className="font-normal text-neutral-400">(optional)</span>
+            </div>
+            <div className="rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-400 leading-snug min-h-[4rem]">
+              Anything else you'd like us to know about your community...
+            </div>
+          </div>
+
+          <button className="w-full rounded-xl bg-primary-600 px-4 py-2.5 text-sm font-semibold text-white">
+            Submit Proposal
+          </button>
+        </div>
       </div>
     </PhoneFrame>
   );
 }
 
-function MockField({ label, value }: { label: string; value: string }) {
+function MockField({
+  label,
+  value,
+  required,
+}: {
+  label: string;
+  value: string;
+  required?: boolean;
+}) {
   return (
     <div>
-      <div className="text-xs font-semibold text-neutral-700 mb-1">{label}</div>
+      <div className="text-xs font-semibold text-neutral-900 mb-1">
+        {label} {required && <span className="text-red-500">*</span>}
+      </div>
       <div className="rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-900">
         {value}
       </div>

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -1,0 +1,565 @@
+import { Fragment } from "react";
+import { GuideLayout, type TocItem } from "../../components/guide/GuideLayout";
+import {
+  Lead,
+  Section,
+  P,
+  Callout,
+  Term,
+  Figure,
+} from "../../components/guide/primitives";
+import { PhoneFrame } from "../../components/guide/PhoneFrame";
+import { DesktopFrame } from "../../components/guide/DesktopFrame";
+
+const toc: TocItem[] = [
+  { id: "what", label: "What event plans are" },
+  { id: "teams", label: "Teams & roles" },
+  { id: "plans", label: "Event plans" },
+  { id: "availability", label: "Availability" },
+  { id: "grid", label: "The roster grid" },
+  { id: "runsheet", label: "Run sheets" },
+];
+
+/**
+ * Guide post: "Event plans: teams, rostering & run sheets."
+ *
+ * Togather's answer to Planning Center Services. Reconstructs the rostering UI
+ * as code mockups — the My Availability screen, a published plan card, the
+ * desktop roster grid, and the run sheet. Labels are kept in sync with the
+ * rostering feature (apps/mobile features/rostering + apps/convex rostering
+ * functions). No live demo fixture exists for this surface yet.
+ */
+export function EventPlans() {
+  return (
+    <GuideLayout slug="event-plans" toc={toc}>
+      <Lead>
+        This is Togather's answer to Planning Center Services. Any group can plan
+        its events: define the serving teams, collect availability, roster
+        volunteers into the slots you need, and run the day itself from a shared
+        run sheet. It all lives at the group level, so the same flow works for a
+        worship team, a whole campus, or a single small group.
+      </Lead>
+
+      <Section id="what" title="What event plans are">
+        <P>
+          An event plan is everything you need to staff and run a gathering: who
+          serves, in which roles, at which service times, and the order of
+          service for the day. Rostering is a tab inside any group, with three
+          views — <Term>Schedule</Term>, <Term>Teams</Term>, and{" "}
+          <Term>Cross-team</Term> — so a leader can move between building teams,
+          filling plans, and seeing where people overlap.
+        </P>
+        <Callout tone="note">
+          Because rostering is scoped to the group, you don't need a separate
+          tool for your worship team and your hospitality team. Each group runs
+          its own plans, and people who serve on more than one show up across
+          them.
+        </Callout>
+      </Section>
+
+      <Section id="teams" title="Teams & roles">
+        <P>
+          Inside a group's Rostering area, leaders create the teams that do the
+          serving — <Term>Worship</Term>, <Term>Hospitality</Term>,{" "}
+          <Term>Communion Prep</Term>, whatever your church runs. A team takes a{" "}
+          <Term>Team name</Term> and an optional description, and you can flip on{" "}
+          <Term>Give this team a chat channel</Term> so the team gets its own
+          chat to coordinate.
+        </P>
+        <P>
+          Each team defines its own free-form roles. Tap <Term>Add role</Term>,
+          give it a name like <Term>Drums</Term>, pick a color, and set{" "}
+          <Term>Usually need</Term> — the default number of slots that role
+          fills on a normal week. To save you typing, the app even suggests roles
+          based on the team's name.
+        </P>
+
+        <Figure caption="A serving team and its roles inside the group's Rostering area.">
+          <TeamSetupMock />
+        </Figure>
+      </Section>
+
+      <Section id="plans" title="Event plans">
+        <P>
+          Tap <Term>+ New event plan</Term> to start a draft — it defaults to
+          next Sunday at 9:00 AM. A plan has a date and one or more{" "}
+          <Term>service times</Term> (say 9:00 AM and 11:00 AM), and the needed
+          roles per team via <Term>Set needed roles</Term>. Everything
+          auto-saves as you go.
+        </P>
+        <P>
+          A plan starts as a <Term>Draft</Term>. When you're ready, tap{" "}
+          <Term>Publish &amp; send requests</Term>: every volunteer with an open
+          request gets a push notification <em>and</em> an SMS asking them to
+          accept or decline. Each plan card shows a fill-progress bar reading{" "}
+          <Term>{"{filled}/{needed} filled"}</Term> alongside the confirmed
+          count, so you can see at a glance which days still need people.
+        </P>
+
+        <Figure caption="A published plan card with its fill-progress bar.">
+          <PlanCardMock />
+        </Figure>
+      </Section>
+
+      <Section id="availability" title="Availability">
+        <P>
+          Members tell you when they can serve from <Term>My Availability</Term>.
+          For each upcoming plan they tap <Term>Available</Term> or{" "}
+          <Term>Can't make it</Term>. Being available doesn't mean you're
+          scheduled yet — it just tells leaders who they can draw from.
+        </P>
+        <P>
+          Leaders can also share a public availability link
+          (togather.nyc/a/…) that works <em>without</em> the app. Recipients
+          verify by phone number, and their responses match back to their
+          Togather account. Either way, availability flows straight into the
+          editor, which shows{" "}
+          <Term>{"{a} available · {b} can't · {c} no response"}</Term> for each
+          plan.
+        </P>
+
+        <Figure caption="My Availability — members mark each upcoming plan.">
+          <AvailabilityMock />
+        </Figure>
+
+        <Callout tone="tip" title="No app required">
+          The public availability link is great for volunteers who haven't
+          installed the app yet. They confirm by phone number and you still get
+          their answer in the grid.
+        </Callout>
+      </Section>
+
+      <Section id="grid" title="The roster grid">
+        <P>
+          The roster grid is the heart of rostering, and it shines on a big
+          screen. Roles run down the left, grouped by team; each event plan is a
+          column; and every cell shows who's filling that role for that day —
+          confirmed, awaiting, or declined — plus any open slots still to fill.
+        </P>
+
+        <Figure caption="The roster grid — roles down the side, plans across the top.">
+          <RosterGridMock />
+        </Figure>
+
+        <P>
+          Confirmed cells tint light green and awaiting cells tint light amber,
+          so a fully-staffed week reads as a wall of green and the gaps jump out.
+          A segmented <Term>Roles</Term> / <Term>People</Term> control flips the
+          grid to a per-person view when you'd rather see one volunteer's whole
+          schedule.
+        </P>
+      </Section>
+
+      <Section id="runsheet" title="Run sheets">
+        <P>
+          Every plan also gets one shared run sheet — the order of service for
+          the day. It's a spreadsheet-style editor with inline editing: type a
+          duration and the start times cascade automatically down the list.
+          Segments group the day into <Term>Before event</Term>,{" "}
+          <Term>During event</Term>, and <Term>After event</Term>, and you drag
+          rows to reorder them.
+        </P>
+        <P>
+          Rows can link to a <Term>role</Term> — which resolves to whoever ends
+          up filling it — and to <Term>songs</Term> from your community's song
+          library, so the team running the day always has the latest list in
+          front of them.
+        </P>
+      </Section>
+    </GuideLayout>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Page-local UI mockups                                              */
+/* ------------------------------------------------------------------ */
+
+/** (a) A team with its colored roles and "usually need" counts. */
+function TeamSetupMock() {
+  const roles = [
+    { name: "Vocals", color: "bg-rose-500", need: 3 },
+    { name: "Acoustic Guitar", color: "bg-amber-500", need: 1 },
+    { name: "Drums", color: "bg-sky-500", need: 1 },
+    { name: "Keys", color: "bg-violet-500", need: 1 },
+  ];
+  return (
+    <PhoneFrame title="Teams">
+      <div className="space-y-3 bg-neutral-50 p-3">
+        <div className="rounded-xl border border-neutral-200 bg-white p-3">
+          <div className="text-sm font-semibold text-neutral-900">Worship</div>
+          <div className="mt-0.5 text-[11px] text-neutral-500">
+            Sunday morning worship team
+          </div>
+          <div className="mt-3 flex items-center justify-between rounded-lg bg-neutral-50 px-3 py-2">
+            <span className="text-[11px] font-medium text-neutral-600">
+              Give this team a chat channel
+            </span>
+            <span className="flex h-5 w-9 items-center rounded-full bg-primary-600 px-0.5">
+              <span className="ml-auto h-4 w-4 rounded-full bg-white" />
+            </span>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {roles.map((r) => (
+            <div
+              key={r.name}
+              className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-white p-3"
+            >
+              <span className={`h-3 w-3 flex-shrink-0 rounded-full ${r.color}`} />
+              <div className="flex-1 text-sm font-medium text-neutral-900">
+                {r.name}
+              </div>
+              <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[10px] font-medium text-neutral-500">
+                Usually need {r.need}
+              </span>
+            </div>
+          ))}
+          <button className="w-full rounded-xl border border-dashed border-primary-300 bg-primary-50/50 py-2.5 text-sm font-semibold text-primary-700">
+            + Add role
+          </button>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/** (b) A published plan card with its fill-progress bar. */
+function PlanCardMock() {
+  const filled = 7;
+  const needed = 10;
+  const pct = Math.round((filled / needed) * 100);
+  return (
+    <PhoneFrame title="Schedule">
+      <div className="space-y-3 bg-neutral-50 p-3">
+        <div className="rounded-2xl border border-neutral-200 bg-white p-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <div className="text-sm font-semibold text-neutral-900">
+                Sunday Service
+              </div>
+              <div className="mt-0.5 text-[11px] text-neutral-500">
+                Sun · Jun 15 · 9:00 AM &amp; 11:00 AM
+              </div>
+            </div>
+            <span className="rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold text-green-700">
+              Published
+            </span>
+          </div>
+
+          <div className="mt-4">
+            <div className="mb-1 flex items-center justify-between text-[11px] font-medium text-neutral-600">
+              <span>
+                {filled}/{needed} filled
+              </span>
+              <span>{filled} confirmed</span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-neutral-100">
+              <div
+                className="h-full rounded-full bg-green-500"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <button className="w-full rounded-xl bg-primary-600 py-2.5 text-sm font-semibold text-white">
+          + New event plan
+        </button>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/** (c) My Availability — green/red pills per upcoming plan. */
+function AvailabilityMock() {
+  const plans = [
+    { title: "Sun · Jun 15", state: "available" as const },
+    { title: "Sun · Jun 22", state: "cant" as const },
+    { title: "Sun · Jun 29", state: "none" as const },
+  ];
+  return (
+    <PhoneFrame title="My Availability">
+      <div className="space-y-3 bg-neutral-50 p-3">
+        <div className="text-[11px] text-neutral-500">
+          Being available doesn't mean you're scheduled yet — it just tells your
+          leaders when they can count on you.
+        </div>
+        {plans.map((p) => (
+          <div
+            key={p.title}
+            className="rounded-xl border border-neutral-200 bg-white p-3"
+          >
+            <div className="mb-2 text-sm font-semibold text-neutral-900">
+              {p.title}
+            </div>
+            <div className="flex gap-2">
+              <span
+                className={`flex-1 rounded-full px-3 py-1.5 text-center text-[11px] font-semibold ${
+                  p.state === "available"
+                    ? "bg-green-600 text-white"
+                    : "border border-neutral-200 bg-white text-neutral-500"
+                }`}
+              >
+                Available
+              </span>
+              <span
+                className={`flex-1 rounded-full px-3 py-1.5 text-center text-[11px] font-semibold ${
+                  p.state === "cant"
+                    ? "bg-red-600 text-white"
+                    : "border border-neutral-200 bg-white text-neutral-500"
+                }`}
+              >
+                Can't make it
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/* ---- Roster grid (desktop) ---- */
+
+type CellStatus = "confirmed" | "awaiting" | "declined" | "open";
+
+/** A small status-ringed avatar used inside grid cells. */
+function GridAvatar({
+  label,
+  status,
+}: {
+  label: string;
+  status: Exclude<CellStatus, "open">;
+}) {
+  const ring =
+    status === "confirmed"
+      ? "ring-green-500"
+      : status === "awaiting"
+        ? "ring-amber-500"
+        : "ring-red-500";
+  return (
+    <span
+      className={`-ml-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary-400 text-[9px] font-semibold text-white ring-2 ${ring} first:ml-0`}
+    >
+      {label}
+    </span>
+  );
+}
+
+/** A dashed "+" chip for an open slot. */
+function OpenChip() {
+  return (
+    <span className="-ml-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full border border-dashed border-neutral-300 bg-neutral-50 text-[11px] font-semibold text-neutral-400 first:ml-0">
+      +
+    </span>
+  );
+}
+
+type Cell = { avatars: { label: string; status: Exclude<CellStatus, "open"> }[]; open: number };
+
+function GridCell({ cell }: { cell: Cell }) {
+  const allConfirmed =
+    cell.open === 0 &&
+    cell.avatars.length > 0 &&
+    cell.avatars.every((a) => a.status === "confirmed");
+  const hasAwaiting = cell.avatars.some((a) => a.status === "awaiting");
+  const tint = allConfirmed
+    ? "bg-green-50"
+    : hasAwaiting
+      ? "bg-amber-50"
+      : "bg-white";
+  return (
+    <td className="border-b border-l border-neutral-100 p-1.5">
+      <div className={`flex items-center rounded-md ${tint} px-1.5 py-1`}>
+        {cell.avatars.map((a, i) => (
+          <GridAvatar key={i} label={a.label} status={a.status} />
+        ))}
+        {Array.from({ length: cell.open }).map((_, i) => (
+          <OpenChip key={`o${i}`} />
+        ))}
+      </div>
+    </td>
+  );
+}
+
+/** The flagship roster grid, reconstructed as a static table. */
+function RosterGridMock() {
+  const columns = [
+    { title: "Sunday Service", weekday: "Sun", date: "Jun 15", open: 1 },
+    { title: "Sunday Service", weekday: "Sun", date: "Jun 22", open: 3 },
+    { title: "Midweek", weekday: "Wed", date: "Jun 25", open: 0 },
+    { title: "Sunday Service", weekday: "Sun", date: "Jun 29", open: 2 },
+  ];
+
+  const teams: {
+    team: string;
+    roles: {
+      name: string;
+      covered: [number, number];
+      cells: Cell[];
+    }[];
+  }[] = [
+    {
+      team: "Worship",
+      roles: [
+        {
+          name: "Vocals",
+          covered: [3, 4],
+          cells: [
+            { avatars: [{ label: "AM", status: "confirmed" }, { label: "JD", status: "confirmed" }, { label: "RS", status: "confirmed" }], open: 0 },
+            { avatars: [{ label: "AM", status: "confirmed" }, { label: "JD", status: "awaiting" }], open: 1 },
+            { avatars: [{ label: "RS", status: "confirmed" }], open: 0 },
+            { avatars: [{ label: "AM", status: "confirmed" }, { label: "KL", status: "declined" }], open: 1 },
+          ],
+        },
+        {
+          name: "Drums",
+          covered: [3, 4],
+          cells: [
+            { avatars: [{ label: "TP", status: "confirmed" }], open: 0 },
+            { avatars: [{ label: "TP", status: "awaiting" }], open: 0 },
+            { avatars: [{ label: "TP", status: "confirmed" }], open: 0 },
+            { avatars: [], open: 1 },
+          ],
+        },
+        {
+          name: "Keys",
+          covered: [2, 4],
+          cells: [
+            { avatars: [{ label: "MK", status: "confirmed" }], open: 0 },
+            { avatars: [], open: 1 },
+            { avatars: [{ label: "MK", status: "confirmed" }], open: 0 },
+            { avatars: [], open: 1 },
+          ],
+        },
+      ],
+    },
+    {
+      team: "Hospitality",
+      roles: [
+        {
+          name: "Greeters",
+          covered: [4, 4],
+          cells: [
+            { avatars: [{ label: "BW", status: "confirmed" }, { label: "CN", status: "confirmed" }], open: 0 },
+            { avatars: [{ label: "BW", status: "awaiting" }, { label: "CN", status: "confirmed" }], open: 0 },
+            { avatars: [{ label: "BW", status: "confirmed" }], open: 0 },
+            { avatars: [{ label: "CN", status: "confirmed" }, { label: "DH", status: "confirmed" }], open: 0 },
+          ],
+        },
+        {
+          name: "Coffee",
+          covered: [3, 4],
+          cells: [
+            { avatars: [{ label: "EF", status: "confirmed" }], open: 0 },
+            { avatars: [{ label: "EF", status: "awaiting" }], open: 0 },
+            { avatars: [], open: 1 },
+            { avatars: [{ label: "EF", status: "confirmed" }], open: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const totalResponded = 18;
+  const totalPeople = 24;
+
+  return (
+    <DesktopFrame url="togather.nyc/rostering">
+      <div className="min-w-[640px] p-4 text-neutral-800">
+        {/* Header */}
+        <div className="mb-3 flex items-center justify-between">
+          <div>
+            <div className="text-base font-bold text-neutral-900">Roster</div>
+            <div className="text-[11px] text-neutral-500">
+              {columns.length} events · {totalResponded}/{totalPeople} responded
+            </div>
+          </div>
+          <div className="flex overflow-hidden rounded-lg border border-neutral-200 text-[11px] font-semibold">
+            <span className="bg-primary-600 px-3 py-1 text-white">Roles</span>
+            <span className="bg-white px-3 py-1 text-neutral-500">People</span>
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div className="mb-3 flex flex-wrap items-center gap-3 text-[10px] text-neutral-500">
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2.5 w-2.5 rounded-full bg-green-500" />
+            Confirmed
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2.5 w-2.5 rounded-full bg-amber-500" />
+            Awaiting
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2.5 w-2.5 rounded-full bg-red-500" />
+            Declined
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2.5 w-2.5 rounded-full border border-dashed border-neutral-400 bg-neutral-50" />
+            Open
+          </span>
+        </div>
+
+        {/* Grid */}
+        <table className="w-full border-collapse text-left">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 w-40 bg-white p-1.5" />
+              {columns.map((c, i) => (
+                <th
+                  key={i}
+                  className="border-b border-l border-neutral-100 p-1.5 align-top"
+                >
+                  <div className="truncate text-[10px] text-neutral-400">
+                    {c.title}
+                  </div>
+                  <div className="text-[10px] uppercase text-neutral-400">
+                    {c.weekday}
+                  </div>
+                  <div className="text-xs font-bold text-neutral-900">
+                    {c.date}
+                  </div>
+                  <div className="text-[10px] text-neutral-400">
+                    {c.open} open
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {teams.map((t) => (
+              <Fragment key={t.team}>
+                {/* Team band header */}
+                <tr>
+                  <td
+                    colSpan={columns.length + 1}
+                    className="sticky left-0 bg-neutral-50 px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-neutral-400"
+                  >
+                    {t.team}
+                  </td>
+                </tr>
+                {t.roles.map((role) => (
+                  <tr key={`${t.team}-${role.name}`}>
+                    <th className="sticky left-0 z-10 w-40 border-b border-neutral-100 bg-white p-1.5 text-left align-middle">
+                      <div className="text-xs font-semibold text-neutral-900">
+                        {role.name}
+                      </div>
+                      <div className="text-[10px] text-neutral-400">
+                        covered {role.covered[0]}/{role.covered[1]}
+                      </div>
+                    </th>
+                    {role.cells.map((cell, ci) => (
+                      <GridCell key={ci} cell={cell} />
+                    ))}
+                  </tr>
+                ))}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </DesktopFrame>
+  );
+}

--- a/apps/web/src/pages/guides/Events.tsx
+++ b/apps/web/src/pages/guides/Events.tsx
@@ -10,87 +10,149 @@ import {
   DeepLink,
   Figure,
 } from "../../components/guide/primitives";
-import { PhoneFrame, Avatar } from "../../components/guide/PhoneFrame";
+import { PhoneFrame } from "../../components/guide/PhoneFrame";
 import { appLinks } from "../../guides/appLinks";
 
 const toc: TocItem[] = [
-  { id: "group", label: "Group events" },
-  { id: "rsvp", label: "RSVP & attendance" },
+  { id: "what", label: "Events aren't event plans" },
+  { id: "anatomy", label: "What an event gives you" },
+  { id: "create", label: "Creating an event" },
+  { id: "card", label: "The event card" },
+  { id: "series", label: "Series: bundle the dates" },
   { id: "cwe", label: "Community-wide events" },
-  { id: "override", label: "Leaders can customize their copy" },
+  { id: "combo", label: "The power combo" },
 ];
 
 /**
- * Guide post: "Create event plans & community-wide events."
+ * Guide post: "Events, series & community-wide events."
  *
- * Reconstructs three in-app screens as code mockups (group create-event form,
- * an event card with RSVP, and a community-wide event form). Field names and
+ * Reconstructs three in-app screens as code mockups (event card, the create
+ * event form, and the community-wide events admin screen). Field names and
  * behavior are kept in sync with the backend:
  *   - meeting fields: apps/convex/functions/meetings/events.ts
  *     (title, scheduledAt, meetingType 1=in-person 2=online, meetingLink,
  *      note, coverImage, rsvpEnabled, rsvpOptions, visibility)
  *   - RSVP options: apps/convex/lib/meetingConfig.ts
- *     (1 = Going, 2 = Maybe, 3 = Can't Go)
+ *     (1 = Going 👍, 2 = Maybe 🤔, 3 = Can't Go 😢; Maybe can be hidden)
+ *   - series: a named bundle of explicit dates (not a recurrence rule); one
+ *     meeting is created per selected date and they share a seriesId.
  *   - community-wide behavior: apps/convex/functions/communityWideEvents.ts
- *     (scope = community + group type, spawns a meeting for every active group,
- *      isOverridden breaks the cascade so leaders can customize their copy)
+ *     (scope = community + group type, spawns a linked meeting for every active
+ *      group; isOverridden breaks the cascade so leaders can customize a copy)
+ *
+ * NOTE: Event *plans* (rostering, run sheets) are a separate feature with its
+ * own guide at /guides/event-plans. This guide is strictly about the public,
+ * RSVP-able event.
  */
 export function Events() {
   return (
     <GuideLayout slug="events" toc={toc}>
       <Lead>
-        Events are what keep your groups actually gathering. With Togather you
-        can schedule a single small-group meetup, or roll out one church-wide
-        push that lands on every team's calendar at once — all from a quick form
-        on your phone.
+        An event is a full-stack invitation — "the men's group is having a
+        picnic." A few taps creates it, texts the group, collects RSVPs with
+        plus-ones, and opens a chat just for the people coming. This guide
+        covers events, series, and how an admin can light one up across an
+        entire community at once.
       </Lead>
 
-      <Section id="group" title="Group events">
+      <Section id="what" title="Events aren't event plans">
         <P>
-          The everyday case: a group leader schedules a meeting inside their own
-          group. You give it a title, pick a date and time, choose whether it's
-          in person or online, and add either a location or a meeting link. An
-          optional note and cover image make it feel warm and on-brand, and RSVP
-          lets people tell you they're coming.
+          It's worth drawing one line up front, because the two get confused. An{" "}
+          <Term>event</Term> is the public-facing invitation: a picnic, a dinner,
+          a service night — something people see, RSVP to, and show up for. An{" "}
+          <Term>event plan</Term> is the behind-the-scenes service plan that
+          makes a gathering run: rostering volunteers, assigning positions,
+          building a run sheet.
+        </P>
+        <P>
+          They're independent. An event might have no plan at all (a casual
+          picnic needs no run sheet), and a plan might have no public event (a
+          volunteer team can be rostered without ever inviting a crowd). This
+          guide is about events. For rostering and run sheets, see the{" "}
+          <a
+            href="/guides/event-plans"
+            className="font-medium text-primary-700 underline decoration-primary-300 underline-offset-2 hover:text-primary-800"
+          >
+            Event plans guide
+          </a>
+          .
+        </P>
+      </Section>
+
+      <Section id="anatomy" title="What an event gives you">
+        <P>
+          Every event has a <Term>hosting group</Term> and a time and place — an
+          address, an online link, or just <Term>Location TBD</Term> — plus a
+          description and a poster image you pick from a curated library or
+          upload yourself. From there, the event does the legwork:
         </P>
 
         <Steps>
           <Step n={1}>
-            From your group, open the leader tools and tap{" "}
-            <Term>Create event</Term>.
+            <strong>Invites by text and push.</strong> Invite group members and
+            they get an SMS <em>and</em> a push invitation. If turnout's thin,
+            fire off another manual reminder round to whoever hasn't responded.
           </Step>
           <Step n={2}>
-            Add a <Term>Title</Term> and pick a <Term>Date &amp; Time</Term>.
+            <strong>RSVPs with plus-ones.</strong> Response options are
+            customizable — the defaults are{" "}
+            <Term>Going 👍</Term> / <Term>Maybe 🤔</Term> /{" "}
+            <Term>Can't Go 😢</Term>, and you can hide <Term>Maybe</Term>.
+            Guests can add plus-ones with <Term>Bringing guests</Term>, so you
+            get a real headcount. You can also hide the RSVP count from
+            attendees while leaders still see it.
           </Step>
           <Step n={3}>
-            Choose <Term>In-person</Term> or <Term>Online Event</Term>. For an
-            in-person event, enter a <Term>Location</Term> (or mark{" "}
-            <Term>Location TBD</Term>); for an online one, paste a{" "}
-            <Term>meeting link</Term>.
+            <strong>Text blasts.</strong> Message everyone who's going or
+            interested by SMS in one shot — the same message also posts to the
+            event's activity feed.
           </Step>
           <Step n={4}>
-            Optionally add a description and a cover image, leave{" "}
-            <Term>RSVP</Term> on, and save.
+            <strong>Event chat.</strong> Flip on an optional chat scoped to just
+            this event. Only people who've RSVP'd can read or post in it.
+          </Step>
+          <Step n={5}>
+            <strong>Visibility.</strong> Choose <Term>Group Only</Term>,{" "}
+            <Term>Community</Term>, or <Term>Public</Term>. Public means anyone
+            with the link can view the event; RSVPing still requires login.
           </Step>
         </Steps>
 
-        <Figure caption="Creating an event inside a single group.">
+        <Callout tone="note" title="Reminders: which channel?">
+          <p>
+            <strong>SMS</strong> goes out for invites, manual re-invites, and
+            text blasts — moments you trigger by hand. <strong>Automatic</strong>{" "}
+            reminders as an event approaches are <em>push</em> notifications, not
+            texts. Togather won't auto-text your group.
+          </p>
+        </Callout>
+      </Section>
+
+      <Section id="create" title="Creating an event">
+        <P>
+          Open the <Term>Create Event</Term> form, pick the hosting group, and
+          fill in as much or as little as you like. Title is optional — leave it
+          blank and Togather uses the group type as the title. Everything else
+          lives on one scrollable form: date and time, poster, location or
+          online toggle, description, hosts, RSVP options, and visibility.
+        </P>
+
+        <Figure caption="A representative slice of the Create Event form. Every label shown here is the real one.">
           {/* swap-in: <img src="/images/guides/events-create.png" /> */}
           <CreateEventMock />
         </Figure>
       </Section>
 
-      <Section id="rsvp" title="RSVP & attendance">
+      <Section id="card" title="The event card">
         <P>
-          Once an event is posted, members RSVP right from the event card —{" "}
-          <Term>Going</Term>, <Term>Maybe</Term>, or <Term>Can't Go</Term>. As a
-          leader you can see who's coming and watch the going count climb, so you
-          know what to plan for. After the event, attendance can be confirmed so
-          your records reflect who actually showed up.
+          Once posted, the event shows up as a card in the events feed: a cover
+          image with the date badged in your community's color, the hosting
+          group, the title, time, location, and a live row of who's going. Tap
+          it to RSVP, bring guests, or jump into the event chat.
         </P>
 
-        <Figure caption="An event card with RSVP options and a live going count.">
-          {/* swap-in: <img src="/images/guides/events-rsvp.png" /> */}
+        <Figure caption="An event card as members see it in the feed.">
+          {/* swap-in: <img src="/images/guides/events-card.png" /> */}
           <EventCardMock />
         </Figure>
 
@@ -103,45 +165,45 @@ export function Events() {
         <Figure caption="The live events list: upcoming gatherings with dates, hosting group, and a running going count.">
           <EventsLiveDemo />
         </Figure>
+      </Section>
 
-        <Callout tone="note">
-          The going count is the number of people who tapped <Term>Going</Term>.
-          You can preview who's attending at a glance before the doors even open,
-          which makes setting out chairs and coffee a lot easier.
+      <Section id="series" title="Series: bundle the dates">
+        <P>
+          A series is a <strong>named bundle of dates</strong>, not a recurrence
+          rule — you pick exactly which dates you want rather than describing a
+          "every other Tuesday" pattern. Flip{" "}
+          <Term>Create / Add to Series</Term> on the event form, tap the dates
+          you want on the calendar, pick one <Term>Time</Term> for all of them,
+          and give it a <Term>Series Name</Term> like{" "}
+          <Term>Weekly Dinner Party</Term>. Togather creates one event per date,
+          all linked together.
+        </P>
+
+        <Callout tone="tip">
+          Editing or cancelling later asks for scope: <Term>this event only</Term>{" "}
+          or <Term>all in series</Term>. Move one week's dinner without touching
+          the rest, or push the whole run at once.
         </Callout>
       </Section>
 
       <Section id="cwe" title="Community-wide events">
         <P>
-          Sometimes you want every group of a kind to gather on the same night —
-          a shared study, a service push, a prayer evening. That's a
-          community-wide event. As an admin you create one event scoped to your
-          community and a <Term>group type</Term>, and Togather automatically
-          creates a meeting for every active group of that type. Schedule a study
-          night for <Term>Small Groups</Term> once, and all of them get the same
-          meeting on the same date.
+          Sometimes you want every group of a kind to gather — a shared study, a
+          prayer night, a serve day. As an admin, create one event scoped to a{" "}
+          <Term>group type</Term> (the form shows{" "}
+          <Term>{`{N} groups`}</Term> so you know the reach), and Togather gives{" "}
+          <em>each group its own linked copy</em> of the event.
+        </P>
+        <P>
+          It's uniform by default but flexible per group. A group's leader can
+          edit their copy — which <strong>disconnects it</strong> from future
+          parent updates — or cancel just theirs, without touching anyone else's.
+          You manage all of them from the{" "}
+          <Term>Community-Wide Events</Term> admin screen, which flags any copy a
+          leader has customized.
         </P>
 
-        <Steps>
-          <Step n={1}>
-            Open <Term>Community-wide events</Term> from your admin area.
-          </Step>
-          <Step n={2}>
-            Add a <Term>Title</Term>, a <Term>Date &amp; Time</Term>, and choose
-            in person or online just like a group event.
-          </Step>
-          <Step n={3}>
-            Pick the <Term>group type</Term> the event applies to — Togather
-            shows how many active groups it will create meetings for.
-          </Step>
-          <Step n={4}>
-            Save, and a meeting lands in every one of those groups at once. (If
-            no active groups of that type exist yet, you'll be asked to create
-            some first.)
-          </Step>
-        </Steps>
-
-        <Figure caption="A community-wide event scoped to a group type.">
+        <Figure caption="The Community-Wide Events admin screen, showing reach and any leader overrides.">
           {/* swap-in: <img src="/images/guides/events-community-wide.png" /> */}
           <CommunityWideEventMock />
         </Figure>
@@ -151,20 +213,20 @@ export function Events() {
         </DeepLink>
       </Section>
 
-      <Section id="override" title="Leaders can customize their copy">
+      <Section id="combo" title="The power combo">
         <P>
-          A church-wide plan shouldn't box anyone in. Each group's leader can
-          override their own copy of a community-wide event — nudge the time,
-          change the location — without touching anyone else's. Only that group's
-          meeting changes; every other group keeps the original.
+          Community-wide and series stack. Want{" "}
+          <em>"all Small Groups meet every Wednesday at 7 for the rest of the
+          semester"</em>? Pick the dates once and pick the group type once.
         </P>
 
-        <Callout tone="tip">
-          Overrides are smart. The moment a leader customizes their meeting it's
-          marked as overridden and stops following the parent event. Groups that
-          haven't been customized still update automatically if you, the admin,
-          later edit the parent — so a single tweak keeps every un-touched group
-          in sync.
+        <Callout tone="tip" title="One form, dozens of events">
+          <p>
+            Select your dates, select your group type, and the form previews the
+            whole rollout before you commit —{" "}
+            <Term>3 dates · 12 groups · 36 events total</Term>. Tap once and
+            Togather creates the event in every small group, for every date.
+          </p>
         </Callout>
       </Section>
     </GuideLayout>
@@ -191,69 +253,29 @@ function EventsLiveDemo() {
   );
 }
 
-/** (a) Create-event form for a single group. */
-function CreateEventMock() {
+/** A small UI label / field heading used inside the mock forms. */
+function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
-    <PhoneFrame title="New Event">
-      <div className="space-y-3 bg-white p-3">
-        <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Title
-          </div>
-          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-800">
-            Tuesday Dinner &amp; Study
-          </div>
-        </div>
-
-        <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Date &amp; Time
-          </div>
-          <div className="flex items-center justify-between rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm">
-            <span className="text-neutral-900">Tue, Jun 16 · 7:00 PM</span>
-            <span className="text-neutral-400">▾</span>
-          </div>
-        </div>
-
-        <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Location type
-          </div>
-          <div className="flex gap-2">
-            <span className="flex-1 rounded-lg border border-primary-600 bg-primary-600 px-3 py-1.5 text-center text-[12px] font-semibold text-white">
-              In-person
-            </span>
-            <span className="flex-1 rounded-lg border border-neutral-200 bg-white px-3 py-1.5 text-center text-[12px] font-medium text-neutral-600">
-              Online
-            </span>
-          </div>
-        </div>
-
-        <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Location
-          </div>
-          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-800">
-            114 Grace Ave · Apt 3
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between rounded-xl border border-neutral-200 bg-white p-3">
-          <div className="text-sm font-semibold text-neutral-900">RSVP</div>
-          <span className="flex h-5 w-9 items-center rounded-full bg-primary-600 px-0.5">
-            <span className="ml-auto h-4 w-4 rounded-full bg-white" />
-          </span>
-        </div>
-
-        <button className="w-full rounded-xl bg-primary-600 py-2.5 text-sm font-semibold text-white">
-          Create event
-        </button>
-      </div>
-    </PhoneFrame>
+    <div className="mb-1 text-[11px] font-semibold text-neutral-500">
+      {children}
+    </div>
   );
 }
 
-/** (b) Event card showing date, location, and RSVP buttons with a count. */
+/** A pill toggle (on state) used inside the mock forms. */
+function ToggleOn() {
+  return (
+    <span className="flex h-5 w-9 flex-shrink-0 items-center rounded-full bg-primary-600 px-0.5">
+      <span className="ml-auto h-4 w-4 rounded-full bg-white" />
+    </span>
+  );
+}
+
+/**
+ * (a) Event card — matches the real feed card:
+ * full-width cover with a date badge overlaid top-left, hosting group row,
+ * title, date line, location line, then the RSVP row above a hairline divider.
+ */
 function EventCardMock() {
   const guests = [
     { label: "JD", color: "bg-primary-400" },
@@ -261,45 +283,64 @@ function EventCardMock() {
     { label: "RS", color: "bg-amber-500" },
   ];
   return (
-    <PhoneFrame title="Event">
+    <PhoneFrame title="Events">
       <div className="bg-neutral-50 p-3">
-        <div className="overflow-hidden rounded-2xl border border-neutral-200 bg-white">
-          <div className="flex h-20 items-center justify-center bg-gradient-to-br from-primary-200 to-primary-400 text-2xl">
+        <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
+          {/* Cover with date badge overlaid top-left. */}
+          <div className="relative flex h-[140px] items-center justify-center bg-gradient-to-br from-primary-300 to-primary-500 text-3xl">
             🍽️
-          </div>
-          <div className="space-y-3 p-3">
-            <div>
-              <div className="text-sm font-bold text-neutral-900">
-                Tuesday Dinner &amp; Study
+            <div className="absolute left-3 top-3 rounded-xl bg-white px-2.5 py-1 text-center shadow-sm">
+              <div className="text-[10px] font-bold uppercase leading-none text-primary-600">
+                Jun
               </div>
-              <div className="mt-1 text-[11px] text-neutral-500">
-                Tue, Jun 16 · 7:00 PM
-              </div>
-              <div className="text-[11px] text-neutral-500">
-                114 Grace Ave · Apt 3
+              <div className="text-base font-bold leading-tight text-neutral-900">
+                12
               </div>
             </div>
+          </div>
 
+          <div className="p-3.5">
+            {/* Hosting group row. */}
             <div className="flex items-center gap-2">
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary-100 text-[9px] font-semibold text-primary-700">
+                MG
+              </span>
+              <span className="text-[12px] text-neutral-500">Men's Group</span>
+            </div>
+
+            {/* Title. */}
+            <div className="mt-1.5 text-[17px] font-semibold leading-snug text-neutral-900">
+              Tuesday Dinner &amp; Study
+            </div>
+
+            {/* Date line. */}
+            <div className="mt-1.5 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">📅</span>
+              <span>Wed, Jun 12 · 7:00 PM</span>
+            </div>
+            {/* Location line. */}
+            <div className="mt-1 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">📍</span>
+              <span>114 Grace Ave · Apt 3</span>
+            </div>
+
+            {/* RSVP row above a hairline divider. */}
+            <div className="mt-3 flex items-center gap-2 border-t border-neutral-100 pt-3">
               <div className="flex -space-x-2">
                 {guests.map((g) => (
-                  <Avatar key={g.label} label={g.label} color={g.color} />
+                  <span
+                    key={g.label}
+                    className={`inline-flex h-6 w-6 items-center justify-center rounded-full ${g.color} text-[9px] font-semibold text-white ring-2 ring-white`}
+                  >
+                    {g.label}
+                  </span>
                 ))}
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-neutral-200 text-[9px] font-semibold text-neutral-600 ring-2 ring-white">
+                  +9
+                </span>
               </div>
-              <span className="text-[11px] font-medium text-neutral-600">
-                12 going
-              </span>
-            </div>
-
-            <div className="flex gap-2">
-              <span className="flex-1 rounded-lg border border-primary-600 bg-primary-600 px-2 py-1.5 text-center text-[12px] font-semibold text-white">
-                Going
-              </span>
-              <span className="flex-1 rounded-lg border border-neutral-200 bg-white px-2 py-1.5 text-center text-[12px] font-medium text-neutral-600">
-                Maybe
-              </span>
-              <span className="flex-1 rounded-lg border border-neutral-200 bg-white px-2 py-1.5 text-center text-[12px] font-medium text-neutral-600">
-                Can't Go
+              <span className="text-[12px] font-medium text-neutral-600">
+                12 people going
               </span>
             </div>
           </div>
@@ -309,45 +350,185 @@ function EventCardMock() {
   );
 }
 
-/** (c) Community-wide event form with a group-type selector. */
-function CommunityWideEventMock() {
+/**
+ * (b) Create Event form — a representative subset of the real form:
+ * Hosting Group, the Create / Add to Series switch with its helper, Title with
+ * helper, the poster slot, RSVP Options (toggle + three editable rows + Hide
+ * RSVP count), and the Create Event button. Every label is the real one.
+ */
+function CreateEventMock() {
+  const rsvpRows = ["Going 👍", "Maybe 🤔", "Can't Go 😢"];
   return (
-    <PhoneFrame title="New Event">
-      <div className="space-y-3 bg-white p-3">
-        <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Title
-          </div>
-          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-800">
-            Church-wide Study Night
-          </div>
-        </div>
+    <PhoneFrame title="Create Event">
+      {/* Drag handle. */}
+      <div className="flex justify-center pt-1.5">
+        <span className="h-1 w-9 rounded-full bg-neutral-300" />
+      </div>
 
-        <div className="flex items-center justify-between rounded-xl border border-primary-200 bg-primary-50 p-3">
-          <div className="text-sm font-semibold text-primary-800">
-            Community-wide event
-          </div>
-          <span className="flex h-5 w-9 items-center rounded-full bg-primary-600 px-0.5">
-            <span className="ml-auto h-4 w-4 rounded-full bg-white" />
-          </span>
-        </div>
-
+      <div className="space-y-3.5 bg-white p-3">
+        {/* Hosting Group. */}
         <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Group type
-          </div>
-          <div className="flex items-center justify-between rounded-lg border border-primary-300 bg-white px-3 py-2 text-sm">
-            <span className="font-medium text-neutral-900">Small Groups</span>
+          <FieldLabel>Hosting Group *</FieldLabel>
+          <div className="flex items-center justify-between rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm">
+            <span className="text-neutral-900">Men's Group</span>
             <span className="text-neutral-400">▾</span>
           </div>
-          <div className="mt-1.5 rounded-lg bg-accent-400/10 px-3 py-2 text-[11px] font-medium text-neutral-700">
-            This will create meetings for 6 groups.
+        </div>
+
+        {/* Create / Add to Series switch. */}
+        <div className="rounded-xl border border-neutral-200 bg-white p-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-semibold text-neutral-900">
+              Create / Add to Series
+            </div>
+            <ToggleOn />
+          </div>
+          <div className="mt-1 text-[11px] text-neutral-500">
+            Select multiple dates to create linked events
+          </div>
+        </div>
+
+        {/* Title. */}
+        <div>
+          <FieldLabel>Title</FieldLabel>
+          <div className="rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-800">
+            Tuesday Dinner &amp; Study
+          </div>
+          <div className="mt-1 text-[11px] text-neutral-400">
+            Leave blank to use "Men's Group" as the title
+          </div>
+        </div>
+
+        {/* Poster slot. */}
+        <div>
+          <FieldLabel>Poster</FieldLabel>
+          <div className="flex aspect-square w-full items-center justify-center rounded-xl border-2 border-dashed border-neutral-300 bg-neutral-50 text-[12px] font-medium text-neutral-400">
+            Tap to choose a poster
+          </div>
+        </div>
+
+        {/* RSVP Options. */}
+        <div className="rounded-xl border border-neutral-200 bg-white p-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-semibold text-neutral-900">
+              Enable RSVPs
+            </div>
+            <ToggleOn />
+          </div>
+          <div className="mt-2.5 space-y-1.5">
+            {rsvpRows.map((row) => (
+              <div
+                key={row}
+                className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-1.5 text-[12px] text-neutral-800"
+              >
+                {row}
+              </div>
+            ))}
+          </div>
+          <div className="mt-2.5 flex items-center justify-between">
+            <div className="text-[12px] font-medium text-neutral-700">
+              Hide RSVP count
+            </div>
+            <span className="flex h-5 w-9 flex-shrink-0 items-center rounded-full bg-neutral-200 px-0.5">
+              <span className="h-4 w-4 rounded-full bg-white" />
+            </span>
           </div>
         </div>
 
         <button className="w-full rounded-xl bg-primary-600 py-2.5 text-sm font-semibold text-white">
-          Schedule event
+          Create Event
         </button>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/**
+ * (c) Community-Wide Events admin screen — header + event cards with a
+ * "Scheduled" status badge, date line, group-type and group-count rows (with an
+ * italic orange override note), and outlined Edit / red Cancel actions.
+ */
+function CommunityWideEventMock() {
+  return (
+    <PhoneFrame title="Community-Wide Events">
+      <div className="bg-neutral-50 p-3">
+        <div className="mb-3 px-0.5">
+          <div className="text-[15px] font-bold text-neutral-900">
+            Community-Wide Events
+          </div>
+          <div className="text-[11px] text-neutral-500">2 upcoming, 5 past</div>
+        </div>
+
+        <div className="space-y-2.5">
+          {/* Card 1 — with overrides. */}
+          <div className="rounded-2xl bg-white p-3.5 shadow-sm">
+            <div className="flex items-start justify-between gap-2">
+              <div className="text-[15px] font-semibold leading-snug text-neutral-900">
+                Wednesday Study Night
+              </div>
+              <span className="flex-shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold text-green-700">
+                Scheduled
+              </span>
+            </div>
+
+            <div className="mt-1.5 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">📅</span>
+              <span>Wed, Jun 18 · 7:00 PM</span>
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">🗂️</span>
+              <span>Small Groups</span>
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">👥</span>
+              <span>12 groups</span>
+              <span className="italic text-orange-500">(2 overridden)</span>
+            </div>
+
+            <div className="mt-3 flex gap-2">
+              <span className="flex-1 rounded-lg border border-neutral-300 bg-white px-3 py-1.5 text-center text-[12px] font-medium text-neutral-700">
+                Edit
+              </span>
+              <span className="flex-1 rounded-lg border border-red-300 bg-white px-3 py-1.5 text-center text-[12px] font-medium text-red-600">
+                Cancel
+              </span>
+            </div>
+          </div>
+
+          {/* Card 2 — no overrides. */}
+          <div className="rounded-2xl bg-white p-3.5 shadow-sm">
+            <div className="flex items-start justify-between gap-2">
+              <div className="text-[15px] font-semibold leading-snug text-neutral-900">
+                Community Serve Day
+              </div>
+              <span className="flex-shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold text-green-700">
+                Scheduled
+              </span>
+            </div>
+
+            <div className="mt-1.5 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">📅</span>
+              <span>Sat, Jun 21 · 9:00 AM</span>
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">🗂️</span>
+              <span>Ministry Teams</span>
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 text-[12px] text-neutral-600">
+              <span className="text-neutral-400">👥</span>
+              <span>8 groups</span>
+            </div>
+
+            <div className="mt-3 flex gap-2">
+              <span className="flex-1 rounded-lg border border-neutral-300 bg-white px-3 py-1.5 text-center text-[12px] font-medium text-neutral-700">
+                Edit
+              </span>
+              <span className="flex-1 rounded-lg border border-red-300 bg-white px-3 py-1.5 text-center text-[12px] font-medium text-red-600">
+                Cancel
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </PhoneFrame>
   );

--- a/apps/web/src/pages/guides/GroupTypes.tsx
+++ b/apps/web/src/pages/guides/GroupTypes.tsx
@@ -10,24 +10,25 @@ import {
   DeepLink,
   Figure,
 } from "../../components/guide/primitives";
-import { PhoneFrame, Avatar } from "../../components/guide/PhoneFrame";
+import { PhoneFrame } from "../../components/guide/PhoneFrame";
 import { appLinks } from "../../guides/appLinks";
 
 const toc: TocItem[] = [
   { id: "what", label: "What is a group type?" },
-  { id: "create", label: "Create a group type" },
+  { id: "starter", label: "A starting set for churches" },
+  { id: "create", label: "Create your group types" },
   { id: "events", label: "Community-wide events" },
   { id: "explore", label: "Explore & filtering" },
-  { id: "naming", label: "A tip on naming" },
+  { id: "naming", label: "Name types in the singular" },
 ];
 
 /**
  * Guide post: "Group types and why they matter."
  *
- * Reconstructs three in-app screens as code mockups (admin list, Explore
- * filtering, community-wide event form). Default group-type names and the
- * create-form fields are kept in sync with the seeded data in
- * apps/convex/functions/seed.ts and apps/convex/functions/admin/settings.ts.
+ * Mockups mirror the real app screens: the Group Types card in Admin →
+ * Settings (apps/mobile admin settings), the New Group Type bottom sheet, and
+ * the Explore map's filter modal / group cards. The only auto-created type is
+ * Announcements — everything else is created by the church.
  */
 export function GroupTypes() {
   return (
@@ -41,107 +42,172 @@ export function GroupTypes() {
 
       <Section id="what" title="What is a group type?">
         <P>
-          A group type is a category that every group belongs to. When your
-          community is created, Togather starts you off with a sensible set of
-          defaults: <Term>Small Groups</Term>, <Term>Teams</Term>,{" "}
-          <Term>Classes</Term>, and <Term>Announcements</Term>.
+          A group type is a category that every group belongs to. The type's
+          name appears as a colored badge on each group's card, it powers the
+          filters on the Explore map, and it's how admins schedule one event
+          across many groups at once.
         </P>
         <P>
-          Nothing here is set in stone. From admin you can rename a type,
-          reorder them, add new ones that fit your church's culture, or
-          deactivate any you don't use. Your groups, your labels.
+          When your community is created, Togather sets up exactly one thing
+          for you: an <Term>Announcements</Term> group type with a single
+          announcement group named after your community. Every member is
+          automatically in it, nobody can leave it, and roles inside it mirror
+          community-admin status on their own. Everything else — every other
+          type and every other group — is yours to create.
         </P>
 
-        <Figure caption="Group types admin — your community's default categories.">
+        <Callout tone="note" title="One announcements group per community">
+          There should be exactly one announcements group, and the app creates
+          and manages it for you. You'll never need to add another group to
+          the <Term>Announcements</Term> type — spend your energy on the types
+          below instead.
+        </Callout>
+      </Section>
+
+      <Section id="starter" title="A starting set for churches">
+        <P>
+          Since Togather doesn't pre-fill categories for you, here's the set we
+          recommend most churches start with:
+        </P>
+        <P>
+          <Term>Team</Term> — for serving teams: worship, hospitality, kids,
+          production, and so on. Each team group gets its own chat, its own
+          events, and its own rostering, so your worship team can plan a setlist
+          while the kids team schedules check-in shifts.
+        </P>
+        <P>
+          <Term>Small Group</Term> — whatever your church calls them: life
+          groups, community groups, connect groups. One type covers them all,
+          and the name on the badge is whatever you choose.
+        </P>
+        <P>
+          <Term>Campus</Term> — for multi-site churches, create one group per
+          campus (say Brooklyn, Manhattan, and Queens) all under a single{" "}
+          <Term>Campus</Term> type. That lets you push uniform community-wide
+          events across every campus at once, while each campus group still
+          runs its own rostering and serving requests. Central teams that span
+          campuses can live as regular <Term>Team</Term> groups, and a
+          campus-specific crew — a "Brooklyn Kids Team" that needs to
+          self-organize — simply gets its own team group.
+        </P>
+        <P>
+          Optionally, add a <Term>Course</Term> (or <Term>Class</Term>) type
+          for classes, membership courses, and other things with a start and an
+          end.
+        </P>
+
+        <Figure caption="The Group Types card in Admin → Settings, with a starting set created.">
           {/* swap-in: <img src="/images/guides/group-types.png" /> */}
-          <GroupTypesAdminMock />
+          <GroupTypesSettingsMock />
+        </Figure>
+      </Section>
+
+      <Section id="create" title="Create your group types">
+        <P>
+          Group types live in your admin settings, in a card titled{" "}
+          <Term>Group Types</Term>. Adding one takes a few seconds — it's just
+          a name and an optional description.
+        </P>
+
+        <Steps>
+          <Step n={1}>
+            Open <Term>Admin</Term> → <Term>Settings</Term> and scroll to the{" "}
+            <Term>Group Types</Term> card.
+          </Step>
+          <Step n={2}>
+            Tap <Term>Add New</Term> in the card's header.
+          </Step>
+          <Step n={3}>
+            Enter a <Term>Name</Term> (e.g., "Small Group") and an optional
+            one-line <Term>Description</Term>.
+          </Step>
+          <Step n={4}>
+            Tap <Term>Create</Term>. The type is ready to use immediately —
+            you'll pick it whenever you create a group.
+          </Step>
+        </Steps>
+
+        <Figure caption="The New Group Type sheet — just a name and an optional description.">
+          {/* swap-in: <img src="/images/guides/group-types.png" /> */}
+          <NewGroupTypeModalMock />
         </Figure>
 
         <Callout tone="note" title="Live preview">
           This is the real admin settings screen running in your browser with
           sample data — scroll down to the <Term>Group Types</Term> section to
-          see the defaults and the <Term>Add New</Term> action.
+          see the card and the <Term>Add New</Term> action.
         </Callout>
         <Figure caption="The live admin settings screen — Group Types running on mock data.">
           <SettingsLiveDemo />
         </Figure>
-      </Section>
 
-      <Section id="create" title="Create a group type">
-        <P>
-          Adding a type takes a few seconds. Open Group Types from your admin
-          area and create one — give it a name, an optional description, an
-          icon, and a display order that decides where it sits in the list.
-        </P>
-
-        <Steps>
-          <Step n={1}>
-            Open <Term>Group Types</Term> from your community's admin area.
-          </Step>
-          <Step n={2}>
-            Tap <Term>Add group type</Term> and enter a{" "}
-            <Term>name</Term> (Togather builds the <Term>slug</Term> from it
-            automatically).
-          </Step>
-          <Step n={3}>
-            Add an optional <Term>description</Term>, pick an{" "}
-            <Term>icon</Term>, and set the <Term>display order</Term>.
-          </Step>
-          <Step n={4}>
-            Save. New types are active (<Term>isActive</Term>) by default, so
-            they're ready to use right away.
-          </Step>
-        </Steps>
-
-        <DeepLink href={appLinks.groupTypes}>Open group types</DeepLink>
+        <DeepLink href={appLinks.groupTypes}>Open admin settings</DeepLink>
       </Section>
 
       <Section id="events" title="Why they matter: community-wide events">
         <P>
-          Here's where group types really earn their keep. They power
-          community-wide events: as an admin you can schedule one event scoped
-          to a group type — say <Term>Teams</Term> — and Togather automatically
-          creates a meeting for every active group of that type. One form,
-          every team's calendar updated.
+          Here's where group types really earn their keep. Community-wide
+          events target a group type: as an admin you create one event — say
+          "all Small Groups meet Wednesday at 7" — and Togather creates a
+          linked copy of it in every small group at once.
+        </P>
+        <P>
+          The copies stay linked, but group leaders keep control of their own.
+          A leader can edit their group's copy (editing disconnects that copy
+          from future parent updates) or cancel just theirs without touching
+          anyone else's. Combined with series — the same event across multiple
+          dates — one action can schedule a whole semester across twenty
+          groups.
         </P>
 
-        <Figure caption="A community-wide event scoped to a group type.">
-          {/* swap-in: <img src="/images/guides/group-types.png" /> */}
-          <CommunityWideEventMock />
+        <Figure caption="One community-wide event becomes a linked copy in every group of that type.">
+          <CommunityWideEventDiagram />
         </Figure>
 
         <Callout tone="note">
-          Schedule once, reach every group. If you have ten <Term>Teams</Term>,
-          one community-wide event creates ten meetings — no copy-pasting. We
-          cover this end to end in the Events guide.
+          For multi-site churches this is the payoff of a <Term>Campus</Term>{" "}
+          type: one community-wide event lands on every campus's calendar in a
+          single step. We cover community-wide events end to end in the Events
+          guide.
         </Callout>
+
+        <DeepLink href={appLinks.communityWideEvents}>
+          Open community-wide events
+        </DeepLink>
       </Section>
 
       <Section id="explore" title="Why they matter: Explore & filtering">
         <P>
-          Group types also shape how people find their way in. On the Explore
-          screen, members filter and discover groups by group type, so someone
-          looking for a class isn't wading through every team and small group.
-          As an admin you can choose which types appear by default.
+          Group types also shape how people find their way in. Explore is a
+          full-screen map with a draggable sheet of groups, and the floating
+          filter button opens a filter by group type — so someone looking for a
+          small group isn't wading through every team and class. Every group
+          card carries its type as a colored badge, too.
         </P>
 
-        <Figure caption="Explore — members filter groups by group type.">
+        <Figure caption="Explore — group cards carry the type badge, and the filter modal narrows by group type.">
           {/* swap-in: <img src="/images/guides/group-types.png" /> */}
-          <ExploreFilterMock />
+          <div className="flex flex-wrap items-start justify-center gap-6">
+            <ExploreMapMock />
+            <ExploreFiltersMock />
+          </div>
         </Figure>
       </Section>
 
-      <Section id="naming" title="A tip on naming">
+      <Section id="naming" title="Name types in the singular">
         <P>
-          Keep your types broad and few. A short, clear list helps people find
-          their group quickly — a sprawling one just adds friction.
+          Name your group types in the singular: <Term>Team</Term>, not
+          "Teams"; <Term>Small Group</Term>, not "Small Groups";{" "}
+          <Term>Dinner Party</Term>, not "Dinner Parties". The type label
+          appears as a badge on each individual group's card, so the singular
+          reads correctly — "SMALL GROUP" on the Young Adults card, not "SMALL
+          GROUPS".
         </P>
 
         <Callout tone="tip">
-          Throughout the app, prefer a type's display name for labels rather
-          than hardcoding categories. Display names can differ from one
-          community to the next, so leaning on the name keeps everything reading
-          the way your church expects.
+          Beyond naming, keep your list of types broad and few. A short, clear
+          list helps people find their group quickly — a sprawling one just
+          adds friction.
         </Callout>
       </Section>
     </GuideLayout>
@@ -151,6 +217,9 @@ export function GroupTypes() {
 /* ------------------------------------------------------------------ */
 /* Page-local UI mockups                                              */
 /* ------------------------------------------------------------------ */
+
+/** Default community primary color (the green used for admin actions). */
+const PRIMARY = "#1E8449";
 
 /**
  * Live demo: the REAL admin SettingsContent screen rendered via
@@ -169,132 +238,342 @@ function SettingsLiveDemo() {
   );
 }
 
-const DEFAULT_TYPES = [
-  { name: "Small Groups", desc: "Weekly small group gatherings", count: 6, icon: "👥" },
-  { name: "Teams", desc: "Ministry and service teams", count: 4, icon: "🧰" },
-  { name: "Classes", desc: "Educational classes and workshops", count: 3, icon: "📖" },
-  { name: "Announcements", desc: "Community announcements", count: 1, icon: "📣" },
+const STARTER_TYPES = [
+  {
+    name: "Team",
+    desc: "Serving teams — worship, hospitality, kids",
+    count: 8,
+  },
+  {
+    name: "Small Group",
+    desc: "Weekly gatherings in homes around the city",
+    count: 12,
+  },
+  {
+    name: "Campus",
+    desc: "One group per campus location",
+    count: 3,
+  },
+  {
+    name: "Announcements",
+    desc: "Community announcements",
+    count: 1,
+  },
 ];
 
-/** (a) Group-types admin list with the seeded defaults. */
-function GroupTypesAdminMock() {
+/** Ionicons-style add-circle glyph used by the card's "Add New" action. */
+function AddCircleIcon() {
   return (
-    <PhoneFrame title="Group Types">
-      <div className="p-3 space-y-2 bg-neutral-50">
-        {DEFAULT_TYPES.map((t) => (
-          <div
-            key={t.name}
-            className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-white p-3"
+    <svg width="18" height="18" viewBox="0 0 24 24" fill={PRIMARY}>
+      <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
+    </svg>
+  );
+}
+
+/** (a) The Group Types card in Admin → Settings, as it appears in the app. */
+function GroupTypesSettingsMock() {
+  return (
+    <PhoneFrame title="Settings">
+      <div className="bg-white p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="text-base font-semibold text-neutral-900">
+            Group Types
+          </div>
+          <span
+            className="flex items-center gap-1 text-sm font-medium"
+            style={{ color: PRIMARY }}
           >
-            <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-50 text-base">
-              {t.icon}
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="text-sm font-semibold text-neutral-900">
-                {t.name}
-              </div>
-              <div className="truncate text-[11px] text-neutral-500">
-                {t.desc}
-              </div>
-            </div>
-            <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[10px] font-medium text-neutral-500">
-              {t.count}
-            </span>
-          </div>
-        ))}
-        <button className="w-full rounded-xl border border-dashed border-primary-300 bg-primary-50/50 py-2.5 text-sm font-semibold text-primary-700">
-          + Add group type
-        </button>
-      </div>
-    </PhoneFrame>
-  );
-}
-
-/** (b) Explore page with group-type filter chips. */
-function ExploreFilterMock() {
-  const chips = ["All", "Small Groups", "Teams", "Classes"];
-  const results = [
-    { name: "Young Adults", type: "Small Groups", lead: "JD" },
-    { name: "Worship Team", type: "Teams", lead: "MK" },
-    { name: "Intro to the Bible", type: "Classes", lead: "RS" },
-  ];
-  return (
-    <PhoneFrame title="Explore">
-      <div className="bg-white">
-        <div className="flex gap-2 overflow-hidden px-3 py-3">
-          {chips.map((c, i) => (
-            <span
-              key={c}
-              className={`whitespace-nowrap rounded-full border px-3 py-1 text-[11px] font-medium ${
-                i === 1
-                  ? "border-primary-600 bg-primary-600 text-white"
-                  : "border-neutral-200 bg-white text-neutral-600"
-              }`}
-            >
-              {c}
-            </span>
-          ))}
-        </div>
-        <div className="space-y-2 px-3 pb-3">
-          {results.map((r) => (
-            <div
-              key={r.name}
-              className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-white p-3"
-            >
-              <Avatar label={r.lead} />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-semibold text-neutral-900">
-                  {r.name}
-                </div>
-                <div className="text-[11px] text-neutral-500">{r.type}</div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </PhoneFrame>
-  );
-}
-
-/** (c) Community-wide event form with a group-type selector. */
-function CommunityWideEventMock() {
-  return (
-    <PhoneFrame title="New Event">
-      <div className="space-y-3 bg-white p-3">
-        <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Event name
-          </div>
-          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-800">
-            Quarterly Team Huddle
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between rounded-xl border border-primary-200 bg-primary-50 p-3">
-          <div className="text-sm font-semibold text-primary-800">
-            Community-wide event
-          </div>
-          <span className="flex h-5 w-9 items-center rounded-full bg-primary-600 px-0.5">
-            <span className="ml-auto h-4 w-4 rounded-full bg-white" />
+            <AddCircleIcon />
+            Add New
           </span>
         </div>
+        <div className="space-y-2">
+          {STARTER_TYPES.map((t) => (
+            <div
+              key={t.name}
+              className="flex items-center rounded-lg border border-neutral-200 bg-[#f5f5f5] p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="text-base font-semibold text-neutral-900">
+                  {t.name}
+                </div>
+                <div className="truncate text-sm text-neutral-500">
+                  {t.desc}
+                </div>
+                <div className="mt-0.5 text-xs text-neutral-400">
+                  {t.count} {t.count === 1 ? "group" : "groups"}
+                </div>
+              </div>
+              <span className="ml-2 text-lg text-neutral-300">›</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
 
-        <div>
-          <div className="mb-1 text-[11px] font-medium text-neutral-500">
-            Group type
+/** (b) The New Group Type bottom sheet — name + optional description. */
+function NewGroupTypeModalMock() {
+  return (
+    <PhoneFrame>
+      <div className="relative flex h-full flex-col bg-neutral-200">
+        {/* Dimmed settings screen behind the sheet. */}
+        <div className="absolute inset-0 bg-black/50" />
+        <div className="relative mt-auto rounded-t-2xl bg-white p-4 pb-5">
+          <div className="mb-4 flex items-center justify-between">
+            <div className="text-base font-semibold text-neutral-900">
+              New Group Type
+            </div>
+            <span className="text-lg leading-none text-neutral-400">✕</span>
           </div>
-          <div className="flex items-center justify-between rounded-lg border border-primary-300 bg-white px-3 py-2 text-sm">
-            <span className="font-medium text-neutral-900">Teams</span>
-            <span className="text-neutral-400">▾</span>
+
+          <div className="mb-1 text-sm font-medium text-neutral-700">
+            Name *
           </div>
-          <div className="mt-1.5 text-[11px] text-neutral-500">
-            Creates a meeting for every active group of this type.
+          <div className="mb-4 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2.5 text-sm text-neutral-400">
+            e.g., Small Group, Bible Study
+          </div>
+
+          <div className="mb-1 text-sm font-medium text-neutral-700">
+            Description
+          </div>
+          <div className="mb-5 h-20 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2.5 text-sm text-neutral-400">
+            Brief description of this group type...
+          </div>
+
+          <div className="flex gap-3">
+            <span className="flex-1 rounded-lg bg-neutral-200 py-2.5 text-center text-sm font-semibold text-neutral-700">
+              Cancel
+            </span>
+            <span
+              className="flex-1 rounded-lg py-2.5 text-center text-sm font-semibold text-white"
+              style={{ backgroundColor: PRIMARY }}
+            >
+              Create
+            </span>
           </div>
         </div>
+      </div>
+    </PhoneFrame>
+  );
+}
 
-        <button className="w-full rounded-xl bg-primary-600 py-2.5 text-sm font-semibold text-white">
-          Schedule event
-        </button>
+/** Conceptual fan-out: one community-wide event → a linked copy per group. */
+function CommunityWideEventDiagram() {
+  const copies = [
+    { group: "Young Adults", note: "Linked to parent" },
+    { group: "Eastside Group", note: "Edited by leader — detached" },
+    { group: "Riverside Group", note: "Linked to parent" },
+  ];
+  return (
+    <div className="w-full max-w-md">
+      <div className="rounded-xl border border-neutral-200 bg-white p-3 shadow-sm">
+        <div className="mb-1 flex items-center gap-2">
+          <span
+            className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase text-white"
+            style={{ backgroundColor: PRIMARY }}
+          >
+            Community-wide
+          </span>
+          <span className="text-[11px] text-neutral-400">
+            every Small Group
+          </span>
+        </div>
+        <div className="text-sm font-semibold text-neutral-900">
+          Midweek Gathering
+        </div>
+        <div className="text-[11px] text-neutral-500">Wednesday · 7:00 PM</div>
+      </div>
+
+      <div className="my-2 flex justify-center">
+        <span className="text-neutral-300">↓ ↓ ↓</span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {copies.map((c) => (
+          <div
+            key={c.group}
+            className="rounded-xl border border-neutral-200 bg-white p-2.5"
+          >
+            <div className="text-xs font-semibold text-neutral-900">
+              {c.group}
+            </div>
+            <div className="text-[11px] text-neutral-500">Wed · 7:00 PM</div>
+            <div className="mt-1 text-[10px] text-neutral-400">{c.note}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Small overlapping member avatars used on Explore group cards. */
+function MemberStack() {
+  const members = ["JD", "MK", "RS"];
+  return (
+    <div className="flex items-center">
+      <div className="flex -space-x-2">
+        {members.map((m) => (
+          <span
+            key={m}
+            className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-white bg-primary-400 text-[9px] font-semibold text-white"
+          >
+            {m}
+          </span>
+        ))}
+      </div>
+      <span className="ml-1.5 text-[11px] text-neutral-500">+9</span>
+    </div>
+  );
+}
+
+/** (c) Explore — full-screen map, draggable sheet, search, badged group card. */
+function ExploreMapMock() {
+  return (
+    <PhoneFrame>
+      <div className="relative flex h-full flex-col">
+        {/* Map */}
+        <div className="relative flex-1 overflow-hidden bg-[#e8f0e9]">
+          <div className="absolute left-0 right-0 top-1/3 h-2 -rotate-6 bg-white/70" />
+          <div className="absolute bottom-0 top-0 left-1/4 w-2 rotate-12 bg-white/70" />
+          <span className="absolute left-1/4 top-1/4 h-4 w-4 rounded-full border-2 border-white bg-[#3498DB] shadow" />
+          <span className="absolute left-2/3 top-1/2 h-4 w-4 rounded-full border-2 border-white bg-[#8E44AD] shadow" />
+          <span
+            className="absolute left-1/2 top-1/3 h-4 w-4 rounded-full border-2 border-white shadow"
+            style={{ backgroundColor: PRIMARY }}
+          />
+          {/* Floating filter button with active-filter count badge. */}
+          <div className="absolute right-3 top-3">
+            <span className="relative flex h-9 w-9 items-center justify-center rounded-full bg-white shadow">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#404040"
+                strokeWidth="2"
+                strokeLinecap="round"
+              >
+                <line x1="4" y1="7" x2="20" y2="7" />
+                <circle cx="9" cy="7" r="2" fill="white" />
+                <line x1="4" y1="12" x2="20" y2="12" />
+                <circle cx="15" cy="12" r="2" fill="white" />
+                <line x1="4" y1="17" x2="20" y2="17" />
+                <circle cx="7" cy="17" r="2" fill="white" />
+              </svg>
+              <span
+                className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold text-white"
+                style={{ backgroundColor: PRIMARY }}
+              >
+                1
+              </span>
+            </span>
+          </div>
+        </div>
+        {/* Draggable bottom sheet. */}
+        <div
+          className="relative -mt-3 flex flex-col rounded-t-2xl bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.08)]"
+          style={{ height: "58%" }}
+        >
+          <div className="flex justify-center py-2">
+            <span className="h-1 w-9 rounded-full bg-neutral-300" />
+          </div>
+          <div className="mx-3 mb-3 rounded-full bg-neutral-100 px-3 py-2 text-sm text-neutral-400">
+            Search groups...
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden px-3">
+            <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
+              <div className="relative h-[180px] bg-gradient-to-br from-primary-200 to-primary-400">
+                <span className="absolute left-2 top-2 rounded-sm bg-[#3498DB] px-1.5 py-0.5 text-[11px] font-bold uppercase text-white">
+                  Small Group
+                </span>
+              </div>
+              <div className="p-3">
+                <div className="text-sm font-semibold text-neutral-900">
+                  Young Adults
+                </div>
+                <div className="mb-2 text-[11px] text-neutral-500">
+                  Brooklyn, NY
+                </div>
+                <MemberStack />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+const FILTER_TYPES = [
+  { name: "All Types", color: null },
+  { name: "Team", color: PRIMARY },
+  { name: "Small Group", color: "#3498DB" },
+  { name: "Campus", color: "#8E44AD" },
+];
+
+/** (c) The Explore filter modal — chips per group type plus meeting type. */
+function ExploreFiltersMock() {
+  const selectedType = "Small Group";
+  const meeting = ["All", "In-Person", "Online"];
+  return (
+    <PhoneFrame>
+      <div className="relative flex h-full flex-col bg-neutral-200">
+        <div className="absolute inset-0 bg-black/50" />
+        <div className="relative mt-auto rounded-t-2xl bg-white p-4 pb-5">
+          <div className="mb-4 flex items-center justify-between">
+            <div className="text-base font-semibold text-neutral-900">
+              Filters
+            </div>
+            <span className="text-lg leading-none text-neutral-400">✕</span>
+          </div>
+
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+            Group Type
+          </div>
+          <div className="mb-4 flex flex-wrap gap-2">
+            {FILTER_TYPES.map((t) => {
+              const selected = t.name === selectedType;
+              return (
+                <span
+                  key={t.name}
+                  className={`rounded-full border px-3 py-1.5 text-xs font-medium ${
+                    selected
+                      ? "border-transparent text-white"
+                      : "border-neutral-200 bg-white text-neutral-600"
+                  }`}
+                  style={
+                    selected
+                      ? { backgroundColor: t.color ?? "#262626" }
+                      : undefined
+                  }
+                >
+                  {t.name}
+                </span>
+              );
+            })}
+          </div>
+
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+            Meeting Type
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {meeting.map((m, i) => (
+              <span
+                key={m}
+                className={`rounded-full border px-3 py-1.5 text-xs font-medium ${
+                  i === 0
+                    ? "border-transparent text-white"
+                    : "border-neutral-200 bg-white text-neutral-600"
+                }`}
+                style={i === 0 ? { backgroundColor: PRIMARY } : undefined}
+              >
+                {m}
+              </span>
+            ))}
+          </div>
+        </div>
       </div>
     </PhoneFrame>
   );

--- a/apps/web/src/pages/guides/GroupsAndChannels.tsx
+++ b/apps/web/src/pages/guides/GroupsAndChannels.tsx
@@ -11,76 +11,220 @@ import {
   DeepLink,
   Figure,
 } from "../../components/guide/primitives";
-import { PhoneFrame, Avatar } from "../../components/guide/PhoneFrame";
+import { PhoneFrame } from "../../components/guide/PhoneFrame";
 import { appLinks } from "../../guides/appLinks";
 
 const toc: TocItem[] = [
   { id: "create", label: "Create groups for teams & campuses" },
-  { id: "channels", label: "Every group has channels" },
-  { id: "leaders", label: "Making someone a leader" },
-  { id: "announcements", label: "The announcements channel" },
-  { id: "scale", label: "Large churches" },
+  { id: "channels", label: "The channels inside a group" },
+  { id: "custom-channels", label: "Custom channels & invite links" },
+  { id: "leaders", label: "Members & leaders" },
+  { id: "make-leader", label: "Making someone a leader" },
 ];
 
 /* ------------------------------------------------------------------ */
 /* Page-local mockups — code-reconstructed app screens for the figures */
+/*                                                                     */
+/* These reconstruct real Togather screens closely enough to teach     */
+/* from. Icons are inline SVGs that mirror the Ionicons used in the    */
+/* app (chatbubbles, star, megaphone, chatbubble, etc.).               */
 /* ------------------------------------------------------------------ */
 
-/** A single row in a channel list. */
+/** Inline Ionicons-style glyphs, sized to fill a 40×40 round container. */
+function Icon({ name, color }: { name: string; color: string }) {
+  const common = {
+    width: 20,
+    height: 20,
+    viewBox: "0 0 512 512",
+    fill: color,
+    "aria-hidden": true,
+  } as const;
+  switch (name) {
+    case "chatbubbles":
+      return (
+        <svg {...common}>
+          <path d="M398.33 105.84C372.18 78.71 333.07 64 288 64c-88.22 0-160 65.95-160 147s71.78 147 160 147a204 204 0 0046.54-5.39 10 10 0 018.13 1.6l40.7 26.74a13.5 13.5 0 0020.84-12.62l-3.26-36.62a8.36 8.36 0 013-7.15C434.2 360.36 448 333.2 448 304c0-23.49-9.32-45.62-25.31-64.27l-.13-.15z" />
+          <path d="M167.71 416.71c-39.29 0-71.06-25.66-71.06-57.32 0-9.46 2.84-18.46 8.05-26.39a4.39 4.39 0 00-2.41-6.62A111 111 0 0164 304c-35.35 0-64-25.55-64-57S28.65 190 64 190q3.51 0 7 .35" opacity="0" />
+        </svg>
+      );
+    case "star":
+      return (
+        <svg {...common}>
+          <path d="M394 480a16 16 0 01-9.39-3L256 383.76 127.39 477a16 16 0 01-24.55-18.08L153 310.35 23 221.2a16 16 0 019-29.2h160.38l48.4-148.95a16 16 0 0130.44 0l48.4 149H480a16 16 0 019.05 29.2L359 310.35l50.13 148.53A16 16 0 01394 480z" />
+        </svg>
+      );
+    case "megaphone":
+      return (
+        <svg {...common}>
+          <path d="M48 271.92v-31.84a16 16 0 0110.35-15L224 160v192L58.35 286.91a16 16 0 01-10.35-14.99zM272 354.05V157.95l165.71-65.08A16 16 0 01464 107.92v296.16a16 16 0 01-26.29 15.05zM112 384v-12.28l-48-18.86V408a40 40 0 0040 40h0a40 40 0 0040-40v-11.18l-32-12.58z" />
+        </svg>
+      );
+    case "chatbubble":
+      return (
+        <svg {...common}>
+          <path d="M408 64H104a72.08 72.08 0 00-72 72v224a72.08 72.08 0 0072 72h63.72l34.69 50.06a16 16 0 0026.32-.18L262.39 432H408a72.08 72.08 0 0072-72V136a72.08 72.08 0 00-72-72z" />
+        </svg>
+      );
+    case "person-add":
+      return (
+        <svg {...common}>
+          <path d="M288 256a112 112 0 10-112-112 112 112 0 00112 112zm0 32c-69.42 0-208 42.88-208 128v32a16 16 0 0016 16h280a8 8 0 005.71-13.62A175.49 175.49 0 01336 365.13" />
+          <path d="M496 224h-48v-48a16 16 0 00-32 0v48h-48a16 16 0 000 32h48v48a16 16 0 0032 0v-48h48a16 16 0 000-32z" />
+        </svg>
+      );
+    case "arrow-up":
+      return (
+        <svg {...common}>
+          <path d="M256 464a16 16 0 01-16-16V92.42l-94.13 94.13a16 16 0 01-22.62-22.63l121.44-121.45a16 16 0 0122.62 0L390.75 163.9a16 16 0 01-22.62 22.63L274 92.42V448a16 16 0 01-16 16z" />
+        </svg>
+      );
+    case "person-remove":
+      return (
+        <svg {...common}>
+          <path d="M288 256a112 112 0 10-112-112 112 112 0 00112 112zm0 32c-69.42 0-208 42.88-208 128v32a16 16 0 0016 16h280a8 8 0 005.71-13.62A175.49 175.49 0 01336 365.13" />
+          <path d="M496 240H352a16 16 0 000 32h144a16 16 0 000-32z" />
+        </svg>
+      );
+    case "add":
+      return (
+        <svg {...common}>
+          <path d="M256 112v288M400 256H112" stroke={color} strokeWidth="48" strokeLinecap="round" fill="none" />
+        </svg>
+      );
+    case "link":
+      return (
+        <svg {...common} fill="none" stroke={color} strokeWidth="32" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M208 352h-64a96 96 0 010-192h64M304 160h64a96 96 0 010 192h-64M163.29 256h187.42" />
+        </svg>
+      );
+    default:
+      return <svg {...common} />;
+  }
+}
+
+/** A round 40×40 icon container tinted with the icon color at ~15% opacity. */
+function ChannelIcon({ name, color }: { name: string; color: string }) {
+  return (
+    <span
+      className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0"
+      style={{ backgroundColor: `${color}26` }}
+    >
+      <Icon name={name} color={color} />
+    </span>
+  );
+}
+
+/** Chevron used at the trailing edge of iOS-settings-style rows. */
+function Chevron() {
+  return (
+    <svg
+      className="flex-shrink-0 text-neutral-300"
+      width="16"
+      height="16"
+      viewBox="0 0 512 512"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M184.49 136.49a16 16 0 0122.62 0l112 112a16 16 0 010 22.62l-112 112a16 16 0 01-22.62-22.62L284.69 256 184.49 159.11a16 16 0 010-22.62z" />
+    </svg>
+  );
+}
+
+/** A single iOS-settings-style channel row. */
 function ChannelRow({
   icon,
+  color,
   name,
   subtitle,
-  muted = false,
-  active = false,
+  unread,
 }: {
-  icon: ReactNode;
+  icon: string;
+  color: string;
   name: string;
-  subtitle?: string;
-  muted?: boolean;
-  active?: boolean;
+  subtitle: string;
+  unread?: number;
 }) {
   return (
-    <div
-      className={`flex items-center gap-3 px-4 py-3 border-b border-neutral-100 ${
-        active ? "bg-primary-50" : ""
-      } ${muted ? "opacity-50" : ""}`}
-    >
-      <span className="w-7 h-7 rounded-lg bg-neutral-100 flex items-center justify-center text-sm text-neutral-600 flex-shrink-0">
-        {icon}
-      </span>
+    <div className="flex items-center gap-3 px-4 py-2.5">
+      <ChannelIcon name={icon} color={color} />
       <div className="min-w-0 flex-1">
-        <div className="text-sm font-medium text-neutral-900 truncate">
+        <div className="text-[16px] font-semibold text-neutral-900 truncate leading-tight">
           {name}
         </div>
-        {subtitle && (
-          <div className="text-[11px] text-neutral-400 truncate">{subtitle}</div>
-        )}
+        <div className="text-[13px] text-neutral-400 truncate">{subtitle}</div>
       </div>
+      {unread != null && (
+        <span
+          className="flex-shrink-0 min-w-[20px] h-5 px-1.5 rounded-full flex items-center justify-center text-[11px] font-semibold text-white"
+          style={{ backgroundColor: color }}
+        >
+          {unread}
+        </span>
+      )}
+      <Chevron />
     </div>
   );
 }
 
-/** (a) A group's channel list: general + locked leaders + announcements. */
+const PRIMARY = "#1E8449"; // community primary (default green)
+const ORANGE = "#FFA500";
+const RED = "#E11D48";
+const CYAN = "#00BCD4";
+
+/** (a) The CHANNELS card with the four canonical rows + Create Channel row. */
 function ChannelListMock() {
   return (
     <PhoneFrame title="Worship Team">
-      <ChannelRow
-        icon="#"
-        name="general"
-        subtitle="Everyone can read and post"
-        active
-      />
-      <ChannelRow
-        icon="🔒"
-        name="leaders"
-        subtitle="Private to leaders"
-      />
-      <ChannelRow
-        icon="📣"
-        name="Announcements"
-        subtitle="Leaders post · everyone reads"
-      />
+      <div className="px-4 pt-4">
+        <div className="rounded-2xl bg-white border border-neutral-200 overflow-hidden divide-y divide-neutral-100">
+          <div className="px-4 pt-3 pb-1 text-[11px] font-semibold tracking-[0.08em] text-neutral-400">
+            CHANNELS
+          </div>
+          <ChannelRow
+            icon="chatbubbles"
+            color={PRIMARY}
+            name="General"
+            subtitle="All members"
+          />
+          <ChannelRow
+            icon="star"
+            color={ORANGE}
+            name="Leaders"
+            subtitle="3 leaders"
+          />
+          <ChannelRow
+            icon="megaphone"
+            color={RED}
+            name="Announcements"
+            subtitle="48 members · Leaders post"
+            unread={2}
+          />
+          <ChannelRow
+            icon="chatbubble"
+            color={CYAN}
+            name="Prayer Chain"
+            subtitle="12 members"
+          />
+        </div>
+
+        {/* Leaders-only: Create Channel row card */}
+        <div className="mt-3 rounded-2xl bg-white border border-neutral-200 overflow-hidden">
+          <div className="flex items-center gap-3 px-4 py-3">
+            <span
+              className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0"
+              style={{ backgroundColor: `${PRIMARY}26` }}
+            >
+              <Icon name="add" color={PRIMARY} />
+            </span>
+            <div
+              className="text-[16px] font-semibold flex-1"
+              style={{ color: PRIMARY }}
+            >
+              Create Channel
+            </div>
+          </div>
+        </div>
+      </div>
     </PhoneFrame>
   );
 }
@@ -99,129 +243,136 @@ function LiveChannelList() {
   );
 }
 
-/** A single member row with role pill. */
+/** A member row: white card, 44px avatar, name, role pill, chevron. */
 function MemberRow({
   label,
   color,
   name,
-  role,
-  highlighted = false,
+  isLeader,
+  dimmed = false,
 }: {
   label: string;
   color?: string;
-  name: string;
-  role?: string;
-  highlighted?: boolean;
+  name: ReactNode;
+  isLeader?: boolean;
+  dimmed?: boolean;
 }) {
   return (
     <div
-      className={`flex items-center gap-3 px-4 py-3 border-b border-neutral-100 ${
-        highlighted ? "bg-primary-50" : ""
+      className={`flex items-center gap-3 rounded-xl border border-neutral-200 bg-white px-3 py-2.5 ${
+        dimmed ? "opacity-40" : ""
       }`}
     >
-      <Avatar label={label} color={color} />
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-medium text-neutral-900 truncate">
-          {name}
-        </div>
+      <span
+        className={`inline-flex items-center justify-center w-11 h-11 rounded-full ${
+          color ?? "bg-primary-400"
+        } text-white text-sm font-semibold flex-shrink-0`}
+      >
+        {label}
+      </span>
+      <div className="min-w-0 flex-1 text-[15px] font-medium text-neutral-900 truncate">
+        {name}
       </div>
-      {role && (
-        <span className="text-[11px] font-semibold text-primary-700 bg-primary-100 rounded-full px-2 py-0.5">
-          {role}
+      {isLeader && (
+        <span
+          className="text-[11px] font-semibold rounded-full px-2 py-0.5"
+          style={{ backgroundColor: `${PRIMARY}1A`, color: PRIMARY }}
+        >
+          Leader
         </span>
       )}
+      <Chevron />
     </div>
   );
 }
 
-/** (b) Member list with an open role menu offering "Promote to Leader". */
-function MemberRoleMock() {
+/** A row inside the member-action bottom sheet. */
+function SheetRow({
+  icon,
+  label,
+  color = "#111827",
+}: {
+  icon: string;
+  label: string;
+  color?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3.5">
+      <Icon name={icon} color={color} />
+      <span className="text-[16px] font-medium" style={{ color }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/** (b) Member list (dimmed) with the member-action bottom sheet over it. */
+function MemberActionSheetMock() {
   return (
     <PhoneFrame title="Members">
-      <MemberRow label="JR" name="Jordan Rivera" role="Leader" />
-      <MemberRow
-        label="SP"
-        color="bg-accent-500"
-        name="Sam Patel"
-        highlighted
-      />
-      {/* Role action menu for the selected member */}
-      <div className="px-4 py-3">
-        <div className="rounded-xl border border-neutral-200 bg-white shadow-sm overflow-hidden">
-          <button
-            type="button"
-            className="w-full text-left px-4 py-2.5 text-sm font-medium text-primary-700 hover:bg-primary-50"
-          >
-            Promote to Leader
-          </button>
-          <div className="border-t border-neutral-100" />
-          <button
-            type="button"
-            className="w-full text-left px-4 py-2.5 text-sm text-neutral-500 hover:bg-neutral-50"
-          >
-            Remove from group
-          </button>
-        </div>
+      {/* Group-name subtitle + person-add affordance under the title */}
+      <div className="px-4 pt-1 pb-2 flex items-center justify-between">
+        <span className="text-[12px] text-neutral-400">Worship Team</span>
+        <Icon name="person-add" color={PRIMARY} />
       </div>
-      <MemberRow
-        label="MA"
-        color="bg-neutral-400"
-        name="Maria Alvarez"
-        role="Member"
-      />
-    </PhoneFrame>
-  );
-}
 
-/** (a/announcements) The announcements channel with a read-only composer. */
-function AnnouncementsMock() {
-  return (
-    <PhoneFrame title="Announcements">
-      <div className="px-4 py-3 bg-primary-50 border-b border-neutral-100 text-[11px] text-primary-700">
-        Visible to all members · only leaders can post
-      </div>
-      <div className="px-4 py-4 space-y-3">
-        <div className="flex gap-2">
-          <Avatar label="JR" />
-          <div className="rounded-2xl rounded-tl-sm bg-neutral-100 px-3 py-2 text-sm text-neutral-800 max-w-[80%]">
-            Rehearsal moved to 6:30 this Thursday. See you there! 🙌
+      {/* Dimmed underlying member list */}
+      <div className="relative">
+        <div className="px-4 pb-4 space-y-3 pointer-events-none">
+          {/* Search bar */}
+          <div className="rounded-xl bg-neutral-100 px-3 py-2 text-[13px] text-neutral-400 opacity-40">
+            Search members...
+          </div>
+          {/* Channel filter chips */}
+          <div className="flex gap-2 opacity-40">
+            <span
+              className="text-[12px] font-medium text-white rounded-full px-3 py-1"
+              style={{ backgroundColor: PRIMARY }}
+            >
+              All
+            </span>
+            <span className="text-[12px] font-medium text-neutral-600 bg-neutral-100 rounded-full px-3 py-1">
+              General
+            </span>
+            <span className="text-[12px] font-medium text-neutral-600 bg-neutral-100 rounded-full px-3 py-1">
+              Prayer Chain
+            </span>
+          </div>
+          <MemberRow label="JR" name="Jordan Rivera (you)" isLeader dimmed />
+          <MemberRow
+            label="SP"
+            color="bg-accent-500"
+            name="Sam Patel"
+            dimmed
+          />
+          <MemberRow
+            label="MA"
+            color="bg-neutral-400"
+            name="Maria Alvarez"
+            dimmed
+          />
+        </div>
+
+        {/* Bottom-sheet action modal */}
+        <div className="absolute inset-x-0 bottom-0">
+          <div className="rounded-t-3xl bg-white border-t border-neutral-200 shadow-2xl overflow-hidden">
+            <div className="flex justify-center pt-2 pb-1">
+              <span className="w-9 h-1 rounded-full bg-neutral-300" />
+            </div>
+            <div className="px-4 pb-2 text-center text-[15px] font-semibold text-neutral-900">
+              Sam Patel
+            </div>
+            <div className="divide-y divide-neutral-100">
+              <SheetRow icon="chatbubble" label="View profile" />
+              <SheetRow icon="arrow-up" label="Promote to Leader" />
+              <SheetRow
+                icon="person-remove"
+                label="Remove from Group"
+                color={RED}
+              />
+            </div>
           </div>
         </div>
-      </div>
-      {/* Composer replaced by a read-only notice */}
-      <div className="px-4 py-3 border-t border-neutral-100">
-        <div className="rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2.5 text-center text-xs text-neutral-500">
-          Only leaders can post here. You can react to messages.
-        </div>
-      </div>
-    </PhoneFrame>
-  );
-}
-
-/** (c) Larger-church config: general OFF, announcements as primary. */
-function LargeChurchConfigMock() {
-  return (
-    <PhoneFrame title="Channel settings">
-      <ChannelRow
-        icon="#"
-        name="general"
-        subtitle="Hidden — turned off"
-        muted
-      />
-      <ChannelRow
-        icon="🔒"
-        name="leaders"
-        subtitle="Private to leaders"
-      />
-      <ChannelRow
-        icon="📣"
-        name="Announcements"
-        subtitle="Primary channel · leaders post"
-        active
-      />
-      <div className="px-4 py-3 text-[11px] text-neutral-400 leading-relaxed">
-        General is hidden. Members will not be able to use it until you turn it
-        back on.
       </div>
     </PhoneFrame>
   );
@@ -235,10 +386,10 @@ export function GroupsAndChannels() {
       <Lead>
         Groups are how your church&rsquo;s teams, ministries, and campuses live
         in Togather. Each group has its own members, events, and conversations.
-        Those conversations happen in <strong>channels</strong> — and a couple
-        of them are created for you the moment a group exists. This guide walks
-        through creating groups, the channels inside them, how to make someone a
-        leader, and how larger churches keep things calm at scale.
+        Those conversations happen in <strong>channels</strong> — and two of
+        them are created for you the moment a group exists. This guide covers
+        creating groups, the channels inside them, the custom channels and
+        invite links leaders can spin up, and how members and leaders differ.
       </Lead>
 
       <Section id="create" title="Create groups for teams & campuses">
@@ -253,7 +404,9 @@ export function GroupsAndChannels() {
           type, a <strong>Downtown Campus</strong> group for a specific
           location, or a <strong>Tuesday Small Group</strong> that meets weekly.
           Each one gets its own members, channels, and events — nothing is
-          shared by accident.
+          shared by accident. A group inherits the label of its type, so it
+          shows up as a &ldquo;Team&rdquo; or a &ldquo;Campus&rdquo; wherever
+          it&rsquo;s listed.
         </P>
 
         <Steps>
@@ -278,34 +431,46 @@ export function GroupsAndChannels() {
 
         <Callout tone="tip" title="Group types vary by church">
           The exact group types you see — Teams, Campuses, Small Groups — are
-          set up per community, so the labels in your church may differ. Pick the
-          type that best matches what the group is for.
+          set up per community, so the labels in your church may differ. A group
+          always inherits its type&rsquo;s label, so pick the type that best
+          matches what the group is for.
         </Callout>
       </Section>
 
-      <Section id="channels" title="Every group has channels">
+      <Section id="channels" title="The channels inside a group">
         <P>
-          When a group is created, Togather sets up two channels for you right
-          away — you never start from a blank screen:
+          When a group is created, Togather sets up exactly{" "}
+          <strong>two channels</strong> for you right away — you never start from
+          a blank screen:
         </P>
         <P>
-          A <Term>general</Term> channel where everyone in the group can read and
-          post, and a private <Term>leaders</Term> channel that only the
-          group&rsquo;s leaders and admins can see. The leaders channel is the
-          quiet back room for planning and coordination that members don&rsquo;t
-          need in their feed.
+          <Term>General</Term>, which every member of the group can read and
+          post in, and <Term>Leaders</Term>, a private channel only the
+          group&rsquo;s leaders can see. The Leaders channel is the quiet back
+          room for planning and coordination that members don&rsquo;t need in
+          their feed. If a member doesn&rsquo;t see it, that&rsquo;s working as
+          intended.
+        </P>
+        <P>
+          A third channel, <Term>Announcements</Term>, is{" "}
+          <strong>opt-in per group</strong>. A leader taps to enable it; once
+          it&rsquo;s on, leaders post and every member reads. It&rsquo;s the
+          right place for &ldquo;here&rsquo;s what&rsquo;s happening&rdquo;
+          messages that shouldn&rsquo;t turn into a thread. This is distinct from
+          your community-wide announcement group — the Announcements channel is
+          scoped to just this one group.
         </P>
 
-        <Figure caption="A group's channel list: #general for everyone, a locked leaders channel, and Announcements.">
-          {/* swap-in: <img src="/images/guides/channel-list.png" /> */}
+        <Figure caption="A group's CHANNELS card: General for all members, the leaders-only Leaders channel, an enabled Announcements channel, and a custom Prayer Chain. Leaders also see Create Channel.">
           <ChannelListMock />
         </Figure>
 
         <Callout tone="note">
-          The <Term>leaders</Term> channel is described in the app as
-          &ldquo;Leaders channel is visible to leaders and admins of this
-          group.&rdquo; If a member doesn&rsquo;t see it, that&rsquo;s working as
-          intended — it&rsquo;s private on purpose.
+          The four rows above are the canonical ones: General (all members),
+          Leaders (leaders only), Announcements (opt-in; leaders post, members
+          read), and any custom channels a leader has created. Before
+          Announcements is enabled, its row reads &ldquo;Tap to enable — leaders
+          post, members read.&rdquo;
         </Callout>
 
         <Callout tone="note" title="Live preview">
@@ -314,36 +479,106 @@ export function GroupsAndChannels() {
           the app.
         </Callout>
 
-        <Figure caption="Live render of the app's CHANNELS card: General, the private Leaders channel, Announcements, and more.">
+        <Figure caption="Live render of the app's CHANNELS card.">
           <LiveChannelList />
         </Figure>
       </Section>
 
-      <Section id="leaders" title="Making someone a leader">
+      <Section id="custom-channels" title="Custom channels & invite links">
         <P>
-          Leaders keep a group running: they get the private leaders channel and
-          they&rsquo;re the ones who can post announcements. Promoting someone
-          takes a few taps from the group&rsquo;s member list.
+          Beyond the built-in channels, leaders can create their own{" "}
+          <Term>custom channels</Term> — up to <strong>20 per group</strong>.
+          A custom channel is perfect for an opt-in subgroup: a prayer chain, a
+          class cohort, or a volunteer interest list that not everyone in the
+          group needs to be in.
+        </P>
+        <P>
+          Each custom channel has a <Term>join mode</Term> that decides how
+          people get in:
+        </P>
+        <Steps>
+          <Step n={1}>
+            <strong>Open</strong> — &ldquo;Anyone in the group can join via
+            invite link.&rdquo; Share the link and people add themselves.
+          </Step>
+          <Step n={2}>
+            <strong>Approval required</strong> — &ldquo;Members must request and
+            be approved by a leader.&rdquo; Good when you want to keep an eye on
+            who joins.
+          </Step>
+        </Steps>
+
+        <P>
+          Custom channels also have <Term>invite links</Term>. A leader can
+          share a link in the format <Term>togather.nyc/ch/…</Term>, regenerate
+          it (the old link dies instantly), or disable it entirely. That makes
+          links the easiest way to grow an opt-in subgroup without adding people
+          by hand.
+        </P>
+
+        <Callout tone="tip" title="Regenerating kills the old link">
+          When you regenerate a channel invite link, the previous one stops
+          working immediately. Use that if a link was shared too widely — make a
+          new one and the old one can&rsquo;t be used to join.
+        </Callout>
+      </Section>
+
+      <Section id="leaders" title="Members & leaders">
+        <P>
+          Inside a group there are two roles: <Term>member</Term> and{" "}
+          <Term>leader</Term>. (Community admin is a separate role that lives at
+          the community level, not inside a single group.) Most people are
+          members — they can read and post in General, join custom channels they
+          have access to, and read Announcements.
+        </P>
+        <P>
+          <Term>Leaders</Term> keep the group running. A leader can:
+        </P>
+        <Steps>
+          <Step n={1}>
+            Create custom channels and enable the Announcements channel.
+          </Step>
+          <Step n={2}>
+            Post in the Announcements channel (members can only read it).
+          </Step>
+          <Step n={3}>
+            Manage channel invite links and approve or decline join requests.
+          </Step>
+          <Step n={4}>
+            Add, remove, and promote members within the group.
+          </Step>
+          <Step n={5}>
+            Run the group&rsquo;s events, rostering, and follow-ups.
+          </Step>
+        </Steps>
+      </Section>
+
+      <Section id="make-leader" title="Making someone a leader">
+        <P>
+          Promoting someone takes a few taps from the group&rsquo;s member list.
+          Open the group, go to <Term>Members</Term>, and tap the person you
+          want to promote — a bottom-sheet action menu slides up.
         </P>
 
         <Steps>
           <Step n={1}>
-            Open the group and go to its <Term>Members</Term> list.
+            Open the group and go to its <Term>Members</Term> list. You can
+            search or filter by channel to find someone.
           </Step>
-          <Step n={2}>Tap the member you want to promote.</Step>
+          <Step n={2}>Tap the member&rsquo;s row to open the action sheet.</Step>
           <Step n={3}>
-            Choose <Term>Promote to Leader</Term> from their role menu. Their
-            badge changes from <Term>Member</Term> to <Term>Leader</Term>.
+            Choose <Term>Promote to Leader</Term>. Their role pill changes from{" "}
+            <Term>Member</Term> to <Term>Leader</Term>. (For an existing leader
+            this row reads <Term>Demote to Member</Term> instead.)
           </Step>
           <Step n={4}>
-            They immediately gain access to the leaders channel and can post in
-            the announcements channel.
+            They immediately gain the Leaders channel and everything else a
+            leader can do.
           </Step>
         </Steps>
 
-        <Figure caption="Open a member and choose Promote to Leader to change their role.">
-          {/* swap-in: <img src="/images/guides/member-role-menu.png" /> */}
-          <MemberRoleMock />
+        <Figure caption="Tap a member to open the action sheet: View profile, Promote to Leader, or Remove from Group.">
+          <MemberActionSheetMock />
         </Figure>
 
         <Callout tone="warn" title="Announcement groups are different">
@@ -351,70 +586,6 @@ export function GroupsAndChannels() {
           roles aren&rsquo;t set by hand. The app will tell you: &ldquo;Roles are
           managed automatically based on community admin status.&rdquo; To change
           who can post there, change who is a community admin.
-        </Callout>
-      </Section>
-
-      <Section id="announcements" title="The announcements channel">
-        <P>
-          Alongside <Term>general</Term> and <Term>leaders</Term>, a group can
-          have an <Term>Announcements</Term> channel. It&rsquo;s a one-way
-          broadcast: leaders post, and every member can read — but members
-          can&rsquo;t reply. It&rsquo;s the right place for &ldquo;here&rsquo;s
-          what&rsquo;s happening&rdquo; messages that shouldn&rsquo;t turn into a
-          thread.
-        </P>
-        <P>
-          The app describes the channel exactly this way:{" "}
-          <em>
-            &ldquo;Leader announcements — visible to all members; only leaders
-            can post.&rdquo;
-          </em>
-        </P>
-
-        <Figure caption="In Announcements the composer is replaced by a read-only notice for members.">
-          {/* swap-in: <img src="/images/guides/announcements-channel.png" /> */}
-          <AnnouncementsMock />
-        </Figure>
-
-        <Callout tone="note">
-          When a member opens Announcements, they don&rsquo;t see a text box.
-          Instead they see &ldquo;Only leaders can post in Announcements. You can
-          react to messages.&rdquo; — so the channel stays clean while members
-          can still show they&rsquo;ve seen a post.
-        </Callout>
-      </Section>
-
-      <Section id="scale" title="Large churches: turn off general, use announcements">
-        <P>
-          A wide-open <Term>general</Term> channel is wonderful for a small team
-          where everyone knows each other. For a large congregation it can get
-          noisy fast — hundreds of people all able to post means the important
-          messages get buried.
-        </P>
-        <P>
-          For bigger churches we recommend a simpler shape: turn the{" "}
-          <Term>general</Term> channel off and make <Term>Announcements</Term>{" "}
-          the primary channel. Only leaders broadcast, and members read — calm,
-          clear, and easy to follow.
-        </P>
-        <P>
-          You control this with each channel&rsquo;s <Term>enabled</Term> toggle
-          in the channel settings: switch <Term>general</Term> off and leave{" "}
-          <Term>Announcements</Term> on. Turning general off hides it from
-          members but keeps their memberships, so you can always switch it back
-          on later.
-        </P>
-
-        <Figure caption="A large-church setup: general turned off, Announcements as the primary channel.">
-          {/* swap-in: <img src="/images/guides/large-church-config.png" /> */}
-          <LargeChurchConfigMock />
-        </Figure>
-
-        <Callout tone="tip" title="Reversible at any time">
-          Disabling a channel is not the same as deleting it. The app keeps the
-          history and memberships, so if you ever want the open conversation
-          back, flip <Term>general</Term> on again and everything returns just as
-          it was.
         </Callout>
       </Section>
     </GuideLayout>

--- a/apps/web/src/pages/guides/Prayer.tsx
+++ b/apps/web/src/pages/guides/Prayer.tsx
@@ -41,8 +41,9 @@ export function Prayer() {
 
       <Section id="enable" title="Turn on prayer">
         <P>
-          Prayer is off until an admin turns it on. You'll find it in your
-          community's church-features settings — flip the{" "}
+          Prayer is off until an admin turns it on. You'll find it in{" "}
+          <Term>Admin → Settings</Term>, under the{" "}
+          <Term>Church Features</Term> card — flip the{" "}
           <Term>Prayer Requests</Term> toggle and a Prayer tab appears for your
           members. Nothing changes for anyone until you do this, so you're free
           to turn it on whenever your church is ready.
@@ -50,25 +51,25 @@ export function Prayer() {
 
         <Steps>
           <Step n={1}>
-            Open your community's <Term>Church features</Term> settings from the
-            admin area.
+            Open <Term>Admin</Term> and go to the <Term>Settings</Term> tab.
           </Step>
           <Step n={2}>
-            Find <Term>Prayer Requests</Term> and switch the toggle on. This
-            adds a Prayer tab where members post and pray.
+            Scroll to the <Term>Church Features</Term> card ("Opt-in features
+            for religious communities. Off by default.").
           </Step>
           <Step n={3}>
-            That's it — prayer is live for your community. Toggle it back off any
-            time and the tab goes away.
+            Find <Term>Prayer Requests</Term> and switch the toggle on. This
+            adds a Prayer tab where members post and pray. Toggle it back off
+            any time and the tab goes away.
           </Step>
         </Steps>
 
-        <Figure caption="Church features settings — flip Prayer Requests on.">
+        <Figure caption="Admin → Settings → Church Features — flip Prayer Requests on.">
           {/* swap-in: <img src="/images/guides/prayer-settings.png" /> */}
           <ChurchFeaturesMock />
         </Figure>
 
-        <DeepLink href={appLinks.features}>Open church features</DeepLink>
+        <DeepLink href={appLinks.features}>Open admin settings</DeepLink>
       </Section>
 
       <Section id="use" title="How members use it">
@@ -176,44 +177,35 @@ function LivePrayerDemo() {
   );
 }
 
-/** (a) Church-features settings with the Prayer Requests toggle on. */
+/** (a) Admin → Settings → "Church Features" card with the Prayer Requests row. */
 function ChurchFeaturesMock() {
   return (
-    <PhoneFrame title="Church features">
-      <div className="space-y-3 bg-neutral-50 p-3">
-        <div className="flex items-start gap-3 rounded-xl border border-neutral-200 bg-white p-3">
-          <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary-50 text-base">
-            🙏
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-semibold text-neutral-900">
-              Prayer Requests
-            </div>
-            <div className="text-[11px] leading-snug text-neutral-500">
-              Members can post prayer requests and pray for each other. Adds a
-              Prayer tab.
-            </div>
-          </div>
-          {/* On toggle */}
-          <span className="mt-0.5 flex h-5 w-9 flex-shrink-0 items-center rounded-full bg-accent-500 px-0.5">
-            <span className="ml-auto h-4 w-4 rounded-full bg-white" />
-          </span>
-        </div>
-
+    <PhoneFrame title="Settings">
+      <div className="bg-neutral-50 p-3">
         <div className="rounded-xl border border-neutral-200 bg-white p-3">
-          <div className="flex items-center gap-3">
-            <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary-50 text-base">
-              ✅
-            </span>
+          {/* Card header */}
+          <div className="mb-1 text-sm font-semibold text-neutral-900">
+            Church Features
+          </div>
+          <div className="mb-3 text-[11px] leading-snug text-neutral-500">
+            Opt-in features for religious communities. Off by default.
+          </div>
+
+          {/* Prayer Requests row */}
+          <div className="flex items-start gap-3 border-t border-neutral-100 pt-3">
             <div className="min-w-0 flex-1">
               <div className="text-sm font-semibold text-neutral-900">
-                Prayer Reviews
+                Prayer Requests
               </div>
-              <div className="text-[11px] text-neutral-500">
-                Approve or reject held prayers
+              <div className="text-[11px] leading-snug text-neutral-500">
+                Members can post prayer requests and pray for each other. Adds a
+                Prayer tab.
               </div>
             </div>
-            <span className="text-neutral-300">›</span>
+            {/* On switch */}
+            <span className="mt-0.5 flex h-5 w-9 flex-shrink-0 items-center rounded-full bg-accent-500 px-0.5">
+              <span className="ml-auto h-4 w-4 rounded-full bg-white" />
+            </span>
           </div>
         </div>
       </div>
@@ -221,57 +213,72 @@ function ChurchFeaturesMock() {
   );
 }
 
-/** (b) The prayer feed — cards with a request, a pray count, and a Pray button. */
+/**
+ * (b) The prayer screen — one request at a time (NOT a scrolling feed).
+ * Matches apps/mobile/features/prayer/components/PrayerScreen.tsx: a heading,
+ * add + "My prayers" actions, a "Prayer N of 3" progress row with dots, and a
+ * single hero card (initials avatar, author, time · others prayed, an oversized
+ * quote mark in the community color, the request, and a solid Pray button).
+ */
 function PrayerFeedMock() {
-  const prayers = [
-    {
-      author: "Anonymous",
-      anon: true,
-      body: "Please pray for my mom's surgery on Thursday.",
-      count: "Be the first to pray",
-      initials: "",
-    },
-    {
-      author: "Sarah M.",
-      anon: false,
-      body: "Wisdom for a big decision at work this week.",
-      count: "3 people prayed",
-      initials: "SM",
-    },
-    {
-      author: "David L.",
-      anon: false,
-      body: "Strength for our family in a hard season.",
-      count: "8 people prayed",
-      initials: "DL",
-    },
-  ];
   return (
     <PhoneFrame title="Prayer">
-      <div className="space-y-2.5 bg-neutral-50 p-3">
-        {prayers.map((p) => (
-          <div
-            key={p.body}
-            className="rounded-xl border border-neutral-200 bg-white p-3"
-          >
-            <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium text-neutral-400">
-              <span>{p.anon ? "🙈" : "👤"}</span>
-              <span>{p.author}</span>
-            </div>
-            <div className="mb-3 text-sm leading-snug text-neutral-800">
-              {p.body}
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-1.5 text-[11px] text-neutral-400">
-                <span>👥</span>
-                <span>{p.count}</span>
-              </div>
-              <button className="flex items-center gap-1.5 rounded-full bg-primary-600 px-4 py-1.5 text-[12px] font-semibold text-white">
-                <span>♥</span> Pray
-              </button>
-            </div>
+      <div className="bg-neutral-50 px-4 pb-4 pt-3">
+        {/* Top bar: heading + add / my prayers */}
+        <div className="mb-3 flex items-center justify-between">
+          <div className="text-base font-bold text-neutral-900">
+            Pray for your community
           </div>
-        ))}
+          <div className="flex items-center gap-3 text-primary-600">
+            <span className="text-lg leading-none">+</span>
+            <span className="text-[12px] font-semibold">My prayers</span>
+          </div>
+        </div>
+
+        {/* Progress row: "Prayer 1 of 3" + three dots */}
+        <div className="mb-5 flex items-center gap-2.5">
+          <span className="text-[12px] font-semibold tracking-wide text-neutral-500">
+            Prayer 1 of 3
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-neutral-300" />
+            <span className="h-2 w-2 rounded-full bg-neutral-300" />
+            <span className="h-2 w-2 rounded-full bg-neutral-300" />
+          </span>
+        </div>
+
+        {/* Single hero prayer card */}
+        <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+          <div className="mb-4 flex items-center gap-3">
+            {/* Initials avatar on a pastel background — never a photo. */}
+            <span className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-[#A0C4FF] text-sm font-bold text-[#3A3A3F]">
+              SM
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-[15px] font-bold text-neutral-900">
+                Sarah M.
+              </div>
+              <div className="text-[12px] text-neutral-400">
+                2h ago · 3 others prayed
+              </div>
+            </div>
+            <span className="text-neutral-400">⋯</span>
+          </div>
+
+          {/* Body with oversized decorative opening quote */}
+          <div className="relative mb-5 pl-6 pr-1 pt-2">
+            <span className="absolute -left-0.5 -top-3 select-none text-6xl font-bold leading-none text-primary-600 opacity-35">
+              “
+            </span>
+            <p className="text-[18px] font-medium leading-7 text-neutral-900">
+              Wisdom for a big decision at work this week.
+            </p>
+          </div>
+
+          <button className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary-600 py-3.5 text-[15px] font-bold text-white">
+            <span>♥</span> Pray
+          </button>
+        </div>
       </div>
     </PhoneFrame>
   );


### PR DESCRIPTION
## Summary

Rewrote the onboarding guides for accuracy against the real app, and added two new guides:

- **Branding** — uses a path-link (not a subdomain), dropped the app-icon / preview sections, added an interactive light/dark color widget.
- **Group Types** — real church starter set, singular naming, correct defaults.
- **Groups & Channels** — channel types / join-modes / invite links, plus the real leader-promote flow.
- **Events** — clarifies events vs. event plans, series, and the community-wide combo.
- **Create Community** — competitive pricing guidance and the real proposal form.
- **Prayer** — correct enable path and real prayer-screen mocks.
- **New: Event Plans guide** — desktop roster-grid mock.
- **New: Check-in guide.**
- Rebuilt all phone mocks to match the real mobile UI; added a `DesktopFrame` component.
- Fixed `/demo/*` live-preview routing in the Cloudflare worker (+ test).
- Pointed deep links same-origin instead of the nonexistent `app.togather.nyc`.

## Why

The old guides had invented mockups, broken live previews, and dead deep links that didn't reflect the real product.

## Test plan

- Typecheck clean.
- `vite build` succeeds (all demo entry points).
- Playwright visual check of all 9 guide routes at 1280px with zero console errors.
- Note: the live-preview iframes need the deployed Cloudflare worker (the `/demo/` routing fix) to render on staging — they 404 in raw dev, which is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)