### PR TITLE
fix(theme): restore default chat icons when Knicks mode is off

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -9,7 +9,7 @@ import { DesktopSideNav } from '@components/DesktopSideNav';
 
 export default function TabsLayout() {
   const { user, community } = useAuth();
-  const { primaryColor } = useCommunityTheme();
+  const { primaryColor, isKnicksMode } = useCommunityTheme();
   const { colors } = useTheme();
   const isDesktopWeb = useIsDesktopWeb();
   const isAdmin = user?.is_admin === true;
@@ -117,7 +117,15 @@ export default function TabsLayout() {
           href: hasCommunity ? '/(tabs)/chat' : null,
           tabBarIcon: ({ color, focused }) => (
             <Ionicons
-              name={focused ? 'basketball' : 'basketball-outline'}
+              name={
+                isKnicksMode
+                  ? focused
+                    ? 'basketball'
+                    : 'basketball-outline'
+                  : focused
+                    ? 'chatbubbles'
+                    : 'chatbubbles-outline'
+              }
               size={24}
               color={color}
             />

--- a/apps/mobile/components/DesktopSideNav.tsx
+++ b/apps/mobile/components/DesktopSideNav.tsx
@@ -22,7 +22,7 @@ type NavItem = {
 export function DesktopSideNav() {
   const pathname = usePathname();
   const { user, community } = useAuth();
-  const { primaryColor } = useCommunityTheme();
+  const { primaryColor, isKnicksMode } = useCommunityTheme();
   const { colors } = useTheme();
 
   const isAdmin = user?.is_admin === true;
@@ -50,8 +50,12 @@ export function DesktopSideNav() {
           {
             key: "inbox",
             label: "Inbox",
-            icon: "basketball-outline" as keyof typeof Ionicons.glyphMap,
-            iconFocused: "basketball" as keyof typeof Ionicons.glyphMap,
+            icon: (isKnicksMode
+              ? "basketball-outline"
+              : "chatbubbles-outline") as keyof typeof Ionicons.glyphMap,
+            iconFocused: (isKnicksMode
+              ? "basketball"
+              : "chatbubbles") as keyof typeof Ionicons.glyphMap,
             href: "/inbox/",
             match: (p: string) =>
               p.startsWith("/inbox") || p.startsWith("/chat"),

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -44,6 +44,7 @@ import {
   type FileCategory,
 } from '../utils/fileTypes';
 import { useTheme } from '@hooks/useTheme';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { VoiceRecorderBar } from './VoiceRecorderBar';
 import { AttachmentPanel } from './AttachmentPanel';
 import { useDraftStore } from '../../../stores/draftStore';
@@ -127,6 +128,7 @@ const filterMembers = (members: ChannelMember[], searchText: string): ChannelMem
 
 export function MessageInput({ channelId, replyToMessage, onCancelReply, hideReplyPreview, externalSendMessage, externalIsSending, recipientPending = false }: MessageInputProps) {
   const { colors: themeColors } = useTheme();
+  const { isKnicksMode } = useCommunityTheme();
   const { getDraft, setDraft: saveDraft, clearDraft } = useDraftStore();
   const initialDraft = channelId ? getDraft(channelId) : '';
   const [text, setText] = useState(initialDraft);
@@ -1149,7 +1151,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
           {isSending ? (
             <ActivityIndicator size="small" color="#fff" />
           ) : (
-            <Ionicons name="basketball" size={20} color="#fff" />
+            <Ionicons name={isKnicksMode ? 'basketball' : 'send'} size={20} color="#fff" />
           )}
         </Pressable>
       </View>

--- a/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
+++ b/apps/mobile/features/chat/components/VoiceRecorderBar.tsx
@@ -23,6 +23,7 @@ import { WaveformBars } from './WaveformBars';
 import { useVoiceRecorder } from '../hooks/useVoiceRecorder';
 import { isAudioSupported, isAudioVideoSupported } from '../utils/fileTypes';
 import { ThemeContext } from '@/providers/ThemeProvider';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
 
 const DISCLAIMER_TEXT = 'Voice messages delete after 7 days';
 
@@ -40,6 +41,7 @@ interface VoiceRecorderBarProps {
 
 export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
   const { colors } = useContext(ThemeContext);
+  const { isKnicksMode } = useCommunityTheme();
   const {
     state,
     durationMs,
@@ -298,7 +300,7 @@ export function VoiceRecorderBar({ onSend, onCancel }: VoiceRecorderBarProps) {
             </Pressable>
             {/* Send */}
             <Pressable style={[styles.iconButton, styles.sendButton, { backgroundColor: colors.link }]} onPress={handleSend}>
-              <Ionicons name="basketball" size={20} color="#fff" />
+              <Ionicons name={isKnicksMode ? 'basketball' : 'send'} size={20} color="#fff" />
             </Pressable>
           </>
         )}


### PR DESCRIPTION
## Summary

The basketball icons added for Knicks mode were hardcoded, so they remained even when a community turned Knicks mode **off**. This gates all four basketball icons on the existing `isKnicksMode` flag from `useCommunityTheme()`, restoring the original icons when Knicks mode is off.

| Location | Knicks ON | Knicks OFF (restored) |
|---|---|---|
| Inbox tab (`(tabs)/_layout.tsx`) | `basketball` | `chatbubbles` |
| Desktop side nav (`DesktopSideNav.tsx`) | `basketball` | `chatbubbles` |
| Composer send button (`MessageInput.tsx`) | `basketball` | `send` |
| Voice recorder send (`VoiceRecorderBar.tsx`) | `basketball` | `send` |

## Why

Knicks mode is a per-community opt-out theme. Toggling it off restores brand colors but the basketball icons were left hardcoded, so communities that disabled Knicks mode still saw basketballs in the Inbox tab and chat send buttons.

## Test plan

- [ ] With Knicks mode ON: Inbox tab + send buttons show basketball
- [ ] With Knicks mode OFF: Inbox tab shows chat bubbles, send buttons show paper-plane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnS5x4vuP4Dd4gReLowoMY)_