### PR TITLE
fix(images): preserve EXIF orientation in Cloudflare transforms

### DIFF
--- a/apps/convex/lib/utils.ts
+++ b/apps/convex/lib/utils.ts
@@ -211,6 +211,11 @@ export function getMediaUrlWithTransform(
   if (options.height) transforms.push(`height=${options.height}`);
   if (options.fit) transforms.push(`fit=${options.fit}`);
   if (options.quality) transforms.push(`quality=${options.quality}`);
+  // Preserve EXIF metadata so the orientation tag survives the transform.
+  // Without this, Cloudflare strips the orientation tag without rotating the
+  // pixels, so photos taken in a rotated orientation render upside-down in
+  // transformed images while the untransformed original displays correctly.
+  transforms.push("metadata=keep");
   transforms.push("format=auto"); // Always optimize format (WebP/AVIF)
 
   const transformString = transforms.join(",");

--- a/apps/mobile/utils/__tests__/media.test.ts
+++ b/apps/mobile/utils/__tests__/media.test.ts
@@ -1,0 +1,63 @@
+import { getMediaUrl, getMediaUrlWithTransform } from '../media';
+
+const CDN = 'https://images.togather.nyc';
+
+describe('getMediaUrl', () => {
+  test('returns undefined for empty input', () => {
+    expect(getMediaUrl(undefined)).toBeUndefined();
+    expect(getMediaUrl(null)).toBeUndefined();
+    expect(getMediaUrl('')).toBeUndefined();
+  });
+
+  test('returns http(s) URLs as-is', () => {
+    expect(getMediaUrl('https://example.com/a.jpg')).toBe('https://example.com/a.jpg');
+    expect(getMediaUrl('http://example.com/a.jpg')).toBe('http://example.com/a.jpg');
+  });
+
+  test('returns local file URIs as-is', () => {
+    expect(getMediaUrl('file:///tmp/a.jpg')).toBe('file:///tmp/a.jpg');
+  });
+
+  test('expands r2: paths to the CDN URL', () => {
+    expect(getMediaUrl('r2:chat/a.jpg')).toBe(`${CDN}/chat/a.jpg`);
+  });
+
+  test('returns undefined for unrecognized paths', () => {
+    expect(getMediaUrl('s3:bucket/a.jpg')).toBeUndefined();
+  });
+});
+
+describe('getMediaUrlWithTransform', () => {
+  test('preserves EXIF metadata so orientation survives the transform', () => {
+    // Regression: without metadata=keep, Cloudflare strips the orientation tag
+    // without rotating the pixels, so rotated photos render upside-down inline.
+    const url = getMediaUrlWithTransform('r2:chat/a.jpg', { width: 400 });
+    expect(url).toContain('metadata=keep');
+  });
+
+  test('builds a same-zone cdn-cgi transform URL with the expected options', () => {
+    const url = getMediaUrlWithTransform('r2:chat/a.jpg', {
+      width: 400,
+      height: 300,
+      fit: 'cover',
+      quality: 85,
+    });
+    expect(url).toBe(
+      `${CDN}/cdn-cgi/image/width=400,height=300,fit=cover,quality=85,metadata=keep,format=auto/chat/a.jpg`
+    );
+  });
+
+  test('always requests automatic format optimization', () => {
+    const url = getMediaUrlWithTransform('r2:chat/a.jpg', { width: 400 });
+    expect(url).toContain('format=auto');
+  });
+
+  test('does not apply transforms to non-R2 (legacy) images', () => {
+    const legacy = 'https://example.com/a.jpg';
+    expect(getMediaUrlWithTransform(legacy, { width: 400 })).toBe(legacy);
+  });
+
+  test('returns undefined when the path cannot be resolved', () => {
+    expect(getMediaUrlWithTransform(undefined, { width: 400 })).toBeUndefined();
+  });
+});

--- a/apps/mobile/utils/media.ts
+++ b/apps/mobile/utils/media.ts
@@ -61,7 +61,7 @@ export function getMediaUrl(path: string | null | undefined): string | undefined
  *
  * @example
  * getMediaUrlWithTransform('r2:profiles/abc.jpg', { width: 100, height: 100 })
- * // => '{R2_PUBLIC_URL}/cdn-cgi/image/width=100,height=100,fit=cover,format=auto/profiles/abc.jpg'
+ * // => '{R2_PUBLIC_URL}/cdn-cgi/image/width=100,height=100,fit=cover,metadata=keep,format=auto/profiles/abc.jpg'
  */
 export function getMediaUrlWithTransform(
   path: string | null | undefined,
@@ -86,6 +86,13 @@ export function getMediaUrlWithTransform(
   if (options.height) transforms.push(`height=${options.height}`);
   if (options.fit) transforms.push(`fit=${options.fit}`);
   if (options.quality) transforms.push(`quality=${options.quality}`);
+  // Preserve EXIF metadata so the orientation tag survives the transform.
+  // Without this, Cloudflare strips the orientation tag without rotating the
+  // pixels, so photos taken in a rotated orientation render upside-down in
+  // transformed thumbnails (while the untransformed full-size original, which
+  // still carries the tag, displays correctly). Keeping metadata lets the
+  // client apply the rotation just like it does for the original.
+  transforms.push('metadata=keep');
   transforms.push('format=auto'); // Always optimize format (WebP/AVIF)
 
   const transformString = transforms.join(',');


### PR DESCRIPTION
## Problem

Photos taken in a rotated orientation rendered **upside-down in inline chat thumbnails** while displaying **correctly in the full-screen viewer**.

## Root cause

The inline chat grid (`ImageAttachmentsGrid.tsx`) routes images through Cloudflare Image Transformations (`getMediaUrlWithTransform` → `/cdn-cgi/image/...`), whereas the full-screen viewer (`ImageViewer.tsx`) loads the **untransformed original**.

The transform stripped the EXIF orientation tag *without* baking the rotation into the pixels, so the client had no way to orient the image. The original still carries the tag, so the viewer rotated it correctly — which is why one was wrong and the other right.

## Fix

Add `metadata=keep` to the transform options so the orientation tag survives the transform and the client applies the rotation, matching the original. Applied to both the mobile (`apps/mobile/utils/media.ts`) and convex (`apps/convex/lib/utils.ts`) helpers, which mirror each other (the convex one powers notification/email images, which had the identical bug).

- Ships via OTA, no native dependency
- Fixes **existing images** too, since it only changes the request URL
- No new privacy concern — the originals already serve full EXIF via the viewer's `getMediaUrl`

## Tests

- New `apps/mobile/utils/__tests__/media.test.ts` covering both URL helpers, including a regression test asserting the orientation tag survives.
- Full mobile suite (1100 tests) and convex uploads suites pass.

## Verification note

I couldn't run the real app against the live CDN from the dev environment, so a quick visual check in the simulator (or reopening the affected thread on a build) is worthwhile to confirm the previously-broken photo now displays upright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELusNhC8Qifv7y1ZyQPNhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELusNhC8Qifv7y1ZyQPNhZ)_