### PR TITLE
Add monthly frequency option to the task reminder bot

### DIFF
--- a/apps/convex/__tests__/scheduledJobs.task-reminder.test.ts
+++ b/apps/convex/__tests__/scheduledJobs.task-reminder.test.ts
@@ -463,11 +463,13 @@ describe("shouldFireMonthlyOnDate", () => {
   });
 
   test("Nth occurrence respects 7-day windows", () => {
-    // Days 1-7 => 1st, 8-14 => 2nd, 15-21 => 3rd, 22-28 => 4th, 29-31 => 5th.
+    // Days 1-7 => 1st, 8-14 => 2nd, 15-21 => 3rd, 22-28 => 4th.
     expect(shouldFireMonthlyOnDate("2026-06-07", 1)).toBe(true);
     expect(shouldFireMonthlyOnDate("2026-06-14", 2)).toBe(true);
-    expect(shouldFireMonthlyOnDate("2026-06-29", 5)).toBe(true);
+    expect(shouldFireMonthlyOnDate("2026-06-22", 4)).toBe(true);
+    // June 29 is a 5th Monday: not the 4th, so only "last" catches it.
     expect(shouldFireMonthlyOnDate("2026-06-29", 4)).toBe(false);
+    expect(shouldFireMonthlyOnDate("2026-06-29", "last")).toBe(true);
   });
 
   test("returns false for a malformed date key", () => {

--- a/apps/convex/__tests__/scheduledJobs.task-reminder.test.ts
+++ b/apps/convex/__tests__/scheduledJobs.task-reminder.test.ts
@@ -12,6 +12,7 @@ import { expect, test, describe, vi, afterEach } from "vitest";
 import schema from "../schema";
 import { internal } from "../_generated/api";
 import { modules } from "../test.setup";
+import { shouldFireMonthlyOnDate } from "../functions/scheduledJobs";
 
 import type { Id } from "../_generated/dataModel";
 
@@ -424,6 +425,53 @@ describe("getGroupById", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// shouldFireMonthlyOnDate Tests (monthly task reminder gating)
+// ============================================================================
+
+describe("shouldFireMonthlyOnDate", () => {
+  // June 2026 has Mondays on the 1st, 8th, 15th, 22nd, and 29th.
+  test("matches the Nth occurrence of a weekday", () => {
+    expect(shouldFireMonthlyOnDate("2026-06-01", 1)).toBe(true); // 1st Monday
+    expect(shouldFireMonthlyOnDate("2026-06-08", 2)).toBe(true); // 2nd Monday
+    expect(shouldFireMonthlyOnDate("2026-06-15", 3)).toBe(true); // 3rd Monday
+    expect(shouldFireMonthlyOnDate("2026-06-22", 4)).toBe(true); // 4th Monday
+  });
+
+  test("does not match other occurrences", () => {
+    expect(shouldFireMonthlyOnDate("2026-06-08", 1)).toBe(false); // 2nd, want 1st
+    expect(shouldFireMonthlyOnDate("2026-06-01", 2)).toBe(false); // 1st, want 2nd
+    expect(shouldFireMonthlyOnDate("2026-06-22", 1)).toBe(false); // 4th, want 1st
+  });
+
+  test("'last' matches the final occurrence of the weekday in the month", () => {
+    // Last Monday of June 2026 is the 29th.
+    expect(shouldFireMonthlyOnDate("2026-06-29", "last")).toBe(true);
+    expect(shouldFireMonthlyOnDate("2026-06-22", "last")).toBe(false);
+  });
+
+  test("'last' handles a 5th occurrence and a short final month", () => {
+    // March 2026: 31 days. Last Tuesday is the 31st (also the 5th Tuesday).
+    expect(shouldFireMonthlyOnDate("2026-03-31", "last")).toBe(true);
+    expect(shouldFireMonthlyOnDate("2026-03-24", "last")).toBe(false);
+    // February 2026 (28 days): last day is the 28th.
+    expect(shouldFireMonthlyOnDate("2026-02-28", "last")).toBe(true);
+    expect(shouldFireMonthlyOnDate("2026-02-21", "last")).toBe(false);
+  });
+
+  test("Nth occurrence respects 7-day windows", () => {
+    // Days 1-7 => 1st, 8-14 => 2nd, 15-21 => 3rd, 22-28 => 4th, 29-31 => 5th.
+    expect(shouldFireMonthlyOnDate("2026-06-07", 1)).toBe(true);
+    expect(shouldFireMonthlyOnDate("2026-06-14", 2)).toBe(true);
+    expect(shouldFireMonthlyOnDate("2026-06-29", 5)).toBe(true);
+    expect(shouldFireMonthlyOnDate("2026-06-29", 4)).toBe(false);
+  });
+
+  test("returns false for a malformed date key", () => {
+    expect(shouldFireMonthlyOnDate("not-a-date", 1)).toBe(false);
   });
 });
 

--- a/apps/convex/functions/groupBots.ts
+++ b/apps/convex/functions/groupBots.ts
@@ -232,12 +232,15 @@ function normalizeTaskReminderConfig(rawConfig: Record<string, unknown>) {
 
   const frequency = rawConfig.frequency === "monthly" ? "monthly" : "weekly";
   const rawWeekOfMonth = rawConfig.weekOfMonth;
+  // Accept the 1st–4th occurrence or "last". We deliberately omit a "5th"
+  // option: a 5th occurrence exists in only some months, so "last" is the
+  // intuitive (and UI-exposed) way to target the final occurrence.
   const weekOfMonth =
     rawWeekOfMonth === "last"
       ? "last"
       : typeof rawWeekOfMonth === "number" &&
           rawWeekOfMonth >= 1 &&
-          rawWeekOfMonth <= 5
+          rawWeekOfMonth <= 4
         ? rawWeekOfMonth
         : 1;
 

--- a/apps/convex/functions/groupBots.ts
+++ b/apps/convex/functions/groupBots.ts
@@ -140,7 +140,7 @@ const botDefinitions: Record<string, BotDefinition> = {
   "task-reminder": {
     id: "task-reminder",
     name: "Task Reminder Bot",
-    description: "Sends daily reminders to role-assigned members",
+    description: "Sends weekly or monthly reminders to role-assigned members",
     icon: "📋",
     triggerType: "cron",
     customConfigUI: true,
@@ -155,6 +155,10 @@ const botDefinitions: Record<string, BotDefinition> = {
         saturday: [],
         sunday: [],
       },
+      // "weekly" fires the schedule every week; "monthly" fires it only on
+      // the configured weekday occurrence (weekOfMonth) each month.
+      frequency: "weekly",
+      weekOfMonth: 1,
       deliveryMode: "task_and_channel_post",
       targetChannelSlugs: [],
     },
@@ -226,9 +230,22 @@ function normalizeTaskReminderConfig(rawConfig: Record<string, unknown>) {
       ? [rawConfig.targetChannelSlug]
       : [];
 
+  const frequency = rawConfig.frequency === "monthly" ? "monthly" : "weekly";
+  const rawWeekOfMonth = rawConfig.weekOfMonth;
+  const weekOfMonth =
+    rawWeekOfMonth === "last"
+      ? "last"
+      : typeof rawWeekOfMonth === "number" &&
+          rawWeekOfMonth >= 1 &&
+          rawWeekOfMonth <= 5
+        ? rawWeekOfMonth
+        : 1;
+
   return {
     roles: Array.isArray(rawConfig.roles) ? rawConfig.roles : [],
     schedule,
+    frequency,
+    weekOfMonth,
     deliveryMode,
     targetChannelSlugs: [...new Set([...channelSlugsFromArray, ...channelSlugsFromLegacy])],
   };

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -1019,7 +1019,8 @@ type TaskReminderDeliveryMode = "task_only" | "task_and_channel_post";
 type TaskReminderFrequency = "weekly" | "monthly";
 
 // Which occurrence of a weekday within the month a monthly reminder targets:
-// 1-5 for the Nth occurrence, or "last" for the final one in the month.
+// 1-4 for the Nth occurrence (1st–4th), or "last" for the final one in the
+// month. "last" is how the final occurrence is targeted, so there is no 5th.
 type TaskReminderWeekOfMonth = number | "last";
 
 type TaskReminderConfigData = {
@@ -1046,7 +1047,7 @@ type TaskReminderConfigData = {
  * the Nth one, or the last one in the month.
  *
  * @param dateKey "YYYY-MM-DD" for today in the community's timezone.
- * @param weekOfMonth 1-5 for the Nth occurrence, or "last" for the final one.
+ * @param weekOfMonth 1-4 for the Nth occurrence, or "last" for the final one.
  */
 export function shouldFireMonthlyOnDate(
   dateKey: string,

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -1016,15 +1016,63 @@ type TaskReminderSchedule = Record<string, TaskReminderTask[]>;
 
 type TaskReminderDeliveryMode = "task_only" | "task_and_channel_post";
 
+type TaskReminderFrequency = "weekly" | "monthly";
+
+// Which occurrence of a weekday within the month a monthly reminder targets:
+// 1-5 for the Nth occurrence, or "last" for the final one in the month.
+type TaskReminderWeekOfMonth = number | "last";
+
 type TaskReminderConfigData = {
   roles: TaskReminderRole[];
   schedule: TaskReminderSchedule;
   deliveryMode?: TaskReminderDeliveryMode;
   targetChannelSlugs?: string[];
+  // Monthly reminders reuse the weekday schedule but only fire on the
+  // configured weekday occurrence within the month (e.g. the first Monday).
+  frequency?: TaskReminderFrequency;
+  weekOfMonth?: TaskReminderWeekOfMonth;
   // Legacy fields kept for backwards compatibility with existing configs.
   delivery?: "chat" | "notification" | "both";
   targetChannelSlug?: string;
 };
+
+/**
+ * Decide whether a monthly task reminder should fire on a given date.
+ *
+ * Monthly reminders reuse the weekday schedule but only fire on a single
+ * occurrence of each weekday within the month. The weekday is already
+ * implied by which schedule list runs (e.g. Monday's tasks run on Mondays),
+ * so this only needs to confirm that today is the configured occurrence —
+ * the Nth one, or the last one in the month.
+ *
+ * @param dateKey "YYYY-MM-DD" for today in the community's timezone.
+ * @param weekOfMonth 1-5 for the Nth occurrence, or "last" for the final one.
+ */
+export function shouldFireMonthlyOnDate(
+  dateKey: string,
+  weekOfMonth: TaskReminderWeekOfMonth,
+): boolean {
+  const [yearStr, monthStr, dayStr] = dateKey.split("-");
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10); // 1-based
+  const day = parseInt(dayStr, 10);
+
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return false;
+  }
+
+  if (weekOfMonth === "last") {
+    // Day 0 of the next month is the last day of this month.
+    const daysInMonth = new Date(year, month, 0).getDate();
+    // The last occurrence of a weekday is whenever adding 7 days would
+    // overflow into the next month.
+    return day + 7 > daysInMonth;
+  }
+
+  // The Nth occurrence of a weekday falls in day ranges 1-7, 8-14, etc.
+  const occurrence = Math.ceil(day / 7);
+  return occurrence === weekOfMonth;
+}
 
 /**
  * Helper query to get group by ID.
@@ -1125,6 +1173,24 @@ export const runTaskReminderBot = internalAction({
     );
     const todayName: string = dayFormatter.format(nowDate).toLowerCase();
     const todayDateKey: string = dateFormatter.format(nowDate);
+
+    // Monthly reminders reuse the weekday schedule but only fire on the
+    // configured weekday occurrence within the month (e.g. the first Monday).
+    // The bucket cron still wakes this bot daily at 9 AM, so we filter here.
+    const frequency: TaskReminderFrequency = configData.frequency ?? "weekly";
+    if (
+      frequency === "monthly" &&
+      !shouldFireMonthlyOnDate(todayDateKey, configData.weekOfMonth ?? 1)
+    ) {
+      console.log(
+        `[TaskReminder] Monthly schedule not due today (${todayDateKey}) for group ${groupId}`,
+      );
+      return {
+        skipped: true,
+        reason: "not_scheduled_week_of_month",
+        day: todayName,
+      };
+    }
 
     const todayTasks: TaskReminderTask[] = schedule[todayName] || [];
 

--- a/apps/mobile/features/leader-tools/components/TaskReminderConfigModal.tsx
+++ b/apps/mobile/features/leader-tools/components/TaskReminderConfigModal.tsx
@@ -45,9 +45,17 @@ type Task = {
 
 type Schedule = Record<DayOfWeek, Task[]>;
 
+type Frequency = "weekly" | "monthly";
+
+// Which occurrence of a weekday a monthly reminder targets:
+// 1-5 for the Nth occurrence, or "last" for the final one in the month.
+type WeekOfMonth = number | "last";
+
 type TaskReminderConfig = {
   roles: Role[];
   schedule: Schedule;
+  frequency: Frequency;
+  weekOfMonth: WeekOfMonth;
   deliveryMode: "task_only" | "task_and_channel_post";
   targetChannelSlugs: string[];
 };
@@ -73,6 +81,19 @@ const DELIVERY_MODE_OPTIONS = [
   { value: "task_and_channel_post", label: "Create tasks + post task cards to channels" },
 ] as const;
 
+const FREQUENCY_OPTIONS: { value: Frequency; label: string }[] = [
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+];
+
+const WEEK_OF_MONTH_OPTIONS: { value: WeekOfMonth; label: string; ordinal: string }[] = [
+  { value: 1, label: "1st", ordinal: "first" },
+  { value: 2, label: "2nd", ordinal: "second" },
+  { value: 3, label: "3rd", ordinal: "third" },
+  { value: 4, label: "4th", ordinal: "fourth" },
+  { value: "last", label: "Last", ordinal: "last" },
+];
+
 const DEFAULT_CONFIG: TaskReminderConfig = {
   roles: [],
   schedule: {
@@ -84,6 +105,8 @@ const DEFAULT_CONFIG: TaskReminderConfig = {
     saturday: [],
     sunday: [],
   },
+  frequency: "weekly",
+  weekOfMonth: 1,
   deliveryMode: "task_and_channel_post",
   targetChannelSlugs: [],
 };
@@ -210,9 +233,19 @@ export function TaskReminderConfigModal({
         : loadedConfig.targetChannelSlug
           ? [loadedConfig.targetChannelSlug]
           : [];
+      const frequency: Frequency =
+        loadedConfig.frequency === "monthly" ? "monthly" : "weekly";
+      const weekOfMonth: WeekOfMonth =
+        loadedConfig.weekOfMonth === "last"
+          ? "last"
+          : typeof loadedConfig.weekOfMonth === "number"
+            ? loadedConfig.weekOfMonth
+            : 1;
       setConfig({
         roles: loadedConfig.roles || [],
         schedule: loadedConfig.schedule || DEFAULT_CONFIG.schedule,
+        frequency,
+        weekOfMonth,
         deliveryMode,
         targetChannelSlugs,
       });
@@ -389,6 +422,11 @@ export function TaskReminderConfigModal({
       .map((id) => config.roles.find((r) => r.id === id)?.name || "Unknown")
       .join(", ");
   };
+
+  // Human-readable ordinal for the selected week of month ("first", "last", …)
+  const selectedWeekOfMonthOrdinal =
+    WEEK_OF_MONTH_OPTIONS.find((o) => o.value === config.weekOfMonth)?.ordinal ??
+    "first";
 
   // Render role item
   const renderRoleItem = (role: Role) => {
@@ -811,9 +849,93 @@ export function TaskReminderConfigModal({
                 ) : null}
               </View>
 
-              {/* Weekly Schedule Section */}
+              {/* Frequency Section */}
               <View style={styles.section}>
-                <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>WEEKLY SCHEDULE</Text>
+                <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>FREQUENCY</Text>
+                <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
+                  Weekly fires the schedule every week. Monthly fires it once a
+                  month, on the chosen occurrence of each weekday.
+                </Text>
+
+                <View style={styles.deliveryOptions}>
+                  {FREQUENCY_OPTIONS.map((option) => {
+                    const isSelected = config.frequency === option.value;
+                    return (
+                      <TouchableOpacity
+                        key={option.value}
+                        style={[
+                          styles.deliveryOption,
+                          { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                          isSelected && [styles.deliveryOptionSelected, { backgroundColor: primaryColor, borderColor: primaryColor }],
+                        ]}
+                        onPress={() => {
+                          setConfig((prev) => ({ ...prev, frequency: option.value }));
+                          setIsDirty(true);
+                        }}
+                      >
+                        <Text
+                          style={[
+                            styles.deliveryOptionText,
+                            { color: colors.text },
+                            isSelected && styles.deliveryOptionTextSelected,
+                          ]}
+                        >
+                          {option.label}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+
+                {config.frequency === "monthly" ? (
+                  <>
+                    <Text style={[styles.sectionTitle, { marginTop: 16, color: colors.textSecondary }]}>
+                      WEEK OF MONTH
+                    </Text>
+                    <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
+                      Tasks run on the {selectedWeekOfMonthOrdinal}{" "}
+                      occurrence of each weekday (e.g. the {selectedWeekOfMonthOrdinal}{" "}
+                      {DAYS.find((d) => d.key === selectedDay)?.label}).
+                    </Text>
+
+                    <View style={styles.deliveryOptions}>
+                      {WEEK_OF_MONTH_OPTIONS.map((option) => {
+                        const isSelected = config.weekOfMonth === option.value;
+                        return (
+                          <TouchableOpacity
+                            key={String(option.value)}
+                            style={[
+                              styles.deliveryOption,
+                              { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                              isSelected && [styles.deliveryOptionSelected, { backgroundColor: primaryColor, borderColor: primaryColor }],
+                            ]}
+                            onPress={() => {
+                              setConfig((prev) => ({ ...prev, weekOfMonth: option.value }));
+                              setIsDirty(true);
+                            }}
+                          >
+                            <Text
+                              style={[
+                                styles.deliveryOptionText,
+                                { color: colors.text },
+                                isSelected && styles.deliveryOptionTextSelected,
+                              ]}
+                            >
+                              {option.label}
+                            </Text>
+                          </TouchableOpacity>
+                        );
+                      })}
+                    </View>
+                  </>
+                ) : null}
+              </View>
+
+              {/* Schedule Section */}
+              <View style={styles.section}>
+                <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+                  {config.frequency === "monthly" ? "MONTHLY SCHEDULE" : "WEEKLY SCHEDULE"}
+                </Text>
 
                 {/* Day tabs */}
                 <ScrollView

--- a/apps/mobile/features/leader-tools/components/TaskReminderConfigModal.tsx
+++ b/apps/mobile/features/leader-tools/components/TaskReminderConfigModal.tsx
@@ -48,7 +48,8 @@ type Schedule = Record<DayOfWeek, Task[]>;
 type Frequency = "weekly" | "monthly";
 
 // Which occurrence of a weekday a monthly reminder targets:
-// 1-5 for the Nth occurrence, or "last" for the final one in the month.
+// 1-4 for the Nth occurrence (1st–4th), or "last" for the final one. There is
+// no 5th option — "last" targets the final occurrence in the month.
 type WeekOfMonth = number | "last";
 
 type TaskReminderConfig = {

--- a/apps/mobile/features/leader-tools/components/__tests__/TaskReminderConfigModal.test.tsx
+++ b/apps/mobile/features/leader-tools/components/__tests__/TaskReminderConfigModal.test.tsx
@@ -17,4 +17,13 @@ describe("TaskReminderConfigModal keyboard UX safeguards", () => {
     expect(source).toContain("onPress={Keyboard.dismiss}");
     expect(source).toContain('testID="task-editor-scroll"');
   });
+
+  it("exposes weekly/monthly frequency controls", () => {
+    expect(source).toContain("FREQUENCY_OPTIONS");
+    expect(source).toContain("WEEK_OF_MONTH_OPTIONS");
+    // The schedule heading reflects the chosen frequency.
+    expect(source).toContain('"MONTHLY SCHEDULE" : "WEEKLY SCHEDULE"');
+    // Week-of-month picker only shows when monthly is selected.
+    expect(source).toContain('config.frequency === "monthly"');
+  });
 });


### PR DESCRIPTION
## Summary

Leaders asked for a **monthly** version of the weekly task reminder bot ("The weekly one is super helpful!"). The task reminder bot is driven by a per-weekday schedule fired by a daily 9 AM cron, so rather than cloning it into a parallel "monthly bot", this adds a **frequency** setting to the existing bot.

When frequency is `monthly`, the same weekday schedule only fires on the configured occurrence of each weekday within the month — e.g. the **first Monday** or the **last Friday** — selected via a new week-of-month control. `weekly` remains the default, so existing configs are unaffected.

## Why this approach

The existing bot already stores one task list per weekday and the cron wakes it daily at 9 AM. Reusing that path means:
- Leaders keep the mental model (and UI) they already know.
- No day-of-month edge cases ("there's no 31st this month").
- The weekly path stays untouched and fully backwards compatible.

The daily cron simply filters in-code via a new `shouldFireMonthlyOnDate()` gate; no scheduling changes.

## Changes

- **`scheduledJobs.ts`** — add pure `shouldFireMonthlyOnDate()` helper + a guard in `runTaskReminderBot` so monthly configs only fire on the configured weekday-occurrence of the month.
- **`groupBots.ts`** — add `frequency`/`weekOfMonth` to the bot's default config and normalization.
- **`TaskReminderConfigModal.tsx`** — Weekly/Monthly toggle + week-of-month picker (1st–4th / Last); schedule heading reflects the chosen frequency.
- **Tests** — monthly date-gating logic (Nth occurrence, `last`, short months, malformed input) and the new UI controls.

## Verification

- Convex + mobile typecheck clean (remaining errors are pre-existing in unrelated files).
- Backend: 22 tests pass (6 new for the monthly gating).
- Mobile: full suite green (1081 passed).

## Backwards compatibility

Existing configs without `frequency` default to `weekly` in the handler, normalizer, and UI loader — current weekly behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtKvx6TJ3z6eeu5eaFpFQQ)_