### PR TITLE
Fix typing in "Log Past Contact" Note field on desktop web

### DIFF
--- a/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDetailScreen.tsx
@@ -12,7 +12,6 @@ import {
   Modal,
   Pressable,
   Image,
-  Keyboard,
   KeyboardAvoidingView,
   Platform,
 } from "react-native";
@@ -1542,10 +1541,7 @@ export function FollowupDetailContent({
         >
           <Pressable
             style={[styles.modalContent, { backgroundColor: colors.modalBackground }]}
-            onPress={(e) => {
-              e.stopPropagation();
-              Keyboard.dismiss();
-            }}
+            onPress={(e) => e.stopPropagation()}
           >
             <Text style={[styles.modalTitle, { color: colors.text }]}>Log Past Contact</Text>
             <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]}>


### PR DESCRIPTION
## Problem

On the desktop web build, the **Note** field in the **Log Past Contact** modal (`FollowupDetailScreen`) could only be typed into while a mouse button was held down. Releasing the click immediately blurred the field, so normal typing didn't register.

**Repro**
1. Open the "Log Past Contact" feature on desktop web.
2. Click into the "Note" field and try to type.
3. Typing is only recognized while holding a mouse click.

## Root cause

The modal content `Pressable` wrapping the form had:

```tsx
onPress={(e) => {
  e.stopPropagation();
  Keyboard.dismiss();
}}
```

On React Native Web, a click on the inner `TextInput` bubbles up to this ancestor `Pressable`, firing its `onPress`. `Keyboard.dismiss()` then blurs the just-focused input. Focus only survived while the mouse button was held (before the click event completed) — producing the "must hold a click to type" behavior.

The sibling **Quick-Action Note** modal in the same file has the identical nested-`Pressable` structure but only calls `e.stopPropagation()` (no `Keyboard.dismiss()`), and it types correctly.

## Fix

Align the Log Past Contact modal with that working pattern: drop the `Keyboard.dismiss()` call from the content `Pressable`'s `onPress`, and remove the now-unused `Keyboard` import.

```diff
   <Pressable
     style={[styles.modalContent, { backgroundColor: colors.modalBackground }]}
-    onPress={(e) => {
-      e.stopPropagation();
-      Keyboard.dismiss();
-    }}
+    onPress={(e) => e.stopPropagation()}
   >
```

Tapping the backdrop still closes the modal (outer overlay `Pressable`), and `e.stopPropagation()` still prevents content taps from closing it. The `KeyboardAvoidingView` wrapper is unchanged.

## Verification

- `eslint features/leader-tools/components/FollowupDetailScreen.tsx` — 0 errors (no new warnings; no unused-`Keyboard` warning, confirming the import removal).
- `tsc --noEmit` — 0 type errors in the changed file.
- Pre-commit hooks (lint-staged) passed on push.

Single-file, behavior-only change; no API, schema, or native-dependency impact, so no guide/ADR updates are required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G51QzhMxyGHcmbNtwPD5Ty)_