### PR TITLE
fix(dev-assistant): send anthropic-version header on routine dispatch

### DIFF
--- a/apps/convex/__tests__/dev-assistant-bugs.test.ts
+++ b/apps/convex/__tests__/dev-assistant-bugs.test.ts
@@ -2,9 +2,11 @@
  * Tests for the dev-assistant bug lifecycle DB ops (functions/devAssistant/bugs.ts).
  *
  * Covers the state machine guards, dispatch idempotency (markDispatched), and
- * callback idempotency/transition handling (applyCallback). The agent loop,
- * OpenAI calls, and outbound routine POST are out of scope here — this exercises
- * the pure DB transitions the rest of the pipeline depends on.
+ * callback idempotency/transition handling (applyCallback). The agent loop and
+ * OpenAI calls are out of scope here — this exercises the pure DB transitions
+ * the rest of the pipeline depends on, plus the required headers on the outbound
+ * routine POST (the Claude Code fire endpoint rejects requests missing
+ * anthropic-version).
  */
 
 import { convexTest } from "convex-test";
@@ -231,5 +233,52 @@ describe("dev-assistant bug lifecycle", () => {
     );
     expect(replay?.status).toBe("READY_TO_MERGE");
     expect(replay?.lastError).toContain("Ignored callback transition");
+  });
+});
+
+describe("dev-assistant routine dispatch", () => {
+  const ROUTINE_ENV = {
+    CLAUDE_ROUTINES_TRIGGER_URL:
+      "https://api.anthropic.com/v1/claude_code/routines/trig_test/fire",
+    CLAUDE_ROUTINES_TOKEN: "test-token",
+    CONVEX_SITE_URL: "https://example.convex.site",
+  } as const;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const key of Object.keys(ROUTINE_ENV)) delete process.env[key];
+  });
+
+  test("dispatchBug sends the required anthropic-version header", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { communityId, channelId, userId } = await seedContext(t);
+    const { bugId } = await t.mutation(
+      internal.functions.devAssistant.bugs.createBug,
+      { communityId, channelId, originatorUserId: userId, title: "T", body: "B" },
+    );
+    await t.run(async (ctx) => {
+      await ctx.db.patch(bugId, { status: "READY_FOR_IMPL" });
+    });
+
+    Object.assign(process.env, ROUTINE_ENV);
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(internal.functions.devAssistant.actions.dispatchBug, {
+      bugId,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.headers).toMatchObject({
+      "anthropic-version": "2023-06-01",
+    });
+
+    // The endpoint accepted it, so the bug stays in the dispatched lane.
+    const bug = await t.query(internal.functions.devAssistant.bugs.getBug, {
+      bugId,
+    });
+    expect(bug?.status).toBe("IN_PROGRESS");
   });
 });

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -150,6 +150,10 @@ export const dispatchBug = internalAction({
         headers: {
           Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
+          // Required on every api.anthropic.com endpoint, including the
+          // Claude Code routine fire endpoint — without it the gateway
+          // rejects the request with 400 "anthropic-version: header is required".
+          "anthropic-version": "2023-06-01",
         },
         body: JSON.stringify(payload),
       });


### PR DESCRIPTION
## Problem

The staff-only @Togather bug pipeline (PRs #483/#485) dispatches ready bugs to the Claude Code **routine fire** endpoint:

```
https://api.anthropic.com/v1/claude_code/routines/{trigger}/fire
```

That endpoint sits behind the Anthropic API gateway, which requires an `anthropic-version` header on **every** request. `dispatchBug` only sent `Authorization: Bearer …` + `Content-Type`, so the gateway rejected every dispatch before it reached the routine:

```
Routine POST 400: {"error":{"message":"anthropic-version: header is required",
"type":"invalid_request_error"},"type":"error"}
```

Bugs marked ready stalled in `IN_PROGRESS` with that error (surfaced in the in-app Bug review screen as "Last error: Routine POST 400 …").

## Fix

Add `anthropic-version: 2023-06-01` to the dispatch `POST` headers in `apps/convex/functions/devAssistant/actions.ts`. The trigger URL and the existing `Bearer` auth (an OAuth token) were already correct — only the version header was missing.

## Verification

Live A/B against the real staging trigger (secrets from 1Password, minimal body):

| Request | Result |
|---|---|
| **without** `anthropic-version` | `400 anthropic-version: header is required` (reproduces the reported error) |
| **with** `anthropic-version: 2023-06-01` | `200 {"type":"routine_fire", …}` |

Added a regression test (`dev-assistant routine dispatch`) that mocks `fetch` and asserts the header is sent. Full `dev-assistant-bugs` suite green (7/7); changed files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)