### PR TITLE
fix(notifications): clear & collapse a chat channel's OS push notifications

### DIFF
--- a/apps/convex/__tests__/notifications-internal-push.test.ts
+++ b/apps/convex/__tests__/notifications-internal-push.test.ts
@@ -43,4 +43,67 @@ describe("sendBatchPushNotifications", () => {
     expect(requestBody[0].richContent).toBeUndefined();
     expect(requestBody[0].data.type).toBe("new_message");
   });
+
+  test("collapses chat notifications per channel via collapseId + tag", async () => {
+    const t = convexTest(schema, modules);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "ticket-1", status: "ok" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(
+      internal.functions.notifications.internal.sendBatchPushNotifications,
+      {
+        notifications: [
+          {
+            token: "ExponentPushToken[chat-collapse-test]",
+            title: "Test Sender",
+            body: "Test Group: General\nMessage body",
+            data: {
+              type: "new_message",
+              groupId: "group_123",
+              channelId: "channel_123",
+            },
+          },
+        ],
+      }
+    );
+
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    // Same channel id keys both fields so a new message replaces the channel's
+    // existing tray card (iOS uses collapseId, Android uses tag).
+    expect(requestBody[0].collapseId).toBe("channel_123");
+    expect(requestBody[0].tag).toBe("channel_123");
+  });
+
+  test("leaves non-chat notifications uncollapsed (no channelId)", async () => {
+    const t = convexTest(schema, modules);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "ticket-1", status: "ok" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(
+      internal.functions.notifications.internal.sendBatchPushNotifications,
+      {
+        notifications: [
+          {
+            token: "ExponentPushToken[non-chat-test]",
+            title: "Join request",
+            body: "Someone wants to join your group",
+            data: {
+              type: "join_request_received",
+              groupId: "group_123",
+            },
+          },
+        ],
+      }
+    );
+
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(requestBody[0].collapseId).toBeUndefined();
+    expect(requestBody[0].tag).toBeUndefined();
+  });
 });

--- a/apps/convex/__tests__/notifications-internal-push.test.ts
+++ b/apps/convex/__tests__/notifications-internal-push.test.ts
@@ -44,8 +44,16 @@ describe("sendBatchPushNotifications", () => {
     expect(requestBody[0].data.type).toBe("new_message");
   });
 
-  test("collapses chat notifications per channel via collapseId + tag", async () => {
+  test("collapses chat notifications per channel when the flag is enabled", async () => {
     const t = convexTest(schema, modules);
+    // The collapse behavior is gated by the app-wide feature flag — enable it.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("featureFlags", {
+        key: "chat-notification-collapse",
+        enabled: true,
+        updatedAt: Date.now(),
+      });
+    });
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ data: [{ id: "ticket-1", status: "ok" }] }),
@@ -75,6 +83,38 @@ describe("sendBatchPushNotifications", () => {
     // existing tray card (iOS uses collapseId, Android uses tag).
     expect(requestBody[0].collapseId).toBe("channel_123");
     expect(requestBody[0].tag).toBe("channel_123");
+  });
+
+  test("does not collapse chat notifications when the flag is disabled (default)", async () => {
+    const t = convexTest(schema, modules);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "ticket-1", status: "ok" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(
+      internal.functions.notifications.internal.sendBatchPushNotifications,
+      {
+        notifications: [
+          {
+            token: "ExponentPushToken[chat-collapse-off-test]",
+            title: "Test Sender",
+            body: "Test Group: General\nMessage body",
+            data: {
+              type: "new_message",
+              groupId: "group_123",
+              channelId: "channel_123",
+            },
+          },
+        ],
+      }
+    );
+
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    // No featureFlags row → flag default-off → chat notifications stack as before.
+    expect(requestBody[0].collapseId).toBeUndefined();
+    expect(requestBody[0].tag).toBeUndefined();
   });
 
   test("leaves non-chat notifications uncollapsed (no channelId)", async () => {

--- a/apps/convex/functions/notifications/internal.ts
+++ b/apps/convex/functions/notifications/internal.ts
@@ -7,6 +7,7 @@
 
 import { v } from "convex/values";
 import { internalQuery, internalAction } from "../../_generated/server";
+import { api } from "../../_generated/api";
 import { Id } from "../../_generated/dataModel";
 import { COMMUNITY_ADMIN_THRESHOLD } from "../../lib/permissions";
 import { isLeaderRole } from "../../lib/helpers";
@@ -365,6 +366,13 @@ export const sendEmailNotification = internalAction({
 });
 
 /**
+ * App-wide feature flag (see `functions/admin/featureFlags.ts`) gating whether
+ * chat pushes collapse to one tray card per channel. Default-off: until a
+ * superuser flips it on in /admin/features, chat notifications stack normally.
+ */
+const CHAT_NOTIFICATION_COLLAPSE_FLAG = "chat-notification-collapse";
+
+/**
  * Read a chat channel id from a notification's `data` payload.
  *
  * Chat pushes carry `channelId` at the top level; iOS sometimes nests fields
@@ -395,10 +403,22 @@ export const sendBatchPushNotifications = internalAction({
       })
     ),
   },
-  handler: async (_ctx, args) => {
+  handler: async (ctx, args) => {
     if (args.notifications.length === 0) {
       return { success: true, ticketIds: [], errors: [], tickets: [] };
     }
+
+    // Per-channel collapse is gated by an app-wide feature flag. Only chat
+    // pushes carry a channelId, so skip the flag read entirely for non-chat
+    // batches (the common case for most notification types).
+    const hasChannelScopedPush = args.notifications.some((n) =>
+      extractChannelId(n.data)
+    );
+    const collapseChatNotifications = hasChannelScopedPush
+      ? await ctx.runQuery(api.functions.admin.featureFlags.getFeatureFlag, {
+          key: CHAT_NOTIFICATION_COLLAPSE_FLAG,
+        })
+      : false;
 
     try {
       const response = await fetch("https://exp.host/--/api/v2/push/send", {
@@ -441,7 +461,9 @@ export const sendBatchPushNotifications = internalAction({
             // - collapseId (iOS): replaces the already-displayed notification.
             // - tag (Android): replaces the already-displayed notification
             //   (collapseId on Android only coalesces in transit, not on-device).
-            const channelId = extractChannelId(n.data);
+            const channelId = collapseChatNotifications
+              ? extractChannelId(n.data)
+              : undefined;
             if (channelId) {
               message.collapseId = channelId;
               message.tag = channelId;

--- a/apps/convex/functions/notifications/internal.ts
+++ b/apps/convex/functions/notifications/internal.ts
@@ -365,6 +365,22 @@ export const sendEmailNotification = internalAction({
 });
 
 /**
+ * Read a chat channel id from a notification's `data` payload.
+ *
+ * Chat pushes carry `channelId` at the top level; iOS sometimes nests fields
+ * under `data.data`, so both levels are checked (mirrors the mobile-side
+ * extraction in `resolveNotificationNavigation` and `dismissChannelNotifications`).
+ * Returns undefined for non-chat notifications, which carry no channelId.
+ */
+function extractChannelId(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const record = data as Record<string, unknown>;
+  const nested = record.data as Record<string, unknown> | undefined;
+  const channelId = record.channelId ?? nested?.channelId;
+  return typeof channelId === "string" ? channelId : undefined;
+}
+
+/**
  * Send batch push notifications
  */
 export const sendBatchPushNotifications = internalAction({
@@ -401,6 +417,8 @@ export const sendBatchPushNotifications = internalAction({
               data: unknown;
               richContent?: { image: string };
               mutableContent?: boolean;
+              collapseId?: string;
+              tag?: string;
             } = {
               to: n.token,
               title: n.title,
@@ -412,6 +430,21 @@ export const sendBatchPushNotifications = internalAction({
             if (n.imageUrl) {
               // Expo maps richContent.image to platform-specific rich media payloads.
               message.richContent = { image: n.imageUrl };
+            }
+
+            // Collapse chat notifications per channel so a new message replaces
+            // that channel's existing tray card instead of stacking a new one.
+            // Only chat-type pushes carry a channelId, so non-chat notifications
+            // are left untouched. Expo's push service has no iOS thread-id field
+            // (grouping needs unreleased native work — see expo/expo#43388), so
+            // collapse/replace is the no-native-dep way to keep the tray tidy.
+            // - collapseId (iOS): replaces the already-displayed notification.
+            // - tag (Android): replaces the already-displayed notification
+            //   (collapseId on Android only coalesces in transit, not on-device).
+            const channelId = extractChannelId(n.data);
+            if (channelId) {
+              message.collapseId = channelId;
+              message.tag = channelId;
             }
 
             return message;

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -33,6 +33,7 @@ import { useTheme } from "@hooks/useTheme";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { ReactionsProvider } from "@/features/chat/context/ReactionsContext";
 import { useReadState } from "@/features/chat/hooks/useReadState";
+import { dismissChannelNotifications } from "@features/notifications/utils/dismissChannelNotifications";
 import { Ionicons } from "@expo/vector-icons";
 import { EventComment } from "./EventComment";
 import { EventCommentSheet } from "./EventCommentSheet";
@@ -170,6 +171,10 @@ export function EventActivity({
       // Silently swallow — markAsRead also no-ops for ad-hoc channels with
       // missing profile photo. We don't want a toast here.
     });
+    // Sweep this channel's stacked OS push notifications from the tray (same
+    // rationale as ConvexChatRoomScreen — expo-notifications only auto-clears
+    // the single tapped notification).
+    dismissChannelNotifications(channelId);
   }, [channelId, canAccess, latestMessageId, markAsRead]);
 
   const handleLoadOlder = useCallback(() => {

--- a/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
+++ b/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
@@ -47,6 +47,11 @@ const KNOWN_FLAGS: Array<{ key: string; description: string }> = [
     description:
       "1:1 direct messages and ad-hoc group chats. Enables the compose button on the inbox, the start-chat picker, and the request-flow inbox.",
   },
+  {
+    key: "chat-notification-collapse",
+    description:
+      "Collapse a chat channel's push notifications into a single tray card — a new message replaces that channel's existing notification instead of stacking a new one. Off: each message shows its own notification.",
+  },
 ];
 
 type FlagRow = {

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -26,6 +26,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useLocalSearchParams, usePathname, useRouter } from "expo-router";
 import { useAuth } from "@providers/AuthProvider";
 import { useNotifications } from "@providers/NotificationProvider";
+import { dismissChannelNotifications } from "@features/notifications/utils/dismissChannelNotifications";
 import { useLeaveGroup } from "@features/groups/hooks/useLeaveGroup";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
@@ -490,6 +491,10 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   useEffect(() => {
     if (activeChannelId && currentUserId) {
       markAsRead();
+      // Clear this channel's stacked OS push notifications from the tray —
+      // expo-notifications only auto-clears the single tapped notification, so
+      // siblings linger until we sweep them here.
+      dismissChannelNotifications(activeChannelId);
     }
   }, [activeChannelId, currentUserId, markAsRead]);
 

--- a/apps/mobile/features/notifications/utils/__tests__/dismissChannelNotifications.test.ts
+++ b/apps/mobile/features/notifications/utils/__tests__/dismissChannelNotifications.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for dismissChannelNotifications — the OS-tray sweep that removes a
+ * chat channel's stacked push notifications when the channel is opened.
+ *
+ * The native tray behavior itself can't be unit-tested, so these tests cover
+ * the filter logic: only notifications whose payload channel id matches are
+ * dismissed, the nested `data.data.channelId` shape is supported, and errors
+ * never escape (tray cleanup is best-effort).
+ *
+ * Run with: cd apps/mobile && pnpm test features/notifications/utils/__tests__/dismissChannelNotifications.test.ts
+ */
+
+import { dismissChannelNotifications } from "../dismissChannelNotifications";
+
+jest.mock("expo-notifications", () => ({
+  getPresentedNotificationsAsync: jest.fn(),
+  dismissNotificationAsync: jest.fn(),
+}));
+
+import * as Notifications from "expo-notifications";
+
+const mockGetPresented =
+  Notifications.getPresentedNotificationsAsync as unknown as jest.Mock;
+const mockDismiss =
+  Notifications.dismissNotificationAsync as unknown as jest.Mock;
+
+/** Build a minimal presented-notification shape with the given data payload. */
+function makePresented(identifier: string, data: Record<string, unknown>) {
+  return {
+    request: {
+      identifier,
+      content: { data },
+    },
+  };
+}
+
+describe("dismissChannelNotifications", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDismiss.mockResolvedValue(undefined);
+  });
+
+  it("dismisses only notifications matching the channel id (top-level and nested)", async () => {
+    mockGetPresented.mockResolvedValue([
+      makePresented("match-top", { channelId: "chan_1" }),
+      makePresented("match-nested", { data: { channelId: "chan_1" } }),
+      makePresented("other-channel", { channelId: "chan_2" }),
+      makePresented("no-channel", { type: "new_message" }),
+    ]);
+
+    await dismissChannelNotifications("chan_1");
+
+    expect(mockDismiss).toHaveBeenCalledTimes(2);
+    expect(mockDismiss).toHaveBeenCalledWith("match-top");
+    expect(mockDismiss).toHaveBeenCalledWith("match-nested");
+    expect(mockDismiss).not.toHaveBeenCalledWith("other-channel");
+    expect(mockDismiss).not.toHaveBeenCalledWith("no-channel");
+  });
+
+  it("does nothing when channelId is empty", async () => {
+    await dismissChannelNotifications("");
+
+    expect(mockGetPresented).not.toHaveBeenCalled();
+    expect(mockDismiss).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors from getPresentedNotificationsAsync without throwing", async () => {
+    mockGetPresented.mockRejectedValue(new Error("native bridge unavailable"));
+
+    await expect(dismissChannelNotifications("chan_1")).resolves.toBeUndefined();
+    expect(mockDismiss).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors from an individual dismiss without throwing", async () => {
+    mockGetPresented.mockResolvedValue([
+      makePresented("match-top", { channelId: "chan_1" }),
+    ]);
+    mockDismiss.mockRejectedValue(new Error("already dismissed"));
+
+    await expect(dismissChannelNotifications("chan_1")).resolves.toBeUndefined();
+    expect(mockDismiss).toHaveBeenCalledWith("match-top");
+  });
+});

--- a/apps/mobile/features/notifications/utils/dismissChannelNotifications.ts
+++ b/apps/mobile/features/notifications/utils/dismissChannelNotifications.ts
@@ -1,0 +1,53 @@
+/**
+ * Dismiss every delivered OS push notification belonging to a chat channel.
+ *
+ * `expo-notifications` only auto-clears the single notification a user taps.
+ * When several pushes from the SAME channel are stacked in the OS tray, the
+ * siblings linger after the user has read the channel. Every chat push already
+ * carries its channel id at `content.data.channelId` (set backend-side in
+ * `apps/convex/functions/messaging/events.ts`); this helper uses that id to
+ * sweep the tray and remove the stragglers when the channel is opened.
+ *
+ * iOS push payloads sometimes nest fields under `data.data`, so the channel id
+ * is read from both levels — mirroring `resolveNotificationNavigation.ts`.
+ *
+ * This is a best-effort, fire-and-forget cleanup: it must NEVER throw into a
+ * screen render, so the whole body is guarded.
+ */
+import * as Notifications from "expo-notifications";
+
+/** Read a channel id from a notification's data payload (top-level or nested). */
+function extractChannelId(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const record = data as Record<string, unknown>;
+  const nested = record.data as Record<string, unknown> | undefined;
+  const channelId = record.channelId ?? nested?.channelId;
+  return typeof channelId === "string" ? channelId : undefined;
+}
+
+/**
+ * Remove all delivered notifications for `channelId` from the OS tray.
+ *
+ * @param channelId The `Id<"chatChannels">` of the opened channel.
+ */
+export async function dismissChannelNotifications(channelId: string): Promise<void> {
+  if (!channelId) return;
+
+  try {
+    const presented = await Notifications.getPresentedNotificationsAsync();
+    await Promise.all(
+      presented
+        .filter(
+          (notification) =>
+            extractChannelId(notification.request.content.data) === channelId,
+        )
+        .map((notification) =>
+          Notifications.dismissNotificationAsync(notification.request.identifier).catch(
+            () => {},
+          ),
+        ),
+    );
+  } catch {
+    // Tray cleanup is best-effort — never surface an error into the UI.
+  }
+}


### PR DESCRIPTION
## Problem

On the OS push tray (lock screen / notification shade), when a user had several pushes from the **same chat channel** and tapped one, only that one was removed — the siblings lingered. `expo-notifications` only auto-clears the single tapped notification, and the app never dismissed the rest, even though every chat push already carries its `channelId`.

## What this does

Three commits, each independently understandable:

### 1. Dismiss a channel's stacked pushes when it's opened
- New helper `apps/mobile/features/notifications/utils/dismissChannelNotifications.ts` — sweeps the delivered tray via `getPresentedNotificationsAsync()` and `dismissNotificationAsync()`, removing every notification whose payload `channelId` matches (reads both top-level and the nested `data.data` shape, mirroring `resolveNotificationNavigation`). Best-effort and fully guarded so tray cleanup can never throw into a render.
- Wired into the two channel-open `markAsRead` mount effects: `ConvexChatRoomScreen` and `EventActivity`. Opening a channel — by in-app nav **or** by tapping one of its pushes — now clears all of that channel's notifications.

### 2. Collapse a channel's chat pushes into one tray card
- Backend push payload (`apps/convex/functions/notifications/internal.ts`) now sets `collapseId` (iOS) + `tag` (Android), keyed on the chat `channelId`, so a new message **replaces** that channel's existing tray card instead of stacking a new one. Net effect: at most one notification per channel.
- Only chat pushes carry a `channelId`, so non-chat notifications (join requests, events, etc.) are untouched.

### 3. Gate the collapse behind a feature flag (default-off)
- The one-card-per-channel collapse is a behavior change we're not sure we want on for everyone, so it's gated by the app-wide **`chat-notification-collapse`** flag (the `featureFlags` system flipped at `/admin/features`).
- **Default-off**: until a superuser enables it, chat pushes stack exactly as before. The flag is read once per batch, and only when a chat push is present.
- Registered in the `/admin/features` catalog (`KNOWN_FLAGS`) so superusers can see and toggle it.

## Why not true threading?

True conversation threading (iOS `thread-id` / Android groups) isn't reachable through Expo's managed push service — the message format exposes no `threadId`, and the native support is still **unmerged** ([expo/expo#43388](https://github.com/expo/expo/pull/43388)). That path needs a native `expo-notifications` bump + `runtimeVersion` change, which our native-dep rules forbid. `collapseId` + `tag` are supported by the Expo relay and are a pure payload change, giving a decluttered tray with no native surface.

## Out of scope / follow-ups
- Native visual threading (when expo/expo#43388 ships and we're ready to bump native + `runtimeVersion`).
- Per-community granularity — the flag is the **global** `featureFlags` table, so it's all-or-nothing; per-community would be a separate `churchFeatures`-style change.
- Badge-count management and per-channel unread counts in the collapsed card.

## Testing
- New: `dismissChannelNotifications.test.ts` (4 cases — matching/nested/non-matching/no-channelId filter + error swallowing).
- `notifications-internal-push.test.ts` extended (4 cases — collapses when flag on, stacks when flag off/default, non-chat untouched).
- Full mobile suite green (1090 passing); convex push suite green; `tsc` clean on both packages.
- **Manual note:** the OS tray itself can't be exercised in CI — coverage is unit tests + typecheck; real-device confirmation is the remaining manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7YdM7NCxYBaxRxN3rKMMH)_