### PR TITLE
Fix bold markdown rendering in chat messages

### DIFF
--- a/apps/mobile/app/e/[shortId]/EventComment.tsx
+++ b/apps/mobile/app/e/[shortId]/EventComment.tsx
@@ -245,6 +245,13 @@ function EventCommentInner({ message, currentUserId, groupId, eventShortId, even
               </Text>
             );
           }
+          if (part.type === 'bold') {
+            return (
+              <Text key={index} style={{ fontWeight: 'bold' }}>
+                {part.displayValue ?? part.value}
+              </Text>
+            );
+          }
           return <Text key={index}>{part.value}</Text>;
         })}
       </Text>

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -534,6 +534,13 @@ function MessageItemInner({
               </Text>
             );
           }
+          if (part.type === 'bold') {
+            return (
+              <Text key={index} style={{ fontWeight: 'bold' }}>
+                {part.displayValue ?? part.value}
+              </Text>
+            );
+          }
           return <Text key={index}>{part.value}</Text>;
         })}
       </Text>

--- a/apps/mobile/features/shared/utils/linkify.tsx
+++ b/apps/mobile/features/shared/utils/linkify.tsx
@@ -12,9 +12,10 @@ import React from 'react';
 import { Linking, StyleProp, Text, TextStyle } from 'react-native';
 
 export type ContentPart = {
-  type: 'text' | 'mention' | 'url';
+  type: 'text' | 'mention' | 'url' | 'bold';
   value: string;
-  /** For mentions, the display string without brackets (e.g. `@John Smith`). */
+  /** For mentions, the display string without brackets (e.g. `@John Smith`).
+   *  For bold segments, the inner text without the surrounding `**` markers. */
   displayValue?: string;
 };
 
@@ -30,9 +31,11 @@ export function parseMessageContent(content: string): ContentPart[] {
 
   const mentionRegex = /@\[([^\]]+)\]/g;
   const urlRegex = /(https?:\/\/[^\s]+)/g;
+  // Matches **bold text** — single line only (. does not match \n)
+  const boldRegex = /\*\*(.+?)\*\*/g;
 
   const allMatches: Array<{
-    type: 'mention' | 'url';
+    type: 'mention' | 'url' | 'bold';
     value: string;
     displayValue?: string;
     index: number;
@@ -49,6 +52,14 @@ export function parseMessageContent(content: string): ContentPart[] {
   }
   while ((match = urlRegex.exec(content)) !== null) {
     allMatches.push({ type: 'url', value: match[0], index: match.index });
+  }
+  while ((match = boldRegex.exec(content)) !== null) {
+    allMatches.push({
+      type: 'bold',
+      value: match[0],
+      displayValue: match[1],
+      index: match.index,
+    });
   }
 
   allMatches.sort((a, b) => a.index - b.index);
@@ -137,6 +148,13 @@ export function LinkifiedText({
               onPress={() => onMentionPress?.(part.value)}
             >
               {part.displayValue || part.value}
+            </Text>
+          );
+        }
+        if (part.type === 'bold') {
+          return (
+            <Text key={index} style={{ fontWeight: 'bold' }}>
+              {part.displayValue ?? part.value}
             </Text>
           );
         }

--- a/apps/mobile/features/shared/utils/linkify.tsx
+++ b/apps/mobile/features/shared/utils/linkify.tsx
@@ -66,6 +66,9 @@ export function parseMessageContent(content: string): ContentPart[] {
 
   let lastIndex = 0;
   for (const m of allMatches) {
+    // Skip matches that overlap with already-consumed content (e.g. a URL
+    // inside **…** is consumed by the bold match that comes first).
+    if (m.index < lastIndex) continue;
     if (m.index > lastIndex) {
       parts.push({ type: 'text', value: content.substring(lastIndex, m.index) });
     }


### PR DESCRIPTION
## Problem

Bot messages containing `**bold**` markdown syntax (task reminders, test notifications, birthday reminders) were displaying literal `**` asterisks instead of rendered bold text. See screenshot: the message header `**Task Reminder (Test)**` showed raw asterisks.

## Root cause

`parseMessageContent()` in `linkify.tsx` only detected `@[mentions]` and `http(s)` URLs. Bold markdown was treated as plain text and passed through as-is.

## Fix

Extended the content parser to detect `**…**` patterns and emit `'bold'` `ContentPart` entries. Updated all three rendering sites to display them with `fontWeight: 'bold'` (stripping the surrounding `**` delimiters):

- `apps/mobile/features/shared/utils/linkify.tsx` — parser + `LinkifiedText` component
- `apps/mobile/features/chat/components/MessageItem.tsx` — `renderMessageContent()`
- `apps/mobile/app/e/[shortId]/EventComment.tsx` — comment rendering

No new dependencies required. All 1100 existing tests pass.

## Test plan

- [ ] Send a test notification with `**Title**` format — header renders bold in chat
- [ ] Verify task reminder messages still render correctly as task cards
- [ ] Verify `@mentions` and URLs still linkify correctly alongside bold text
- [ ] Verify messages with no markdown are unaffected

Fixes bug `xx7fgtz3sxa2m333dqjrbr9qhn8997t4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Knqr7hafztVGpEPYWh9zrz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Knqr7hafztVGpEPYWh9zrz)_