### PR TITLE
feat(channels): fold archived channels into one collapsible section

### DIFF
--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -112,9 +112,16 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
   const pcoSyncedChannels = channels?.filter((c: Channel) => c.channelType === "pco_services") ?? [];
   const customChannels = channels?.filter((c: Channel) => c.channelType === "custom") ?? [];
 
-  const leadersEnabled = !!leadersChannel && !leadersChannel.isArchived;
-  const mainEnabled = !!mainChannel && !mainChannel.isArchived;
-  const reachOutEnabled = !!reachOutChannel && !reachOutChannel.isArchived;
+  // A channel is inactive if it's archived OR a leader hid it (isEnabled ===
+  // false) — the backend active-state checks treat either flag as inactive,
+  // so both must fold under Archived and read as "Disabled". Undefined
+  // isEnabled means enabled (memberships intact).
+  const leadersEnabled =
+    !!leadersChannel && !leadersChannel.isArchived && leadersChannel.isEnabled !== false;
+  const mainEnabled =
+    !!mainChannel && !mainChannel.isArchived && mainChannel.isEnabled !== false;
+  const reachOutEnabled =
+    !!reachOutChannel && !reachOutChannel.isArchived && reachOutChannel.isEnabled !== false;
   const announcementsEnabled =
     !!announcementsChannel &&
     !announcementsChannel.isArchived &&

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -73,6 +73,12 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
 
+  // Archived/disabled channels are folded away under a single collapsible
+  // "Archived" row so a long tail of turned-off channels doesn't clutter the
+  // list. Collapsed by default; only leaders ever have archived rows since
+  // members never receive disabled channels from the query.
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
+
   // The legacy `groupMembers.role === "admin"` enum is no longer assigned
   // by the backend (only "member" / "leader" exist). The defensive `||
   // "admin"` checks scattered through the app are dead — drop them as we
@@ -177,6 +183,10 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
     onPress?: () => void;
     unreadCount?: number;
     pinned?: boolean;
+    /** True when this row is backed by a real channel record that is
+     *  disabled/archived. Such rows fold into the collapsible "Archived"
+     *  section. Placeholder/CTA rows (no record yet) are never archived. */
+    archived?: boolean;
   };
 
   const rows: Row[] = [];
@@ -195,6 +205,7 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
       onPress: () => navigateToChannelInfo(mainChannel.slug),
       unreadCount: mainChannel.unreadCount,
       pinned: mainChannel.isPinned,
+      archived: !mainEnabled,
     });
   }
 
@@ -216,6 +227,9 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
         : undefined,
       unreadCount: leadersChannel?.unreadCount,
       pinned: leadersChannel?.isPinned,
+      // Fold only a real, disabled Leaders channel — never the "create"
+      // placeholder shown to leaders before the record exists.
+      archived: !!leadersChannel && !leadersEnabled,
     });
   }
 
@@ -247,6 +261,9 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
           : undefined,
       unreadCount: announcementsChannel?.unreadCount,
       pinned: announcementsChannel?.isPinned,
+      // Keep the "Tap to enable" CTA (no record) in the main list; fold only
+      // an existing-but-disabled Announcements channel.
+      archived: !!announcementsChannel && !announcementsEnabled,
     });
   }
 
@@ -268,6 +285,10 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
         : undefined,
       unreadCount: reachOutChannel?.unreadCount,
       pinned: reachOutChannel?.isPinned,
+      // Fold a real, disabled Reach Out channel. The "Requires Leaders
+      // channel" / create-placeholder states (no record) stay in the main
+      // list as actionable affordances.
+      archived: !!reachOutChannel && !reachOutEnabled,
     });
   }
 
@@ -286,6 +307,7 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
       onPress: () => navigateToChannelInfo(channel.slug),
       unreadCount: channel.unreadCount,
       pinned: channel.isPinned,
+      archived: !enabled,
     });
   });
 
@@ -304,82 +326,138 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
       onPress: () => navigateToChannelInfo(channel.slug),
       unreadCount: channel.unreadCount,
       pinned: channel.isPinned,
+      archived: !enabled,
     });
   });
+
+  const activeRows = rows.filter((r) => !r.archived);
+  const archivedRows = rows.filter((r) => r.archived);
+
+  const renderRow = (row: Row, idx: number) => {
+    const isFirst = idx === 0;
+    const dimmed = !row.enabled;
+    // Disabled channels stay tappable so a leader can re-enable from the info
+    // screen's Active state. Placeholder rows with no onPress fall through to
+    // disabled.
+    const tappable = !!row.onPress;
+    return (
+      <TouchableOpacity
+        key={row.key}
+        activeOpacity={0.7}
+        onPress={row.onPress}
+        disabled={!tappable}
+        style={[
+          styles.row,
+          !isFirst && {
+            borderTopWidth: StyleSheet.hairlineWidth,
+            borderTopColor: colors.border,
+          },
+        ]}
+      >
+        <View style={[styles.iconContainer, { backgroundColor: row.iconBg }]}>
+          <Ionicons name={row.icon} size={20} color={row.iconColor} />
+        </View>
+        <View style={styles.rowInfo}>
+          <View style={styles.rowNameLine}>
+            <Text
+              style={[
+                styles.rowName,
+                { color: dimmed ? colors.textTertiary : colors.text },
+              ]}
+              numberOfLines={1}
+            >
+              {row.name}
+            </Text>
+            {row.pinned && (
+              <Ionicons
+                name="pin"
+                size={13}
+                color={colors.iconSecondary}
+                style={styles.pinIcon}
+              />
+            )}
+          </View>
+          <Text
+            style={[styles.rowSubtitle, { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            {row.subtitle}
+          </Text>
+        </View>
+        {row.enabled && row.unreadCount && row.unreadCount > 0 ? (
+          <View style={[styles.unreadBadge, { backgroundColor: row.iconColor }]}>
+            <Text style={styles.unreadText}>
+              {row.unreadCount > 99 ? "99+" : row.unreadCount}
+            </Text>
+          </View>
+        ) : null}
+        {tappable && (
+          <Ionicons
+            name="chevron-forward"
+            size={18}
+            color={colors.textTertiary}
+          />
+        )}
+      </TouchableOpacity>
+    );
+  };
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <Text style={[styles.header, { color: colors.textSecondary }]}>CHANNELS</Text>
-      <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
-        {rows.map((row, idx) => {
-          const isFirst = idx === 0;
-          const dimmed = !row.enabled;
-          // Disabled channels stay tappable so a leader can re-enable from
-          // the info screen's Active state. Placeholder rows with no
-          // onPress fall through to disabled.
-          const tappable = !!row.onPress;
-          return (
-            <TouchableOpacity
-              key={row.key}
-              activeOpacity={0.7}
-              onPress={row.onPress}
-              disabled={!tappable}
+      {activeRows.length > 0 && (
+        <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
+          {activeRows.map((row, idx) => renderRow(row, idx))}
+        </View>
+      )}
+
+      {/* Archived/disabled channels fold into one collapsible group so they
+          don't clutter the active list. Leaders only — members never receive
+          disabled channels, so archivedRows is empty for them. */}
+      {archivedRows.length > 0 && (
+        <>
+          <TouchableOpacity
+            style={[styles.archivedToggle, { backgroundColor: colors.surfaceSecondary }]}
+            onPress={() => setArchivedExpanded((v) => !v)}
+            activeOpacity={0.7}
+          >
+            <View
               style={[
-                styles.row,
-                !isFirst && {
-                  borderTopWidth: StyleSheet.hairlineWidth,
-                  borderTopColor: colors.border,
-                },
+                styles.iconContainer,
+                { backgroundColor: colors.textTertiary + "15" },
               ]}
             >
-              <View style={[styles.iconContainer, { backgroundColor: row.iconBg }]}>
-                <Ionicons name={row.icon} size={20} color={row.iconColor} />
-              </View>
-              <View style={styles.rowInfo}>
-                <View style={styles.rowNameLine}>
-                  <Text
-                    style={[
-                      styles.rowName,
-                      { color: dimmed ? colors.textTertiary : colors.text },
-                    ]}
-                    numberOfLines={1}
-                  >
-                    {row.name}
-                  </Text>
-                  {row.pinned && (
-                    <Ionicons
-                      name="pin"
-                      size={13}
-                      color={colors.iconSecondary}
-                      style={styles.pinIcon}
-                    />
-                  )}
-                </View>
-                <Text
-                  style={[styles.rowSubtitle, { color: colors.textSecondary }]}
-                  numberOfLines={1}
-                >
-                  {row.subtitle}
-                </Text>
-              </View>
-              {row.enabled && row.unreadCount && row.unreadCount > 0 ? (
-                <View style={[styles.unreadBadge, { backgroundColor: row.iconColor }]}>
-                  <Text style={styles.unreadText}>
-                    {row.unreadCount > 99 ? "99+" : row.unreadCount}
-                  </Text>
-                </View>
-              ) : null}
-              {tappable && (
-                <Ionicons
-                  name="chevron-forward"
-                  size={18}
-                  color={colors.textTertiary}
-                />
-              )}
-            </TouchableOpacity>
-          );
-        })}
-      </View>
+              <Ionicons name="archive-outline" size={20} color={colors.textSecondary} />
+            </View>
+            <View style={styles.rowInfo}>
+              <Text style={[styles.rowName, { color: colors.text }]}>Archived</Text>
+              <Text
+                style={[styles.rowSubtitle, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                {archivedRows.length} channel{archivedRows.length !== 1 ? "s" : ""} ·
+                hidden from members
+              </Text>
+            </View>
+            <Ionicons
+              name={archivedExpanded ? "chevron-up" : "chevron-down"}
+              size={18}
+              color={colors.textTertiary}
+            />
+          </TouchableOpacity>
+          {archivedExpanded && (
+            <View
+              style={[
+                styles.card,
+                styles.archivedCard,
+                { backgroundColor: colors.surfaceSecondary },
+              ]}
+            >
+              {archivedRows.map((row, idx) => renderRow(row, idx))}
+            </View>
+          )}
+        </>
+      )}
 
       {/* Solid Create Channel affordance — matches the DM "Add people"
           card. Replaces the dashed-border button. */}
@@ -550,6 +628,19 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderRadius: 12,
     minHeight: 48,
+  },
+  archivedToggle: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginTop: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    minHeight: 56,
+  },
+  archivedCard: {
+    marginTop: 8,
   },
   createIcon: {
     width: 32,

--- a/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
@@ -373,4 +373,80 @@ describe("ChannelsSection (redesigned)", () => {
       expect(getByText("Disabled")).toBeTruthy();
     });
   });
+
+  describe("Archived channels fold into one collapsible section", () => {
+    const disabledCustomChannel = {
+      _id: "channel-custom-archived",
+      slug: "old-team",
+      channelType: "custom",
+      name: "Old Team",
+      memberCount: 0,
+      isArchived: false,
+      isMember: false,
+      unreadCount: 0,
+      isPinned: false,
+      isEnabled: false, // leader hid it → "Hidden — visible to leaders"
+    };
+
+    it("hides archived/disabled channels behind a single 'Archived' toggle for leaders", () => {
+      mockChannelsData = [
+        mockMainChannel,
+        mockLeadersChannel,
+        ...mockCustomChannels,
+        disabledCustomChannel,
+      ];
+
+      const { getByText, queryByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      // The disabled channel is folded away — not shown directly…
+      expect(queryByText("Old Team")).toBeNull();
+      // …but a single Archived toggle summarizes it.
+      expect(getByText("Archived")).toBeTruthy();
+      expect(getByText(/1 channel/)).toBeTruthy();
+    });
+
+    it("expands the archived channel when the toggle is pressed", () => {
+      mockChannelsData = [
+        mockMainChannel,
+        mockLeadersChannel,
+        disabledCustomChannel,
+      ];
+
+      const { getByText, queryByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(queryByText("Old Team")).toBeNull();
+
+      act(() => {
+        fireEvent.press(getByText("Archived").parent!.parent!);
+      });
+
+      expect(getByText("Old Team")).toBeTruthy();
+    });
+
+    it("does not show an Archived toggle when there are no archived channels", () => {
+      mockChannelsData = [mockMainChannel, mockLeadersChannel];
+
+      const { queryByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(queryByText("Archived")).toBeNull();
+    });
+
+    it("does not show an Archived toggle to members (they never receive disabled channels)", () => {
+      // Members are filtered to enabled channels before rows are built, so
+      // there is nothing to fold and no toggle appears.
+      mockChannelsData = [mockMainChannel, ...mockCustomChannels];
+
+      const { queryByText } = render(
+        <ChannelsSection groupId="test-group" userRole="member" />
+      );
+
+      expect(queryByText("Archived")).toBeNull();
+    });
+  });
 });

--- a/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
@@ -437,6 +437,29 @@ describe("ChannelsSection (redesigned)", () => {
       expect(queryByText("Archived")).toBeNull();
     });
 
+    it("folds a General channel hidden via isEnabled=false (not just isArchived)", () => {
+      // Regression: a disabled General (isEnabled: false, isArchived: false)
+      // must read as Disabled and fold under Archived, not show as active
+      // "All members".
+      mockChannelsData = [
+        { ...mockMainChannel, isEnabled: false, isArchived: false },
+        mockLeadersChannel,
+      ];
+
+      const { getByText, queryByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(queryByText("All members")).toBeNull();
+      expect(getByText("Archived")).toBeTruthy();
+
+      act(() => {
+        fireEvent.press(getByText("Archived").parent!.parent!);
+      });
+
+      expect(getByText("General")).toBeTruthy();
+    });
+
     it("does not show an Archived toggle to members (they never receive disabled channels)", () => {
       // Members are filtered to enabled channels before rows are built, so
       // there is nothing to fold and no toggle appears.


### PR DESCRIPTION
## Problem

Disabled/archived channels (and any duplicate channels that share a name) piled up in a group's channel list, cluttering it for leaders. A user reported their list showing the same channel multiple times after archiving — e.g. "MH Sunday" appearing several times as "Disabled" and "Hidden — visible to leaders".

Archiving itself does **not** create duplicates (it only flips an `isArchived`/`isEnabled` flag on the existing record), so the duplicate records pre-existed. This PR addresses the **clutter** by hiding archived/disabled channels behind a single collapsible section. It intentionally does **not** mutate any channel data.

## Change

In `ChannelsSection`, every row backed by a real, disabled/archived channel record now folds into a single collapsible **`Archived (N) · hidden from members`** row that sits below the active channels (collapsed by default). Tapping it expands the folded channels so a leader can still re-enable one.

- Placeholder / call-to-action rows (e.g. "Tap to enable Announcements", the Leaders create-placeholder) stay in the main list — they aren't archived channels.
- Members are unaffected: they never receive disabled channels, so the section never appears for them.
- The row renderer was extracted into a shared helper so active and archived rows render identically.

## Tests

Added 4 tests covering the folding behavior (toggle visibility, expand, no-toggle-when-empty, hidden-from-members). All 24 tests in `ChannelsSection.test.tsx` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jHihYES474vnro8wgmfSQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019jHihYES474vnro8wgmfSQ)_