### PR TITLE
Show run-sheet toolbar tool for any group with a run sheet

### DIFF
--- a/apps/convex/__tests__/scheduling/eventItems.test.ts
+++ b/apps/convex/__tests__/scheduling/eventItems.test.ts
@@ -681,3 +681,66 @@ describe("run sheet segments (before / during / after)", () => {
     ).rejects.toThrow(ConvexError);
   });
 });
+
+describe("groupHasRunSheet", () => {
+  it("returns false when the group has no event plans", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const result = await t.query(
+      api.functions.scheduling.events.groupHasRunSheet,
+      { token, groupId: world.groupId },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns false when a plan exists but has no items", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await createPlan(t, token, world.groupId);
+
+    const result = await t.query(
+      api.functions.scheduling.events.groupHasRunSheet,
+      { token, groupId: world.groupId },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true once a plan has at least one item", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, token, world.groupId);
+    await t.mutation(api.functions.scheduling.eventItems.createItem, {
+      token,
+      planId,
+      type: "item",
+      title: "Welcome",
+    });
+
+    const result = await t.query(
+      api.functions.scheduling.events.groupHasRunSheet,
+      { token, groupId: world.groupId },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a non-member token (no throw)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await createPlan(t, leaderToken, world.groupId);
+    await t.mutation(api.functions.scheduling.eventItems.createItem, {
+      token: leaderToken,
+      planId,
+      type: "item",
+      title: "Welcome",
+    });
+
+    // Outsider has no membership anywhere — should get false, not an error.
+    const outsiderToken = (await generateTokens(world.outsiderId)).accessToken;
+    const result = await t.query(
+      api.functions.scheduling.events.groupHasRunSheet,
+      { token: outsiderToken, groupId: world.groupId },
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -684,6 +684,49 @@ export const getEvent = query({
   },
 });
 
+/**
+ * Whether a group has any native run sheet to show — i.e. at least one
+ * `eventPlan` that has at least one `eventItem` (ADR-026). Used to decide
+ * whether the "Run Sheet" toolbar tool should surface for a non-PCO group.
+ *
+ * Auth: like `hasAutoChannels`, this gates on group membership but returns
+ * `false` (rather than throwing) for non-members so the toolbar filter can
+ * call it for everyone without breaking outsiders / loading states.
+ */
+export const groupHasRunSheet = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const membership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", args.groupId).eq("userId", userId),
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+    if (!membership) return false;
+
+    const plans = await ctx.db
+      .query("eventPlans")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .collect();
+
+    for (const plan of plans) {
+      const firstItem = await ctx.db
+        .query("eventItems")
+        .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+        .first();
+      if (firstItem) return true;
+    }
+
+    return false;
+  },
+});
+
 /** Midnight (local server time) at the start of today, in ms. */
 function startOfTodayMs(): number {
   const d = new Date();

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/toolbar-settings.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/toolbar-settings.tsx
@@ -74,6 +74,13 @@ export default function ToolbarSettingsScreen() {
     token && groupId ? { token, groupId } : "skip"
   );
 
+  // Query if group has a native run sheet (event plan with ≥1 item). Lets the
+  // Run Sheet tool surface for native-only groups, not just PCO-connected ones.
+  const hasNativeRunSheet = useQuery(
+    api.functions.scheduling.events.groupHasRunSheet,
+    token && groupId ? { token, groupId } : "skip"
+  );
+
   // Query resources for the group
   const resources = useQuery(
     api.functions.groupResources.index.listByGroup,
@@ -210,10 +217,18 @@ export default function ToolbarSettingsScreen() {
   // NOTE: This must be a useMemo to ensure hooks are called in consistent order
   const availableTools = useMemo(() => {
     return ALL_TOOLS.filter((tool) => {
-      if (tool.requiresPco && !hasPcoChannels) return false;
+      // A PCO-required tool stays hidden unless the group has PCO channels —
+      // OR it opts into native run sheets and the group has one.
+      if (
+        tool.requiresPco &&
+        !hasPcoChannels &&
+        !(tool.showsWithRunSheet && hasNativeRunSheet)
+      ) {
+        return false;
+      }
       return true;
     });
-  }, [hasPcoChannels]);
+  }, [hasPcoChannels, hasNativeRunSheet]);
 
   // Create unified list of all toolbar items (tools + resources)
   const allUnifiedItems = useMemo((): UnifiedToolbarItem[] => {

--- a/apps/mobile/features/chat/components/ChatNavigation.tsx
+++ b/apps/mobile/features/chat/components/ChatNavigation.tsx
@@ -154,6 +154,7 @@ type ChatToolbarProps = {
   showLeaderTools: boolean;
   tools?: string[];           // Ordered list of tool IDs (undefined = default)
   hasPcoChannels?: boolean;   // Filter out "sync" if no PCO channels
+  hasNativeRunSheet?: boolean; // Surface "runsheet" for native-only groups
   toolVisibility?: Record<string, string>;  // Per-tool visibility settings
   toolDisplayNames?: Record<string, string>; // Custom display names for tools
   userRole?: "admin" | "leader" | "member"; // Current user's role in the group
@@ -176,6 +177,7 @@ export const ChatToolbar = memo(function ChatToolbar({
   showLeaderTools,
   tools,
   hasPcoChannels,
+  hasNativeRunSheet,
   toolVisibility,
   toolDisplayNames,
   userRole,
@@ -241,11 +243,19 @@ export const ChatToolbar = memo(function ChatToolbar({
           icon: string;
           label: string;
           requiresPco?: boolean;
+          showsWithRunSheet?: boolean;
           defaultVisibility?: "leaders" | "everyone";
         };
 
-        // Filter out PCO-required tools if hasPcoChannels is false
-        if (tool.requiresPco && !hasPcoChannels) return null;
+        // Hide PCO-required tools when the group has no PCO channels — unless
+        // the tool opts into native run sheets and the group has one.
+        if (
+          tool.requiresPco &&
+          !hasPcoChannels &&
+          !(tool.showsWithRunSheet && hasNativeRunSheet)
+        ) {
+          return null;
+        }
 
         const label = toolDisplayNames?.[toolId] || tool.label;
 
@@ -279,6 +289,7 @@ export const ChatToolbar = memo(function ChatToolbar({
     resources,
     isLeaderOrAdmin,
     hasPcoChannels,
+    hasNativeRunSheet,
     toolVisibility,
     toolDisplayNames,
   ]);
@@ -352,6 +363,8 @@ type ChatNavigationProps = {
   tools?: string[];
   /** Whether the group has PCO channels (filters out "sync" if false) */
   hasPcoChannels?: boolean;
+  /** Whether the group has a native run sheet (surfaces "runsheet" without PCO) */
+  hasNativeRunSheet?: boolean;
   /** Per-tool visibility settings */
   toolVisibility?: Record<string, string>;
   /** Custom display names for tools */
@@ -374,6 +387,7 @@ export const ChatNavigation = memo(function ChatNavigation({
   onExternalChatPress,
   tools,
   hasPcoChannels,
+  hasNativeRunSheet,
   toolVisibility,
   toolDisplayNames,
   userRole,
@@ -394,6 +408,7 @@ export const ChatNavigation = memo(function ChatNavigation({
         showLeaderTools={showLeaderTools}
         tools={tools}
         hasPcoChannels={hasPcoChannels}
+        hasNativeRunSheet={hasNativeRunSheet}
         toolVisibility={toolVisibility}
         toolDisplayNames={toolDisplayNames}
         userRole={userRole}

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -221,6 +221,13 @@ const ConvexChatRoomScreenInner: React.FC = () => {
     resolvedGroupId && token ? { token, groupId: resolvedGroupId } : "skip"
   );
 
+  // Whether the group has a native run sheet — surfaces the Run Sheet tool
+  // for native-only groups even without PCO channels.
+  const hasNativeRunSheet = useQuery(
+    api.functions.scheduling.events.groupHasRunSheet,
+    resolvedGroupId && token ? { token, groupId: resolvedGroupId } : "skip"
+  );
+
   // Cache integration for group channels (eliminates tab bar flash)
   const { setGroupChannels: cacheGroupChannels, getGroupChannels: getCachedGroupChannels } = useChannelsCache();
 
@@ -1120,6 +1127,7 @@ const ConvexChatRoomScreenInner: React.FC = () => {
             onExternalChatPress={() => setExternalChatModalVisible(true)}
             tools={(groupDetails as { leaderToolbarTools?: string[] } | undefined)?.leaderToolbarTools}
             hasPcoChannels={hasPcoChannels ?? false}
+            hasNativeRunSheet={hasNativeRunSheet ?? false}
             toolVisibility={groupWithVisibility?.toolVisibility}
             toolDisplayNames={groupWithVisibility?.toolDisplayNames}
             userRole={userRole}

--- a/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/LeaderChatNavigation.test.tsx
@@ -85,6 +85,11 @@ jest.mock('@services/api/convex', () => ({
           triggerGroupSync: 'api.functions.pcoServices.index.triggerGroupSync',
         },
       },
+      scheduling: {
+        events: {
+          groupHasRunSheet: 'api.functions.scheduling.events.groupHasRunSheet',
+        },
+      },
       groupResources: {
         index: {
           getVisibleForUser: 'api.functions.groupResources.index.getVisibleForUser',

--- a/apps/mobile/features/chat/constants/toolbarTools.ts
+++ b/apps/mobile/features/chat/constants/toolbarTools.ts
@@ -10,6 +10,13 @@ export interface ToolDefinition {
   icon: string;
   label: string;
   requiresPco?: boolean;
+  /**
+   * For a `requiresPco` tool, also surface it when the group has a native
+   * run sheet (an event plan with ≥1 item) even without PCO channels. Lets
+   * the Run Sheet tool appear for native-only groups while keeping other
+   * PCO-only tools (e.g. "sync") gated on PCO.
+   */
+  showsWithRunSheet?: boolean;
   defaultVisibility?: "leaders" | "everyone"; // Controls who can see this tool
 }
 
@@ -40,6 +47,7 @@ export const TOOLBAR_TOOLS = {
     icon: "list-outline",
     label: "Run Sheet",
     requiresPco: true,
+    showsWithRunSheet: true,
     defaultVisibility: "everyone",
   },
 } as const satisfies Record<string, ToolDefinition>;

--- a/apps/mobile/features/leader-tools/components/RunSheetToolScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/RunSheetToolScreen.tsx
@@ -6,8 +6,11 @@
  *   - "native" → the group's upcoming event plan run sheets (NativeRunSheetView)
  *   - "pco" (default) → the legacy Planning Center run sheet (RunSheetScreen)
  *
- * The source is set in Run Sheet Settings. Kept as a thin wrapper so the PCO
- * screen's hook-heavy body is never conditionally mounted mid-render.
+ * The source is set in Run Sheet Settings. When no explicit source is saved,
+ * a non-PCO group that has a native run sheet still resolves to the native
+ * view (the default `getById` "pco" source would otherwise show an empty PCO
+ * screen). Kept as a thin wrapper so the PCO screen's hook-heavy body is never
+ * conditionally mounted mid-render.
  */
 import React from "react";
 import { View, ActivityIndicator, StyleSheet } from "react-native";
@@ -28,7 +31,24 @@ export function RunSheetToolScreen() {
     group_id ? { groupId } : "skip",
   ) as { runSheetSource?: string; userRole?: string } | null | undefined;
 
-  if (groupData === undefined) {
+  // Used to resolve the effective source when no explicit source is saved: a
+  // non-PCO group with a native run sheet should show the native view, not the
+  // empty PCO screen the default "pco" source would otherwise render.
+  const hasNativeRunSheet = useAuthenticatedQuery(
+    api.functions.scheduling.events.groupHasRunSheet,
+    group_id ? { groupId } : "skip",
+  ) as boolean | undefined;
+
+  const hasPcoChannels = useAuthenticatedQuery(
+    api.functions.messaging.channels.hasAutoChannels,
+    group_id ? { groupId } : "skip",
+  ) as boolean | undefined;
+
+  if (
+    groupData === undefined ||
+    hasNativeRunSheet === undefined ||
+    hasPcoChannels === undefined
+  ) {
     return (
       <View style={[styles.centered, { backgroundColor: colors.surface }]}>
         <ActivityIndicator size="small" color={colors.text} />
@@ -36,7 +56,13 @@ export function RunSheetToolScreen() {
     );
   }
 
-  if (groupData?.runSheetSource === "native") {
+  // Explicit "native" always wins; otherwise fall back to native when the
+  // group has a native run sheet and no PCO channels (no explicit source set).
+  const resolveToNative =
+    groupData?.runSheetSource === "native" ||
+    (hasNativeRunSheet && !hasPcoChannels);
+
+  if (resolveToNative) {
     return (
       <NativeRunSheetView
         groupId={groupId}

--- a/apps/mobile/features/leader-tools/components/RunSheetToolSettings.tsx
+++ b/apps/mobile/features/leader-tools/components/RunSheetToolSettings.tsx
@@ -74,6 +74,18 @@ export function RunSheetToolSettings({ groupId }: Props) {
     { groupId }
   ) as GroupWithRunSheetConfig | undefined | null;
 
+  // Signals used to pick a sensible default source when none is saved yet:
+  // a native-only group (has a native run sheet, no PCO) should default to
+  // "native" rather than preselecting Planning Center.
+  const hasNativeRunSheet = useAuthenticatedQuery(
+    api.functions.scheduling.events.groupHasRunSheet,
+    { groupId }
+  ) as boolean | undefined;
+  const hasPcoChannels = useAuthenticatedQuery(
+    api.functions.messaging.channels.hasAutoChannels,
+    { groupId }
+  ) as boolean | undefined;
+
   // Mutation to update run sheet config
   const updateRunSheetConfig = useAuthenticatedMutation(
     api.functions.groups.mutations.updateRunSheetConfig
@@ -111,14 +123,26 @@ export function RunSheetToolSettings({ groupId }: Props) {
     }
   }, [groupData, hasInitializedDefaults]);
 
-  // Load existing source from group data (only once on initial load)
+  // Load existing source from group data (only once on initial load). An
+  // explicitly saved source always wins. When none is saved, default a
+  // native-only group (native run sheet, no PCO) to "native" so the toggle
+  // doesn't preselect Planning Center for a group that can't use it.
   useEffect(() => {
     if (hasInitializedSource) return;
-    if (groupData !== undefined && groupData !== null) {
-      setSource(groupData.runSheetConfig?.source ?? "pco");
+    if (groupData === undefined || groupData === null) return;
+
+    const savedSource = groupData.runSheetConfig?.source;
+    if (savedSource) {
+      setSource(savedSource);
       setHasInitializedSource(true);
+      return;
     }
-  }, [groupData, hasInitializedSource]);
+
+    // No saved source — wait for the native/PCO signals before defaulting.
+    if (hasNativeRunSheet === undefined || hasPcoChannels === undefined) return;
+    setSource(hasNativeRunSheet && !hasPcoChannels ? "native" : "pco");
+    setHasInitializedSource(true);
+  }, [groupData, hasInitializedSource, hasNativeRunSheet, hasPcoChannels]);
 
   // Load existing chipConfig from group data (only once on initial load)
   const [hasInitializedChipConfig, setHasInitializedChipConfig] = useState(false);

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -393,19 +393,11 @@ export function EventPlans() {
           plan.
         </P>
 
-        <Callout tone="note">
-          <strong>Surfacing the run sheet in the group toolbar</strong> — so
-          every member can pull up the order of service — currently requires the
-          group to be <Term>connected to Planning Center</Term>. The{" "}
-          <Term>Run Sheet</Term> toolbar tool only appears for PCO-connected
-          groups; a non-PCO group's leaders still build and use the native run
-          sheet inside Rostering, but can't yet expose it to members through the
-          toolbar.
-        </Callout>
-
         <P>
-          <strong>Surfacing it to the whole group (PCO-connected groups).</strong>{" "}
-          For a group connected to Planning Center, a leader opens{" "}
+          <strong>Surfacing it to the whole group.</strong> The{" "}
+          <Term>Run Sheet</Term> toolbar tool appears for <em>any</em> group
+          that has a run sheet — a native Togather run sheet or a Planning
+          Center connection. A leader opens{" "}
           <Term>GROUP ACTIONS → Toolbar Settings</Term>, enables the{" "}
           <Term>Run Sheet</Term> tool, turns on{" "}
           <Term>Show toolbar to members</Term>, and sets the Run Sheet tool's
@@ -413,7 +405,7 @@ export function EventPlans() {
           sheet in the group toolbar.
         </P>
 
-        <Figure caption="Toolbar Settings (PCO-connected groups) — flip Run Sheet on, show the toolbar to members, and set its visibility to Everyone.">
+        <Figure caption="Toolbar Settings — flip Run Sheet on, show the toolbar to members, and set its visibility to Everyone.">
           <ToolbarSettingsMock />
         </Figure>
 
@@ -1350,7 +1342,7 @@ function ToolbarSettingsMock() {
     <PhoneFrame title="Toolbar Settings">
       <div className="space-y-3 bg-neutral-50 p-3">
         <div className="text-[10px] font-semibold uppercase tracking-wider text-neutral-400">
-          Toolbar Items · Planning Center connected
+          Toolbar Items
         </div>
         <div className="flex items-center gap-2.5 rounded-xl border border-neutral-200 bg-white p-3">
           <Ion name="list-outline" size={18} className="text-neutral-600" />


### PR DESCRIPTION
## Summary
The group-toolbar **Run Sheet** tool was hard-gated on Planning Center (`requiresPco: true`), so a group with a native Togather run sheet couldn't surface it to members. Now it appears whenever the group has **any** run sheet — a native event-plan run sheet (≥1 `eventItem`) **or** PCO channels.

- New Convex query `groupHasRunSheet(groupId)` — true if the group has an event plan with at least one run-sheet item.
- Added a declarative `showsWithRunSheet` flag on the `runsheet` tool; both gating sites (leader Toolbar Settings + the live member toolbar) keep it when `hasPcoChannels || hasNativeRunSheet`. The `sync` tool stays strictly PCO-gated.
- **Member-view fix:** `RunSheetToolScreen` resolves to the **native** run sheet when a non-PCO group has one (previously it fell back to the empty PCO view). Explicit leader source choices and PCO groups are unchanged.
- Run Sheet Settings defaults the source toggle to Togather (native) for native-only groups with no saved choice.
- Updated the Event Plans guide — removed the PCO-only caveat (added in #452); the toolbar surface now works for any group with a run sheet.

## Test plan
- apps/convex scheduling suite: **198 pass** incl. 4 new `groupHasRunSheet` tests (no plans→false, plan w/o items→false, plan w/ item→true, non-member→false).
- apps/mobile jest suite: **118 suites / 1080 tests pass** (added the `groupHasRunSheet` mock to the chat-room tests).
- Typecheck clean (convex + web); apps/mobile has 13 pre-existing unrelated errors, identical count on base (zero new). codegen succeeds.

## PCO impact
None — `requiresPco` retained on `runsheet`, `sync` untouched, member-view branch only redirects the no-explicit-source non-PCO native case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)