### PR TITLE
Fix availability chat card layout for long event content

### DIFF
--- a/apps/mobile/app/ui-test/availability-card.tsx
+++ b/apps/mobile/app/ui-test/availability-card.tsx
@@ -1,0 +1,139 @@
+/**
+ * Browser preview for AvailabilityRequestCard layout.
+ * Visit /ui-test/availability-card when running Expo web.
+ */
+import React, { useCallback, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@hooks/useTheme';
+import { AvailabilityRequestCard } from '@features/chat/components/AvailabilityRequestCard';
+import type { AvailabilityRequestEvent } from '@features/chat/components/AvailabilityRequestCard';
+import type { Id } from '@services/api/convex';
+
+const FAKE_EVENTS: AvailabilityRequestEvent[] = [
+  {
+    _id: 'plan-1' as Id<'eventPlans'>,
+    title: 'MH Service 7/5',
+    eventDate: new Date('2025-07-05T10:00:00').getTime(),
+    times: [
+      { label: '10:00 AM', startsAt: new Date('2025-07-05T10:00:00').getTime() },
+      { label: '12:00 PM', startsAt: new Date('2025-07-05T12:00:00').getTime() },
+    ],
+    myStatus: 'available',
+  },
+  {
+    _id: 'plan-2' as Id<'eventPlans'>,
+    title: 'MH Service 7/12',
+    eventDate: new Date('2025-07-12T10:00:00').getTime(),
+    times: [
+      { label: '10:00 AM', startsAt: new Date('2025-07-12T10:00:00').getTime() },
+      { label: '12:00 PM', startsAt: new Date('2025-07-12T12:00:00').getTime() },
+    ],
+    myStatus: 'available',
+  },
+  {
+    _id: 'plan-3' as Id<'eventPlans'>,
+    title: 'MH Service 7/19',
+    eventDate: new Date('2025-07-19T10:00:00').getTime(),
+    times: [
+      { label: '10:00 AM', startsAt: new Date('2025-07-19T10:00:00').getTime() },
+      { label: '12:00 PM', startsAt: new Date('2025-07-19T12:00:00').getTime() },
+    ],
+    myStatus: 'available',
+  },
+  {
+    _id: 'plan-4' as Id<'eventPlans'>,
+    title: 'MH Service 7/26 with extended rehearsal and sound check',
+    eventDate: new Date('2025-07-26T10:00:00').getTime(),
+    times: [
+      { label: '10:00 AM', startsAt: new Date('2025-07-26T10:00:00').getTime() },
+      { label: '12:00 PM', startsAt: new Date('2025-07-26T12:00:00').getTime() },
+      { label: '2:00 PM', startsAt: new Date('2025-07-26T14:00:00').getTime() },
+    ],
+    myStatus: null,
+  },
+  {
+    _id: 'plan-5' as Id<'eventPlans'>,
+    title: 'MH Service 8/2',
+    eventDate: new Date('2025-08-02T10:00:00').getTime(),
+    times: [
+      { label: '10:00 AM', startsAt: new Date('2025-08-02T10:00:00').getTime() },
+      { label: '12:00 PM', startsAt: new Date('2025-08-02T12:00:00').getTime() },
+    ],
+    myStatus: 'unavailable',
+  },
+];
+
+export default function AvailabilityCardPreviewScreen() {
+  const { colors } = useTheme();
+  const [events, setEvents] = useState(FAKE_EVENTS);
+  const [busyPlanId, setBusyPlanId] = useState<string | null>(null);
+
+  const onSetStatus = useCallback(
+    (planId: Id<'eventPlans'>, status: 'available' | 'unavailable') => {
+      setBusyPlanId(planId);
+      setEvents((current) =>
+        current.map((event) =>
+          event._id === planId
+            ? { ...event, myStatus: event.myStatus === status ? null : status }
+            : event,
+        ),
+      );
+      setBusyPlanId(null);
+    },
+    [],
+  );
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.surfaceSecondary }]}
+      contentContainerStyle={styles.content}
+      testID="availability-card-preview"
+    >
+      <Text style={[styles.title, { color: colors.text }]}>Availability Card Preview</Text>
+      <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+        Fake chat data — stacked layout with long titles and multi-slot times
+      </Text>
+
+      <View style={[styles.chatColumn, { maxWidth: 320 }]}>
+        <AvailabilityRequestCard
+          message="When can everyone serve this month?"
+          events={events}
+          busyPlanId={busyPlanId}
+          onSetStatus={onSetStatus}
+          copyLinkUrl="https://togather.nyc/a/demo-token"
+          onOpenPage={() => undefined}
+        />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 24,
+    paddingBottom: 48,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 4,
+    alignSelf: 'flex-start',
+    width: '100%',
+    maxWidth: 360,
+  },
+  subtitle: {
+    fontSize: 14,
+    marginBottom: 20,
+    alignSelf: 'flex-start',
+    width: '100%',
+    maxWidth: 360,
+  },
+  chatColumn: {
+    width: '100%',
+    alignSelf: 'center',
+  },
+});

--- a/apps/mobile/features/chat/components/AvailabilityRequestCard.tsx
+++ b/apps/mobile/features/chat/components/AvailabilityRequestCard.tsx
@@ -8,9 +8,9 @@
  * (AvailabilityRequestCardFromMessage) owns the mutations and the busy state;
  * this component just draws pills and surfaces taps.
  *
- * Mirrors PollCard's visual density: rounded card, themed surface, compact
- * rows. Each event shows a title + date/time line on the left and two pill
- * buttons ("Available" / "Can't") on the right. The selected pill is filled.
+ * Mirrors PollCard's visual density: rounded card, themed surface. Each event
+ * stacks title, date/time, then full-width pill buttons ("Available" / "Can't")
+ * so long titles and multi-slot times are never truncated in chat.
  */
 import React, { useCallback, useMemo, useState } from 'react';
 import { View, Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
@@ -118,71 +118,62 @@ export function AvailabilityRequestCard({
           const isUnavailable = event.myStatus === 'unavailable';
 
           return (
-            <View key={event._id} style={styles.eventRow}>
-              <View style={styles.eventTextWrap}>
-                <Text style={[styles.eventTitle, { color: colors.text }]} numberOfLines={2}>
-                  {event.title}
-                </Text>
-                {dateLine ? (
-                  <Text
-                    style={[styles.eventDate, { color: colors.textTertiary }]}
-                    numberOfLines={2}
-                  >
-                    {dateLine}
-                  </Text>
-                ) : null}
-              </View>
+            <View key={event._id} style={styles.eventBlock}>
+              <Text style={[styles.eventTitle, { color: colors.text }]}>{event.title}</Text>
+              {dateLine ? (
+                <Text style={[styles.eventDate, { color: colors.textTertiary }]}>{dateLine}</Text>
+              ) : null}
 
-              <View style={styles.pills}>
-                {isBusy ? (
+              {isBusy ? (
+                <View style={styles.busyRow}>
                   <ActivityIndicator size="small" color={colors.textSecondary} />
-                ) : (
-                  <>
-                    <Pressable
-                      onPress={() => onSetStatus(event._id, 'available')}
-                      hitSlop={4}
-                      style={({ pressed }) => [
-                        styles.pill,
-                        {
-                          backgroundColor: isAvailable ? colors.success : 'transparent',
-                          borderColor: isAvailable ? colors.success : colors.border,
-                        },
-                        pressed && styles.pillPressed,
+                </View>
+              ) : (
+                <View style={styles.pills}>
+                  <Pressable
+                    onPress={() => onSetStatus(event._id, 'available')}
+                    hitSlop={4}
+                    style={({ pressed }) => [
+                      styles.pill,
+                      {
+                        backgroundColor: isAvailable ? colors.success : 'transparent',
+                        borderColor: isAvailable ? colors.success : colors.border,
+                      },
+                      pressed && styles.pillPressed,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.pillLabel,
+                        { color: isAvailable ? '#fff' : colors.textSecondary },
                       ]}
                     >
-                      <Text
-                        style={[
-                          styles.pillLabel,
-                          { color: isAvailable ? '#fff' : colors.textSecondary },
-                        ]}
-                      >
-                        Available
-                      </Text>
-                    </Pressable>
-                    <Pressable
-                      onPress={() => onSetStatus(event._id, 'unavailable')}
-                      hitSlop={4}
-                      style={({ pressed }) => [
-                        styles.pill,
-                        {
-                          backgroundColor: isUnavailable ? colors.destructive : 'transparent',
-                          borderColor: isUnavailable ? colors.destructive : colors.border,
-                        },
-                        pressed && styles.pillPressed,
+                      Available
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => onSetStatus(event._id, 'unavailable')}
+                    hitSlop={4}
+                    style={({ pressed }) => [
+                      styles.pill,
+                      {
+                        backgroundColor: isUnavailable ? colors.destructive : 'transparent',
+                        borderColor: isUnavailable ? colors.destructive : colors.border,
+                      },
+                      pressed && styles.pillPressed,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.pillLabel,
+                        { color: isUnavailable ? '#fff' : colors.textSecondary },
                       ]}
                     >
-                      <Text
-                        style={[
-                          styles.pillLabel,
-                          { color: isUnavailable ? '#fff' : colors.textSecondary },
-                        ]}
-                      >
-                        Can't
-                      </Text>
-                    </Pressable>
-                  </>
-                )}
-              </View>
+                      Can't
+                    </Text>
+                  </Pressable>
+                </View>
+              )}
             </View>
           );
         })}
@@ -202,9 +193,7 @@ export function AvailabilityRequestCard({
                 {copied ? 'Copied' : 'Copy link'}
               </Text>
             </Pressable>
-          ) : (
-            <View />
-          )}
+          ) : null}
           {onOpenPage ? (
             <Pressable onPress={onOpenPage} hitSlop={6} style={styles.footer}>
               <Text style={[styles.footerText, { color: colors.link }]}>
@@ -226,6 +215,7 @@ const styles = StyleSheet.create({
     padding: 12,
     minWidth: 240,
     maxWidth: 360,
+    alignSelf: 'stretch',
   },
   headerBadgeRow: {
     flexDirection: 'row',
@@ -250,36 +240,39 @@ const styles = StyleSheet.create({
   },
   events: {
     marginTop: 12,
-    gap: 10,
+    gap: 12,
   },
-  eventRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  eventTextWrap: {
-    flex: 1,
+  eventBlock: {
+    gap: 2,
   },
   eventTitle: {
     fontSize: 14,
     fontWeight: '600',
+    lineHeight: 19,
   },
   eventDate: {
     fontSize: 12,
-    marginTop: 2,
+    lineHeight: 17,
+  },
+  busyRow: {
+    marginTop: 10,
+    height: 34,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   pills: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 6,
-    minWidth: 56,
-    justifyContent: 'flex-end',
+    gap: 8,
+    marginTop: 10,
   },
   pill: {
+    flex: 1,
     borderWidth: 1,
     borderRadius: 999,
     paddingHorizontal: 10,
-    paddingVertical: 5,
+    paddingVertical: 6,
+    alignItems: 'center',
   },
   pillPressed: {
     opacity: 0.7,
@@ -289,9 +282,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   footerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
     gap: 8,
     marginTop: 12,
     paddingTop: 10,
@@ -301,6 +291,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
+    alignSelf: 'flex-start',
   },
   footerText: {
     fontSize: 13,

--- a/apps/mobile/features/chat/components/__tests__/AvailabilityRequestCard.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/AvailabilityRequestCard.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { AvailabilityRequestCard } from '../AvailabilityRequestCard';
+import type { Id } from '@services/api/convex';
+
+jest.mock('@hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      text: '#111',
+      textSecondary: '#666',
+      textTertiary: '#888',
+      border: '#ccc',
+      surfaceSecondary: '#f5f5f5',
+      success: '#0a0',
+      destructive: '#c00',
+      link: '#06f',
+    },
+  }),
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+
+const planId = 'plan-1' as Id<'eventPlans'>;
+
+const longTitleEvent = {
+  _id: planId,
+  title: 'MH Service 7/5 with extended rehearsal and sound check',
+  eventDate: new Date('2025-07-05T10:00:00').getTime(),
+  times: [
+    { label: '10:00 AM', startsAt: new Date('2025-07-05T10:00:00').getTime() },
+    { label: '12:00 PM', startsAt: new Date('2025-07-05T12:00:00').getTime() },
+  ],
+  myStatus: null as const,
+};
+
+describe('AvailabilityRequestCard', () => {
+  it('renders full event title and date/time without truncation', () => {
+    render(
+      <AvailabilityRequestCard
+        events={[longTitleEvent]}
+        busyPlanId={null}
+        onSetStatus={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('MH Service 7/5 with extended rehearsal and sound check'),
+    ).toBeTruthy();
+    expect(screen.getByText('Sat, Jul 5 · 10:00 AM, 12:00 PM')).toBeTruthy();
+  });
+
+  it('renders footer actions on separate rows so they do not overlap', () => {
+    const onOpenPage = jest.fn();
+
+    render(
+      <AvailabilityRequestCard
+        events={[longTitleEvent]}
+        busyPlanId={null}
+        onSetStatus={jest.fn()}
+        copyLinkUrl="https://example.com/a/token"
+        onOpenPage={onOpenPage}
+      />,
+    );
+
+    fireEvent.press(screen.getByText('Copy link'));
+    fireEvent.press(screen.getByText('Manage all upcoming'));
+    expect(onOpenPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSetStatus when a pill is pressed', () => {
+    const onSetStatus = jest.fn();
+
+    render(
+      <AvailabilityRequestCard
+        events={[longTitleEvent]}
+        busyPlanId={null}
+        onSetStatus={onSetStatus}
+      />,
+    );
+
+    fireEvent.press(screen.getByText('Available'));
+    expect(onSetStatus).toHaveBeenCalledWith(planId, 'available');
+  });
+});

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -887,40 +887,44 @@ function AvailabilityCardMock() {
 
           <div className="mt-3 space-y-2.5">
             {events.map((e, i) => (
-              <div key={i}>
+              <div key={i} className="space-y-1.5">
                 <div className="text-[12px] font-semibold text-neutral-900">
                   {e.title}
                 </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-[11px] text-neutral-500">{e.date}</span>
-                  <div className="flex gap-1.5">
-                    <span
-                      className={`rounded-full px-2.5 py-1 text-[10px] font-semibold ${
-                        e.state === "available"
-                          ? "bg-green-600 text-white"
-                          : "border border-neutral-200 text-neutral-500"
-                      }`}
-                    >
-                      Available
-                    </span>
-                    <span
-                      className={`rounded-full px-2.5 py-1 text-[10px] font-semibold ${
-                        e.state === "cant"
-                          ? "bg-red-600 text-white"
-                          : "border border-neutral-200 text-neutral-500"
-                      }`}
-                    >
-                      Can't
-                    </span>
-                  </div>
+                <div className="text-[11px] text-neutral-500">{e.date}</div>
+                <div className="flex gap-2">
+                  <span
+                    className={`flex-1 rounded-full px-2.5 py-1.5 text-center text-[10px] font-semibold ${
+                      e.state === "available"
+                        ? "bg-green-600 text-white"
+                        : "border border-neutral-200 text-neutral-500"
+                    }`}
+                  >
+                    Available
+                  </span>
+                  <span
+                    className={`flex-1 rounded-full px-2.5 py-1.5 text-center text-[10px] font-semibold ${
+                      e.state === "cant"
+                        ? "bg-red-600 text-white"
+                        : "border border-neutral-200 text-neutral-500"
+                    }`}
+                  >
+                    Can't
+                  </span>
                 </div>
               </div>
             ))}
           </div>
 
-          <div className="mt-3 flex items-center gap-1.5 border-t border-neutral-100 pt-2 text-[11px] font-medium text-primary-700">
-            <Ion name="link-outline" size={13} className="text-primary-700" />
-            Copy link
+          <div className="mt-3 space-y-2 border-t border-neutral-100 pt-2">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium text-primary-700">
+              <Ion name="link-outline" size={13} className="text-primary-700" />
+              Copy link
+            </div>
+            <div className="flex items-center gap-1 text-[11px] font-medium text-primary-700">
+              Manage all upcoming
+              <Ion name="chevron-forward" size={13} className="text-primary-700" />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -858,12 +858,34 @@ function PublishBarMock() {
 /** Native availability card rendered inside a chat thread. */
 function AvailabilityCardMock() {
   const events = [
-    { title: "Sunday Service", date: "Sun, Jun 15 · 9:00 AM", state: "available" as const },
-    { title: "Sunday Service", date: "Sun, Jun 22 · 9:00 AM", state: "none" as const },
-    { title: "Midweek", date: "Wed, Jun 25 · 7:00 PM", state: "cant" as const },
+    {
+      title: "MH Service 7/5",
+      date: "Sat, Jul 5 · 10:00 AM, 12:00 PM",
+      state: "available" as const,
+    },
+    {
+      title: "MH Service 7/12",
+      date: "Sat, Jul 12 · 10:00 AM, 12:00 PM",
+      state: "available" as const,
+    },
+    {
+      title: "MH Service 7/19",
+      date: "Sat, Jul 19 · 10:00 AM, 12:00 PM",
+      state: "none" as const,
+    },
+    {
+      title: "MH Service 7/26 with extended rehearsal and sound check",
+      date: "Sat, Jul 26 · 10:00 AM, 12:00 PM, 2:00 PM",
+      state: "none" as const,
+    },
+    {
+      title: "MH Service 8/2",
+      date: "Sat, Aug 2 · 10:00 AM, 12:00 PM",
+      state: "cant" as const,
+    },
   ];
   return (
-    <PhoneFrame title="Worship Team">
+    <PhoneFrame title="Fount Production">
       <div className="space-y-3 bg-neutral-50 p-3">
         {/* A normal message above the card */}
         <div className="max-w-[80%] rounded-2xl rounded-tl-sm bg-white px-3 py-2 text-[12px] text-neutral-700 shadow-sm">
@@ -882,7 +904,7 @@ function AvailabilityCardMock() {
             Let us know when you can serve this month 🙏
           </div>
           <div className="mt-0.5 text-[11px] text-neutral-500">
-            Tap a date to share your availability
+            You're available for 3 of 5
           </div>
 
           <div className="mt-3 space-y-2.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes broken UX in availability chat message cards where event titles, date/time strings, and footer links were truncated or overlapping.

## Changes

- **Stacked event layout** — Each event now shows title, then date/time, then full-width pill buttons on separate rows (matching `MyAvailabilityScreen`), so multi-slot times and long titles can grow vertically instead of being squeezed beside the pills.
- **Footer stacking** — "Copy link" and "Manage all upcoming" render on separate rows so they no longer overlap on narrow chat bubbles.
- **Browser preview** — Added `/ui-test/availability-card` Expo web route with realistic fake data for visual verification.
- **Tests** — Added unit tests for full text rendering, footer interaction, and pill taps.
- **Guide mock** — Updated `EventPlans.tsx` availability card mock to reflect the new layout.

## Visual verification

Run Expo web and open the preview page:

```bash
cd apps/mobile && npx expo start --web
```

Then visit: http://localhost:8081/ui-test/availability-card

The preview shows 5 fake events including a long title and multi-slot times — all text renders fully with stacked pills and footer links.

## Test plan

- [x] `pnpm test -- features/chat/components/__tests__/AvailabilityRequestCard.test.tsx` passes
- [x] Browser preview at `/ui-test/availability-card` renders correctly with fake data
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c327aee0-2393-4c8b-90a3-3f0e8c6379f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c327aee0-2393-4c8b-90a3-3f0e8c6379f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

