### PR TITLE
fix(scheduling): open assignment notifications in-app, not the browser

### DIFF
--- a/apps/convex/__tests__/scheduling/reminders.test.ts
+++ b/apps/convex/__tests__/scheduling/reminders.test.ts
@@ -120,6 +120,28 @@ async function latestInboxTitle(
   });
 }
 
+/** The newest scheduling-request inbox deep-link url for a user (or null). */
+async function latestInboxUrl(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+): Promise<string | null> {
+  return t.run(async (ctx) => {
+    const rows = await ctx.db
+      .query("notifications")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("userId"), userId),
+          q.eq(q.field("notificationType"), "scheduling_assignment_request"),
+        ),
+      )
+      .collect();
+    if (rows.length === 0) return null;
+    rows.sort((a, b) => b.createdAt - a.createdAt);
+    const data = rows[0].data as { url?: string } | undefined;
+    return data?.url ?? null;
+  });
+}
+
 describe("scheduling reminders — schedule on publish", () => {
   it("schedules both 4d and 1d reminders at the right times with stored ids", async () => {
     vi.useFakeTimers();
@@ -235,6 +257,42 @@ describe("scheduling reminders — fire behavior", () => {
     const plan = await t.run((ctx) => ctx.db.get(planId));
     expect(plan?.reminder4dSent).toBe(true);
     expect(plan?.reminder1dSent).toBeFalsy();
+  });
+
+  it("stores a RELATIVE in-app path for the assignment link (opens app, not browser)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z").getTime());
+
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 10);
+    await assign(t, world, leaderToken, planId, world.channelMemberId);
+    await t.action(api.functions.scheduling.assignments.publishEvent, {
+      token: leaderToken,
+      planId,
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    // The initial accept/decline request fan-out (sendAssignmentRequests).
+    await t.action(
+      internal.functions.scheduling.assignments.sendAssignmentRequests,
+      { planId, publisherId: world.groupLeaderId },
+    );
+    const requestUrl = await latestInboxUrl(t, world.channelMemberId);
+    expect(requestUrl).not.toBeNull();
+    // Must be a relative expo-router path — an absolute https:// URL would be
+    // treated as an external link and open in the browser instead of the app.
+    expect(requestUrl).toMatch(/^\/scheduling\/assignment\//);
+    expect(requestUrl).not.toMatch(/^https?:\/\//);
+
+    // The reminder fan-out (a separate code path) must do the same.
+    await t.action(
+      internal.functions.scheduling.assignments.sendUnconfirmedReminders,
+      { planId, kind: "4d" },
+    );
+    const reminderUrl = await latestInboxUrl(t, world.channelMemberId);
+    expect(reminderUrl).toMatch(/^\/scheduling\/assignment\//);
+    expect(reminderUrl).not.toMatch(/^https?:\/\//);
   });
 
   it("4d skips a confirmed volunteer but 1d sends them a serving-tomorrow heads-up", async () => {

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -1145,8 +1145,14 @@ export const sendUnconfirmedReminders = internalAction({
       month: "short",
       day: "numeric",
     });
+    // SMS needs an absolute web link; push/in-app navigation needs a RELATIVE
+    // path. expo-router treats an absolute `https://…` URL as an external link
+    // and opens it in the browser instead of routing in-app, so the inbox/push
+    // `url` must stay relative (see resolveNotificationNavigation).
     const linkFor = (assignmentId: string) =>
       `${DOMAIN_CONFIG.appUrl}/scheduling/assignment/${assignmentId}`;
+    const pathFor = (assignmentId: string) =>
+      `/scheduling/assignment/${assignmentId}`;
 
     // Copy branches on the recipient's current status. A `confirmed`
     // volunteer (only present in the 1-day pass) gets a no-ask heads-up;
@@ -1183,7 +1189,7 @@ export const sendUnconfirmedReminders = internalAction({
     const pushNotifications = recipients.flatMap((recipient) => {
       const tokens = tokensByUser.get(recipient.userId) ?? [];
       const { title, body } = copyFor(recipient);
-      const url = linkFor(recipient.assignmentId);
+      const url = pathFor(recipient.assignmentId);
       return tokens.map((token) => ({
         token,
         title,
@@ -1233,7 +1239,7 @@ export const sendUnconfirmedReminders = internalAction({
             groupId: targets.groupId,
             title,
             body,
-            url: linkFor(recipient.assignmentId),
+            url: pathFor(recipient.assignmentId),
           };
         }),
       },
@@ -1413,9 +1419,14 @@ export const sendAssignmentRequests = internalAction({
     });
 
     // Build per-assignment deep links so a tapped request opens straight to
-    // the volunteer's accept/decline screen.
+    // the volunteer's accept/decline screen. SMS needs the absolute web link;
+    // push/in-app navigation needs a RELATIVE path, because expo-router opens
+    // an absolute `https://…` URL in the browser instead of routing in-app
+    // (see resolveNotificationNavigation).
     const linkFor = (assignmentId: string) =>
       `${DOMAIN_CONFIG.appUrl}/scheduling/assignment/${assignmentId}`;
+    const pathFor = (assignmentId: string) =>
+      `/scheduling/assignment/${assignmentId}`;
     // Placeholder users don't have the app yet — point them at the signup
     // deeplink with phone prefilled. The phone-OTP claim logic takes over
     // and the assignment is inherited via the placeholder's stable `_id`.
@@ -1445,7 +1456,7 @@ export const sendAssignmentRequests = internalAction({
       const tokens = tokensByUser.get(recipient.userId) ?? [];
       const title = `You're scheduled: ${targets.title}`;
       const body = `${recipient.roleName} on ${eventDate}. Tap to accept or decline.`;
-      const url = linkFor(recipient.assignmentId);
+      const url = pathFor(recipient.assignmentId);
       return tokens.map((token) => ({
         token,
         title,
@@ -1523,7 +1534,7 @@ export const sendAssignmentRequests = internalAction({
           groupId: targets.groupId,
           title: `You're scheduled: ${targets.title}`,
           body: `${recipient.roleName} on ${eventDate}.`,
-          url: linkFor(recipient.assignmentId),
+          url: pathFor(recipient.assignmentId),
         })),
       },
     );

--- a/apps/mobile/features/notifications/utils/__tests__/resolveNotificationNavigation.test.ts
+++ b/apps/mobile/features/notifications/utils/__tests__/resolveNotificationNavigation.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for resolveNotificationNavigation — the shared mapping from a
+ * notification `data` payload to an in-app navigation action.
+ *
+ * The regression these cover: volunteering-assignment notifications used to
+ * store an ABSOLUTE app URL (`https://togather.nyc/scheduling/assignment/x`)
+ * in `data.url`. expo-router treats an absolute `https://…` URL as an external
+ * link and opens it in the browser (Safari, stuck on an infinite-loading
+ * "Your assignment" web page) instead of routing in-app. The resolver now
+ * normalizes our own origin down to a relative path so the tap opens the app.
+ *
+ * Run with: cd apps/mobile && pnpm test features/notifications/utils/__tests__/resolveNotificationNavigation.test.ts
+ */
+
+jest.mock("expo-router", () => ({
+  router: { push: jest.fn() },
+}));
+
+import { router } from "expo-router";
+import { DOMAIN_CONFIG } from "@togather/shared";
+import { resolveNotificationNavigation } from "../resolveNotificationNavigation";
+
+const mockPush = router.push as unknown as jest.Mock;
+
+afterEach(() => {
+  mockPush.mockClear();
+});
+
+describe("resolveNotificationNavigation — pre-computed url", () => {
+  it("rewrites an absolute app URL to a relative in-app path (no browser)", async () => {
+    await resolveNotificationNavigation({
+      type: "scheduling_assignment_request",
+      url: `${DOMAIN_CONFIG.appUrl}/scheduling/assignment/abc123`,
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith("/scheduling/assignment/abc123");
+    // The browser-opening absolute form must never reach the router.
+    expect(mockPush.mock.calls[0][0]).not.toMatch(/^https?:\/\//);
+  });
+
+  it("handles an absolute app URL nested under data.data (iOS push shape)", async () => {
+    await resolveNotificationNavigation({
+      data: {
+        type: "scheduling_assignment_request",
+        url: `${DOMAIN_CONFIG.appUrl}/scheduling/assignment/nested1`,
+      },
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/scheduling/assignment/nested1");
+  });
+
+  it("passes an already-relative path through unchanged", async () => {
+    await resolveNotificationNavigation({
+      type: "scheduling_assignment_request",
+      url: "/scheduling/assignment/rel1",
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/scheduling/assignment/rel1");
+  });
+
+  it("leaves a genuinely external URL untouched", async () => {
+    const external = "https://example.com/somewhere";
+    await resolveNotificationNavigation({ url: external });
+
+    expect(mockPush).toHaveBeenCalledWith(external);
+  });
+});
+
+describe("resolveNotificationNavigation — type-based routing still works", () => {
+  it("routes an event notification to its short link", async () => {
+    await resolveNotificationNavigation({
+      type: "event_rsvp_received",
+      shortId: "evt99",
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/e/evt99?source=app");
+  });
+});

--- a/apps/mobile/features/notifications/utils/resolveNotificationNavigation.ts
+++ b/apps/mobile/features/notifications/utils/resolveNotificationNavigation.ts
@@ -12,7 +12,22 @@
  * always already inside the right community context.
  */
 import { router } from "expo-router";
+import { DOMAIN_CONFIG } from "@togather/shared";
 import type { Id } from "@services/api/convex";
+
+/**
+ * Normalize a pre-computed notification link into something expo-router can
+ * navigate to in-app. Some backend notifications stored an absolute app URL
+ * (e.g. `https://togather.nyc/scheduling/assignment/x`); expo-router treats an
+ * absolute `https://…` URL as an external link and hands it to the browser
+ * instead of routing within the app. Strip our own origin down to a relative
+ * path so the tap opens the app. Non-app (genuinely external) URLs pass
+ * through untouched.
+ */
+function toInAppLink(url: string): string {
+  const origin = DOMAIN_CONFIG.appUrl;
+  return url.startsWith(`${origin}/`) ? url.slice(origin.length) : url;
+}
 
 /**
  * Side-effecting dependencies the resolver needs. NotificationProvider passes
@@ -51,7 +66,7 @@ export async function resolveNotificationNavigation(
 
   // A pre-computed URL always wins.
   if (url) {
-    router.push(url as never);
+    router.push(toInAppLink(url) as never);
     return;
   }
 


### PR DESCRIPTION
## Problem

Tapping a volunteering-assignment notification (accept/decline) opened the link in **Safari** instead of the app, landing on a "Your assignment" web page stuck in an **infinite loading** state. It reproduced from both the OS push tap and the in-app notification feed.

**Root cause:** the assignment notifications stored an **absolute** app URL — `https://togather.nyc/scheduling/assignment/<id>` — in their `url` payload. Every other notification type uses a **relative** path. expo-router treats an absolute `https://…` URL as an *external* link and hands it to the browser, so the tap left the app. The web context is unauthenticated, so the `myAssignments` query never resolves → the spinner never stops (the "infinite loading"). Both push taps and the in-app feed flow through the same `resolveNotificationNavigation` resolver, which is why it happened in-app too.

## Fix

- **Backend** (`functions/scheduling/assignments.ts`): emit a **relative** path (`/scheduling/assignment/<id>`) for the push `data.url` and in-app inbox records in both fan-out paths (`sendUnconfirmedReminders` and `sendAssignmentRequests`). The **SMS body keeps the absolute web link**, which it needs to be tappable from a text message.
- **Mobile** (`features/notifications/utils/resolveNotificationNavigation.ts`): defensively strip our own app origin from any pre-computed `url` before `router.push`, so already-queued notifications and any future absolute links also route in-app instead of the browser. Genuinely external URLs pass through untouched.

The assignment screen itself needed no change — it only spins forever in an unauthenticated browser; in-app the authenticated query resolves normally.

## Tests

- Backend: asserts the stored inbox link is a relative `/scheduling/assignment/…` path (not `https://…`) for both the request and reminder fan-out paths.
- Mobile: unit tests for the resolver's origin normalization (absolute app URL → relative, nested `data.data` shape, relative passthrough, external-URL passthrough, and that type-based routing still works).

All `apps/convex` scheduling tests (240) and the touched mobile suites pass; lint clean.

## Notes / out of scope

The **SMS link** is still an absolute `togather.nyc` web URL and will continue to open in the browser, because the app does not register iOS Associated Domains / Android App Links (`apps/mobile/app.json` has no `applinks:`). Making SMS web links open the app would require a native universal-links config + rebuild (gated by `runtimeVersion`), which is a separate, larger change. This PR fixes the reported in-app/push notification behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ki7qqqcVhgGdiDCmdX3eGu)_