### PR TITLE
Add "also in group" filter to roster People view

### DIFF
--- a/apps/convex/__tests__/scheduling/roster.test.ts
+++ b/apps/convex/__tests__/scheduling/roster.test.ts
@@ -137,3 +137,123 @@ describe("rosterMatrix", () => {
     ).rejects.toThrow(ConvexError);
   });
 });
+
+describe("roster group filter", () => {
+  /**
+   * Add a second group in the world's community with the given members, and an
+   * announcement group + an archived group the leader is also in — to prove the
+   * filter list excludes those. Returns the "production" group's id and the
+   * member it shares with the rostered group.
+   */
+  async function seedFilterGroups(
+    t: ReturnType<typeof convexTest>,
+    world: Awaited<ReturnType<typeof buildSchedulingWorld>>,
+  ) {
+    return t.run(async (ctx) => {
+      const groupTypeId = await ctx.db.insert("groupTypes", {
+        communityId: world.communityId,
+        name: "Team",
+        slug: "team",
+        isActive: true,
+        createdAt: Date.now(),
+        displayOrder: 2,
+      });
+      const make = async (
+        name: string,
+        extra: Record<string, unknown> = {},
+      ) =>
+        ctx.db.insert("groups", {
+          communityId: world.communityId,
+          groupTypeId,
+          name,
+          isArchived: false,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          ...extra,
+        });
+
+      const productionId = await make("Production");
+      const announceId = await make("Announcements", {
+        isAnnouncementGroup: true,
+      });
+      const archivedId = await make("Old Group", { isArchived: true });
+
+      // The leader belongs to all three. channelMember also serves Production
+      // (the overlap the filter should surface); channelAdmin does not.
+      for (const groupId of [productionId, announceId, archivedId]) {
+        await ctx.db.insert("groupMembers", {
+          groupId,
+          userId: world.groupLeaderId,
+          role: "leader",
+          joinedAt: Date.now(),
+          notificationsEnabled: true,
+        });
+      }
+      await ctx.db.insert("groupMembers", {
+        groupId: productionId,
+        userId: world.channelMemberId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+
+      return { productionId, announceId, archivedId };
+    });
+  }
+
+  it("lists the leader's other groups, excluding self/announcement/archived", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { productionId } = await seedFilterGroups(t, world);
+
+    const groups = await t.query(
+      api.functions.scheduling.roster.rosterFilterGroups,
+      { token: leader, groupId: world.groupId },
+    );
+
+    // Only the non-announcement, non-archived OTHER group is offered.
+    expect(groups.map((g) => g.name)).toEqual(["Production"]);
+    expect(groups[0].id).toBe(productionId);
+  });
+
+  it("rejects rosterFilterGroups for a non-scheduler", async () => {
+    const { t, world } = await setup();
+    const member = (await generateTokens(world.channelMemberId)).accessToken;
+    await expect(
+      t.query(api.functions.scheduling.roster.rosterFilterGroups, {
+        token: member,
+        groupId: world.groupId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("returns active member ids of a filter group the caller belongs to", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { productionId } = await seedFilterGroups(t, world);
+
+    const ids = await t.query(
+      api.functions.scheduling.roster.rosterFilterMemberIds,
+      { token: leader, groupId: productionId },
+    );
+
+    expect(new Set(ids)).toEqual(
+      new Set([world.groupLeaderId, world.channelMemberId]),
+    );
+  });
+
+  it("rejects rosterFilterMemberIds for a non-member of the filter group", async () => {
+    const { t, world } = await setup();
+    const { productionId } = await seedFilterGroups(t, world);
+    // channelAdmin is in the rostered group but NOT in Production.
+    const outsiderToProduction = (
+      await generateTokens(world.channelAdminId)
+    ).accessToken;
+    await expect(
+      t.query(api.functions.scheduling.roster.rosterFilterMemberIds, {
+        token: outsiderToProduction,
+        groupId: productionId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -21,7 +21,7 @@ import { query } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
-import { requireGroupScheduler } from "./permissions";
+import { requireGroupMember, requireGroupScheduler } from "./permissions";
 
 /** Column cap — a leader rosters a horizon of upcoming events. */
 const MAX_EVENTS = 10;
@@ -390,5 +390,95 @@ export const rosterMatrix = query({
         ).length,
       },
     };
+  },
+});
+
+/**
+ * The other groups the current user can use to filter the roster's People
+ * view — every active group membership of theirs in the same community as the
+ * group being rostered, EXCEPT the rostering group itself and announcement
+ * groups (a community-wide broadcast group is not a meaningful cross-reference).
+ *
+ * Backs the "also in group" dropdown on the roster grid: pick one of these and
+ * the grid narrows to people who are also in that group (a leader rostering the
+ * Manhattan team can isolate just their Production folk, say). Returns `[]`
+ * when the leader has no other groups, so the control hides itself.
+ *
+ * Scheduler-gated on the rostering group (same gate as `rosterMatrix`) — the
+ * dropdown only appears for someone already allowed to see the grid.
+ */
+export const rosterFilterGroups = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const rosteringGroup = await requireGroupScheduler(
+      ctx,
+      args.groupId,
+      userId,
+    );
+
+    const memberships = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("leftAt"), undefined),
+          q.or(
+            q.eq(q.field("requestStatus"), undefined),
+            q.eq(q.field("requestStatus"), "accepted"),
+          ),
+        ),
+      )
+      .collect();
+
+    const groups = await Promise.all(
+      memberships.map((m) => ctx.db.get(m.groupId)),
+    );
+
+    return groups
+      .filter(
+        (g): g is Doc<"groups"> =>
+          g !== null &&
+          g._id !== args.groupId &&
+          !g.isArchived &&
+          g.isAnnouncementGroup !== true &&
+          g.communityId === rosteringGroup.communityId,
+      )
+      .map((g) => ({ id: g._id, name: g.name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  },
+});
+
+/**
+ * The active member user ids of a group, for the roster "also in group" filter.
+ * The client intersects this set against the roster's People rows client-side
+ * (mirroring how the search / available-only filters already work), so the
+ * roster tallies stay whole while the visible rows narrow.
+ *
+ * Member-gated on the *filter* group: you can only enumerate a group you
+ * belong to — and `rosterFilterGroups` only ever offers the caller their own
+ * groups, so the picker can't be used to peek into a group you're not in.
+ */
+export const rosterFilterMemberIds = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupMember(ctx, args.groupId, userId);
+
+    const rows = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+
+    return rows
+      .filter((m) => !m.requestStatus || m.requestStatus === "accepted")
+      .map((m) => m.userId as string);
   },
 });

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -239,9 +239,17 @@ export function RosterGridScreen() {
     groupId ? { groupId } : "skip",
   ) as Array<{ id: Id<"groups">; name: string }> | undefined;
 
+  // Gate the member-id query on the selection still being present in the loaded
+  // group list. If it goes stale mid-session (the leader left the filter group,
+  // or it was archived), this skips on the SAME render — before
+  // `rosterFilterMemberIds`' `requireGroupMember` gate could throw into the
+  // error boundary — rather than relying on the effect below, which only runs
+  // after render.
   const filterMemberIds = useAuthenticatedQuery(
     api.functions.scheduling.roster.rosterFilterMemberIds,
-    filterGroupId ? { groupId: filterGroupId } : "skip",
+    filterGroupId && filterGroups?.some((g) => g.id === filterGroupId)
+      ? { groupId: filterGroupId }
+      : "skip",
   ) as string[] | undefined;
 
   const filterMemberSet = useMemo(
@@ -253,12 +261,12 @@ export function RosterGridScreen() {
     ? filterGroups?.find((g) => g.id === filterGroupId)?.name
     : undefined;
 
-  // Drop a stale selection once the loaded group list no longer contains it —
+  // Reset a stale selection once the loaded group list no longer contains it —
   // the group was archived, the leader left it, or the screen was reused for a
   // different roster group. Without this the filter chip (which only renders
   // while `filterGroups` is non-empty) can vanish with the filter still active,
-  // stranding the People view filtered/empty, and `rosterFilterMemberIds` would
-  // keep querying a group the leader may no longer belong to.
+  // stranding the People view filtered/empty. (The query above is already gated
+  // on the same condition; this clears the lingering UI state.)
   useEffect(() => {
     if (
       filterGroupId &&

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -253,6 +253,22 @@ export function RosterGridScreen() {
     ? filterGroups?.find((g) => g.id === filterGroupId)?.name
     : undefined;
 
+  // Drop a stale selection once the loaded group list no longer contains it —
+  // the group was archived, the leader left it, or the screen was reused for a
+  // different roster group. Without this the filter chip (which only renders
+  // while `filterGroups` is non-empty) can vanish with the filter still active,
+  // stranding the People view filtered/empty, and `rosterFilterMemberIds` would
+  // keep querying a group the leader may no longer belong to.
+  useEffect(() => {
+    if (
+      filterGroupId &&
+      filterGroups &&
+      !filterGroups.some((g) => g.id === filterGroupId)
+    ) {
+      setFilterGroupId(null);
+    }
+  }, [filterGroups, filterGroupId]);
+
   // --- Synced scroll scaffold (frozen header row + frozen first column) ---
   const headerScrollRef = useRef<ScrollView>(null);
   const frozenScrollRef = useRef<ScrollView>(null);

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -228,6 +228,31 @@ export function RosterGridScreen() {
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 300);
 
+  // "Also in group" filter — narrows People rows to members who also belong to
+  // another of the leader's groups. `filterGroups` populates the picker;
+  // `filterMemberIds` is the chosen group's member set (skipped until picked).
+  const [filterGroupId, setFilterGroupId] = useState<Id<"groups"> | null>(null);
+  const [groupFilterOpen, setGroupFilterOpen] = useState(false);
+
+  const filterGroups = useAuthenticatedQuery(
+    api.functions.scheduling.roster.rosterFilterGroups,
+    groupId ? { groupId } : "skip",
+  ) as Array<{ id: Id<"groups">; name: string }> | undefined;
+
+  const filterMemberIds = useAuthenticatedQuery(
+    api.functions.scheduling.roster.rosterFilterMemberIds,
+    filterGroupId ? { groupId: filterGroupId } : "skip",
+  ) as string[] | undefined;
+
+  const filterMemberSet = useMemo(
+    () => (filterMemberIds ? new Set(filterMemberIds) : null),
+    [filterMemberIds],
+  );
+
+  const filterGroupName = filterGroupId
+    ? filterGroups?.find((g) => g.id === filterGroupId)?.name
+    : undefined;
+
   // --- Synced scroll scaffold (frozen header row + frozen first column) ---
   const headerScrollRef = useRef<ScrollView>(null);
   const frozenScrollRef = useRef<ScrollView>(null);
@@ -368,6 +393,8 @@ export function RosterGridScreen() {
     return data.members.filter((m) => {
       if (q && !m.userName.toLowerCase().includes(q)) return false;
       if (availableOnly && m.availableCount === 0) return false;
+      if (filterMemberSet && !filterMemberSet.has(m.userId as string))
+        return false;
       if (openOnly) {
         // Keep only people with at least one available-and-unassigned cell.
         const hasOpenCell = events.some((ev) => {
@@ -378,7 +405,7 @@ export function RosterGridScreen() {
       }
       return true;
     });
-  }, [data, events, debouncedSearch, availableOnly, openOnly]);
+  }, [data, events, debouncedSearch, availableOnly, openOnly, filterMemberSet]);
 
   /** Open roles for an event, computed client-side (the placement menu). */
   const openRolesForEvent = useCallback(
@@ -496,6 +523,15 @@ export function RosterGridScreen() {
             label="Available only"
             active={availableOnly}
             onPress={() => setAvailableOnly((v) => !v)}
+            colors={colors}
+          />
+        )}
+        {mode === "people" && filterGroups && filterGroups.length > 0 && (
+          <Chip
+            icon="funnel"
+            label={filterGroupName ? `In: ${filterGroupName}` : "Also in group"}
+            active={filterGroupId !== null}
+            onPress={() => setGroupFilterOpen(true)}
             colors={colors}
           />
         )}
@@ -938,6 +974,19 @@ export function RosterGridScreen() {
           onClose={() => setOpenRolesModal(null)}
         />
       )}
+
+      {groupFilterOpen && (
+        <GroupFilterMenu
+          groups={filterGroups ?? []}
+          selectedId={filterGroupId}
+          colors={colors}
+          onPick={(id) => {
+            setFilterGroupId(id);
+            setGroupFilterOpen(false);
+          }}
+          onClose={() => setGroupFilterOpen(false)}
+        />
+      )}
     </View>
   );
 }
@@ -1345,6 +1394,63 @@ function OpenRolesMenu({
           })}
         </ScrollView>
       )}
+    </ModalShell>
+  );
+}
+
+/**
+ * "Also in group" picker — narrows the People view to members who also belong
+ * to one of the leader's other groups. "Everyone" clears the filter.
+ */
+function GroupFilterMenu({
+  groups,
+  selectedId,
+  colors,
+  onPick,
+  onClose,
+}: {
+  groups: Array<{ id: Id<"groups">; name: string }>;
+  selectedId: Id<"groups"> | null;
+  colors: Colors;
+  onPick: (id: Id<"groups"> | null) => void;
+  onClose: () => void;
+}) {
+  return (
+    <ModalShell
+      title="Also in group"
+      subtitle="Show only people who are also in…"
+      colors={colors}
+      onClose={onClose}
+    >
+      <ScrollView style={styles.popoverList}>
+        <Pressable
+          onPress={() => onPick(null)}
+          style={[styles.menuRow, { borderBottomColor: colors.border }]}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+            Everyone
+          </Text>
+          {selectedId === null && (
+            <Ionicons name="checkmark" size={20} color={colors.link} />
+          )}
+        </Pressable>
+        {groups.map((g) => (
+          <Pressable
+            key={g.id}
+            onPress={() => onPick(g.id)}
+            style={[styles.menuRow, { borderBottomColor: colors.border }]}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+              {g.name}
+            </Text>
+            {selectedId === g.id && (
+              <Ionicons name="checkmark" size={20} color={colors.link} />
+            )}
+          </Pressable>
+        ))}
+      </ScrollView>
     </ModalShell>
   );
 }


### PR DESCRIPTION
## What & why

Rostering shows **every** member of the group being rostered, which is clunky when a leader only cares about the slice of people who also belong to another of their groups (e.g. rostering the Manhattan team but wanting just the Production folk).

This adds an **"also in group"** filter to the roster grid's **People** view. It lists the current user's other active groups in the same community — excluding the rostering group itself and announcement groups — and narrows the visible rows to people who are also in the picked group.

## How it works

Filtering is **client-side**, mirroring the existing search / "available only" filters, so the roster's tallies stay whole while the rows narrow:

- `rosterFilterGroups` — the leader's other groups for the picker (scheduler-gated on the rostering group, same gate as `rosterMatrix`). Excludes the current group, announcement groups, and archived groups.
- `rosterFilterMemberIds` — a group's active member ids to intersect against the People rows (member-gated on the *filter* group, so you can only enumerate a group you belong to).

The control hides itself when the leader has no other groups, and only appears in the People view.

## UI

A compact filter chip (`In: <group>` when active, `Also in group` otherwise) in the existing People-view filter bar, opening a picker modal built from the screen's existing `ModalShell` pattern. An **"Everyone"** entry clears the filter.

## Tests

Added 4 backend tests in `roster.test.ts`:
- lists the leader's other groups, excluding self / announcement / archived
- rejects `rosterFilterGroups` for a non-scheduler
- returns active member ids of a filter group the caller belongs to
- rejects `rosterFilterMemberIds` for a non-member of the filter group

All scheduling tests pass; lint and the full mobile jest suite pass on push. Type errors in the changed files: none (the pre-existing `@togather/shared/config` resolution warnings and unrelated chat/tasks errors are not touched by this PR).

## Notes

- No native dependencies added — pure JS/TS change, safe for OTA.
- No onboarding guide is affected (rostering isn't covered by the `apps/web` guides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1R2BvFXuxbQLEERrvJpFo)_