### PR TITLE
fix(dev-assistant): sync routine secrets through the real deploy path

### DIFF
--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -144,6 +144,11 @@ OPTIONAL_SECRETS=(
   "EXPO_PUBLIC_POSTHOG_API_KEY"
   "GOOGLE_MAPS_API_KEY"
   "EXPO_PUBLIC_KLIPY_API_KEY"
+  # Dev-assistant bot (@Togather pipeline). Optional — only present once the
+  # feature is being enabled; missing items are skipped without failing.
+  "CLAUDE_ROUTINES_TRIGGER_URL"
+  "CLAUDE_ROUTINES_TOKEN"
+  "DEV_ASSISTANT_CALLBACK_SECRET"
 )
 
 # ---------------------------------------------------------------------------

--- a/ee/scripts/sync-secrets-to-convex.sh
+++ b/ee/scripts/sync-secrets-to-convex.sh
@@ -99,8 +99,9 @@ SECRET_KEYS=(
   "STRIPE_SECRET_KEY"
   "STRIPE_WEBHOOK_SECRET"
   "STRIPE_PRODUCT_ID"
-  # Dev-assistant bot (@Togather pipeline). Optional — synced only when present
-  # (loaded via the optional-secrets block in ee/actions/load-secrets).
+  # Dev-assistant bot (@Togather pipeline). Optional — synced only when present.
+  # Sourced from 1Password via sync-1password-to-github.sh (OPTIONAL_SECRETS),
+  # then exported into the deploy env by .github/actions/load-secrets.
   "CLAUDE_ROUTINES_TRIGGER_URL"
   "CLAUDE_ROUTINES_TOKEN"
   "DEV_ASSISTANT_CALLBACK_SECRET"


### PR DESCRIPTION
## Summary

Follow-up to #483. That PR's deploy-sync fix added the dev-assistant routine secrets to `ee/actions/load-secrets/action.yml` — but **that composite action is referenced by zero workflows** (dead file). So the keys you put in 1Password never actually reach Convex.

The **real** secret pipeline for Convex is three hops:

```
1Password
  └─(ee/scripts/sync-1password-to-github.sh, run by the manual "Sync secrets" workflow)→  GitHub Actions secrets
        └─(.github/actions/load-secrets — exports all GH secrets to env)→  deploy job env
              └─(ee/scripts/sync-secrets-to-convex.sh — SECRET_KEYS whitelist)→  Convex env
```

The **first hop's allowlist** (`OPTIONAL_SECRETS` in `sync-1password-to-github.sh`) was missing the three keys, so `CLAUDE_ROUTINES_TRIGGER_URL`, `CLAUDE_ROUTINES_TOKEN`, and `DEV_ASSISTANT_CALLBACK_SECRET` in 1Password never became GitHub secrets — and thus never reached Convex. Every ready bug would log `Routine trigger env not configured` and never dispatch.

## Changes

- **`ee/scripts/sync-1password-to-github.sh`**: add the three keys to `OPTIONAL_SECRETS` (optional ⇒ missing items skip cleanly with `|| true`, matching the feature's gated rollout — no failed deploys before the 1Password items exist).
- **`ee/scripts/sync-secrets-to-convex.sh`**: fix the now-stale comment to point at the real upstream (`sync-1password-to-github.sh` + `.github/actions/load-secrets`) instead of the dead `ee/actions/load-secrets` action.

The second-hop whitelist (`sync-secrets-to-convex.sh` SECRET_KEYS) already includes the three keys from #483, so no change needed there.

> Note: `ee/actions/load-secrets/action.yml` (1Password-based) appears to be unused/dead — every deploy workflow uses `.github/actions/load-secrets` (GitHub-secrets-based). Left as-is here to keep this change focused; flagging for a possible cleanup.

## To propagate after merge

1. Confirm the 1Password items exist in the **Togather** vault, named exactly `CLAUDE_ROUTINES_TRIGGER_URL` / `CLAUDE_ROUTINES_TOKEN` / `DEV_ASSISTANT_CALLBACK_SECRET`, each with `staging` and `production` fields.
2. Run the **Sync secrets** workflow (`workflow_dispatch`) for staging and production → pushes them into GitHub Actions secrets.
3. Redeploy Convex (or wait for the next deploy) → `sync-secrets-to-convex.sh` pushes them into Convex env.

## Testing

Both scripts pass `bash -n`. No app/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQZgBC7oSiYZqrW5ibKjRP)_