### PR TITLE
fix(chat): render image-only messages edge-to-edge like iMessage

### DIFF
--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -1350,8 +1350,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
   // Edge-to-edge image-only bubble: image fills the bubble with no surrounding color.
+  // Restore the full corner radius — own/otherMessageBubble flatten the tail-side bottom
+  // corner to 3 to seat the tail, but image-only bubbles render no tail, so all four
+  // corners should match (otherwise the photo looks asymmetric under overflow: 'hidden').
   imageOnlyBubble: {
     backgroundColor: 'transparent',
+    borderBottomLeftRadius: 14,
+    borderBottomRightRadius: 14,
   },
   imageOnlyAttachments: {
     marginTop: 0,

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -697,6 +697,19 @@ function MessageItemInner({
     };
   }, [message.attachments]);
 
+  // An image-only message (images, no text or other attachments) renders edge-to-edge
+  // like iMessage: no bubble background, padding, footer, or tail around the image, so
+  // the blue/gray bubble color never shows as a border. Reply/reactions are unaffected —
+  // their handlers live on the outer Pressable and the reactions row outside the bubble.
+  // Blast messages keep their bubble so the "Also sent via SMS" badge stays readable.
+  const isImageOnlyMessage =
+    validImageAttachments.length > 0 &&
+    !hasTextContent &&
+    !message.blastId &&
+    documentAttachments.length === 0 &&
+    audioAttachments.length === 0 &&
+    videoAttachments.length === 0;
+
   // Handle image tap - open gallery viewer
   const handleImagePress = useCallback((index: number) => {
     setImageViewerInitialIndex(index);
@@ -710,7 +723,7 @@ function MessageItemInner({
     }
 
     return (
-      <View style={styles.attachmentsContainer}>
+      <View style={isImageOnlyMessage ? styles.imageOnlyAttachments : styles.attachmentsContainer}>
         <ImageAttachmentsGrid
           images={validImageAttachments}
           onImagePress={handleImagePress}
@@ -1045,9 +1058,10 @@ function MessageItemInner({
               <View
                 style={[
                   styles.messageBubble,
-                  isOwnMessage
-                    ? [styles.ownMessageBubble, { backgroundColor: themeColors.chatBubbleOwn }]
-                    : [styles.otherMessageBubble, { backgroundColor: themeColors.chatBubbleOther }],
+                  isOwnMessage ? styles.ownMessageBubble : styles.otherMessageBubble,
+                  isImageOnlyMessage
+                    ? styles.imageOnlyBubble
+                    : { backgroundColor: isOwnMessage ? themeColors.chatBubbleOwn : themeColors.chatBubbleOther },
                 ]}
               >
                 {hasTextContent && (
@@ -1078,38 +1092,45 @@ function MessageItemInner({
                   </View>
                 )}
 
-                {/* Timestamp and edited badge */}
-                <View style={[styles.messageFooter, styles.bubbleFooter]}>
-                  <Text
-                    style={[
-                      styles.timestamp,
-                      { color: themeColors.textTertiary },
-                      isOwnMessage && { color: themeColors.textSecondary },
-                    ]}
-                  >
-                    {formatMessageTime(message.createdAt)}
-                  </Text>
-                  {message.editedAt && !message.isDeleted && (
+                {/* Timestamp and edited badge — hidden on edge-to-edge image-only bubbles
+                    (iMessage shows no inline timestamp on photos; date separators and the
+                    read-receipt row below the bubble still convey timing). */}
+                {!isImageOnlyMessage && (
+                  <View style={[styles.messageFooter, styles.bubbleFooter]}>
                     <Text
                       style={[
-                        styles.editedBadge,
+                        styles.timestamp,
                         { color: themeColors.textTertiary },
                         isOwnMessage && { color: themeColors.textSecondary },
                       ]}
                     >
-                      (edited)
+                      {formatMessageTime(message.createdAt)}
                     </Text>
-                  )}
-                </View>
+                    {message.editedAt && !message.isDeleted && (
+                      <Text
+                        style={[
+                          styles.editedBadge,
+                          { color: themeColors.textTertiary },
+                          isOwnMessage && { color: themeColors.textSecondary },
+                        ]}
+                      >
+                        (edited)
+                      </Text>
+                    )}
+                  </View>
+                )}
               </View>
-              {/* Bubble tail */}
-              <View
-                style={
-                  isOwnMessage
-                    ? [styles.ownMessageTail, { borderLeftColor: themeColors.chatBubbleOwn }]
-                    : [styles.otherMessageTail, { borderRightColor: themeColors.chatBubbleOther }]
-                }
-              />
+              {/* Bubble tail — omitted for edge-to-edge image-only bubbles so no
+                  blue/gray tail floats beside the photo. */}
+              {!isImageOnlyMessage && (
+                <View
+                  style={
+                    isOwnMessage
+                      ? [styles.ownMessageTail, { borderLeftColor: themeColors.chatBubbleOwn }]
+                      : [styles.otherMessageTail, { borderRightColor: themeColors.chatBubbleOther }]
+                  }
+                />
+              )}
             </View>
           )}
 
@@ -1327,6 +1348,14 @@ const styles = StyleSheet.create({
   attachmentsContainer: {
     marginTop: 4,
     paddingHorizontal: 10,
+  },
+  // Edge-to-edge image-only bubble: image fills the bubble with no surrounding color.
+  imageOnlyBubble: {
+    backgroundColor: 'transparent',
+  },
+  imageOnlyAttachments: {
+    marginTop: 0,
+    paddingHorizontal: 0,
   },
   bubbleTextContent: {
     paddingHorizontal: 10,

--- a/apps/mobile/features/chat/components/__tests__/MessageItem.imageBubble.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageItem.imageBubble.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for edge-to-edge image-only message bubbles.
+ *
+ * An image with no caption renders like iMessage: the photo fills the bubble with
+ * no surrounding blue/gray color, and no inline timestamp footer. A captioned image
+ * (or any other content) keeps the normal bubble + timestamp.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { MessageItem } from '../MessageItem';
+
+// Mock all heavy dependencies (mirrors MessageItem.status.test.tsx)
+jest.mock('@features/chat/hooks/useReadReceipts', () => ({
+  useReadReceipts: () => ({ readByCount: 0, totalMembers: 0, isLoading: false }),
+}));
+jest.mock('@features/chat/hooks/useReactions', () => ({
+  useReactions: () => ({ reactions: [], toggleReaction: jest.fn(), isLoading: false }),
+}));
+jest.mock('@features/chat/hooks/useLinkPreview', () => ({
+  useLinkPreview: () => ({ preview: null, loading: false }),
+}));
+jest.mock('@services/api/convex', () => ({ api: {} }));
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('../EventLinkCard', () => ({ EventLinkCard: () => null }));
+jest.mock('../LinkPreviewCard', () => ({ LinkPreviewCard: () => null }));
+jest.mock('../FileAttachment', () => ({ FileAttachment: () => null }));
+jest.mock('../AudioPlayer', () => ({ AudioPlayer: () => null }));
+jest.mock('../VideoPlayer', () => ({ VideoPlayer: () => null }));
+jest.mock('../ImageAttachmentsGrid', () => ({ ImageAttachmentsGrid: () => null }));
+jest.mock('../ThreadReplies', () => ({ ThreadReplies: () => null }));
+jest.mock('../ReactionDetailsModal', () => ({ ReactionDetailsModal: () => null }));
+jest.mock('../TaskCardFromMessage', () => ({ TaskCardFromMessage: () => null }));
+jest.mock('@components/ui', () => ({ AppImage: () => null, ImageViewer: () => null }));
+jest.mock('@/utils/media', () => ({ getMediaUrl: (url: string) => url }));
+
+// Matches the "today" timestamp formatMessageTime renders inside the bubble footer
+// (e.g. "3:07 PM"). Captions like "Nice shot" never match this pattern.
+const TIME_RE = /\d{1,2}:\d{2} (AM|PM)/;
+
+const baseMessage = {
+  _id: 'msg-1' as any,
+  channelId: 'ch-1' as any,
+  senderId: 'user-1' as any,
+  content: '',
+  contentType: 'text',
+  createdAt: Date.now(),
+  isDeleted: false,
+  senderName: 'Test User',
+  attachments: [{ type: 'image', url: 'https://images.togather.nyc/chat/photo.jpg' }],
+};
+
+describe('MessageItem image-only bubble', () => {
+  it('hides the inline timestamp footer for an image with no caption', () => {
+    const { queryByText } = render(
+      <MessageItem message={baseMessage} currentUserId={'user-1' as any} />
+    );
+    // Edge-to-edge image-only bubble shows no inline timestamp (iMessage-style).
+    expect(queryByText(TIME_RE)).toBeNull();
+  });
+
+  it('keeps the timestamp footer when the image has a caption', () => {
+    const { queryByText } = render(
+      <MessageItem
+        message={{ ...baseMessage, content: 'Nice shot' }}
+        currentUserId={'user-1' as any}
+      />
+    );
+    // Caption means a normal text+image bubble, which keeps the timestamp.
+    expect(queryByText(TIME_RE)).toBeTruthy();
+  });
+
+  it('keeps the timestamp footer for a plain text message', () => {
+    const { queryByText } = render(
+      <MessageItem
+        message={{ ...baseMessage, content: 'Hello!', attachments: [] }}
+        currentUserId={'user-1' as any}
+      />
+    );
+    expect(queryByText(TIME_RE)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What & why

Images sent **without a caption** rendered with the message-bubble color showing as a border around the photo — blue (`chatBubbleOwn`) for your own messages, gray for others. This looked unlike iMessage, where a photo fills the bubble edge-to-edge.

The blue came from three places, all the bubble background peeking through:
- `attachmentsContainer`'s `paddingHorizontal: 10` and `marginTop: 4` → blue strip on the sides and top
- the timestamp footer below the image → blue strip at the bottom
- the bubble tail → blue triangle beside the photo

### Fix

Detect an **image-only message** (has image attachments, no text, no other attachment types, and not an SMS-blast) and render it iMessage-style:

- transparent bubble background (`imageOnlyBubble`)
- no padding/margin around the image — edge-to-edge (`imageOnlyAttachments`)
- no inline timestamp footer
- no bubble tail

Captioned images and plain text messages are **unchanged** — they keep the normal bubble, padding, timestamp, and tail.

### Reply & reactions preserved (per the bug's repro)

These were explicitly required to keep working, and they do — the change is purely cosmetic styling on the bubble:
- **Long-press to reply / context menu** and **double-tap to react** live on the outer `Pressable` and use `bubbleRef`, both untouched.
- The **reactions row** renders *below* the bubble (outside it), unaffected.
- **Read receipts / delivery status** (`✓✓`) also render below the bubble, so image-only messages still show delivery state even without the inline timestamp.

> Note on the dropped inline timestamp: this matches iMessage (no per-photo timestamp; date separators between message groups still convey timing). Flagging it explicitly in case reviewers prefer to keep a timestamp — e.g. as a scrim overlay on the image corner instead.

## Testing

- New `MessageItem.imageBubble.test.tsx`: asserts the timestamp footer is hidden for an uncaptioned image but shown for a captioned image and a plain text message.
- Full mobile suite green via pre-push hook: **121 suites, 1103 passed, 9 skipped, 0 failed**.
- ESLint: 0 errors on the changed file.

## Screenshots

The reported behavior (blue padding/border around sent photos) is visible in the bug's attached screenshots. This was implemented from a remote container without a simulator, so before/after captures aren't included — visual verification on a device/simulator would be a good review step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqZx42yoipFKmDipLXBxrk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqZx42yoipFKmDipLXBxrk)_