### PR TITLE
Fix prayer body overflow hiding the Pray button

### DIFF
--- a/apps/mobile/features/prayer/components/PrayerScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayerScreen.tsx
@@ -25,6 +25,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
+  ScrollView,
   Alert,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -312,16 +313,27 @@ export function PrayerScreen() {
             </TouchableOpacity>
           </View>
 
-          <View style={styles.bodyWrap}>
-            <Text
-              style={[styles.quoteMark, { color: primaryColor }]}
-              accessibilityElementsHidden
-              importantForAccessibility="no"
-            >
-              “
-            </Text>
-            <Text style={[styles.body, { color: colors.text }]}>{current.bodyText}</Text>
-          </View>
+          {/*
+           * Body scrolls *inside* the card so a long request can't push the
+           * Pray button off the bottom and out from under the prayed-for rail.
+           * The button stays pinned and tappable no matter how long the text.
+           */}
+          <ScrollView
+            style={styles.bodyScroll}
+            contentContainerStyle={styles.bodyContent}
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={styles.bodyWrap}>
+              <Text
+                style={[styles.quoteMark, { color: primaryColor }]}
+                accessibilityElementsHidden
+                importantForAccessibility="no"
+              >
+                “
+              </Text>
+              <Text style={[styles.body, { color: colors.text }]}>{current.bodyText}</Text>
+            </View>
+          </ScrollView>
 
           <TouchableOpacity
             style={[styles.prayButton, { backgroundColor: primaryColor }]}
@@ -529,10 +541,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 36,
   },
   cardWrap: {
+    flex: 1,
     paddingHorizontal: 16,
     paddingTop: 4,
+    paddingBottom: 4,
   },
   card: {
+    // flexShrink lets the card cap at the available height for long prayers
+    // (so the body scrolls) while still sizing to content for short ones.
+    flexShrink: 1,
     borderRadius: 20,
     padding: 22,
     borderWidth: StyleSheet.hairlineWidth,
@@ -545,7 +562,15 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,
-    marginBottom: 18,
+    marginBottom: 12,
+  },
+  bodyScroll: {
+    flexShrink: 1,
+  },
+  bodyContent: {
+    // Headroom so the negative-offset quote mark isn't clipped at the
+    // scroll viewport's top edge.
+    paddingTop: 8,
   },
   avatar: {
     width: 44,


### PR DESCRIPTION
## Problem

A user reported they couldn't tap the **Pray** button — it was buried behind "the little squares at the bottom."

Those squares are the **"Prayers you've prayed" rail**. The prayer feed card's body text had no height constraint and wasn't scrollable, so a long prayer request made the card grow past the hero region and overflow *downward*. Because the rail renders after the card, it painted on top of the overflow — burying the **Pray** button (and the tail of the prayer text), making it untappable.

## Fix

In `apps/mobile/features/prayer/components/PrayerScreen.tsx`:

- The prayer body now scrolls **inside** the card, so long text can't overflow into the rail.
- The **Pray** button is pinned to the bottom of the card and stays reachable regardless of body length.
- Short prayers still hug their content high in the viewport; only long ones scroll (`flexShrink` on the card + body so it caps at the available height).

## Verification

- ✅ Typecheck clean
- ✅ ESLint clean
- ✅ Full mobile test suite (1080 tests) passing via the pre-push hook

Note: this was developed on Linux, so the iOS Simulator wasn't available for a live visual check — validated via the type/lint/test gates and layout reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJDmxUqWmRfnB6j3wQuSSh)_