### PR TITLE
feat(dev-assistant): super-admin-managed maintainers

### DIFF
--- a/apps/convex/__tests__/devAssistant-maintainers.test.ts
+++ b/apps/convex/__tests__/devAssistant-maintainers.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Dev-Assistant Maintainers — access + role management tests.
+ *
+ * Covers the "maintainers managed by super admins" feature:
+ * - the trigger gate (canUseDevAssistant / getUserAccess) admits superusers,
+ *   staff, and dev maintainers but no one else;
+ * - only super admins (superuser/staff) can grant/revoke/list maintainers;
+ * - grant/revoke mutate `users.platformRoles` idempotently and without
+ *   clobbering other platform roles.
+ *
+ * Auth is mocked (mirrors security-pii-exposure.test.ts): the token IS the
+ * caller's user id, so each test "logs in" by passing a user id as the token.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi } from "vitest";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import {
+  canUseDevAssistant,
+  isDevAssistantSuperAdmin,
+  DEV_MAINTAINER_ROLE,
+} from "../functions/devAssistant/maintainers";
+import type { Doc } from "../_generated/dataModel";
+
+const modules = import.meta.glob([
+  "../**/*.*s",
+  "!../__mocks__/**",
+  "!../__tests__/**",
+]);
+
+// Token == userId in these tests. requireAuthUser resolves the doc from the db.
+vi.mock("../lib/auth", () => ({
+  requireAuth: vi.fn(async (_ctx: any, token: string) => {
+    if (!token) throw new Error("Not authenticated");
+    return token;
+  }),
+  requireAuthUser: vi.fn(async (ctx: any, token: string) => {
+    if (!token) throw new Error("Not authenticated");
+    const user = await ctx.db.get(token);
+    if (!user) throw new Error("User not found");
+    return user;
+  }),
+}));
+
+function user(overrides: Partial<Doc<"users">>): Partial<Doc<"users">> {
+  return { isActive: true, ...overrides };
+}
+
+// ============================================================================
+// Pure access helpers — the authorization decision
+// ============================================================================
+
+describe("canUseDevAssistant", () => {
+  test("admits superusers, staff, and dev maintainers", () => {
+    expect(canUseDevAssistant({ isSuperuser: true } as Doc<"users">)).toBe(true);
+    expect(canUseDevAssistant({ isStaff: true } as Doc<"users">)).toBe(true);
+    expect(
+      canUseDevAssistant({
+        platformRoles: [DEV_MAINTAINER_ROLE],
+      } as Doc<"users">),
+    ).toBe(true);
+  });
+
+  test("rejects everyone else", () => {
+    expect(canUseDevAssistant(null)).toBe(false);
+    expect(canUseDevAssistant(undefined)).toBe(false);
+    expect(canUseDevAssistant({} as Doc<"users">)).toBe(false);
+    expect(
+      canUseDevAssistant({ platformRoles: ["poster_admin"] } as Doc<"users">),
+    ).toBe(false);
+  });
+});
+
+describe("isDevAssistantSuperAdmin", () => {
+  test("only superusers and staff can manage maintainers", () => {
+    expect(isDevAssistantSuperAdmin({ isSuperuser: true } as Doc<"users">)).toBe(
+      true,
+    );
+    expect(isDevAssistantSuperAdmin({ isStaff: true } as Doc<"users">)).toBe(
+      true,
+    );
+    // A maintainer is NOT a super admin — they can't manage the list.
+    expect(
+      isDevAssistantSuperAdmin({
+        platformRoles: [DEV_MAINTAINER_ROLE],
+      } as Doc<"users">),
+    ).toBe(false);
+    expect(isDevAssistantSuperAdmin(null)).toBe(false);
+  });
+});
+
+// ============================================================================
+// Trigger gate — getUserAccess (used by processThreadMention)
+// ============================================================================
+
+describe("getUserAccess (trigger gate)", () => {
+  test("reports isMaintainer for delegated maintainers", async () => {
+    const t = convexTest(schema, modules);
+    const maintainerId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: [DEV_MAINTAINER_ROLE] })),
+    );
+    const access = await t.query(
+      internal.functions.devAssistant.bugs.getUserAccess,
+      { userId: maintainerId },
+    );
+    expect(access).toEqual({
+      isStaff: false,
+      isSuperuser: false,
+      isMaintainer: true,
+    });
+  });
+
+  test("a plain user is admitted by none of the gates", async () => {
+    const t = convexTest(schema, modules);
+    const plainId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Plain" })),
+    );
+    const access = await t.query(
+      internal.functions.devAssistant.bugs.getUserAccess,
+      { userId: plainId },
+    );
+    expect(access.isStaff || access.isSuperuser || access.isMaintainer).toBe(
+      false,
+    );
+  });
+});
+
+// ============================================================================
+// Management mutations — super admin only
+// ============================================================================
+
+describe("maintainer management", () => {
+  test("grant adds the role; revoke removes it", async () => {
+    const t = convexTest(schema, modules);
+    const superId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ isSuperuser: true })),
+    );
+    const targetId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Target" })),
+    );
+
+    await t.mutation(api.functions.devAssistant.maintainers.grantMaintainer, {
+      token: superId,
+      userId: targetId,
+    });
+    let target = await t.run((ctx) => ctx.db.get(targetId));
+    expect(target?.platformRoles).toContain(DEV_MAINTAINER_ROLE);
+
+    await t.mutation(api.functions.devAssistant.maintainers.revokeMaintainer, {
+      token: superId,
+      userId: targetId,
+    });
+    target = await t.run((ctx) => ctx.db.get(targetId));
+    expect(target?.platformRoles ?? []).not.toContain(DEV_MAINTAINER_ROLE);
+  });
+
+  test("grant is idempotent and preserves other platform roles", async () => {
+    const t = convexTest(schema, modules);
+    const superId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ isStaff: true })),
+    );
+    const targetId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: ["poster_admin"] })),
+    );
+
+    await t.mutation(api.functions.devAssistant.maintainers.grantMaintainer, {
+      token: superId,
+      userId: targetId,
+    });
+    await t.mutation(api.functions.devAssistant.maintainers.grantMaintainer, {
+      token: superId,
+      userId: targetId,
+    });
+
+    const target = await t.run((ctx) => ctx.db.get(targetId));
+    expect(target?.platformRoles).toEqual(["poster_admin", DEV_MAINTAINER_ROLE]);
+  });
+
+  test("revoke preserves other platform roles", async () => {
+    const t = convexTest(schema, modules);
+    const superId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ isSuperuser: true })),
+    );
+    const targetId = await t.run((ctx) =>
+      ctx.db.insert(
+        "users",
+        user({ platformRoles: ["poster_admin", DEV_MAINTAINER_ROLE] }),
+      ),
+    );
+
+    await t.mutation(api.functions.devAssistant.maintainers.revokeMaintainer, {
+      token: superId,
+      userId: targetId,
+    });
+
+    const target = await t.run((ctx) => ctx.db.get(targetId));
+    expect(target?.platformRoles).toEqual(["poster_admin"]);
+  });
+
+  test("non-superusers cannot grant", async () => {
+    const t = convexTest(schema, modules);
+    const maintainerId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: [DEV_MAINTAINER_ROLE] })),
+    );
+    const targetId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Target" })),
+    );
+
+    await expect(
+      t.mutation(api.functions.devAssistant.maintainers.grantMaintainer, {
+        token: maintainerId,
+        userId: targetId,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("non-superusers cannot list maintainers", async () => {
+    const t = convexTest(schema, modules);
+    const plainId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Plain" })),
+    );
+    await expect(
+      t.query(api.functions.devAssistant.maintainers.listMaintainers, {
+        token: plainId,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("listMaintainers returns only granted users", async () => {
+    const t = convexTest(schema, modules);
+    const superId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ isSuperuser: true })),
+    );
+    const maintainerId = await t.run((ctx) =>
+      ctx.db.insert(
+        "users",
+        user({ firstName: "Maint", platformRoles: [DEV_MAINTAINER_ROLE] }),
+      ),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Other" })),
+    );
+
+    const list = await t.query(
+      api.functions.devAssistant.maintainers.listMaintainers,
+      { token: superId },
+    );
+    expect(list.map((u) => u._id)).toEqual([maintainerId]);
+  });
+});
+
+// ============================================================================
+// myAccess — drives the client gating
+// ============================================================================
+
+describe("myAccess", () => {
+  test("reflects super admin, maintainer, and assistant access", async () => {
+    const t = convexTest(schema, modules);
+    const superId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ isSuperuser: true })),
+    );
+    const maintainerId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: [DEV_MAINTAINER_ROLE] })),
+    );
+    const plainId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Plain" })),
+    );
+
+    expect(
+      await t.query(api.functions.devAssistant.maintainers.myAccess, {
+        token: superId,
+      }),
+    ).toEqual({ isMaintainer: false, isSuperAdmin: true, canUseAssistant: true });
+
+    expect(
+      await t.query(api.functions.devAssistant.maintainers.myAccess, {
+        token: maintainerId,
+      }),
+    ).toEqual({ isMaintainer: true, isSuperAdmin: false, canUseAssistant: true });
+
+    expect(
+      await t.query(api.functions.devAssistant.maintainers.myAccess, {
+        token: plainId,
+      }),
+    ).toEqual({
+      isMaintainer: false,
+      isSuperAdmin: false,
+      canUseAssistant: false,
+    });
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -48,6 +48,7 @@ import type * as functions_devAssistant_actions from "../functions/devAssistant/
 import type * as functions_devAssistant_agent from "../functions/devAssistant/agent.js";
 import type * as functions_devAssistant_bugs from "../functions/devAssistant/bugs.js";
 import type * as functions_devAssistant_index from "../functions/devAssistant/index.js";
+import type * as functions_devAssistant_maintainers from "../functions/devAssistant/maintainers.js";
 import type * as functions_devAssistant_prompts from "../functions/devAssistant/prompts.js";
 import type * as functions_devAssistant_tools from "../functions/devAssistant/tools.js";
 import type * as functions_ee_billing from "../functions/ee/billing.js";
@@ -265,6 +266,7 @@ declare const fullApi: ApiFromModules<{
   "functions/devAssistant/agent": typeof functions_devAssistant_agent;
   "functions/devAssistant/bugs": typeof functions_devAssistant_bugs;
   "functions/devAssistant/index": typeof functions_devAssistant_index;
+  "functions/devAssistant/maintainers": typeof functions_devAssistant_maintainers;
   "functions/devAssistant/prompts": typeof functions_devAssistant_prompts;
   "functions/devAssistant/tools": typeof functions_devAssistant_tools;
   "functions/ee/billing": typeof functions_ee_billing;

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -35,12 +35,13 @@ export const processThreadMention = internalAction({
     );
     if (!enabled) return;
 
-    // Staff gate — the bot only ever works for Togather staff/superusers.
+    // Access gate — the bot works for Togather staff/superusers and for
+    // delegated dev maintainers (granted via /(user)/admin/maintainers).
     const access = await ctx.runQuery(
       internal.functions.devAssistant.bugs.getUserAccess,
       { userId: args.originatorUserId },
     );
-    if (!access.isStaff && !access.isSuperuser) return;
+    if (!access.isStaff && !access.isSuperuser && !access.isMaintainer) return;
 
     // Load the thread window + screenshots + any existing bug.
     const threadCtx = await ctx.runQuery(

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -21,6 +21,7 @@ import { internal } from "../../_generated/api";
 import { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getMediaUrl } from "../../lib/utils";
+import { DEV_MAINTAINER_ROLE } from "./maintainers";
 
 // ============================================================================
 // Status machine
@@ -384,14 +385,23 @@ export const applyCallback = internalMutation({
 // Thread context for the agent
 // ============================================================================
 
-/** Lightweight staff/superuser check used by the (action-side) gate. */
+/**
+ * Lightweight access check used by the (action-side) trigger gate. Superusers
+ * and staff have implicit access; delegated `dev_maintainer`s can summon the
+ * assistant too (but not the superuser-only review/merge ops — see
+ * maintainers.ts).
+ */
 export const getUserAccess = internalQuery({
   args: { userId: v.id("users") },
-  handler: async (ctx, args): Promise<{ isStaff: boolean; isSuperuser: boolean }> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ isStaff: boolean; isSuperuser: boolean; isMaintainer: boolean }> => {
     const user = await ctx.db.get(args.userId);
     return {
       isStaff: user?.isStaff ?? false,
       isSuperuser: user?.isSuperuser ?? false,
+      isMaintainer: user?.platformRoles?.includes(DEV_MAINTAINER_ROLE) ?? false,
     };
   },
 });

--- a/apps/convex/functions/devAssistant/index.ts
+++ b/apps/convex/functions/devAssistant/index.ts
@@ -6,9 +6,12 @@
  * once marked READY_FOR_IMPL hands it to a Claude Code Routine (outbound POST)
  * which writes code, opens a PR, and reports back via a signed HTTP callback.
  *
- * Gated behind the "dev-assistant-bot" feature flag; staff/superuser only.
+ * Gated behind the "dev-assistant-bot" feature flag. Triggerable by Togather
+ * staff/superusers and by delegated dev maintainers (see maintainers.ts);
+ * reviewing/merging stays superuser-only.
  *
- * - bugs.ts     — devBugs DB ops + token-authed review-screen queries
+ * - bugs.ts        — devBugs DB ops + token-authed review-screen queries
+ * - maintainers.ts — dev_maintainer role grants + trigger-access helpers
  * - agent.ts    — OpenAI tool-use loop (gpt-4o, vision for screenshots)
  * - tools.ts    — tool definitions + dispatcher
  * - prompts.ts  — brief-synthesis system prompt

--- a/apps/convex/functions/devAssistant/maintainers.ts
+++ b/apps/convex/functions/devAssistant/maintainers.ts
@@ -1,0 +1,168 @@
+/**
+ * Dev-Assistant Maintainers — superuser-managed delegate access.
+ *
+ * A "dev maintainer" is a user granted the `dev_maintainer` platform role so
+ * they can summon the @Togather dev-assistant (mention it in a thread to turn a
+ * discussion into a bug brief) WITHOUT being a Togather superuser/staff.
+ *
+ * Maintainers get the trigger capability ONLY — they cannot review, reject,
+ * retry, or merge bugs (those stay superuser-only, see bugs.ts `requireSuperuser`).
+ * That's the "can call the assistant, but without full super admin privileges"
+ * split the feature asks for.
+ *
+ * This mirrors the `poster_admin` platform-role model in functions/posters.ts:
+ * the role lives in `users.platformRoles`, isSuperuser/isStaff implicitly bypass
+ * the role check, and only super admins can grant/revoke it (via the
+ * `/(user)/admin/maintainers` screen).
+ */
+
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "../../_generated/server";
+import type { QueryCtx, MutationCtx } from "../../_generated/server";
+import type { Doc } from "../../_generated/dataModel";
+import { requireAuth, requireAuthUser } from "../../lib/auth";
+
+export const DEV_MAINTAINER_ROLE = "dev_maintainer" as const;
+
+// ============================================================================
+// Access helpers
+// ============================================================================
+
+/**
+ * True if the user may summon the dev-assistant — Togather superuser/staff
+ * (implicit) or a delegated dev maintainer. This is the single source of truth
+ * for the trigger gate; bugs.getUserAccess derives `isMaintainer` from the same
+ * role constant.
+ */
+export function canUseDevAssistant(
+  user: Doc<"users"> | null | undefined,
+): boolean {
+  if (!user) return false;
+  if (user.isSuperuser === true || user.isStaff === true) return true;
+  return user.platformRoles?.includes(DEV_MAINTAINER_ROLE) ?? false;
+}
+
+/** True if the user can manage (grant/revoke) the maintainer list. Superuser/staff only. */
+export function isDevAssistantSuperAdmin(
+  user: Doc<"users"> | null | undefined,
+): boolean {
+  return user?.isSuperuser === true || user?.isStaff === true;
+}
+
+async function requireSuperAdmin(
+  ctx: QueryCtx | MutationCtx,
+  token: string,
+): Promise<Doc<"users">> {
+  const user = await requireAuthUser(ctx, token);
+  if (!isDevAssistantSuperAdmin(user)) {
+    throw new ConvexError("Not authorized: superuser required");
+  }
+  return user;
+}
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+/**
+ * Current user's dev-assistant permissions. Used by the client to decide
+ * whether to render the maintainers admin screen and the management controls.
+ */
+export const myAccess = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const user = await ctx.db.get(userId);
+    return {
+      isMaintainer: user?.platformRoles?.includes(DEV_MAINTAINER_ROLE) ?? false,
+      isSuperAdmin: isDevAssistantSuperAdmin(user),
+      canUseAssistant: canUseDevAssistant(user),
+    };
+  },
+});
+
+/**
+ * List of users currently holding the maintainer role. Superuser-only (drives
+ * the "Current maintainers" list on the admin screen).
+ */
+export const listMaintainers = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    await requireSuperAdmin(ctx, args.token);
+    // No index on platformRoles array membership — a scan is acceptable given
+    // this list is small and the page is operator-only (mirrors listPosterAdmins).
+    const users = await ctx.db.query("users").collect();
+    return users
+      .filter((u) => u.platformRoles?.includes(DEV_MAINTAINER_ROLE))
+      .map((u) => ({
+        _id: u._id,
+        firstName: u.firstName ?? null,
+        lastName: u.lastName ?? null,
+        email: u.email ?? null,
+        phone: u.phone ?? null,
+        profilePhoto: u.profilePhoto ?? null,
+        isSuperuser: u.isSuperuser === true || u.isStaff === true,
+      }));
+  },
+});
+
+/**
+ * Superuser-only user search for the "Add maintainer" picker. Matches against
+ * the denormalized users.searchText index.
+ */
+export const searchUsersForGrant = query({
+  args: { token: v.string(), query: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    await requireSuperAdmin(ctx, args.token);
+    const limit = Math.min(args.limit ?? 10, 50);
+    const trimmed = args.query.trim();
+    if (trimmed.length < 2) return [];
+    const users = await ctx.db
+      .query("users")
+      .withSearchIndex("search_users", (q) => q.search("searchText", trimmed))
+      .take(limit);
+    return users.map((u) => ({
+      _id: u._id,
+      firstName: u.firstName ?? null,
+      lastName: u.lastName ?? null,
+      email: u.email ?? null,
+      phone: u.phone ?? null,
+      profilePhoto: u.profilePhoto ?? null,
+      // Superusers/staff already have implicit access — surface that so the
+      // picker can disable "Add" rather than grant a redundant role.
+      alreadyMaintainer: canUseDevAssistant(u),
+    }));
+  },
+});
+
+// ============================================================================
+// Mutations — role grants (superuser-only)
+// ============================================================================
+
+export const grantMaintainer = mutation({
+  args: { token: v.string(), userId: v.id("users") },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    await requireSuperAdmin(ctx, args.token);
+    const target = await ctx.db.get(args.userId);
+    if (!target) throw new ConvexError("User not found");
+    const current = target.platformRoles ?? [];
+    if (current.includes(DEV_MAINTAINER_ROLE)) return { ok: true };
+    await ctx.db.patch(args.userId, {
+      platformRoles: [...current, DEV_MAINTAINER_ROLE],
+    });
+    return { ok: true };
+  },
+});
+
+export const revokeMaintainer = mutation({
+  args: { token: v.string(), userId: v.id("users") },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    await requireSuperAdmin(ctx, args.token);
+    const target = await ctx.db.get(args.userId);
+    if (!target) throw new ConvexError("User not found");
+    const current = target.platformRoles ?? [];
+    const next = current.filter((r) => r !== DEV_MAINTAINER_ROLE);
+    await ctx.db.patch(args.userId, { platformRoles: next });
+    return { ok: true };
+  },
+});

--- a/apps/mobile/app/(user)/admin/maintainers/index.tsx
+++ b/apps/mobile/app/(user)/admin/maintainers/index.tsx
@@ -1,0 +1,17 @@
+import { Stack } from "expo-router";
+import { MaintainersContent } from "@features/admin";
+
+export default function MaintainersRoute() {
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: "Maintainers",
+          headerBackTitle: "Back",
+        }}
+      />
+      <MaintainersContent />
+    </>
+  );
+}

--- a/apps/mobile/features/admin/components/AdminDashboardScreen.tsx
+++ b/apps/mobile/features/admin/components/AdminDashboardScreen.tsx
@@ -104,6 +104,13 @@ export function AdminDashboardScreen() {
             <Text style={[styles.actionTitle, { color: colors.text }]}>Feature Flags</Text>
             <Text style={[styles.actionSubtext, { color: colors.textSecondary }]}>Toggle staged rollouts</Text>
           </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.actionCard, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
+            onPress={() => router.push("/(user)/admin/maintainers" as any)}
+          >
+            <Text style={[styles.actionTitle, { color: colors.text }]}>Maintainers</Text>
+            <Text style={[styles.actionSubtext, { color: colors.textSecondary }]}>Manage dev-assistant access</Text>
+          </TouchableOpacity>
           <View style={[styles.actionCard, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
             <Text style={[styles.actionTitle, { color: colors.text }]}>Groups</Text>
             <Text style={[styles.actionSubtext, { color: colors.textSecondary }]}>Manage small groups</Text>

--- a/apps/mobile/features/admin/components/MaintainersContent.tsx
+++ b/apps/mobile/features/admin/components/MaintainersContent.tsx
@@ -1,0 +1,429 @@
+/**
+ * MaintainersContent
+ *
+ * Superuser-only screen for managing dev maintainers — users granted the
+ * `dev_maintainer` platform role so they can summon the @Togather dev-assistant
+ * (mention it in a thread to open a bug) without being a Togather superuser/staff.
+ *
+ * Maintainers get the trigger capability ONLY; reviewing, rejecting, and merging
+ * bugs stay superuser-only. The route is gated on the backend `myAccess.isSuperAdmin`
+ * (server also enforces every mutation); non-superusers see a permission-denied state.
+ *
+ * Mirrors the poster-admin access UI (PosterAccessModal) but as a full screen,
+ * since maintainer management is its own admin destination (/admin/maintainers).
+ */
+import React, { useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+  Platform,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import {
+  useQuery,
+  api,
+  useAuthenticatedMutation,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useAuth } from "@providers/AuthProvider";
+import { useTheme } from "@hooks/useTheme";
+import { Avatar } from "@components/ui/Avatar";
+
+type UserResult = {
+  _id: Id<"users">;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  profilePhoto: string | null;
+  alreadyMaintainer?: boolean;
+  isSuperuser?: boolean;
+};
+
+export function MaintainersContent() {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { token } = useAuth();
+
+  const access = useQuery(
+    api.functions.devAssistant.maintainers.myAccess,
+    token ? { token } : "skip",
+  );
+  const isSuperAdmin = access?.isSuperAdmin === true;
+
+  const [query, setQuery] = useState("");
+  const [busyUserId, setBusyUserId] = useState<Id<"users"> | null>(null);
+
+  const maintainers = useQuery(
+    api.functions.devAssistant.maintainers.listMaintainers,
+    token && isSuperAdmin ? { token } : "skip",
+  ) as UserResult[] | undefined;
+
+  const searchResults = useQuery(
+    api.functions.devAssistant.maintainers.searchUsersForGrant,
+    token && isSuperAdmin && query.trim().length >= 2
+      ? { token, query, limit: 10 }
+      : "skip",
+  ) as UserResult[] | undefined;
+
+  const grant = useAuthenticatedMutation(
+    api.functions.devAssistant.maintainers.grantMaintainer,
+  );
+  const revoke = useAuthenticatedMutation(
+    api.functions.devAssistant.maintainers.revokeMaintainer,
+  );
+
+  const handleGrant = async (userId: Id<"users">) => {
+    setBusyUserId(userId);
+    try {
+      await grant({ userId });
+      setQuery("");
+    } catch (err) {
+      Alert.alert(
+        "Add failed",
+        err instanceof Error ? err.message : "Unknown error",
+      );
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const handleRevoke = async (userId: Id<"users">) => {
+    const ok = await confirmRevoke();
+    if (!ok) return;
+    setBusyUserId(userId);
+    try {
+      await revoke({ userId });
+    } catch (err) {
+      Alert.alert(
+        "Remove failed",
+        err instanceof Error ? err.message : "Unknown error",
+      );
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  // Access gate — non-superusers can't manage maintainers.
+  if (access !== undefined && !isSuperAdmin) {
+    return (
+      <View
+        style={[
+          styles.container,
+          styles.centered,
+          { backgroundColor: colors.surface },
+        ]}
+      >
+        <Text style={[styles.empty, { color: colors.textSecondary }]}>
+          Maintainers are managed by Togather staff. You don't have access.
+        </Text>
+      </View>
+    );
+  }
+
+  if (access === undefined) {
+    return (
+      <View
+        style={[
+          styles.container,
+          styles.centered,
+          { backgroundColor: colors.surface },
+        ]}
+      >
+        <ActivityIndicator size="small" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.surface }]}
+      contentContainerStyle={[
+        styles.content,
+        { paddingBottom: insets.bottom + 32 },
+      ]}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={[styles.intro, { color: colors.textSecondary }]}>
+        Maintainers can summon the @Togather dev-assistant in chat to open bugs.
+        They can't review, reject, or merge — those stay staff-only.
+      </Text>
+
+      <Text style={[styles.sectionLabel, { color: colors.text }]}>
+        Current maintainers
+      </Text>
+      {maintainers === undefined ? (
+        <ActivityIndicator style={{ marginVertical: 12 }} />
+      ) : maintainers.length === 0 ? (
+        <Text style={{ color: colors.textSecondary, fontSize: 14 }}>
+          No maintainers yet. Staff and superusers always have access.
+        </Text>
+      ) : (
+        <View style={{ gap: 8 }}>
+          {maintainers.map((u) => (
+            <UserRow
+              key={u._id}
+              user={u}
+              busy={busyUserId === u._id}
+              trailing={
+                <TouchableOpacity
+                  onPress={() => handleRevoke(u._id)}
+                  disabled={busyUserId === u._id}
+                  style={styles.revokeBtn}
+                >
+                  <Text style={styles.revokeBtnText}>Remove</Text>
+                </TouchableOpacity>
+              }
+            />
+          ))}
+        </View>
+      )}
+
+      <Text
+        style={[styles.sectionLabel, { color: colors.text, marginTop: 24 }]}
+      >
+        Add a maintainer
+      </Text>
+      <View
+        style={[
+          styles.searchBar,
+          {
+            backgroundColor: colors.surfaceSecondary,
+            borderColor: colors.border,
+          },
+        ]}
+      >
+        <Ionicons name="search" size={18} color={colors.textSecondary} />
+        <TextInput
+          style={[styles.searchInput, { color: colors.text }]}
+          placeholder="Search by name, email, phone…"
+          placeholderTextColor={colors.textSecondary}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        {query ? (
+          <TouchableOpacity onPress={() => setQuery("")} hitSlop={12}>
+            <Ionicons
+              name="close-circle"
+              size={18}
+              color={colors.textSecondary}
+            />
+          </TouchableOpacity>
+        ) : null}
+      </View>
+
+      {query.trim().length >= 2 ? (
+        searchResults === undefined ? (
+          <ActivityIndicator style={{ marginTop: 12 }} />
+        ) : searchResults.length === 0 ? (
+          <Text
+            style={{
+              color: colors.textSecondary,
+              fontSize: 14,
+              marginTop: 8,
+            }}
+          >
+            No matches.
+          </Text>
+        ) : (
+          <View style={{ gap: 8, marginTop: 8 }}>
+            {searchResults.map((u) => (
+              <UserRow
+                key={u._id}
+                user={u}
+                busy={busyUserId === u._id}
+                trailing={
+                  u.alreadyMaintainer ? (
+                    <Text
+                      style={{ color: colors.textSecondary, fontSize: 12 }}
+                    >
+                      {u.isSuperuser ? "Staff" : "Already added"}
+                    </Text>
+                  ) : (
+                    <TouchableOpacity
+                      onPress={() => handleGrant(u._id)}
+                      disabled={busyUserId === u._id}
+                      style={[styles.grantBtn, { backgroundColor: colors.text }]}
+                    >
+                      <Text
+                        style={[
+                          styles.grantBtnText,
+                          { color: colors.background },
+                        ]}
+                      >
+                        Add
+                      </Text>
+                    </TouchableOpacity>
+                  )
+                }
+              />
+            ))}
+          </View>
+        )
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function UserRow({
+  user,
+  trailing,
+  busy,
+}: {
+  user: UserResult;
+  trailing: React.ReactNode;
+  busy: boolean;
+}) {
+  const { colors } = useTheme();
+  const displayName = useMemo(() => {
+    const parts = [user.firstName, user.lastName].filter(Boolean);
+    if (parts.length > 0) return parts.join(" ");
+    return user.email ?? user.phone ?? "Unknown user";
+  }, [user]);
+  const sub = user.email ?? user.phone ?? "";
+  return (
+    <View
+      style={[
+        styles.row,
+        {
+          backgroundColor: colors.surfaceSecondary,
+          borderColor: colors.border,
+        },
+      ]}
+    >
+      <Avatar
+        imageUrl={user.profilePhoto ?? undefined}
+        name={displayName}
+        size={36}
+      />
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text
+          style={[styles.rowName, { color: colors.text }]}
+          numberOfLines={1}
+        >
+          {displayName}
+          {user.isSuperuser ? (
+            <Text style={{ color: colors.textSecondary, fontSize: 12 }}>
+              {"  · staff"}
+            </Text>
+          ) : null}
+        </Text>
+        {sub ? (
+          <Text
+            style={[styles.rowSub, { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            {sub}
+          </Text>
+        ) : null}
+      </View>
+      {busy ? <ActivityIndicator size="small" /> : trailing}
+    </View>
+  );
+}
+
+async function confirmRevoke(): Promise<boolean> {
+  const title = "Remove maintainer?";
+  const message = "They'll lose dev-assistant access immediately.";
+  if (Platform.OS === "web") {
+    return window.confirm(`${title}\n\n${message}`);
+  }
+  return new Promise((resolve) => {
+    Alert.alert(
+      title,
+      message,
+      [
+        { text: "Cancel", style: "cancel", onPress: () => resolve(false) },
+        { text: "Remove", style: "destructive", onPress: () => resolve(true) },
+      ],
+      { cancelable: true, onDismiss: () => resolve(false) },
+    );
+  });
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  centered: {
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  empty: {
+    fontSize: 15,
+    textAlign: "center",
+  },
+  intro: {
+    fontSize: 14,
+    marginBottom: 20,
+    lineHeight: 20,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    marginBottom: 8,
+  },
+  searchBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    padding: 0,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    padding: 10,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  rowName: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  rowSub: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  grantBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 16,
+  },
+  grantBtnText: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  revokeBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  revokeBtnText: {
+    color: "#e5484d",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/features/admin/components/index.ts
+++ b/apps/mobile/features/admin/components/index.ts
@@ -6,6 +6,7 @@ export { DeveloperApiKeysScreen } from "./DeveloperApiKeysScreen";
 export { DuplicateAccountsScreen } from "./DuplicateAccountsScreen";
 export { ExportBottomSheet } from "./ExportBottomSheet";
 export { FeatureFlagsContent } from "./FeatureFlagsContent";
+export { MaintainersContent } from "./MaintainersContent";
 export { GroupAttendanceDetails } from "./GroupAttendanceDetails";
 export { GroupTypeEditModal } from "./GroupTypeEditModal";
 export { PendingRequestsContent } from "./PendingRequestsContent";

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -194,18 +194,21 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
   const { setTyping } = useTypingIndicators(channelId);
   const { members: baseMembers } = useChannelMembers(channelId);
 
-  // Dev-assistant bot: staff/superusers can @mention @Togather. Gated behind
-  // the dev-assistant-bot flag. The synthetic entry is appended to the member
-  // list so both the autocomplete dropdown and the @[Display Name] -> userId
-  // resolver (extractMentionedUserIds) see it.
-  const { user: currentAuthUser } = useAuth();
+  // Dev-assistant bot: staff/superusers and delegated dev maintainers can
+  // @mention @Togather. Gated behind the dev-assistant-bot flag. The synthetic
+  // entry is appended to the member list so both the autocomplete dropdown and
+  // the @[Display Name] -> userId resolver (extractMentionedUserIds) see it.
+  // `canUseAssistant` is the same gate the server enforces on trigger.
+  const { token } = useAuth();
   const { enabled: devAssistantFlagEnabled } = useConvexFeatureFlag(
     "dev-assistant-bot",
   );
+  const assistantAccess = useQuery(
+    api.functions.devAssistant.maintainers.myAccess,
+    token && devAssistantFlagEnabled ? { token } : "skip",
+  );
   const canMentionBot =
-    (currentAuthUser?.is_superuser === true ||
-      currentAuthUser?.is_staff === true) &&
-    devAssistantFlagEnabled;
+    devAssistantFlagEnabled && assistantAccess?.canUseAssistant === true;
   const botUserId = useQuery(
     api.functions.devAssistant.index.getBotUserId,
     canMentionBot ? {} : "skip",

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
@@ -102,7 +102,12 @@ jest.mock('../GifPicker', () => ({
 jest.mock('@services/api/convex', () => ({
   useQuery: jest.fn(),
   api: {
-    functions: { devAssistant: { index: { getBotUserId: 'getBotUserId' } } },
+    functions: {
+      devAssistant: {
+        index: { getBotUserId: 'getBotUserId' },
+        maintainers: { myAccess: 'myAccess' },
+      },
+    },
   },
 }));
 


### PR DESCRIPTION
## What & why

Currently only Togather super admins (`isSuperuser`/`isStaff`) can summon the
@Togather dev-assistant. This adds a super-admin-managed list of **maintainers**
who can also call the assistant — **without** receiving full super-admin
privileges.

A maintainer holds the new `dev_maintainer` platform role (stored in
`users.platformRoles`), mirroring the existing `poster_admin` role model in
`functions/posters.ts`. The role grants **only** the ability to trigger the
assistant in chat to open bugs. Reviewing, rejecting, retrying, and merging bugs
stay superuser-only (the `requireSuperuser` gates in `bugs.ts` are untouched).

## Changes

**Backend** (`apps/convex/functions/devAssistant`)
- New `maintainers.ts`:
  - `canUseDevAssistant` / `isDevAssistantSuperAdmin` access helpers (single
    source of truth for the trigger gate vs. management gate).
  - `myAccess` (per-user flags for client gating), `listMaintainers`,
    `searchUsersForGrant`, `grantMaintainer`, `revokeMaintainer`. All management
    ops are superuser-gated and server-enforced.
- `bugs.getUserAccess` now also reports `isMaintainer`; `actions.processThreadMention`
  admits maintainers through the trigger gate.

**Frontend** (`apps/mobile`)
- New `/(user)/admin/maintainers` screen (`MaintainersContent`) for super admins
  to add/remove maintainers (search → add, list → remove). Non-superusers see a
  permission-denied state. Reachable from a new quick-access card on the admin
  dashboard.
- `MessageInput` now offers the `@Togather` mention to anyone with
  `canUseAssistant` (the same gate the server enforces), not just staff/superusers.

## Privilege split

| Capability | Super admin | Maintainer |
| --- | --- | --- |
| Summon @Togather / open bugs | ✅ | ✅ |
| Review / reject / retry / merge bugs | ✅ | ❌ |
| Manage the maintainer list | ✅ | ❌ |

## Tests / checks

- New `apps/convex/__tests__/devAssistant-maintainers.test.ts` (12 tests): access
  helpers, the `getUserAccess` trigger gate, and grant/revoke/list/myAccess
  authorization (idempotency, role-preservation, superuser-only enforcement).
- `npx convex typecheck` ✅ · Convex suite: 1793 + 12 new ✅ · mobile jest suite
  (1103) ✅ · navigator-screens check ✅ · lint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0199V7MRiN7dVyPniXNojDEa)_