### PR TITLE
Add per-group per-day attendance summary endpoint

### DIFF
--- a/apps/convex/__tests__/api-keys.test.ts
+++ b/apps/convex/__tests__/api-keys.test.ts
@@ -548,3 +548,120 @@ describe("getCommunityAttendanceAggregate", () => {
     expect(all.hasMore).toBe(false);
   });
 });
+
+// ============================================================================
+// getCommunityAttendanceSummary (internal)
+// ============================================================================
+
+describe("getCommunityAttendanceSummary", () => {
+  test("rolls up multiple events for the same group+day into one row", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    // Two dinner events on the same local day (2026-06-10, America/New_York).
+    const morning = Date.UTC(2026, 5, 10, 18, 0, 0); // 14:00 ET
+    const evening = Date.UTC(2026, 5, 10, 23, 0, 0); // 19:00 ET (same ET day)
+    await seedMeeting(t, {
+      communityId: s.communityId,
+      groupId: s.dinnerGroupId,
+      scheduledAt: morning,
+      attendedUserIds: [s.adminId],
+      guestCount: 1,
+      rsvps: { going: 2 },
+    });
+    await seedMeeting(t, {
+      communityId: s.communityId,
+      groupId: s.dinnerGroupId,
+      scheduledAt: evening,
+      attendedUserIds: [s.memberId],
+      rsvps: { going: 1, maybe: 1 },
+    });
+    // A small-group event on a different day.
+    await seedMeeting(t, {
+      communityId: s.communityId,
+      groupId: s.smallGroupId,
+      scheduledAt: Date.UTC(2026, 5, 12, 18, 0, 0),
+      attendedUserIds: [s.adminId],
+    });
+
+    const result = await t.query(
+      internal.functions.publicApi.getCommunityAttendanceSummary,
+      { communityId: s.communityId }
+    );
+
+    expect(result.timezone).toBe("America/New_York");
+    expect(result.bucket).toBe("day");
+    expect(result.truncated).toBe(false);
+    expect(result.summary).toHaveLength(2);
+
+    const dinnerRow = result.summary.find(
+      (r: any) => r.groupTypeSlug === "dinner-parties"
+    ) as any;
+    expect(dinnerRow.date).toBe("2026-06-10");
+    expect(dinnerRow.events).toBe(2);
+    expect(dinnerRow.attended).toBe(2);
+    expect(dinnerRow.guests).toBe(1);
+    expect(dinnerRow.rsvps).toEqual({
+      going: 3,
+      notGoing: 0,
+      maybe: 1,
+      guestsExpected: 0,
+    });
+
+    // Newest day first.
+    expect((result.summary[0] as any).date).toBe("2026-06-12");
+  });
+
+  test("buckets by the community's local date, not UTC", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    // 2026-06-11 01:00 UTC == 2026-06-10 21:00 in America/New_York.
+    await seedMeeting(t, {
+      communityId: s.communityId,
+      groupId: s.dinnerGroupId,
+      scheduledAt: Date.UTC(2026, 5, 11, 1, 0, 0),
+      attendedUserIds: [s.adminId],
+    });
+
+    const result = await t.query(
+      internal.functions.publicApi.getCommunityAttendanceSummary,
+      { communityId: s.communityId }
+    );
+
+    expect(result.summary).toHaveLength(1);
+    // Local ET date, not the UTC date (which would be 2026-06-11).
+    expect((result.summary[0] as any).date).toBe("2026-06-10");
+  });
+
+  test("filters by group type", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await seedMeeting(t, {
+      communityId: s.communityId,
+      groupId: s.dinnerGroupId,
+      scheduledAt: Date.UTC(2026, 5, 10, 18, 0, 0),
+      attendedUserIds: [s.adminId],
+    });
+    await seedMeeting(t, {
+      communityId: s.communityId,
+      groupId: s.smallGroupId,
+      scheduledAt: Date.UTC(2026, 5, 10, 18, 0, 0),
+      attendedUserIds: [s.memberId],
+    });
+
+    const dinners = await t.query(
+      internal.functions.publicApi.getCommunityAttendanceSummary,
+      { communityId: s.communityId, groupTypeSlug: "dinner-parties" }
+    );
+    expect(dinners.summary).toHaveLength(1);
+    expect((dinners.summary[0] as any).groupTypeSlug).toBe("dinner-parties");
+
+    const unknown = await t.query(
+      internal.functions.publicApi.getCommunityAttendanceSummary,
+      { communityId: s.communityId, groupTypeSlug: "nope" }
+    );
+    expect(unknown.summary).toHaveLength(0);
+  });
+});

--- a/apps/convex/functions/publicApi.ts
+++ b/apps/convex/functions/publicApi.ts
@@ -7,7 +7,7 @@
  */
 
 import { v } from "convex/values";
-import { internalQuery, internalMutation } from "../_generated/server";
+import { internalQuery, internalMutation, QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { now } from "../lib/utils";
 
@@ -51,6 +51,141 @@ export const verifyApiKey = internalMutation({
   },
 });
 
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+interface MeetingCounts {
+  attended: number;
+  guests: number;
+  going: number;
+  notGoing: number;
+  maybe: number;
+  guestsExpected: number;
+}
+
+/**
+ * Count attendance, guests, and RSVPs for a single meeting.
+ * Shared by the per-event and summary aggregations.
+ */
+async function countMeeting(
+  ctx: QueryCtx,
+  meetingId: Id<"meetings">
+): Promise<MeetingCounts> {
+  const [attendances, guests, rsvps] = await Promise.all([
+    ctx.db
+      .query("meetingAttendances")
+      .withIndex("by_meeting", (q) => q.eq("meetingId", meetingId))
+      .collect(),
+    ctx.db
+      .query("meetingGuests")
+      .withIndex("by_meeting", (q) => q.eq("meetingId", meetingId))
+      .collect(),
+    ctx.db
+      .query("meetingRsvps")
+      .withIndex("by_meeting", (q) => q.eq("meetingId", meetingId))
+      .collect(),
+  ]);
+
+  const attended = attendances.filter((a) => a.status === ATTENDED_STATUS).length;
+
+  let going = 0;
+  let notGoing = 0;
+  let maybe = 0;
+  let guestsExpected = 0;
+  for (const rsvp of rsvps) {
+    if (rsvp.rsvpOptionId === RSVP_GOING) {
+      going++;
+      guestsExpected += rsvp.guestCount ?? 0;
+    } else if (rsvp.rsvpOptionId === RSVP_NOT_GOING) {
+      notGoing++;
+    } else if (rsvp.rsvpOptionId === RSVP_MAYBE) {
+      maybe++;
+    }
+  }
+
+  return { attended, guests: guests.length, going, notGoing, maybe, guestsExpected };
+}
+
+/** Pre-fetch a community's groups and group types into lookup maps. */
+async function loadCommunityGroups(ctx: QueryCtx, communityId: Id<"communities">) {
+  const [groups, groupTypes] = await Promise.all([
+    ctx.db
+      .query("groups")
+      .withIndex("by_community", (q) => q.eq("communityId", communityId))
+      .collect(),
+    ctx.db
+      .query("groupTypes")
+      .withIndex("by_community", (q) => q.eq("communityId", communityId))
+      .collect(),
+  ]);
+  return {
+    groupTypes,
+    groupMap: new Map<Id<"groups">, Doc<"groups">>(groups.map((g) => [g._id, g])),
+    groupTypeMap: new Map<Id<"groupTypes">, Doc<"groupTypes">>(
+      groupTypes.map((gt) => [gt._id, gt])
+    ),
+  };
+}
+
+/** A community's meetings ordered newest-first, optionally bounded by date. */
+function meetingsByCommunityDesc(
+  ctx: QueryCtx,
+  communityId: Id<"communities">,
+  since?: number,
+  until?: number
+) {
+  return ctx.db
+    .query("meetings")
+    .withIndex("by_community_scheduledAt", (q) => {
+      const base = q.eq("communityId", communityId);
+      if (since !== undefined && until !== undefined) {
+        return base.gte("scheduledAt", since).lte("scheduledAt", until);
+      }
+      if (since !== undefined) {
+        return base.gte("scheduledAt", since);
+      }
+      if (until !== undefined) {
+        return base.lte("scheduledAt", until);
+      }
+      return base;
+    })
+    .order("desc");
+}
+
+/** Validate an IANA time zone, falling back to UTC if unsupported/missing. */
+function resolveTimeZone(tz: string | undefined): string {
+  if (!tz) return "UTC";
+  try {
+    // Throws RangeError for an invalid/unsupported zone.
+    new Intl.DateTimeFormat("en-CA", { timeZone: tz });
+    return tz;
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * Format a timestamp as a YYYY-MM-DD calendar date in the given (already
+ * validated) time zone. en-CA's locale formats as YYYY-MM-DD.
+ */
+function localDateString(ts: number, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(ts));
+}
+
+function communityRef(community: Doc<"communities">) {
+  return {
+    id: community._id,
+    name: community.name ?? null,
+    subdomain: community.subdomain ?? null,
+  };
+}
+
 /**
  * Aggregate attendance for every group in a community.
  *
@@ -80,23 +215,9 @@ export const getCommunityAttendanceAggregate = internalQuery({
 
     const limit = Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
 
-    // Pre-fetch groups and group types so each event can be labeled and
-    // filtered without per-meeting lookups.
-    const [groups, groupTypes] = await Promise.all([
-      ctx.db
-        .query("groups")
-        .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
-        .collect(),
-      ctx.db
-        .query("groupTypes")
-        .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
-        .collect(),
-    ]);
-    const groupMap = new Map<Id<"groups">, Doc<"groups">>(
-      groups.map((g) => [g._id, g])
-    );
-    const groupTypeMap = new Map<Id<"groupTypes">, Doc<"groupTypes">>(
-      groupTypes.map((gt) => [gt._id, gt])
+    const { groupTypes, groupMap, groupTypeMap } = await loadCommunityGroups(
+      ctx,
+      args.communityId
     );
 
     // Resolve the optional group-type filter to an id up front.
@@ -105,34 +226,28 @@ export const getCommunityAttendanceAggregate = internalQuery({
       const match = groupTypes.find((gt) => gt.slug === args.groupTypeSlug);
       if (!match) {
         // Unknown type -> no events match.
-        return buildResponse(community, [], limit, false);
+        return {
+          community: communityRef(community),
+          generatedAt: new Date(now()).toISOString(),
+          limit,
+          hasMore: false,
+          events: [],
+        };
       }
       filterGroupTypeId = match._id;
     }
 
-    // Walk meetings newest-first via the community/scheduledAt index, stopping
-    // once we've collected `limit` matches or scanned the safety cap.
+    // Walk meetings newest-first, stopping once we've collected `limit` matches
+    // or scanned the safety cap.
     const matched: Doc<"meetings">[] = [];
     let scanned = 0;
     let hitScanCap = false;
-    const iterator = ctx.db
-      .query("meetings")
-      .withIndex("by_community_scheduledAt", (q) => {
-        const base = q.eq("communityId", args.communityId);
-        if (args.since !== undefined && args.until !== undefined) {
-          return base.gte("scheduledAt", args.since).lte("scheduledAt", args.until);
-        }
-        if (args.since !== undefined) {
-          return base.gte("scheduledAt", args.since);
-        }
-        if (args.until !== undefined) {
-          return base.lte("scheduledAt", args.until);
-        }
-        return base;
-      })
-      .order("desc");
-
-    for await (const meeting of iterator) {
+    for await (const meeting of meetingsByCommunityDesc(
+      ctx,
+      args.communityId,
+      args.since,
+      args.until
+    )) {
       if (scanned >= MAX_SCAN) {
         hitScanCap = true;
         break;
@@ -161,43 +276,9 @@ export const getCommunityAttendanceAggregate = internalQuery({
     // Callers page by narrowing the since/until window.
     const hasMore = matched.length >= limit || hitScanCap;
 
-    // Aggregate counts per matched event.
     const events = await Promise.all(
       matched.map(async (meeting) => {
-        const [attendances, guests, rsvps] = await Promise.all([
-          ctx.db
-            .query("meetingAttendances")
-            .withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id))
-            .collect(),
-          ctx.db
-            .query("meetingGuests")
-            .withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id))
-            .collect(),
-          ctx.db
-            .query("meetingRsvps")
-            .withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id))
-            .collect(),
-        ]);
-
-        const attended = attendances.filter(
-          (a) => a.status === ATTENDED_STATUS
-        ).length;
-
-        let going = 0;
-        let notGoing = 0;
-        let maybe = 0;
-        let goingGuests = 0;
-        for (const rsvp of rsvps) {
-          if (rsvp.rsvpOptionId === RSVP_GOING) {
-            going++;
-            goingGuests += rsvp.guestCount ?? 0;
-          } else if (rsvp.rsvpOptionId === RSVP_NOT_GOING) {
-            notGoing++;
-          } else if (rsvp.rsvpOptionId === RSVP_MAYBE) {
-            maybe++;
-          }
-        }
-
+        const counts = await countMeeting(ctx, meeting._id);
         const group = groupMap.get(meeting.groupId);
         const groupType = group?.groupTypeId
           ? groupTypeMap.get(group.groupTypeId)
@@ -215,38 +296,172 @@ export const getCommunityAttendanceAggregate = internalQuery({
             groupTypeSlug: groupType?.slug ?? null,
           },
           attendance: {
-            attended,
-            guests: guests.length,
+            attended: counts.attended,
+            guests: counts.guests,
             rsvps: {
-              going,
-              notGoing,
-              maybe,
-              guestsExpected: goingGuests,
+              going: counts.going,
+              notGoing: counts.notGoing,
+              maybe: counts.maybe,
+              guestsExpected: counts.guestsExpected,
             },
           },
         };
       })
     );
 
-    return buildResponse(community, events, limit, hasMore);
+    return {
+      community: communityRef(community),
+      generatedAt: new Date(now()).toISOString(),
+      limit,
+      hasMore,
+      events,
+    };
   },
 });
 
-function buildResponse(
-  community: Doc<"communities">,
-  events: unknown[],
-  limit: number,
-  hasMore: boolean
-) {
-  return {
-    community: {
-      id: community._id,
-      name: community.name ?? null,
-      subdomain: community.subdomain ?? null,
-    },
-    generatedAt: new Date(now()).toISOString(),
-    limit,
-    hasMore,
-    events,
-  };
-}
+/**
+ * Per-group, per-day attendance rollup for a community.
+ *
+ * A lighter-weight companion to getCommunityAttendanceAggregate: instead of one
+ * row per event, it returns one row per (group, calendar day) with summed
+ * counts — ideal for dashboards/charts that don't need event-level detail.
+ *
+ * Dates are bucketed by the community's time zone (falling back to UTC), so an
+ * evening event lands on its local calendar date. Rows are newest-day-first.
+ *
+ * Filters mirror the detailed endpoint (since/until/groupTypeSlug/status).
+ * There is no `limit`: response size is bounded by the date window and the
+ * number of groups. `truncated` is true if the internal scan cap was hit before
+ * the timeline was exhausted (narrow the window to get complete buckets).
+ */
+export const getCommunityAttendanceSummary = internalQuery({
+  args: {
+    communityId: v.id("communities"),
+    since: v.optional(v.number()),
+    until: v.optional(v.number()),
+    groupTypeSlug: v.optional(v.string()),
+    status: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const community = await ctx.db.get(args.communityId);
+    if (!community) {
+      throw new Error("Community not found");
+    }
+
+    const timeZone = resolveTimeZone(community.timezone);
+    const { groupTypes, groupMap, groupTypeMap } = await loadCommunityGroups(
+      ctx,
+      args.communityId
+    );
+
+    let filterGroupTypeId: Id<"groupTypes"> | undefined;
+    if (args.groupTypeSlug) {
+      const match = groupTypes.find((gt) => gt.slug === args.groupTypeSlug);
+      if (!match) {
+        return {
+          community: communityRef(community),
+          generatedAt: new Date(now()).toISOString(),
+          timezone: timeZone,
+          bucket: "day" as const,
+          truncated: false,
+          summary: [],
+        };
+      }
+      filterGroupTypeId = match._id;
+    }
+
+    // Collect matching meetings (bounded by the scan cap), then count in
+    // parallel — same read pattern as the detailed endpoint.
+    const matched: Doc<"meetings">[] = [];
+    let scanned = 0;
+    let truncated = false;
+    for await (const meeting of meetingsByCommunityDesc(
+      ctx,
+      args.communityId,
+      args.since,
+      args.until
+    )) {
+      if (scanned >= MAX_SCAN) {
+        truncated = true;
+        break;
+      }
+      scanned++;
+
+      if (args.status && meeting.status !== args.status) continue;
+
+      const group = groupMap.get(meeting.groupId);
+      if (filterGroupTypeId && group?.groupTypeId !== filterGroupTypeId) {
+        continue;
+      }
+
+      matched.push(meeting);
+    }
+
+    const counts = await Promise.all(
+      matched.map((meeting) => countMeeting(ctx, meeting._id))
+    );
+
+    // Roll up into one bucket per (group, local calendar day).
+    interface SummaryRow {
+      groupId: Id<"groups">;
+      groupName: string | null;
+      groupType: string | null;
+      groupTypeSlug: string | null;
+      date: string;
+      events: number;
+      attended: number;
+      guests: number;
+      rsvps: { going: number; notGoing: number; maybe: number; guestsExpected: number };
+    }
+    const buckets = new Map<string, SummaryRow>();
+
+    matched.forEach((meeting, i) => {
+      const c = counts[i];
+      const date = localDateString(meeting.scheduledAt, timeZone);
+      const key = `${meeting.groupId}|${date}`;
+
+      let row = buckets.get(key);
+      if (!row) {
+        const group = groupMap.get(meeting.groupId);
+        const groupType = group?.groupTypeId
+          ? groupTypeMap.get(group.groupTypeId)
+          : undefined;
+        row = {
+          groupId: meeting.groupId,
+          groupName: group?.name ?? null,
+          groupType: groupType?.name ?? null,
+          groupTypeSlug: groupType?.slug ?? null,
+          date,
+          events: 0,
+          attended: 0,
+          guests: 0,
+          rsvps: { going: 0, notGoing: 0, maybe: 0, guestsExpected: 0 },
+        };
+        buckets.set(key, row);
+      }
+
+      row.events += 1;
+      row.attended += c.attended;
+      row.guests += c.guests;
+      row.rsvps.going += c.going;
+      row.rsvps.notGoing += c.notGoing;
+      row.rsvps.maybe += c.maybe;
+      row.rsvps.guestsExpected += c.guestsExpected;
+    });
+
+    // Newest day first, then group name.
+    const summary = [...buckets.values()].sort((a, b) => {
+      if (a.date !== b.date) return a.date < b.date ? 1 : -1;
+      return (a.groupName ?? "").localeCompare(b.groupName ?? "");
+    });
+
+    return {
+      community: communityRef(community),
+      generatedAt: new Date(now()).toISOString(),
+      timezone: timeZone,
+      bucket: "day" as const,
+      truncated,
+      summary,
+    };
+  },
+});

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -882,6 +882,86 @@ http.route({
   }),
 });
 
+/**
+ * GET /api/v1/attendance/summary
+ *
+ * A lighter, rolled-up companion to /api/v1/attendance: returns one row per
+ * (group, calendar day) with summed attendance/guest/RSVP counts instead of one
+ * row per event. Dates are bucketed in the community's time zone. No personal
+ * information is exposed.
+ *
+ * Auth and `since`/`until`/`groupType`/`status` filters match /api/v1/attendance.
+ * There is no `limit` — response size is bounded by the date window and the
+ * number of groups; `truncated: true` means the internal scan cap was hit
+ * (narrow the window for complete buckets).
+ */
+http.route({
+  path: "/api/v1/attendance/summary",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    const apiKey = extractApiKey(request);
+    if (!apiKey) {
+      return apiJsonResponse(
+        { error: "Missing API key. Provide an Authorization: Bearer <key> header." },
+        401
+      );
+    }
+
+    const keyHash = await hashApiKey(apiKey);
+    const verified = await ctx.runMutation(internal.functions.publicApi.verifyApiKey, {
+      keyHash,
+    });
+    if (!verified) {
+      return apiJsonResponse({ error: "Invalid or revoked API key" }, 401);
+    }
+
+    const url = new URL(request.url);
+
+    const since = parseTimestampParam(url.searchParams.get("since"));
+    if (since === null) {
+      return apiJsonResponse({ error: "Invalid 'since' parameter" }, 400);
+    }
+    const until = parseTimestampParam(url.searchParams.get("until"));
+    if (until === null) {
+      return apiJsonResponse({ error: "Invalid 'until' parameter" }, 400);
+    }
+
+    const status = url.searchParams.get("status") || undefined;
+    if (status && !VALID_MEETING_STATUSES.includes(status)) {
+      return apiJsonResponse(
+        { error: `Invalid 'status'. Must be one of: ${VALID_MEETING_STATUSES.join(", ")}` },
+        400
+      );
+    }
+
+    try {
+      const data = await ctx.runQuery(
+        internal.functions.publicApi.getCommunityAttendanceSummary,
+        {
+          communityId: verified.communityId,
+          since: since ?? undefined,
+          until: until ?? undefined,
+          groupTypeSlug: url.searchParams.get("groupType") || undefined,
+          status,
+        }
+      );
+      return apiJsonResponse(data);
+    } catch (error) {
+      console.error("[AttendanceAPI] Error building attendance summary:", error);
+      return apiJsonResponse({ error: "Failed to fetch attendance summary" }, 500);
+    }
+  }),
+});
+
+// Handle CORS preflight for /api/v1/attendance/summary
+http.route({
+  path: "/api/v1/attendance/summary",
+  method: "OPTIONS",
+  handler: httpAction(async () => {
+    return new Response(null, { status: 204, headers: apiCorsHeaders });
+  }),
+});
+
 // ============================================================================
 // Health Check
 // ============================================================================

--- a/apps/web/src/pages/Developers.tsx
+++ b/apps/web/src/pages/Developers.tsx
@@ -188,8 +188,51 @@ export function Developers() {
           />
         </Section>
 
-        <Section title="5. What's possible">
+        <Section title="5. Summary endpoint (rolled up)">
+          <P>
+            For dashboards that only need totals, <Code>/summary</Code> returns
+            one row per group <em>per calendar day</em> instead of one row per
+            event &mdash; smaller responses, no client-side aggregation.
+          </P>
+          <CodeBlock>{`GET https://<your-deployment>.convex.site/api/v1/attendance/summary`}</CodeBlock>
+          <P>
+            Same auth and <Code>since</Code>/<Code>until</Code>/
+            <Code>groupType</Code>/<Code>status</Code> filters as above. There is
+            no <Code>limit</Code> &mdash; response size is bounded by the date
+            window and the number of groups.
+          </P>
+          <CodeBlock>{`{
+  "community": { "id": "...", "name": "Fount", "subdomain": "fount" },
+  "generatedAt": "2026-06-16T14:22:13.000Z",
+  "timezone": "America/New_York",
+  "bucket": "day",
+  "truncated": false,
+  "summary": [
+    {
+      "groupId": "...",
+      "groupName": "Tuesday Dinner",
+      "groupType": "Dinner Parties",
+      "groupTypeSlug": "dinner-parties",
+      "date": "2026-06-10",
+      "events": 2,
+      "attended": 23,
+      "guests": 5,
+      "rsvps": { "going": 27, "notGoing": 2, "maybe": 3, "guestsExpected": 8 }
+    }
+  ]
+}`}</CodeBlock>
+          <Callout>
+            Days are bucketed in the community&rsquo;s time zone (echoed in the{" "}
+            <Code>timezone</Code> field), so an evening event lands on its local
+            date. Rows are newest-day-first. <Code>truncated: true</Code> means
+            the internal scan cap was hit before the window was exhausted &mdash;
+            narrow <Code>since</Code>/<Code>until</Code> for complete buckets.
+          </Callout>
+        </Section>
+
+        <Section title="6. What's possible">
           <ul className="list-disc pl-6 text-neutral-600 space-y-1">
+            <li>Get a lightweight per-group, per-day rollup from <Code>/summary</Code> for dashboards and charts.</li>
             <li>Pull attendance, guest, and RSVP counts for every event in the community.</li>
             <li>Filter by date range, group type, and event status.</li>
             <li>Build dashboards and charts of attendance over time (e.g. dinner-party turnout per week).</li>
@@ -198,7 +241,7 @@ export function Developers() {
           </ul>
         </Section>
 
-        <Section title="6. What's not possible">
+        <Section title="7. What's not possible">
           <ul className="list-disc pl-6 text-neutral-600 space-y-1">
             <li>
               <Strong>No personal data.</Strong> You cannot retrieve who attended
@@ -227,7 +270,7 @@ export function Developers() {
           </ul>
         </Section>
 
-        <Section title="7. Errors">
+        <Section title="8. Errors">
           <Table
             headers={["Status", "Meaning"]}
             rows={[
@@ -239,7 +282,7 @@ export function Developers() {
           <P>All errors return a JSON body of the form <Code>{`{ "error": "..." }`}</Code>.</P>
         </Section>
 
-        <Section title="8. Example integration">
+        <Section title="9. Example integration">
           <P>Fetch completed dinner-party events since the start of the year:</P>
           <CodeBlock>{`curl -H "Authorization: Bearer $TOGATHER_API_KEY" \\
   "https://<deployment>.convex.site/api/v1/attendance?groupType=dinner-parties&status=completed&since=2026-01-01"`}</CodeBlock>
@@ -287,7 +330,7 @@ async function refreshWindow(daysBack = 90) {
             <li>Timestamps in responses are ISO 8601 UTC strings; request filters accept ISO strings or Unix milliseconds.</li>
             <li><Code>since</Code>/<Code>until</Code> filter on each event&rsquo;s scheduled date, not on when attendance was recorded. There is no &ldquo;updated since&rdquo; change cursor &mdash; to capture late attendance edits, re-pull a trailing date window rather than advancing a cursor.</li>
             <li>Treat the response as additive &mdash; new fields may appear over time; do not assume a fixed key set.</li>
-            <li>There is exactly one resource; pagination is by date range, not cursors or offsets.</li>
+            <li>Two read endpoints: <Code>/api/v1/attendance</Code> (one row per event) and <Code>/api/v1/attendance/summary</Code> (one row per group per day). Pagination is by date range, not cursors or offsets.</li>
           </ul>
         </Section>
 

--- a/docs/api/attendance-api.md
+++ b/docs/api/attendance-api.md
@@ -98,6 +98,45 @@ Field notes:
 - `guests` — number of guest (non-member) records logged for the event.
 - `rsvps.guestsExpected` — sum of plus-ones declared by "going" RSVPs.
 
+## Summary endpoint (rolled up)
+
+```
+GET https://<deployment>.convex.site/api/v1/attendance/summary
+```
+
+A lighter companion to `/api/v1/attendance`: returns one row per group **per
+calendar day** with summed counts instead of one row per event — for dashboards
+that don't need event-level detail. Same auth and
+`since`/`until`/`groupType`/`status` filters; no `limit`.
+
+Days are bucketed in the community's time zone (echoed in `timezone`, falling
+back to `UTC`), so an evening event lands on its local date. Rows are
+newest-day-first. `truncated: true` means the internal scan cap was hit before
+the window was exhausted — narrow `since`/`until` for complete buckets.
+
+```json
+{
+  "community": { "id": "...", "name": "Fount", "subdomain": "fount" },
+  "generatedAt": "2026-06-16T14:22:13.000Z",
+  "timezone": "America/New_York",
+  "bucket": "day",
+  "truncated": false,
+  "summary": [
+    {
+      "groupId": "...",
+      "groupName": "Tuesday Dinner",
+      "groupType": "Dinner Parties",
+      "groupTypeSlug": "dinner-parties",
+      "date": "2026-06-10",
+      "events": 2,
+      "attended": 23,
+      "guests": 5,
+      "rsvps": { "going": 27, "notGoing": 2, "maybe": 3, "guestsExpected": 8 }
+    }
+  ]
+}
+```
+
 ## Errors
 
 | Status | Meaning                                              |
@@ -108,8 +147,8 @@ Field notes:
 
 ## Implementation
 
-- Route + auth: `apps/convex/http.ts` (`GET /api/v1/attendance`)
-- Key verification + aggregation: `apps/convex/functions/publicApi.ts`
+- Routes + auth: `apps/convex/http.ts` (`GET /api/v1/attendance`, `GET /api/v1/attendance/summary`)
+- Key verification + aggregation/rollup: `apps/convex/functions/publicApi.ts`
 - Key management (admin): `apps/convex/functions/admin/apiKeys.ts`
 - Key generation/hashing: `apps/convex/lib/apiKeys.ts`
 - Schema: `apiKeys` table in `apps/convex/schema.ts`


### PR DESCRIPTION
## Summary

Follow-up to #458. Adds a **rolled-up summary endpoint** so dashboards can pull lightweight per-group, per-day attendance totals instead of paging through every event.

```
GET /api/v1/attendance/summary
```

Returns one row per **(group, calendar day)** with summed attendance / guest / RSVP counts — smaller responses, no client-side aggregation. Same API-key auth and `since`/`until`/`groupType`/`status` filters as the per-event endpoint; no `limit`.

```json
{
  "community": { "id": "...", "name": "Fount", "subdomain": "fount" },
  "generatedAt": "...",
  "timezone": "America/New_York",
  "bucket": "day",
  "truncated": false,
  "summary": [
    {
      "groupId": "...", "groupName": "Tuesday Dinner",
      "groupType": "Dinner Parties", "groupTypeSlug": "dinner-parties",
      "date": "2026-06-10",
      "events": 2, "attended": 23, "guests": 5,
      "rsvps": { "going": 27, "notGoing": 2, "maybe": 3, "guestsExpected": 8 }
    }
  ]
}
```

## Details

- **`publicApi.ts`** — new `getCommunityAttendanceSummary` internal query. Extracted shared helpers (`countMeeting`, `loadCommunityGroups`, `meetingsByCommunityDesc`) now used by both the detailed and summary aggregations (removes duplication). Days are bucketed in the community's **time zone** (`Intl`, UTC fallback) so an evening event lands on its local date; rows are newest-day-first; `truncated` flags an internal scan-cap hit.
- **`http.ts`** — `GET /api/v1/attendance/summary` (same auth + filters, no `limit`).
- **Docs** — `/developers` page and `docs/api/attendance-api.md` document the endpoint and response shape.

## Design decisions (confirmed with the requester)
- New dedicated `/summary` endpoint (per-event endpoint untouched).
- Computed on read (no schema/write-path changes; bounded by date window + scan cap).
- Day buckets, in the community's local time zone.

## Tests

`apps/convex/__tests__/api-keys.test.ts` (+3 tests, 15 total): rollup correctness (multiple events same group+day → one summed row), local-timezone bucketing (UTC-vs-local boundary), and group-type filtering.

Backend tests pass locally; web `tsc` + eslint clean. The endpoint is served on `*.convex.site` directly, so no Cloudflare-worker changes are involved.

https://claude.ai/code/session_01Lp2XKdw2mQMTFJpuDykUMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp2XKdw2mQMTFJpuDykUMQ)_