### PR TITLE
feat(chat): basketball send button in channel composer

### DIFF
--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -1149,7 +1149,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
           {isSending ? (
             <ActivityIndicator size="small" color="#fff" />
           ) : (
-            <Ionicons name="send" size={20} color="#fff" />
+            <Ionicons name="basketball" size={20} color="#fff" />
           )}
         </Pressable>
       </View>

--- a/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
+++ b/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
@@ -298,7 +298,7 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
             </Pressable>
             {/* Send */}
             <Pressable style={[styles.iconButton, styles.sendButton, { backgroundColor: colors.link }]} onPress={handleSend}>
-              <Ionicons name="send" size={20} color="#fff" />
+              <Ionicons name="basketball" size={20} color="#fff" />
             </Pressable>
           </>
         )}


### PR DESCRIPTION
## What

Continues the Knicks theme — swaps the channel composer's **send icon** from the paper-plane to a 🏀 **basketball**, in both:
- the text message input (`MessageInput.tsx`)
- the voice-message recorder bar (`VoiceRecorderBar.tsx`)

The separate Reach-Out and Broadcast composers are intentionally left as-is (not "channels").

## Verification

- Lint + pre-push mobile tests pass
- Verified live in the browser: the channel send button renders a basketball

🤖 Generated with [Claude Code](https://claude.com/claude-code)