### PR TITLE
Add "Enable chat" row per team in scheduling grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,4 @@ apps/mobile/secrets/
 /*.png
 /*.csv
 apps/mobile/build-output/
+shots/

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -263,8 +263,17 @@ export const rosterMatrix = query({
           a.sortOrder - b.sortOrder ||
           a.roleName.localeCompare(b.roleName),
       );
-    const teams = [...teamDocs.values()]
-      .map((t) => ({ teamId: t._id, teamName: t.name }))
+    const teamDocsList = [...teamDocs.values()];
+    const channelDocs = await Promise.all(
+      teamDocsList.map((t) => (t.channelId ? ctx.db.get(t.channelId) : Promise.resolve(null))),
+    );
+    const teams = teamDocsList
+      .map((t, idx) => ({
+        teamId: t._id,
+        teamName: t.name,
+        hasChannel: t.channelId !== undefined,
+        channelMemberCount: channelDocs[idx]?.memberCount ?? 0,
+      }))
       .sort((a, b) => a.teamName.localeCompare(b.teamName));
 
     // --- People-centric rows: active group members. ---

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -58,6 +58,7 @@ import { AssignSheet } from "./AssignSheet";
 import { GridPresenceBar } from "./GridPresenceBar";
 import { EventEditorPanel } from "./EventEditorPanel";
 import { DateColumnHeaderEditor } from "./DateColumnHeaderEditor";
+import { TeamChannelToggle } from "./TeamChannelToggle";
 
 // ---------------------------------------------------------------------------
 // Backend contract (mirrors scheduling.roster.rosterMatrix)
@@ -75,7 +76,12 @@ type RosterEvent = {
   pendingCount: number;
 };
 
-type RosterTeam = { teamId: Id<"teams">; teamName: string };
+type RosterTeam = {
+  teamId: Id<"teams">;
+  teamName: string;
+  hasChannel: boolean;
+  channelMemberCount: number;
+};
 
 type RosterRole = {
   roleId: Id<"teamRoles">;
@@ -152,6 +158,13 @@ type RoleRow =
   | { kind: "section"; teamId: string; teamName: string }
   | { kind: "role"; role: RosterRole }
   | { kind: "addRole"; teamId: Id<"teams">; teamName: string }
+  | {
+      kind: "enableChat";
+      teamId: Id<"teams">;
+      teamName: string;
+      hasChannel: boolean;
+      channelMemberCount: number;
+    }
   | { kind: "addTeam" };
 
 /** A team header or role row the leader has right-clicked to delete. */
@@ -672,6 +685,13 @@ export function RosterGridScreen() {
         kind: "addRole",
         teamId: team.teamId,
         teamName: team.teamName,
+      });
+      out.push({
+        kind: "enableChat",
+        teamId: team.teamId,
+        teamName: team.teamName,
+        hasChannel: team.hasChannel,
+        channelMemberCount: team.channelMemberCount,
       });
     }
     // Trailing "＋ Add team". When a team is isolated, hide it so the rows stay
@@ -1447,6 +1467,29 @@ export function RosterGridScreen() {
             </View>
           );
         }
+        if (r.kind === "enableChat") {
+          return (
+            <View
+              key={`enablechat-${r.teamId}`}
+              style={[
+                styles.addRow,
+                {
+                  width: NAME_W,
+                  height: ROW_H,
+                  backgroundColor: colors.surface,
+                  borderBottomColor: colors.border,
+                },
+              ]}
+            >
+              <TeamChannelToggle
+                teamId={r.teamId}
+                teamName={r.teamName}
+                hasChannel={r.hasChannel}
+                channelMemberCount={r.channelMemberCount}
+              />
+            </View>
+          );
+        }
         if (r.kind === "addTeam") {
           return (
             <View
@@ -1587,13 +1630,19 @@ export function RosterGridScreen() {
               />
             );
           }
-          // The "＋ Add role" / "＋ Add team" rows live only in the frozen
-          // column; the body renders an empty spacer of the SAME height so the
-          // synced vertical scroll + frozen-column alignment stay intact.
-          if (r.kind === "addRole" || r.kind === "addTeam") {
+          // The "＋ Add role" / "＋ Add team" / "Enable chat" rows live only in
+          // the frozen column; the body renders an empty spacer of the SAME
+          // height so the synced vertical scroll + frozen-column alignment stay.
+          if (r.kind === "addRole" || r.kind === "addTeam" || r.kind === "enableChat") {
+            const key =
+              r.kind === "addRole"
+                ? `addrole-${r.teamId}`
+                : r.kind === "enableChat"
+                  ? `enablechat-${r.teamId}`
+                  : "addteam";
             return (
               <View
-                key={r.kind === "addRole" ? `addrole-${r.teamId}` : "addteam"}
+                key={key}
                 style={[
                   styles.row,
                   {


### PR DESCRIPTION
## Summary

- Adds a dedicated **"Enable chat"** row at the bottom of each team's role list in the scheduling grid (Roles view)
- The toggle renders the existing `TeamChannelToggle` component inline in the frozen left column, keeping the team header uncluttered
- Each team's row in the scrollable cell body gets a matching empty spacer so vertical scroll alignment stays in sync
- Backend: `rosterMatrix` now fetches each team's channel doc and returns `hasChannel` + `channelMemberCount` alongside existing team fields

## Changes

**`apps/convex/functions/scheduling/roster.ts`**
- Fetch the channel doc for each team in parallel
- Include `hasChannel` and `channelMemberCount` in the returned team objects

**`apps/mobile/features/scheduling/components/RosterGridScreen.tsx`**
- Updated `RosterTeam` type with `hasChannel` / `channelMemberCount`
- Added `enableChat` variant to the `RoleRow` union type
- Inserted one `enableChat` row per team after the `addRole` row in `roleRows`
- Rendered `TeamChannelToggle` in `renderRoleFrozen` for the new row
- Added matching empty spacer in `renderRoleCells`

## Test plan

- [ ] Open the scheduling grid for a group with multiple teams
- [ ] Verify each team has an "Enable chat" row at the bottom of its role list (below "+ Add role")
- [ ] Tap the toggle on a team without a channel — confirm the "Turn on chat?" alert appears and chat is created
- [ ] Tap the toggle on a team with a channel — confirm the "Turn off chat?" alert appears and channel is unlinked
- [ ] Confirm the team header row is unchanged (no toggle in the header)
- [ ] Confirm frozen-column / scrollable-body stay in vertical alignment after toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vzj6rUVkHEhbVUahU5c7pM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vzj6rUVkHEhbVUahU5c7pM)_