### PR TITLE
Rostering grid: live-test fixes (loading, header, delete/rename, needed coupling)

### DIFF
--- a/apps/convex/__tests__/scheduling/deletion.test.ts
+++ b/apps/convex/__tests__/scheduling/deletion.test.ts
@@ -134,6 +134,85 @@ describe("deleteRole", () => {
     expect(m.roles.some((r) => r.roleId === world.roleId)).toBe(false);
   });
 
+  it("only purges upcoming assignments + notifies for them; past ones are preserved", async () => {
+    const { t, world } = await setup();
+    vi.stubEnv("OTP_TEST_PHONE_NUMBERS", "+12025550003");
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // A past plan and an upcoming plan, both staffing the same role.
+    const pastPlan = await createPlan(t, leader, world.groupId, "Past Service", Date.now() - 14 * DAY);
+    const futurePlan = await createPlan(t, leader, world.groupId, "Future Service", Date.now() + 7 * DAY);
+
+    for (const planId of [pastPlan, futurePlan]) {
+      await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+        token: leader,
+        planId,
+        roles: [{ teamId: world.teamId, roleId: world.roleId, count: 1 }],
+      });
+    }
+    // Assign the same member on both plans. A past-event assignment skips the
+    // future-event guard, so seed the past row directly.
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: futurePlan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+    const pastAssignmentId = await t.run(async (ctx) => {
+      const plan = await ctx.db.get(pastPlan);
+      return ctx.db.insert("roleAssignments", {
+        planId: pastPlan,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+        eventDate: plan!.eventDate,
+        status: "confirmed",
+        assignedById: world.groupLeaderId,
+        assignedAt: Date.now(),
+      });
+    });
+
+    const res = await t.mutation(api.functions.scheduling.deletion.deleteRole, {
+      token: leader,
+      roleId: world.roleId,
+    });
+    // Only the upcoming assignment is notified.
+    expect(res.notifiedCount).toBe(1);
+    expect(await pendingNotifyJobs(t)).toBe(1);
+
+    const survived = await t.run(async (ctx) => {
+      const past = await ctx.db.get(pastAssignmentId);
+      const pastNeeded = await ctx.db
+        .query("neededRoles")
+        .withIndex("by_plan", (q) => q.eq("planId", pastPlan))
+        .collect();
+      const futureNeeded = await ctx.db
+        .query("neededRoles")
+        .withIndex("by_plan", (q) => q.eq("planId", futurePlan))
+        .collect();
+      const futureAssigns = await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan", (q) => q.eq("planId", futurePlan))
+        .collect();
+      return {
+        pastExists: past !== null,
+        pastNeeded: pastNeeded.length,
+        futureNeeded: futureNeeded.length,
+        futureAssigns: futureAssigns.length,
+      };
+    });
+    // Past assignment + neededRole untouched; upcoming ones purged.
+    expect(survived).toEqual({
+      pastExists: true,
+      pastNeeded: 1,
+      futureNeeded: 0,
+      futureAssigns: 0,
+    });
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
   it("sends no text when nobody is staffed", async () => {
     const { t, world } = await setup();
     const leader = (await generateTokens(world.groupLeaderId)).accessToken;

--- a/apps/convex/__tests__/scheduling/deletion.test.ts
+++ b/apps/convex/__tests__/scheduling/deletion.test.ts
@@ -74,6 +74,19 @@ async function pendingNotifyJobs(
   });
 }
 
+/** Count *pending* scheduler jobs whose function name contains `needle`. */
+async function pendingJobsNamed(
+  t: ReturnType<typeof convexTest>,
+  needle: string,
+): Promise<number> {
+  return t.run(async (ctx) => {
+    const jobs = await ctx.db.system.query("_scheduled_functions").collect();
+    return jobs.filter(
+      (j) => j.state.kind === "pending" && String(j.name).includes(needle),
+    ).length;
+  });
+}
+
 describe("deleteRole", () => {
   it("archives the role, removes its neededRoles + assignments, and schedules a notification", async () => {
     const { t, world } = await setup();
@@ -370,6 +383,249 @@ describe("deleteTeam", () => {
     await expect(
       t.mutation(api.functions.scheduling.deletion.deleteTeam, {
         token: member,
+        teamId: world.teamId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("channel reconciliation on delete", () => {
+  it("deleteRole schedules a team-channel + cross-team reconcile for the affected team", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const plan = await createPlan(t, leader, world.groupId, "Service", Date.now() + 7 * DAY);
+    // Seed the assignment directly (bypassing `assignRole`) so the ONLY
+    // reconcile jobs in the queue are the ones the delete schedules — the
+    // assertion stays deterministic regardless of convex-test's runAfter(0)
+    // timing.
+    await t.run(async (ctx) => {
+      const p = await ctx.db.get(plan);
+      await ctx.db.insert("roleAssignments", {
+        planId: plan,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+        eventDate: p!.eventDate,
+        status: "unconfirmed",
+        assignedById: world.groupLeaderId,
+        assignedAt: Date.now(),
+      });
+    });
+
+    expect(await pendingJobsNamed(t, "reconcileTeamChannel")).toBe(0);
+
+    await t.mutation(api.functions.scheduling.deletion.deleteRole, {
+      token: leader,
+      roleId: world.roleId,
+    });
+
+    // The cascade dropped the assignment, so the team's channel must be
+    // reconciled (and any cross-team channel drawing from it) — exactly one
+    // pending job of each kind for the affected team.
+    expect(await pendingJobsNamed(t, "reconcileTeamChannel")).toBe(1);
+    expect(
+      await pendingJobsNamed(t, "reconcileCrossTeamChannelsForSource"),
+    ).toBe(1);
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
+  it("does not schedule a reconcile when no upcoming assignment is removed", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // A neededRole but no assignment → nothing staffed, nothing to reconcile.
+    const plan = await createPlan(t, leader, world.groupId, "Service", Date.now() + 7 * DAY);
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: plan,
+      roles: [{ teamId: world.teamId, roleId: world.roleId, count: 1 }],
+    });
+
+    await t.mutation(api.functions.scheduling.deletion.deleteRole, {
+      token: leader,
+      roleId: world.roleId,
+    });
+
+    expect(await pendingJobsNamed(t, "reconcileTeamChannel")).toBe(0);
+  });
+});
+
+describe("neededRoles cascade is role-scoped and bounded", () => {
+  it("only deletes the target role's neededRoles, leaving sibling roles intact", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // A second role on the same team — its neededRoles must survive a
+    // single-role delete.
+    const { roleId: siblingRole } = await t.mutation(
+      api.functions.scheduling.roles.createRole,
+      { token: leader, teamId: world.teamId, name: "Bass" },
+    );
+
+    // Two upcoming plans, each needing both roles.
+    const planA = await createPlan(t, leader, world.groupId, "A", Date.now() + 7 * DAY);
+    const planB = await createPlan(t, leader, world.groupId, "B", Date.now() + 14 * DAY);
+    for (const planId of [planA, planB]) {
+      await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+        token: leader,
+        planId,
+        roles: [
+          { teamId: world.teamId, roleId: world.roleId, count: 1 },
+          { teamId: world.teamId, roleId: siblingRole as Id<"teamRoles">, count: 1 },
+        ],
+      });
+    }
+
+    await t.mutation(api.functions.scheduling.deletion.deleteRole, {
+      token: leader,
+      roleId: world.roleId,
+    });
+
+    const counts = await t.run(async (ctx) => {
+      const target = await ctx.db
+        .query("neededRoles")
+        .filter((q) => q.eq(q.field("roleId"), world.roleId))
+        .collect();
+      const sibling = await ctx.db
+        .query("neededRoles")
+        .filter((q) => q.eq(q.field("roleId"), siblingRole))
+        .collect();
+      return { target: target.length, sibling: sibling.length };
+    });
+    // The deleted role's needed rows are gone on both upcoming plans; the
+    // sibling role's two needed rows are untouched.
+    expect(counts).toEqual({ target: 0, sibling: 2 });
+  });
+});
+
+describe("affectedByDeletion", () => {
+  it("counts a person once across multiple upcoming dates and lists each date", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const planA = await createPlan(t, leader, world.groupId, "A", Date.now() + 7 * DAY);
+    const planB = await createPlan(t, leader, world.groupId, "B", Date.now() + 14 * DAY);
+    for (const planId of [planA, planB]) {
+      await t.mutation(api.functions.scheduling.assignments.assignRole, {
+        token: leader,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+      });
+    }
+    await t.finishInProgressScheduledFunctions();
+
+    const res = await t.query(api.functions.scheduling.deletion.affectedByDeletion, {
+      token: leader,
+      roleId: world.roleId,
+    });
+    // Same person on both dates → counted once; two distinct dates listed.
+    expect(res.peopleCount).toBe(1);
+    expect(res.dates.length).toBe(2);
+    expect(res.names).toContain("Memberly Test");
+  });
+
+  it("excludes past and declined assignments", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const member = (await generateTokens(world.channelMemberId)).accessToken;
+
+    const future = await createPlan(t, leader, world.groupId, "Future", Date.now() + 7 * DAY);
+    // A declined upcoming assignment must not count.
+    const { assignmentId } = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leader,
+        planId: future,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+      },
+    );
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: member,
+      assignmentId,
+      status: "declined",
+    });
+    // A past assignment (seeded directly to skip the future-event guard) must
+    // not count either.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("roleAssignments", {
+        planId: future,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelAdminId,
+        eventDate: Date.now() - 14 * DAY,
+        status: "confirmed",
+        assignedById: world.groupLeaderId,
+        assignedAt: Date.now(),
+      });
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    const res = await t.query(api.functions.scheduling.deletion.affectedByDeletion, {
+      token: leader,
+      roleId: world.roleId,
+    });
+    expect(res.peopleCount).toBe(0);
+    expect(res.dates).toEqual([]);
+  });
+
+  it("counts all of a team's live roles for a team delete", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { roleId: role2 } = await t.mutation(
+      api.functions.scheduling.roles.createRole,
+      { token: leader, teamId: world.teamId, name: "Bass" },
+    );
+    const plan = await createPlan(t, leader, world.groupId, "Service", Date.now() + 7 * DAY);
+    // Two different people, one per role.
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: plan,
+      teamId: world.teamId,
+      roleId: role2 as Id<"teamRoles">,
+      userId: world.channelAdminId,
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    const res = await t.query(api.functions.scheduling.deletion.affectedByDeletion, {
+      token: leader,
+      teamId: world.teamId,
+    });
+    expect(res.peopleCount).toBe(2);
+    expect(res.dates.length).toBe(1);
+  });
+
+  it("rejects a non-scheduler", async () => {
+    const { t, world } = await setup();
+    const outsider = (await generateTokens(world.outsiderId)).accessToken;
+    await expect(
+      t.query(api.functions.scheduling.deletion.affectedByDeletion, {
+        token: outsider,
+        roleId: world.roleId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects passing both roleId and teamId", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    await expect(
+      t.query(api.functions.scheduling.deletion.affectedByDeletion, {
+        token: leader,
+        roleId: world.roleId,
         teamId: world.teamId,
       }),
     ).rejects.toThrow(ConvexError);

--- a/apps/convex/__tests__/scheduling/deletion.test.ts
+++ b/apps/convex/__tests__/scheduling/deletion.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for destructive team/role deletion (deletion.ts) — the roster-grid
+ * right-click "Delete role" / "Delete team" flow.
+ *
+ * Verifies the cascade (archives the team/role; hard-deletes its `neededRoles`
+ * + `roleAssignments` across plans), the notification fan-out (one scheduled
+ * `notifyRoleRemovals` job per delete that touched staffed people, none when
+ * nobody is staffed), and the scheduler auth gate.
+ *
+ * The `sendSMS` Twilio path is best-effort (try/catch) and self-bypasses for
+ * test phones, so — like the publish/reminder tests — we assert the DB side
+ * effects (cascade + the scheduled job + the action's `smsSent` count) rather
+ * than mocking Twilio. The fixture phones are stubbed into
+ * `OTP_TEST_PHONE_NUMBERS` so the drained action's sends "succeed".
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api, internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+  vi.unstubAllEnvs();
+});
+
+async function setup() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+const DAY = 86400000;
+
+async function createPlan(
+  t: ReturnType<typeof convexTest>,
+  token: string,
+  groupId: Id<"groups">,
+  title: string,
+  eventDate: number,
+): Promise<Id<"eventPlans">> {
+  const { planId } = await t.mutation(
+    api.functions.scheduling.events.createEvent,
+    {
+      token,
+      groupId,
+      title,
+      eventDate,
+      times: [{ label: "9 AM", startsAt: eventDate }],
+    },
+  );
+  return planId as Id<"eventPlans">;
+}
+
+/** Count pending `notifyRoleRemovals` jobs in the scheduler queue. */
+async function pendingNotifyJobs(
+  t: ReturnType<typeof convexTest>,
+): Promise<number> {
+  return t.run(async (ctx) => {
+    const jobs = await ctx.db.system.query("_scheduled_functions").collect();
+    return jobs.filter((j) =>
+      String(j.name).includes("notifyRoleRemovals"),
+    ).length;
+  });
+}
+
+describe("deleteRole", () => {
+  it("archives the role, removes its neededRoles + assignments, and schedules a notification", async () => {
+    const { t, world } = await setup();
+    // Stub the staffed member's phone so the drained SMS action succeeds.
+    vi.stubEnv("OTP_TEST_PHONE_NUMBERS", "+12025550003");
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const planA = await createPlan(t, leader, world.groupId, "Service A", Date.now() + 7 * DAY);
+    const planB = await createPlan(t, leader, world.groupId, "Service B", Date.now() + 14 * DAY);
+
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: planA,
+      roles: [{ teamId: world.teamId, roleId: world.roleId, count: 1 }],
+    });
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: planA,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+
+    const res = await t.mutation(api.functions.scheduling.deletion.deleteRole, {
+      token: leader,
+      roleId: world.roleId,
+    });
+    expect(res.notifiedCount).toBe(1);
+
+    // Role archived (still exists, flagged).
+    const role = await t.run((ctx) => ctx.db.get(world.roleId));
+    expect(role?.isArchived).toBe(true);
+
+    // neededRoles + roleAssignments for the role are gone across all plans.
+    const counts = await t.run(async (ctx) => {
+      const needed = await ctx.db
+        .query("neededRoles")
+        .filter((q) => q.eq(q.field("roleId"), world.roleId))
+        .collect();
+      const assigns = await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_role", (q) => q.eq("roleId", world.roleId))
+        .collect();
+      return { needed: needed.length, assigns: assigns.length };
+    });
+    expect(counts).toEqual({ needed: 0, assigns: 0 });
+
+    // A notify job was scheduled; draining it sends one text.
+    expect(await pendingNotifyJobs(t)).toBe(1);
+    void planB;
+    await t.finishInProgressScheduledFunctions();
+
+    // Role is excluded from the live roster after deletion.
+    const m = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+    });
+    expect(m.roles.some((r) => r.roleId === world.roleId)).toBe(false);
+  });
+
+  it("sends no text when nobody is staffed", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planA = await createPlan(t, leader, world.groupId, "Service A", Date.now() + 7 * DAY);
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: planA,
+      roles: [{ teamId: world.teamId, roleId: world.roleId, count: 1 }],
+    });
+
+    const res = await t.mutation(api.functions.scheduling.deletion.deleteRole, {
+      token: leader,
+      roleId: world.roleId,
+    });
+    expect(res.notifiedCount).toBe(0);
+    expect(await pendingNotifyJobs(t)).toBe(0);
+  });
+
+  it("does not notify someone who already declined", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const member = (await generateTokens(world.channelMemberId)).accessToken;
+    const planA = await createPlan(t, leader, world.groupId, "Service A", Date.now() + 7 * DAY);
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: planA,
+      roles: [{ teamId: world.teamId, roleId: world.roleId, count: 1 }],
+    });
+    const { assignmentId } = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leader,
+        planId: planA,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+      },
+    );
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: member,
+      assignmentId,
+      status: "declined",
+    });
+
+    const res = await t.mutation(api.functions.scheduling.deletion.deleteRole, {
+      token: leader,
+      roleId: world.roleId,
+    });
+    expect(res.notifiedCount).toBe(0);
+    expect(await pendingNotifyJobs(t)).toBe(0);
+  });
+
+  it("rejects a non-scheduler", async () => {
+    const { t, world } = await setup();
+    const outsider = (await generateTokens(world.outsiderId)).accessToken;
+    await expect(
+      t.mutation(api.functions.scheduling.deletion.deleteRole, {
+        token: outsider,
+        roleId: world.roleId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("deleteTeam", () => {
+  it("archives the team + channel and cascades to all its roles", async () => {
+    const { t, world } = await setup();
+    vi.stubEnv("OTP_TEST_PHONE_NUMBERS", "+12025550003");
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Add a second role to the team to prove the cascade spans all roles.
+    const { roleId: role2 } = await t.mutation(
+      api.functions.scheduling.roles.createRole,
+      { token: leader, teamId: world.teamId, name: "Bass" },
+    );
+
+    const planA = await createPlan(t, leader, world.groupId, "Service A", Date.now() + 7 * DAY);
+    await t.mutation(api.functions.scheduling.events.setNeededRoles, {
+      token: leader,
+      planId: planA,
+      roles: [
+        { teamId: world.teamId, roleId: world.roleId, count: 1 },
+        { teamId: world.teamId, roleId: role2 as Id<"teamRoles">, count: 1 },
+      ],
+    });
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: planA,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leader,
+      planId: planA,
+      teamId: world.teamId,
+      roleId: role2 as Id<"teamRoles">,
+      userId: world.channelMemberId,
+    });
+
+    const res = await t.mutation(api.functions.scheduling.deletion.deleteTeam, {
+      token: leader,
+      teamId: world.teamId,
+    });
+    // Two assignments removed (same user, two roles) → 2 notifications.
+    expect(res.notifiedCount).toBe(2);
+
+    const state = await t.run(async (ctx) => {
+      const team = await ctx.db.get(world.teamId);
+      const channel = team?.channelId ? await ctx.db.get(team.channelId) : null;
+      const r1 = await ctx.db.get(world.roleId);
+      const r2 = await ctx.db.get(role2 as Id<"teamRoles">);
+      const needed = await ctx.db
+        .query("neededRoles")
+        .withIndex("by_plan_team", (q) =>
+          q.eq("planId", planA).eq("teamId", world.teamId),
+        )
+        .collect();
+      const assigns = await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan", (q) => q.eq("planId", planA))
+        .collect();
+      return {
+        teamArchived: team?.isArchived,
+        channelArchived: channel?.isArchived,
+        r1Archived: r1?.isArchived,
+        r2Archived: r2?.isArchived,
+        needed: needed.length,
+        assigns: assigns.length,
+      };
+    });
+    expect(state).toEqual({
+      teamArchived: true,
+      channelArchived: true,
+      r1Archived: true,
+      r2Archived: true,
+      needed: 0,
+      assigns: 0,
+    });
+
+    expect(await pendingNotifyJobs(t)).toBe(1);
+    await t.finishInProgressScheduledFunctions();
+
+    // Team gone from the roster.
+    const m = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+    });
+    expect(m.teams.some((tm) => tm.teamId === world.teamId)).toBe(false);
+  });
+
+  it("rejects a non-scheduler", async () => {
+    const { t, world } = await setup();
+    const member = (await generateTokens(world.channelMemberId)).accessToken;
+    await expect(
+      t.mutation(api.functions.scheduling.deletion.deleteTeam, {
+        token: member,
+        teamId: world.teamId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/apps/convex/__tests__/scheduling/people.test.ts
+++ b/apps/convex/__tests__/scheduling/people.test.ts
@@ -13,6 +13,7 @@ import { modules } from "../../test.setup";
 import { generateTokens } from "../../lib/auth";
 import { api } from "../../_generated/api";
 import { buildSchedulingWorld } from "./fixtures";
+import { buildSearchText } from "../../lib/utils";
 
 async function setupSchedulingWorld() {
   const t = convexTest(schema, modules);
@@ -172,6 +173,153 @@ describe("searchCommunityPeople", () => {
       ).toBe(true);
     }
     expect(typed.map((r) => r.userId)).toContain(world.staleGroupMemberId);
+  });
+
+  it("bounds reads on empty search: full group + only a small community tail (no 3000-row over-fetch)", async () => {
+    // Regression for the roster-grid infinite spinner. The empty-search path
+    // must return EVERY group member (FR-1) while keeping the wider-community
+    // "extras" tail a small constant — not a slice that scales with the 1000
+    // group ceiling (which over-fetched up to ~3000 userCommunities rows on a
+    // real ~85+ member community and threw past Convex's read cap).
+    const t = convexTest(schema, modules);
+
+    const GROUP_SIZE = 40; // a sizeable serving group
+    const COMMUNITY_EXTRAS = 300; // many more community-only people around it
+
+    const { communityId, groupId, leaderId, groupMemberIds } = await t.run(
+      async (ctx) => {
+        const communityId = await ctx.db.insert("communities", {
+          name: "Big Community",
+          slug: "big",
+          isPublic: true,
+        });
+        const groupTypeId = await ctx.db.insert("groupTypes", {
+          communityId,
+          name: "Campus",
+          slug: "campus",
+          isActive: true,
+          createdAt: Date.now(),
+          displayOrder: 1,
+        });
+        const groupId = await ctx.db.insert("groups", {
+          communityId,
+          groupTypeId,
+          name: "Big Campus",
+          isArchived: false,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+
+        async function newUser(first: string) {
+          const userId = await ctx.db.insert("users", {
+            firstName: first,
+            lastName: "Test",
+            email: `${first.toLowerCase()}@example.com`,
+            isActive: true,
+            roles: 1,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            searchText: buildSearchText({
+              firstName: first,
+              lastName: "Test",
+              email: `${first.toLowerCase()}@example.com`,
+            }),
+          });
+          await ctx.db.insert("userCommunities", {
+            communityId,
+            userId,
+            roles: 1,
+            status: 1,
+            // Distinct lastLogin so recency ordering is deterministic; group
+            // members get the OLDEST stamps so a recency-bounded tail would
+            // never surface them — proving completeness comes from the union.
+            lastLogin: 1,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          });
+          return userId;
+        }
+
+        // Leader (caller) — in the group so requireGroupMember passes.
+        const leaderId = await newUser("Leader");
+        await ctx.db.insert("groupMembers", {
+          groupId,
+          userId: leaderId,
+          role: "leader",
+          joinedAt: Date.now(),
+          notificationsEnabled: true,
+        });
+
+        // The group's full membership (the completeness set).
+        const groupMemberIds: string[] = [];
+        for (let i = 0; i < GROUP_SIZE; i++) {
+          const userId = await newUser(`Grp${String(i).padStart(3, "0")}`);
+          await ctx.db.insert("groupMembers", {
+            groupId,
+            userId,
+            role: "member",
+            joinedAt: Date.now(),
+            notificationsEnabled: true,
+          });
+          groupMemberIds.push(userId);
+        }
+
+        // Many community-only people NOT in the group. Give them the MOST
+        // recent lastLogin so they dominate the recency index — the empty
+        // search must still cap them to the small constant tail.
+        for (let i = 0; i < COMMUNITY_EXTRAS; i++) {
+          const userId = await ctx.db.insert("users", {
+            firstName: `Ext${String(i).padStart(3, "0")}`,
+            lastName: "Test",
+            email: `ext${i}@example.com`,
+            isActive: true,
+            roles: 1,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            searchText: buildSearchText({
+              firstName: `Ext${i}`,
+              lastName: "Test",
+            }),
+          });
+          await ctx.db.insert("userCommunities", {
+            communityId,
+            userId,
+            roles: 1,
+            status: 1,
+            lastLogin: Date.now() + i, // most recent
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          });
+        }
+
+        return { communityId, groupId, leaderId, groupMemberIds };
+      },
+    );
+
+    expect(communityId).toBeDefined();
+
+    const leaderToken = (await generateTokens(leaderId)).accessToken;
+    const results = await t.query(
+      api.functions.scheduling.people.searchCommunityPeople,
+      { token: leaderToken, groupId, search: "" },
+    );
+
+    // 1) Completeness: EVERY group member appears (caller excluded), each
+    //    flagged inGroup. Recency-bounded fallbacks would have dropped these
+    //    (oldest lastLogin), so their presence proves the group union.
+    const inGroupIds = new Set(
+      results.filter((r) => r.inGroup).map((r) => r.userId),
+    );
+    for (const id of groupMemberIds) {
+      expect(inGroupIds.has(id as never)).toBe(true);
+    }
+
+    // 2) Bounded tail: community-only ("extras") rows are capped to a small
+    //    constant — NOT all 300. Before the fix this tier scaled toward the
+    //    1000 ceiling (×3 over-fetch). Assert far fewer than the population.
+    const extras = results.filter((r) => !r.inGroup);
+    expect(extras.length).toBeLessThanOrEqual(50);
+    expect(extras.length).toBeLessThan(COMMUNITY_EXTRAS);
   });
 
   it("rejects a non-group, non-community-admin caller with a ConvexError", async () => {

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -133,6 +133,7 @@ import type * as functions_scheduledJobs from "../functions/scheduledJobs.js";
 import type * as functions_scheduling_assignments from "../functions/scheduling/assignments.js";
 import type * as functions_scheduling_availability from "../functions/scheduling/availability.js";
 import type * as functions_scheduling_crossTeamChannels from "../functions/scheduling/crossTeamChannels.js";
+import type * as functions_scheduling_deletion from "../functions/scheduling/deletion.js";
 import type * as functions_scheduling_eventItems from "../functions/scheduling/eventItems.js";
 import type * as functions_scheduling_events from "../functions/scheduling/events.js";
 import type * as functions_scheduling_index from "../functions/scheduling/index.js";
@@ -342,6 +343,7 @@ declare const fullApi: ApiFromModules<{
   "functions/scheduling/assignments": typeof functions_scheduling_assignments;
   "functions/scheduling/availability": typeof functions_scheduling_availability;
   "functions/scheduling/crossTeamChannels": typeof functions_scheduling_crossTeamChannels;
+  "functions/scheduling/deletion": typeof functions_scheduling_deletion;
   "functions/scheduling/eventItems": typeof functions_scheduling_eventItems;
   "functions/scheduling/events": typeof functions_scheduling_events;
   "functions/scheduling/index": typeof functions_scheduling_index;

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -215,8 +215,8 @@ import type * as lib_utils from "../lib/utils.js";
 import type * as lib_validation from "../lib/validation.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as migrations_addChannelSlugs from "../migrations/addChannelSlugs.js";
-import type * as migrations_ensureDevAssistantBotUser from "../migrations/ensureDevAssistantBotUser.js";
 import type * as migrations_backfillLastActivityAt from "../migrations/backfillLastActivityAt.js";
+import type * as migrations_ensureDevAssistantBotUser from "../migrations/ensureDevAssistantBotUser.js";
 
 import type {
   ApiFromModules,
@@ -432,8 +432,8 @@ declare const fullApi: ApiFromModules<{
   "lib/validation": typeof lib_validation;
   "lib/validators": typeof lib_validators;
   "migrations/addChannelSlugs": typeof migrations_addChannelSlugs;
-  "migrations/ensureDevAssistantBotUser": typeof migrations_ensureDevAssistantBotUser;
   "migrations/backfillLastActivityAt": typeof migrations_backfillLastActivityAt;
+  "migrations/ensureDevAssistantBotUser": typeof migrations_ensureDevAssistantBotUser;
 }>;
 
 /**

--- a/apps/convex/functions/scheduling/deletion.ts
+++ b/apps/convex/functions/scheduling/deletion.ts
@@ -1,0 +1,272 @@
+/**
+ * Scheduling — destructive team/role deletion (roster grid right-click).
+ *
+ * A leader can delete a whole serving team or a single role from the roster
+ * grid. Both follow the established soft-delete pattern (ADR-025): the team /
+ * role is *archived* (`isArchived: true`), never hard-deleted, so historical
+ * assignments on past events still resolve. What we DO hard-delete is the
+ * forward-looking scheduling state — `neededRoles` rows and `roleAssignments`
+ * across all of the group's plans — because a deleted role/team must vanish
+ * from every upcoming event's roster.
+ *
+ * Anyone still staffed on a future event is texted that their role was
+ * removed, reusing the exact SMS primitive the publish path uses
+ * (`auth.phoneOtp.sendSMS`) — a mutation can't run an action, so we schedule
+ * an internal action that resolves phones and fans out the texts, mirroring
+ * `assignments.sendAssignmentRequests`.
+ *
+ * Auth: `requireGroupScheduler` for the role/team's group (group leader or
+ * community admin). Calling either mutation when nobody is staffed simply
+ * archives + cleans up and sends no texts.
+ */
+
+import { ConvexError, v } from "convex/values";
+import {
+  mutation,
+  internalAction,
+  internalQuery,
+} from "../../_generated/server";
+import type { MutationCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
+import { requireAuth } from "../../lib/auth";
+import { purgeSyncedMembers } from "./teamChannelSync";
+import { requireGroupScheduler } from "./permissions";
+
+/**
+ * A person who lost a role on a specific upcoming event — the unit the
+ * notification action texts about. Carried through the scheduler boundary by
+ * value because the underlying `roleAssignments` rows are deleted before the
+ * action runs.
+ */
+type RemovedAssignment = {
+  userId: Id<"users">;
+  roleName: string;
+  /** Event date (ms) the role was removed for. */
+  eventDate: number;
+};
+
+const removedAssignmentValidator = v.object({
+  userId: v.id("users"),
+  roleName: v.string(),
+  eventDate: v.number(),
+});
+
+/**
+ * Delete `roleAssignments` + `neededRoles` for a set of roles across all of a
+ * group's plans, returning the affected (user, role, date) tuples so the
+ * caller can notify them. Only assignments whose `status !== "declined"` are
+ * reported — a volunteer who already declined isn't "staffed" and shouldn't be
+ * texted. Shared by `deleteRole` (one role) and `deleteTeam` (all the team's
+ * roles).
+ */
+async function cascadeDeleteRoles(
+  ctx: MutationCtx,
+  roleIds: Set<Id<"teamRoles">>,
+  roleNameById: Map<Id<"teamRoles">, string>,
+): Promise<RemovedAssignment[]> {
+  const removed: RemovedAssignment[] = [];
+
+  for (const roleId of roleIds) {
+    // Assignments for this role across every plan (the `by_role` index spans
+    // all plans, so we don't need to enumerate plans ourselves).
+    const assignments = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_role", (q) => q.eq("roleId", roleId))
+      .collect();
+
+    for (const a of assignments) {
+      if (a.status !== "declined") {
+        removed.push({
+          userId: a.userId,
+          roleName: roleNameById.get(roleId) ?? "your role",
+          eventDate: a.eventDate,
+        });
+      }
+      await ctx.db.delete(a._id);
+    }
+
+    // neededRoles for this role (the `by_plan_team` index is plan-scoped, so
+    // we filter the role's team rows by roleId — a small set per plan).
+    const needed = await ctx.db
+      .query("neededRoles")
+      .filter((q) => q.eq(q.field("roleId"), roleId))
+      .collect();
+    for (const n of needed) {
+      await ctx.db.delete(n._id);
+    }
+  }
+
+  return removed;
+}
+
+/**
+ * Delete a single role: archive the `teamRole`, remove its `neededRoles` +
+ * `roleAssignments` across all plans, and text everyone who was staffed.
+ *
+ * Auth: scheduler for the role's group.
+ */
+export const deleteRole = mutation({
+  args: {
+    token: v.string(),
+    roleId: v.id("teamRoles"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const role = await ctx.db.get(args.roleId);
+    if (!role) {
+      throw new ConvexError("Role not found");
+    }
+    const team = await ctx.db.get(role.teamId);
+    if (!team) {
+      throw new ConvexError("Team not found");
+    }
+    await requireGroupScheduler(ctx, team.groupId, userId);
+
+    const removed = await cascadeDeleteRoles(
+      ctx,
+      new Set([args.roleId]),
+      new Map([[args.roleId, role.name]]),
+    );
+
+    await ctx.db.patch(args.roleId, { isArchived: true });
+
+    if (removed.length > 0) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.scheduling.deletion.notifyRoleRemovals,
+        { removed },
+      );
+    }
+
+    return { roleId: args.roleId, notifiedCount: removed.length };
+  },
+});
+
+/**
+ * Delete a whole team: archive the `team` (and its chat channel, mirroring
+ * `archiveTeam`), archive its non-archived roles, remove their `neededRoles` +
+ * `roleAssignments` across all plans, and text everyone who was staffed.
+ *
+ * Auth: scheduler for the team's group.
+ */
+export const deleteTeam = mutation({
+  args: {
+    token: v.string(),
+    teamId: v.id("teams"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const team = await ctx.db.get(args.teamId);
+    if (!team) {
+      throw new ConvexError("Team not found");
+    }
+    await requireGroupScheduler(ctx, team.groupId, userId);
+
+    // The team's live (non-archived) roles — these get archived + cascaded.
+    const roles = await ctx.db
+      .query("teamRoles")
+      .withIndex("by_team", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    const liveRoles = roles.filter((r) => r.isArchived !== true);
+
+    const roleIds = new Set(liveRoles.map((r) => r._id));
+    const roleNameById = new Map(liveRoles.map((r) => [r._id, r.name]));
+
+    const removed = await cascadeDeleteRoles(ctx, roleIds, roleNameById);
+
+    for (const r of liveRoles) {
+      await ctx.db.patch(r._id, { isArchived: true });
+    }
+
+    // Archive the team + its chat channel exactly like `archiveTeam` does, so
+    // we don't orphan or hard-break the channel.
+    const now = Date.now();
+    await ctx.db.patch(args.teamId, { isArchived: true, updatedAt: now });
+    if (team.channelId) {
+      await ctx.db.patch(team.channelId, {
+        isArchived: true,
+        archivedAt: now,
+        updatedAt: now,
+      });
+      await purgeSyncedMembers(ctx, team.channelId);
+    }
+
+    if (removed.length > 0) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.scheduling.deletion.notifyRoleRemovals,
+        { removed },
+      );
+    }
+
+    return { teamId: args.teamId, notifiedCount: removed.length };
+  },
+});
+
+/**
+ * Internal: resolve phones for users who lost a role and return one tuple per
+ * (user, role, event date). Kept as a query so the action can read the DB.
+ */
+export const getRemovalPhones = internalQuery({
+  args: { removed: v.array(removedAssignmentValidator) },
+  handler: async (ctx, args) => {
+    const out: Array<{
+      phone: string;
+      roleName: string;
+      eventDate: number;
+    }> = [];
+    // Cache user lookups so a person staffed on several events is fetched once.
+    const phoneByUser = new Map<Id<"users">, string | null>();
+    for (const r of args.removed) {
+      if (!phoneByUser.has(r.userId)) {
+        const user = await ctx.db.get(r.userId);
+        phoneByUser.set(r.userId, user?.phone ?? null);
+      }
+      const phone = phoneByUser.get(r.userId);
+      if (phone) {
+        out.push({ phone, roleName: r.roleName, eventDate: r.eventDate });
+      }
+    }
+    return out;
+  },
+});
+
+/**
+ * Internal: text each affected person that their role was removed for a given
+ * event date. Reuses the publish-path SMS primitive
+ * (`auth.phoneOtp.sendSMS`); each send is best-effort. One message per
+ * (user, role, date) removed.
+ */
+export const notifyRoleRemovals = internalAction({
+  args: { removed: v.array(removedAssignmentValidator) },
+  handler: async (ctx, args) => {
+    const targets = await ctx.runQuery(
+      internal.functions.scheduling.deletion.getRemovalPhones,
+      { removed: args.removed },
+    );
+
+    let smsSent = 0;
+    for (const t of targets) {
+      const eventDate = new Date(t.eventDate).toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      });
+      const message =
+        `Your ${t.roleName} role for ${eventDate} has been removed.`;
+      try {
+        await ctx.runAction(internal.functions.auth.phoneOtp.sendSMS, {
+          phone: t.phone,
+          message,
+        });
+        smsSent += 1;
+      } catch {
+        // Best-effort: a failed text must not abort the rest of the fan-out.
+      }
+    }
+    return { smsSent };
+  },
+});

--- a/apps/convex/functions/scheduling/deletion.ts
+++ b/apps/convex/functions/scheduling/deletion.ts
@@ -6,8 +6,9 @@
  * role is *archived* (`isArchived: true`), never hard-deleted, so historical
  * assignments on past events still resolve. What we DO hard-delete is the
  * forward-looking scheduling state — `neededRoles` rows and `roleAssignments`
- * across all of the group's plans — because a deleted role/team must vanish
- * from every upcoming event's roster.
+ * on the group's UPCOMING plans only (event date >= start of today) — because a
+ * deleted role/team must vanish from every upcoming event's roster. Past plans'
+ * neededRoles/assignments are left intact so historical rosters survive.
  *
  * Anyone still staffed on a future event is texted that their role was
  * removed, reusing the exact SMS primitive the publish path uses
@@ -52,30 +53,62 @@ const removedAssignmentValidator = v.object({
   eventDate: v.number(),
 });
 
+/** Start-of-today (local) cutoff — mirrors `roster.ts`'s upcoming convention. */
+function startOfTodayMs(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
 /**
- * Delete `roleAssignments` + `neededRoles` for a set of roles across all of a
- * group's plans, returning the affected (user, role, date) tuples so the
- * caller can notify them. Only assignments whose `status !== "declined"` are
- * reported — a volunteer who already declined isn't "staffed" and shouldn't be
- * texted. Shared by `deleteRole` (one role) and `deleteTeam` (all the team's
- * roles).
+ * Collect the IDs of a group's UPCOMING plans (event date >= start of today),
+ * fetched once so the cascade can test plan membership without an N+1 lookup
+ * per `neededRoles` row.
+ */
+async function upcomingPlanIds(
+  ctx: MutationCtx,
+  groupId: Id<"groups">,
+): Promise<Set<Id<"eventPlans">>> {
+  const cutoff = startOfTodayMs();
+  const plans = await ctx.db
+    .query("eventPlans")
+    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+    .collect();
+  return new Set(
+    plans.filter((p) => p.eventDate >= cutoff).map((p) => p._id),
+  );
+}
+
+/**
+ * Delete `roleAssignments` + `neededRoles` for a set of roles across the
+ * group's UPCOMING plans only, returning the affected (user, role, date)
+ * tuples so the caller can notify them. Past plans are left intact: their
+ * historical rosters must survive and we must not text anyone about a service
+ * that already happened.
+ *
+ * Only assignments whose `status !== "declined"` are reported — a volunteer
+ * who already declined isn't "staffed" and shouldn't be texted. Shared by
+ * `deleteRole` (one role) and `deleteTeam` (all the team's roles).
  */
 async function cascadeDeleteRoles(
   ctx: MutationCtx,
   roleIds: Set<Id<"teamRoles">>,
   roleNameById: Map<Id<"teamRoles">, string>,
+  upcomingPlans: Set<Id<"eventPlans">>,
 ): Promise<RemovedAssignment[]> {
   const removed: RemovedAssignment[] = [];
+  const cutoff = startOfTodayMs();
 
   for (const roleId of roleIds) {
     // Assignments for this role across every plan (the `by_role` index spans
-    // all plans, so we don't need to enumerate plans ourselves).
+    // all plans). Filter to upcoming events by the denormalized `eventDate`.
     const assignments = await ctx.db
       .query("roleAssignments")
       .withIndex("by_role", (q) => q.eq("roleId", roleId))
       .collect();
 
     for (const a of assignments) {
+      if (a.eventDate < cutoff) continue; // past event — leave the row intact
       if (a.status !== "declined") {
         removed.push({
           userId: a.userId,
@@ -86,13 +119,14 @@ async function cascadeDeleteRoles(
       await ctx.db.delete(a._id);
     }
 
-    // neededRoles for this role (the `by_plan_team` index is plan-scoped, so
-    // we filter the role's team rows by roleId — a small set per plan).
+    // neededRoles for this role. They carry no date, so test membership against
+    // the group's pre-collected upcoming-plan set (avoids per-row plan lookups).
     const needed = await ctx.db
       .query("neededRoles")
       .filter((q) => q.eq(q.field("roleId"), roleId))
       .collect();
     for (const n of needed) {
+      if (!upcomingPlans.has(n.planId)) continue; // past plan — leave intact
       await ctx.db.delete(n._id);
     }
   }
@@ -124,10 +158,12 @@ export const deleteRole = mutation({
     }
     await requireGroupScheduler(ctx, team.groupId, userId);
 
+    const upcomingPlans = await upcomingPlanIds(ctx, team.groupId);
     const removed = await cascadeDeleteRoles(
       ctx,
       new Set([args.roleId]),
       new Map([[args.roleId, role.name]]),
+      upcomingPlans,
     );
 
     await ctx.db.patch(args.roleId, { isArchived: true });
@@ -175,7 +211,13 @@ export const deleteTeam = mutation({
     const roleIds = new Set(liveRoles.map((r) => r._id));
     const roleNameById = new Map(liveRoles.map((r) => [r._id, r.name]));
 
-    const removed = await cascadeDeleteRoles(ctx, roleIds, roleNameById);
+    const upcomingPlans = await upcomingPlanIds(ctx, team.groupId);
+    const removed = await cascadeDeleteRoles(
+      ctx,
+      roleIds,
+      roleNameById,
+      upcomingPlans,
+    );
 
     for (const r of liveRoles) {
       await ctx.db.patch(r._id, { isArchived: true });

--- a/apps/convex/functions/scheduling/deletion.ts
+++ b/apps/convex/functions/scheduling/deletion.ts
@@ -24,10 +24,11 @@
 import { ConvexError, v } from "convex/values";
 import {
   mutation,
+  query,
   internalAction,
   internalQuery,
 } from "../../_generated/server";
-import type { MutationCtx } from "../../_generated/server";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { internal } from "../../_generated/api";
 import { requireAuth } from "../../lib/auth";
@@ -66,7 +67,7 @@ function startOfTodayMs(): number {
  * per `neededRoles` row.
  */
 async function upcomingPlanIds(
-  ctx: MutationCtx,
+  ctx: QueryCtx | MutationCtx,
   groupId: Id<"groups">,
 ): Promise<Set<Id<"eventPlans">>> {
   const cutoff = startOfTodayMs();
@@ -79,24 +80,42 @@ async function upcomingPlanIds(
   );
 }
 
+/** The cascade's side effects the caller still needs after it runs. */
+type CascadeResult = {
+  /** Affected (user, role, date) tuples to text. Past + declined excluded. */
+  removed: RemovedAssignment[];
+  /**
+   * Serving teams that lost at least one assignment — the caller schedules a
+   * channel reconcile for each so team / cross-team channel membership stays
+   * correct after the bulk delete (mirroring the assign / unassign paths).
+   */
+  affectedTeamIds: Set<Id<"teams">>;
+};
+
 /**
  * Delete `roleAssignments` + `neededRoles` for a set of roles across the
  * group's UPCOMING plans only, returning the affected (user, role, date)
- * tuples so the caller can notify them. Past plans are left intact: their
- * historical rosters must survive and we must not text anyone about a service
- * that already happened.
+ * tuples so the caller can notify them, plus the serving teams whose channel
+ * membership must be reconciled. Past plans are left intact: their historical
+ * rosters must survive and we must not text anyone about a service that
+ * already happened.
  *
  * Only assignments whose `status !== "declined"` are reported — a volunteer
  * who already declined isn't "staffed" and shouldn't be texted. Shared by
  * `deleteRole` (one role) and `deleteTeam` (all the team's roles).
+ *
+ * `neededRoles` has no `by_role` index, so rather than scan the whole table we
+ * query the pre-collected upcoming plans via `by_plan` (bounded by plan count)
+ * and drop the rows whose `roleId` is in the doomed set.
  */
 async function cascadeDeleteRoles(
   ctx: MutationCtx,
   roleIds: Set<Id<"teamRoles">>,
   roleNameById: Map<Id<"teamRoles">, string>,
   upcomingPlans: Set<Id<"eventPlans">>,
-): Promise<RemovedAssignment[]> {
+): Promise<CascadeResult> {
   const removed: RemovedAssignment[] = [];
+  const affectedTeamIds = new Set<Id<"teams">>();
   const cutoff = startOfTodayMs();
 
   for (const roleId of roleIds) {
@@ -116,22 +135,55 @@ async function cascadeDeleteRoles(
           eventDate: a.eventDate,
         });
       }
+      // The team's channel membership is derived from its assignments, so a
+      // deletion must trigger the same reconcile that assign / unassign run.
+      affectedTeamIds.add(a.teamId);
       await ctx.db.delete(a._id);
     }
+  }
 
-    // neededRoles for this role. They carry no date, so test membership against
-    // the group's pre-collected upcoming-plan set (avoids per-row plan lookups).
+  // neededRoles for the doomed roles, on upcoming plans only. `neededRoles`
+  // has no `by_role` index — querying per upcoming plan (`by_plan`) and
+  // filtering by roleId is bounded by plan count instead of scanning the
+  // whole table.
+  for (const planId of upcomingPlans) {
     const needed = await ctx.db
       .query("neededRoles")
-      .filter((q) => q.eq(q.field("roleId"), roleId))
+      .withIndex("by_plan", (q) => q.eq("planId", planId))
       .collect();
     for (const n of needed) {
-      if (!upcomingPlans.has(n.planId)) continue; // past plan — leave intact
+      if (!roleIds.has(n.roleId)) continue;
       await ctx.db.delete(n._id);
     }
   }
 
-  return removed;
+  return { removed, affectedTeamIds };
+}
+
+/**
+ * Schedule the team-channel + cross-team-channel reconciliations for every
+ * serving team that lost assignments in the cascade. Mirrors the assign /
+ * unassign / publish trigger sites so channel membership stays correct after
+ * a bulk delete. Best-effort and idempotent — the reconcile recomputes the
+ * full desired set, so a doubled schedule is harmless.
+ */
+async function scheduleChannelReconcile(
+  ctx: MutationCtx,
+  teamIds: Set<Id<"teams">>,
+): Promise<void> {
+  for (const teamId of teamIds) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
+      { teamId },
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.teamChannelSync
+        .reconcileCrossTeamChannelsForSource,
+      { sourceTeamId: teamId },
+    );
+  }
 }
 
 /**
@@ -159,7 +211,7 @@ export const deleteRole = mutation({
     await requireGroupScheduler(ctx, team.groupId, userId);
 
     const upcomingPlans = await upcomingPlanIds(ctx, team.groupId);
-    const removed = await cascadeDeleteRoles(
+    const { removed, affectedTeamIds } = await cascadeDeleteRoles(
       ctx,
       new Set([args.roleId]),
       new Map([[args.roleId, role.name]]),
@@ -167,6 +219,10 @@ export const deleteRole = mutation({
     );
 
     await ctx.db.patch(args.roleId, { isArchived: true });
+
+    // Reconcile each affected team's channel + any cross-team channel that
+    // drew members via these assignments.
+    await scheduleChannelReconcile(ctx, affectedTeamIds);
 
     if (removed.length > 0) {
       await ctx.scheduler.runAfter(
@@ -212,7 +268,7 @@ export const deleteTeam = mutation({
     const roleNameById = new Map(liveRoles.map((r) => [r._id, r.name]));
 
     const upcomingPlans = await upcomingPlanIds(ctx, team.groupId);
-    const removed = await cascadeDeleteRoles(
+    const { removed, affectedTeamIds } = await cascadeDeleteRoles(
       ctx,
       roleIds,
       roleNameById,
@@ -235,6 +291,14 @@ export const deleteTeam = mutation({
       });
       await purgeSyncedMembers(ctx, team.channelId);
     }
+
+    // Reconcile cross-team channels (and any other auto-synced surface) that
+    // drew members from this team's now-deleted assignments. The team's own
+    // channel is already archived above (and `reconcileTeamChannel`
+    // short-circuits for archived teams), but cross-team channels selecting
+    // from it still need their membership recomputed — this runs the same
+    // `reconcileCrossTeamChannelsForSource` the assign / unassign paths do.
+    await scheduleChannelReconcile(ctx, affectedTeamIds);
 
     if (removed.length > 0) {
       await ctx.scheduler.runAfter(
@@ -310,5 +374,100 @@ export const notifyRoleRemovals = internalAction({
       }
     }
     return { smsSent };
+  },
+});
+
+/**
+ * Count the people (and dates) who would be texted if a role / team were
+ * deleted right now — used by the delete-confirm modal so its warning reflects
+ * EVERY upcoming assignment, not just the columns the roster grid happens to
+ * have loaded (it caps visible columns and hides past by default, so the
+ * client-side grid count can undercount who actually gets the removal text).
+ *
+ * Counts non-declined assignments on the group's UPCOMING plans only — the
+ * exact set `cascadeDeleteRoles` would remove + notify. A person serving on
+ * several upcoming dates is counted once in `peopleCount`; `dates` lists the
+ * distinct event dates. `names` is a small preview for the modal.
+ *
+ * Pass exactly one of `roleId` (single role) or `teamId` (all the team's live
+ * roles). Auth: scheduler for the role/team's group — the response leaks
+ * volunteer names, and this gates the same destructive action.
+ */
+export const affectedByDeletion = query({
+  args: {
+    token: v.string(),
+    roleId: v.optional(v.id("teamRoles")),
+    teamId: v.optional(v.id("teams")),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    if ((args.roleId === undefined) === (args.teamId === undefined)) {
+      throw new ConvexError("Pass exactly one of roleId or teamId");
+    }
+
+    // Resolve the target's group + the set of role IDs in scope, and authorize.
+    let groupId: Id<"groups">;
+    let roleIds: Set<Id<"teamRoles">>;
+    if (args.roleId !== undefined) {
+      const role = await ctx.db.get(args.roleId);
+      if (!role) throw new ConvexError("Role not found");
+      const team = await ctx.db.get(role.teamId);
+      if (!team) throw new ConvexError("Team not found");
+      await requireGroupScheduler(ctx, team.groupId, userId);
+      groupId = team.groupId;
+      roleIds = new Set([args.roleId]);
+    } else {
+      const team = await ctx.db.get(args.teamId!);
+      if (!team) throw new ConvexError("Team not found");
+      await requireGroupScheduler(ctx, team.groupId, userId);
+      groupId = team.groupId;
+      const roles = await ctx.db
+        .query("teamRoles")
+        .withIndex("by_team", (q) => q.eq("teamId", args.teamId!))
+        .collect();
+      roleIds = new Set(
+        roles.filter((r) => r.isArchived !== true).map((r) => r._id),
+      );
+    }
+
+    const upcoming = await upcomingPlanIds(ctx, groupId);
+    const cutoff = startOfTodayMs();
+
+    // Distinct affected people and dates across the doomed roles' upcoming,
+    // non-declined assignments — exactly what the cascade would text about.
+    const userIds = new Set<Id<"users">>();
+    const dates = new Set<number>();
+    for (const roleId of roleIds) {
+      const assignments = await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_role", (q) => q.eq("roleId", roleId))
+        .collect();
+      for (const a of assignments) {
+        if (a.eventDate < cutoff) continue;
+        if (!upcoming.has(a.planId)) continue;
+        if (a.status === "declined") continue;
+        userIds.add(a.userId);
+        dates.add(a.eventDate);
+      }
+    }
+
+    // A small name preview for the modal — bounded so a huge roster doesn't
+    // build a giant array. The headline count comes from `peopleCount`.
+    const NAME_PREVIEW_LIMIT = 20;
+    const names: string[] = [];
+    for (const id of userIds) {
+      if (names.length >= NAME_PREVIEW_LIMIT) break;
+      const user = await ctx.db.get(id);
+      names.push(
+        `${user?.firstName ?? ""} ${user?.lastName ?? ""}`.trim() || "Someone",
+      );
+    }
+
+    return {
+      peopleCount: userIds.size,
+      dates: [...dates].sort((a, b) => a - b),
+      names,
+    };
   },
 });

--- a/apps/convex/functions/scheduling/people.ts
+++ b/apps/convex/functions/scheduling/people.ts
@@ -90,6 +90,13 @@ export const searchCommunityPeople = query({
     // (completeness > the recency cap — FR-1.1/FR-1.4). When the leader is
     // SEARCHING, the search index already covers everyone, so we keep the
     // tighter `MAX_LIMIT` and slice as before.
+    //
+    // Read cost is bounded: the helper sources completeness from the group's
+    // OWN membership (O(group size)) and caps the wider-community recency tail
+    // to a small constant — it does NOT over-fetch the community in proportion
+    // to `GROUP_FULL_LIST_LIMIT`. (Earlier the tail scaled with this 1000
+    // ceiling → up to 3000 `userCommunities` reads → past Convex's per-query
+    // cap → the query threw → infinite spinner on larger communities.)
     const isEmptySearch = args.search.trim().length === 0;
     const rows = await searchCommunityMembersInternal(ctx, {
       communityId: group.communityId,

--- a/apps/convex/lib/memberSearch.ts
+++ b/apps/convex/lib/memberSearch.ts
@@ -27,6 +27,22 @@ import { getUsersWithNotificationsDisabled } from "./notifications/enabledStatus
 const GROUP_COMPLETE_LIMIT = 1000;
 
 /**
+ * Cap on the wider-community "extra people not in the group" tail on the
+ * empty-search path. When `includeAllGroupMembersWhenEmpty` is set the group-
+ * member union ALREADY guarantees completeness (FR-1), so this recency tier
+ * only needs to surface a small set of community-only people the leader might
+ * want to add+assign — they can always type a name to reach anyone past it.
+ *
+ * Keeping this a small CONSTANT (rather than scaling with the 1000-row group
+ * ceiling) is what bounds the empty-search read count to O(group size) +
+ * O(constant): on an 85+ member real community the old `effectiveLimit * 3` =
+ * up to 3000 `userCommunities` rows — each followed by a `ctx.db.get` AND a
+ * membership re-check — blew past Convex's per-query read cap and the query
+ * threw, surfacing as a permanent infinite spinner (roster grid fix).
+ */
+const COMMUNITY_TAIL_LIMIT = 50;
+
+/**
  * Base member result returned by search
  */
 export interface MemberSearchResult {
@@ -267,6 +283,11 @@ export async function searchCommunityMembersInternal(
   // recent-members fallback, use `userCommunities.by_community_lastLogin` to
   // surface the most recently-active people without scanning every user.
   const allMatchingUsers: Map<Id<"users">, Doc<"users">> = new Map();
+  // Users sourced from `includeAllGroupMembersWhenEmpty`'s active membership.
+  // These are already known-active members of the group (and therefore of the
+  // community), so we skip the per-row `userCommunities` membership re-check
+  // for them below — only the (now small, bounded) community tail needs it.
+  const knownGroupMemberIds = new Set<Id<"users">>();
 
   if (searchQuery) {
     // Build the set of terms to issue against the search index. Comma-
@@ -337,17 +358,34 @@ export async function searchCommunityMembersInternal(
         groupMemberships.map((m) => ctx.db.get(m.userId)),
       );
       for (const user of groupUsers) {
-        if (user && !allMatchingUsers.has(user._id)) {
-          allMatchingUsers.set(user._id, user);
+        if (user) {
+          knownGroupMemberIds.add(user._id);
+          if (!allMatchingUsers.has(user._id)) {
+            allMatchingUsers.set(user._id, user);
+          }
         }
       }
     }
 
     if (fallbackToRecentWhenEmpty) {
       // Pull the most recently-active community members directly off the
-      // descending `by_community_lastLogin` index. We over-fetch to account
-      // for downstream filters (excluded users, isActive, etc.) but the read
-      // count is bounded by `effectiveLimit`, not community size.
+      // descending `by_community_lastLogin` index.
+      //
+      // When `includeAllGroupMembersWhenEmpty` is also set, the group-member
+      // union above ALREADY guarantees completeness, so this tier only needs a
+      // small constant slice of community-only "extras" — NOT a slice that
+      // scales with the (up to 1000) group ceiling. We bound the take to a
+      // small CONSTANT (`COMMUNITY_TAIL_LIMIT`) in that case so the total
+      // empty-search read count stays O(group size) + O(constant) instead of
+      // O(3000), which previously blew past Convex's per-query read cap on
+      // larger communities and threw (infinite spinner).
+      //
+      // For the plain recency fallback (no group completeness guarantee) we
+      // keep the prior `effectiveLimit * 3` over-fetch — `effectiveLimit` is
+      // capped at 100 there, so it's already bounded.
+      const recencyTake = includeAllGroupMembersWhenEmpty
+        ? COMMUNITY_TAIL_LIMIT
+        : effectiveLimit * 3;
       const recentMemberships = await ctx.db
         .query("userCommunities")
         .withIndex("by_community_lastLogin", (q) =>
@@ -355,7 +393,7 @@ export async function searchCommunityMembersInternal(
         )
         .order("desc")
         .filter((q) => q.eq(q.field("status"), 1))
-        .take(effectiveLimit * 3);
+        .take(recencyTake);
 
       const recentUsers = await Promise.all(
         recentMemberships.map((m) => ctx.db.get(m.userId)),
@@ -468,16 +506,33 @@ export async function searchCommunityMembersInternal(
   // Check which users are active members of this community. One lookup per
   // candidate via the `by_user_community` compound index — read count scales
   // with the number of search-index matches, not community size.
+  //
+  // EXCEPTION: users sourced from `includeAllGroupMembersWhenEmpty`'s active
+  // membership (`knownGroupMemberIds`) are already known-active members of the
+  // group — and you cannot be an active group member without being an active
+  // community member — so we SKIP the per-row `userCommunities` re-check for
+  // them (it's redundant) and still fetch the doc only to surface their
+  // role/lastLogin. The (now bounded) community tail is the only set that
+  // genuinely needs a membership *check*. This keeps the empty-search read
+  // count O(group size) + O(constant) rather than scaling the re-check across
+  // a 3000-row over-fetch (roster grid fix).
   const usersArray = Array.from(allMatchingUsers.values());
-  const membershipPromises = usersArray.map((user) =>
-    ctx.db
+  const membershipPromises = usersArray.map(async (user) => {
+    // Skip the redundant membership read for known-active group members: a
+    // synthetic active membership stands in (roles default to 0 — the assign
+    // sheet doesn't surface admin badges for in-group rows). Only the
+    // community tail and the search path actually need a membership check.
+    if (knownGroupMemberIds.has(user._id)) {
+      return { status: 1, roles: 0 } as Doc<"userCommunities">;
+    }
+    return ctx.db
       .query("userCommunities")
       .withIndex("by_user_community", (q) =>
         q.eq("userId", user._id).eq("communityId", communityId)
       )
       .filter((q) => q.eq(q.field("status"), 1)) // Active status
-      .first()
-  );
+      .first();
+  });
   const memberships = await Promise.all(membershipPromises);
 
   // Apply all filters once up front so we know exactly which rows survive

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -393,6 +393,23 @@ export function AssignSheet({
     [],
   );
 
+  /**
+   * Keep Needed ≥ assigned. Called after every successful assign: if the role
+   * was full (or had 0 needed), grow Needed to cover the person just placed so
+   * "Needed" never reads lower than reality. `assignedCount` is the pre-assign
+   * prop, so the new floor is `assignedCount + 1`. No-op when `onSetNeeded`
+   * isn't provided (stepper hidden) or Needed already has room. Unassigning
+   * never calls this, so freed slots stay open.
+   */
+  const growNeededForAssign = useCallback(() => {
+    if (!onSetNeeded) return;
+    const needed = neededCount ?? 0;
+    const filledAfter = (assignedCount ?? 0) + 1;
+    if (needed < filledAfter) {
+      onSetNeeded(Math.max(needed, filledAfter));
+    }
+  }, [onSetNeeded, neededCount, assignedCount]);
+
   const handleAssignFromGroup = useCallback(
     async (person: CommunityPerson) => {
       if (assignedUserIds.has(person.userId as string)) return;
@@ -405,6 +422,9 @@ export function AssignSheet({
           userId: person.userId,
           timeLabel,
         });
+        // Auto-grow Needed to cover this assignment (e.g. 0→1, or a full
+        // role's count up by one) so assigned never exceeds needed.
+        growNeededForAssign();
         if (result?.doubleBooked) {
           Alert.alert(
             "Heads up — double-booked",
@@ -434,6 +454,7 @@ export function AssignSheet({
       dockedRight,
       onClose,
       surfaceError,
+      growNeededForAssign,
     ],
   );
 
@@ -449,6 +470,8 @@ export function AssignSheet({
           userId: person.userId,
           timeLabel,
         });
+        // Grow Needed to cover this assignment (see handleAssignFromGroup).
+        growNeededForAssign();
         const firstName = person.firstName?.trim() || person.displayName;
         Alert.alert(
           "Assigned",
@@ -474,6 +497,7 @@ export function AssignSheet({
       onClose,
       roleName,
       surfaceError,
+      growNeededForAssign,
     ],
   );
 
@@ -507,6 +531,9 @@ export function AssignSheet({
             existingDisplayName?: string | null;
           }
         | undefined;
+      // Every non-throwing branch below results in an assignment (existing
+      // match, deferred invite, or sent invite), so grow Needed to cover it.
+      growNeededForAssign();
       if (result?.existedAlready) {
         const matched = result.existingDisplayName || firstName;
         Alert.alert(
@@ -555,6 +582,7 @@ export function AssignSheet({
     dockedRight,
     onClose,
     surfaceError,
+    growNeededForAssign,
   ]);
 
   // ---------------------------------------------------------------------------
@@ -819,25 +847,49 @@ export function AssignSheet({
           `onSetNeeded` (e.g. the event editor's own NeededRolesModal). */}
       {onSetNeeded && (
         <View style={[styles.neededRow, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.neededLabel, { color: colors.text }]}>
-            Needed: {needed}
-          </Text>
+          <View style={styles.neededLabelWrap}>
+            <Text style={[styles.neededLabel, { color: colors.text }]}>
+              Needed: {needed}
+            </Text>
+            {floor > 0 && (
+              <Text
+                style={[styles.neededHint, { color: colors.textSecondary }]}
+              >
+                {floor} assigned
+              </Text>
+            )}
+          </View>
           <View style={styles.neededControls}>
-            <TouchableOpacity
-              onPress={() => onSetNeeded(Math.max(floor, needed - 1))}
-              disabled={needed <= floor}
-              accessibilityRole="button"
-              accessibilityLabel="Decrease needed"
-              style={[
-                styles.stepBtn,
-                {
-                  borderColor: colors.border,
-                  opacity: needed <= floor ? 0.4 : 1,
-                },
-              ]}
-            >
-              <Ionicons name="remove" size={20} color={colors.text} />
-            </TouchableOpacity>
+            {/* `−` is floored at the number already assigned (and at 0): you
+                can't drop a slot someone's in. Disabled = greyed + non-tappable
+                so it never silently no-ops. Unassign someone to go lower. */}
+            {(() => {
+              const decreaseDisabled = needed <= floor || needed <= 0;
+              return (
+                <TouchableOpacity
+                  onPress={() => onSetNeeded(Math.max(floor, needed - 1))}
+                  disabled={decreaseDisabled}
+                  accessibilityRole="button"
+                  accessibilityLabel="Decrease needed"
+                  accessibilityState={{ disabled: decreaseDisabled }}
+                  style={[
+                    styles.stepBtn,
+                    {
+                      borderColor: colors.border,
+                      opacity: decreaseDisabled ? 0.35 : 1,
+                    },
+                  ]}
+                >
+                  <Ionicons
+                    name="remove"
+                    size={20}
+                    color={
+                      decreaseDisabled ? colors.textTertiary : colors.text
+                    }
+                  />
+                </TouchableOpacity>
+              );
+            })()}
             <TouchableOpacity
               onPress={() => onSetNeeded(needed + 1)}
               accessibilityRole="button"
@@ -1152,9 +1204,18 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
+  neededLabelWrap: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 8,
+    flexShrink: 1,
+  },
   neededLabel: {
     fontSize: 15,
     fontWeight: "600",
+  },
+  neededHint: {
+    fontSize: 13,
   },
   neededControls: {
     flexDirection: "row",

--- a/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
+++ b/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
@@ -209,8 +209,18 @@ export function DateColumnHeaderEditor({
   const handleChangeDate = useCallback(
     async (date: Date | null) => {
       if (!date) return;
+      const ms = date.getTime();
+      // Guard against intermediate/invalid values while typing into the native
+      // date input. Editing the year digit-by-digit briefly yields a complete
+      // but absurd date (e.g. year 0026); without this guard that gets saved as
+      // `eventDate`, shoving the plan into the far past so it drops out of the
+      // upcoming-only grid and looks like the plan was deleted. Only persist a
+      // valid, plausibly-dated value; ignore the keystrokes in between.
+      if (Number.isNaN(ms)) return;
+      const year = date.getFullYear();
+      if (year < 2000 || year > 3000) return;
       try {
-        await updateEvent({ planId: event._id, eventDate: date.getTime() });
+        await updateEvent({ planId: event._id, eventDate: ms });
       } catch (e) {
         notify("Couldn't update date", errMessage(e));
       }

--- a/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
+++ b/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
@@ -82,11 +82,16 @@ function errMessage(e: unknown): string {
 function formatTimeLabel(date: Date): string {
   return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
 }
-function weekday(ms: number): string {
-  return new Date(ms).toLocaleDateString("en-US", { weekday: "short" });
-}
 function monthDay(ms: number): string {
   return new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+/** "Sun, Jul 5" — the plain-text date shown in the header (no input box). */
+function dateLabel(ms: number): string {
+  return new Date(ms).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
 }
 
 export function DateColumnHeaderEditor({
@@ -140,6 +145,9 @@ export function DateColumnHeaderEditor({
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
+  // Date/time edit popup — the native pickers live ONLY here, never inline in
+  // the header (which previously rendered ugly always-visible input boxes).
+  const [whenEditOpen, setWhenEditOpen] = useState(false);
 
   // --- Title auto-save (debounced) + blur/unmount flush (reused pattern) ---
   const titleSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -279,6 +287,12 @@ export function DateColumnHeaderEditor({
 
   const runSheetCount = runSheetItems?.length ?? 0;
 
+  // "10:00 AM · 12:00 PM" — the plain-text time summary shown in the header.
+  const timesSummary =
+    event.times.length > 0
+      ? event.times.map((t) => formatTimeLabel(new Date(t.startsAt))).join(" · ")
+      : "Add time";
+
   // RN-Web forwards unknown DOM props on the host node; onContextMenu lands on
   // the underlying <div>. The types don't know it, so we attach via a cast on a
   // web-only prop bag. The ⋯ button is the reliable primary; this is the bonus.
@@ -352,41 +366,40 @@ export function DateColumnHeaderEditor({
         </TouchableOpacity>
       </View>
 
-      {/* Date — inline picker trigger. */}
-      <View style={styles.whenRow}>
-        <Text style={[styles.weekday, { color: colors.textSecondary }]}>
-          {weekday(event.eventDate)}
-        </Text>
-        <DatePicker
-          value={new Date(event.eventDate)}
-          onChange={handleChangeDate}
-          mode="date"
-          style={styles.pickerReset}
-        />
-      </View>
-
-      {/* Times — one inline trigger per service, plus a compact "+ time". */}
-      <View style={styles.timesRow}>
-        {event.times.map((t, index) => (
-          <DatePicker
-            key={`${t.startsAt}-${index}`}
-            value={new Date(t.startsAt)}
-            onChange={(d) => handleChangeTimeAt(index, d)}
-            mode="time"
-            style={styles.pickerReset}
-          />
-        ))}
-        <TouchableOpacity
-          onPress={handleAddTime}
-          hitSlop={6}
-          style={styles.addTime}
-          accessibilityRole="button"
-          accessibilityLabel="Add a time"
+      {/* Date — plain text + pencil; tapping opens the edit popup (no inline
+          native input box in the header). */}
+      <TouchableOpacity
+        onPress={() => setWhenEditOpen(true)}
+        style={styles.whenRow}
+        hitSlop={4}
+        accessibilityRole="button"
+        accessibilityLabel={`Edit date — ${dateLabel(event.eventDate)}`}
+      >
+        <Text
+          style={[styles.weekday, { color: colors.textSecondary }]}
+          numberOfLines={1}
         >
-          <Ionicons name="add" size={12} color={colors.link} />
-          <Text style={[styles.addTimeText, { color: colors.link }]}>time</Text>
-        </TouchableOpacity>
-      </View>
+          {dateLabel(event.eventDate)}
+        </Text>
+        <Ionicons name="pencil" size={10} color={colors.textTertiary} />
+      </TouchableOpacity>
+
+      {/* Time(s) — plain text + pencil; same edit popup. */}
+      <TouchableOpacity
+        onPress={() => setWhenEditOpen(true)}
+        style={styles.timesRow}
+        hitSlop={4}
+        accessibilityRole="button"
+        accessibilityLabel={`Edit times — ${timesSummary}`}
+      >
+        <Text
+          style={[styles.timesText, { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
+          {timesSummary}
+        </Text>
+        <Ionicons name="pencil" size={10} color={colors.textTertiary} />
+      </TouchableOpacity>
 
       {/* Coverage / availability tally (rendered by the caller, view-aware). */}
       <View style={styles.tallyRow}>{tally}</View>
@@ -492,6 +505,78 @@ export function DateColumnHeaderEditor({
         </Modal>
       )}
 
+      {/* Date / time edit popup — the actual pickers live here, not inline in
+          the header. Reuses the same save handlers (handleChangeDate /
+          handleChangeTimeAt / handleAddTime / saveTimes). Centered card over a
+          dim backdrop, matching the screen's other menus (ModalShell idiom). */}
+      {whenEditOpen && (
+        <Modal
+          visible
+          transparent
+          animationType="fade"
+          onRequestClose={() => setWhenEditOpen(false)}
+        >
+          <Pressable
+            style={styles.menuBackdrop}
+            onPress={() => setWhenEditOpen(false)}
+          >
+            <Pressable
+              style={[
+                styles.menuCard,
+                { backgroundColor: colors.surface, borderColor: colors.border },
+              ]}
+              onPress={(e) => e.stopPropagation()}
+            >
+              <View style={styles.whenEditHeader}>
+                <Text style={[styles.whenEditTitle, { color: colors.text }]} numberOfLines={1}>
+                  {event.title} · date & times
+                </Text>
+                <TouchableOpacity
+                  onPress={() => setWhenEditOpen(false)}
+                  hitSlop={8}
+                  accessibilityRole="button"
+                  accessibilityLabel="Done"
+                >
+                  <Text style={[styles.whenEditDone, { color: colors.link }]}>Done</Text>
+                </TouchableOpacity>
+              </View>
+
+              <View style={styles.whenEditBody}>
+                <Text style={[styles.whenEditLabel, { color: colors.textSecondary }]}>
+                  Date
+                </Text>
+                <DatePicker
+                  value={new Date(event.eventDate)}
+                  onChange={handleChangeDate}
+                  mode="date"
+                />
+
+                <Text style={[styles.whenEditLabel, { color: colors.textSecondary }]}>
+                  Times
+                </Text>
+                {event.times.map((t, index) => (
+                  <DatePicker
+                    key={`${t.startsAt}-${index}`}
+                    value={new Date(t.startsAt)}
+                    onChange={(d) => handleChangeTimeAt(index, d)}
+                    mode="time"
+                  />
+                ))}
+                <TouchableOpacity
+                  onPress={handleAddTime}
+                  style={styles.addTime}
+                  accessibilityRole="button"
+                  accessibilityLabel="Add a time"
+                >
+                  <Ionicons name="add" size={16} color={colors.link} />
+                  <Text style={[styles.addTimeText, { color: colors.link }]}>Add time</Text>
+                </TouchableOpacity>
+              </View>
+            </Pressable>
+          </Pressable>
+        </Modal>
+      )}
+
       <NeededRolesModal
         visible={neededVisible}
         planId={event._id}
@@ -576,27 +661,40 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 4,
+    gap: 3,
   },
-  weekday: { fontSize: 11, fontWeight: "600" },
+  weekday: { fontSize: 11, fontWeight: "600", flexShrink: 1 },
   timesRow: {
     flexDirection: "row",
-    flexWrap: "wrap",
     alignItems: "center",
     justifyContent: "center",
-    gap: 2,
+    gap: 3,
   },
-  // The shared DatePicker ships a bottom margin + bordered box; zero the margin
-  // so the trigger reads as a compact inline value inside the tight header.
-  pickerReset: { marginBottom: 0 },
+  timesText: { fontSize: 10, fontWeight: "500", flexShrink: 1 },
   addTime: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 1,
-    paddingHorizontal: 4,
-    paddingVertical: 2,
+    gap: 4,
+    paddingVertical: 6,
   },
-  addTimeText: { fontSize: 10, fontWeight: "600" },
+  addTimeText: { fontSize: 14, fontWeight: "600" },
+  whenEditHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 14,
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  whenEditTitle: { fontSize: 13, fontWeight: "700", flexShrink: 1, marginRight: 12 },
+  whenEditDone: { fontSize: 15, fontWeight: "600" },
+  whenEditBody: { paddingHorizontal: 14, paddingBottom: 12 },
+  whenEditLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    marginTop: 8,
+    marginBottom: 4,
+  },
   tallyRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
+++ b/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
@@ -5,16 +5,18 @@
  * grid-first roster screen (≥700px) the docked plan-detail side panel is gone:
  * everything a leader edited there now lives in the column header itself.
  *
- *  - Title — tap to rename inline (debounced auto-save + blur/unmount flush,
- *    the same discipline EventEditorPanel/EventEditorScreen use so an in-flight
- *    rename is never lost).
- *  - Date + time(s) — inline DatePicker triggers; a "+ time" adds a service.
+ *  - Title — plain text; tap to rename inline (debounced auto-save +
+ *    blur/unmount flush, the same discipline EventEditorPanel/EventEditorScreen
+ *    use so an in-flight rename is never lost).
+ *  - Date — plain text; tap opens a date-only popup (just the date picker).
  *  - Run sheet — a compact button showing the item count → the run-sheet route.
  *  - A visible `⋯` button AND a web right-click (`onContextMenu`) open a context
- *    menu: Set needed roles · Add time · Open run sheet · Publish this date ·
+ *    menu: Set needed roles · Edit time · Open run sheet · Publish this date ·
  *    Duplicate · Delete — all wired to the SAME plan mutations the editor uses.
+ *    "Edit time" opens a times-only popup (list of service times with
+ *    add/change/remove).
  *
- * Narrow columns keep title + date/time visible and fold the run-sheet button
+ * Narrow columns keep title + date visible and fold the run-sheet button
  * (and everything else) into the `⋯`/right-click menu.
  *
  * Reuses the plan mutations directly (scheduling.events.updateEvent /
@@ -145,9 +147,11 @@ export function DateColumnHeaderEditor({
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
-  // Date/time edit popup — the native pickers live ONLY here, never inline in
-  // the header (which previously rendered ugly always-visible input boxes).
-  const [whenEditOpen, setWhenEditOpen] = useState(false);
+  // Two separate edit popups — the native pickers live ONLY here, never inline
+  // in the header. The date is a plain-text tap in the header; times moved into
+  // the ⋯ menu ("Edit time").
+  const [dateEditOpen, setDateEditOpen] = useState(false);
+  const [timesEditOpen, setTimesEditOpen] = useState(false);
 
   // --- Title auto-save (debounced) + blur/unmount flush (reused pattern) ---
   const titleSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -243,6 +247,13 @@ export function DateColumnHeaderEditor({
     ]);
   }, [event.times, event.eventDate, saveTimes]);
 
+  const handleRemoveTimeAt = useCallback(
+    (index: number) => {
+      void saveTimes(event.times.filter((_, i) => i !== index));
+    },
+    [event.times, saveTimes],
+  );
+
   // --- Menu actions ---
   const openRunSheet = useCallback(() => {
     setMenuOpen(false);
@@ -286,12 +297,6 @@ export function DateColumnHeaderEditor({
   }, [planDoc?.roles]);
 
   const runSheetCount = runSheetItems?.length ?? 0;
-
-  // "10:00 AM · 12:00 PM" — the plain-text time summary shown in the header.
-  const timesSummary =
-    event.times.length > 0
-      ? event.times.map((t) => formatTimeLabel(new Date(t.startsAt))).join(" · ")
-      : "Add time";
 
   // RN-Web forwards unknown DOM props on the host node; onContextMenu lands on
   // the underlying <div>. The types don't know it, so we attach via a cast on a
@@ -352,7 +357,6 @@ export function DateColumnHeaderEditor({
             >
               {event.title}
             </Text>
-            <Ionicons name="pencil" size={10} color={colors.textTertiary} />
           </Pressable>
         )}
         <TouchableOpacity
@@ -366,10 +370,10 @@ export function DateColumnHeaderEditor({
         </TouchableOpacity>
       </View>
 
-      {/* Date — plain text + pencil; tapping opens the edit popup (no inline
-          native input box in the header). */}
+      {/* Date — plain text; tapping opens the date-only edit popup (no inline
+          native input box, no pencil, no times in the header). */}
       <TouchableOpacity
-        onPress={() => setWhenEditOpen(true)}
+        onPress={() => setDateEditOpen(true)}
         style={styles.whenRow}
         hitSlop={4}
         accessibilityRole="button"
@@ -381,24 +385,6 @@ export function DateColumnHeaderEditor({
         >
           {dateLabel(event.eventDate)}
         </Text>
-        <Ionicons name="pencil" size={10} color={colors.textTertiary} />
-      </TouchableOpacity>
-
-      {/* Time(s) — plain text + pencil; same edit popup. */}
-      <TouchableOpacity
-        onPress={() => setWhenEditOpen(true)}
-        style={styles.timesRow}
-        hitSlop={4}
-        accessibilityRole="button"
-        accessibilityLabel={`Edit times — ${timesSummary}`}
-      >
-        <Text
-          style={[styles.timesText, { color: colors.textSecondary }]}
-          numberOfLines={1}
-        >
-          {timesSummary}
-        </Text>
-        <Ionicons name="pencil" size={10} color={colors.textTertiary} />
       </TouchableOpacity>
 
       {/* Coverage / availability tally (rendered by the caller, view-aware). */}
@@ -461,11 +447,11 @@ export function DateColumnHeaderEditor({
               />
               <MenuItem
                 icon="time-outline"
-                label="Add time"
+                label="Edit time"
                 colors={colors}
                 onPress={() => {
                   setMenuOpen(false);
-                  handleAddTime();
+                  setTimesEditOpen(true);
                 }}
               />
               <MenuItem
@@ -505,20 +491,18 @@ export function DateColumnHeaderEditor({
         </Modal>
       )}
 
-      {/* Date / time edit popup — the actual pickers live here, not inline in
-          the header. Reuses the same save handlers (handleChangeDate /
-          handleChangeTimeAt / handleAddTime / saveTimes). Centered card over a
-          dim backdrop, matching the screen's other menus (ModalShell idiom). */}
-      {whenEditOpen && (
+      {/* Date-only edit popup — opened by tapping the plain-text date in the
+          header. Just the date picker + Done. Reuses handleChangeDate. */}
+      {dateEditOpen && (
         <Modal
           visible
           transparent
           animationType="fade"
-          onRequestClose={() => setWhenEditOpen(false)}
+          onRequestClose={() => setDateEditOpen(false)}
         >
           <Pressable
             style={styles.menuBackdrop}
-            onPress={() => setWhenEditOpen(false)}
+            onPress={() => setDateEditOpen(false)}
           >
             <Pressable
               style={[
@@ -529,10 +513,10 @@ export function DateColumnHeaderEditor({
             >
               <View style={styles.whenEditHeader}>
                 <Text style={[styles.whenEditTitle, { color: colors.text }]} numberOfLines={1}>
-                  {event.title} · date & times
+                  {event.title} · date
                 </Text>
                 <TouchableOpacity
-                  onPress={() => setWhenEditOpen(false)}
+                  onPress={() => setDateEditOpen(false)}
                   hitSlop={8}
                   accessibilityRole="button"
                   accessibilityLabel="Done"
@@ -550,17 +534,67 @@ export function DateColumnHeaderEditor({
                   onChange={handleChangeDate}
                   mode="date"
                 />
+              </View>
+            </Pressable>
+          </Pressable>
+        </Modal>
+      )}
 
-                <Text style={[styles.whenEditLabel, { color: colors.textSecondary }]}>
-                  Times
+      {/* Times-only editor — opened by the ⋯ menu's "Edit time". Lists each
+          service time (change inline) with a remove ✕, an Add time button, and
+          Done. Reuses handleChangeTimeAt / handleAddTime / handleRemoveTimeAt. */}
+      {timesEditOpen && (
+        <Modal
+          visible
+          transparent
+          animationType="fade"
+          onRequestClose={() => setTimesEditOpen(false)}
+        >
+          <Pressable
+            style={styles.menuBackdrop}
+            onPress={() => setTimesEditOpen(false)}
+          >
+            <Pressable
+              style={[
+                styles.menuCard,
+                { backgroundColor: colors.surface, borderColor: colors.border },
+              ]}
+              onPress={(e) => e.stopPropagation()}
+            >
+              <View style={styles.whenEditHeader}>
+                <Text style={[styles.whenEditTitle, { color: colors.text }]} numberOfLines={1}>
+                  {event.title} · times
                 </Text>
+                <TouchableOpacity
+                  onPress={() => setTimesEditOpen(false)}
+                  hitSlop={8}
+                  accessibilityRole="button"
+                  accessibilityLabel="Done"
+                >
+                  <Text style={[styles.whenEditDone, { color: colors.link }]}>Done</Text>
+                </TouchableOpacity>
+              </View>
+
+              <View style={styles.whenEditBody}>
                 {event.times.map((t, index) => (
-                  <DatePicker
-                    key={`${t.startsAt}-${index}`}
-                    value={new Date(t.startsAt)}
-                    onChange={(d) => handleChangeTimeAt(index, d)}
-                    mode="time"
-                  />
+                  <View key={`${t.startsAt}-${index}`} style={styles.timeEditRow}>
+                    <View style={styles.timeEditPicker}>
+                      <DatePicker
+                        value={new Date(t.startsAt)}
+                        onChange={(d) => handleChangeTimeAt(index, d)}
+                        mode="time"
+                      />
+                    </View>
+                    <TouchableOpacity
+                      onPress={() => handleRemoveTimeAt(index)}
+                      hitSlop={8}
+                      style={styles.removeTime}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Remove time ${t.label}`}
+                    >
+                      <Ionicons name="close" size={16} color={colors.textSecondary} />
+                    </TouchableOpacity>
+                  </View>
                 ))}
                 <TouchableOpacity
                   onPress={handleAddTime}
@@ -664,13 +698,18 @@ const styles = StyleSheet.create({
     gap: 3,
   },
   weekday: { fontSize: 11, fontWeight: "600", flexShrink: 1 },
-  timesRow: {
+  timeEditRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
-    gap: 3,
+    gap: 8,
   },
-  timesText: { fontSize: 10, fontWeight: "500", flexShrink: 1 },
+  timeEditPicker: { flex: 1, minWidth: 0 },
+  removeTime: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   addTime: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -2120,9 +2120,6 @@ export function RosterGridScreen() {
       {deleteTarget && (
         <DeleteRowFlow
           target={deleteTarget}
-          events={events}
-          roles={data.roles}
-          roleCells={roleCells}
           colors={colors}
           deleteRole={deleteRole}
           deleteTeam={deleteTeam}
@@ -2981,52 +2978,6 @@ function LegendItem({
 // Delete team / role flow
 // ---------------------------------------------------------------------------
 
-/** A person staffed in the doomed team/role, with the dates they'd lose. */
-type StaffedPerson = { userId: string; userName: string; dates: number[] };
-
-/**
- * Compute the people currently staffed (non-declined) in the target team/role
- * across all visible event columns, from the already-loaded `roleCells`. This
- * is what powers the "<N> people are staffed…" confirmation — no extra query.
- */
-function staffedForTarget(
-  target: DeleteTarget,
-  events: RosterEvent[],
-  roles: RosterRole[],
-  roleCells: Record<string, RoleCell>,
-): StaffedPerson[] {
-  const roleIds =
-    target.kind === "role"
-      ? [target.roleId as string]
-      : roles
-          .filter((r) => (r.teamId as string) === (target.teamId as string))
-          .map((r) => r.roleId as string);
-
-  const byUser = new Map<string, StaffedPerson>();
-  for (const roleId of roleIds) {
-    for (const ev of events) {
-      const cell = roleCells[`${roleId}:${ev._id}`];
-      if (!cell) continue;
-      for (const o of cell.occupants) {
-        if (o.status === "declined") continue;
-        const existing = byUser.get(o.userId as string);
-        if (existing) {
-          if (!existing.dates.includes(ev.eventDate)) {
-            existing.dates.push(ev.eventDate);
-          }
-        } else {
-          byUser.set(o.userId as string, {
-            userId: o.userId as string,
-            userName: o.userName,
-            dates: [ev.eventDate],
-          });
-        }
-      }
-    }
-  }
-  return [...byUser.values()];
-}
-
 /** "Sun, Jul 5" / "Sun, Jul 5 and Sun, Jul 12" / "3 dates" — the affected-date copy. */
 function describeDates(dates: number[]): string {
   const unique = [...new Set(dates)].sort((a, b) => a - b);
@@ -3048,9 +2999,6 @@ function describeDates(dates: number[]): string {
  */
 function DeleteRowFlow({
   target,
-  events,
-  roles,
-  roleCells,
   colors,
   deleteRole,
   deleteTeam,
@@ -3060,9 +3008,6 @@ function DeleteRowFlow({
   onClose,
 }: {
   target: DeleteTarget;
-  events: RosterEvent[];
-  roles: RosterRole[];
-  roleCells: Record<string, RoleCell>;
   colors: Colors;
   deleteRole: (args: { roleId: Id<"teamRoles"> }) => Promise<unknown>;
   deleteTeam: (args: { teamId: Id<"teams"> }) => Promise<unknown>;
@@ -3082,14 +3027,23 @@ function DeleteRowFlow({
   const name = target.kind === "team" ? target.teamName : target.roleName;
   const noun = target.kind === "team" ? "team" : "role";
   const [draftName, setDraftName] = useState(name);
-  const staffed = useMemo(
-    () => staffedForTarget(target, events, roles, roleCells),
-    [target, events, roles, roleCells],
-  );
-  const allDates = useMemo(
-    () => staffed.flatMap((p) => p.dates),
-    [staffed],
-  );
+
+  // Who actually gets texted, queried server-side across ALL upcoming plans —
+  // not just the grid's visible columns (which cap at ~10 and hide past), so
+  // the warning never undercounts. Fetched lazily: only once the user opens the
+  // destructive confirm step (the menu / rename steps don't need it).
+  const wantStaffed = step === "confirm" || step === "notify";
+  const affected = useAuthenticatedQuery(
+    api.functions.scheduling.deletion.affectedByDeletion,
+    wantStaffed
+      ? target.kind === "role"
+        ? { roleId: target.roleId }
+        : { teamId: target.teamId }
+      : "skip",
+  ) as
+    | { peopleCount: number; dates: number[]; names: string[] }
+    | undefined;
+  const affectedLoading = wantStaffed && affected === undefined;
 
   const runDelete = useCallback(async () => {
     setBusy(true);
@@ -3106,14 +3060,17 @@ function DeleteRowFlow({
     }
   }, [target, deleteTeam, deleteRole, onClose, onError, noun]);
 
-  // Step 1 → either jump to the notify modal (staffed) or delete after confirm.
+  // Step 1 → jump to the notify modal when the server says people are staffed,
+  // otherwise delete straight away. Wait for the count to load first so we
+  // never silently skip the notify warning when affected events are off-screen.
   const onConfirmFirst = useCallback(() => {
-    if (staffed.length > 0) {
+    if (affected === undefined) return; // still loading — button shows a spinner
+    if (affected.peopleCount > 0) {
       setStep("notify");
     } else {
       void runDelete();
     }
-  }, [staffed.length, runDelete]);
+  }, [affected, runDelete]);
 
   const runRename = useCallback(async () => {
     const trimmed = draftName.trim();
@@ -3258,12 +3215,12 @@ function DeleteRowFlow({
                 </TouchableOpacity>
                 <TouchableOpacity
                   onPress={onConfirmFirst}
-                  disabled={busy}
+                  disabled={busy || affectedLoading}
                   style={[styles.deleteBtn, { backgroundColor: colors.destructive }]}
                   accessibilityRole="button"
                   accessibilityLabel="Delete"
                 >
-                  {busy ? (
+                  {busy || affectedLoading ? (
                     <ActivityIndicator size="small" color="#fff" />
                   ) : (
                     <Text style={[styles.deleteBtnText, { color: "#fff" }]}>Delete</Text>
@@ -3279,12 +3236,16 @@ function DeleteRowFlow({
                 Delete &ldquo;{name}&rdquo;?
               </Text>
               <Text style={[styles.deleteBody, { color: colors.textSecondary }]}>
-                {staffed.length} {staffed.length === 1 ? "person is" : "people are"}{" "}
+                {affected?.peopleCount ?? 0}{" "}
+                {(affected?.peopleCount ?? 0) === 1 ? "person is" : "people are"}{" "}
                 staffed in this {noun}. They&rsquo;ll receive a text that their{" "}
-                {noun} has been removed for {describeDates(allDates)}.
+                {noun} has been removed for {describeDates(affected?.dates ?? [])}.
               </Text>
               <Text style={[styles.deleteNames, { color: colors.textTertiary }]} numberOfLines={2}>
-                {staffed.map((p) => p.userName).join(", ")}
+                {(affected?.names ?? []).join(", ")}
+                {affected && affected.names.length < affected.peopleCount
+                  ? ", …"
+                  : ""}
               </Text>
               <View style={styles.deleteActions}>
                 <TouchableOpacity

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -154,6 +154,11 @@ type RoleRow =
   | { kind: "addRole"; teamId: Id<"teams">; teamName: string }
   | { kind: "addTeam" };
 
+/** A team header or role row the leader has right-clicked to delete. */
+type DeleteTarget =
+  | { kind: "team"; teamId: Id<"teams">; teamName: string }
+  | { kind: "role"; roleId: Id<"teamRoles">; roleName: string; teamId: Id<"teams"> };
+
 // ---------------------------------------------------------------------------
 // Local helpers
 // ---------------------------------------------------------------------------
@@ -165,6 +170,22 @@ function monthDay(ms: number): string {
     month: "short",
     day: "numeric",
   });
+}
+
+/**
+ * Web-only right-click prop bag. RN-Web forwards unknown DOM props onto the
+ * host node, so `onContextMenu` lands on the underlying <div>. The RN types
+ * don't know it, hence the cast. Mirrors the idiom in DateColumnHeaderEditor.
+ * On native this returns `{}` (no right-click) — long-press is the fallback.
+ */
+function webContextMenu(onOpen: () => void): Record<string, unknown> {
+  if (typeof document === "undefined") return {};
+  return {
+    onContextMenu: (e: { preventDefault?: () => void }) => {
+      e.preventDefault?.();
+      onOpen();
+    },
+  };
 }
 
 /** Next Sunday at 9:00 AM local time — the neutral default for a new plan. */
@@ -292,6 +313,14 @@ export function RosterGridScreen() {
   // Create a serving team inline from the row-header "＋ Add team" affordance.
   const createServingTeam = useAuthenticatedMutation(
     api.functions.scheduling.teams.createServingTeam,
+  );
+  // Delete a role / team from the frozen column (right-click → confirm). Both
+  // archive + cascade their assignments and text staffed people server-side.
+  const deleteRole = useAuthenticatedMutation(
+    api.functions.scheduling.deletion.deleteRole,
+  );
+  const deleteTeam = useAuthenticatedMutation(
+    api.functions.scheduling.deletion.deleteTeam,
   );
   // Publish from the grid (#477 FR-3) — the SAME action the event editor uses,
   // not a fork. The grid is group-scoped with multiple date columns, so the
@@ -425,6 +454,11 @@ export function RosterGridScreen() {
   const [addTeamOpen, setAddTeamOpen] = useState(false);
   const [addTeamName, setAddTeamName] = useState("");
   const [savingRow, setSavingRow] = useState(false);
+
+  // Right-click (web) / long-press (mobile) on a team header or role row opens
+  // a one-item menu → "Delete team" / "Delete role" → confirm flow. See
+  // `DeleteRowFlow` below.
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 
   // Single docked side-panel at a time (desktop). The assign panel and the two
   // cell-management panels (role / member) all share the grid's right dock
@@ -1296,9 +1330,17 @@ export function RosterGridScreen() {
     >
       {roleRows.map((r, i) => {
         if (r.kind === "section") {
+          const teamId = r.teamId as Id<"teams">;
           return (
-            <View
+            <Pressable
               key={`sec-${r.teamId}`}
+              onLongPress={() =>
+                setDeleteTarget({ kind: "team", teamId, teamName: r.teamName })
+              }
+              {...webContextMenu(() =>
+                setDeleteTarget({ kind: "team", teamId, teamName: r.teamName }),
+              )}
+              accessibilityLabel={`${r.teamName} team — long-press to delete`}
               style={[
                 styles.sectionCell,
                 { width: NAME_W, height: SECTION_H, backgroundColor: colors.surfaceSecondary, borderBottomColor: colors.border },
@@ -1307,7 +1349,7 @@ export function RosterGridScreen() {
               <Text style={[styles.sectionText, { color: colors.textSecondary }]} numberOfLines={1}>
                 {r.teamName.toUpperCase()}
               </Text>
-            </View>
+            </Pressable>
           );
         }
         if (r.kind === "addRole") {
@@ -1461,9 +1503,20 @@ export function RosterGridScreen() {
           const c = roleCells[`${r.role.roleId}:${ev._id}`];
           return n + (c && c.needed > 0 && c.open === 0 ? 1 : 0);
         }, 0);
+        const role = r.role;
+        const openRoleDelete = () =>
+          setDeleteTarget({
+            kind: "role",
+            roleId: role.roleId,
+            roleName: role.roleName,
+            teamId: role.teamId,
+          });
         return (
-          <View
-            key={r.role.roleId}
+          <Pressable
+            key={role.roleId}
+            onLongPress={openRoleDelete}
+            {...webContextMenu(openRoleDelete)}
+            accessibilityLabel={`${role.roleName} role — long-press to delete`}
             style={[
               styles.nameCell,
               {
@@ -1476,13 +1529,13 @@ export function RosterGridScreen() {
           >
             <View style={styles.nameTextWrap}>
               <Text style={[styles.nameText, { color: colors.text }]} numberOfLines={1}>
-                {r.role.roleName}
+                {role.roleName}
               </Text>
               <Text style={[styles.subCount, { color: colors.textTertiary }]}>
                 covered {coveredCount}/{events.length}
               </Text>
             </View>
-          </View>
+          </Pressable>
         );
       })}
     </ScrollView>
@@ -2040,6 +2093,20 @@ export function RosterGridScreen() {
             setTeamMenuOpen(false);
           }}
           onClose={() => setTeamMenuOpen(false)}
+        />
+      )}
+
+      {deleteTarget && (
+        <DeleteRowFlow
+          target={deleteTarget}
+          events={events}
+          roles={data.roles}
+          roleCells={roleCells}
+          colors={colors}
+          deleteRole={deleteRole}
+          deleteTeam={deleteTeam}
+          onError={surfaceError}
+          onClose={() => setDeleteTarget(null)}
         />
       )}
 
@@ -2887,6 +2954,245 @@ function LegendItem({
   );
 }
 
+// ---------------------------------------------------------------------------
+// Delete team / role flow
+// ---------------------------------------------------------------------------
+
+/** A person staffed in the doomed team/role, with the dates they'd lose. */
+type StaffedPerson = { userId: string; userName: string; dates: number[] };
+
+/**
+ * Compute the people currently staffed (non-declined) in the target team/role
+ * across all visible event columns, from the already-loaded `roleCells`. This
+ * is what powers the "<N> people are staffed…" confirmation — no extra query.
+ */
+function staffedForTarget(
+  target: DeleteTarget,
+  events: RosterEvent[],
+  roles: RosterRole[],
+  roleCells: Record<string, RoleCell>,
+): StaffedPerson[] {
+  const roleIds =
+    target.kind === "role"
+      ? [target.roleId as string]
+      : roles
+          .filter((r) => (r.teamId as string) === (target.teamId as string))
+          .map((r) => r.roleId as string);
+
+  const byUser = new Map<string, StaffedPerson>();
+  for (const roleId of roleIds) {
+    for (const ev of events) {
+      const cell = roleCells[`${roleId}:${ev._id}`];
+      if (!cell) continue;
+      for (const o of cell.occupants) {
+        if (o.status === "declined") continue;
+        const existing = byUser.get(o.userId as string);
+        if (existing) {
+          if (!existing.dates.includes(ev.eventDate)) {
+            existing.dates.push(ev.eventDate);
+          }
+        } else {
+          byUser.set(o.userId as string, {
+            userId: o.userId as string,
+            userName: o.userName,
+            dates: [ev.eventDate],
+          });
+        }
+      }
+    }
+  }
+  return [...byUser.values()];
+}
+
+/** "Sun, Jul 5" / "Sun, Jul 5 and Sun, Jul 12" / "3 dates" — the affected-date copy. */
+function describeDates(dates: number[]): string {
+  const unique = [...new Set(dates)].sort((a, b) => a - b);
+  if (unique.length === 0) return "upcoming events";
+  if (unique.length === 1) return monthDay(unique[0]);
+  if (unique.length === 2) return `${monthDay(unique[0])} and ${monthDay(unique[1])}`;
+  return `${unique.length} dates`;
+}
+
+/**
+ * Right-click delete flow for a team header or role row: a one-item menu →
+ * "cannot be undone" confirm → (only if people are staffed) a "they'll be
+ * texted" confirm → the delete mutation. The staffed count + names + dates are
+ * computed client-side from the grid's `roleCells`, so the second modal can
+ * show them before any mutation runs.
+ */
+function DeleteRowFlow({
+  target,
+  events,
+  roles,
+  roleCells,
+  colors,
+  deleteRole,
+  deleteTeam,
+  onError,
+  onClose,
+}: {
+  target: DeleteTarget;
+  events: RosterEvent[];
+  roles: RosterRole[];
+  roleCells: Record<string, RoleCell>;
+  colors: Colors;
+  deleteRole: (args: { roleId: Id<"teamRoles"> }) => Promise<unknown>;
+  deleteTeam: (args: { teamId: Id<"teams"> }) => Promise<unknown>;
+  onError: (title: string, e: unknown) => void;
+  onClose: () => void;
+}) {
+  // "menu" → "confirm" → "notify" (only when staffed). Starts at the one-item
+  // menu so right-click and long-press both land on a consistent, discoverable
+  // surface (matching the date-column ⋯ menu idiom).
+  const [step, setStep] = useState<"menu" | "confirm" | "notify">("menu");
+  const [busy, setBusy] = useState(false);
+
+  const name = target.kind === "team" ? target.teamName : target.roleName;
+  const noun = target.kind === "team" ? "team" : "role";
+  const staffed = useMemo(
+    () => staffedForTarget(target, events, roles, roleCells),
+    [target, events, roles, roleCells],
+  );
+  const allDates = useMemo(
+    () => staffed.flatMap((p) => p.dates),
+    [staffed],
+  );
+
+  const runDelete = useCallback(async () => {
+    setBusy(true);
+    try {
+      if (target.kind === "team") {
+        await deleteTeam({ teamId: target.teamId });
+      } else {
+        await deleteRole({ roleId: target.roleId });
+      }
+      onClose();
+    } catch (e) {
+      onError(`Couldn't delete ${noun}`, e);
+      setBusy(false);
+    }
+  }, [target, deleteTeam, deleteRole, onClose, onError, noun]);
+
+  // Step 1 → either jump to the notify modal (staffed) or delete after confirm.
+  const onConfirmFirst = useCallback(() => {
+    if (staffed.length > 0) {
+      setStep("notify");
+    } else {
+      void runDelete();
+    }
+  }, [staffed.length, runDelete]);
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.deleteBackdrop} onPress={busy ? undefined : onClose}>
+        <Pressable
+          style={[
+            styles.deleteCard,
+            { backgroundColor: colors.surface, borderColor: colors.border },
+          ]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          {step === "menu" && (
+            <>
+              <Text
+                style={[styles.deleteHeading, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                {name}
+              </Text>
+              <TouchableOpacity
+                onPress={() => setStep("confirm")}
+                style={styles.deleteMenuItem}
+                accessibilityRole="button"
+                accessibilityLabel={`Delete ${noun}`}
+              >
+                <Ionicons name="trash-outline" size={16} color={colors.destructive} />
+                <Text style={[styles.deleteMenuItemText, { color: colors.destructive }]}>
+                  Delete {noun}
+                </Text>
+              </TouchableOpacity>
+            </>
+          )}
+
+          {step === "confirm" && (
+            <>
+              <Text style={[styles.deleteTitle, { color: colors.text }]}>
+                Delete &ldquo;{name}&rdquo;?
+              </Text>
+              <Text style={[styles.deleteBody, { color: colors.textSecondary }]}>
+                This action cannot be undone.
+              </Text>
+              <View style={styles.deleteActions}>
+                <TouchableOpacity
+                  onPress={onClose}
+                  style={[styles.deleteBtn, { borderColor: colors.border }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel"
+                >
+                  <Text style={[styles.deleteBtnText, { color: colors.text }]}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={onConfirmFirst}
+                  disabled={busy}
+                  style={[styles.deleteBtn, { backgroundColor: colors.destructive }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Delete"
+                >
+                  {busy ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <Text style={[styles.deleteBtnText, { color: "#fff" }]}>Delete</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            </>
+          )}
+
+          {step === "notify" && (
+            <>
+              <Text style={[styles.deleteTitle, { color: colors.text }]}>
+                Delete &ldquo;{name}&rdquo;?
+              </Text>
+              <Text style={[styles.deleteBody, { color: colors.textSecondary }]}>
+                {staffed.length} {staffed.length === 1 ? "person is" : "people are"}{" "}
+                staffed in this {noun}. They&rsquo;ll receive a text that their{" "}
+                {noun} has been removed for {describeDates(allDates)}.
+              </Text>
+              <Text style={[styles.deleteNames, { color: colors.textTertiary }]} numberOfLines={2}>
+                {staffed.map((p) => p.userName).join(", ")}
+              </Text>
+              <View style={styles.deleteActions}>
+                <TouchableOpacity
+                  onPress={onClose}
+                  disabled={busy}
+                  style={[styles.deleteBtn, { borderColor: colors.border }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel"
+                >
+                  <Text style={[styles.deleteBtnText, { color: colors.text }]}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={() => void runDelete()}
+                  disabled={busy}
+                  style={[styles.deleteBtn, { backgroundColor: colors.destructive }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Delete and notify"
+                >
+                  {busy ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <Text style={[styles.deleteBtnText, { color: "#fff" }]}>Delete &amp; notify</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            </>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
 const styles = StyleSheet.create({
   container: { flex: 1 },
   header: {
@@ -3207,4 +3513,55 @@ const styles = StyleSheet.create({
   publishBtnTextFull: {
     fontSize: 16,
   },
+
+  // Delete team/role flow (right-click menu → confirm → notify). A centered
+  // card over a dim backdrop — a Modal, not an in-column popover, so the
+  // frozen-column ScrollView can't clip it (same reason as DateColumnHeaderEditor).
+  deleteBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  deleteCard: {
+    width: "100%",
+    maxWidth: 340,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 18,
+  },
+  deleteHeading: {
+    fontSize: 12,
+    fontWeight: "700",
+    paddingHorizontal: 4,
+    paddingBottom: 6,
+  },
+  deleteMenuItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 4,
+    paddingVertical: 10,
+  },
+  deleteMenuItemText: { fontSize: 15, fontWeight: "500" },
+  deleteTitle: { fontSize: 17, fontWeight: "700", marginBottom: 8 },
+  deleteBody: { fontSize: 14, lineHeight: 20 },
+  deleteNames: { fontSize: 13, marginTop: 8, fontStyle: "italic" },
+  deleteActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 10,
+    marginTop: 18,
+  },
+  deleteBtn: {
+    minWidth: 96,
+    height: 40,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 14,
+  },
+  deleteBtnText: { fontSize: 15, fontWeight: "600" },
 });

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -261,10 +261,15 @@ export function RosterGridScreen() {
   const ROW_H = 52;
   const SECTION_H = 28;
   // The header row is a plain tally column on mobile and a richer inline plan
-  // editor on desktop (title + date/times + run-sheet), so it's taller there.
-  // Only the header cells share this height — body cells use ROW_H — so growing
-  // it doesn't disturb frozen-column/body alignment.
-  const HEADER_H = isWide ? 132 : 70;
+  // editor on desktop (title row + date text + tally + run-sheet button), so
+  // it's taller there. Sized to fit that simplified content snugly: the desktop
+  // header stacks a ~22px title row, a ~16px date row, a 14px tally, and a ~16px
+  // run-sheet button (gap 2 each + 12px vertical padding ≈ 86px). The earlier
+  // 132 was sized for the removed inline date/time INPUT boxes and left an
+  // obvious empty gap. The cell uses `minHeight` so nothing clips. Only the
+  // header cells share this height — body cells use ROW_H — so it doesn't
+  // disturb frozen-column/body alignment.
+  const HEADER_H = isWide ? 88 : 70;
   // Minimum legible column width per platform. On desktop the cells region
   // grows to fill the viewport (see `CELL_W` below) so a 1–2 date roster reads
   // as a real table rather than a sliver hugging the left edge. There is no

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -322,6 +322,14 @@ export function RosterGridScreen() {
   const deleteTeam = useAuthenticatedMutation(
     api.functions.scheduling.deletion.deleteTeam,
   );
+  // Rename a role / team from the same right-click menu — reuses the existing
+  // update mutations the Teams setup screen uses (both scheduler-gated).
+  const updateRole = useAuthenticatedMutation(
+    api.functions.scheduling.roles.updateRole,
+  );
+  const updateTeam = useAuthenticatedMutation(
+    api.functions.scheduling.teams.updateTeam,
+  );
   // Publish from the grid (#477 FR-3) — the SAME action the event editor uses,
   // not a fork. The grid is group-scoped with multiple date columns, so the
   // chooser below targets a specific plan (or all draft plans).
@@ -2105,6 +2113,8 @@ export function RosterGridScreen() {
           colors={colors}
           deleteRole={deleteRole}
           deleteTeam={deleteTeam}
+          updateRole={updateRole}
+          updateTeam={updateTeam}
           onError={surfaceError}
           onClose={() => setDeleteTarget(null)}
         />
@@ -3014,11 +3024,14 @@ function describeDates(dates: number[]): string {
 }
 
 /**
- * Right-click delete flow for a team header or role row: a one-item menu →
- * "cannot be undone" confirm → (only if people are staffed) a "they'll be
- * texted" confirm → the delete mutation. The staffed count + names + dates are
- * computed client-side from the grid's `roleCells`, so the second modal can
- * show them before any mutation runs.
+ * Right-click actions for a team header or role row: a menu (Rename · Delete)
+ * → either an inline rename field, or the "cannot be undone" confirm → (only
+ * if people are staffed) a "they'll be texted" confirm → the delete mutation.
+ * The staffed count + names + dates are computed client-side from the grid's
+ * `roleCells`, so the second modal can show them before any mutation runs.
+ *
+ * Rename reuses the existing `updateRole` / `updateTeam` mutations (both
+ * scheduler-gated) — the same ones the Teams setup screen uses.
  */
 function DeleteRowFlow({
   target,
@@ -3028,6 +3041,8 @@ function DeleteRowFlow({
   colors,
   deleteRole,
   deleteTeam,
+  updateRole,
+  updateTeam,
   onError,
   onClose,
 }: {
@@ -3038,17 +3053,22 @@ function DeleteRowFlow({
   colors: Colors;
   deleteRole: (args: { roleId: Id<"teamRoles"> }) => Promise<unknown>;
   deleteTeam: (args: { teamId: Id<"teams"> }) => Promise<unknown>;
+  updateRole: (args: { roleId: Id<"teamRoles">; name: string }) => Promise<unknown>;
+  updateTeam: (args: { teamId: Id<"teams">; name: string }) => Promise<unknown>;
   onError: (title: string, e: unknown) => void;
   onClose: () => void;
 }) {
-  // "menu" → "confirm" → "notify" (only when staffed). Starts at the one-item
-  // menu so right-click and long-press both land on a consistent, discoverable
-  // surface (matching the date-column ⋯ menu idiom).
-  const [step, setStep] = useState<"menu" | "confirm" | "notify">("menu");
+  // "menu" → "rename" (inline field) | "confirm" → "notify" (only when
+  // staffed). Starts at the menu so right-click and long-press both land on a
+  // consistent, discoverable surface (matching the date-column ⋯ menu idiom).
+  const [step, setStep] = useState<"menu" | "rename" | "confirm" | "notify">(
+    "menu",
+  );
   const [busy, setBusy] = useState(false);
 
   const name = target.kind === "team" ? target.teamName : target.roleName;
   const noun = target.kind === "team" ? "team" : "role";
+  const [draftName, setDraftName] = useState(name);
   const staffed = useMemo(
     () => staffedForTarget(target, events, roles, roleCells),
     [target, events, roles, roleCells],
@@ -3082,6 +3102,26 @@ function DeleteRowFlow({
     }
   }, [staffed.length, runDelete]);
 
+  const runRename = useCallback(async () => {
+    const trimmed = draftName.trim();
+    if (!trimmed || trimmed === name) {
+      onClose();
+      return;
+    }
+    setBusy(true);
+    try {
+      if (target.kind === "team") {
+        await updateTeam({ teamId: target.teamId, name: trimmed });
+      } else {
+        await updateRole({ roleId: target.roleId, name: trimmed });
+      }
+      onClose();
+    } catch (e) {
+      onError(`Couldn't rename ${noun}`, e);
+      setBusy(false);
+    }
+  }, [draftName, name, target, updateTeam, updateRole, onClose, onError, noun]);
+
   return (
     <Modal visible transparent animationType="fade" onRequestClose={onClose}>
       <Pressable style={styles.deleteBackdrop} onPress={busy ? undefined : onClose}>
@@ -3101,6 +3141,20 @@ function DeleteRowFlow({
                 {name}
               </Text>
               <TouchableOpacity
+                onPress={() => {
+                  setDraftName(name);
+                  setStep("rename");
+                }}
+                style={styles.deleteMenuItem}
+                accessibilityRole="button"
+                accessibilityLabel={`Rename ${noun}`}
+              >
+                <Ionicons name="pencil-outline" size={16} color={colors.text} />
+                <Text style={[styles.deleteMenuItemText, { color: colors.text }]}>
+                  Rename
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
                 onPress={() => setStep("confirm")}
                 style={styles.deleteMenuItem}
                 accessibilityRole="button"
@@ -3111,6 +3165,64 @@ function DeleteRowFlow({
                   Delete {noun}
                 </Text>
               </TouchableOpacity>
+            </>
+          )}
+
+          {step === "rename" && (
+            <>
+              <Text
+                style={[styles.deleteHeading, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                Rename {noun}
+              </Text>
+              <TextInput
+                style={[
+                  styles.renameInput,
+                  { color: colors.text, borderColor: colors.border },
+                ]}
+                value={draftName}
+                onChangeText={setDraftName}
+                placeholder={`${noun === "team" ? "Team" : "Role"} name`}
+                placeholderTextColor={colors.textTertiary}
+                autoFocus
+                autoCapitalize="words"
+                autoCorrect={false}
+                editable={!busy}
+                onSubmitEditing={() => void runRename()}
+                returnKeyType="done"
+                accessibilityLabel={`${noun} name`}
+              />
+              <View style={styles.deleteActions}>
+                <TouchableOpacity
+                  onPress={onClose}
+                  disabled={busy}
+                  style={[styles.deleteBtn, { borderColor: colors.border }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel"
+                >
+                  <Text style={[styles.deleteBtnText, { color: colors.text }]}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={() => void runRename()}
+                  disabled={busy || !draftName.trim()}
+                  style={[
+                    styles.deleteBtn,
+                    {
+                      backgroundColor: colors.link,
+                      opacity: !draftName.trim() ? 0.5 : 1,
+                    },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Save name"
+                >
+                  {busy ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <Text style={[styles.deleteBtnText, { color: "#fff" }]}>Save</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
             </>
           )}
 
@@ -3545,6 +3657,14 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
   },
   deleteMenuItemText: { fontSize: 15, fontWeight: "500" },
+  renameInput: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    height: 42,
+    fontSize: 15,
+    marginTop: 4,
+  },
   deleteTitle: { fontSize: 17, fontWeight: "700", marginBottom: 8 },
   deleteBody: { fontSize: 14, lineHeight: 20 },
   deleteNames: { fontSize: 13, marginTop: 8, fontStyle: "italic" },

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -634,38 +634,46 @@ export function RosterGridScreen() {
   }, [data, events, roleCells, isolatedTeamId, openOnly]);
 
   /**
-   * Interleave team section-header rows into the (already team-sorted) role
-   * list. Computed unconditionally (above the early returns) to respect the
-   * Rules of Hooks.
+   * Build the frozen-column rows from `data.teams` — the authoritative team
+   * list — rather than from "teams that happen to have roles". Every team gets
+   * a section header, its (filtered) role rows, and its "＋ Add role"
+   * affordance, so a team with zero roles still renders (header + Add role) and
+   * is usable. Roles are grouped under their team via `visibleRoles`. Computed
+   * unconditionally (above the early returns) to respect the Rules of Hooks.
    */
   const roleRows = useMemo<RoleRow[]>(() => {
-    const out: RoleRow[] = [];
-    let lastTeam: RosterRole | null = null;
-    const flushAddRole = () => {
-      if (lastTeam) {
-        out.push({
-          kind: "addRole",
-          teamId: lastTeam.teamId,
-          teamName: lastTeam.teamName,
-        });
-      }
-    };
+    if (!data) return [];
+    // Group the already-filtered roles by team for O(1) lookup per team.
+    const rolesByTeam = new Map<string, RosterRole[]>();
     for (const role of visibleRoles) {
       const tid = role.teamId as string;
-      if (tid !== (lastTeam?.teamId as string | undefined)) {
-        // Close the previous team's role list with its "＋ Add role" row.
-        flushAddRole();
-        out.push({ kind: "section", teamId: tid, teamName: role.teamName });
-        lastTeam = role;
-      }
-      out.push({ kind: "role", role });
+      const list = rolesByTeam.get(tid);
+      if (list) list.push(role);
+      else rolesByTeam.set(tid, [role]);
     }
-    // "＋ Add role" for the final team, then the trailing "＋ Add team". When a
-    // team is isolated, hide "Add team" so the row stays scoped to that team.
-    flushAddRole();
+    const out: RoleRow[] = [];
+    for (const team of data.teams) {
+      const tid = team.teamId as string;
+      // When a team is isolated, render only that team's section.
+      if (isolatedTeamId && tid !== isolatedTeamId) continue;
+      // With "Open only" active, hide teams that have no visible roles so the
+      // filter still reads as a coverage view — but always show an isolated
+      // team and any team that has visible roles.
+      const teamRoles = rolesByTeam.get(tid) ?? [];
+      if (openOnly && teamRoles.length === 0 && tid !== isolatedTeamId) continue;
+      out.push({ kind: "section", teamId: tid, teamName: team.teamName });
+      for (const role of teamRoles) out.push({ kind: "role", role });
+      out.push({
+        kind: "addRole",
+        teamId: team.teamId,
+        teamName: team.teamName,
+      });
+    }
+    // Trailing "＋ Add team". When a team is isolated, hide it so the rows stay
+    // scoped to that team.
     if (!isolatedTeamId) out.push({ kind: "addTeam" });
     return out;
-  }, [visibleRoles, isolatedTeamId]);
+  }, [data, visibleRoles, isolatedTeamId, openOnly]);
 
   /** Members after team* + search + open/available filters. (*teams don't gate people rows.) */
   const visibleMembers = useMemo(() => {


### PR DESCRIPTION
Follow-up fixes to the grid-first rostering overhaul (#484), from a live test pass on a real community.

## Fixes
- **People list infinite-loaded on larger communities** — the assign panel's empty-search "full group" path over-fetched ~3000 `userCommunities` rows (with per-row `.get()` + membership re-check), blowing Convex's read cap so the query threw and `useQuery` spun forever. Bounded the community-recency tail to a small constant (the group-member union already covers completeness) and dropped the N+1 membership re-check for known group members. O(group)+O(const) reads now. **(Verify on staging's real roster.)**
- **Date edit could "delete" a plan** — typing into the column-header date briefly produced a complete-but-absurd date (e.g. year 0026) that got saved, shoving the plan into the far past so it dropped out of the upcoming grid. Now ignores invalid / implausibly-dated (year outside 2000–3000) intermediate values.
- **Column header cleanup** — date/time are plain text (no input boxes / pencils); time editing moved into the ⋯ menu ("Add time" → **"Edit time"** with add/remove); header height tightened (132→88) to kill the dead space.
- **Right-click Rename / Delete on teams & roles** — Delete shows a "this cannot be undone" modal, then (if people are staffed) a second modal noting they'll be texted, then archives the team/role + removes its assignments and **texts each affected person** ("Your Greeter role for Sun, Jul 5 has been removed.") via the existing Twilio path. Rename reuses the existing update mutations.
- **Empty teams now render** — the grid builds team sections off the full `rosterMatrix` team list, so a newly-added team (and empty ones) show with an "＋ Add role" row instead of being invisible.
- **Smart Needed ↔ assigned coupling** in the assign panel — assigning auto-grows Needed when it's full (Needed 0 → assign → Needed 1); `−` is disabled when Needed == assigned (can't drop a slot someone's in); unassigning keeps the slot open; a subtle "N assigned" hint.

## Testing
- **Convex: 1777 pass** (incl. new `deletion.test.ts` — cascade + notification scheduling + no-staff-no-text + non-scheduler reject). **Mobile Jest: 1100 pass.** `tsc`/lint clean for touched files.
- **Manually verified in-browser (desktop):** clean header + date popup, date-edit guard, right-click delete (confirm flow) + rename, empty-team render + add-role, header spacing, and the Needed auto-grow / disabled-minus coupling.

## Notes
- `deleteRole`/`deleteTeam` reuse the publish path's SMS primitive (best-effort; fake test numbers no-op). Merging auto-deploys Convex to **staging** (prod manual).
- The loading fix is the one thing only verifiable on staging's real ~85-member community.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwTHgpiPRaZHPNgBjFNYrW