### PR TITLE
fix(dev-assistant): deliver bug brief via the routine `text` field

### DIFF
--- a/apps/convex/__tests__/dev-assistant-bugs.test.ts
+++ b/apps/convex/__tests__/dev-assistant-bugs.test.ts
@@ -249,7 +249,7 @@ describe("dev-assistant routine dispatch", () => {
     for (const key of Object.keys(ROUTINE_ENV)) delete process.env[key];
   });
 
-  test("dispatchBug sends the required anthropic-version header", async () => {
+  test("dispatchBug posts the brief in `text` with the anthropic-version header", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
     const { communityId, channelId, userId } = await seedContext(t);
@@ -273,6 +273,18 @@ describe("dev-assistant routine dispatch", () => {
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(init.headers).toMatchObject({
       "anthropic-version": "2023-06-01",
+    });
+
+    // The fire endpoint reads the per-invocation payload from `text` and ignores
+    // other top-level fields, so the brief must be JSON-stringified into `text`.
+    const sentBody = JSON.parse(init.body as string);
+    expect(Object.keys(sentBody)).toEqual(["text"]);
+    const brief = JSON.parse(sentBody.text);
+    expect(brief).toMatchObject({
+      bugId,
+      title: "T",
+      body: "B",
+      callbackUrl: `${ROUTINE_ENV.CONVEX_SITE_URL}/dev-assistant/callback`,
     });
 
     // The endpoint accepted it, so the bug stays in the dispatched lane.

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -155,7 +155,11 @@ export const dispatchBug = internalAction({
           // rejects the request with 400 "anthropic-version: header is required".
           "anthropic-version": "2023-06-01",
         },
-        body: JSON.stringify(payload),
+        // The routine fire endpoint delivers the per-invocation `text` string
+        // as the routine's triggering message and ignores any other top-level
+        // fields. The routine parses the bug brief out of that message, so the
+        // payload must be JSON-stringified into `text` (not sent as the body).
+        body: JSON.stringify({ text: JSON.stringify(payload) }),
       });
       if (!res.ok) {
         const errBody = await res.text();


### PR DESCRIPTION
## Problem (follow-up to #488)

After #488 fixed the `anthropic-version` header, the dispatch reached the routine — but the routine fired with **no payload**:

> "the triggering message contained only the routine instructions — no JSON object with bugId, routineRunId, title, body, or repro. No implementation work was performed."

The Claude Code routine **fire** endpoint reads the per-invocation input from a single **`text`** string and silently ignores any other top-level fields. We were posting the flat `{ bugId, routineRunId, title, body, repro, screenshotUrls, callbackUrl }` object as the body, so the entire brief was dropped.

## Fix

Send the brief as a JSON string inside `text`:

```js
body: JSON.stringify({ text: JSON.stringify(payload) })
```

This puts the `{ bugId, ... }` JSON into the routine's triggering message, exactly as the routine prompt expects ("the triggering message contains a JSON payload … Parse the payload").

The `anthropic-beta: experimental-cc-routine-2026-04-01` header is **intentionally omitted** — verified live that the request returns `200 routine_fire` without it, so adding an experimental beta value would only create future fragility.

## Verification

Live against the real staging trigger (secrets from 1Password):

| Body | Result |
|---|---|
| `{ "text": "…" }` (no beta header) | `200 routine_fire` |
| `{ "text": "…" }` (with beta header) | `200 routine_fire` (header not required) |

Extends the dispatch regression test to assert the brief is JSON-stringified into `text`. Full `dev-assistant-bugs` suite green (7/7); changed files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)