### PR TITLE
feat(chat): per-thread notification control (mentions-only by default)

### DIFF
--- a/apps/convex/__tests__/messaging/threadSubscriptions.test.ts
+++ b/apps/convex/__tests__/messaging/threadSubscriptions.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for per-thread notification control.
+ *
+ * Covers the pure recipient-routing helper (`decideRecipientBucket`) and the
+ * `getThreadSubscription` / `setThreadSubscription` functions.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import { decideRecipientBucket } from "../../functions/messaging/events";
+import type { Id } from "../../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// ============================================================================
+// decideRecipientBucket — recipient routing rules
+// ============================================================================
+
+describe("decideRecipientBucket", () => {
+  test("top-level messages notify everyone (mention vs regular)", () => {
+    expect(decideRecipientBucket({ isMentioned: true, isReply: false })).toBe(
+      "mention",
+    );
+    expect(decideRecipientBucket({ isMentioned: false, isReply: false })).toBe(
+      "regular",
+    );
+  });
+
+  test("thread replies default to mentions only", () => {
+    // Mentioned member still gets a mention notification.
+    expect(decideRecipientBucket({ isMentioned: true, isReply: true })).toBe(
+      "mention",
+    );
+    // Non-mentioned member is skipped by default.
+    expect(decideRecipientBucket({ isMentioned: false, isReply: true })).toBe(
+      "skip",
+    );
+  });
+
+  test("'all' subscribers are notified about every reply", () => {
+    expect(
+      decideRecipientBucket({
+        isMentioned: false,
+        isReply: true,
+        threadState: "all",
+      }),
+    ).toBe("regular");
+    expect(
+      decideRecipientBucket({
+        isMentioned: true,
+        isReply: true,
+        threadState: "all",
+      }),
+    ).toBe("mention");
+  });
+
+  test("'none' subscribers are never notified, even when mentioned", () => {
+    expect(
+      decideRecipientBucket({
+        isMentioned: false,
+        isReply: true,
+        threadState: "none",
+      }),
+    ).toBe("skip");
+    expect(
+      decideRecipientBucket({
+        isMentioned: true,
+        isReply: true,
+        threadState: "none",
+      }),
+    ).toBe("skip");
+  });
+
+  test("thread state does not affect top-level messages", () => {
+    expect(
+      decideRecipientBucket({
+        isMentioned: false,
+        isReply: false,
+        threadState: "none",
+      }),
+    ).toBe("regular");
+  });
+});
+
+// ============================================================================
+// getThreadSubscription / setThreadSubscription
+// ============================================================================
+
+interface ThreadTestData {
+  userId: Id<"users">;
+  channelId: Id<"chatChannels">;
+  threadId: Id<"chatMessages">;
+  accessToken: string;
+}
+
+async function seedThreadData(
+  t: ReturnType<typeof convexTest>,
+): Promise<ThreadTestData> {
+  const communityId = await t.run(async (ctx) =>
+    ctx.db.insert("communities", {
+      name: "Test Community",
+      subdomain: "test",
+      slug: "test",
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }),
+  );
+
+  const userId = await t.run(async (ctx) =>
+    ctx.db.insert("users", {
+      firstName: "Test",
+      lastName: "User",
+      phone: "+15555550001",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }),
+  );
+
+  const channelId = await t.run(async (ctx) =>
+    ctx.db.insert("chatChannels", {
+      communityId,
+      channelType: "main",
+      name: "General",
+      slug: "general",
+      createdById: userId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isArchived: false,
+      memberCount: 1,
+    }),
+  );
+
+  await t.run(async (ctx) => {
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId,
+      role: "admin",
+      joinedAt: Date.now(),
+      isMuted: false,
+    });
+  });
+
+  const threadId = await t.run(async (ctx) =>
+    ctx.db.insert("chatMessages", {
+      channelId,
+      senderId: userId,
+      content: "Parent message",
+      contentType: "text",
+      createdAt: Date.now(),
+      isDeleted: false,
+    }),
+  );
+
+  const { accessToken } = await generateTokens(userId);
+  return { userId, channelId, threadId, accessToken };
+}
+
+describe("thread subscription functions", () => {
+  test("defaults to 'default' when no preference is stored", async () => {
+    const t = convexTest(schema, modules);
+    const { threadId, accessToken } = await seedThreadData(t);
+
+    const result = await t.query(
+      api.functions.messaging.threadSubscriptions.getThreadSubscription,
+      { token: accessToken, threadId },
+    );
+
+    expect(result.state).toBe("default");
+  });
+
+  test("set and read back an 'all' preference", async () => {
+    const t = convexTest(schema, modules);
+    const { threadId, accessToken } = await seedThreadData(t);
+
+    await t.mutation(
+      api.functions.messaging.threadSubscriptions.setThreadSubscription,
+      { token: accessToken, threadId, state: "all" },
+    );
+
+    const result = await t.query(
+      api.functions.messaging.threadSubscriptions.getThreadSubscription,
+      { token: accessToken, threadId },
+    );
+    expect(result.state).toBe("all");
+  });
+
+  test("setting 'default' clears a stored preference", async () => {
+    const t = convexTest(schema, modules);
+    const { threadId, accessToken } = await seedThreadData(t);
+
+    await t.mutation(
+      api.functions.messaging.threadSubscriptions.setThreadSubscription,
+      { token: accessToken, threadId, state: "none" },
+    );
+    await t.mutation(
+      api.functions.messaging.threadSubscriptions.setThreadSubscription,
+      { token: accessToken, threadId, state: "default" },
+    );
+
+    const result = await t.query(
+      api.functions.messaging.threadSubscriptions.getThreadSubscription,
+      { token: accessToken, threadId },
+    );
+    expect(result.state).toBe("default");
+
+    // No row should remain in the table.
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatThreadSubscriptions")
+        .withIndex("by_thread", (q) => q.eq("threadId", threadId))
+        .collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("updating an existing preference overwrites it (no duplicate rows)", async () => {
+    const t = convexTest(schema, modules);
+    const { threadId, accessToken } = await seedThreadData(t);
+
+    await t.mutation(
+      api.functions.messaging.threadSubscriptions.setThreadSubscription,
+      { token: accessToken, threadId, state: "all" },
+    );
+    await t.mutation(
+      api.functions.messaging.threadSubscriptions.setThreadSubscription,
+      { token: accessToken, threadId, state: "none" },
+    );
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatThreadSubscriptions")
+        .withIndex("by_thread", (q) => q.eq("threadId", threadId))
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].state).toBe("none");
+  });
+
+  test("non-members cannot set a preference", async () => {
+    const t = convexTest(schema, modules);
+    const { threadId } = await seedThreadData(t);
+
+    const outsiderId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Out",
+        lastName: "Sider",
+        phone: "+15555550002",
+        phoneVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const { accessToken: outsiderToken } = await generateTokens(outsiderId);
+
+    await expect(
+      t.mutation(
+        api.functions.messaging.threadSubscriptions.setThreadSubscription,
+        { token: outsiderToken, threadId, state: "all" },
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -101,6 +101,7 @@ import type * as functions_messaging_reachOut from "../functions/messaging/reach
 import type * as functions_messaging_reactions from "../functions/messaging/reactions.js";
 import type * as functions_messaging_readState from "../functions/messaging/readState.js";
 import type * as functions_messaging_sharedChannels from "../functions/messaging/sharedChannels.js";
+import type * as functions_messaging_threadSubscriptions from "../functions/messaging/threadSubscriptions.js";
 import type * as functions_messaging_typing from "../functions/messaging/typing.js";
 import type * as functions_migrations from "../functions/migrations.js";
 import type * as functions_migrations_migrateToCommunityPeople from "../functions/migrations/migrateToCommunityPeople.js";
@@ -319,6 +320,7 @@ declare const fullApi: ApiFromModules<{
   "functions/messaging/reactions": typeof functions_messaging_reactions;
   "functions/messaging/readState": typeof functions_messaging_readState;
   "functions/messaging/sharedChannels": typeof functions_messaging_sharedChannels;
+  "functions/messaging/threadSubscriptions": typeof functions_messaging_threadSubscriptions;
   "functions/messaging/typing": typeof functions_messaging_typing;
   "functions/migrations": typeof functions_migrations;
   "functions/migrations/migrateToCommunityPeople": typeof functions_migrations_migrateToCommunityPeople;

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -25,6 +25,42 @@ import { chatRequestEmail } from "../../lib/notifications/emailTemplates";
 const MAX_PREVIEW_LENGTH = 100;
 
 // ============================================================================
+// Notification routing
+// ============================================================================
+
+/** Where a single member's notification for a message should go. */
+type RecipientBucket = "mention" | "regular" | "skip";
+
+/**
+ * Decide whether a channel member should be notified about a message and, if
+ * so, in which bucket ("mention" → rich push + email, "regular" → push only).
+ *
+ * Top-level messages keep the original behavior: mentioned members get the
+ * mention notification, everyone else gets a regular new-message push.
+ *
+ * Thread replies default to "mentions only" to avoid notification overload —
+ * a member is not notified unless they were @mentioned. Members can override
+ * this per thread via `chatThreadSubscriptions`:
+ *   - "all":  notified on every reply (as a mention if also mentioned)
+ *   - "none": never notified, even when mentioned
+ */
+export function decideRecipientBucket(opts: {
+  isMentioned: boolean;
+  isReply: boolean;
+  threadState?: "all" | "none";
+}): RecipientBucket {
+  if (!opts.isReply) {
+    return opts.isMentioned ? "mention" : "regular";
+  }
+  if (opts.threadState === "none") return "skip";
+  if (opts.threadState === "all") {
+    return opts.isMentioned ? "mention" : "regular";
+  }
+  // Default for thread replies: only notify members who were mentioned.
+  return opts.isMentioned ? "mention" : "skip";
+}
+
+// ============================================================================
 // Event Handlers
 // ============================================================================
 
@@ -126,6 +162,23 @@ export const onMessageSent = internalMutation({
     // so the Activity feed's inbox badge reflects the new message.
     if (message.blastId) return;
 
+    // Thread replies (messages with a parentMessageId) default to "mentions
+    // only" so members aren't notified about every reply. Members can opt in
+    // ("all") or fully mute ("none") a thread; load those overrides once here
+    // and apply them while partitioning recipients below.
+    const threadId = message.parentMessageId;
+    const isReply = !!threadId;
+    const threadStates = new Map<string, "all" | "none">();
+    if (threadId) {
+      const subscriptions = await ctx.db
+        .query("chatThreadSubscriptions")
+        .withIndex("by_thread", (q) => q.eq("threadId", threadId))
+        .collect();
+      for (const sub of subscriptions) {
+        threadStates.set(sub.userId, sub.state);
+      }
+    }
+
     // Send push notifications via centralized notification system
     // Schedule an action to send notifications (actions can make external API calls)
     if (members.length > 0) {
@@ -215,9 +268,14 @@ export const onMessageSent = internalMutation({
           }
 
           const bucket = groupBuckets.get(key)!;
-          if (message.mentionedUserIds?.includes(member.userId)) {
+          const target = decideRecipientBucket({
+            isMentioned: !!message.mentionedUserIds?.includes(member.userId),
+            isReply,
+            threadState: threadStates.get(member.userId),
+          });
+          if (target === "mention") {
             bucket.mentionRecipients.push(member.userId);
-          } else {
+          } else if (target === "regular") {
             bucket.regularRecipients.push(member.userId);
           }
         }
@@ -259,6 +317,11 @@ export const onMessageSent = internalMutation({
         const pendingRecipients: Id<"users">[] = [];
         const acceptedRecipients: Id<"users">[] = [];
         for (const member of members) {
+          // DMs are low-volume, so replies still notify by default; only an
+          // explicit "none" mute on the thread suppresses the notification.
+          if (isReply && threadStates.get(member.userId) === "none") {
+            continue;
+          }
           if (member.requestState === "pending") {
             pendingRecipients.push(member.userId);
           } else {
@@ -299,9 +362,14 @@ export const onMessageSent = internalMutation({
         const regularRecipients: Id<"users">[] = [];
 
         for (const member of members) {
-          if (message.mentionedUserIds?.includes(member.userId)) {
+          const target = decideRecipientBucket({
+            isMentioned: !!message.mentionedUserIds?.includes(member.userId),
+            isReply,
+            threadState: threadStates.get(member.userId),
+          });
+          if (target === "mention") {
             mentionRecipients.push(member.userId);
-          } else {
+          } else if (target === "regular") {
             regularRecipients.push(member.userId);
           }
         }

--- a/apps/convex/functions/messaging/threadSubscriptions.ts
+++ b/apps/convex/functions/messaging/threadSubscriptions.ts
@@ -1,0 +1,114 @@
+/**
+ * Thread Notification Subscriptions
+ *
+ * Per-user notification preference for a chat thread (a parent message and its
+ * replies). By default a member is only notified about a reply when they are
+ * @mentioned; these functions let a member override that for a specific thread:
+ *
+ *   - "all":     notify on every reply, even without a mention
+ *   - "none":    never notify, even when @mentioned
+ *   - "default": fall back to the mention-only behavior (stored as no row)
+ *
+ * The reply notification fanout in `events.ts` reads these rows. See
+ * `decideRecipientBucket` there for how the preference is applied.
+ */
+
+import { v } from "convex/values";
+import { query, mutation } from "../../_generated/server";
+import { requireAuth } from "../../lib/auth";
+
+/** A user's notification preference for a thread, including the implicit default. */
+const threadNotificationState = v.union(
+  v.literal("all"),
+  v.literal("none"),
+  v.literal("default"),
+);
+
+/**
+ * Read the current user's notification preference for a thread.
+ * Returns "default" when no explicit preference is stored.
+ */
+export const getThreadSubscription = query({
+  args: {
+    token: v.string(),
+    threadId: v.id("chatMessages"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const subscription = await ctx.db
+      .query("chatThreadSubscriptions")
+      .withIndex("by_thread_user", (q) =>
+        q.eq("threadId", args.threadId).eq("userId", userId),
+      )
+      .first();
+
+    return {
+      threadId: args.threadId,
+      state: subscription?.state ?? "default",
+    };
+  },
+});
+
+/**
+ * Set (or clear) the current user's notification preference for a thread.
+ * Passing "default" removes any stored override so the thread falls back to the
+ * mention-only default.
+ */
+export const setThreadSubscription = mutation({
+  args: {
+    token: v.string(),
+    threadId: v.id("chatMessages"),
+    state: threadNotificationState,
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const thread = await ctx.db.get(args.threadId);
+    if (!thread) {
+      throw new Error("Thread not found");
+    }
+
+    // Only members of the thread's channel may set a preference for it.
+    const membership = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", thread.channelId).eq("userId", userId),
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+
+    if (!membership) {
+      throw new Error("Not a member of this channel");
+    }
+
+    const existing = await ctx.db
+      .query("chatThreadSubscriptions")
+      .withIndex("by_thread_user", (q) =>
+        q.eq("threadId", args.threadId).eq("userId", userId),
+      )
+      .first();
+
+    if (args.state === "default") {
+      // No explicit override needed — remove any stored row.
+      if (existing) {
+        await ctx.db.delete(existing._id);
+      }
+    } else if (existing) {
+      await ctx.db.patch(existing._id, {
+        state: args.state,
+        updatedAt: Date.now(),
+      });
+    } else {
+      await ctx.db.insert("chatThreadSubscriptions", {
+        threadId: args.threadId,
+        userId,
+        state: args.state,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    }
+
+    return { threadId: args.threadId, state: args.state };
+  },
+});

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1892,6 +1892,29 @@ export default defineSchema({
     .index("by_channel_user", ["channelId", "userId"]),
 
   /**
+   * Chat Thread Subscriptions
+   *
+   * Per-user notification preference for a single thread (a parent message and
+   * its replies). The absence of a row is the default: a member is notified
+   * about a reply only when they are @mentioned. A row overrides that default:
+   *   - "all":  notify on every reply, even without a mention
+   *   - "none": never notify, even when @mentioned
+   *
+   * `threadId` is the parent (root) message of the thread. Toggled from the
+   * bell control in the thread view (see ThreadHeader on mobile).
+   */
+  chatThreadSubscriptions: defineTable({
+    threadId: v.id("chatMessages"),
+    userId: v.id("users"),
+    state: v.union(v.literal("all"), v.literal("none")),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_thread", ["threadId"])
+    .index("by_thread_user", ["threadId", "userId"])
+    .index("by_user", ["userId"]),
+
+  /**
    * Chat Typing Indicators
    * Ephemeral typing indicators with automatic cleanup.
    */

--- a/apps/mobile/features/chat/components/ThreadHeader.tsx
+++ b/apps/mobile/features/chat/components/ThreadHeader.tsx
@@ -1,23 +1,58 @@
 /**
  * ThreadHeader Component
  *
- * Header for thread page showing "Thread" title with channel name and back navigation.
+ * Header for thread page showing "Thread" title with channel name, back
+ * navigation, and a bell toggle for per-thread notification control.
  */
 import React, { memo } from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 
+/**
+ * Per-thread notification preference:
+ *   - "default": notify only when @mentioned (the app-wide default)
+ *   - "all":     notify on every reply
+ *   - "none":    never notify, even when @mentioned
+ */
+export type ThreadNotificationState = "default" | "all" | "none";
+
 interface ThreadHeaderProps {
   channelName?: string;
   onBack: () => void;
+  /**
+   * Current notification preference for this thread. When provided (together
+   * with `onToggleNotifications`), the bell control is rendered.
+   */
+  notificationState?: ThreadNotificationState;
+  /** Advance the notification preference to its next state. */
+  onToggleNotifications?: () => void;
 }
+
+const BELL_ICON: Record<
+  ThreadNotificationState,
+  keyof typeof Ionicons.glyphMap
+> = {
+  default: "notifications-outline",
+  all: "notifications",
+  none: "notifications-off-outline",
+};
+
+const BELL_LABEL: Record<ThreadNotificationState, string> = {
+  default: "Notifications: only when mentioned",
+  all: "Notifications: all replies",
+  none: "Notifications: muted",
+};
 
 export const ThreadHeader = memo(function ThreadHeader({
   channelName,
   onBack,
+  notificationState,
+  onToggleNotifications,
 }: ThreadHeaderProps) {
   const { colors } = useTheme();
+
+  const showBell = !!notificationState && !!onToggleNotifications;
 
   return (
     <View style={[styles.header, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
@@ -31,6 +66,22 @@ export const ThreadHeader = memo(function ThreadHeader({
           <Text style={[styles.channelName, { color: colors.textSecondary }]}>#{channelName}</Text>
         )}
       </View>
+
+      {showBell && (
+        <TouchableOpacity
+          onPress={onToggleNotifications}
+          style={styles.bellButton}
+          accessibilityRole="button"
+          accessibilityLabel={BELL_LABEL[notificationState!]}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons
+            name={BELL_ICON[notificationState!]}
+            size={22}
+            color={notificationState === "all" ? colors.link : colors.text}
+          />
+        </TouchableOpacity>
+      )}
     </View>
   );
 });
@@ -57,5 +108,9 @@ const styles = StyleSheet.create({
   channelName: {
     fontSize: 13,
     marginTop: 1,
+  },
+  bellButton: {
+    padding: 8,
+    marginLeft: 8,
   },
 });

--- a/apps/mobile/features/chat/components/ThreadHeader.tsx
+++ b/apps/mobile/features/chat/components/ThreadHeader.tsx
@@ -27,32 +27,54 @@ interface ThreadHeaderProps {
   notificationState?: ThreadNotificationState;
   /** Advance the notification preference to its next state. */
   onToggleNotifications?: () => void;
+  /**
+   * Whether this is a DM/group_dm thread. DM replies notify by default
+   * (mentions are meaningless in a 1:1), so the bell only distinguishes
+   * "all replies" from "muted" rather than the group three-state cycle.
+   */
+  isDm?: boolean;
 }
 
-const BELL_ICON: Record<
-  ThreadNotificationState,
-  keyof typeof Ionicons.glyphMap
-> = {
-  default: "notifications-outline",
-  all: "notifications",
-  none: "notifications-off-outline",
-};
-
-const BELL_LABEL: Record<ThreadNotificationState, string> = {
-  default: "Notifications: only when mentioned",
-  all: "Notifications: all replies",
-  none: "Notifications: muted",
-};
+/** Icon, label, and active styling for the bell given the state and channel kind. */
+function bellDisplay(
+  state: ThreadNotificationState,
+  isDm: boolean,
+): { icon: keyof typeof Ionicons.glyphMap; label: string; active: boolean } {
+  if (state === "none") {
+    return {
+      icon: "notifications-off-outline",
+      label: "Notifications: muted",
+      active: false,
+    };
+  }
+  // In DMs both "default" and "all" mean every reply notifies.
+  if (isDm || state === "all") {
+    return {
+      icon: "notifications",
+      label: "Notifications: all replies",
+      active: true,
+    };
+  }
+  return {
+    icon: "notifications-outline",
+    label: "Notifications: only when mentioned",
+    active: false,
+  };
+}
 
 export const ThreadHeader = memo(function ThreadHeader({
   channelName,
   onBack,
   notificationState,
   onToggleNotifications,
+  isDm = false,
 }: ThreadHeaderProps) {
   const { colors } = useTheme();
 
   const showBell = !!notificationState && !!onToggleNotifications;
+  const display = notificationState
+    ? bellDisplay(notificationState, isDm)
+    : null;
 
   return (
     <View style={[styles.header, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
@@ -67,18 +89,18 @@ export const ThreadHeader = memo(function ThreadHeader({
         )}
       </View>
 
-      {showBell && (
+      {showBell && display && (
         <TouchableOpacity
           onPress={onToggleNotifications}
           style={styles.bellButton}
           accessibilityRole="button"
-          accessibilityLabel={BELL_LABEL[notificationState!]}
+          accessibilityLabel={display.label}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
         >
           <Ionicons
-            name={BELL_ICON[notificationState!]}
+            name={display.icon}
             size={22}
-            color={notificationState === "all" ? colors.link : colors.text}
+            color={display.active ? colors.link : colors.text}
           />
         </TouchableOpacity>
       )}

--- a/apps/mobile/features/chat/components/ThreadPage.tsx
+++ b/apps/mobile/features/chat/components/ThreadPage.tsx
@@ -94,11 +94,16 @@ export function ThreadPage({
     (threadSubscription?.state as ThreadNotificationState | undefined) ??
     "default";
 
-  // Cycle the bell: mentions-only (default) → all replies → muted → default.
+  // DM replies notify by default, so the bell is a simple on/off there. Group
+  // threads cycle: mentions-only (default) → all replies → muted → default.
+  const isDm = !!dmChannelId;
   const handleToggleNotifications = useCallback(async () => {
     if (!token) return;
-    const next: ThreadNotificationState =
-      notificationState === "default"
+    const next: ThreadNotificationState = isDm
+      ? notificationState === "none"
+        ? "default"
+        : "none"
+      : notificationState === "default"
         ? "all"
         : notificationState === "all"
           ? "none"
@@ -109,7 +114,7 @@ export function ThreadPage({
       console.error("[ThreadPage] Failed to update thread notifications:", error);
       Alert.alert("Error", "Failed to update notification settings.");
     }
-  }, [token, notificationState, messageId, setThreadSubscriptionMutation]);
+  }, [token, notificationState, messageId, isDm, setThreadSubscriptionMutation]);
 
   // Message actions overlay state
   const [overlayVisible, setOverlayVisible] = useState(false);
@@ -283,6 +288,7 @@ export function ThreadPage({
         onBack={handleBack}
         notificationState={notificationState}
         onToggleNotifications={handleToggleNotifications}
+        isDm={isDm}
       />
 
       <View style={[styles.content, { backgroundColor: colors.surfaceSecondary }]}>

--- a/apps/mobile/features/chat/components/ThreadPage.tsx
+++ b/apps/mobile/features/chat/components/ThreadPage.tsx
@@ -26,11 +26,11 @@ import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
-import { useMutation, api, useStoredAuthToken } from "@services/api/convex";
+import { useMutation, useQuery, api, useStoredAuthToken } from "@services/api/convex";
 import { useParentMessage } from "../hooks/useParentMessage";
 import { useThreadReplies } from "../hooks/useThreadReplies";
 import { useGroupDetails } from "../../groups/hooks/useGroupDetails";
-import { ThreadHeader } from "./ThreadHeader";
+import { ThreadHeader, type ThreadNotificationState } from "./ThreadHeader";
 import { MessageItem } from "./MessageItem";
 import { MessageInput } from "./MessageInput";
 import { MessageActionsOverlay } from "./MessageActionsOverlay";
@@ -79,6 +79,37 @@ export function ThreadPage({
   const toggleReactionMutation = useMutation(api.functions.messaging.reactions.toggleReaction);
   const deleteMessageMutation = useMutation(api.functions.messaging.messages.deleteMessage);
   const flagMessageMutation = useMutation(api.functions.messaging.flagging.flagMessage);
+
+  // Per-thread notification preference (bell control in the header).
+  const setThreadSubscriptionMutation = useMutation(
+    api.functions.messaging.threadSubscriptions.setThreadSubscription,
+  );
+  const threadSubscription = useQuery(
+    api.functions.messaging.threadSubscriptions.getThreadSubscription,
+    token ? { token, threadId: messageId } : "skip",
+  );
+  // The query's return type widens `state` to `string` over the wire; the
+  // backend constrains it to the ThreadNotificationState union.
+  const notificationState =
+    (threadSubscription?.state as ThreadNotificationState | undefined) ??
+    "default";
+
+  // Cycle the bell: mentions-only (default) → all replies → muted → default.
+  const handleToggleNotifications = useCallback(async () => {
+    if (!token) return;
+    const next: ThreadNotificationState =
+      notificationState === "default"
+        ? "all"
+        : notificationState === "all"
+          ? "none"
+          : "default";
+    try {
+      await setThreadSubscriptionMutation({ token, threadId: messageId, state: next });
+    } catch (error) {
+      console.error("[ThreadPage] Failed to update thread notifications:", error);
+      Alert.alert("Error", "Failed to update notification settings.");
+    }
+  }, [token, notificationState, messageId, setThreadSubscriptionMutation]);
 
   // Message actions overlay state
   const [overlayVisible, setOverlayVisible] = useState(false);
@@ -247,7 +278,12 @@ export function ThreadPage({
       behavior={Platform.OS === "ios" ? "padding" : undefined}
       keyboardVerticalOffset={0}
     >
-      <ThreadHeader channelName={channelName} onBack={handleBack} />
+      <ThreadHeader
+        channelName={channelName}
+        onBack={handleBack}
+        notificationState={notificationState}
+        onToggleNotifications={handleToggleNotifications}
+      />
 
       <View style={[styles.content, { backgroundColor: colors.surfaceSecondary }]}>
         <FlashList


### PR DESCRIPTION
## What & why

Thread replies previously notified **every** channel member, leading to notification overload. This change makes thread replies **mentions-only by default** and gives members per-thread control via a bell toggle.

### Behavior

For a **thread reply** (a message with a `parentMessageId`):

| Member's thread preference | Result |
| --- | --- |
| _default_ (no preference set) | Notified **only if @mentioned** |
| **All replies** (`"all"`) | Notified on every reply (rich mention notification if also mentioned) |
| **Muted** (`"none"`) | Never notified, even when @mentioned |

Top-level (non-reply) messages are **unchanged** — everyone is still notified. DMs keep notifying by default (low volume) but honor an explicit `"none"` mute.

## Changes

**Backend (`apps/convex`)**
- New `chatThreadSubscriptions` table — per-user, per-thread preference (`"all"` | `"none"`; absence = default). Keyed by the parent message (`threadId`).
- `decideRecipientBucket` in `messaging/events.ts` centralizes the routing rule and is applied across all three fanout paths (shared, ad-hoc, standard) in `onMessageSent`.
- `getThreadSubscription` / `setThreadSubscription` (`messaging/threadSubscriptions.ts`) — read/set a member's preference. `setThreadSubscription("default")` clears the row. Membership-guarded.

**Mobile (`apps/mobile`)**
- Bell control in `ThreadHeader` that cycles: mentions-only (outline) → all replies (filled) → muted (off) → default, with an accessibility label.
- `ThreadPage` wires the control to the new functions.

## Testing

- New `threadSubscriptions.test.ts` (10 tests): `decideRecipientBucket` routing rules + the get/set functions (default, roundtrip, clear, no-duplicate, non-member guard).
- `pnpm test` (convex): **444 passed**.
- `npx tsc` convex + mobile: clean on the touched code.
- Pre-push hook ran the full mobile Jest suite: **1103 passed**.
- Native-import gating and navigator-screen checks pass.

## Notes / design decisions

- A single bell **cycles** three states (rather than a separate mute menu) to satisfy "enable or disable regardless of mentions" with one discoverable control.
- Channel-level unread counts are intentionally left unchanged — this PR scopes only push/email notification fanout, not the inbox badge.
- `_generated/api.d.ts` was hand-updated for the new module since `convex codegen` can't run without a deployment in this environment; CI's `convex typecheck` will regenerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYAkj8K6A3tPG7oa8RitdY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYAkj8K6A3tPG7oa8RitdY)_