### PR TITLE
Rostering redesign: #477 fixes + assign/grid UX, presence, nav cleanup

### DIFF
--- a/apps/convex/__tests__/scheduling/availability.test.ts
+++ b/apps/convex/__tests__/scheduling/availability.test.ts
@@ -201,11 +201,11 @@ describe("availabilityForPlan (leader grid)", () => {
     if (!result) return;
 
     // Active group members in the fixture world: leader, channel admin,
-    // moderator, member, and the placeholder = 5.
-    expect(result.counts.total).toBe(5);
+    // moderator, member, the placeholder, and the stale "Zeb" member = 6.
+    expect(result.counts.total).toBe(6);
     expect(result.counts.available).toBe(1);
     expect(result.counts.unavailable).toBe(1);
-    expect(result.counts.noResponse).toBe(3);
+    expect(result.counts.noResponse).toBe(4);
 
     // Sorted available-first, unavailable last.
     expect(result.members[0].status).toBe("available");

--- a/apps/convex/__tests__/scheduling/fixtures.ts
+++ b/apps/convex/__tests__/scheduling/fixtures.ts
@@ -56,6 +56,13 @@ export interface SchedulingWorld {
    * `isActive: false`. Used by people-search / claim tests.
    */
   placeholderUserId: Id<"users">;
+  /**
+   * An active group member whose `userCommunities.lastLogin` is very old (and
+   * who sorts LAST by recency). Used to prove roster #477 FR-1: every
+   * assignable group member appears on empty search even if they haven't
+   * logged in recently. Name "Zeb" sorts last alphabetically too.
+   */
+  staleGroupMemberId: Id<"users">;
 }
 
 async function insertUser(
@@ -127,6 +134,10 @@ export async function buildSchedulingWorld(
     // sort: "Casey" < "Comonly", so the search ordering is predictable.
     const communityOnlyAId = await insertUser(ctx, "Casey", "+12025550007");
     const communityOnlyBId = await insertUser(ctx, "Comonly", "+12025550008");
+    // A group member who never logs in — the FR-1 regression target. "Zeb"
+    // sorts last alphabetically and (below) gets the oldest lastLogin, so a
+    // recency-capped search would drop them.
+    const staleGroupMemberId = await insertUser(ctx, "Zeb", "+12025550010");
     // Placeholder user — inserted as if `inviteAndAssign` had created them.
     // Active in community + group, but flagged so the UI / claim path can
     // recognise them.
@@ -189,6 +200,7 @@ export async function buildSchedulingWorld(
       channelAdminId,
       channelModeratorId,
       channelMemberId,
+      staleGroupMemberId,
     ]) {
       await ctx.db.insert("groupMembers", {
         groupId,
@@ -240,6 +252,22 @@ export async function buildSchedulingWorld(
       });
     }
 
+    // The stale group member is an active community member, but with the
+    // OLDEST lastLogin in the world — so a recency-ordered/-capped empty search
+    // would surface them last (and drop them under a tight cap). FR-1 requires
+    // them present regardless. The others above leave lastLogin unset (treated
+    // as "never", sorted to the end too) — giving this row an explicit ancient
+    // timestamp makes the recency ordering unambiguous.
+    await ctx.db.insert("userCommunities", {
+      communityId,
+      userId: staleGroupMemberId,
+      roles: 1,
+      status: 1,
+      lastLogin: 1, // epoch+1ms — the least-recent possible
+      createdAt: ts(),
+      updatedAt: ts(),
+    });
+
     // The placeholder is "already in the group" (the leader added them when
     // they were invited), but the community-only members are NOT.
     await ctx.db.insert("groupMembers", {
@@ -289,6 +317,7 @@ export async function buildSchedulingWorld(
       communityOnlyAId,
       communityOnlyBId,
       placeholderUserId,
+      staleGroupMemberId,
     };
   });
 

--- a/apps/convex/__tests__/scheduling/people.test.ts
+++ b/apps/convex/__tests__/scheduling/people.test.ts
@@ -106,26 +106,72 @@ describe("searchCommunityPeople", () => {
     if (casey) expect(casey.isPlaceholder).toBe(false);
   });
 
-  it("limit caps the result count; default applies when omitted", async () => {
+  it("empty search returns the FULL group list regardless of `limit` (FR-1)", async () => {
     const { t, world } = await setupSchedulingWorld();
     const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
 
-    const unlimited = await t.query(
+    // On empty search, completeness takes precedence over the recency cap
+    // (roster #477 FR-1.1) — passing a tiny `limit` must NOT truncate group
+    // members away. This is the inverse of the pre-#477 behavior.
+    const full = await t.query(
       api.functions.scheduling.people.searchCommunityPeople,
       { token: leaderToken, groupId: world.groupId, search: "" },
     );
-
-    const limited = await t.query(
+    const tinyLimit = await t.query(
       api.functions.scheduling.people.searchCommunityPeople,
       { token: leaderToken, groupId: world.groupId, search: "", limit: 2 },
     );
-    expect(limited).toHaveLength(2);
 
-    // Default limit applies — the world has fewer than 30 candidates, so the
-    // unlimited call returns everything that matched (no truncation).
-    // This protects against a regression that drops the default cap.
-    expect(unlimited.length).toBeGreaterThan(limited.length);
-    expect(unlimited.length).toBeLessThanOrEqual(30);
+    // Both must contain every active group member (caller excluded).
+    const inGroupFull = full.filter((r) => r.inGroup).map((r) => r.userId);
+    const inGroupTiny = tinyLimit.filter((r) => r.inGroup).map((r) => r.userId);
+    expect(new Set(inGroupTiny)).toEqual(new Set(inGroupFull));
+    expect(inGroupFull).toContain(world.channelAdminId);
+    expect(inGroupFull).toContain(world.channelMemberId);
+    expect(inGroupFull).toContain(world.staleGroupMemberId);
+  });
+
+  it("surfaces a group member with the OLDEST lastLogin on empty search (FR-1.1)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // "Zeb" is an active group member whose lastLogin is the least-recent in
+    // the world — the pre-#477 recency-capped fallback dropped exactly this
+    // person until you typed their name. They MUST appear without typing.
+    const results = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId: world.groupId, search: "" },
+    );
+    const stale = results.find((r) => r.userId === world.staleGroupMemberId);
+    expect(stale, "stale group member must appear on empty search").toBeDefined();
+    expect(stale!.inGroup).toBe(true);
+  });
+
+  it("typing NARROWS the empty-search set — no new names appear (FR-1.3)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const onOpen = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId: world.groupId, search: "" },
+    );
+    const onOpenIds = new Set(onOpen.map((r) => r.userId));
+
+    // "z" matches only "Zeb" (display name "Zeb Test"). The typed result must
+    // be a strict SUBSET of what was shown on open — never an expansion.
+    const typed = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId: world.groupId, search: "z" },
+    );
+    expect(typed.length).toBeGreaterThan(0);
+    expect(typed.length).toBeLessThan(onOpen.length);
+    for (const r of typed) {
+      expect(
+        onOpenIds.has(r.userId),
+        `"${r.displayName}" appeared after typing but was absent on open`,
+      ).toBe(true);
+    }
+    expect(typed.map((r) => r.userId)).toContain(world.staleGroupMemberId);
   });
 
   it("rejects a non-group, non-community-admin caller with a ConvexError", async () => {

--- a/apps/convex/__tests__/scheduling/presence.test.ts
+++ b/apps/convex/__tests__/scheduling/presence.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for roster-grid live presence (#477) — `heartbeat`, `listViewers`,
+ * `leave`. Covers: heartbeat creates then updates a single row; listViewers
+ * excludes the caller and omits stale rows; leave removes the row; auth gating
+ * (only roster schedulers); and an invalid gridKey is rejected.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import { buildSchedulingWorld } from "./fixtures";
+
+const GRID_STALE_MS = 30_000;
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  const world = await buildSchedulingWorld(t);
+  // gridKey IS the rostering group's id.
+  return { t, world, gridKey: world.groupId as string };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("roster presence", () => {
+  it("heartbeat creates a row, then updates the same row (idempotent upsert)", async () => {
+    const { t, world, gridKey } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await t.mutation(api.functions.scheduling.presence.heartbeat, {
+      token: leaderToken,
+      gridKey,
+    });
+    await t.mutation(api.functions.scheduling.presence.heartbeat, {
+      token: leaderToken,
+      gridKey,
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("rosterPresence")
+        .withIndex("by_gridKey", (q) => q.eq("gridKey", gridKey))
+        .collect(),
+    );
+    // Two heartbeats from the same user => exactly one row.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(world.groupLeaderId);
+  });
+
+  it("listViewers excludes the calling user (shows only others)", async () => {
+    const { t, world, gridKey } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+
+    // Both are present. (communityAdmin passes requireGroupScheduler — the
+    // same gate rosterMatrix uses — without being a group member.)
+    await t.mutation(api.functions.scheduling.presence.heartbeat, {
+      token: leaderToken,
+      gridKey,
+    });
+    await t.mutation(api.functions.scheduling.presence.heartbeat, {
+      token: adminToken,
+      gridKey,
+    });
+
+    // The leader sees only the admin (not themselves).
+    const asLeader = await t.query(
+      api.functions.scheduling.presence.listViewers,
+      { token: leaderToken, gridKey },
+    );
+    expect(asLeader.map((v) => v.userId)).toEqual([world.communityAdminId]);
+
+    // And the admin sees only the leader.
+    const asAdmin = await t.query(
+      api.functions.scheduling.presence.listViewers,
+      { token: adminToken, gridKey },
+    );
+    expect(asAdmin.map((v) => v.userId)).toEqual([world.groupLeaderId]);
+  });
+
+  it("listViewers omits stale rows past the staleness window", async () => {
+    vi.useFakeTimers();
+    const start = new Date("2026-06-23T12:00:00Z").getTime();
+    vi.setSystemTime(start);
+
+    const { t, world, gridKey } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+
+    // Admin heartbeats now; leader will observe later.
+    await t.mutation(api.functions.scheduling.presence.heartbeat, {
+      token: adminToken,
+      gridKey,
+    });
+
+    // Within the window: admin is visible to the leader.
+    vi.setSystemTime(start + GRID_STALE_MS - 1_000);
+    const fresh = await t.query(
+      api.functions.scheduling.presence.listViewers,
+      { token: leaderToken, gridKey },
+    );
+    expect(fresh.map((v) => v.userId)).toEqual([world.communityAdminId]);
+
+    // Past the window with no new heartbeat: admin drops out.
+    vi.setSystemTime(start + GRID_STALE_MS + 1_000);
+    const stale = await t.query(
+      api.functions.scheduling.presence.listViewers,
+      { token: leaderToken, gridKey },
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it("leave removes the caller's presence row", async () => {
+    const { t, world, gridKey } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const adminToken = (await generateTokens(world.communityAdminId)).accessToken;
+
+    await t.mutation(api.functions.scheduling.presence.heartbeat, {
+      token: adminToken,
+      gridKey,
+    });
+    // Leader sees admin.
+    expect(
+      (
+        await t.query(api.functions.scheduling.presence.listViewers, {
+          token: leaderToken,
+          gridKey,
+        })
+      ).map((v) => v.userId),
+    ).toEqual([world.communityAdminId]);
+
+    // Admin leaves.
+    await t.mutation(api.functions.scheduling.presence.leave, {
+      token: adminToken,
+      gridKey,
+    });
+    expect(
+      await t.query(api.functions.scheduling.presence.listViewers, {
+        token: leaderToken,
+        gridKey,
+      }),
+    ).toEqual([]);
+  });
+
+  it("rejects a non-scheduler caller (plain group member) with ConvexError", async () => {
+    const { t, world, gridKey } = await setupSchedulingWorld();
+    // channelMember is in the group but not a leader/admin — not a scheduler.
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+
+    await expect(
+      t.mutation(api.functions.scheduling.presence.heartbeat, {
+        token: memberToken,
+        gridKey,
+      }),
+    ).rejects.toThrow(ConvexError);
+    await expect(
+      t.query(api.functions.scheduling.presence.listViewers, {
+        token: memberToken,
+        gridKey,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects an invalid gridKey", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await expect(
+      t.mutation(api.functions.scheduling.presence.heartbeat, {
+        token: leaderToken,
+        gridKey: "not-a-real-id",
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/apps/convex/__tests__/scheduling/roster.test.ts
+++ b/apps/convex/__tests__/scheduling/roster.test.ts
@@ -126,6 +126,51 @@ describe("rosterMatrix", () => {
     expect(adminRow?.availableCount).toBe(1);
   });
 
+  it("pendingCount counts assignments orphaned by a removed needed role", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const eventDate = Date.now() + 7 * DAY;
+    const plan = await createPlan(t, leader, world.groupId, "Service", eventDate);
+
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: plan,
+      roles: [{ teamId: world.teamId, roleId: world.roleId, count: 1 }],
+    });
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+
+    // Baseline: one unconfirmed assignment, surfaced as a cell AND in pendingCount.
+    let m = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+    });
+    expect(m.roleCells[`${world.roleId}:${plan}`]?.occupants).toHaveLength(1);
+    expect(m.events.find((e) => e._id === plan)?.pendingCount).toBe(1);
+
+    // Remove the needed role: deletes the neededRoles row but leaves the
+    // assignment orphaned (no cell). `markPublished` still notifies that
+    // volunteer (it counts by_plan), so pendingCount must stay 1 — otherwise
+    // the grid's publish confirm dialog would undercount the fan-out.
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: plan,
+      roles: [],
+    });
+
+    m = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+    });
+    expect(m.roleCells[`${world.roleId}:${plan}`]).toBeUndefined();
+    expect(m.events.find((e) => e._id === plan)?.pendingCount).toBe(1);
+  });
+
   it("rejects a non-scheduler", async () => {
     const { t, world } = await setup();
     const member = (await generateTokens(world.channelMemberId)).accessToken;

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -139,6 +139,7 @@ import type * as functions_scheduling_index from "../functions/scheduling/index.
 import type * as functions_scheduling_mySchedule from "../functions/scheduling/mySchedule.js";
 import type * as functions_scheduling_people from "../functions/scheduling/people.js";
 import type * as functions_scheduling_permissions from "../functions/scheduling/permissions.js";
+import type * as functions_scheduling_presence from "../functions/scheduling/presence.js";
 import type * as functions_scheduling_publicAvailability from "../functions/scheduling/publicAvailability.js";
 import type * as functions_scheduling_roles from "../functions/scheduling/roles.js";
 import type * as functions_scheduling_roster from "../functions/scheduling/roster.js";
@@ -345,6 +346,7 @@ declare const fullApi: ApiFromModules<{
   "functions/scheduling/mySchedule": typeof functions_scheduling_mySchedule;
   "functions/scheduling/people": typeof functions_scheduling_people;
   "functions/scheduling/permissions": typeof functions_scheduling_permissions;
+  "functions/scheduling/presence": typeof functions_scheduling_presence;
   "functions/scheduling/publicAvailability": typeof functions_scheduling_publicAvailability;
   "functions/scheduling/roles": typeof functions_scheduling_roles;
   "functions/scheduling/roster": typeof functions_scheduling_roster;

--- a/apps/convex/functions/scheduling/index.ts
+++ b/apps/convex/functions/scheduling/index.ts
@@ -81,6 +81,12 @@ export {
 export { searchCommunityPeople } from "./people";
 
 // ============================================================================
+// Live presence — "who's viewing/editing this roster" (#477).
+// Frontend resolves these as `api.functions.scheduling.presence.*`.
+// ============================================================================
+export { heartbeat, listViewers, leave } from "./presence";
+
+// ============================================================================
 // My Schedule (volunteer view)
 // ============================================================================
 export { myAssignments } from "./mySchedule";

--- a/apps/convex/functions/scheduling/people.ts
+++ b/apps/convex/functions/scheduling/people.ts
@@ -27,10 +27,16 @@ import { requireAuth } from "../../lib/auth";
 import { searchCommunityMembersInternal } from "../../lib/memberSearch";
 import { requireGroupMember } from "./permissions";
 
-/** Default cap on returned candidates. */
+/** Default cap on returned candidates when the leader is searching. */
 const DEFAULT_LIMIT = 30;
-/** Hard cap to keep the query bounded even when callers pass a large limit. */
+/** Hard cap to keep the SEARCH path bounded even when callers pass a large limit. */
 const MAX_LIMIT = 100;
+/**
+ * Cap on the EMPTY-search (full-list) path — roster #477 FR-1. Large enough to
+ * return every assignable member of a very large church group (≥500) without
+ * search-gating the population; mirrors the helper's `GROUP_COMPLETE_LIMIT`.
+ */
+const GROUP_FULL_LIST_LIMIT = 1000;
 
 /**
  * Build the user's display name the same way the rest of the app does:
@@ -72,21 +78,27 @@ export const searchCommunityPeople = query({
     // Delegate to the shared helper — same search index + isActive /
     // isPlaceholder rules as the admin People and group Add People searches.
     // `annotateGroupId` makes each row carry `inGroup`; `fallbackToRecentWhenEmpty`
-    // surfaces a sensible default list before the leader has typed anything.
+    // surfaces wider-community people before the leader has typed anything; and
+    // `includeAllGroupMembersWhenEmpty` guarantees EVERY assignable group
+    // member is in the set on empty search (roster #477 FR-1) — not just a
+    // recency slice. A volunteer who hasn't logged in recently must be findable
+    // without typing their name.
     //
-    // Pass `MAX_LIMIT` (the helper's own hard cap) instead of the caller's
-    // `limit` so we don't truncate in-group members away before the
-    // AssignSheet-specific in-group-first re-sort below — the helper
-    // returns rows in relevance / last-login order, which would drop
-    // in-group people ranked below the cutoff and leave them invisible
-    // after the re-sort. Slicing happens after the re-sort.
+    // On EMPTY search, pass a high limit (`GROUP_FULL_LIST_LIMIT`) so the full
+    // group population survives the helper's truncation before the in-group-
+    // first re-sort below; we deliberately do NOT slice the empty-search result
+    // (completeness > the recency cap — FR-1.1/FR-1.4). When the leader is
+    // SEARCHING, the search index already covers everyone, so we keep the
+    // tighter `MAX_LIMIT` and slice as before.
+    const isEmptySearch = args.search.trim().length === 0;
     const rows = await searchCommunityMembersInternal(ctx, {
       communityId: group.communityId,
       search: args.search,
       excludeUserIds: [callerId],
       annotateGroupId: args.groupId,
-      limit: MAX_LIMIT,
+      limit: isEmptySearch ? GROUP_FULL_LIST_LIMIT : MAX_LIMIT,
       fallbackToRecentWhenEmpty: true,
+      includeAllGroupMembersWhenEmpty: args.groupId,
     });
 
     const candidates = rows.map((row) => ({
@@ -110,6 +122,13 @@ export const searchCommunityPeople = query({
       return a.displayName.localeCompare(b.displayName);
     });
 
+    // On empty search return the COMPLETE list (FR-1) — slicing to `limit`
+    // here would re-introduce the very recency cap the fix removes. The leader
+    // can still pass a small `limit` for the SEARCH path (e.g. typeahead). The
+    // client scrolls / virtualizes the full list (FR-1.4 / FR-9).
+    if (isEmptySearch) {
+      return candidates;
+    }
     return candidates.slice(0, limit);
   },
 });

--- a/apps/convex/functions/scheduling/presence.ts
+++ b/apps/convex/functions/scheduling/presence.ts
@@ -1,0 +1,170 @@
+/**
+ * Scheduling — live presence for the roster grid (#477)
+ *
+ * "Who else is viewing/editing this roster right now." A deliberately
+ * lightweight, Convex-native presence system: clients send a `heartbeat` every
+ * few seconds while the grid is open, and a reactive `listViewers` query
+ * returns whoever's heartbeat is still fresh. No external presence service, no
+ * native deps.
+ *
+ * Grid scope (`gridKey`): the rostering group's id as a string. The roster grid
+ * is scoped per campus group (`rosterMatrix({ groupId })`), so the group id is
+ * the natural, stable grid scope. `heartbeat`/`leave`/`listViewers` resolve the
+ * key back to a `groups` doc and gate on `requireGroupScheduler` — the same
+ * permission `rosterMatrix` requires — so only people who can actually open the
+ * grid appear in presence.
+ *
+ * Staleness is enforced READ-side in `listViewers`: any row whose `lastSeenAt`
+ * is older than `PRESENCE_STALE_MS` is treated as "gone". This means a missed
+ * `leave` (tab closed, app backgrounded) self-heals after the window — a
+ * cleanup cron is optional, not required for correctness. (If row volume ever
+ * matters, add a cron that deletes rows older than the window.)
+ *
+ * @see ./roster.ts (`rosterMatrix`) for the grid this tracks.
+ */
+
+import { ConvexError, v } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { getMediaUrl } from "../../lib/utils";
+import { requireGroupScheduler } from "./permissions";
+
+/**
+ * How long after a heartbeat a viewer is still considered present. A client
+ * heartbeats well inside this window (e.g. every ~10s); 30s tolerates a missed
+ * beat or two before the viewer drops out of `listViewers`.
+ */
+export const PRESENCE_STALE_MS = 30_000;
+
+/** Build the user's display name the same way the rest of the app does. */
+function buildName(
+  firstName: string | undefined,
+  lastName: string | undefined,
+): string {
+  const first = (firstName ?? "").trim();
+  const last = (lastName ?? "").trim();
+  if (first && last) return `${first} ${last}`;
+  return first || last || "Someone";
+}
+
+/**
+ * Validate that `gridKey` is a real `groups` id and that the caller may view
+ * its roster grid (scheduler gate, matching `rosterMatrix`). Returns the
+ * resolved group id. Throws `ConvexError` so the mobile `AuthErrorBoundary`
+ * can recover.
+ */
+async function requireGridAccess(
+  ctx: Parameters<typeof requireGroupScheduler>[0],
+  gridKey: string,
+  userId: Id<"users">,
+): Promise<Id<"groups">> {
+  // `gridKey` is the group id as a string. `db.get` with a malformed/foreign
+  // id throws; `requireGroupScheduler` re-checks existence + permission.
+  const groupId = ctx.db.normalizeId("groups", gridKey);
+  if (!groupId) {
+    throw new ConvexError("Invalid roster grid");
+  }
+  await requireGroupScheduler(ctx, groupId, userId);
+  return groupId;
+}
+
+/**
+ * Upsert the calling user's presence row for a grid, stamping the current
+ * time. Idempotent per (gridKey, userId): the client calls this on an interval
+ * while the grid is open. Auth: roster scheduler for the grid's group.
+ */
+export const heartbeat = mutation({
+  args: {
+    token: v.string(),
+    gridKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGridAccess(ctx, args.gridKey, userId);
+
+    const now = Date.now();
+    const user = await ctx.db.get(userId);
+    const name = buildName(user?.firstName, user?.lastName);
+    const avatarUrl = getMediaUrl(user?.profilePhoto);
+
+    const existing = await ctx.db
+      .query("rosterPresence")
+      .withIndex("by_gridKey_user", (q) =>
+        q.eq("gridKey", args.gridKey).eq("userId", userId),
+      )
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, { lastSeenAt: now, name, avatarUrl });
+    } else {
+      await ctx.db.insert("rosterPresence", {
+        gridKey: args.gridKey,
+        userId,
+        lastSeenAt: now,
+        name,
+        avatarUrl,
+      });
+    }
+    return null;
+  },
+});
+
+/**
+ * Reactive list of OTHER viewers currently present on a grid (caller excluded —
+ * the UI shows "others editing"). Rows older than `PRESENCE_STALE_MS` are
+ * filtered out, so a missed `leave` self-heals. Auth: roster scheduler.
+ */
+export const listViewers = query({
+  args: {
+    token: v.string(),
+    gridKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGridAccess(ctx, args.gridKey, userId);
+
+    const cutoff = Date.now() - PRESENCE_STALE_MS;
+    const rows = await ctx.db
+      .query("rosterPresence")
+      .withIndex("by_gridKey", (q) => q.eq("gridKey", args.gridKey))
+      .collect();
+
+    return rows
+      .filter((r) => r.userId !== userId && r.lastSeenAt >= cutoff)
+      .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+      .map((r) => ({
+        userId: r.userId,
+        name: r.name,
+        avatarUrl: r.avatarUrl,
+        lastSeenAt: r.lastSeenAt,
+      }));
+  },
+});
+
+/**
+ * Best-effort removal of the caller's presence row on grid unmount. Not
+ * required for correctness (the staleness window handles drop-off), but keeps
+ * the "others" list tight when a viewer leaves cleanly. No-op if no row exists.
+ */
+export const leave = mutation({
+  args: {
+    token: v.string(),
+    gridKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGridAccess(ctx, args.gridKey, userId);
+
+    const existing = await ctx.db
+      .query("rosterPresence")
+      .withIndex("by_gridKey_user", (q) =>
+        q.eq("gridKey", args.gridKey).eq("userId", userId),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+    return null;
+  },
+});

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -69,14 +69,6 @@ export const rosterMatrix = query({
       .sort((a, b) => a.eventDate - b.eventDate)
       .slice(0, cap);
 
-    const events = plans.map((p) => ({
-      _id: p._id,
-      title: p.title,
-      eventDate: p.eventDate,
-      times: p.times,
-      status: p.status, // "draft" | "published" — AssignSheet needs this
-    }));
-
     // --- Fan out the three per-plan reads. ---
     const perPlan = await Promise.all(
       plans.map(async (plan) => {
@@ -97,6 +89,20 @@ export const rosterMatrix = query({
         return { plan, neededRoles, assignments, availability };
       }),
     );
+
+    const events = perPlan.map(({ plan, assignments }) => ({
+      _id: plan._id,
+      title: plan.title,
+      eventDate: plan.eventDate,
+      times: plan.times,
+      status: plan.status, // "draft" | "published" — AssignSheet needs this
+      // Authoritative count of who publish will notify: every `unconfirmed`
+      // assignment for the plan, counted off `by_plan` exactly as
+      // `markPublished` does. This includes assignments orphaned by a removed
+      // needed role (which have no `roleCells` entry), so the grid's publish
+      // confirm dialog can't undercount the request fan-out.
+      pendingCount: assignments.filter((a) => a.status === "unconfirmed").length,
+    }));
 
     // --- Resolve display names for every role and user referenced. ---
     const roleIds = new Set<string>();

--- a/apps/convex/lib/memberSearch.ts
+++ b/apps/convex/lib/memberSearch.ts
@@ -17,6 +17,16 @@ import { COMMUNITY_ADMIN_THRESHOLD, PRIMARY_ADMIN_ROLE } from "./permissions";
 import { getUsersWithNotificationsDisabled } from "./notifications/enabledStatus";
 
 /**
+ * Upper bound on candidates returned when guaranteeing a group's FULL
+ * membership on empty search (roster #477 FR-1 / FR-9). Large enough to cover
+ * a very large church group (≥500 members) so the "Assign someone" sheet never
+ * search-gates the population, while still bounding the per-row lookups. If a
+ * single group ever exceeds this, the overflow falls back to recency order —
+ * an extreme edge no real serving roster hits today.
+ */
+const GROUP_COMPLETE_LIMIT = 1000;
+
+/**
  * Base member result returned by search
  */
 export interface MemberSearchResult {
@@ -88,6 +98,20 @@ export interface MemberSearchOptions {
    * UIs surface a sensible default list before the leader types anything.
    */
   fallbackToRecentWhenEmpty?: boolean;
+  /**
+   * When set and `search` is empty, guarantee that EVERY active member of this
+   * group is in the returned candidate set — not just a recency-bounded slice
+   * (roster #477 FR-1). The rostering "Assign someone" sheet relies on this:
+   * a leader must see every assignable group member on open, including
+   * volunteers who haven't logged in recently. Group members are unioned with
+   * the recency-surfaced community members (`fallbackToRecentWhenEmpty`); the
+   * group set is exhaustive, the wider-community set stays recency-bounded
+   * (you can always type to find more community-only people).
+   *
+   * Has no effect when `search` is non-empty — typing narrows the set via the
+   * search index, which already covers every indexed member.
+   */
+  includeAllGroupMembersWhenEmpty?: Id<"groups">;
 }
 
 /**
@@ -215,11 +239,23 @@ export async function searchCommunityMembersInternal(
     limit = 30,
     includeAdminFields = false,
     fallbackToRecentWhenEmpty = false,
+    includeAllGroupMembersWhenEmpty,
   } = options;
 
   // Hard cap regardless of caller — protects the per-row notif-disabled /
   // membership lookups from quadratic blow-ups.
-  const effectiveLimit = Math.max(1, Math.min(limit, 100));
+  //
+  // When `includeAllGroupMembersWhenEmpty` is in play we must NOT truncate the
+  // group's membership away (roster #477 FR-1 / FR-9: every assignable group
+  // member must be reachable on open, even for a ≥500-member group). We raise
+  // the ceiling to GROUP_COMPLETE_LIMIT for that case so the full group set
+  // survives the final filter loop; the per-row lookups still scale with the
+  // group size, not the whole community, so this stays bounded.
+  const searchIsEmptyForGroup =
+    !!includeAllGroupMembersWhenEmpty && !(search?.trim());
+  const effectiveLimit = searchIsEmptyForGroup
+    ? Math.max(1, Math.min(limit, GROUP_COMPLETE_LIMIT))
+    : Math.max(1, Math.min(limit, 100));
   const excludeIds = new Set(excludeUserIds);
   const searchQuery = search?.trim() || "";
 
@@ -263,24 +299,71 @@ export async function searchCommunityMembersInternal(
         }
       }
     }
-  } else if (fallbackToRecentWhenEmpty) {
-    // Pull the most recently-active community members directly off the
-    // descending `by_community_lastLogin` index. We over-fetch to account
-    // for downstream filters (excluded users, isActive, etc.) but the read
-    // count is bounded by `effectiveLimit`, not community size.
-    const recentMemberships = await ctx.db
-      .query("userCommunities")
-      .withIndex("by_community_lastLogin", (q) => q.eq("communityId", communityId))
-      .order("desc")
-      .filter((q) => q.eq(q.field("status"), 1))
-      .take(effectiveLimit * 3);
+  } else if (includeAllGroupMembersWhenEmpty || fallbackToRecentWhenEmpty) {
+    // --- Empty search ---------------------------------------------------------
+    // Two complementary sources, unioned:
+    //
+    //   1. The FULL active membership of `includeAllGroupMembersWhenEmpty`
+    //      (roster #477 FR-1). This is the completeness guarantee — every
+    //      assignable group member must appear on open, even one who never
+    //      logs in. Read off the `groupMembers.by_group` index, bounded by the
+    //      group's size (not the community's). No recency cap here.
+    //
+    //   2. The most recently-active COMMUNITY members
+    //      (`fallbackToRecentWhenEmpty`), so the leader can also see wider-
+    //      community people to add+assign. This tier stays recency-bounded —
+    //      the leader types a name to reach anyone past the cap.
+    //
+    // Order matters: gather group members first so they always survive the
+    // `effectiveLimit` truncation below; community-only recency fills the rest.
+    if (includeAllGroupMembersWhenEmpty) {
+      const groupMemberships = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group", (q) =>
+          q.eq("groupId", includeAllGroupMembersWhenEmpty),
+        )
+        .filter((q) =>
+          q.and(
+            q.eq(q.field("leftAt"), undefined),
+            q.or(
+              q.eq(q.field("requestStatus"), undefined),
+              q.eq(q.field("requestStatus"), null),
+              q.eq(q.field("requestStatus"), "accepted"),
+            ),
+          ),
+        )
+        .collect();
+      const groupUsers = await Promise.all(
+        groupMemberships.map((m) => ctx.db.get(m.userId)),
+      );
+      for (const user of groupUsers) {
+        if (user && !allMatchingUsers.has(user._id)) {
+          allMatchingUsers.set(user._id, user);
+        }
+      }
+    }
 
-    const recentUsers = await Promise.all(
-      recentMemberships.map((m) => ctx.db.get(m.userId)),
-    );
-    for (const user of recentUsers) {
-      if (user && !allMatchingUsers.has(user._id)) {
-        allMatchingUsers.set(user._id, user);
+    if (fallbackToRecentWhenEmpty) {
+      // Pull the most recently-active community members directly off the
+      // descending `by_community_lastLogin` index. We over-fetch to account
+      // for downstream filters (excluded users, isActive, etc.) but the read
+      // count is bounded by `effectiveLimit`, not community size.
+      const recentMemberships = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_community_lastLogin", (q) =>
+          q.eq("communityId", communityId),
+        )
+        .order("desc")
+        .filter((q) => q.eq(q.field("status"), 1))
+        .take(effectiveLimit * 3);
+
+      const recentUsers = await Promise.all(
+        recentMemberships.map((m) => ctx.db.get(m.userId)),
+      );
+      for (const user of recentUsers) {
+        if (user && !allMatchingUsers.has(user._id)) {
+          allMatchingUsers.set(user._id, user);
+        }
       }
     }
   } else {

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3078,4 +3078,32 @@ export default defineSchema({
     type: v.string(),
     sentAt: v.number(),
   }).index("by_prayer_type", ["prayerId", "type"]),
+
+  /**
+   * Lightweight live presence for the roster grid (#477) — "who else is
+   * viewing/editing this roster right now". Convex-native: a heartbeat row per
+   * (gridKey, user), refreshed every few seconds by the client; a reactive
+   * `listViewers` query returns whoever's row is within the staleness window.
+   * No external presence service.
+   *
+   * `gridKey` is the rostering group's id as a string — the grid is scoped per
+   * campus group (`rosterMatrix({ groupId })`), so the group id is the natural
+   * stable grid scope. `name`/`avatarUrl` are denormalized from the user at
+   * heartbeat time so `listViewers` needs no per-row user join. Staleness is
+   * enforced read-side in `listViewers` (rows older than the window are
+   * filtered out), so a missed `leave` self-heals; a cleanup cron is optional.
+   */
+  rosterPresence: defineTable({
+    /** The grid scope — the rostering group's id, as a string. */
+    gridKey: v.string(),
+    userId: v.id("users"),
+    /** Unix ms of the last heartbeat. Drives the staleness filter. */
+    lastSeenAt: v.number(),
+    /** Denormalized display name (snapshot at heartbeat). */
+    name: v.string(),
+    /** Denormalized resolved avatar URL, if any (snapshot at heartbeat). */
+    avatarUrl: v.optional(v.string()),
+  })
+    .index("by_gridKey", ["gridKey"])
+    .index("by_gridKey_user", ["gridKey", "userId"]),
 });

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -270,11 +270,6 @@ export function GroupDetailScreen() {
     router.push(`/(user)/leader-tools/${group._id}/toolbar-settings`);
   };
 
-  const handleScheduling = () => {
-    if (!group?._id) return;
-    router.push(`/rostering/${group._id}`);
-  };
-
   if (isLoading) {
     return <GroupDetailSkeleton />;
   }
@@ -544,8 +539,8 @@ export function GroupDetailScreen() {
             events. */}
         {group._id && <UpcomingEventsSection groupId={group._id} />}
 
-        {/* ROSTERING — leader-only horizontal list of event plans. Hidden
-            when the group has no plans yet. */}
+        {/* ROSTERING — leader-only entry row into the rostering hub, with a
+            light status summary (plan count · next date · fill). */}
         {group._id && isLeader && <RosteringSection groupId={group._id} />}
 
         {/* CHANNELS */}
@@ -686,17 +681,6 @@ export function GroupDetailScreen() {
                 icon="options-outline"
                 label="Toolbar Settings"
                 onPress={handleToolbarSettings}
-                color={colors.text}
-                iconColor={colors.icon}
-                topBorder
-                borderColor={colors.border}
-              />
-            )}
-            {isLeader && (
-              <ActionRow
-                icon="calendar-outline"
-                label="Rostering"
-                onPress={handleScheduling}
                 color={colors.text}
                 iconColor={colors.icon}
                 topBorder

--- a/apps/mobile/features/groups/components/RosteringSection.tsx
+++ b/apps/mobile/features/groups/components/RosteringSection.tsx
@@ -1,39 +1,27 @@
 /**
  * RosteringSection
  *
- * Leader-only horizontal scroll list of the group's event plans on the group
- * page. Sits directly below UpcomingEventsSection and mirrors its aesthetic.
+ * Leader-only single entry row on the group page that opens the Rostering hub
+ * (/rostering/[group_id]). It sits below UpcomingEventsSection and matches the
+ * aesthetic of the sibling Check-in / Add people tiles.
  *
- * Each card shows the plan title, date/time, a draft/published status pill,
- * and a compact confirmed/filled fill bar (the two-segment bar from
- * EventListScreen). A trailing "+" card creates a draft plan and routes
- * straight to its editor.
+ * The row carries a light status summary (plan count · next date · fill),
+ * sourced from the same listEvents query the hub uses, so a leader can see at a
+ * glance whether anything needs attention before tapping in. The hub is the one
+ * home for everything else — the plan list, the roster grid, availability
+ * collection — so this screen exposes exactly one door, not a parallel façade.
  *
- * Hidden when the group has no event plans — leaders can still start
- * rostering via Group Actions → Rostering.
+ * Hidden while loading. When the group has no event plans yet it still renders
+ * a "Start rostering" row so leaders have an entry point to create the first
+ * plan inside the hub.
  */
-import React, { useCallback, useState } from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  ScrollView,
-  Pressable,
-  ActivityIndicator,
-  Share,
-  Alert,
-} from "react-native";
+import React from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import { DOMAIN_CONFIG } from "@togather/shared";
-import {
-  useAuthenticatedQuery,
-  useAuthenticatedMutation,
-  api,
-} from "@services/api/convex";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { useTheme } from "@hooks/useTheme";
-import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { formatEventDate } from "../../scheduling/utils/format";
 
 interface Props {
@@ -53,383 +41,122 @@ type EventRow = {
   };
 };
 
-/** Next Sunday at 9:00 AM local time — sensible default for a new draft. */
-function nextSundayAtNine(): Date {
-  const d = new Date();
-  const daysUntilSunday = (7 - d.getDay()) % 7 || 7;
-  d.setDate(d.getDate() + daysUntilSunday);
-  d.setHours(9, 0, 0, 0);
-  return d;
+/**
+ * Build the one-line status summary shown under "Rostering".
+ *
+ * Combines plan count, the next upcoming date, and the aggregate fill across
+ * upcoming plans (e.g. "3 plans · next Sun Jul 5 · 7/42 filled"). Falls back to
+ * a gentle prompt when there are no plans yet.
+ */
+function buildSummary(events: EventRow[]): string {
+  if (events.length === 0) return "Plan who serves and when";
+
+  const planLabel = `${events.length} ${events.length === 1 ? "plan" : "plans"}`;
+
+  const now = Date.now();
+  const upcoming = events
+    .filter((e) => e.eventDate >= now)
+    .sort((a, b) => a.eventDate - b.eventDate);
+
+  const parts = [planLabel];
+
+  if (upcoming.length > 0) {
+    parts.push(`next ${formatEventDate(upcoming[0].eventDate)}`);
+
+    // Aggregate fill across upcoming plans — the leader's "is anything still
+    // open?" glance. Past plans are excluded so the number stays actionable.
+    const totals = upcoming.reduce(
+      (acc, e) => {
+        acc.filled += e.fillSummary.totalFilled;
+        acc.needed += e.fillSummary.totalNeeded;
+        return acc;
+      },
+      { filled: 0, needed: 0 },
+    );
+    if (totals.needed > 0) {
+      parts.push(`${totals.filled}/${totals.needed} filled`);
+    }
+  }
+
+  return parts.join(" · ");
 }
 
 export function RosteringSection({ groupId }: Props) {
   const router = useRouter();
   const { colors } = useTheme();
-  const { primaryColor } = useCommunityTheme();
 
   const events = useAuthenticatedQuery(
     api.functions.scheduling.events.listEvents,
     groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   ) as EventRow[] | undefined;
 
-  const createEvent = useAuthenticatedMutation(
-    api.functions.scheduling.events.createEvent,
-  );
-  const createAvailabilityLink = useAuthenticatedMutation(
-    api.functions.scheduling.publicAvailability.createAvailabilityLink,
-  );
-  const [creating, setCreating] = useState(false);
-  const [sharingLink, setSharingLink] = useState(false);
-
-  const goToRostering = useCallback(() => {
-    router.push(`/rostering/${groupId}` as any);
-  }, [router, groupId]);
-
-  const goToAvailability = useCallback(() => {
-    router.push(`/rostering/${groupId}/availability` as any);
-  }, [router, groupId]);
-
-  const goToRosterGrid = useCallback(() => {
-    router.push(`/rostering/${groupId}/grid` as any);
-  }, [router, groupId]);
-
-  // Generate a public, app-optional availability link and hand it to the OS
-  // share sheet — people can respond in a browser without the app.
-  const handleShareLink = useCallback(async () => {
-    if (sharingLink) return;
-    setSharingLink(true);
-    try {
-      const { publicToken } = await createAvailabilityLink({
-        groupId: groupId as Id<"groups">,
-      });
-      const url = DOMAIN_CONFIG.availabilityLinkUrl(publicToken);
-      await Share.share({
-        message: `Let us know when you can serve: ${url}`,
-      });
-    } catch (e) {
-      const err = e as { data?: { message?: string }; message?: string };
-      Alert.alert(
-        "Couldn't create link",
-        err?.data?.message ??
-          err?.message ??
-          "Add an upcoming event plan first, then try again.",
-      );
-    } finally {
-      setSharingLink(false);
-    }
-  }, [sharingLink, createAvailabilityLink, groupId]);
-
-  const handleNewEvent = useCallback(async () => {
-    if (creating) return;
-    setCreating(true);
-    try {
-      // Default a new draft to next Sunday at 9 AM — the scheduler tunes it
-      // in the editor. Keeps "New event plan" a single tap to a usable draft.
-      const date = nextSundayAtNine();
-      const result = await createEvent({
-        groupId: groupId as Id<"groups">,
-        title: "Untitled event plan",
-        eventDate: date.getTime(),
-        times: [{ label: "9:00 AM", startsAt: date.getTime() }],
-      });
-      router.push(`/rostering/${groupId}/event/${result.planId}` as any);
-    } finally {
-      setCreating(false);
-    }
-  }, [creating, createEvent, groupId, router]);
-
-  // Don't render while loading, or when the group has no event plans —
-  // leaders can still start rostering via Group Actions → Rostering.
+  // Don't render while loading — avoids a flash of the empty-state copy before
+  // the plan count resolves.
   if (events === undefined) return null;
-  if (events.length === 0) return null;
+
+  const summary = buildSummary(events);
 
   return (
     <View style={styles.section}>
-      <Text style={[styles.header, { color: colors.textSecondary }]}>
-        ROSTERING
-      </Text>
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.scrollContent}
+      <TouchableOpacity
+        onPress={() => router.push(`/rostering/${groupId}` as any)}
+        activeOpacity={0.7}
+        style={[styles.tile, { backgroundColor: colors.surfaceSecondary }]}
+        accessibilityRole="button"
+        accessibilityLabel="Rostering"
       >
-        {events.map((event) => {
-          const { totalNeeded, totalFilled, totalConfirmed } =
-            event.fillSummary;
-          const confirmedPct =
-            totalNeeded > 0 ? (totalConfirmed / totalNeeded) * 100 : 0;
-          const filledPct =
-            totalNeeded > 0 ? (totalFilled / totalNeeded) * 100 : 0;
-          // Filled-but-not-yet-confirmed portion of the bar.
-          const pendingPct = Math.max(0, filledPct - confirmedPct);
-          const isPublished = event.status === "published";
-          return (
-            <Pressable
-              key={event._id}
-              onPress={() =>
-                router.push(
-                  `/rostering/${groupId}/event/${event._id}` as any,
-                )
-              }
-              style={({ pressed }) => [
-                styles.card,
-                {
-                  backgroundColor: colors.surfaceSecondary,
-                  borderColor: colors.border,
-                },
-                pressed && { opacity: 0.85 },
-              ]}
-            >
-              <View style={styles.cardTopRow}>
-                <Text
-                  style={[styles.cardTitle, { color: colors.text }]}
-                  numberOfLines={2}
-                >
-                  {event.title}
-                </Text>
-                <View
-                  style={[
-                    styles.pill,
-                    {
-                      backgroundColor: isPublished
-                        ? colors.success + "22"
-                        : colors.border,
-                    },
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.pillText,
-                      {
-                        color: isPublished
-                          ? colors.success
-                          : colors.textSecondary,
-                      },
-                    ]}
-                  >
-                    {isPublished ? "Published" : "Draft"}
-                  </Text>
-                </View>
-              </View>
-              <Text
-                style={[styles.cardDate, { color: colors.textSecondary }]}
-                numberOfLines={1}
-              >
-                {formatEventDate(event.eventDate)}
-                {event.times.length > 0
-                  ? ` · ${event.times.map((t) => t.label).join(", ")}`
-                  : ""}
-              </Text>
-              <View
-                style={[styles.fillTrack, { backgroundColor: colors.border }]}
-              >
-                {/* Confirmed (accepted) — solid. */}
-                <View
-                  style={{
-                    width: `${confirmedPct}%`,
-                    backgroundColor: colors.success,
-                  }}
-                />
-                {/* Filled but awaiting a response — faded. */}
-                <View
-                  style={{
-                    width: `${pendingPct}%`,
-                    backgroundColor: colors.success + "59",
-                  }}
-                />
-              </View>
-              <Text
-                style={[styles.fillText, { color: colors.textSecondary }]}
-                numberOfLines={1}
-              >
-                {totalFilled}/{totalNeeded} filled · {totalConfirmed} confirmed
-              </Text>
-            </Pressable>
-          );
-        })}
-
-        {/* Trailing "+" card — creates a draft plan and opens its editor. */}
-        <Pressable
-          onPress={handleNewEvent}
-          disabled={creating}
-          style={({ pressed }) => [
-            styles.newCard,
-            { borderColor: colors.border },
-            pressed && { opacity: 0.85 },
-          ]}
-        >
-          {creating ? (
-            <ActivityIndicator size="small" color={primaryColor} />
-          ) : (
-            <Ionicons name="add" size={28} color={primaryColor} />
-          )}
+        <View style={[styles.icon, { backgroundColor: colors.link + "1A" }]}>
+          <Ionicons name="calendar-outline" size={18} color={colors.link} />
+        </View>
+        <View style={styles.textWrap}>
+          <Text style={[styles.label, { color: colors.text }]}>Rostering</Text>
           <Text
-            style={[styles.newCardLabel, { color: colors.textSecondary }]}
+            style={[styles.summary, { color: colors.textSecondary }]}
+            numberOfLines={1}
           >
-            New event plan
+            {summary}
           </Text>
-        </Pressable>
-      </ScrollView>
-
-      {/* Quick actions into the rest of the rostering surface. */}
-      <View style={styles.actions}>
-        <ActionButton
-          icon="options-outline"
-          label="Rostering settings"
-          color={colors.text}
-          borderColor={colors.border}
-          onPress={goToRostering}
+        </View>
+        <Ionicons
+          name="chevron-forward"
+          size={18}
+          color={colors.textTertiary}
         />
-        <ActionButton
-          icon="share-outline"
-          label={sharingLink ? "Sharing…" : "Share availability link"}
-          color={colors.text}
-          borderColor={colors.border}
-          onPress={handleShareLink}
-          disabled={sharingLink}
-        />
-        <ActionButton
-          icon="calendar-outline"
-          label="Availability"
-          color={colors.text}
-          borderColor={colors.border}
-          onPress={goToAvailability}
-        />
-        <ActionButton
-          icon="grid-outline"
-          label="Roster grid"
-          color={colors.text}
-          borderColor={colors.border}
-          onPress={goToRosterGrid}
-        />
-      </View>
+      </TouchableOpacity>
     </View>
-  );
-}
-
-function ActionButton({
-  icon,
-  label,
-  color,
-  borderColor,
-  onPress,
-  disabled,
-}: {
-  icon: keyof typeof Ionicons.glyphMap;
-  label: string;
-  color: string;
-  borderColor: string;
-  onPress: () => void;
-  disabled?: boolean;
-}) {
-  return (
-    <Pressable
-      onPress={onPress}
-      disabled={disabled}
-      style={({ pressed }) => [
-        styles.actionBtn,
-        { borderColor },
-        pressed && { opacity: 0.7 },
-        disabled && { opacity: 0.5 },
-      ]}
-    >
-      <Ionicons name={icon} size={16} color={color} />
-      <Text style={[styles.actionLabel, { color }]} numberOfLines={1}>
-        {label}
-      </Text>
-    </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
   section: {
-    marginTop: 24,
-    gap: 8,
-  },
-  header: {
-    fontSize: 11,
-    fontWeight: "700",
-    letterSpacing: 0.6,
-    paddingHorizontal: 16,
-  },
-  scrollContent: {
     paddingHorizontal: 12,
-    gap: 12,
-  },
-  card: {
-    width: 200,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-    padding: 12,
-    gap: 8,
-  },
-  cardTopRow: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 8,
-  },
-  cardTitle: {
-    flex: 1,
-    fontSize: 14,
-    fontWeight: "600",
-    lineHeight: 18,
-  },
-  cardDate: {
-    fontSize: 12,
-  },
-  fillTrack: {
-    height: 6,
-    borderRadius: 3,
-    flexDirection: "row",
-    overflow: "hidden",
-    marginTop: 2,
-  },
-  fillText: {
-    fontSize: 11,
-    fontWeight: "500",
-  },
-  pill: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 999,
-  },
-  pillText: {
-    fontSize: 10,
-    fontWeight: "700",
-  },
-  newCard: {
-    width: 120,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderStyle: "dashed",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 6,
-    padding: 12,
-  },
-  newCardLabel: {
-    fontSize: 12,
-    fontWeight: "600",
-    textAlign: "center",
-  },
-  actions: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 8,
-    paddingHorizontal: 16,
     marginTop: 4,
   },
-  actionBtn: {
+  tile: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 6,
+    gap: 12,
     paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 999,
-    borderWidth: StyleSheet.hairlineWidth,
+    paddingVertical: 12,
+    borderRadius: 12,
+    minHeight: 48,
   },
-  actionLabel: {
-    fontSize: 13,
-    fontWeight: "600",
+  icon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  textWrap: {
+    flex: 1,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  summary: {
+    fontSize: 12,
+    marginTop: 2,
   },
 });

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -291,6 +291,16 @@ export function AssignSheet({
     [filterMemberIds],
   );
 
+  // A group scope is chosen but its member IDs haven't arrived yet. Until they
+  // do, the sheet must NOT fall back to "unfiltered" — otherwise, on a slow
+  // connection, the active filter chip shows while every candidate stays
+  // tappable, letting a leader assign someone outside the selected group.
+  // We render a loading state and treat the candidate list as empty meanwhile.
+  const filterPending =
+    !!filterGroupId &&
+    !!filterGroups?.some((g) => g.id === filterGroupId) &&
+    !filterMemberSet;
+
   const filterGroupName = filterGroupId
     ? filterGroups?.find((g) => g.id === filterGroupId)?.name
     : undefined;
@@ -332,8 +342,10 @@ export function AssignSheet({
     // Apply the "also in group" scope first — it's presentation-only, so it
     // narrows every section (previous / group / community) uniformly. The
     // roster's own coverage tallies live elsewhere and stay whole (FR-4.4).
-    const list = (candidates ?? []).filter(
-      (c) => !filterMemberSet || filterMemberSet.has(c.userId as string),
+    const list = (candidates ?? []).filter((c) =>
+      filterPending
+        ? false
+        : !filterMemberSet || filterMemberSet.has(c.userId as string),
     );
     const byUser = new Map<string, CommunityPerson>(
       list.map((c) => [c.userId as string, c]),
@@ -380,6 +392,7 @@ export function AssignSheet({
     prioritizeAvailable,
     availabilityByUser,
     filterMemberSet,
+    filterPending,
   ]);
 
   // ---------------------------------------------------------------------------
@@ -708,7 +721,7 @@ export function AssignSheet({
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
-  const loading = candidates === undefined;
+  const loading = candidates === undefined || filterPending;
   const teamName = team?.name;
   const subtitle = [roleName, teamName].filter(Boolean).join(" · ");
   const showEmpty =

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -57,6 +57,7 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from "react-native";
+import { FlashList } from "@shopify/flash-list";
 import { Ionicons } from "@expo/vector-icons";
 import { Avatar } from "@components/ui/Avatar";
 import { useTheme } from "@hooks/useTheme";
@@ -211,6 +212,12 @@ export function AssignSheet({
   const [invitePhone, setInvitePhone] = useState("");
   const [invitingSubmit, setInvitingSubmit] = useState(false);
 
+  // "Also in group" candidate scope (#477 FR-4). Independent of the People-view
+  // row filter — it's modal-local state that narrows whom the leader is looking
+  // at right now. Reuses the same backend as the People view (PR #474).
+  const [filterGroupId, setFilterGroupId] = useState<Id<"groups"> | null>(null);
+  const [groupFilterOpen, setGroupFilterOpen] = useState(false);
+
   // Reset transient state whenever the sheet closes so a re-open starts
   // clean (the parent unmounts us when assignTarget clears, but be defensive).
   useEffect(() => {
@@ -221,6 +228,8 @@ export function AssignSheet({
       setInviteFirstName("");
       setInvitePhone("");
       setInvitingSubmit(false);
+      setFilterGroupId(null);
+      setGroupFilterOpen(false);
     }
   }, [visible]);
 
@@ -260,6 +269,45 @@ export function AssignSheet({
     [availability],
   );
 
+  // "Also in group" scope (#477 FR-4). `filterGroups` populates the picker
+  // (excludes this group / announcement / archived groups — enforced backend-
+  // side); `filterMemberIds` is the chosen group's membership, intersected
+  // client-side. Gated on the selection still being present in the loaded list
+  // so a stale pick can't throw into the error boundary.
+  const filterGroups = useAuthenticatedQuery(
+    api.functions.scheduling.roster.rosterFilterGroups,
+    visible ? { groupId } : "skip",
+  ) as Array<{ id: Id<"groups">; name: string }> | undefined;
+
+  const filterMemberIds = useAuthenticatedQuery(
+    api.functions.scheduling.roster.rosterFilterMemberIds,
+    visible && filterGroupId && filterGroups?.some((g) => g.id === filterGroupId)
+      ? { groupId: filterGroupId }
+      : "skip",
+  ) as string[] | undefined;
+
+  const filterMemberSet = useMemo(
+    () => (filterMemberIds ? new Set(filterMemberIds) : null),
+    [filterMemberIds],
+  );
+
+  const filterGroupName = filterGroupId
+    ? filterGroups?.find((g) => g.id === filterGroupId)?.name
+    : undefined;
+
+  // Clear a stale selection once the loaded list no longer contains it (left /
+  // archived). The query above is already gated on the same condition; this
+  // drops the lingering UI state. (Mirrors RosterGridScreen's People filter.)
+  useEffect(() => {
+    if (
+      filterGroupId &&
+      filterGroups &&
+      !filterGroups.some((g) => g.id === filterGroupId)
+    ) {
+      setFilterGroupId(null);
+    }
+  }, [filterGroups, filterGroupId]);
+
   const assignRole = useAuthenticatedMutation(
     api.functions.scheduling.assignments.assignRole,
   );
@@ -281,7 +329,12 @@ export function AssignSheet({
   // is hidden — the candidate list IS the result of their query.
   // ---------------------------------------------------------------------------
   const { previousRows, groupRows, communityRows } = useMemo(() => {
-    const list = candidates ?? [];
+    // Apply the "also in group" scope first — it's presentation-only, so it
+    // narrows every section (previous / group / community) uniformly. The
+    // roster's own coverage tallies live elsewhere and stay whole (FR-4.4).
+    const list = (candidates ?? []).filter(
+      (c) => !filterMemberSet || filterMemberSet.has(c.userId as string),
+    );
     const byUser = new Map<string, CommunityPerson>(
       list.map((c) => [c.userId as string, c]),
     );
@@ -320,7 +373,14 @@ export function AssignSheet({
       );
     }
     return { previousRows, groupRows, communityRows };
-  }, [candidates, previous, debouncedSearch, prioritizeAvailable, availabilityByUser]);
+  }, [
+    candidates,
+    previous,
+    debouncedSearch,
+    prioritizeAvailable,
+    availabilityByUser,
+    filterMemberSet,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Mutation handlers
@@ -657,6 +717,60 @@ export function AssignSheet({
     groupRows.length === 0 &&
     communityRows.length === 0;
 
+  // Flatten the three sections into a single list for FlashList. The candidate
+  // pool can now be the FULL group membership (≥500 in big churches — #477
+  // FR-1/FR-9), so the rows must virtualize rather than render all at once.
+  // Section labels are interleaved as their own items; the search box + group
+  // filter live in the list header, the invite form in the footer.
+  type AssignListItem =
+    | { kind: "label"; key: string; label: string }
+    | { kind: "group"; key: string; person: CommunityPerson; prior: boolean }
+    | { kind: "community"; key: string; person: CommunityPerson };
+
+  const listData = useMemo<AssignListItem[]>(() => {
+    const out: AssignListItem[] = [];
+    if (previousRows.length > 0) {
+      out.push({ kind: "label", key: "l-prev", label: "PREVIOUSLY FILLED BY" });
+      for (const p of previousRows) {
+        out.push({ kind: "group", key: `prev-${p.userId}`, person: p, prior: true });
+      }
+    }
+    if (groupRows.length > 0) {
+      out.push({ kind: "label", key: "l-group", label: "GROUP" });
+      for (const p of groupRows) {
+        out.push({ kind: "group", key: `grp-${p.userId}`, person: p, prior: false });
+      }
+    }
+    if (communityRows.length > 0) {
+      out.push({
+        kind: "label",
+        key: "l-comm",
+        label: "COMMUNITY",
+      });
+      for (const p of communityRows) {
+        out.push({ kind: "community", key: `comm-${p.userId}`, person: p });
+      }
+    }
+    return out;
+  }, [previousRows, groupRows, communityRows]);
+
+  const renderListItem = useCallback(
+    ({ item }: { item: AssignListItem }) => {
+      if (item.kind === "label") {
+        return (
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+            {item.label}
+          </Text>
+        );
+      }
+      if (item.kind === "group") {
+        return renderGroupRow(item.person, item.prior);
+      }
+      return renderCommunityRow(item.person);
+    },
+    [colors.textSecondary, renderGroupRow, renderCommunityRow],
+  );
+
   return (
     <Modal
       visible={visible}
@@ -696,235 +810,326 @@ export function AssignSheet({
             style={styles.cardBody}
             behavior={Platform.OS === "ios" ? "padding" : undefined}
           >
-          <ScrollView
-            style={styles.scrollFlex}
+          <FlashList
+            data={listData}
+            extraData={`${busyUserId ?? ""}|${invitingSubmit}`}
+            keyExtractor={(item) => item.key}
+            renderItem={renderListItem}
             contentContainerStyle={styles.scrollContent}
             keyboardShouldPersistTaps="handled"
-            automaticallyAdjustKeyboardInsets={Platform.OS === "ios"}
-          >
-            <View
-              style={[
-                styles.searchBox,
-                { backgroundColor: colors.surface, borderColor: colors.border },
-              ]}
-            >
-              <Ionicons name="search" size={16} color={colors.textSecondary} />
-              <TextInput
-                style={[styles.searchInput, { color: colors.text }]}
-                placeholder="Search by name…"
-                placeholderTextColor={colors.textSecondary}
-                value={search}
-                onChangeText={setSearch}
-                autoCorrect={false}
-                autoCapitalize="none"
-              />
-            </View>
-
-            {loading ? (
-              <View style={styles.centered}>
-                <ActivityIndicator size="small" color={colors.text} />
-              </View>
-            ) : (
-              <>
-                {previousRows.length > 0 && (
-                  <>
-                    <Text
-                      style={[styles.sectionLabel, { color: colors.textSecondary }]}
-                    >
-                      PREVIOUSLY FILLED BY
-                    </Text>
-                    <View
-                      style={[
-                        styles.group,
-                        { backgroundColor: colors.surfaceSecondary },
-                      ]}
-                    >
-                      {previousRows.map((m) => renderGroupRow(m, true))}
-                    </View>
-                  </>
-                )}
-
-                {groupRows.length > 0 && (
-                  <>
-                    <Text
-                      style={[styles.sectionLabel, { color: colors.textSecondary }]}
-                    >
-                      GROUP
-                    </Text>
-                    <View
-                      style={[
-                        styles.group,
-                        { backgroundColor: colors.surfaceSecondary },
-                      ]}
-                    >
-                      {groupRows.map((m) => renderGroupRow(m, false))}
-                    </View>
-                  </>
-                )}
-
-                {communityRows.length > 0 && (
-                  <>
-                    <Text
-                      style={[styles.sectionLabel, { color: colors.textSecondary }]}
-                    >
-                      COMMUNITY
-                    </Text>
-                    <View
-                      style={[
-                        styles.group,
-                        { backgroundColor: colors.surfaceSecondary },
-                      ]}
-                    >
-                      {communityRows.map(renderCommunityRow)}
-                    </View>
-                  </>
-                )}
-
-                {showEmpty && (
-                  <Text
-                    style={[styles.emptyText, { color: colors.textSecondary }]}
-                  >
-                    {debouncedSearch.trim()
-                      ? `No one in this community matches "${debouncedSearch.trim()}".`
-                      : "No assignable people yet — invite someone new below."}
-                  </Text>
-                )}
-              </>
-            )}
-
-            {/* Invite someone new — collapsed by default. */}
-            <Text
-              style={[styles.sectionLabel, { color: colors.textSecondary }]}
-            >
-              INVITE SOMEONE NEW
-            </Text>
-            {inviteOpen ? (
-              <View
-                style={[
-                  styles.inviteCard,
-                  { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
-                ]}
-              >
-                <TextInput
+            keyboardDismissMode="on-drag"
+            ListHeaderComponent={
+              <View>
+                <View
                   style={[
-                    styles.inviteInput,
-                    { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
+                    styles.searchBox,
+                    { backgroundColor: colors.surface, borderColor: colors.border },
                   ]}
-                  placeholder="Name"
-                  placeholderTextColor={colors.textSecondary}
-                  value={inviteFirstName}
-                  onChangeText={setInviteFirstName}
-                  autoCapitalize="words"
-                  autoCorrect={false}
-                  editable={!invitingSubmit}
-                />
-                <TextInput
-                  style={[
-                    styles.inviteInput,
-                    { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
-                  ]}
-                  placeholder="Phone (e.g. (555) 123-4567)"
-                  placeholderTextColor={colors.textSecondary}
-                  value={invitePhone}
-                  onChangeText={setInvitePhone}
-                  keyboardType="phone-pad"
-                  autoCorrect={false}
-                  editable={!invitingSubmit}
-                />
-                <View style={styles.inviteActions}>
+                >
+                  <Ionicons name="search" size={16} color={colors.textSecondary} />
+                  <TextInput
+                    style={[styles.searchInput, { color: colors.text }]}
+                    placeholder="Search by name…"
+                    placeholderTextColor={colors.textSecondary}
+                    value={search}
+                    onChangeText={setSearch}
+                    autoCorrect={false}
+                    autoCapitalize="none"
+                  />
+                </View>
+
+                {/* "Also in group" scope (#477 FR-4). Hidden when the leader
+                    has no other eligible groups. */}
+                {filterGroups && filterGroups.length > 0 && (
                   <Pressable
-                    onPress={() => {
-                      if (invitingSubmit) return;
-                      setInviteOpen(false);
-                      setInviteFirstName("");
-                      setInvitePhone("");
-                    }}
-                    disabled={invitingSubmit}
+                    onPress={() => setGroupFilterOpen(true)}
                     accessibilityRole="button"
-                    accessibilityLabel="Cancel invite"
-                  >
-                    <View style={styles.inviteCancelInner}>
-                      <Text
-                        style={[styles.inviteCancelText, { color: colors.textSecondary }]}
-                      >
-                        Cancel
-                      </Text>
-                    </View>
-                  </Pressable>
-                  <Pressable
-                    onPress={handleInviteSubmit}
-                    disabled={invitingSubmit}
-                    accessibilityRole="button"
-                    accessibilityLabel={
-                      planStatus === "draft"
-                        ? "Invite and assign"
-                        : "Send invite and assign"
-                    }
+                    accessibilityLabel="Filter by also in group"
                   >
                     <View
                       style={[
-                        styles.inviteSubmitInner,
+                        styles.scopeRow,
                         {
-                          backgroundColor: primaryColor,
-                          opacity: invitingSubmit ? 0.6 : 1,
+                          borderColor: filterGroupId ? primaryColor : colors.border,
+                          backgroundColor: filterGroupId
+                            ? primaryColor + "14"
+                            : colors.surface,
                         },
                       ]}
                     >
-                      {invitingSubmit ? (
-                        <ActivityIndicator size="small" color={colors.surface} />
-                      ) : (
-                        <Text
-                          style={[styles.inviteSubmitText, { color: colors.surface }]}
-                        >
-                          {planStatus === "draft"
-                            ? "Invite & assign"
-                            : "Send invite & assign"}
-                        </Text>
-                      )}
+                      <Ionicons
+                        name="funnel"
+                        size={14}
+                        color={filterGroupId ? primaryColor : colors.textSecondary}
+                      />
+                      <Text
+                        style={[
+                          styles.scopeText,
+                          {
+                            color: filterGroupId ? primaryColor : colors.textSecondary,
+                          },
+                        ]}
+                        numberOfLines={1}
+                      >
+                        {filterGroupName
+                          ? `Also in: ${filterGroupName}`
+                          : "Also in group"}
+                      </Text>
+                      <Ionicons
+                        name="chevron-down"
+                        size={14}
+                        color={filterGroupId ? primaryColor : colors.textSecondary}
+                      />
                     </View>
                   </Pressable>
-                </View>
-                <Text
-                  style={[
-                    styles.inviteHelperText,
-                    { color: colors.textSecondary },
-                  ]}
-                >
-                  {planStatus === "draft"
-                    ? `We'll text ${inviteFirstName.trim() || "them"} the invite when you publish this event plan.`
-                    : "An SMS invite will be sent now."}
-                </Text>
+                )}
+
+                {loading && (
+                  <View style={styles.centered}>
+                    <ActivityIndicator size="small" color={colors.text} />
+                  </View>
+                )}
+                {showEmpty && (
+                  <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                    {debouncedSearch.trim() || filterGroupId
+                      ? "No one matches these filters."
+                      : "No assignable people yet — invite someone new below."}
+                  </Text>
+                )}
               </View>
-            ) : (
-              <Pressable
-                onPress={() => setInviteOpen(true)}
-                accessibilityRole="button"
-                accessibilityLabel="Invite someone new"
-              >
-                <View
-                  style={[
-                    styles.inviteToggle,
-                    { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
-                  ]}
-                >
-                  <Ionicons
-                    name="add-circle-outline"
-                    size={18}
-                    color={primaryColor}
-                  />
-                  <Text
+            }
+            ListFooterComponent={
+              <View>
+                {/* Invite someone new — collapsed by default. */}
+                <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+                  INVITE SOMEONE NEW
+                </Text>
+                {inviteOpen ? (
+                  <View
                     style={[
-                      styles.inviteToggleText,
-                      { color: primaryColor },
+                      styles.inviteCard,
+                      { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
                     ]}
                   >
-                    Invite someone new
+                    <TextInput
+                      style={[
+                        styles.inviteInput,
+                        { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
+                      ]}
+                      placeholder="Name"
+                      placeholderTextColor={colors.textSecondary}
+                      value={inviteFirstName}
+                      onChangeText={setInviteFirstName}
+                      autoCapitalize="words"
+                      autoCorrect={false}
+                      editable={!invitingSubmit}
+                    />
+                    <TextInput
+                      style={[
+                        styles.inviteInput,
+                        { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface },
+                      ]}
+                      placeholder="Phone (e.g. (555) 123-4567)"
+                      placeholderTextColor={colors.textSecondary}
+                      value={invitePhone}
+                      onChangeText={setInvitePhone}
+                      keyboardType="phone-pad"
+                      autoCorrect={false}
+                      editable={!invitingSubmit}
+                    />
+                    <View style={styles.inviteActions}>
+                      <Pressable
+                        onPress={() => {
+                          if (invitingSubmit) return;
+                          setInviteOpen(false);
+                          setInviteFirstName("");
+                          setInvitePhone("");
+                        }}
+                        disabled={invitingSubmit}
+                        accessibilityRole="button"
+                        accessibilityLabel="Cancel invite"
+                      >
+                        <View style={styles.inviteCancelInner}>
+                          <Text
+                            style={[styles.inviteCancelText, { color: colors.textSecondary }]}
+                          >
+                            Cancel
+                          </Text>
+                        </View>
+                      </Pressable>
+                      <Pressable
+                        onPress={handleInviteSubmit}
+                        disabled={invitingSubmit}
+                        accessibilityRole="button"
+                        accessibilityLabel={
+                          planStatus === "draft"
+                            ? "Invite and assign"
+                            : "Send invite and assign"
+                        }
+                      >
+                        <View
+                          style={[
+                            styles.inviteSubmitInner,
+                            {
+                              backgroundColor: primaryColor,
+                              opacity: invitingSubmit ? 0.6 : 1,
+                            },
+                          ]}
+                        >
+                          {invitingSubmit ? (
+                            <ActivityIndicator size="small" color={colors.surface} />
+                          ) : (
+                            <Text
+                              style={[styles.inviteSubmitText, { color: colors.surface }]}
+                            >
+                              {planStatus === "draft"
+                                ? "Invite & assign"
+                                : "Send invite & assign"}
+                            </Text>
+                          )}
+                        </View>
+                      </Pressable>
+                    </View>
+                    <Text
+                      style={[styles.inviteHelperText, { color: colors.textSecondary }]}
+                    >
+                      {planStatus === "draft"
+                        ? `We'll text ${inviteFirstName.trim() || "them"} the invite when you publish this event plan.`
+                        : "An SMS invite will be sent now."}
+                    </Text>
+                  </View>
+                ) : (
+                  <Pressable
+                    onPress={() => setInviteOpen(true)}
+                    accessibilityRole="button"
+                    accessibilityLabel="Invite someone new"
+                  >
+                    <View
+                      style={[
+                        styles.inviteToggle,
+                        { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                      ]}
+                    >
+                      <Ionicons
+                        name="add-circle-outline"
+                        size={18}
+                        color={primaryColor}
+                      />
+                      <Text
+                        style={[styles.inviteToggleText, { color: primaryColor }]}
+                      >
+                        Invite someone new
+                      </Text>
+                    </View>
+                  </Pressable>
+                )}
+              </View>
+            }
+          />
+          </KeyboardAvoidingView>
+
+          {groupFilterOpen && (
+            <AssignGroupFilterMenu
+              groups={filterGroups ?? []}
+              selectedId={filterGroupId}
+              colors={colors}
+              onPick={(id) => {
+                setFilterGroupId(id);
+                setGroupFilterOpen(false);
+              }}
+              onClose={() => setGroupFilterOpen(false)}
+            />
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+type ThemeColors = ReturnType<typeof useTheme>["colors"];
+
+/**
+ * "Also in group" picker for the assign sheet (#477 FR-4). A single-select
+ * menu over the leader's other groups; "Everyone" clears the scope. Mirrors the
+ * People-view picker but is independent modal-local state.
+ */
+function AssignGroupFilterMenu({
+  groups,
+  selectedId,
+  colors,
+  onPick,
+  onClose,
+}: {
+  groups: Array<{ id: Id<"groups">; name: string }>;
+  selectedId: Id<"groups"> | null;
+  colors: ThemeColors;
+  onPick: (id: Id<"groups"> | null) => void;
+  onClose: () => void;
+}) {
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.menuBackdrop} onPress={onClose}>
+        <Pressable
+          style={[
+            styles.menuCard,
+            { backgroundColor: colors.surface, borderColor: colors.border },
+          ]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={[styles.menuHead, { borderBottomColor: colors.border }]}>
+            <View style={styles.menuHeadText}>
+              <Text style={[styles.menuTitle, { color: colors.text }]}>
+                Also in group
+              </Text>
+              <Text style={[styles.menuSub, { color: colors.textSecondary }]}>
+                Show only people who are also in…
+              </Text>
+            </View>
+            <TouchableOpacity onPress={onClose} hitSlop={12}>
+              <Ionicons name="close" size={22} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+          <ScrollView style={styles.menuList}>
+            <Pressable
+              onPress={() => onPick(null)}
+              accessibilityRole="button"
+              accessibilityLabel="Everyone"
+            >
+              <View style={[styles.menuRow, { borderBottomColor: colors.border }]}>
+                <Text
+                  style={[styles.menuRowText, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  Everyone
+                </Text>
+                {selectedId === null && (
+                  <Ionicons name="checkmark" size={20} color={colors.link} />
+                )}
+              </View>
+            </Pressable>
+            {groups.map((g) => (
+              <Pressable
+                key={g.id}
+                onPress={() => onPick(g.id)}
+                accessibilityRole="button"
+                accessibilityLabel={g.name}
+              >
+                <View
+                  style={[styles.menuRow, { borderBottomColor: colors.border }]}
+                >
+                  <Text
+                    style={[styles.menuRowText, { color: colors.text }]}
+                    numberOfLines={1}
+                  >
+                    {g.name}
                   </Text>
+                  {selectedId === g.id && (
+                    <Ionicons name="checkmark" size={20} color={colors.link} />
+                  )}
                 </View>
               </Pressable>
-            )}
+            ))}
           </ScrollView>
-          </KeyboardAvoidingView>
         </Pressable>
       </Pressable>
     </Modal>
@@ -948,9 +1153,6 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
   cardBody: {
-    flexShrink: 1,
-  },
-  scrollFlex: {
     flexShrink: 1,
   },
   header: {
@@ -1005,9 +1207,20 @@ const styles = StyleSheet.create({
     marginTop: 16,
     marginBottom: 8,
   },
-  group: {
-    borderRadius: 12,
-    overflow: "hidden",
+  scopeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    marginTop: 10,
+  },
+  scopeText: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: "600",
   },
   memberRow: {
     flexDirection: "row",
@@ -1131,4 +1344,37 @@ const styles = StyleSheet.create({
     lineHeight: 16,
     marginTop: 2,
   },
+  menuBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  menuCard: {
+    width: "100%",
+    maxWidth: 380,
+    maxHeight: "70%",
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+  },
+  menuHead: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    marginBottom: 8,
+  },
+  menuHeadText: { flex: 1, minWidth: 0 },
+  menuTitle: { fontSize: 17, fontWeight: "700" },
+  menuSub: { fontSize: 12, marginTop: 2 },
+  menuList: { flexGrow: 0 },
+  menuRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  menuRowText: { flex: 1, fontSize: 15, fontWeight: "500" },
 });

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -754,22 +754,22 @@ export function AssignSheet({
     return out;
   }, [previousRows, groupRows, communityRows]);
 
-  const renderListItem = useCallback(
-    ({ item }: { item: AssignListItem }) => {
-      if (item.kind === "label") {
-        return (
-          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
-            {item.label}
-          </Text>
-        );
-      }
-      if (item.kind === "group") {
-        return renderGroupRow(item.person, item.prior);
-      }
-      return renderCommunityRow(item.person);
-    },
-    [colors.textSecondary, renderGroupRow, renderCommunityRow],
-  );
+  // Plain function (not memoized): the row renderers it delegates to close over
+  // fresh state each render, so memoizing here would be a no-op. FlashList still
+  // recycles rows by `keyExtractor` + `extraData`.
+  const renderListItem = ({ item }: { item: AssignListItem }) => {
+    if (item.kind === "label") {
+      return (
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+          {item.label}
+        </Text>
+      );
+    }
+    if (item.kind === "group") {
+      return renderGroupRow(item.person, item.prior);
+    }
+    return renderCommunityRow(item.person);
+  };
 
   return (
     <Modal
@@ -812,7 +812,10 @@ export function AssignSheet({
           >
           <FlashList
             data={listData}
-            extraData={`${busyUserId ?? ""}|${invitingSubmit}`}
+            // Re-render rows when these change the per-row affordance (busy
+            // spinner, disabled state, "Assigned" greying as the parent
+            // reactively updates `assignedUserIds`).
+            extraData={`${busyUserId ?? ""}|${invitingSubmit}|${assignedUserIds.size}`}
             keyExtractor={(item) => item.key}
             renderItem={renderListItem}
             contentContainerStyle={styles.scrollContent}

--- a/apps/mobile/features/scheduling/components/EventListScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventListScreen.tsx
@@ -309,28 +309,43 @@ export function EventListScreen() {
         { paddingBottom: insets.bottom + 24 },
       ]}
     >
-      <Pressable
-        onPress={handleNewEvent}
-        disabled={creating}
-        style={[styles.newRow, { borderColor: primaryColor }]}
-        accessibilityRole="button"
-      >
-        {creating ? (
-          <ActivityIndicator size="small" color={primaryColor} />
-        ) : (
-          <Ionicons name="add" size={20} color={primaryColor} />
-        )}
-        <Text style={[styles.newLabel, { color: primaryColor }]}>
-          New event plan
-        </Text>
-      </Pressable>
+      {/* Two primary build actions, side by side: create a plan, or open the
+          roster grid (the matrix where assignment happens). The grid is the
+          main build surface, so it gets the filled, accented treatment. */}
+      <View style={styles.primaryActions}>
+        <Pressable
+          onPress={handleNewEvent}
+          disabled={creating}
+          style={[styles.newRow, { borderColor: primaryColor }]}
+          accessibilityRole="button"
+        >
+          {creating ? (
+            <ActivityIndicator size="small" color={primaryColor} />
+          ) : (
+            <Ionicons name="add" size={20} color={primaryColor} />
+          )}
+          <Text style={[styles.newLabel, { color: primaryColor }]}>
+            New event plan
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={() => router.push(`/rostering/${groupId}/grid` as never)}
+          style={[styles.gridRow, { backgroundColor: primaryColor }]}
+          accessibilityRole="button"
+          accessibilityLabel="Open the roster grid"
+        >
+          <Ionicons name="git-network-outline" size={20} color="#fff" />
+          <Text style={styles.gridLabel}>Open roster grid</Text>
+        </Pressable>
+      </View>
 
       <Pressable
         onPress={handleShareLink}
         disabled={sharingLink}
         style={styles.shareRow}
         accessibilityRole="button"
-        accessibilityLabel="Share an availability link"
+        accessibilityLabel="Collect availability"
       >
         {sharingLink ? (
           <ActivityIndicator size="small" color={colors.textSecondary} />
@@ -342,23 +357,7 @@ export function EventListScreen() {
           />
         )}
         <Text style={[styles.shareLabel, { color: colors.textSecondary }]}>
-          Share availability link
-        </Text>
-      </Pressable>
-
-      <Pressable
-        onPress={() => router.push(`/rostering/${groupId}/grid` as never)}
-        style={styles.shareRow}
-        accessibilityRole="button"
-        accessibilityLabel="Open the roster grid"
-      >
-        <Ionicons
-          name="git-network-outline"
-          size={18}
-          color={colors.textSecondary}
-        />
-        <Text style={[styles.shareLabel, { color: colors.textSecondary }]}>
-          Roster grid
+          Collect availability
         </Text>
       </Pressable>
 
@@ -455,7 +454,12 @@ const styles = StyleSheet.create({
     padding: 16,
     gap: 12,
   },
+  primaryActions: {
+    flexDirection: "row",
+    gap: 12,
+  },
   newRow: {
+    flex: 1,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
@@ -468,6 +472,20 @@ const styles = StyleSheet.create({
   newLabel: {
     fontSize: 15,
     fontWeight: "600",
+  },
+  gridRow: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    borderRadius: 12,
+    paddingVertical: 14,
+  },
+  gridLabel: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#fff",
   },
   shareRow: {
     flexDirection: "row",

--- a/apps/mobile/features/scheduling/components/GridPresenceBar.tsx
+++ b/apps/mobile/features/scheduling/components/GridPresenceBar.tsx
@@ -1,0 +1,140 @@
+/**
+ * GridPresenceBar
+ *
+ * Lightweight "others viewing this roster right now" affordance for the roster
+ * grid (#477). While mounted it heartbeats on an interval and renders the live
+ * `listViewers` query as a compact, overlapping stack of avatars; on unmount it
+ * calls `leave` to drop out cleanly (the backend's 30s staleness window covers
+ * a missed leave). Deliberately subtle so it doesn't clutter the toolbar — it
+ * renders nothing when no one else is present.
+ *
+ * Backend: scheduling.presence.heartbeat / listViewers / leave. `gridKey` is the
+ * rostering group's id as a string (the same id the grid screen holds). The
+ * auth token is injected by the `useAuthenticated*` hooks.
+ */
+import React, { useEffect, useRef } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Avatar } from "@components/ui/Avatar";
+import { useTheme } from "@hooks/useTheme";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+
+/** Heartbeat cadence — well inside the backend's 30s staleness window. */
+const HEARTBEAT_MS = 10_000;
+/** Max avatars shown before collapsing into a "+N" chip. */
+const MAX_AVATARS = 4;
+const AV = 24;
+
+type Viewer = {
+  userId: Id<"users">;
+  name: string;
+  avatarUrl?: string | null;
+  lastSeenAt: number;
+};
+
+export function GridPresenceBar({ groupId }: { groupId: Id<"groups"> }) {
+  const { colors } = useTheme();
+  const gridKey = groupId as string;
+
+  const heartbeat = useAuthenticatedMutation(
+    api.functions.scheduling.presence.heartbeat,
+  );
+  const leave = useAuthenticatedMutation(
+    api.functions.scheduling.presence.leave,
+  );
+
+  const viewers = useAuthenticatedQuery(
+    api.functions.scheduling.presence.listViewers,
+    groupId ? { gridKey } : "skip",
+  ) as Viewer[] | undefined;
+
+  // Heartbeat immediately on mount, then on an interval. `leave` on unmount.
+  // Keep the latest mutation refs so the effect runs once (stable interval) and
+  // doesn't churn when the hook identities change.
+  const heartbeatRef = useRef(heartbeat);
+  heartbeatRef.current = heartbeat;
+  const leaveRef = useRef(leave);
+  leaveRef.current = leave;
+
+  useEffect(() => {
+    if (!groupId) return;
+    const beat = () => {
+      // Presence is best-effort — a dropped beat self-heals on the next one.
+      heartbeatRef.current({ gridKey }).catch(() => {});
+    };
+    beat();
+    const id = setInterval(beat, HEARTBEAT_MS);
+    return () => {
+      clearInterval(id);
+      leaveRef.current({ gridKey }).catch(() => {});
+    };
+  }, [groupId, gridKey]);
+
+  if (!viewers || viewers.length === 0) return null;
+
+  const shown = viewers.slice(0, MAX_AVATARS);
+  const overflow = viewers.length - shown.length;
+
+  return (
+    <View
+      style={styles.wrap}
+      accessibilityLabel={`${viewers.length} other${viewers.length === 1 ? "" : "s"} viewing`}
+    >
+      {shown.map((v, idx) => (
+        <View
+          key={v.userId}
+          style={[
+            styles.avatarRing,
+            {
+              borderColor: colors.surface,
+              backgroundColor: colors.surface,
+              marginLeft: idx === 0 ? 0 : -8,
+              zIndex: shown.length - idx,
+            },
+          ]}
+        >
+          <Avatar name={v.name} imageUrl={v.avatarUrl ?? undefined} size={AV} />
+        </View>
+      ))}
+      {overflow > 0 && (
+        <View
+          style={[
+            styles.avatarRing,
+            styles.overflow,
+            { borderColor: colors.surface, backgroundColor: colors.surfaceSecondary, marginLeft: -8 },
+          ]}
+        >
+          <Text style={[styles.overflowText, { color: colors.textSecondary }]}>
+            +{overflow}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  avatarRing: {
+    borderWidth: 1.5,
+    borderRadius: 999,
+    padding: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  overflow: {
+    width: AV + 4,
+    height: AV + 4,
+  },
+  overflowText: {
+    fontSize: 11,
+    fontWeight: "700",
+  },
+});

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -222,7 +222,11 @@ export function RosterGridScreen() {
 
   // --- View + filter state ---
   const [mode, setMode] = useState<ViewMode>("roles");
-  const [hiddenTeams, setHiddenTeams] = useState<Set<string>>(new Set());
+  // Team scope: a single isolated team, or null for "All teams" (#477 FR-2).
+  // Picking a team shows only its roles; "All teams" shows everything. Gates
+  // the Roles view only — People rows stay ungated.
+  const [isolatedTeamId, setIsolatedTeamId] = useState<string | null>(null);
+  const [teamMenuOpen, setTeamMenuOpen] = useState(false);
   const [openOnly, setOpenOnly] = useState(false);
   const [availableOnly, setAvailableOnly] = useState(false);
   const [search, setSearch] = useState("");
@@ -360,25 +364,27 @@ export function RosterGridScreen() {
   const events = data?.events ?? [];
   const roleCells = data?.roleCells ?? {};
 
-  const teamVisible = useCallback(
-    (teamId: string) => !hiddenTeams.has(teamId),
-    [hiddenTeams],
-  );
+  // Clear a stale isolated team once it's no longer in the loaded team list
+  // (e.g. its roles were removed). Keeps the dropdown label honest.
+  useEffect(() => {
+    if (
+      isolatedTeamId &&
+      data &&
+      !data.teams.some((t) => (t.teamId as string) === isolatedTeamId)
+    ) {
+      setIsolatedTeamId(null);
+    }
+  }, [data, isolatedTeamId]);
 
-  const toggleTeam = useCallback((teamId: string) => {
-    setHiddenTeams((prev) => {
-      const next = new Set(prev);
-      if (next.has(teamId)) next.delete(teamId);
-      else next.add(teamId);
-      return next;
-    });
-  }, []);
+  const isolatedTeamName = isolatedTeamId
+    ? data?.teams.find((t) => (t.teamId as string) === isolatedTeamId)?.teamName
+    : undefined;
 
   /** Roles after team + "open only" filters; grouped headers are derived on render. */
   const visibleRoles = useMemo(() => {
     if (!data) return [];
     return data.roles.filter((r) => {
-      if (!teamVisible(r.teamId as string)) return false;
+      if (isolatedTeamId && (r.teamId as string) !== isolatedTeamId) return false;
       if (openOnly) {
         // Keep only roles with at least one open slot across visible events.
         const hasOpen = events.some((ev) => {
@@ -389,7 +395,7 @@ export function RosterGridScreen() {
       }
       return true;
     });
-  }, [data, events, roleCells, teamVisible, openOnly]);
+  }, [data, events, roleCells, isolatedTeamId, openOnly]);
 
   /**
    * Interleave team section-header rows into the (already team-sorted) role
@@ -512,28 +518,20 @@ export function RosterGridScreen() {
   // -------------------------------------------------------------------------
   const renderFilterBar = () => (
     <View style={[styles.filterBar, { borderBottomColor: colors.border }]}>
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.chipRow}
-      >
-        <Chip
-          label="All teams"
-          active={hiddenTeams.size === 0}
-          onPress={() => setHiddenTeams(new Set())}
-          colors={colors}
-        />
-        {data.teams.map((t) => (
+      <View style={styles.chipRow}>
+        {/* Team scope — single-select dropdown (#477 FR-2). Picking a team
+            isolates it; "All teams" shows everything. Gates Roles view only,
+            so it's only shown there. */}
+        {mode === "roles" && data.teams.length > 0 && (
           <Chip
-            key={t.teamId}
-            label={t.teamName}
-            active={teamVisible(t.teamId as string)}
-            onPress={() => toggleTeam(t.teamId as string)}
+            icon="people-outline"
+            label={isolatedTeamName ?? "All teams"}
+            trailingIcon="chevron-down"
+            active={isolatedTeamId !== null}
+            onPress={() => setTeamMenuOpen(true)}
             colors={colors}
           />
-        ))}
-      </ScrollView>
-      <View style={styles.chipRow}>
+        )}
         <Chip
           icon={openOnly ? "checkbox" : "square-outline"}
           label="Open only"
@@ -1011,6 +1009,19 @@ export function RosterGridScreen() {
           onClose={() => setGroupFilterOpen(false)}
         />
       )}
+
+      {teamMenuOpen && (
+        <TeamFilterMenu
+          teams={data.teams}
+          selectedId={isolatedTeamId}
+          colors={colors}
+          onPick={(id) => {
+            setIsolatedTeamId(id);
+            setTeamMenuOpen(false);
+          }}
+          onClose={() => setTeamMenuOpen(false)}
+        />
+      )}
     </View>
   );
 }
@@ -1479,6 +1490,63 @@ function GroupFilterMenu({
   );
 }
 
+/**
+ * Team scope picker (#477 FR-2) — a single-select menu that isolates one
+ * team's roles in the Roles view. "All teams" clears the scope.
+ */
+function TeamFilterMenu({
+  teams,
+  selectedId,
+  colors,
+  onPick,
+  onClose,
+}: {
+  teams: RosterTeam[];
+  selectedId: string | null;
+  colors: Colors;
+  onPick: (id: string | null) => void;
+  onClose: () => void;
+}) {
+  return (
+    <ModalShell
+      title="Teams"
+      subtitle="Show roles for…"
+      colors={colors}
+      onClose={onClose}
+    >
+      <ScrollView style={styles.popoverList}>
+        <Pressable
+          onPress={() => onPick(null)}
+          style={[styles.menuRow, { borderBottomColor: colors.border }]}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+            All teams
+          </Text>
+          {selectedId === null && (
+            <Ionicons name="checkmark" size={20} color={colors.link} />
+          )}
+        </Pressable>
+        {teams.map((t) => (
+          <Pressable
+            key={t.teamId}
+            onPress={() => onPick(t.teamId as string)}
+            style={[styles.menuRow, { borderBottomColor: colors.border }]}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+              {t.teamName}
+            </Text>
+            {selectedId === (t.teamId as string) && (
+              <Ionicons name="checkmark" size={20} color={colors.link} />
+            )}
+          </Pressable>
+        ))}
+      </ScrollView>
+    </ModalShell>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Small shared UI
 // ---------------------------------------------------------------------------
@@ -1511,17 +1579,21 @@ function SegBtn({
 
 function Chip({
   icon,
+  trailingIcon,
   label,
   active,
   onPress,
   colors,
 }: {
   icon?: keyof typeof Ionicons.glyphMap;
+  /** Optional icon after the label — e.g. a chevron marking a dropdown. */
+  trailingIcon?: keyof typeof Ionicons.glyphMap;
   label: string;
   active: boolean;
   onPress: () => void;
   colors: Colors;
 }) {
+  const tint = active ? colors.link : colors.textSecondary;
   return (
     <Pressable
       onPress={onPress}
@@ -1533,12 +1605,9 @@ function Chip({
         },
       ]}
     >
-      {icon && (
-        <Ionicons name={icon} size={14} color={active ? colors.link : colors.textSecondary} />
-      )}
-      <Text style={[styles.chipText, { color: active ? colors.link : colors.textSecondary }]}>
-        {label}
-      </Text>
+      {icon && <Ionicons name={icon} size={14} color={tint} />}
+      <Text style={[styles.chipText, { color: tint }]}>{label}</Text>
+      {trailingIcon && <Ionicons name={trailingIcon} size={13} color={tint} />}
     </Pressable>
   );
 }

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -53,6 +53,7 @@ import {
 import type { Id } from "@services/api/convex";
 import { confirmAsync, notify } from "@/utils/platformAlert";
 import { AssignSheet } from "./AssignSheet";
+import { GridPresenceBar } from "./GridPresenceBar";
 
 // ---------------------------------------------------------------------------
 // Backend contract (mirrors scheduling.roster.rosterMatrix)
@@ -593,6 +594,7 @@ export function RosterGridScreen() {
           </Text>
         )}
       </View>
+      {groupId && <GridPresenceBar groupId={groupId} />}
       <View style={styles.segmented}>
         <SegBtn
           label="Roles"

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -41,14 +41,17 @@ import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { Avatar } from "@components/ui/Avatar";
 import { EmptyState } from "@components/ui/EmptyState";
 import {
   useAuthenticatedQuery,
   useAuthenticatedMutation,
+  useAuthenticatedAction,
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { confirmAsync, notify } from "@/utils/platformAlert";
 import { AssignSheet } from "./AssignSheet";
 
 // ---------------------------------------------------------------------------
@@ -195,6 +198,7 @@ type AssignTarget = {
 
 export function RosterGridScreen() {
   const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { width } = useWindowDimensions();
@@ -218,6 +222,12 @@ export function RosterGridScreen() {
   );
   const unassign = useAuthenticatedMutation(
     api.functions.scheduling.assignments.unassign,
+  );
+  // Publish from the grid (#477 FR-3) — the SAME action the event editor uses,
+  // not a fork. The grid is group-scoped with multiple date columns, so the
+  // chooser below targets a specific plan (or all draft plans).
+  const publishEvent = useAuthenticatedAction(
+    api.functions.scheduling.assignments.publishEvent,
   );
 
   // --- View + filter state ---
@@ -318,6 +328,9 @@ export function RosterGridScreen() {
     event: RosterEvent;
     note?: string;
   } | null>(null);
+  // Publish chooser (#477 FR-3): which date(s) to publish & send requests.
+  const [publishMenuOpen, setPublishMenuOpen] = useState(false);
+  const [publishing, setPublishing] = useState(false);
 
   const surfaceError = useCallback((title: string, e: unknown) => {
     const err = e as { data?: { message?: string }; message?: string };
@@ -448,6 +461,116 @@ export function RosterGridScreen() {
     },
     [data, roleCells],
   );
+
+  // -------------------------------------------------------------------------
+  // Publish (#477 FR-3)
+  //
+  // `publishEvent` notifies only *unconfirmed* assignments (confirmed people
+  // are never re-pinged), so the per-event "request count" we show in the
+  // confirm dialog is the number of unconfirmed occupants across that plan's
+  // role cells — the same population `markPublished` counts server-side.
+  // -------------------------------------------------------------------------
+  const requestCountForEvent = useCallback(
+    (event: RosterEvent): number => {
+      let n = 0;
+      for (const role of data?.roles ?? []) {
+        const c = roleCells[`${role.roleId}:${event._id}`];
+        if (!c) continue;
+        n += c.occupants.filter((o) => o.status === "unconfirmed").length;
+      }
+      return n;
+    },
+    [data, roleCells],
+  );
+
+  /** Draft event plans — the default publish target (unpublished dates). */
+  const draftEvents = useMemo(
+    () => events.filter((e) => e.status === "draft"),
+    [events],
+  );
+
+  /** Publish a single plan, with a confirm listing its request count. */
+  const publishOne = useCallback(
+    async (event: RosterEvent) => {
+      const count = requestCountForEvent(event);
+      const dateLabel = `${weekday(event.eventDate)} ${monthDay(event.eventDate)}`;
+      const already = event.status === "published";
+      const ok = await confirmAsync({
+        title: already ? "Re-send requests?" : "Publish & send requests?",
+        message:
+          `${dateLabel} — ${count} request${count === 1 ? "" : "s"} will be sent.` +
+          (count > 0
+            ? "\n\nConfirmed people won't be re-notified."
+            : "\n\nNo one is awaiting a response on this date yet."),
+        confirmText: already ? "Re-send" : "Send",
+      });
+      if (!ok) return;
+      setPublishing(true);
+      try {
+        const result = await publishEvent({ planId: event._id });
+        notify(
+          already ? "Requests re-sent" : "Published",
+          result.requestCount > 0
+            ? `Sent ${result.requestCount} request${result.requestCount === 1 ? "" : "s"}.`
+            : "No pending requests to send.",
+        );
+      } catch (e) {
+        surfaceError("Couldn't publish", e);
+      } finally {
+        setPublishing(false);
+      }
+    },
+    [requestCountForEvent, publishEvent, surfaceError],
+  );
+
+  /** Publish every draft plan, with a confirm listing each date + its count. */
+  const publishAllDrafts = useCallback(async () => {
+    if (draftEvents.length === 0) return;
+    const lines = draftEvents
+      .map((e) => {
+        const count = requestCountForEvent(e);
+        return `• ${weekday(e.eventDate)} ${monthDay(e.eventDate)} — ${count} request${count === 1 ? "" : "s"}`;
+      })
+      .join("\n");
+    const ok = await confirmAsync({
+      title: "Publish all draft dates?",
+      message: `These dates will notify volunteers:\n${lines}\n\nConfirmed people won't be re-notified.`,
+      confirmText: "Send",
+    });
+    if (!ok) return;
+    setPublishing(true);
+    try {
+      let total = 0;
+      for (const e of draftEvents) {
+        const result = await publishEvent({ planId: e._id });
+        total += result.requestCount;
+      }
+      notify(
+        "Published",
+        total > 0
+          ? `Sent ${total} request${total === 1 ? "" : "s"} across ${draftEvents.length} date${draftEvents.length === 1 ? "" : "s"}.`
+          : "No pending requests to send.",
+      );
+    } catch (e) {
+      surfaceError("Couldn't publish", e);
+    } finally {
+      setPublishing(false);
+    }
+  }, [draftEvents, requestCountForEvent, publishEvent, surfaceError]);
+
+  /**
+   * Entry point for the Publish action. With a single date in the grid, skip
+   * the chooser and publish it directly; with several, open the chooser so the
+   * leader picks a date (or all drafts) — every path goes through a confirm.
+   */
+  const handlePublishPress = useCallback(() => {
+    if (publishing) return;
+    if (events.length === 1) {
+      void publishOne(events[0]);
+    } else {
+      setPublishMenuOpen(true);
+    }
+  }, [publishing, events, publishOne]);
 
   // -------------------------------------------------------------------------
   // Header
@@ -893,6 +1016,20 @@ export function RosterGridScreen() {
       ? `${visibleRoles.length} ${visibleRoles.length === 1 ? "role" : "roles"}`
       : `${visibleMembers.length} ${visibleMembers.length === 1 ? "person" : "people"}`;
 
+  // Publish button label (#477 FR-3). One event → name the date; several with
+  // drafts left → generic; all published → "Re-send". Anyone who can see this
+  // grid is a scheduler (rosterMatrix requires it), so the action is always
+  // permission-appropriate — no extra gate needed.
+  const allPublished = events.length > 0 && draftEvents.length === 0;
+  const publishLabel =
+    events.length === 1
+      ? allPublished
+        ? `Re-send · ${monthDay(events[0].eventDate)}`
+        : `Publish & send · ${monthDay(events[0].eventDate)}`
+      : allPublished
+        ? "Re-send requests"
+        : "Publish & send requests";
+
   return (
     <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
       {renderHeaderBar()}
@@ -919,6 +1056,39 @@ export function RosterGridScreen() {
             {renderPeopleCells()}
           </>
         )}
+      </View>
+
+      {/* Publish bar — present in BOTH views (#477 FR-3). Scoped to a chosen
+          date via the chooser; single-date grids publish that date directly. */}
+      <View
+        style={[
+          styles.publishBar,
+          {
+            backgroundColor: colors.surface,
+            borderTopColor: colors.border,
+            paddingBottom: insets.bottom + 12,
+          },
+        ]}
+      >
+        <Pressable
+          onPress={handlePublishPress}
+          disabled={publishing}
+          accessibilityRole="button"
+          accessibilityLabel={publishLabel}
+        >
+          <View
+            style={[
+              styles.publishBtn,
+              { backgroundColor: primaryColor, opacity: publishing ? 0.7 : 1 },
+            ]}
+          >
+            {publishing ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text style={styles.publishBtnText}>{publishLabel}</Text>
+            )}
+          </View>
+        </Pressable>
       </View>
 
       {/* ===== Modals ===== */}
@@ -1020,6 +1190,24 @@ export function RosterGridScreen() {
             setTeamMenuOpen(false);
           }}
           onClose={() => setTeamMenuOpen(false)}
+        />
+      )}
+
+      {publishMenuOpen && (
+        <PublishMenu
+          events={events}
+          draftCount={draftEvents.length}
+          requestCountForEvent={requestCountForEvent}
+          colors={colors}
+          onPublishOne={(event) => {
+            setPublishMenuOpen(false);
+            void publishOne(event);
+          }}
+          onPublishAll={() => {
+            setPublishMenuOpen(false);
+            void publishAllDrafts();
+          }}
+          onClose={() => setPublishMenuOpen(false)}
         />
       )}
     </View>
@@ -1547,6 +1735,79 @@ function TeamFilterMenu({
   );
 }
 
+/**
+ * Publish chooser (#477 FR-3) — when the grid spans multiple dates, the leader
+ * picks which date to publish (each row shows its pending request count), or
+ * publishes all draft dates at once. Single-date grids skip this and publish
+ * directly. Every path runs through a confirm dialog before notifying anyone.
+ */
+function PublishMenu({
+  events,
+  draftCount,
+  requestCountForEvent,
+  colors,
+  onPublishOne,
+  onPublishAll,
+  onClose,
+}: {
+  events: RosterEvent[];
+  draftCount: number;
+  requestCountForEvent: (event: RosterEvent) => number;
+  colors: Colors;
+  onPublishOne: (event: RosterEvent) => void;
+  onPublishAll: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <ModalShell
+      title="Publish & send"
+      subtitle="Pick a date to send requests for"
+      colors={colors}
+      onClose={onClose}
+    >
+      <ScrollView style={styles.popoverList}>
+        {events.map((ev) => {
+          const count = requestCountForEvent(ev);
+          const published = ev.status === "published";
+          return (
+            <Pressable
+              key={ev._id}
+              onPress={() => onPublishOne(ev)}
+              style={[styles.menuRow, { borderBottomColor: colors.border }]}
+              accessibilityRole="button"
+            >
+              <View style={styles.menuRowText}>
+                <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+                  {weekday(ev.eventDate)} {monthDay(ev.eventDate)}
+                </Text>
+                <Text style={[styles.menuRowSub, { color: colors.textTertiary }]} numberOfLines={1}>
+                  {published ? "Published · " : ""}
+                  {count} request{count === 1 ? "" : "s"}
+                </Text>
+              </View>
+              <Text style={[styles.menuRowCount, { color: colors.link }]}>
+                {published ? "Re-send" : "Send"}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+      {draftCount > 1 && (
+        <Pressable
+          onPress={onPublishAll}
+          style={[styles.addBtn, { borderColor: colors.link }]}
+          accessibilityRole="button"
+        >
+          <Ionicons name="paper-plane-outline" size={16} color={colors.link} />
+          <Text style={[styles.addBtnText, { color: colors.link }]}>
+            Publish all draft dates ({draftCount})
+          </Text>
+        </Pressable>
+      )}
+    </ModalShell>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Small shared UI
 // ---------------------------------------------------------------------------
@@ -1817,4 +2078,20 @@ const styles = StyleSheet.create({
   menuRowText: { flex: 1, minWidth: 0 },
   menuRowSub: { fontSize: 11, marginTop: 1 },
   menuRowCount: { fontSize: 13, fontWeight: "600" },
+  publishBar: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  publishBtn: {
+    minHeight: 50,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  publishBtnText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#fff",
+  },
 });

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -67,6 +67,8 @@ type RosterEvent = {
   eventDate: number;
   times: Array<{ label: string; startsAt: number }>;
   status: "draft" | "published";
+  /** Unconfirmed assignments for the plan — who publish will notify. */
+  pendingCount: number;
 };
 
 type RosterTeam = { teamId: Id<"teams">; teamName: string };
@@ -467,21 +469,14 @@ export function RosterGridScreen() {
   // Publish (#477 FR-3)
   //
   // `publishEvent` notifies only *unconfirmed* assignments (confirmed people
-  // are never re-pinged), so the per-event "request count" we show in the
-  // confirm dialog is the number of unconfirmed occupants across that plan's
-  // role cells — the same population `markPublished` counts server-side.
+  // are never re-pinged). We surface `event.pendingCount` straight from
+  // `rosterMatrix`, which counts unconfirmed assignments off `by_plan` — the
+  // exact population `markPublished` notifies. Summing `roleCells` here would
+  // undercount assignments orphaned by a removed needed role (no cell exists).
   // -------------------------------------------------------------------------
   const requestCountForEvent = useCallback(
-    (event: RosterEvent): number => {
-      let n = 0;
-      for (const role of data?.roles ?? []) {
-        const c = roleCells[`${role.roleId}:${event._id}`];
-        if (!c) continue;
-        n += c.occupants.filter((o) => o.status === "unconfirmed").length;
-      }
-      return n;
-    },
-    [data, roleCells],
+    (event: RosterEvent): number => event.pendingCount,
+    [],
   );
 
   /** Draft event plans — the default publish target (unpublished dates). */

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,7 +37,7 @@
     "testTimeout": 5000,
     "forceExit": true,
     "transformIgnorePatterns": [
-      "node_modules/(?!(?:.pnpm/)?((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|@expo/vector-icons/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|@sentry/.*|native-base|react-native-svg|@tanstack/react-query|date-fns|bad-words|badwords-list))"
+      "node_modules/(?!(?:.pnpm/)?((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|@expo/vector-icons/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|@sentry/.*|native-base|react-native-svg|@shopify[/+]flash-list|@tanstack/react-query|date-fns|bad-words|badwords-list))"
     ],
     "testMatch": [
       "**/__tests__/**/*.(ts|tsx|js)",


### PR DESCRIPTION
Closes #477.

Fixes the four #477 issues and, per a working session with the Production Director, redesigns the rostering grid/assign flow for mobile + desktop, adds live presence, and consolidates the confusing rostering entry points. Two senior PM/UX agents produced grounded design docs first; this PR implements the decisions taken from them.

## The four #477 fixes
- **Full assign list on open** (root-caused to a backend bug). The empty-search path of `searchCommunityPeople` returned only a recency-capped slice of ~30, so a member who hadn't logged in recently was invisible until you typed their name (the "Irvin only after typing 'ir'" bug). Empty search now returns the **complete active group membership**; typing only narrows. List virtualized with `FlashList` for 500+ groups.
- **Team filter** — replaced the inverted "tap a chip to *hide* a team" (`hiddenTeams` set) with a single-select **`All teams ▾` dropdown** that isolates one team; gates the Roles view only.
- **Publish from the grid** — a persistent publish bar now lives in **both** Roles and People views (not just the event editor), calling the same `publishEvent` action (no fork). Single-date grids publish directly with the date in the label; multi-date grids open a chooser listing each date + its pending-request count, plus "Publish all draft dates (N)". Confirm dialog names exactly which dates notify; confirmed people are never re-pinged.
- **"Also in group" on assign** — the candidate filter #474 added to the People view is now in the assign sheet too, reusing `rosterFilterGroups`/`rosterFilterMemberIds` (no new backend), as independent modal state.

## Redesign extras (requested in the session)
- **Live presence** — a subtle "others viewing" avatar stack in the grid header, backed by a new lightweight Convex heartbeat API (`scheduling.presence.{heartbeat,listViewers,leave}`, `gridKey` = group id, 30s self-healing staleness, no cron). Gated to schedulers, matching exactly who can open the grid. Renders nothing when you're alone.
- **Navigation / IA cleanup** — the team screen had a near-duplicate of the rostering hub (plan list + four mislabeled pills + a *second* hub link). Collapsed to **one "Rostering" entry row** ("3 plans · next Sun Jul 5 · 7/42 filled") that opens the hub. In the hub's Schedule tab, **Open roster grid** is now a primary action and **Share availability link → Collect availability**. No routes/deep links changed — only entry buttons.

## Not included (deliberately)
- **"My availability" on Profile** — declined to wire it because availability is strictly group-scoped (`/rostering/[group_id]/availability` needs a group id) and there's no global availability screen/backend; a Profile entry would be a broken route. Members still reach availability via the chat request card. Filed as a follow-up (needs a net-new cross-group screen).

## Testing
- Convex: **1761 tests pass** (added presence + full-list characterization tests).
- Mobile: **120 suites / 1100 tests pass**. Added `@shopify/flash-list` to Jest `transformIgnorePatterns` (AssignSheet's new FlashList import is pulled into the inbox/create test graph and Jest couldn't parse its ESM).
- `tsc --noEmit` clean for all touched files in both packages.
- RN-Web pitfalls respected on every new control (no Pressable function-style; frozen-column flex pinning untouched).

## Notes for review
- A transient `convex codegen` push 500'd against the dev backend during development; generated types are committed and typecheck — the next successful deploy re-pushes the presence functions.
- Not yet visually verified in a running app (presence needs a successful convex dev push). Happy to add a Playwright pass if you'd like before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwTHgpiPRaZHPNgBjFNYrW