### PR TITLE
fix(ci): secret sync wrote literal '-' (gh secret set --body -)

### DIFF
--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -180,7 +180,7 @@ sync_environment() {
         echo "  [dry-run] Would set $KEY"
       else
         echo -n "  Setting $KEY..."
-        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO" --body -; then
+        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO"; then
           echo " done"
         else
           echo " FAILED"
@@ -206,7 +206,7 @@ sync_environment() {
         echo "  [dry-run] Would set $KEY"
       else
         echo -n "  Setting $KEY..."
-        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO" --body -; then
+        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO"; then
           echo " done"
         else
           echo " FAILED"
@@ -230,7 +230,7 @@ sync_environment() {
       echo "  [dry-run] Would set IMAGE_CDN_URL (alias for R2_PUBLIC_URL)"
     else
       echo -n "  Setting IMAGE_CDN_URL (alias for R2_PUBLIC_URL)..."
-      if printf '%s' "$R2_URL" | gh secret set "IMAGE_CDN_URL" --env "$env" --repo "$REPO" --body -; then
+      if printf '%s' "$R2_URL" | gh secret set "IMAGE_CDN_URL" --env "$env" --repo "$REPO"; then
         echo " done"
       else
         echo " FAILED"


### PR DESCRIPTION
## The bug
`ee/scripts/sync-1password-to-github.sh` piped each 1Password value into `gh secret set … --body -`. In this gh version `--body -` is **not** a stdin marker — it sets the secret to the literal string `-`. So every synced GitHub *environment* secret (CONVEX_DEPLOY_KEY, EXPO_TOKEN, …) became `-`, even though 1Password held the correct values.

## Symptoms it caused
- **Deploy Convex** (staging): `✖ Please set CONVEX_DEPLOY_KEY to a new key` — because the key was `-`.
- **Deploy Web / Mobile (EAS)**: `The bearer token is invalid` — because EXPO_TOKEN was `-`.
- Re-syncing never helped (it re-pushed `-`); setting the secret **directly** with `--body "<value>"` worked, which isolated it to the sync path.

## Fix
Drop `--body -` from the three `gh secret set` calls so gh reads the piped value from stdin.

## Verified
Set staging CONVEX_DEPLOY_KEY via the corrected pattern (`printf '%s' "$VALUE" | gh secret set …`) → **Deploy Convex ran green**. (Manual deploys confirmed end-to-end.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwTHgpiPRaZHPNgBjFNYrW