### PR TITLE
Add "Specific Groups" event visibility option

### DIFF
--- a/apps/convex/__tests__/community-events-visibility.test.ts
+++ b/apps/convex/__tests__/community-events-visibility.test.ts
@@ -64,14 +64,18 @@ interface TestSetup {
   otherCommunityId: Id<"communities">;
   groupTypeId: Id<"groupTypes">;
   groupId: Id<"groups">;
+  secondGroupId: Id<"groups">;
   communityMemberId: Id<"users">;
   groupMemberId: Id<"users">;
+  secondGroupMemberId: Id<"users">;
   nonMemberId: Id<"users">;
   publicMeetingId: Id<"meetings">;
   communityMeetingId: Id<"meetings">;
   groupMeetingId: Id<"meetings">;
+  specificGroupsMeetingId: Id<"meetings">;
   communityMemberToken: string;
   groupMemberToken: string;
+  secondGroupMemberToken: string;
   nonMemberToken: string;
 }
 
@@ -146,6 +150,18 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestSetu
       updatedAt: timestamp,
     });
 
+    // Member of a second group (used for "specific groups" visibility tests).
+    const secondGroupMemberId = await ctx.db.insert("users", {
+      firstName: "Second",
+      lastName: "Group",
+      email: "secondgroup@test.com",
+      phone: "+12025551004",
+      phoneVerified: true,
+      isActive: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
     // Create a group
     const groupId = await ctx.db.insert("groups", {
       communityId,
@@ -187,6 +203,36 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestSetu
       notificationsEnabled: true,
     });
 
+    // Create a second group + member in the same community, shared with via
+    // the "specific groups" visibility level.
+    const secondGroupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Second Group",
+      description: "Another test group",
+      isArchived: false,
+      isPublic: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    await ctx.db.insert("userCommunities", {
+      userId: secondGroupMemberId,
+      communityId,
+      roles: 1,
+      status: 1,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    await ctx.db.insert("groupMembers", {
+      groupId: secondGroupId,
+      userId: secondGroupMemberId,
+      role: "member",
+      joinedAt: timestamp,
+      notificationsEnabled: true,
+    });
+
     // Create meetings with different visibility levels
     const publicMeetingId = await ctx.db.insert("meetings", {
       groupId,
@@ -221,19 +267,36 @@ async function setupTestData(t: ReturnType<typeof convexTest>): Promise<TestSetu
       createdAt: timestamp,
     });
 
+    // Hosted by `groupId`, explicitly shared with `secondGroupId`.
+    const specificGroupsMeetingId = await ctx.db.insert("meetings", {
+      groupId,
+      title: "Specific Groups Event",
+      scheduledAt: futureTime + 3000,
+      meetingType: 1,
+      status: "scheduled",
+      visibility: "groups",
+      visibleGroupIds: [secondGroupId],
+      createdById: groupMemberId,
+      createdAt: timestamp,
+    });
+
     return {
       communityId,
       otherCommunityId,
       groupTypeId,
       groupId,
+      secondGroupId,
       communityMemberId,
       groupMemberId,
+      secondGroupMemberId,
       nonMemberId,
       publicMeetingId,
       communityMeetingId,
       groupMeetingId,
+      specificGroupsMeetingId,
       communityMemberToken: `test-token-${communityMemberId}`,
       groupMemberToken: `test-token-${groupMemberId}`,
+      secondGroupMemberToken: `test-token-${secondGroupMemberId}`,
       nonMemberToken: `test-token-${nonMemberId}`,
     };
   });
@@ -415,6 +478,69 @@ describe("Group events visibility", () => {
 });
 
 // ============================================================================
+// Specific Groups Event Visibility Tests
+// ============================================================================
+
+describe("Specific groups events visibility", () => {
+  test("Specific-groups events are NOT visible to unauthenticated users", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupTestData(t);
+
+    const result = await t.query(api.functions.meetings.index.communityEvents, {
+      communityId: setup.communityId,
+      includePast: true,
+    });
+
+    const event = result.events.find((e) => e.id === setup.specificGroupsMeetingId);
+    expect(event).toBeUndefined();
+  });
+
+  test("Specific-groups events are NOT visible to community members outside the shared groups", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupTestData(t);
+
+    const result = await t.query(api.functions.meetings.index.communityEvents, {
+      token: setup.communityMemberToken,
+      communityId: setup.communityId,
+      includePast: true,
+    });
+
+    const event = result.events.find((e) => e.id === setup.specificGroupsMeetingId);
+    expect(event).toBeUndefined();
+  });
+
+  test("Specific-groups events ARE visible to hosting group members", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupTestData(t);
+
+    const result = await t.query(api.functions.meetings.index.communityEvents, {
+      token: setup.groupMemberToken,
+      communityId: setup.communityId,
+      includePast: true,
+    });
+
+    const event = result.events.find((e) => e.id === setup.specificGroupsMeetingId);
+    expect(event).toBeDefined();
+    expect(event?.title).toBe("Specific Groups Event");
+  });
+
+  test("Specific-groups events ARE visible to members of a shared-with group", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupTestData(t);
+
+    const result = await t.query(api.functions.meetings.index.communityEvents, {
+      token: setup.secondGroupMemberToken,
+      communityId: setup.communityId,
+      includePast: true,
+    });
+
+    const event = result.events.find((e) => e.id === setup.specificGroupsMeetingId);
+    expect(event).toBeDefined();
+    expect(event?.title).toBe("Specific Groups Event");
+  });
+});
+
+// ============================================================================
 // Filtering by Hosting Group Tests
 // ============================================================================
 
@@ -431,12 +557,14 @@ describe("Events filtered by hosting group", () => {
       includePast: true,
     });
 
-    // Should see all 3 events (public, community, group)
-    expect(result.events).toHaveLength(3);
+    // Should see all 4 events (public, community, group, specific-groups —
+    // the group member hosts the specific-groups event's group)
+    expect(result.events).toHaveLength(4);
     const titles = result.events.map((e) => e.title);
     expect(titles).toContain("Public Event");
     expect(titles).toContain("Community Event");
     expect(titles).toContain("Group Event");
+    expect(titles).toContain("Specific Groups Event");
   });
 
   test("Community member filtering by group only sees public and community events", async () => {
@@ -524,6 +652,7 @@ describe("Visibility Summary", () => {
     expect(unauthResult.events.length).toBe(1); // Only public
     expect(nonMemberResult.events.length).toBe(1); // Only public
     expect(communityMemberResult.events.length).toBe(2); // Public + Community
-    expect(groupMemberResult.events.length).toBe(3); // Public + Community + Group
+    // Public + Community + Group + Specific Groups (host group member)
+    expect(groupMemberResult.events.length).toBe(4);
   });
 });

--- a/apps/convex/functions/meetingRsvps.ts
+++ b/apps/convex/functions/meetingRsvps.ts
@@ -411,21 +411,34 @@ export const submit = mutation({
     // Check visibility-based membership
     const visibility = meeting.visibility || "group";
 
-    if (visibility === "group") {
-      // For group-only events, user must be an active member of the group
-      const groupMembership = await ctx.db
-        .query("groupMembers")
-        .withIndex("by_group_user", (q) =>
-          q.eq("groupId", meeting.groupId).eq("userId", userId)
-        )
-        .first();
+    if (visibility === "group" || visibility === "groups") {
+      // For group-scoped events, user must be an active member of the hosting
+      // group — or, for "groups" visibility, of one of the shared-with groups.
+      const isActiveMember = async (groupId: typeof meeting.groupId) => {
+        const membership = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", groupId).eq("userId", userId)
+          )
+          .first();
+        return (
+          !!membership &&
+          !membership.leftAt &&
+          (!membership.requestStatus ||
+            membership.requestStatus === "accepted")
+        );
+      };
 
-      if (
-        !groupMembership ||
-        groupMembership.leftAt ||
-        (groupMembership.requestStatus &&
-          groupMembership.requestStatus !== "accepted")
-      ) {
+      let allowed = await isActiveMember(meeting.groupId);
+      if (!allowed && visibility === "groups") {
+        for (const sharedGroupId of meeting.visibleGroupIds ?? []) {
+          if (await isActiveMember(sharedGroupId)) {
+            allowed = true;
+            break;
+          }
+        }
+      }
+      if (!allowed) {
         throw new Error("You must be a group member to RSVP to this event");
       }
     } else if (visibility === "community") {

--- a/apps/convex/functions/meetings/attendance.ts
+++ b/apps/convex/functions/meetings/attendance.ts
@@ -373,21 +373,34 @@ export const selfReportAttendance = mutation({
     // Check visibility-based membership
     const visibility = meeting.visibility || "group";
 
-    if (visibility === "group") {
-      // For group-only events, user must be an active member of the group
-      const groupMembership = await ctx.db
-        .query("groupMembers")
-        .withIndex("by_group_user", (q) =>
-          q.eq("groupId", meeting.groupId).eq("userId", userId)
-        )
-        .first();
+    if (visibility === "group" || visibility === "groups") {
+      // For group-scoped events, user must be an active member of the hosting
+      // group — or, for "groups" visibility, of one of the shared-with groups.
+      const isActiveMember = async (groupId: typeof meeting.groupId) => {
+        const membership = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", groupId).eq("userId", userId)
+          )
+          .first();
+        return (
+          !!membership &&
+          !membership.leftAt &&
+          (!membership.requestStatus ||
+            membership.requestStatus === "accepted")
+        );
+      };
 
-      if (
-        !groupMembership ||
-        groupMembership.leftAt ||
-        (groupMembership.requestStatus &&
-          groupMembership.requestStatus !== "accepted")
-      ) {
+      let allowed = await isActiveMember(meeting.groupId);
+      if (!allowed && visibility === "groups") {
+        for (const sharedGroupId of meeting.visibleGroupIds ?? []) {
+          if (await isActiveMember(sharedGroupId)) {
+            allowed = true;
+            break;
+          }
+        }
+      }
+      if (!allowed) {
         throw new Error("You must be a group member to attend this event");
       }
     } else if (visibility === "community") {

--- a/apps/convex/functions/meetings/events.ts
+++ b/apps/convex/functions/meetings/events.ts
@@ -549,6 +549,12 @@ export function isVisible(
   const visibility = m.visibility || "group";
   if (visibility === "public") return true;
   if (visibility === "community") return userId !== null && isCommunityMember;
+  if (visibility === "groups") {
+    // Visible to members of the hosting group OR any of the explicitly
+    // shared-with groups.
+    if (userGroupIds.has(m.groupId)) return true;
+    return (m.visibleGroupIds ?? []).some((id) => userGroupIds.has(id));
+  }
   return userGroupIds.has(m.groupId);
 }
 

--- a/apps/convex/functions/meetings/explore.ts
+++ b/apps/convex/functions/meetings/explore.ts
@@ -217,6 +217,11 @@ export const communityEvents = query({
         // User must be authenticated AND a member of this community
         return userId !== null && userCommunityIds.has(args.communityId);
       }
+      if (visibility === "groups") {
+        // Hosting group members, or members of any explicitly shared-with group.
+        if (userGroupIds.has(m.groupId)) return true;
+        return (m.visibleGroupIds ?? []).some((id) => userGroupIds.has(id));
+      }
       if (visibility === "group") {
         return userGroupIds.has(m.groupId);
       }
@@ -604,6 +609,10 @@ export const searchEvents = query({
       const visibility = meeting.visibility ?? "group";
       if (visibility === "public") return true;
       if (visibility === "community") return isCommunityMember;
+      if (visibility === "groups") {
+        if (userGroupIds.has(meeting.groupId)) return true;
+        return (meeting.visibleGroupIds ?? []).some((id) => userGroupIds.has(id));
+      }
       // Default "group" visibility: must be member
       return userGroupIds.has(meeting.groupId);
     });

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -6,6 +6,8 @@
 
 import { v } from "convex/values";
 import { query, mutation } from "../../_generated/server";
+import type { MutationCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
 import { internal } from "../../_generated/api";
 import { now, generateShortId, getDisplayName, getMediaUrl } from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
@@ -84,6 +86,38 @@ export {
 } from "./migrations";
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Sanitize the list of groups an event is explicitly shared with (used by the
+ * 'groups' visibility level). Drops duplicates, the hosting group itself (it
+ * always has access), and any group that doesn't belong to the same community.
+ * Returns `undefined` when nothing valid remains so the field stays unset.
+ */
+async function resolveVisibleGroupIds(
+  ctx: MutationCtx,
+  requested: Id<"groups">[] | undefined,
+  hostGroupId: Id<"groups">,
+  communityId: Id<"communities">
+): Promise<Id<"groups">[] | undefined> {
+  if (!requested || requested.length === 0) return undefined;
+
+  const seen = new Set<string>();
+  const resolved: Id<"groups">[] = [];
+  for (const groupId of requested) {
+    const key = String(groupId);
+    if (seen.has(key) || key === String(hostGroupId)) continue;
+    seen.add(key);
+    const group = await ctx.db.get(groupId);
+    if (group && group.communityId === communityId) {
+      resolved.push(groupId);
+    }
+  }
+  return resolved.length > 0 ? resolved : undefined;
+}
+
+// ============================================================================
 // Basic Meeting CRUD
 // ============================================================================
 
@@ -128,6 +162,9 @@ export const create = mutation({
     ),
     hideRsvpCount: v.optional(v.boolean()),
     visibility: v.optional(v.string()),
+    // When visibility is 'groups', the additional groups (beyond the hosting
+    // group) whose members can see and RSVP.
+    visibleGroupIds: v.optional(v.array(v.id("groups"))),
     seriesId: v.optional(v.id("eventSeries")),
     // Hosts own the event. When omitted on create we default to
     // [createdById] so the filer is seated as host; pass `[]` to explicitly
@@ -211,6 +248,19 @@ export const create = mutation({
       throw new Error("Group not found");
     }
 
+    // Only persist shared-with groups when visibility is 'groups'. Validate
+    // each belongs to the same community and drop the hosting group (it always
+    // has access) plus duplicates.
+    const visibleGroupIds =
+      args.visibility === "groups"
+        ? await resolveVisibleGroupIds(
+            ctx,
+            args.visibleGroupIds,
+            args.groupId,
+            group.communityId
+          )
+        : undefined;
+
     // Generate a short ID for URLs (e.g., "abc123xyz")
     const shortId = generateShortId();
 
@@ -247,6 +297,7 @@ export const create = mutation({
       rsvpOptions: effectiveRsvpOptions,
       hideRsvpCount: args.hideRsvpCount,
       visibility: args.visibility,
+      visibleGroupIds,
       seriesId: args.seriesId,
       // Scheduled job fields
       reminderAt,
@@ -340,6 +391,10 @@ export const update = mutation({
     ),
     hideRsvpCount: v.optional(v.boolean()),
     visibility: v.optional(v.string()),
+    // When visibility is 'groups', the additional groups whose members can see
+    // and RSVP. Pass `[]` to clear. Ignored unless the (new or existing)
+    // visibility is 'groups'.
+    visibleGroupIds: v.optional(v.array(v.id("groups"))),
     scope: v.optional(v.union(v.literal("this_only"), v.literal("all_in_series"))),
     // Pass an array (including `[]` to delegate to group leaders) to change
     // hosts; omit to leave unchanged.
@@ -445,6 +500,31 @@ export const update = mutation({
     // empty string that every read path would have to treat as falsy).
     if (cleanedUpdates.coverImage === "") {
       cleanedUpdates.coverImage = undefined;
+    }
+
+    // Resolve the shared-with groups for the 'groups' visibility level. We key
+    // off the *effective* visibility (incoming change, or existing value when
+    // unchanged) so editing the group list on an already-'groups' event works,
+    // and switching away from 'groups' clears the stale list.
+    let visibleGroupIdsTouched = false;
+    const effectiveVisibility = updates.visibility ?? meeting.visibility;
+    if (effectiveVisibility === "groups") {
+      if (updates.visibleGroupIds !== undefined) {
+        const meetingGroup = await ctx.db.get(meeting.groupId);
+        cleanedUpdates.visibleGroupIds = meetingGroup
+          ? await resolveVisibleGroupIds(
+              ctx,
+              updates.visibleGroupIds,
+              meeting.groupId,
+              meetingGroup.communityId
+            )
+          : undefined;
+        visibleGroupIdsTouched = true;
+      }
+    } else if (updates.visibility !== undefined) {
+      // Visibility moved away from 'groups' — drop the now-irrelevant list.
+      cleanedUpdates.visibleGroupIds = undefined;
+      visibleGroupIdsTouched = true;
     }
 
     // If this meeting is linked to a community-wide event and hasn't been overridden yet,
@@ -607,6 +687,9 @@ export const update = mutation({
       if (updates.rsvpOptions !== undefined) seriesUpdates.rsvpOptions = updates.rsvpOptions;
       if (updates.hideRsvpCount !== undefined) seriesUpdates.hideRsvpCount = updates.hideRsvpCount;
       if (updates.visibility !== undefined) seriesUpdates.visibility = updates.visibility;
+      // Cascade the resolved shared-with groups alongside visibility so series
+      // siblings stay in sync. `undefined` deletes the field on each sibling.
+      if (visibleGroupIdsTouched) seriesUpdates.visibleGroupIds = cleanedUpdates.visibleGroupIds;
       if (updates.locationOverride !== undefined) seriesUpdates.locationOverride = updates.locationOverride;
       // Hosts cascade like any other non-temporal field. Without this, a
       // "change hosts on all events in series" edit would only touch the
@@ -809,6 +892,7 @@ export const createSeriesEvents = mutation({
     ),
     hideRsvpCount: v.optional(v.boolean()),
     visibility: v.optional(v.string()),
+    visibleGroupIds: v.optional(v.array(v.id("groups"))),
   },
   handler: async (ctx, args) => {
     const createdById = await requireAuth(ctx, args.token);
@@ -854,6 +938,16 @@ export const createSeriesEvents = mutation({
     const effectiveRsvpEnabled = args.rsvpEnabled ?? true;
     const effectiveRsvpOptions = args.rsvpOptions ?? (effectiveRsvpEnabled ? DEFAULT_RSVP_OPTIONS : undefined);
 
+    const visibleGroupIds =
+      args.visibility === "groups"
+        ? await resolveVisibleGroupIds(
+            ctx,
+            args.visibleGroupIds,
+            args.groupId,
+            group.communityId
+          )
+        : undefined;
+
     const meetingIds: string[] = [];
 
     for (const scheduledAt of args.dates) {
@@ -879,6 +973,7 @@ export const createSeriesEvents = mutation({
         rsvpOptions: effectiveRsvpOptions,
         hideRsvpCount: args.hideRsvpCount,
         visibility: args.visibility,
+        visibleGroupIds,
         seriesId,
         reminderAt,
         reminderSent: false,

--- a/apps/convex/functions/meetings/queries.ts
+++ b/apps/convex/functions/meetings/queries.ts
@@ -96,6 +96,30 @@ export const getByShortId = query({
       hasAccess = !!communityMembership;
     } else if (groupMembership) {
       hasAccess = true;
+    } else if (visibility === "groups" && userId) {
+      // Shared with specific groups: grant access to active members of any of
+      // the shared-with groups (the hosting group is already covered above).
+      for (const sharedGroupId of meeting.visibleGroupIds ?? []) {
+        const sharedMembership = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", sharedGroupId).eq("userId", userId)
+          )
+          .filter((q) =>
+            q.and(
+              q.eq(q.field("leftAt"), undefined),
+              q.or(
+                q.eq(q.field("requestStatus"), undefined),
+                q.eq(q.field("requestStatus"), "accepted")
+              )
+            )
+          )
+          .first();
+        if (sharedMembership) {
+          hasAccess = true;
+          break;
+        }
+      }
     }
 
     // Get group type name
@@ -164,6 +188,7 @@ export const getByShortId = query({
       note: hasAccess ? meeting.note : null,
       coverImage: getMediaUrl(effectiveCoverImage ?? undefined),
       visibility: meeting.visibility || "group",
+      visibleGroupIds: meeting.visibleGroupIds ?? [],
       rsvpEnabled: meeting.rsvpEnabled ?? true,
       rsvpOptions: meeting.rsvpOptions || [],
       rsvpCounts,

--- a/apps/convex/functions/meetings/queries.ts
+++ b/apps/convex/functions/meetings/queries.ts
@@ -188,7 +188,11 @@ export const getByShortId = query({
       note: hasAccess ? meeting.note : null,
       coverImage: getMediaUrl(effectiveCoverImage ?? undefined),
       visibility: meeting.visibility || "group",
-      visibleGroupIds: meeting.visibleGroupIds ?? [],
+      // Only expose the shared-with audience to viewers who can access the
+      // event. Otherwise this public share endpoint would leak the intended
+      // private audience to outsiders — matching how meetingLink/note are
+      // redacted above.
+      visibleGroupIds: hasAccess ? meeting.visibleGroupIds ?? [] : [],
       rsvpEnabled: meeting.rsvpEnabled ?? true,
       rsvpOptions: meeting.rsvpOptions || [],
       rsvpCounts,

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -669,7 +669,10 @@ export default defineSchema({
     hideRsvpCount: v.optional(v.boolean()),
 
     // Visibility
-    visibility: v.optional(v.string()), // 'group' | 'community' | 'public'
+    visibility: v.optional(v.string()), // 'group' | 'community' | 'public' | 'groups'
+    // When visibility is 'groups', members of these groups can also see and
+    // RSVP, in addition to the hosting group. Ignored for other visibilities.
+    visibleGroupIds: v.optional(v.array(v.id("groups"))),
 
     // Public sharing
     publicSlug: v.optional(v.string()),

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -31,6 +31,7 @@ import {
   DEFAULT_RSVP_OPTIONS,
 } from "./RsvpOptionsEditor";
 import { VisibilitySelector, VisibilityLevel } from "./VisibilitySelector";
+import { VisibleGroupsSelector } from "./VisibleGroupsSelector";
 import { useCreatableGroups } from "@features/events/hooks/useCommunityEvents";
 import { useMyHostedEvents } from "@features/events/hooks/useMyEvents";
 import { useAnalytics } from "@services/analytics";
@@ -64,6 +65,9 @@ interface CreateMeetingInput {
   rsvpOptions?: RsvpOption[];
   hideRsvpCount?: boolean;
   visibility?: VisibilityLevel;
+  // Groups (beyond the hosting group) whose members can see and RSVP. Only
+  // meaningful when visibility is "groups".
+  visibleGroupIds?: string[];
   hostUserIds?: Id<"users">[];
 }
 
@@ -170,6 +174,8 @@ export function CreateEventScreen() {
   // separately from the meeting update mutation below.
   const [eventChatEnabled, setEventChatEnabled] = useState(true);
   const [visibility, setVisibility] = useState<VisibilityLevel>("public");
+  // Groups the event is explicitly shared with (used when visibility is "groups").
+  const [visibleGroupIds, setVisibleGroupIds] = useState<string[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(hostingGroupId || null);
   const [isGroupDropdownOpen, setIsGroupDropdownOpen] = useState(false);
 
@@ -358,6 +364,9 @@ export function CreateEventScreen() {
       if (meeting.visibility) {
         setVisibility(meeting.visibility as VisibilityLevel);
       }
+      if (Array.isArray((meeting as any).visibleGroupIds)) {
+        setVisibleGroupIds((meeting as any).visibleGroupIds as string[]);
+      }
       // Hosts: honor the stored value (including an explicit empty array,
       // which means "delegated to leaders"). Undefined on legacy rows maps
       // to [] since creator is no longer a fallback — an admin can then
@@ -458,7 +467,7 @@ export function CreateEventScreen() {
   // Wrapper for create mutation with state tracking
   // Note: useAuthenticatedMutation auto-injects the token
   const createMeeting = {
-    mutate: async (data: { groupId: string; scheduledAt: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; hideRsvpCount?: boolean; visibility?: VisibilityLevel; hostUserIds?: Id<"users">[] }) => {
+    mutate: async (data: { groupId: string; scheduledAt: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; hideRsvpCount?: boolean; visibility?: VisibilityLevel; visibleGroupIds?: string[]; hostUserIds?: Id<"users">[] }) => {
       setIsCreating(true);
       try {
         const newMeetingId = await createMeetingMutation({
@@ -479,6 +488,7 @@ export function CreateEventScreen() {
           rsvpOptions: data.rsvpOptions,
           hideRsvpCount: data.hideRsvpCount,
           visibility: data.visibility,
+          visibleGroupIds: data.visibleGroupIds as Id<"groups">[] | undefined,
           hostUserIds: data.hostUserIds,
         });
         // ADR-022 analytics: only fire for non-leader creators so the funnel
@@ -505,7 +515,7 @@ export function CreateEventScreen() {
   // Wrapper for update mutation with state tracking
   // Note: useAuthenticatedMutation auto-injects the token
   const updateMeeting = {
-    mutate: async (data: { meetingId: string; scheduledAt?: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; hideRsvpCount?: boolean; visibility?: VisibilityLevel; notifyGuests?: boolean; hostUserIds?: Id<"users">[] }) => {
+    mutate: async (data: { meetingId: string; scheduledAt?: string; title?: string; meetingType?: number; meetingLink?: string; locationOverride?: string; locationMode?: "address" | "online" | "tbd"; note?: string; coverImage?: string; posterId?: Id<"posters"> | null; rsvpEnabled?: boolean; rsvpOptions?: RsvpOption[]; hideRsvpCount?: boolean; visibility?: VisibilityLevel; visibleGroupIds?: string[]; notifyGuests?: boolean; hostUserIds?: Id<"users">[] }) => {
       setIsUpdating(true);
       try {
         await updateMeetingMutation({
@@ -523,6 +533,7 @@ export function CreateEventScreen() {
           rsvpOptions: data.rsvpOptions,
           hideRsvpCount: data.hideRsvpCount,
           visibility: data.visibility,
+          visibleGroupIds: data.visibleGroupIds as Id<"groups">[] | undefined,
           hostUserIds: data.hostUserIds,
         });
         // Convex automatically updates queries
@@ -805,6 +816,9 @@ export function CreateEventScreen() {
         rsvpOptions: rsvpOptions.filter((opt) => opt.enabled),
         hideRsvpCount: hideRsvpCount,
         visibility: visibility,
+        // Only carry shared-with groups when that's the chosen visibility; an
+        // empty array on edit clears any previously shared-with groups.
+        visibleGroupIds: visibility === "groups" ? visibleGroupIds : [],
         hostUserIds: hostUserIds,
       };
 
@@ -980,6 +994,7 @@ export function CreateEventScreen() {
             rsvpOptions: data.rsvpOptions,
             hideRsvpCount: data.hideRsvpCount,
             visibility: data.visibility,
+            visibleGroupIds: data.visibleGroupIds as Id<"groups">[] | undefined,
           });
           Alert.alert(
             "Series Created",
@@ -1779,6 +1794,14 @@ export function CreateEventScreen() {
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { color: colors.text }]}>Event Visibility</Text>
             <VisibilitySelector value={visibility} onChange={setVisibility} />
+            {visibility === "groups" && community?.id && (
+              <VisibleGroupsSelector
+                communityId={community.id}
+                hostGroupId={effectiveGroupId ?? undefined}
+                value={visibleGroupIds}
+                onChange={setVisibleGroupIds}
+              />
+            )}
           </View>
 
           {/* Event Series - only in edit mode */}

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -176,16 +176,6 @@ export function CreateEventScreen() {
   const [visibility, setVisibility] = useState<VisibilityLevel>("public");
   // Groups the event is explicitly shared with (used when visibility is "groups").
   const [visibleGroupIds, setVisibleGroupIds] = useState<string[]>([]);
-
-  // "Specific Groups" can't carry through a community-wide (group-type) fan-out,
-  // so it's hidden in that mode. If the host had it selected and then enables
-  // community-wide, fall back to "community" so we never persist a "groups"
-  // event with a dropped audience.
-  useEffect(() => {
-    if (isCommunityWideEnabled && visibility === "groups") {
-      setVisibility("community");
-    }
-  }, [isCommunityWideEnabled, visibility]);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(hostingGroupId || null);
   const [isGroupDropdownOpen, setIsGroupDropdownOpen] = useState(false);
 
@@ -311,6 +301,25 @@ export function CreateEventScreen() {
   );
   const meeting = meetingData ?? undefined;
   const isLoadingMeeting = isEditMode && !!meetingId && meetingData === undefined;
+
+  // True when this form targets a community-wide event — either creating one
+  // (the toggle) or editing an existing CWE child. "Specific Groups" can't
+  // carry a hand-picked audience through a group-type fan-out, so it's hidden
+  // in both cases. The edit case matters because the create toggle stays false
+  // when editing; saving a "groups" CWE edit cross-scope would route through
+  // communityWideEvents.update with no visibleGroupIds and silently turn every
+  // child host-group-only.
+  const isCommunityWideContext =
+    isCommunityWideEnabled || (isEditMode && !!meeting?.communityWideEventId);
+
+  // Guard against a stale "groups" selection once we're in a community-wide
+  // context (e.g. host enables the toggle, or a CWE child loads). Falls back to
+  // "community" so we never persist a "groups" event with a dropped audience.
+  useEffect(() => {
+    if (isCommunityWideContext && visibility === "groups") {
+      setVisibility("community");
+    }
+  }, [isCommunityWideContext, visibility]);
 
   // Admin CWE edit: prefill from the parent CWE, not the opened child. The
   // admin screen has to pick *some* child to route through because the edit
@@ -1806,9 +1815,9 @@ export function CreateEventScreen() {
             <VisibilitySelector
               value={visibility}
               onChange={setVisibility}
-              allowSpecificGroups={!isCommunityWideEnabled}
+              allowSpecificGroups={!isCommunityWideContext}
             />
-            {visibility === "groups" && !isCommunityWideEnabled && community?.id && (
+            {visibility === "groups" && !isCommunityWideContext && community?.id && (
               <VisibleGroupsSelector
                 communityId={community.id}
                 hostGroupId={effectiveGroupId ?? undefined}

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -176,6 +176,16 @@ export function CreateEventScreen() {
   const [visibility, setVisibility] = useState<VisibilityLevel>("public");
   // Groups the event is explicitly shared with (used when visibility is "groups").
   const [visibleGroupIds, setVisibleGroupIds] = useState<string[]>([]);
+
+  // "Specific Groups" can't carry through a community-wide (group-type) fan-out,
+  // so it's hidden in that mode. If the host had it selected and then enables
+  // community-wide, fall back to "community" so we never persist a "groups"
+  // event with a dropped audience.
+  useEffect(() => {
+    if (isCommunityWideEnabled && visibility === "groups") {
+      setVisibility("community");
+    }
+  }, [isCommunityWideEnabled, visibility]);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(hostingGroupId || null);
   const [isGroupDropdownOpen, setIsGroupDropdownOpen] = useState(false);
 
@@ -1793,8 +1803,12 @@ export function CreateEventScreen() {
           {/* Visibility */}
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { color: colors.text }]}>Event Visibility</Text>
-            <VisibilitySelector value={visibility} onChange={setVisibility} />
-            {visibility === "groups" && community?.id && (
+            <VisibilitySelector
+              value={visibility}
+              onChange={setVisibility}
+              allowSpecificGroups={!isCommunityWideEnabled}
+            />
+            {visibility === "groups" && !isCommunityWideEnabled && community?.id && (
               <VisibleGroupsSelector
                 communityId={community.id}
                 hostGroupId={effectiveGroupId ?? undefined}

--- a/apps/mobile/features/leader-tools/components/VisibilitySelector.tsx
+++ b/apps/mobile/features/leader-tools/components/VisibilitySelector.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 
-export type VisibilityLevel = "group" | "community" | "public";
+export type VisibilityLevel = "group" | "groups" | "community" | "public";
 
 interface VisibilitySelectorProps {
   value: VisibilityLevel;
@@ -25,6 +25,12 @@ const VISIBILITY_OPTIONS: VisibilityOption[] = [
     label: "Group Only",
     icon: "people",
     description: "Only group members can see and RSVP",
+  },
+  {
+    value: "groups",
+    label: "Specific Groups",
+    icon: "people-circle",
+    description: "Members of the groups you choose can see and RSVP",
   },
   {
     value: "community",

--- a/apps/mobile/features/leader-tools/components/VisibilitySelector.tsx
+++ b/apps/mobile/features/leader-tools/components/VisibilitySelector.tsx
@@ -10,6 +10,12 @@ export type VisibilityLevel = "group" | "groups" | "community" | "public";
 interface VisibilitySelectorProps {
   value: VisibilityLevel;
   onChange: (value: VisibilityLevel) => void;
+  /**
+   * When false, the "Specific Groups" option is hidden. Used by community-wide
+   * flows, where the event fans out across a group type and a hand-picked
+   * audience can't be carried through to each child meeting.
+   */
+  allowSpecificGroups?: boolean;
 }
 
 interface VisibilityOption {
@@ -46,13 +52,21 @@ const VISIBILITY_OPTIONS: VisibilityOption[] = [
   },
 ];
 
-export function VisibilitySelector({ value, onChange }: VisibilitySelectorProps) {
+export function VisibilitySelector({
+  value,
+  onChange,
+  allowSpecificGroups = true,
+}: VisibilitySelectorProps) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
 
+  const options = allowSpecificGroups
+    ? VISIBILITY_OPTIONS
+    : VISIBILITY_OPTIONS.filter((o) => o.value !== "groups");
+
   return (
     <View style={styles.container}>
-      {VISIBILITY_OPTIONS.map((option) => {
+      {options.map((option) => {
         const isSelected = value === option.value;
         return (
           <TouchableOpacity

--- a/apps/mobile/features/leader-tools/components/VisibleGroupsSelector.tsx
+++ b/apps/mobile/features/leader-tools/components/VisibleGroupsSelector.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo } from "react";
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useQuery as useConvexQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useTheme } from "@hooks/useTheme";
+
+interface VisibleGroupsSelectorProps {
+  communityId: string;
+  /** The hosting group — always has access, so it's excluded from the list. */
+  hostGroupId?: string;
+  /** Currently selected group ids. */
+  value: string[];
+  onChange: (groupIds: string[]) => void;
+}
+
+/**
+ * Multi-select checklist of community groups for the "Specific Groups"
+ * visibility level. Members of the hosting group plus any selected group can
+ * see and RSVP, so the hosting group is omitted here.
+ */
+export function VisibleGroupsSelector({
+  communityId,
+  hostGroupId,
+  value,
+  onChange,
+}: VisibleGroupsSelectorProps) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const groups = useConvexQuery(
+    api.functions.groups.queries.listByCommunity,
+    communityId
+      ? {
+          communityId: communityId as Id<"communities">,
+          includePrivate: true,
+          limit: 200,
+        }
+      : "skip"
+  );
+
+  const selectableGroups = useMemo(
+    () => (groups ?? []).filter((g: any) => g._id !== hostGroupId),
+    [groups, hostGroupId]
+  );
+
+  const selected = useMemo(() => new Set(value), [value]);
+
+  const toggle = (groupId: string) => {
+    const next = new Set(selected);
+    if (next.has(groupId)) {
+      next.delete(groupId);
+    } else {
+      next.add(groupId);
+    }
+    onChange(Array.from(next));
+  };
+
+  if (groups === undefined) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="small" color={primaryColor} />
+      </View>
+    );
+  }
+
+  if (selectableGroups.length === 0) {
+    return (
+      <Text style={[styles.empty, { color: colors.textSecondary }]}>
+        No other groups available to share with.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.helper, { color: colors.textSecondary }]}>
+        Choose which groups can see and RSVP to this event.
+      </Text>
+      {selectableGroups.map((group: any) => {
+        const isSelected = selected.has(group._id);
+        return (
+          <TouchableOpacity
+            key={group._id}
+            style={[
+              styles.row,
+              { backgroundColor: colors.surface, borderColor: colors.border },
+              isSelected && { borderColor: primaryColor, backgroundColor: colors.surfaceSecondary },
+            ]}
+            onPress={() => toggle(group._id)}
+            activeOpacity={0.7}
+          >
+            <View
+              style={[
+                styles.checkbox,
+                { borderColor: colors.border },
+                isSelected && { borderColor: primaryColor, backgroundColor: primaryColor },
+              ]}
+            >
+              {isSelected && <Ionicons name="checkmark" size={14} color="#fff" />}
+            </View>
+            <Text style={[styles.label, { color: colors.text }]} numberOfLines={1}>
+              {group.name}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 8,
+    marginTop: 8,
+  },
+  helper: {
+    fontSize: 13,
+    marginBottom: 2,
+  },
+  loading: {
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  empty: {
+    fontSize: 13,
+    fontStyle: "italic",
+    marginTop: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 8,
+    borderWidth: 2,
+    padding: 12,
+  },
+  checkbox: {
+    width: 20,
+    height: 20,
+    borderRadius: 4,
+    borderWidth: 2,
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 10,
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "500",
+    flex: 1,
+  },
+});

--- a/apps/web/src/pages/guides/Events.tsx
+++ b/apps/web/src/pages/guides/Events.tsx
@@ -113,8 +113,13 @@ export function Events() {
           </Step>
           <Step n={5}>
             <strong>Visibility.</strong> Choose <Term>Group Only</Term>,{" "}
-            <Term>Community</Term>, or <Term>Public</Term>. Public means anyone
-            with the link can view the event; RSVPing still requires login.
+            <Term>Specific Groups</Term>, <Term>Community</Term>, or{" "}
+            <Term>Public</Term>. <Term>Specific Groups</Term> lets you pick a
+            handful of groups whose members can see and RSVP alongside the
+            hosting group — handy for an event aimed at a few teams (say, a
+            leaders' dinner across several locations) without opening it to the
+            whole community. Public means anyone with the link can view the
+            event; RSVPing still requires login.
           </Step>
         </Steps>
 


### PR DESCRIPTION
## Summary

Adds a fourth **Event Visibility** level, **"Specific Groups"**, letting a host share an event with a hand-picked set of groups in addition to the hosting group. Members of any shared-with group can both **see and RSVP**, without opening the event to the whole community.

This is driven by a real request (a leaders' dinner / prayer night aimed at a few teams like Brooklyn + Manhattan, not the whole church). The event stays a single record hosted by one group — this is a visibility expansion, not a multi-group duplication (that's the separate admin-only "Create for multiple groups" flow).

## Behavior

- **One event, broader visibility** — hosted by one group; members of the selected groups can see and RSVP alongside the hosting group.
- **Group pool** — the picker lists all groups in the community.

## Changes

**Backend**
- New optional `visibleGroupIds` field on `meetings`; stored only when visibility is `"groups"`, validated to the same community and de-duped (drops the hosting group, which always has access).
- Threaded through `create`, `update` (with series cascade + clearing when visibility moves away from `"groups"`), and `createSeriesEvents`.
- Extended every visibility gate: shared `isVisible()`, the two inline filters in `explore.ts` (community feed + search), the public share page (`getByShortId`), and the RSVP + attendance membership checks.

**Frontend**
- "Specific Groups" radio in `VisibilitySelector`.
- New `VisibleGroupsSelector` multi-select listing community groups, shown when that level is chosen; wired through the create/update/series flows.

**Docs / tests**
- Updated the Events onboarding guide.
- Added visibility tests covering hosting-group members, shared-with-group members, outside-community members, and unauthenticated viewers.

## Visibility coverage

Audited every path events are queried/access-controlled. Confirmed handled: Events tab (`listForEventsTab`), later-events pagination, CWE children, Explore feed, event search, user-profile upcoming events, "my events" buckets, public share page, RSVP, and attendance. Group-scoped listings (a group's own page) intentionally don't cross-list shared events; notification/reminder/blast recipients are pre-filtered by RSVP access, so they don't re-filter by visibility.

## Testing

- Convex visibility / RSVP / attendance suites pass (203 tests across touched areas).
- Full mobile suite passes (1086 tests, via pre-push hook).
- TypeScript clean for all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJmQFC8ef6D5dEWxRGwEz3)_