### PR TITLE
fix(chat/rostering): availability card overflow, event copy-link, debounced leader notify

### DIFF
--- a/apps/convex/__tests__/scheduling/availability.test.ts
+++ b/apps/convex/__tests__/scheduling/availability.test.ts
@@ -475,3 +475,111 @@ describe("public availability link (app-optional, OTP-verified)", () => {
     ).rejects.toThrow(ConvexError);
   });
 });
+
+describe("availability leader notification (debounced)", () => {
+  /** Read the single debounce row for a (group, member), or null. */
+  async function debounceRow(
+    t: ReturnType<typeof convexTest>,
+    groupId: Id<"groups">,
+    userId: Id<"users">,
+  ) {
+    return t.run((ctx) =>
+      ctx.db
+        .query("availabilityNotifyDebounce")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", groupId).eq("userId", userId),
+        )
+        .first(),
+    );
+  }
+
+  it("schedules a debounced leader notification on the first response", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await createPlan(
+      t,
+      leaderToken,
+      world.groupId,
+      "Sunday",
+      Date.now() + 7 * DAY,
+    );
+
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: memberToken,
+      planId,
+      status: "available",
+    });
+
+    const row = await debounceRow(t, world.groupId, world.channelMemberId);
+    expect(row).not.toBeNull();
+    expect(row?.jobId).toBeTruthy();
+  });
+
+  it("debounces a burst into one pending notification (reschedules)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await createPlan(
+      t,
+      leaderToken,
+      world.groupId,
+      "Sunday",
+      Date.now() + 7 * DAY,
+    );
+
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: memberToken,
+      planId,
+      status: "available",
+    });
+    const first = await debounceRow(t, world.groupId, world.channelMemberId);
+
+    // A real change reschedules: still exactly one row, with a fresh job id.
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: memberToken,
+      planId,
+      status: "unavailable",
+    });
+    const all = await t.run((ctx) =>
+      ctx.db
+        .query("availabilityNotifyDebounce")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", world.channelMemberId),
+        )
+        .collect(),
+    );
+    expect(all).toHaveLength(1);
+    expect(all[0].jobId).not.toBe(first?.jobId);
+  });
+
+  it("does not reschedule on a no-op re-tap of the same status", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await createPlan(
+      t,
+      leaderToken,
+      world.groupId,
+      "Sunday",
+      Date.now() + 7 * DAY,
+    );
+
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: memberToken,
+      planId,
+      status: "available",
+    });
+    const first = await debounceRow(t, world.groupId, world.channelMemberId);
+
+    // Re-tapping the already-selected option is a no-op — the pending job id
+    // must not change (no new notification window).
+    await t.mutation(api.functions.scheduling.availability.setMyAvailability, {
+      token: memberToken,
+      planId,
+      status: "available",
+    });
+    const second = await debounceRow(t, world.groupId, world.channelMemberId);
+    expect(second?.jobId).toBe(first?.jobId);
+  });
+});

--- a/apps/convex/functions/notifications/senders.ts
+++ b/apps/convex/functions/notifications/senders.ts
@@ -533,15 +533,20 @@ export const notifyAvailabilityUpdated = internalAction({
   args: {
     groupId: v.id("groups"),
     userId: v.id("users"),
+    nonce: v.string(),
   },
   handler: async (ctx, args): Promise<{ success: boolean; error?: string; sent?: number }> => {
     try {
-      // Always clear the debounce row first so a change that lands after this
-      // job starts schedules a fresh notification rather than being swallowed.
-      await ctx.runMutation(
-        internal.functions.scheduling.availability.clearAvailabilityDebounce,
-        { groupId: args.groupId, userId: args.userId },
+      // Claim the debounce row by nonce. If this job was superseded by a later
+      // edit (the row was rescheduled), the claim fails and we bail without
+      // sending — the newer job will fire and notify once the window settles.
+      const claimed: boolean = await ctx.runMutation(
+        internal.functions.scheduling.availability.claimAvailabilityDebounce,
+        { groupId: args.groupId, userId: args.userId, nonce: args.nonce },
       );
+      if (!claimed) {
+        return { success: true, sent: 0 };
+      }
 
       const groupInfo: NotificationGroupInfo | null = await ctx.runQuery(
         internal.functions.notifications.internal.getGroupInfo,

--- a/apps/convex/functions/notifications/senders.ts
+++ b/apps/convex/functions/notifications/senders.ts
@@ -10,7 +10,7 @@ import { internalAction } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import { Id } from "../../_generated/dataModel";
 import { joinRequestApprovedEmail } from "../../lib/notifications/emailTemplates";
-import { eventCreatedByMember, eventRsvpReceived } from "../../lib/notifications/definitions";
+import { availabilityUpdated, eventCreatedByMember, eventRsvpReceived } from "../../lib/notifications/definitions";
 import type { ExtractNotificationData, FormatterContext } from "../../lib/notifications/types";
 
 type NotificationGroupInfo = {
@@ -513,6 +513,126 @@ export const notifyRsvpReceived = internalAction({
       return { success: result.success, sent: notifications.length };
     } catch (error) {
       console.error("[NotifyRsvpReceived] Error:", error);
+      return { success: false, error: String(error) };
+    }
+  },
+});
+
+// ============================================================================
+// Notification Action for Availability Updates (debounced)
+// ============================================================================
+
+/**
+ * Notify a group's leaders that a member filled out or updated their serving
+ * availability. Fired by the debounced scheduler in scheduling/availability.ts
+ * (`queueAvailabilityLeaderNotice`), so this runs ~5 min after the member's
+ * last change — one notification per burst, not per tap. Clears the debounce
+ * row when done so the next change starts a fresh window.
+ */
+export const notifyAvailabilityUpdated = internalAction({
+  args: {
+    groupId: v.id("groups"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args): Promise<{ success: boolean; error?: string; sent?: number }> => {
+    try {
+      // Always clear the debounce row first so a change that lands after this
+      // job starts schedules a fresh notification rather than being swallowed.
+      await ctx.runMutation(
+        internal.functions.scheduling.availability.clearAvailabilityDebounce,
+        { groupId: args.groupId, userId: args.userId },
+      );
+
+      const groupInfo: NotificationGroupInfo | null = await ctx.runQuery(
+        internal.functions.notifications.internal.getGroupInfo,
+        { groupId: args.groupId },
+      );
+      if (!groupInfo) {
+        return { success: false, error: "Group not found" };
+      }
+
+      const memberName: string = await ctx.runQuery(
+        internal.functions.notifications.internal.getUserDisplayName,
+        { userId: args.userId },
+      );
+
+      const leaderIds: Id<"users">[] = await ctx.runQuery(
+        internal.functions.notifications.internal.getGroupMembersForNotification,
+        { groupId: args.groupId, filter: "leaders" },
+      );
+      const recipientSet = new Set<string>(leaderIds.map((id) => String(id)));
+      // Never notify the member about their own update.
+      recipientSet.delete(String(args.userId));
+      const recipientIds = [...recipientSet] as Id<"users">[];
+      if (recipientIds.length === 0) {
+        return { success: true, sent: 0 };
+      }
+
+      const tokenResults: Array<{ userId: string; tokens: string[] }> = await ctx.runQuery(
+        internal.functions.notifications.tokens.getActiveTokensForUsers,
+        { userIds: recipientIds },
+      );
+
+      const pushFormatter = availabilityUpdated.formatters.push;
+      if (!pushFormatter) {
+        return { success: false, error: "Missing push formatter" };
+      }
+      type AvailabilityPushData = ExtractNotificationData<typeof availabilityUpdated>;
+      const formatterCtx: FormatterContext<AvailabilityPushData> = {
+        data: {
+          memberName,
+          groupName: groupInfo.name,
+          groupId: args.groupId,
+          communityId: groupInfo.communityId,
+        },
+        userId: args.userId,
+      };
+      const { title, body, data: pushData } = pushFormatter(formatterCtx);
+
+      const notificationImageUrl = getSenderNotificationImage(groupInfo);
+      const notifications = tokenResults.flatMap((result) =>
+        result.tokens.map((token) => ({
+          token,
+          title,
+          body,
+          data: { ...pushData, groupAvatarUrl: notificationImageUrl },
+          imageUrl: notificationImageUrl,
+        })),
+      );
+
+      let success = true;
+      if (notifications.length > 0) {
+        const result = await ctx.runAction(
+          internal.functions.notifications.internal.sendBatchPushNotifications,
+          { notifications },
+        );
+        success = result.success;
+      }
+
+      // In-app inbox records for every leader (even those without a push token).
+      const notificationRecords = recipientIds.map((leaderId) => ({
+        userId: leaderId,
+        communityId: groupInfo.communityId as Id<"communities">,
+        groupId: args.groupId,
+        notificationType: "availability_updated",
+        title,
+        body,
+        data: {
+          groupId: args.groupId,
+          communityId: groupInfo.communityId,
+          url: `/rostering/${args.groupId}/grid`,
+          groupAvatarUrl: notificationImageUrl,
+        },
+        status: success ? "sent" : "failed",
+      }));
+      await ctx.runMutation(
+        internal.functions.notifications.mutations.createNotificationsBatch,
+        { notifications: notificationRecords },
+      );
+
+      return { success, sent: notifications.length };
+    } catch (error) {
+      console.error("[NotifyAvailabilityUpdated] Error:", error);
       return { success: false, error: String(error) };
     }
   },

--- a/apps/convex/functions/scheduling/availability.ts
+++ b/apps/convex/functions/scheduling/availability.ts
@@ -19,8 +19,10 @@
  */
 
 import { ConvexError, v } from "convex/values";
-import { mutation, query } from "../../_generated/server";
+import { mutation, query, internalMutation } from "../../_generated/server";
+import type { MutationCtx } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
 import { requireGroupMember, requireGroupScheduler } from "./permissions";
@@ -28,6 +30,83 @@ import { requireGroupMember, requireGroupScheduler } from "./permissions";
 /** Valid availability states a member can report. */
 const AVAILABILITY_STATUSES = new Set(["available", "unavailable"]);
 const MAX_NOTE_LENGTH = 280;
+
+/**
+ * Rolling debounce window for the "member updated availability" leader
+ * notification. Each availability write reschedules the notify job to fire
+ * this long after the *last* change, so a member clicking through several
+ * events produces one notification instead of one per tap.
+ */
+const AVAILABILITY_NOTIFY_DEBOUNCE_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Schedule (or reschedule) the debounced leader notification for one member's
+ * availability changes in a group. Cancels any pending job for the
+ * (group, member) pair and queues a fresh one — a trailing debounce that
+ * collapses a burst of edits into a single notification.
+ */
+export async function queueAvailabilityLeaderNotice(
+  ctx: MutationCtx,
+  args: {
+    groupId: Id<"groups">;
+    userId: Id<"users">;
+    communityId: Id<"communities">;
+  },
+): Promise<void> {
+  const existing = await ctx.db
+    .query("availabilityNotifyDebounce")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", args.groupId).eq("userId", args.userId),
+    )
+    .first();
+
+  if (existing) {
+    try {
+      await ctx.scheduler.cancel(existing.jobId);
+    } catch {
+      // Job may have already fired or been cancelled — ignore.
+    }
+  }
+
+  const jobId = await ctx.scheduler.runAfter(
+    AVAILABILITY_NOTIFY_DEBOUNCE_MS,
+    internal.functions.notifications.senders.notifyAvailabilityUpdated,
+    { groupId: args.groupId, userId: args.userId },
+  );
+
+  const now = Date.now();
+  if (existing) {
+    await ctx.db.patch(existing._id, { jobId, scheduledAt: now });
+  } else {
+    await ctx.db.insert("availabilityNotifyDebounce", {
+      groupId: args.groupId,
+      userId: args.userId,
+      communityId: args.communityId,
+      jobId,
+      scheduledAt: now,
+    });
+  }
+}
+
+/**
+ * Drop the debounce row for a (group, member) pair. Called by the notify job
+ * when it fires so the next change starts a clean window.
+ */
+export const clearAvailabilityDebounce = internalMutation({
+  args: { groupId: v.id("groups"), userId: v.id("users") },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("availabilityNotifyDebounce")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", args.groupId).eq("userId", args.userId),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+    return null;
+  },
+});
 
 /** Midnight (local server time) at the start of today, in ms. */
 function startOfTodayMs(): number {
@@ -87,15 +166,27 @@ export const setMyAvailability = mutation({
       .first();
 
     if (existing) {
+      // Only notify leaders when the response actually changes — a redundant
+      // re-tap of the current state shouldn't (re)start the debounce window.
+      const changed =
+        existing.status !== args.status ||
+        (existing.note || undefined) !== (note || undefined);
       await ctx.db.patch(existing._id, {
         status: args.status,
         note: note || undefined,
         updatedAt: now,
       });
+      if (changed) {
+        await queueAvailabilityLeaderNotice(ctx, {
+          groupId: plan.groupId,
+          userId,
+          communityId: plan.communityId,
+        });
+      }
       return existing._id;
     }
 
-    return ctx.db.insert("eventAvailability", {
+    const newId = await ctx.db.insert("eventAvailability", {
       planId: args.planId,
       groupId: plan.groupId,
       communityId: plan.communityId,
@@ -105,6 +196,12 @@ export const setMyAvailability = mutation({
       respondedAt: now,
       updatedAt: now,
     });
+    await queueAvailabilityLeaderNotice(ctx, {
+      groupId: plan.groupId,
+      userId,
+      communityId: plan.communityId,
+    });
+    return newId;
   },
 });
 

--- a/apps/convex/functions/scheduling/availability.ts
+++ b/apps/convex/functions/scheduling/availability.ts
@@ -68,43 +68,51 @@ export async function queueAvailabilityLeaderNotice(
     }
   }
 
+  // A fresh nonce ties this row to exactly the job we're about to schedule, so
+  // a stale job (one whose cancel didn't take) can't clear a newer row or send.
+  const nonce = crypto.randomUUID();
   const jobId = await ctx.scheduler.runAfter(
     AVAILABILITY_NOTIFY_DEBOUNCE_MS,
     internal.functions.notifications.senders.notifyAvailabilityUpdated,
-    { groupId: args.groupId, userId: args.userId },
+    { groupId: args.groupId, userId: args.userId, nonce },
   );
 
   const now = Date.now();
   if (existing) {
-    await ctx.db.patch(existing._id, { jobId, scheduledAt: now });
+    await ctx.db.patch(existing._id, { jobId, nonce, scheduledAt: now });
   } else {
     await ctx.db.insert("availabilityNotifyDebounce", {
       groupId: args.groupId,
       userId: args.userId,
       communityId: args.communityId,
       jobId,
+      nonce,
       scheduledAt: now,
     });
   }
 }
 
 /**
- * Drop the debounce row for a (group, member) pair. Called by the notify job
- * when it fires so the next change starts a clean window.
+ * Atomically claim the debounce row for a (group, member) pair on behalf of the
+ * firing notify job, identified by `nonce`. Returns true and deletes the row
+ * only when the row still belongs to this job; returns false if the row is
+ * missing or was already rescheduled (a newer job owns it now), so a stale job
+ * neither sends nor removes the replacement row.
  */
-export const clearAvailabilityDebounce = internalMutation({
-  args: { groupId: v.id("groups"), userId: v.id("users") },
-  handler: async (ctx, args) => {
+export const claimAvailabilityDebounce = internalMutation({
+  args: { groupId: v.id("groups"), userId: v.id("users"), nonce: v.string() },
+  handler: async (ctx, args): Promise<boolean> => {
     const existing = await ctx.db
       .query("availabilityNotifyDebounce")
       .withIndex("by_group_user", (q) =>
         q.eq("groupId", args.groupId).eq("userId", args.userId),
       )
       .first();
-    if (existing) {
-      await ctx.db.delete(existing._id);
+    if (!existing || existing.nonce !== args.nonce) {
+      return false;
     }
-    return null;
+    await ctx.db.delete(existing._id);
+    return true;
   },
 });
 

--- a/apps/convex/functions/scheduling/publicAvailability.ts
+++ b/apps/convex/functions/scheduling/publicAvailability.ts
@@ -20,6 +20,7 @@ import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { generateShortId } from "../../lib/utils";
 import { requireGroupScheduler } from "./permissions";
+import { queueAvailabilityLeaderNotice } from "./availability";
 
 const MAX_MESSAGE_LENGTH = 280;
 const MAX_EVENTS = 12;
@@ -233,6 +234,7 @@ export const submitAvailabilityForRequest = mutation({
     // Only events this request asked about are writable.
     const allowed = new Set(request.planIds.map((id) => id as string));
     let savedCount = 0;
+    let changed = false;
     for (const r of args.responses) {
       if (!allowed.has(r.planId as string)) continue;
       const prior = await ctx.db
@@ -242,8 +244,10 @@ export const submitAvailabilityForRequest = mutation({
         )
         .first();
       if (prior) {
+        if (prior.status !== r.status) changed = true;
         await ctx.db.patch(prior._id, { status: r.status, updatedAt: now });
       } else {
+        changed = true;
         await ctx.db.insert("eventAvailability", {
           planId: r.planId,
           groupId: request.groupId,
@@ -255,6 +259,16 @@ export const submitAvailabilityForRequest = mutation({
         });
       }
       savedCount += 1;
+    }
+
+    // One debounced notification to the group's leaders for the whole batch —
+    // submitting the public link writes many plans at once.
+    if (changed) {
+      await queueAvailabilityLeaderNotice(ctx, {
+        groupId: request.groupId,
+        userId,
+        communityId: request.communityId,
+      });
     }
 
     return { savedCount };

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -557,6 +557,36 @@ export const eventCreatedByMember: NotificationDefinition<EventCreatedByMemberDa
   defaultChannels: ['push'],
 };
 
+// Sent to group leaders when a member fills out or updates their serving
+// availability. Debounced (~5 min) so a member clicking through several
+// events produces a single notification, not one per tap. See
+// `queueAvailabilityLeaderNotice` in scheduling/availability.ts.
+interface AvailabilityUpdatedData {
+  memberName: string;
+  groupName: string;
+  groupId: string;
+  communityId?: string;
+}
+
+export const availabilityUpdated: NotificationDefinition<AvailabilityUpdatedData> = {
+  type: 'availability_updated',
+  description:
+    'Sent to group leaders when a member updates their serving availability',
+  formatters: {
+    push: (ctx) => ({
+      title: 'Availability updated',
+      body: `${ctx.data.memberName} updated their availability in ${ctx.data.groupName}`,
+      data: {
+        type: 'availability_updated',
+        groupId: ctx.data.groupId,
+        communityId: ctx.data.communityId,
+        url: `/rostering/${ctx.data.groupId}/grid`,
+      },
+    }),
+  },
+  defaultChannels: ['push'],
+};
+
 // ============================================================================
 // Admin Definitions
 // ============================================================================

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2768,6 +2768,21 @@ export default defineSchema({
     .index("by_group_user", ["groupId", "userId"]),
 
   /**
+   * Debounce bookkeeping for the "member updated their availability" leader
+   * notification. One row per (group, member) holds the pending scheduled
+   * notify job; each availability write cancels and reschedules it, so a burst
+   * of clicks collapses into a single notification that fires once the member
+   * stops (a rolling trailing debounce). Cleared when the job fires.
+   */
+  availabilityNotifyDebounce: defineTable({
+    groupId: v.id("groups"),
+    userId: v.id("users"),
+    communityId: v.id("communities"),
+    jobId: v.id("_scheduled_functions"),
+    scheduledAt: v.number(),
+  }).index("by_group_user", ["groupId", "userId"]),
+
+  /**
    * An availability request. Two flavors share this table:
    *  - **In-chat**: posted into a channel, backed by a `chatMessages` row with
    *    `contentType: "availability_request"` and `availabilityRequestId`

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2779,6 +2779,11 @@ export default defineSchema({
     userId: v.id("users"),
     communityId: v.id("communities"),
     jobId: v.id("_scheduled_functions"),
+    // Identity of the currently-scheduled job. The notify job only sends/clears
+    // when its nonce still matches this row, so a stale job that couldn't be
+    // cancelled can't delete a newer replacement row or fire an early/extra
+    // notification.
+    nonce: v.string(),
     scheduledAt: v.number(),
   }).index("by_group_user", ["groupId", "userId"]),
 

--- a/apps/mobile/features/chat/components/EventLinkCard.tsx
+++ b/apps/mobile/features/chat/components/EventLinkCard.tsx
@@ -16,7 +16,7 @@ import type { Id } from '@services/api/convex';
 import { useRouter } from 'expo-router';
 import { ImageViewerManager } from '@/providers/ImageViewerProvider';
 import type { RsvpOption } from '../types';
-import { handleImageLongPress, handleEventLongPress } from '../utils/imageActions';
+import { handleImageLongPress, handleEventLongPress, copyEventLink } from '../utils/imageActions';
 import { getRsvpStatsForOption, hasPrefetchedRsvpOptions } from '../utils/rsvpStats';
 import { DEFAULT_PRIMARY_COLOR } from '@utils/styles';
 import { useTheme } from '@hooks/useTheme';
@@ -255,6 +255,18 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
     }
   };
 
+  const [linkCopied, setLinkCopied] = useState(false);
+  const handleCopyLink = async () => {
+    const eventShortId = event?.shortId || shortId;
+    if (!eventShortId) {
+      Alert.alert('Error', 'This event is missing a share link.');
+      return;
+    }
+    await copyEventLink(eventShortId);
+    setLinkCopied(true);
+    setTimeout(() => setLinkCopied(false), 2000);
+  };
+
   // Format date
   const formatEventDate = (dateString: string | undefined): string => {
     if (!dateString) return '';
@@ -468,13 +480,26 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
             <Text style={styles.accessPromptText}>{event.accessPrompt.message}</Text>
           </View>
 
-          {/* View Details Button */}
-          <TouchableOpacity
-            style={[styles.viewDetailsButton, { borderTopColor: colors.borderLight }]}
-            onPress={handleViewDetails}
-          >
-            <Text style={styles.viewDetailsText}>View Details</Text>
-          </TouchableOpacity>
+          {/* Footer: Copy link + View Details */}
+          <View style={[styles.footerRow, { borderTopColor: colors.borderLight }]}>
+            <TouchableOpacity
+              style={styles.copyLinkButton}
+              onPress={handleCopyLink}
+              hitSlop={8}
+            >
+              <Ionicons
+                name={linkCopied ? 'checkmark' : 'link-outline'}
+                size={16}
+                color={DEFAULT_PRIMARY_COLOR}
+              />
+              <Text style={styles.viewDetailsText}>
+                {linkCopied ? 'Copied' : 'Copy link'}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={handleViewDetails} hitSlop={8}>
+              <Text style={styles.viewDetailsText}>View Details</Text>
+            </TouchableOpacity>
+          </View>
         </View>
       </Pressable>
     );
@@ -590,13 +615,26 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
           </View>
         )}
 
-        {/* View Details Button */}
-        <TouchableOpacity
-          style={[styles.viewDetailsButton, { borderTopColor: colors.borderLight }]}
-          onPress={handleViewDetails}
-        >
-          <Text style={styles.viewDetailsText}>View Details</Text>
-        </TouchableOpacity>
+        {/* Footer: Copy link + View Details */}
+        <View style={[styles.footerRow, { borderTopColor: colors.borderLight }]}>
+          <TouchableOpacity
+            style={styles.copyLinkButton}
+            onPress={handleCopyLink}
+            hitSlop={8}
+          >
+            <Ionicons
+              name={linkCopied ? 'checkmark' : 'link-outline'}
+              size={16}
+              color={DEFAULT_PRIMARY_COLOR}
+            />
+            <Text style={styles.viewDetailsText}>
+              {linkCopied ? 'Copied' : 'Copy link'}
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={handleViewDetails} hitSlop={8}>
+            <Text style={styles.viewDetailsText}>View Details</Text>
+          </TouchableOpacity>
+        </View>
 
         {/* Cancelled Overlay */}
         {isCancelled && <CancelledOverlay />}
@@ -795,10 +833,18 @@ const styles = StyleSheet.create({
     backgroundColor: DEFAULT_PRIMARY_COLOR,
     borderRadius: 3,
   },
-  viewDetailsButton: {
-    padding: 16,
-    borderTopWidth: 1,
+  footerRow: {
+    flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderTopWidth: 1,
+  },
+  copyLinkButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
   },
   viewDetailsText: {
     fontSize: 15,

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -1027,7 +1027,7 @@ function MessageItemInner({
           )}
 
           {/* Message bubble (hidden for special card messages) */}
-          {message.contentType !== "reach_out_request" && message.contentType !== "task_card" && message.contentType !== "poll" && (
+          {message.contentType !== "reach_out_request" && message.contentType !== "task_card" && message.contentType !== "poll" && message.contentType !== "availability_request" && (
             <View ref={bubbleRef} style={styles.bubbleWrapper}>
               <View
                 style={[


### PR DESCRIPTION
## Summary

Three changes:

1. **Availability card overflow (chat).** The `availability_request` card rendered its (empty) chat bubble *and* the card, so the bubble's timestamp/tail collided with the self-contained card and its reactions/receipts. Added `availability_request` to the bubble-suppression condition in `MessageItem.tsx`, matching how `poll`/`task_card`/`reach_out_request` already suppress the bubble.

2. **Copy link on the chat event card.** Added a visible "Copy link" button to `EventLinkCard`'s footer (both full-access and locked states), beside "View Details" — mirrors the availability card (icon + 2s "Copied" state) and copies the `/e/<shortId>` share URL via the existing `copyEventLink` helper.

3. **Debounced leader notification on availability updates.** Notify a group's leaders when a member fills out or updates their serving availability, **debounced ~5 min** (rolling trailing) so clicking through several events produces one notification, not one per tap.
   - New `availabilityNotifyDebounce` table (one row per group+member holding the pending scheduled job).
   - New `availability_updated` notification definition + `notifyAvailabilityUpdated` sender action (notifies leaders, excludes the responder, push + in-app inbox, deep-links to the roster grid) — modeled on the RSVP notifier.
   - `queueAvailabilityLeaderNotice` cancels & reschedules the job on each write; wired into `setMyAvailability` and the public `submitAvailabilityForRequest`, with a no-op guard so re-tapping the same status doesn't re-notify.

## Test plan

- [x] convex `tsc` clean; mobile `tsc` clean for changed files; pre-commit lint passes.
- [x] 15/15 `availability.test.ts` pass, including 3 new debounce tests (schedules on first response, reschedules on a real change, no-op re-tap doesn't reschedule).
- [ ] **Manual (visual):** availability card no longer overflows; event card "Copy link" copies the URL. (Couldn't reproduce in dev seed data — needs an availability-request message and a shared-event message in a chat.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)