### PR TITLE
feat(bot): Claude model availability check + Opus→Sonnet fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,15 @@ OPENAI_SECRET_KEY=              # OpenAI API key (sk-...). Used by poster
 OLLAMA_API_KEY=
 
 # =============================================================================
+# ANTHROPIC (Optional - Claude model availability check)
+# =============================================================================
+# Standard Anthropic API key (sk-ant-...). The bot probes Anthropic's Models
+# API with this key to confirm a Claude model is reachable before dispatching
+# a task (Opus -> Sonnet fallback). See apps/convex/functions/ai/. When unset,
+# the availability gate fails closed (reports unavailable) rather than polling.
+ANTHROPIC_API_KEY=
+
+# =============================================================================
 # IMAGE CDN (Optional - custom domain)
 # =============================================================================
 EXPO_PUBLIC_IMAGE_CDN_URL=      # Custom image CDN URL

--- a/apps/convex/__tests__/ai/claudeAvailability.test.ts
+++ b/apps/convex/__tests__/ai/claudeAvailability.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Claude model availability + fallback tests.
+ *
+ * Exercises the REAL exported helpers from `lib/ai/claudeAvailability.ts`
+ * with an injected `fetch` so no network is touched:
+ *   - isModelStatusAvailable / describeUnavailableStatus (pure)
+ *   - checkClaudeModelAvailability (single-model probe)
+ *   - selectAvailableClaudeModel (Opus → Sonnet fallback chain)
+ *
+ * Run with: cd apps/convex && pnpm test claudeAvailability
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  CLAUDE_PRIMARY_MODEL,
+  CLAUDE_FALLBACK_MODEL,
+  CLAUDE_FALLBACK_CHAIN,
+  CLAUDE_POLL_INTERVAL_MS,
+  isModelStatusAvailable,
+  describeUnavailableStatus,
+  checkClaudeModelAvailability,
+  selectAvailableClaudeModel,
+} from "../../lib/ai/claudeAvailability";
+
+/**
+ * Build a fake `fetch` that answers by the model id at the end of the URL.
+ * A value of "throw" simulates a network error for that model.
+ */
+function fakeFetch(byModel: Record<string, number | "throw">): typeof fetch {
+  return (async (url: string | URL) => {
+    const model = String(url).split("/").pop() as string;
+    const outcome = byModel[model];
+    if (outcome === undefined) throw new Error(`unexpected model ${model}`);
+    if (outcome === "throw") throw new Error("network down");
+    return { status: outcome } as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("constants", () => {
+  it("prefers Opus then Sonnet in the fallback chain", () => {
+    expect(CLAUDE_PRIMARY_MODEL).toBe("claude-opus-4-8");
+    expect(CLAUDE_FALLBACK_MODEL).toBe("claude-sonnet-4-6");
+    expect(CLAUDE_FALLBACK_CHAIN).toEqual([
+      "claude-opus-4-8",
+      "claude-sonnet-4-6",
+    ]);
+  });
+
+  it("polls hourly when nothing is available", () => {
+    expect(CLAUDE_POLL_INTERVAL_MS).toBe(60 * 60 * 1000);
+  });
+});
+
+describe("isModelStatusAvailable", () => {
+  it("treats 200 as available", () => {
+    expect(isModelStatusAvailable(200)).toBe(true);
+  });
+
+  it("treats every non-200 status as unavailable", () => {
+    for (const s of [401, 403, 404, 429, 500, 529]) {
+      expect(isModelStatusAvailable(s)).toBe(false);
+    }
+  });
+});
+
+describe("describeUnavailableStatus", () => {
+  it("maps common down/overloaded statuses to readable reasons", () => {
+    expect(describeUnavailableStatus(404)).toBe("model not found");
+    expect(describeUnavailableStatus(401)).toBe("not authorized for this model");
+    expect(describeUnavailableStatus(403)).toBe("not authorized for this model");
+    expect(describeUnavailableStatus(429)).toBe("rate limited");
+    expect(describeUnavailableStatus(529)).toBe("overloaded");
+    expect(describeUnavailableStatus(500)).toBe("service error (500)");
+    expect(describeUnavailableStatus(418)).toBe("unexpected status 418");
+  });
+});
+
+describe("checkClaudeModelAvailability", () => {
+  it("returns available for a 200 response", async () => {
+    const result = await checkClaudeModelAvailability(CLAUDE_PRIMARY_MODEL, {
+      apiKey: "test-key",
+      fetchImpl: fakeFetch({ [CLAUDE_PRIMARY_MODEL]: 200 }),
+    });
+    expect(result).toEqual({
+      model: CLAUDE_PRIMARY_MODEL,
+      available: true,
+      status: 200,
+    });
+  });
+
+  it("returns unavailable with a reason for a non-200 response", async () => {
+    const result = await checkClaudeModelAvailability(CLAUDE_PRIMARY_MODEL, {
+      apiKey: "test-key",
+      fetchImpl: fakeFetch({ [CLAUDE_PRIMARY_MODEL]: 529 }),
+    });
+    expect(result.available).toBe(false);
+    expect(result.status).toBe(529);
+    expect(result.reason).toBe("overloaded");
+  });
+
+  it("never throws on a network failure — resolves to unavailable", async () => {
+    const result = await checkClaudeModelAvailability(CLAUDE_PRIMARY_MODEL, {
+      apiKey: "test-key",
+      fetchImpl: fakeFetch({ [CLAUDE_PRIMARY_MODEL]: "throw" }),
+    });
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe("request failed");
+  });
+
+  it("sends the x-api-key and anthropic-version headers", async () => {
+    const spy = vi.fn(async () => ({ status: 200 }) as Response);
+    await checkClaudeModelAvailability(CLAUDE_PRIMARY_MODEL, {
+      apiKey: "secret-123",
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      `https://api.anthropic.com/v1/models/${CLAUDE_PRIMARY_MODEL}`,
+    );
+    expect((init.headers as Record<string, string>)["x-api-key"]).toBe(
+      "secret-123",
+    );
+    expect(
+      (init.headers as Record<string, string>)["anthropic-version"],
+    ).toBe("2023-06-01");
+  });
+});
+
+describe("selectAvailableClaudeModel", () => {
+  it("selects the primary model and skips the fallback probe when Opus is up", async () => {
+    const spy = vi.fn(async () => ({ status: 200 }) as Response);
+    const selection = await selectAvailableClaudeModel({
+      apiKey: "test-key",
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(selection.selectedModel).toBe(CLAUDE_PRIMARY_MODEL);
+    expect(selection.statuses).toHaveLength(1);
+    // Short-circuit: Sonnet must not be probed when Opus is healthy.
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to Sonnet when Opus is down", async () => {
+    const selection = await selectAvailableClaudeModel({
+      apiKey: "test-key",
+      fetchImpl: fakeFetch({
+        [CLAUDE_PRIMARY_MODEL]: 529,
+        [CLAUDE_FALLBACK_MODEL]: 200,
+      }),
+    });
+    expect(selection.selectedModel).toBe(CLAUDE_FALLBACK_MODEL);
+    expect(selection.statuses).toHaveLength(2);
+    expect(selection.statuses[0].available).toBe(false);
+    expect(selection.statuses[1].available).toBe(true);
+  });
+
+  it("returns null when every model in the chain is down", async () => {
+    const selection = await selectAvailableClaudeModel({
+      apiKey: "test-key",
+      fetchImpl: fakeFetch({
+        [CLAUDE_PRIMARY_MODEL]: 500,
+        [CLAUDE_FALLBACK_MODEL]: 503,
+      }),
+    });
+    expect(selection.selectedModel).toBeNull();
+    expect(selection.statuses).toHaveLength(2);
+    expect(selection.statuses.every((s) => !s.available)).toBe(true);
+  });
+});

--- a/apps/convex/__tests__/ai/modelAvailability.poll.test.ts
+++ b/apps/convex/__tests__/ai/modelAvailability.poll.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Poll-state mutation tests for the Claude model availability gate.
+ *
+ * Locks in the multi-thread notify behavior:
+ *   - `beginPoll` starts the loop exactly once and records each affected thread
+ *     at most once (so every thread gets one outage notice, none get spammed).
+ *   - `resolveRecovery` hands back every affected thread once and is idempotent,
+ *     so whichever path detects recovery (a gate retry or the hourly poll)
+ *     announces "back online" to all of them and the other becomes a no-op.
+ *
+ * Exercises the real mutations through convex-test — no network/probe involved.
+ *
+ * Run with: cd apps/convex && pnpm test modelAvailability.poll
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../../schema";
+import { internal } from "../../_generated/api";
+import { modules } from "../../test.setup";
+import type { Id } from "../../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+async function seedGroup(
+  t: ReturnType<typeof convexTest>,
+  slug: string,
+): Promise<Id<"groups">> {
+  const now = Date.now();
+  return await t.run(async (ctx) => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug,
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "General",
+      slug: "general",
+      isActive: true,
+      displayOrder: 0,
+      createdAt: now,
+    });
+    return await ctx.db.insert("groups", {
+      communityId,
+      name: "Test Group",
+      groupTypeId,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+}
+
+describe("claude model availability poll state", () => {
+  test("beginPoll starts the loop once and dedupes notify targets per thread", async () => {
+    const t = convexTest(schema, modules);
+    const g1 = await seedGroup(t, "claude-poll-g1");
+    const g2 = await seedGroup(t, "claude-poll-g2");
+
+    // First thread to trip the gate: starts the loop and is recorded.
+    const first = await t.mutation(
+      internal.functions.ai.modelAvailability.beginPoll,
+      { notifyGroupId: g1 },
+    );
+    expect(first).toEqual({ started: true, targetAdded: true });
+
+    // Same thread trips again during the same outage: no restart, no re-notify.
+    const again = await t.mutation(
+      internal.functions.ai.modelAvailability.beginPoll,
+      { notifyGroupId: g1 },
+    );
+    expect(again).toEqual({ started: false, targetAdded: false });
+
+    // A different thread during the same outage: added (gets its own notice),
+    // but the loop is not restarted.
+    const second = await t.mutation(
+      internal.functions.ai.modelAvailability.beginPoll,
+      { notifyGroupId: g2 },
+    );
+    expect(second).toEqual({ started: false, targetAdded: true });
+
+    const poll = await t.query(
+      internal.functions.ai.modelAvailability.getPoll,
+      {},
+    );
+    expect(poll?.active).toBe(true);
+    expect(poll?.notifyTargets?.map((x) => x.groupId)).toEqual([g1, g2]);
+  });
+
+  test("resolveRecovery clears the loop and returns every affected thread once", async () => {
+    const t = convexTest(schema, modules);
+    const g1 = await seedGroup(t, "claude-rec-g1");
+    const g2 = await seedGroup(t, "claude-rec-g2");
+    await t.mutation(internal.functions.ai.modelAvailability.beginPoll, {
+      notifyGroupId: g1,
+    });
+    await t.mutation(internal.functions.ai.modelAvailability.beginPoll, {
+      notifyGroupId: g2,
+    });
+
+    const recovery = await t.mutation(
+      internal.functions.ai.modelAvailability.resolveRecovery,
+      { lastAvailableModel: "claude-opus-4-8" },
+    );
+    expect(recovery.wasActive).toBe(true);
+    expect(recovery.targets.map((x) => x.groupId)).toEqual([g1, g2]);
+
+    const poll = await t.query(
+      internal.functions.ai.modelAvailability.getPoll,
+      {},
+    );
+    expect(poll?.active).toBe(false);
+    expect(poll?.notifyTargets).toEqual([]);
+    expect(poll?.lastAvailableModel).toBe("claude-opus-4-8");
+
+    // A second recovery (e.g. the scheduled poll firing after a gate retry
+    // already recovered) is a no-op — no duplicate back-online notices.
+    const again = await t.mutation(
+      internal.functions.ai.modelAvailability.resolveRecovery,
+      { lastAvailableModel: "claude-opus-4-8" },
+    );
+    expect(again).toEqual({ wasActive: false, targets: [] });
+  });
+
+  test("beginPoll with no thread target still starts the loop", async () => {
+    const t = convexTest(schema, modules);
+    const first = await t.mutation(
+      internal.functions.ai.modelAvailability.beginPoll,
+      {},
+    );
+    expect(first).toEqual({ started: true, targetAdded: false });
+    const poll = await t.query(
+      internal.functions.ai.modelAvailability.getPoll,
+      {},
+    );
+    expect(poll?.active).toBe(true);
+    expect(poll?.notifyTargets).toEqual([]);
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -26,6 +26,7 @@ import type * as functions_admin_requests from "../functions/admin/requests.js";
 import type * as functions_admin_settings from "../functions/admin/settings.js";
 import type * as functions_admin_stats from "../functions/admin/stats.js";
 import type * as functions_adminBroadcasts from "../functions/adminBroadcasts.js";
+import type * as functions_ai_modelAvailability from "../functions/ai/modelAvailability.js";
 import type * as functions_auth_accountClaim from "../functions/auth/accountClaim.js";
 import type * as functions_auth_emailOtp from "../functions/auth/emailOtp.js";
 import type * as functions_auth_helpers from "../functions/auth/helpers.js";
@@ -221,6 +222,7 @@ declare const fullApi: ApiFromModules<{
   "functions/admin/settings": typeof functions_admin_settings;
   "functions/admin/stats": typeof functions_admin_stats;
   "functions/adminBroadcasts": typeof functions_adminBroadcasts;
+  "functions/ai/modelAvailability": typeof functions_ai_modelAvailability;
   "functions/auth/accountClaim": typeof functions_auth_accountClaim;
   "functions/auth/emailOtp": typeof functions_auth_emailOtp;
   "functions/auth/helpers": typeof functions_auth_helpers;

--- a/apps/convex/functions/ai/ARCHITECTURE.md
+++ b/apps/convex/functions/ai/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+# `functions/ai` — Claude model availability
+
+This folder holds the Togather Bot's guardrail for **executing tasks with
+Claude models**: before a task is dispatched, confirm a Claude model is
+actually reachable, and degrade gracefully when none is.
+
+## Pieces
+
+| File | What it is |
+| --- | --- |
+| `../../lib/ai/claudeAvailability.ts` | Pure, `fetch`-injectable core. Probes Anthropic's Models API and walks the **Opus → Sonnet** fallback chain. Fully unit-tested (`__tests__/ai/claudeAvailability.test.ts`). |
+| `modelAvailability.ts` | Convex actions/mutations that wrap the core with the bot's runtime behavior (notify + poll). |
+
+## Models
+
+The preference chain lives in `claudeAvailability.ts`:
+
+1. **`claude-opus-4-8`** (Claude Opus) — primary
+2. **`claude-sonnet-4-6`** (Claude Sonnet) — fallback
+
+A model counts as available when `GET /v1/models/{id}` returns `200`. `404`
+(unknown/retired id), `401`/`403` (no access), `429` (rate limited), and
+`5xx`/`529` (overloaded/outage) all mean "don't dispatch to it." The probe uses
+`ANTHROPIC_API_KEY` (see `docs/secrets.md`); without it the gate fails closed.
+
+## Flow
+
+```
+task requested
+   │
+   ▼
+ensureModelAvailable(notifyTarget?)
+   │
+   ├─ Opus healthy?  ──► return { available: true, model: "claude-opus-4-8" }
+   ├─ Opus down, Sonnet healthy? ──► return { available: true, model: "claude-sonnet-4-6" }
+   └─ both down:
+        • post a heads-up into the thread (once, on entering the outage)
+        • start the hourly poll loop (idempotent — never stacked)
+        • return { available: false }
+                │
+                ▼
+        pollModelAvailability (every hour, self-rescheduling)
+                │
+                ├─ a model recovered ──► announce "back online", stop
+                └─ still down ──► reschedule one hour out
+```
+
+State lives in the singleton `claudeModelPolls` row (`schema.ts`), which both
+prevents duplicate poll loops and caches the last-known status for
+`checkModelStatus`.
+
+## Tools (callable internal actions)
+
+- **`ensureModelAvailable`** — the gate above. A Claude task path should call
+  this first and only dispatch when `available: true`, passing the originating
+  `notifyGroupId` (+ optional channel slug) so outage/recovery notices land in
+  the right thread.
+- **`checkModelStatus`** — read-only "what's the status right now"; returns each
+  model's availability and the model the bot would pick. Never schedules a poll.
+- **`pollModelAvailability`** — the hourly loop; normally scheduled by
+  `ensureModelAvailable`, not called directly.

--- a/apps/convex/functions/ai/ARCHITECTURE.md
+++ b/apps/convex/functions/ai/ARCHITECTURE.md
@@ -34,20 +34,28 @@ ensureModelAvailable(notifyTarget?)
    ├─ Opus healthy?  ──► return { available: true, model: "claude-opus-4-8" }
    ├─ Opus down, Sonnet healthy? ──► return { available: true, model: "claude-sonnet-4-6" }
    └─ both down:
-        • post a heads-up into the thread (once, on entering the outage)
+        • record this thread as an outage target (deduped) and post it a
+          one-time heads-up
         • start the hourly poll loop (idempotent — never stacked)
         • return { available: false }
                 │
                 ▼
         pollModelAvailability (every hour, self-rescheduling)
                 │
-                ├─ a model recovered ──► announce "back online", stop
+                ├─ a model recovered ──► announce "back online" to every
+                │                        affected thread, then stop
                 └─ still down ──► reschedule one hour out
 ```
 
-State lives in the singleton `claudeModelPolls` row (`schema.ts`), which both
-prevents duplicate poll loops and caches the last-known status for
-`checkModelStatus`.
+Multiple threads can trip the gate during one outage; each is recorded once in
+`notifyTargets` and gets exactly one heads-up and one back-online notice.
+Whichever path notices recovery first — a later gate retry or the hourly poll —
+announces to all of them and clears the loop (`resolveRecovery`); the other
+becomes a no-op.
+
+State lives in the singleton `claudeModelPolls` row (`schema.ts`), which
+prevents duplicate poll loops, holds the outage's notify targets, and caches the
+last-known status for `checkModelStatus`.
 
 ## Tools (callable internal actions)
 

--- a/apps/convex/functions/ai/modelAvailability.ts
+++ b/apps/convex/functions/ai/modelAvailability.ts
@@ -7,9 +7,14 @@
  *
  *   1. Probes Claude Opus, then Claude Sonnet (`selectAvailableClaudeModel`).
  *   2. Returns the first healthy model so the caller can run the task.
- *   3. If BOTH are down, posts a heads-up into the thread and starts an
+ *   3. If BOTH are down, posts a heads-up into the calling thread and starts an
  *      hourly poll (`pollModelAvailability`) that re-checks until a model
- *      recovers — then announces it's back and stops.
+ *      recovers — then announces it's back to every affected thread and stops.
+ *
+ * Multiple threads can trip the gate during the same outage; each is recorded
+ * once in `notifyTargets` and gets exactly one heads-up and one back-online
+ * notice. Whichever path notices recovery first (a later gate retry, or the
+ * hourly poll) announces to all of them and clears the loop.
  *
  * `checkModelStatus` is the read-only "what's the status right now" tool.
  *
@@ -36,11 +41,21 @@ import {
 /** Singleton key for the poll-state row. */
 const POLL_KEY = "global";
 
-/** Where to post availability heads-up messages, when a target is known. */
+interface NotifyTarget {
+  groupId: Id<"groups">;
+  channelSlug?: string;
+}
+
+/** A single thread to notify, as accepted from a calling task. */
 const notifyTargetArgs = {
   notifyGroupId: v.optional(v.id("groups")),
   notifyChannelSlug: v.optional(v.string()),
 };
+
+/** Identity key for deduping notify targets by thread. */
+function targetKey(t: NotifyTarget): string {
+  return `${t.groupId}::${t.channelSlug ?? ""}`;
+}
 
 function getAnthropicApiKey(): string | null {
   return process.env.ANTHROPIC_API_KEY ?? null;
@@ -52,16 +67,22 @@ async function probeModels(apiKey: string): Promise<ModelSelection> {
 
 async function postNotice(
   ctx: ActionCtx,
-  target: { groupId?: Id<"groups">; channelSlug?: string },
+  target: NotifyTarget,
   message: string,
 ): Promise<void> {
-  if (!target.groupId) return; // No thread to notify — log-only path.
   await ctx.runAction(internal.functions.scheduledJobs.sendBotMessage, {
     groupId: target.groupId,
     message,
     targetChannelSlug: target.channelSlug,
     botType: "claude_availability",
   });
+}
+
+const OUTAGE_MESSAGE =
+  "⚠️ Claude is temporarily unavailable — both Opus and Sonnet are unreachable. I'll keep checking every hour and resume automatically once one is back.";
+
+function recoveryMessage(model: string): string {
+  return `✅ Claude is back online (using ${model}). I'll resume from here.`;
 }
 
 // ===========================================================================
@@ -79,26 +100,41 @@ export const getPoll = internalQuery({
 });
 
 /**
- * Start the poll loop if one isn't already running. Idempotent: when a poll is
- * already `active`, this is a no-op and returns `{ started: false }`, so
- * repeated task requests during an outage never stack multiple poll chains.
+ * Start the poll loop if one isn't already running and record the calling
+ * thread as an outage target. Idempotent on both axes:
+ *   - `started`: true only when the loop transitioned from off → on, so poll
+ *     chains never stack.
+ *   - `targetAdded`: true only when this thread wasn't already a target, so a
+ *     thread is warned at most once per outage.
  */
 export const beginPoll = internalMutation({
-  args: notifyTargetArgs,
-  handler: async (ctx, args): Promise<{ started: boolean }> => {
+  args: { ...notifyTargetArgs, statusesJson: v.optional(v.string()) },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ started: boolean; targetAdded: boolean }> => {
     const now = Date.now();
     const existing = await ctx.db
       .query("claudeModelPolls")
       .withIndex("by_key", (q) => q.eq("key", POLL_KEY))
       .unique();
 
-    if (existing?.active) return { started: false };
+    const target: NotifyTarget | null = args.notifyGroupId
+      ? { groupId: args.notifyGroupId, channelSlug: args.notifyChannelSlug }
+      : null;
+
+    const current: NotifyTarget[] = existing?.notifyTargets ?? [];
+    const targetAdded =
+      target !== null && !current.some((t) => targetKey(t) === targetKey(target));
+    const notifyTargets = targetAdded ? [...current, target] : current;
+    const started = !existing?.active;
 
     if (existing) {
       await ctx.db.patch(existing._id, {
         active: true,
-        notifyGroupId: args.notifyGroupId,
-        notifyChannelSlug: args.notifyChannelSlug,
+        notifyTargets,
+        lastCheckedAt: now,
+        lastStatuses: args.statusesJson ?? existing.lastStatuses,
         updatedAt: now,
       });
     } else {
@@ -106,47 +142,63 @@ export const beginPoll = internalMutation({
         key: POLL_KEY,
         active: true,
         lastCheckedAt: now,
-        notifyGroupId: args.notifyGroupId,
-        notifyChannelSlug: args.notifyChannelSlug,
+        lastStatuses: args.statusesJson,
+        notifyTargets,
         createdAt: now,
         updatedAt: now,
       });
     }
-    return { started: true };
+    return { started, targetAdded };
   },
 });
 
-/** Record the latest probe outcome and set whether the loop keeps running. */
-export const recordPollResult = internalMutation({
-  args: {
-    active: v.boolean(),
-    lastAvailableModel: v.optional(v.string()),
-    statusesJson: v.optional(v.string()),
-  },
+/** Record a poll tick that did NOT recover (loop keeps running, or stops on no-key). */
+export const recordTick = internalMutation({
+  args: { active: v.boolean(), statusesJson: v.optional(v.string()) },
   handler: async (ctx, args): Promise<void> => {
     const now = Date.now();
     const existing = await ctx.db
       .query("claudeModelPolls")
       .withIndex("by_key", (q) => q.eq("key", POLL_KEY))
       .unique();
-
-    const patch = {
+    if (!existing) return;
+    await ctx.db.patch(existing._id, {
       active: args.active,
       lastCheckedAt: now,
-      lastAvailableModel: args.lastAvailableModel,
-      lastStatuses: args.statusesJson,
+      lastStatuses: args.statusesJson ?? existing.lastStatuses,
       updatedAt: now,
-    };
+    });
+  },
+});
 
-    if (existing) {
-      await ctx.db.patch(existing._id, patch);
-    } else {
-      await ctx.db.insert("claudeModelPolls", {
-        key: POLL_KEY,
-        createdAt: now,
-        ...patch,
-      });
-    }
+/**
+ * Clear an active poll on recovery and hand back the threads that need a
+ * back-online notice. Returns `wasActive: false` (with no targets) when there
+ * was no outage in progress, so the healthy path stays a cheap no-op and only
+ * one caller ever announces recovery.
+ */
+export const resolveRecovery = internalMutation({
+  args: { lastAvailableModel: v.string(), statusesJson: v.optional(v.string()) },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ wasActive: boolean; targets: NotifyTarget[] }> => {
+    const existing = await ctx.db
+      .query("claudeModelPolls")
+      .withIndex("by_key", (q) => q.eq("key", POLL_KEY))
+      .unique();
+    if (!existing?.active) return { wasActive: false, targets: [] };
+
+    const targets = existing.notifyTargets ?? [];
+    await ctx.db.patch(existing._id, {
+      active: false,
+      notifyTargets: [],
+      lastAvailableModel: args.lastAvailableModel,
+      lastCheckedAt: Date.now(),
+      lastStatuses: args.statusesJson ?? existing.lastStatuses,
+      updatedAt: Date.now(),
+    });
+    return { wasActive: true, targets };
   },
 });
 
@@ -178,8 +230,8 @@ export const checkModelStatus = internalAction({
  * Gate: confirm a Claude model is reachable before executing a task.
  *
  * Returns `{ available: true, model }` with the first healthy model, or
- * `{ available: false }` after notifying the thread and starting the hourly
- * poll. Callers should treat `available: false` as "don't dispatch yet".
+ * `{ available: false }` after notifying the calling thread and starting the
+ * hourly poll. Callers should treat `available: false` as "don't dispatch yet".
  */
 export const ensureModelAvailable = internalAction({
   args: notifyTargetArgs,
@@ -203,17 +255,19 @@ export const ensureModelAvailable = internalAction({
     }
 
     const selection = await probeModels(apiKey);
+    const statusesJson = JSON.stringify(selection.statuses);
 
     if (selection.selectedModel) {
-      // A healthy model means any prior outage is over — clear an active poll.
-      await ctx.runMutation(
-        internal.functions.ai.modelAvailability.recordPollResult,
-        {
-          active: false,
-          lastAvailableModel: selection.selectedModel,
-          statusesJson: JSON.stringify(selection.statuses),
-        },
+      // Healthy. If this retry is the first to see Claude recover, clear the
+      // active poll and deliver the back-online notice to every affected
+      // thread (the scheduled poll will then exit as a no-op).
+      const recovery = await ctx.runMutation(
+        internal.functions.ai.modelAvailability.resolveRecovery,
+        { lastAvailableModel: selection.selectedModel, statusesJson },
       );
+      if (recovery.wasActive) {
+        await announceRecovery(ctx, recovery.targets, selection.selectedModel);
+      }
       return {
         available: true,
         model: selection.selectedModel,
@@ -221,27 +275,25 @@ export const ensureModelAvailable = internalAction({
       };
     }
 
-    // Both models down. Start one poll loop and announce it only on the
-    // transition into the outage (beginPoll is idempotent), so repeated task
-    // requests during the same outage don't spam the thread.
-    const { started } = await ctx.runMutation(
+    // Both models down. Record this thread as a target (idempotently) and start
+    // one poll loop. Notify any newly-affected thread once, regardless of
+    // whether this call is the one that started the loop.
+    const { started, targetAdded } = await ctx.runMutation(
       internal.functions.ai.modelAvailability.beginPoll,
-      args,
+      { ...args, statusesJson },
     );
-    if (started) {
-      await ctx.runMutation(
-        internal.functions.ai.modelAvailability.recordPollResult,
-        { active: true, statusesJson: JSON.stringify(selection.statuses) },
-      );
+    if (targetAdded && args.notifyGroupId) {
       await postNotice(
         ctx,
         { groupId: args.notifyGroupId, channelSlug: args.notifyChannelSlug },
-        "⚠️ Claude is temporarily unavailable — both Opus and Sonnet are unreachable. I'll keep checking every hour and resume automatically once one is back.",
+        OUTAGE_MESSAGE,
       );
+    }
+    if (started) {
       await ctx.scheduler.runAfter(
         CLAUDE_POLL_INTERVAL_MS,
         internal.functions.ai.modelAvailability.pollModelAvailability,
-        args,
+        {},
       );
     }
 
@@ -255,12 +307,13 @@ export const ensureModelAvailable = internalAction({
 
 /**
  * Hourly poll loop. Re-checks the fallback chain; on recovery it announces the
- * model and stops, otherwise it reschedules itself one hour out. Guarded by
- * the poll-state row so a recovered (or cancelled) loop doesn't keep running.
+ * model to every affected thread and stops, otherwise it reschedules itself one
+ * hour out. Reads its notify targets from the poll-state row, so it covers
+ * every thread that tripped the gate during the outage.
  */
 export const pollModelAvailability = internalAction({
-  args: notifyTargetArgs,
-  handler: async (ctx, args): Promise<void> => {
+  args: {},
+  handler: async (ctx): Promise<void> => {
     const poll = await ctx.runQuery(
       internal.functions.ai.modelAvailability.getPoll,
       {},
@@ -272,40 +325,45 @@ export const pollModelAvailability = internalAction({
       // No key means polling can never succeed — stop and let a future
       // ensureModelAvailable restart it once the key is configured.
       await ctx.runMutation(
-        internal.functions.ai.modelAvailability.recordPollResult,
+        internal.functions.ai.modelAvailability.recordTick,
         { active: false },
       );
       return;
     }
 
     const selection = await probeModels(apiKey);
+    const statusesJson = JSON.stringify(selection.statuses);
 
     if (selection.selectedModel) {
-      await ctx.runMutation(
-        internal.functions.ai.modelAvailability.recordPollResult,
-        {
-          active: false,
-          lastAvailableModel: selection.selectedModel,
-          statusesJson: JSON.stringify(selection.statuses),
-        },
+      const recovery = await ctx.runMutation(
+        internal.functions.ai.modelAvailability.resolveRecovery,
+        { lastAvailableModel: selection.selectedModel, statusesJson },
       );
-      await postNotice(
-        ctx,
-        { groupId: args.notifyGroupId, channelSlug: args.notifyChannelSlug },
-        `✅ Claude is back online (using ${selection.selectedModel}). I'll resume from here.`,
-      );
+      if (recovery.wasActive) {
+        await announceRecovery(ctx, recovery.targets, selection.selectedModel);
+      }
       return;
     }
 
     // Still down — record and try again in an hour.
-    await ctx.runMutation(
-      internal.functions.ai.modelAvailability.recordPollResult,
-      { active: true, statusesJson: JSON.stringify(selection.statuses) },
-    );
+    await ctx.runMutation(internal.functions.ai.modelAvailability.recordTick, {
+      active: true,
+      statusesJson,
+    });
     await ctx.scheduler.runAfter(
       CLAUDE_POLL_INTERVAL_MS,
       internal.functions.ai.modelAvailability.pollModelAvailability,
-      args,
+      {},
     );
   },
 });
+
+async function announceRecovery(
+  ctx: ActionCtx,
+  targets: NotifyTarget[],
+  model: string,
+): Promise<void> {
+  for (const target of targets) {
+    await postNotice(ctx, target, recoveryMessage(model));
+  }
+}

--- a/apps/convex/functions/ai/modelAvailability.ts
+++ b/apps/convex/functions/ai/modelAvailability.ts
@@ -1,0 +1,311 @@
+/**
+ * Claude model availability — Convex layer.
+ *
+ * Wraps the pure probe in `lib/ai/claudeAvailability.ts` with the bot's
+ * runtime behavior. Before the Togather Bot dispatches a task to a Claude
+ * model it calls `ensureModelAvailable`, which:
+ *
+ *   1. Probes Claude Opus, then Claude Sonnet (`selectAvailableClaudeModel`).
+ *   2. Returns the first healthy model so the caller can run the task.
+ *   3. If BOTH are down, posts a heads-up into the thread and starts an
+ *      hourly poll (`pollModelAvailability`) that re-checks until a model
+ *      recovers — then announces it's back and stops.
+ *
+ * `checkModelStatus` is the read-only "what's the status right now" tool.
+ *
+ * Availability is decided by Anthropic's Models API; the probe uses
+ * `ANTHROPIC_API_KEY`. Without that key the bot can't reach Anthropic at all,
+ * so the gate fails closed (reports unavailable) rather than polling forever.
+ */
+
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+  type ActionCtx,
+} from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import {
+  CLAUDE_POLL_INTERVAL_MS,
+  selectAvailableClaudeModel,
+  type ModelSelection,
+} from "../../lib/ai/claudeAvailability";
+
+/** Singleton key for the poll-state row. */
+const POLL_KEY = "global";
+
+/** Where to post availability heads-up messages, when a target is known. */
+const notifyTargetArgs = {
+  notifyGroupId: v.optional(v.id("groups")),
+  notifyChannelSlug: v.optional(v.string()),
+};
+
+function getAnthropicApiKey(): string | null {
+  return process.env.ANTHROPIC_API_KEY ?? null;
+}
+
+async function probeModels(apiKey: string): Promise<ModelSelection> {
+  return selectAvailableClaudeModel({ apiKey });
+}
+
+async function postNotice(
+  ctx: ActionCtx,
+  target: { groupId?: Id<"groups">; channelSlug?: string },
+  message: string,
+): Promise<void> {
+  if (!target.groupId) return; // No thread to notify — log-only path.
+  await ctx.runAction(internal.functions.scheduledJobs.sendBotMessage, {
+    groupId: target.groupId,
+    message,
+    targetChannelSlug: target.channelSlug,
+    botType: "claude_availability",
+  });
+}
+
+// ===========================================================================
+// POLL STATE (singleton row)
+// ===========================================================================
+
+export const getPoll = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db
+      .query("claudeModelPolls")
+      .withIndex("by_key", (q) => q.eq("key", POLL_KEY))
+      .unique();
+  },
+});
+
+/**
+ * Start the poll loop if one isn't already running. Idempotent: when a poll is
+ * already `active`, this is a no-op and returns `{ started: false }`, so
+ * repeated task requests during an outage never stack multiple poll chains.
+ */
+export const beginPoll = internalMutation({
+  args: notifyTargetArgs,
+  handler: async (ctx, args): Promise<{ started: boolean }> => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("claudeModelPolls")
+      .withIndex("by_key", (q) => q.eq("key", POLL_KEY))
+      .unique();
+
+    if (existing?.active) return { started: false };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        active: true,
+        notifyGroupId: args.notifyGroupId,
+        notifyChannelSlug: args.notifyChannelSlug,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("claudeModelPolls", {
+        key: POLL_KEY,
+        active: true,
+        lastCheckedAt: now,
+        notifyGroupId: args.notifyGroupId,
+        notifyChannelSlug: args.notifyChannelSlug,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    return { started: true };
+  },
+});
+
+/** Record the latest probe outcome and set whether the loop keeps running. */
+export const recordPollResult = internalMutation({
+  args: {
+    active: v.boolean(),
+    lastAvailableModel: v.optional(v.string()),
+    statusesJson: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("claudeModelPolls")
+      .withIndex("by_key", (q) => q.eq("key", POLL_KEY))
+      .unique();
+
+    const patch = {
+      active: args.active,
+      lastCheckedAt: now,
+      lastAvailableModel: args.lastAvailableModel,
+      lastStatuses: args.statusesJson,
+      updatedAt: now,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+    } else {
+      await ctx.db.insert("claudeModelPolls", {
+        key: POLL_KEY,
+        createdAt: now,
+        ...patch,
+      });
+    }
+  },
+});
+
+// ===========================================================================
+// TOOLS / ACTIONS
+// ===========================================================================
+
+/**
+ * Tool: report the current availability of each Claude model and which one
+ * the bot would use right now. Read-only — never schedules a poll.
+ */
+export const checkModelStatus = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const apiKey = getAnthropicApiKey();
+    if (!apiKey) {
+      return {
+        configured: false as const,
+        selectedModel: null,
+        statuses: [],
+      };
+    }
+    const selection = await probeModels(apiKey);
+    return { configured: true as const, ...selection };
+  },
+});
+
+/**
+ * Gate: confirm a Claude model is reachable before executing a task.
+ *
+ * Returns `{ available: true, model }` with the first healthy model, or
+ * `{ available: false }` after notifying the thread and starting the hourly
+ * poll. Callers should treat `available: false` as "don't dispatch yet".
+ */
+export const ensureModelAvailable = internalAction({
+  args: notifyTargetArgs,
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    | { available: true; model: string; statuses: ModelSelection["statuses"] }
+    | { available: false; reason: string; statuses: ModelSelection["statuses"] }
+  > => {
+    const apiKey = getAnthropicApiKey();
+    if (!apiKey) {
+      console.warn(
+        "[claude-availability] ANTHROPIC_API_KEY not set — cannot reach Claude; reporting unavailable.",
+      );
+      return {
+        available: false,
+        reason: "ANTHROPIC_API_KEY not configured",
+        statuses: [],
+      };
+    }
+
+    const selection = await probeModels(apiKey);
+
+    if (selection.selectedModel) {
+      // A healthy model means any prior outage is over — clear an active poll.
+      await ctx.runMutation(
+        internal.functions.ai.modelAvailability.recordPollResult,
+        {
+          active: false,
+          lastAvailableModel: selection.selectedModel,
+          statusesJson: JSON.stringify(selection.statuses),
+        },
+      );
+      return {
+        available: true,
+        model: selection.selectedModel,
+        statuses: selection.statuses,
+      };
+    }
+
+    // Both models down. Start one poll loop and announce it only on the
+    // transition into the outage (beginPoll is idempotent), so repeated task
+    // requests during the same outage don't spam the thread.
+    const { started } = await ctx.runMutation(
+      internal.functions.ai.modelAvailability.beginPoll,
+      args,
+    );
+    if (started) {
+      await ctx.runMutation(
+        internal.functions.ai.modelAvailability.recordPollResult,
+        { active: true, statusesJson: JSON.stringify(selection.statuses) },
+      );
+      await postNotice(
+        ctx,
+        { groupId: args.notifyGroupId, channelSlug: args.notifyChannelSlug },
+        "⚠️ Claude is temporarily unavailable — both Opus and Sonnet are unreachable. I'll keep checking every hour and resume automatically once one is back.",
+      );
+      await ctx.scheduler.runAfter(
+        CLAUDE_POLL_INTERVAL_MS,
+        internal.functions.ai.modelAvailability.pollModelAvailability,
+        args,
+      );
+    }
+
+    return {
+      available: false,
+      reason: "no Claude model available",
+      statuses: selection.statuses,
+    };
+  },
+});
+
+/**
+ * Hourly poll loop. Re-checks the fallback chain; on recovery it announces the
+ * model and stops, otherwise it reschedules itself one hour out. Guarded by
+ * the poll-state row so a recovered (or cancelled) loop doesn't keep running.
+ */
+export const pollModelAvailability = internalAction({
+  args: notifyTargetArgs,
+  handler: async (ctx, args): Promise<void> => {
+    const poll = await ctx.runQuery(
+      internal.functions.ai.modelAvailability.getPoll,
+      {},
+    );
+    if (!poll?.active) return; // Recovered or cancelled out-of-band; stop.
+
+    const apiKey = getAnthropicApiKey();
+    if (!apiKey) {
+      // No key means polling can never succeed — stop and let a future
+      // ensureModelAvailable restart it once the key is configured.
+      await ctx.runMutation(
+        internal.functions.ai.modelAvailability.recordPollResult,
+        { active: false },
+      );
+      return;
+    }
+
+    const selection = await probeModels(apiKey);
+
+    if (selection.selectedModel) {
+      await ctx.runMutation(
+        internal.functions.ai.modelAvailability.recordPollResult,
+        {
+          active: false,
+          lastAvailableModel: selection.selectedModel,
+          statusesJson: JSON.stringify(selection.statuses),
+        },
+      );
+      await postNotice(
+        ctx,
+        { groupId: args.notifyGroupId, channelSlug: args.notifyChannelSlug },
+        `✅ Claude is back online (using ${selection.selectedModel}). I'll resume from here.`,
+      );
+      return;
+    }
+
+    // Still down — record and try again in an hour.
+    await ctx.runMutation(
+      internal.functions.ai.modelAvailability.recordPollResult,
+      { active: true, statusesJson: JSON.stringify(selection.statuses) },
+    );
+    await ctx.scheduler.runAfter(
+      CLAUDE_POLL_INTERVAL_MS,
+      internal.functions.ai.modelAvailability.pollModelAvailability,
+      args,
+    );
+  },
+});

--- a/apps/convex/lib/ai/claudeAvailability.ts
+++ b/apps/convex/lib/ai/claudeAvailability.ts
@@ -1,0 +1,145 @@
+/**
+ * Claude model availability + fallback.
+ *
+ * Before the Togather Bot hands a task to a Claude model, it should confirm a
+ * model is actually reachable. This module probes Anthropic's Models API
+ * (`GET /v1/models/{id}`) and walks a preference chain:
+ *
+ *   1. Claude Opus   (`claude-opus-4-8`)   — primary
+ *   2. Claude Sonnet (`claude-sonnet-4-6`) — fallback
+ *
+ * It returns the first model that responds healthy, or `null` when both are
+ * down. The Convex layer (`functions/ai/modelAvailability.ts`) wraps this to
+ * notify the thread and schedule an hourly poll when nothing is available.
+ *
+ * Everything here is pure and `fetch`-injectable so it can be unit-tested
+ * without network access (see `__tests__/ai/claudeAvailability.test.ts`).
+ */
+
+/** Primary model the bot prefers for executing tasks. */
+export const CLAUDE_PRIMARY_MODEL = "claude-opus-4-8";
+
+/** Fallback used when the primary model is unavailable. */
+export const CLAUDE_FALLBACK_MODEL = "claude-sonnet-4-6";
+
+/** Preference order: try Opus first, then Sonnet. */
+export const CLAUDE_FALLBACK_CHAIN = [
+  CLAUDE_PRIMARY_MODEL,
+  CLAUDE_FALLBACK_MODEL,
+] as const;
+
+/** Poll cadence when no Claude model is reachable: once per hour. */
+export const CLAUDE_POLL_INTERVAL_MS = 60 * 60 * 1000;
+
+const ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models";
+const ANTHROPIC_VERSION = "2023-06-01";
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export interface ClaudeModelStatus {
+  model: string;
+  available: boolean;
+  /** HTTP status from the Models API probe, when a response was received. */
+  status?: number;
+  /** Human-readable reason, only set when unavailable. */
+  reason?: string;
+}
+
+/**
+ * Interpret a Models API HTTP status into availability.
+ *
+ * A `200` means the model is served and the key can reach it. Everything else
+ * — `404` (retired/unknown id), `401`/`403` (no access), `429` (rate limited),
+ * `5xx`/`529` (overloaded/outage) — means the bot should not dispatch to it.
+ */
+export function isModelStatusAvailable(status: number): boolean {
+  return status === 200;
+}
+
+/** Short explanation for an unavailable status, for logs and thread messages. */
+export function describeUnavailableStatus(status: number): string {
+  if (status === 404) return "model not found";
+  if (status === 401 || status === 403) return "not authorized for this model";
+  if (status === 429) return "rate limited";
+  if (status === 529) return "overloaded";
+  if (status >= 500) return `service error (${status})`;
+  return `unexpected status ${status}`;
+}
+
+export interface ProbeOptions {
+  /** Anthropic API key sent as the `x-api-key` header. */
+  apiKey: string;
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout; defaults to 15s. */
+  timeoutMs?: number;
+}
+
+/**
+ * Probe a single Claude model. Never throws — a network failure or timeout
+ * resolves to `{ available: false }` so callers can fall back cleanly.
+ */
+export async function checkClaudeModelAvailability(
+  model: string,
+  opts: ProbeOptions,
+): Promise<ClaudeModelStatus> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+  try {
+    const res = await fetchImpl(`${ANTHROPIC_MODELS_URL}/${model}`, {
+      method: "GET",
+      headers: {
+        "x-api-key": opts.apiKey,
+        "anthropic-version": ANTHROPIC_VERSION,
+      },
+      signal: controller.signal,
+    });
+    if (isModelStatusAvailable(res.status)) {
+      return { model, available: true, status: res.status };
+    }
+    return {
+      model,
+      available: false,
+      status: res.status,
+      reason: describeUnavailableStatus(res.status),
+    };
+  } catch (err) {
+    const reason =
+      err instanceof Error && err.name === "AbortError"
+        ? "request timed out"
+        : "request failed";
+    return { model, available: false, reason };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export interface ModelSelection {
+  /** First available model in preference order, or `null` if all are down. */
+  selectedModel: string | null;
+  /** Per-model probe results, in the order they were checked. */
+  statuses: ClaudeModelStatus[];
+}
+
+/**
+ * Walk the Opus → Sonnet chain and return the first available model.
+ * Short-circuits: stops probing as soon as a healthy model is found, so a
+ * healthy primary never triggers a fallback probe.
+ */
+export async function selectAvailableClaudeModel(
+  opts: ProbeOptions & { chain?: readonly string[] },
+): Promise<ModelSelection> {
+  const chain = opts.chain ?? CLAUDE_FALLBACK_CHAIN;
+  const statuses: ClaudeModelStatus[] = [];
+  for (const model of chain) {
+    const status = await checkClaudeModelAvailability(model, opts);
+    statuses.push(status);
+    if (status.available) {
+      return { selectedModel: model, statuses };
+    }
+  }
+  return { selectedModel: null, statuses };
+}

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2814,4 +2814,25 @@ export default defineSchema({
     type: v.string(),
     sentAt: v.number(),
   }).index("by_prayer_type", ["prayerId", "type"]),
+
+  // =============================================================================
+  // CLAUDE MODEL AVAILABILITY POLL
+  // =============================================================================
+  // Singleton-ish row (keyed by the constant "global") tracking the bot's
+  // hourly Claude-model availability poll. `active: true` means a self-
+  // rescheduling poll loop is running because both Opus and Sonnet were down;
+  // it flips to false once a model recovers. The row also doubles as a
+  // last-known status cache for the "check model status" tool. See
+  // `functions/ai/modelAvailability.ts`.
+  claudeModelPolls: defineTable({
+    key: v.string(), // singleton key, always "global"
+    active: v.boolean(),
+    lastCheckedAt: v.number(), // Unix ms
+    lastAvailableModel: v.optional(v.string()),
+    lastStatuses: v.optional(v.string()), // JSON snapshot of ClaudeModelStatus[]
+    notifyGroupId: v.optional(v.id("groups")),
+    notifyChannelSlug: v.optional(v.string()),
+    createdAt: v.number(), // Unix ms
+    updatedAt: v.number(), // Unix ms
+  }).index("by_key", ["key"]),
 });

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2821,8 +2821,10 @@ export default defineSchema({
   // Singleton-ish row (keyed by the constant "global") tracking the bot's
   // hourly Claude-model availability poll. `active: true` means a self-
   // rescheduling poll loop is running because both Opus and Sonnet were down;
-  // it flips to false once a model recovers. The row also doubles as a
-  // last-known status cache for the "check model status" tool. See
+  // it flips to false once a model recovers. `notifyTargets` is the deduped set
+  // of threads that tripped the gate during the current outage — each gets one
+  // heads-up and one back-online notice. The row also doubles as a last-known
+  // status cache for the "check model status" tool. See
   // `functions/ai/modelAvailability.ts`.
   claudeModelPolls: defineTable({
     key: v.string(), // singleton key, always "global"
@@ -2830,8 +2832,15 @@ export default defineSchema({
     lastCheckedAt: v.number(), // Unix ms
     lastAvailableModel: v.optional(v.string()),
     lastStatuses: v.optional(v.string()), // JSON snapshot of ClaudeModelStatus[]
-    notifyGroupId: v.optional(v.id("groups")),
-    notifyChannelSlug: v.optional(v.string()),
+    // Threads to notify for this outage (deduped by groupId + channelSlug).
+    notifyTargets: v.optional(
+      v.array(
+        v.object({
+          groupId: v.id("groups"),
+          channelSlug: v.optional(v.string()),
+        }),
+      ),
+    ),
     createdAt: v.number(), // Unix ms
     updatedAt: v.number(), // Unix ms
   }).index("by_key", ["key"]),

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -119,6 +119,12 @@ pnpm dev
 | `OPENAI_SECRET_KEY` | OpenAI API key (already used by poster keywording). The prayer moderator calls `gpt-4o-mini` in JSON mode. | Moderator fails open — every prayer is accepted without LLM screening. |
 | `OLLAMA_API_KEY` | **Escape hatch only.** Used if you flip `PROVIDER` to `"ollama"` in `apps/convex/lib/moderation/prayer.ts` (e.g. if OpenAI spend gets too high). See https://ollama.com/pricing. | Same fail-open behavior when unset. |
 
+### Claude model availability (Togather Bot)
+
+| Secret | Description | Degradation |
+|--------|-------------|-------------|
+| `ANTHROPIC_API_KEY` | Standard Anthropic API key (`sk-ant-...`). The bot probes Anthropic's Models API (`GET /v1/models/{id}`) with this key to confirm a Claude model is reachable before dispatching a task, preferring Claude Opus and falling back to Claude Sonnet. See `apps/convex/functions/ai/`. | The availability gate fails closed (reports unavailable) instead of polling forever, so tasks aren't dispatched into a void. |
+
 ### Development Settings
 
 | Secret | Description |


### PR DESCRIPTION
## What & why

Before the Togather Bot dispatches a task to a Claude model, it should confirm a model is actually reachable — and degrade gracefully when none is. Today there's no such check. This adds a model-availability gate with an **Opus → Sonnet** fallback, a thread heads-up on outage, and an hourly poll that resumes automatically once a model recovers.

## How it works

```
task requested
   └─ ensureModelAvailable(notifyTarget?)
        ├─ Opus healthy?              → { available: true, model: "claude-opus-4-8" }
        ├─ Opus down, Sonnet healthy? → { available: true, model: "claude-sonnet-4-6" }
        └─ both down:
             • post a one-time heads-up into the thread
             • start the hourly poll (idempotent — never stacked)
             • return { available: false }
                  └─ pollModelAvailability (hourly, self-rescheduling)
                       ├─ a model recovered → announce "back online", stop
                       └─ still down        → reschedule one hour out
```

Availability is decided by Anthropic's Models API (`GET /v1/models/{id}` → `200` = healthy; `404`/`401`/`403`/`429`/`5xx`/`529` = don't dispatch).

## Changes

- **`lib/ai/claudeAvailability.ts`** — pure, `fetch`-injectable core: probes a model, walks the fallback chain, short-circuits on the first healthy model. Never throws (network/timeout → unavailable).
- **`functions/ai/modelAvailability.ts`** — Convex layer:
  - `ensureModelAvailable` — the gate (notify + poll on full outage).
  - `pollModelAvailability` — hourly self-rescheduling loop, guarded so loops never stack.
  - `checkModelStatus` — read-only "what's the status right now" tool.
- **`schema.ts`** — `claudeModelPolls` singleton row tracks the active poll + last status.
- **Docs** — `ANTHROPIC_API_KEY` in `.env.example` + `docs/secrets.md`; `functions/ai/ARCHITECTURE.md`.

Fails **closed** when `ANTHROPIC_API_KEY` is unset (reports unavailable rather than polling into a void).

## Tests

- 12 new unit tests for the core (`__tests__/ai/claudeAvailability.test.ts`): status interpretation, single-model probe, fallback selection (Opus up → no Sonnet probe; Opus down → Sonnet; both down → null), header assertions.
- Full Convex suite green (1602 tests); `npx convex typecheck` passes.

## Notes for reviewers

- The `_generated/api.d.ts` change is the codegen entry for the new module (added by hand since codegen needs deployment auth; `dataModel` derives the new table from `schema.ts` automatically).
- These actions are the building-block "tools"; a Claude task path should call `ensureModelAvailable` first and pass its originating `notifyGroupId` so outage/recovery notices land in the right thread (see `ARCHITECTURE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoRjFHCYWoGDnE8PpxQEgU)_