### PR TITLE
feat(people): reactivate on form submission + inline unarchive column

### DIFF
--- a/apps/convex/__tests__/community-people-reactivation.test.ts
+++ b/apps/convex/__tests__/community-people-reactivation.test.ts
@@ -135,4 +135,52 @@ describe("upsertFromSubmission reactivation gating", () => {
     expect(row?.archivedAt).toBeUndefined();
     expect(typeof row?.reactivatedAt).toBe("number");
   });
+
+  test("a generic upsert inherits the archive state when creating a new per-group row", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, userId } = await seedArchivedPerson(t);
+
+    // The archived person joins a second group that has no communityPeople row.
+    await t.run(async (ctx) => {
+      const group = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q: any) => q.eq("communityId", communityId))
+        .filter((q: any) => q.eq(q.field("isAnnouncementGroup"), true))
+        .first();
+      const secondGroupId = await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId: group!.groupTypeId,
+        name: "Dinner Party",
+        isAnnouncementGroup: false,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: secondGroupId,
+        userId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+
+    // Generic upsert (no reactivate) — must not resurrect the person anywhere.
+    await t.mutation(internal.functions.communityPeople.upsertFromSubmission, {
+      communityId,
+      userId,
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("communityPeople")
+        .withIndex("by_community_user", (q: any) =>
+          q.eq("communityId", communityId).eq("userId", userId),
+        )
+        .collect(),
+    );
+    // A new row was created for the second group, and it inherited the archive.
+    expect(rows.length).toBe(2);
+    expect(rows.every((r) => r.isActive === false)).toBe(true);
+  });
 });

--- a/apps/convex/__tests__/community-people-reactivation.test.ts
+++ b/apps/convex/__tests__/community-people-reactivation.test.ts
@@ -233,4 +233,123 @@ describe("upsertFromSubmission reactivation gating", () => {
     expect(placeholder?.isActive).toBe(false);
     expect(typeof placeholder?.archivedAt).toBe("number");
   });
+
+  test("a stale archived row for a left group does not re-archive active rows", async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.now();
+
+    const ids = await t.run(async (ctx) => {
+      const communityId = await ctx.db.insert("communities", {
+        name: "Stale Left Group Community",
+        slug: "stale-left-group",
+        isPublic: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const groupTypeId = await ctx.db.insert("groupTypes", {
+        communityId,
+        name: "Announcements",
+        slug: "announcements",
+        isActive: true,
+        createdAt: now,
+        displayOrder: 0,
+      });
+      const announcementGroupId = await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name: "Announcements",
+        isAnnouncementGroup: true,
+        isArchived: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const userId = await ctx.db.insert("users", {
+        firstName: "Rae",
+        lastName: "Joyne",
+        email: "rae@test.com",
+        phone: "+15555554002",
+        createdAt: now,
+        updatedAt: now,
+      });
+      const groupMemberId = await ctx.db.insert("groupMembers", {
+        groupId: announcementGroupId,
+        userId,
+        role: "member",
+        joinedAt: now,
+        notificationsEnabled: true,
+      });
+      await ctx.db.insert("memberFollowupScores", {
+        groupId: announcementGroupId,
+        groupMemberId,
+        userId,
+        firstName: "Rae",
+        lastName: "Joyne",
+        score1: 0,
+        score2: 0,
+        alerts: [],
+        isSnoozed: false,
+        attendanceScore: 0,
+        connectionScore: 0,
+        followupScore: 0,
+        missedMeetings: 0,
+        consecutiveMissed: 0,
+        scoreIds: [],
+        updatedAt: now,
+        addedAt: now,
+      });
+      // Current announcement row is ACTIVE (e.g. just reactivated).
+      const activeRowId = await ctx.db.insert("communityPeople", {
+        communityId,
+        groupId: announcementGroupId,
+        userId,
+        firstName: "Rae",
+        lastName: "Joyne",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // A group the user has LEFT, with a leftover archived row.
+      const leftGroupId = await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name: "Old Group",
+        isAnnouncementGroup: false,
+        isArchived: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: leftGroupId,
+        userId,
+        role: "member",
+        joinedAt: now - 1000,
+        leftAt: now - 500,
+        notificationsEnabled: true,
+      });
+      await ctx.db.insert("communityPeople", {
+        communityId,
+        groupId: leftGroupId,
+        userId,
+        firstName: "Rae",
+        lastName: "Joyne",
+        isActive: false,
+        archivedAt: now - 400,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      return { communityId, userId, activeRowId };
+    });
+
+    await t.mutation(internal.functions.communityPeople.upsertFromSubmission, {
+      communityId: ids.communityId,
+      userId: ids.userId,
+    });
+
+    // The current active row must stay active — the stale left-group archive
+    // is not authoritative.
+    const activeRow = await t.run((ctx) => ctx.db.get(ids.activeRowId));
+    expect(activeRow?.isActive).toBe(true);
+  });
 });

--- a/apps/convex/__tests__/community-people-reactivation.test.ts
+++ b/apps/convex/__tests__/community-people-reactivation.test.ts
@@ -183,4 +183,54 @@ describe("upsertFromSubmission reactivation gating", () => {
     expect(rows.length).toBe(2);
     expect(rows.every((r) => r.isActive === false)).toBe(true);
   });
+
+  test("a generic upsert archives an active placeholder row (quick-add path)", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, userId } = await seedArchivedPerson(t);
+
+    // Quick-add creates a minimal, active communityPeople row synchronously
+    // before scheduling the generic upsert.
+    const placeholderId = await t.run(async (ctx) => {
+      const announcement = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q: any) => q.eq("communityId", communityId))
+        .filter((q: any) => q.eq(q.field("isAnnouncementGroup"), true))
+        .first();
+      const secondGroupId = await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId: announcement!.groupTypeId,
+        name: "Dinner Party",
+        isAnnouncementGroup: false,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId: secondGroupId,
+        userId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+      // Active placeholder (no isActive set → defaults active).
+      return await ctx.db.insert("communityPeople", {
+        communityId,
+        groupId: secondGroupId,
+        userId,
+        firstName: "Archie",
+        lastName: "Ved",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(internal.functions.communityPeople.upsertFromSubmission, {
+      communityId,
+      userId,
+    });
+
+    const placeholder = await t.run((ctx) => ctx.db.get(placeholderId));
+    expect(placeholder?.isActive).toBe(false);
+    expect(typeof placeholder?.archivedAt).toBe("number");
+  });
 });

--- a/apps/convex/__tests__/community-people-reactivation.test.ts
+++ b/apps/convex/__tests__/community-people-reactivation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * upsertFromSubmission reactivation gating.
+ *
+ * upsertFromSubmission is scheduled from two kinds of callers:
+ *   - the public landing-page form submission (reactivate: true), and
+ *   - generic denormalization paths like CSV import / quick-add (no flag).
+ *
+ * Only the genuine submission may resurrect an archived person; a routine
+ * import must never clear a member's archive. These tests pin that boundary.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import { modules } from "../test.setup";
+
+async function seedArchivedPerson(t: ReturnType<typeof convexTest>) {
+  const now = Date.now();
+  const archivedAt = now - 5 * 24 * 60 * 60 * 1000; // archived 5 days ago
+
+  return await t.run(async (ctx) => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "Reactivation Community",
+      slug: "reactivation-community",
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Announcements",
+      slug: "announcements",
+      isActive: true,
+      createdAt: now,
+      displayOrder: 0,
+    });
+
+    const announcementGroupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Announcements",
+      isAnnouncementGroup: true,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const userId = await ctx.db.insert("users", {
+      firstName: "Archie",
+      lastName: "Ved",
+      email: "archie@test.com",
+      phone: "+15555554001",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const groupMemberId = await ctx.db.insert("groupMembers", {
+      groupId: announcementGroupId,
+      userId,
+      role: "member",
+      joinedAt: now,
+      notificationsEnabled: true,
+    });
+
+    // Canonical score doc read by upsertFromSubmission.
+    await ctx.db.insert("memberFollowupScores", {
+      groupId: announcementGroupId,
+      groupMemberId,
+      userId,
+      firstName: "Archie",
+      lastName: "Ved",
+      score1: 0,
+      score2: 0,
+      alerts: [],
+      isSnoozed: false,
+      attendanceScore: 0,
+      connectionScore: 0,
+      followupScore: 0,
+      missedMeetings: 0,
+      consecutiveMissed: 0,
+      scoreIds: [],
+      updatedAt: now,
+      addedAt: now,
+    });
+
+    // The person is currently archived.
+    const communityPeopleId = await ctx.db.insert("communityPeople", {
+      communityId,
+      groupId: announcementGroupId,
+      userId,
+      firstName: "Archie",
+      lastName: "Ved",
+      isActive: false,
+      archivedAt,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { communityId, userId, communityPeopleId, archivedAt };
+  });
+}
+
+describe("upsertFromSubmission reactivation gating", () => {
+  test("a generic upsert (no reactivate flag) leaves an archived person archived", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, userId, communityPeopleId, archivedAt } =
+      await seedArchivedPerson(t);
+
+    await t.mutation(internal.functions.communityPeople.upsertFromSubmission, {
+      communityId,
+      userId,
+    });
+
+    const row = await t.run((ctx) => ctx.db.get(communityPeopleId));
+    expect(row?.isActive).toBe(false);
+    expect(row?.archivedAt).toBe(archivedAt);
+    expect(row?.reactivatedAt).toBeUndefined();
+  });
+
+  test("a real submission (reactivate: true) reactivates an archived person", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, userId, communityPeopleId } =
+      await seedArchivedPerson(t);
+
+    await t.mutation(internal.functions.communityPeople.upsertFromSubmission, {
+      communityId,
+      userId,
+      reactivate: true,
+    });
+
+    const row = await t.run((ctx) => ctx.db.get(communityPeopleId));
+    expect(row?.isActive).toBe(true);
+    expect(row?.archivedAt).toBeUndefined();
+    expect(typeof row?.reactivatedAt).toBe("number");
+  });
+});

--- a/apps/convex/__tests__/member-archive-notice.test.ts
+++ b/apps/convex/__tests__/member-archive-notice.test.ts
@@ -140,6 +140,34 @@ describe("shouldSendPreArchiveNotice", () => {
       }),
     ).toBe(true);
   });
+
+  test("a recent reactivation suppresses a would-be notice", () => {
+    // Last real activity is deep in the window, but the person was just
+    // reactivated (manual unarchive / form submission) — the clock restarted.
+    expect(
+      shouldSendPreArchiveNotice({
+        nowTs: NOW,
+        isActive: true,
+        lastActivityTs: ageMs(55 * DAY_MS),
+        reactivatedAt: ageMs(2 * DAY_MS),
+      }),
+    ).toBe(false);
+  });
+
+  test("a reactivation does not let a stale notice suppress a later correct one", () => {
+    // Notice was sent during the pre-reactivation spell; the person was then
+    // reactivated and has gone quiet again into the window. The fresh spell
+    // (measured from reactivatedAt) should still allow a notice.
+    expect(
+      shouldSendPreArchiveNotice({
+        nowTs: NOW,
+        isActive: true,
+        lastActivityTs: ageMs(200 * DAY_MS),
+        reactivatedAt: ageMs(55 * DAY_MS),
+        noticeSentAt: ageMs(120 * DAY_MS), // from the previous spell
+      }),
+    ).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/apps/convex/__tests__/person-active-state.test.ts
+++ b/apps/convex/__tests__/person-active-state.test.ts
@@ -136,6 +136,62 @@ describe("computePersonActiveState", () => {
     });
     expect(r.isActive).toBe(true);
   });
+
+  // A manual unarchive (or a form submission) records `reactivatedAt`, which
+  // counts as activity so the 60-day clock restarts from that moment.
+  test("a manual unarchive keeps a long-inactive person active", () => {
+    // Last real activity was 200 days ago, but they were unarchived yesterday.
+    const r = computePersonActiveState({
+      nowTs: NOW,
+      lastActivityTs: daysAgo(200),
+      reactivatedAt: daysAgo(1),
+      addedAt: daysAgo(400),
+      currentIsActive: true,
+    });
+    expect(r.isActive).toBe(true);
+    expect(r.archivedAt).toBeUndefined();
+  });
+
+  test("a manually-unarchived person is re-archived once the unarchive itself goes stale", () => {
+    // Both the last activity and the unarchive are now older than 60 days.
+    const r = computePersonActiveState({
+      nowTs: NOW,
+      lastActivityTs: daysAgo(200),
+      reactivatedAt: daysAgo(75),
+      addedAt: daysAgo(400),
+      currentIsActive: true,
+    });
+    expect(r.isActive).toBe(false);
+    expect(r.archivedAt).toBe(NOW);
+  });
+
+  test("a form submission (reactivatedAt) reactivates a previously archived person", () => {
+    // Archived 30 days ago, no app activity since, but just submitted a form.
+    const r = computePersonActiveState({
+      nowTs: NOW,
+      lastActivityTs: daysAgo(120),
+      reactivatedAt: NOW, // submission timestamp
+      addedAt: daysAgo(400),
+      currentIsActive: false,
+      currentArchivedAt: daysAgo(30),
+    });
+    expect(r.isActive).toBe(true);
+    expect(r.archivedAt).toBeUndefined();
+  });
+
+  test("a stale reactivatedAt does not resurrect an archive that came after it", () => {
+    // Unarchived long ago, then re-archived more recently → stays archived.
+    const r = computePersonActiveState({
+      nowTs: NOW,
+      lastActivityTs: daysAgo(200),
+      reactivatedAt: daysAgo(90),
+      addedAt: daysAgo(400),
+      currentIsActive: false,
+      currentArchivedAt: daysAgo(20),
+    });
+    expect(r.isActive).toBe(false);
+    expect(r.archivedAt).toBe(daysAgo(20));
+  });
 });
 
 describe("mostRecentTimestamp", () => {

--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -700,10 +700,14 @@ export const setCustomFieldsAndNotes = internalMutation({
       }
     }
 
-    // Schedule communityPeople upsert so the People table is immediately populated
+    // Schedule communityPeople upsert so the People table is immediately
+    // populated. This is the genuine public form submission, so reactivate the
+    // person if they were previously archived (the leader-driven import /
+    // quick-add callers deliberately do not pass this).
     await ctx.scheduler.runAfter(0, internal.functions.communityPeople.upsertFromSubmission, {
       communityId: args.communityId,
       userId: args.userId,
+      reactivate: true,
     });
 
     return { smsSnippets, followupNoteId };

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -2507,6 +2507,11 @@ export const upsertFromSubmission = internalMutation({
   args: {
     communityId: v.id("communities"),
     userId: v.id("users"),
+    // Only the public form-submission caller sets this. It reactivates the
+    // person (clears archive + restarts the auto-archive clock). The generic
+    // denormalization callers (CSV import, quick-add) leave it off so a routine
+    // import never resurrects an archived member. See computePersonActiveState.
+    reactivate: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const nowTs = Date.now();
@@ -2593,13 +2598,6 @@ export const upsertFromSubmission = internalMutation({
       alerts: (scoreDoc as any).alerts ?? [],
       isSnoozed: (scoreDoc as any).isSnoozed ?? false,
       snoozedUntil: (scoreDoc as any).snoozedUntil,
-      // A form submission is fresh engagement: reactivate the person across all
-      // their groups and restart the auto-archive clock from now. `reactivatedAt`
-      // keeps them active until the full inactivity window passes, surviving the
-      // daily score refresh. See computePersonActiveState.
-      isActive: true,
-      archivedAt: undefined,
-      reactivatedAt: nowTs,
       customText1: (scoreDoc as any).customText1,
       customText2: (scoreDoc as any).customText2,
       customText3: (scoreDoc as any).customText3,
@@ -2618,6 +2616,15 @@ export const upsertFromSubmission = internalMutation({
       rawValues: (scoreDoc as any).rawValues,
       updatedAt: nowTs,
     };
+
+    // A form submission is fresh engagement: reactivate the person across all
+    // their groups and restart the auto-archive clock from now. `reactivatedAt`
+    // keeps them active until the full inactivity window passes, surviving the
+    // daily score refresh (see computePersonActiveState). Leave archive state
+    // untouched for generic denormalization callers (CSV import, quick-add).
+    const reactivationFields = args.reactivate
+      ? { isActive: true, archivedAt: undefined, reactivatedAt: nowTs }
+      : {};
 
     // 6. Find all active group memberships for this user in this community
     const allMemberships = await ctx.db
@@ -2645,11 +2652,16 @@ export const upsertFromSubmission = internalMutation({
 
       let cpId: Id<"communityPeople">;
       if (existing) {
-        await ctx.db.patch(existing._id, { ...canonicalFields, groupId });
+        await ctx.db.patch(existing._id, {
+          ...canonicalFields,
+          ...reactivationFields,
+          groupId,
+        });
         cpId = existing._id;
       } else {
         cpId = await ctx.db.insert("communityPeople", {
           ...canonicalFields,
+          ...reactivationFields,
           groupId,
           createdAt: nowTs,
         });

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -1554,6 +1554,11 @@ export const setStatus = mutation({
  * sticks — the daily score job won't resurrect it — until the person opens the
  * app again, at which point they're reactivated. `archivedAt` records when the
  * archive happened so the job can detect a later app open.
+ *
+ * A manual unarchive records `reactivatedAt` so the person stays active for the
+ * full inactivity window measured from the unarchive — they won't be re-archived
+ * on the next daily run just because their last real activity is already stale.
+ * See computePersonActiveState in communityScoreComputation.ts.
  */
 export const setActive = mutation({
   args: {
@@ -1571,9 +1576,11 @@ export const setActive = mutation({
 
     await requireCommunityLeader(ctx, cpRecord.communityId, userId);
 
+    const now = Date.now();
     const patchFields = {
       isActive: args.isActive,
-      archivedAt: args.isActive ? undefined : Date.now(),
+      archivedAt: args.isActive ? undefined : now,
+      reactivatedAt: args.isActive ? now : undefined,
     };
     await ctx.db.patch(args.communityPeopleId, {
       ...patchFields,
@@ -2585,6 +2592,13 @@ export const upsertFromSubmission = internalMutation({
       alerts: (scoreDoc as any).alerts ?? [],
       isSnoozed: (scoreDoc as any).isSnoozed ?? false,
       snoozedUntil: (scoreDoc as any).snoozedUntil,
+      // A form submission is fresh engagement: reactivate the person across all
+      // their groups and restart the auto-archive clock from now. `reactivatedAt`
+      // keeps them active until the full inactivity window passes, surviving the
+      // daily score refresh. See computePersonActiveState.
+      isActive: true,
+      archivedAt: undefined,
+      reactivatedAt: nowTs,
       customText1: (scoreDoc as any).customText1,
       customText2: (scoreDoc as any).customText2,
       customText3: (scoreDoc as any).customText3,

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -668,7 +668,7 @@ export const listAllForCsvExport = action({
     const columnKeys = [
       "addedAt", "firstName", "lastName", "email", "phone", "zipCode", "dateOfBirth",
       ...SCORE_COLUMNS.map((s) => s.slot),
-      "assignee", "notes", "tasks", "status", "lastAttendedAt", "lastFollowupAt", "lastActiveAt", "alerts",
+      "assignee", "notes", "tasks", "status", "lastAttendedAt", "lastFollowupAt", "lastActiveAt", "alerts", "archived",
       ...customFields.map((cf) => cf.slot),
     ];
     const columnLabelMap: Record<string, string> = {
@@ -676,7 +676,7 @@ export const listAllForCsvExport = action({
       email: "Email", phone: "Phone", zipCode: "ZIP Code", dateOfBirth: "Birthday",
       assignee: "Assignees", notes: "Notes", tasks: "Tasks", status: "Status",
       lastAttendedAt: "Last Attended", lastFollowupAt: "Last Contact",
-      lastActiveAt: "Date Active", alerts: "Alerts",
+      lastActiveAt: "Date Active", alerts: "Alerts", archived: "Archived",
     };
     for (const sc of SCORE_COLUMNS) columnLabelMap[sc.slot] = sc.name;
     for (const cf of customFields) columnLabelMap[cf.slot] = cf.name;
@@ -718,6 +718,7 @@ export const listAllForCsvExport = action({
           case "lastFollowupAt": return formatTs(m.lastFollowupAt);
           case "lastActiveAt": return formatTs(m.lastActiveAt);
           case "alerts": return (m.alerts ?? []).join("; ");
+          case "archived": return m.isActive === false ? "Archived" : "Active";
           default: {
             if (key.startsWith("custom")) {
               const raw = m[key];

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -2626,31 +2626,6 @@ export const upsertFromSubmission = internalMutation({
       ? { isActive: true, archivedAt: undefined, reactivatedAt: nowTs }
       : {};
 
-    // Archiving is community-wide, so a new per-group row for an already-archived
-    // person must start archived too — otherwise a generic upsert (CSV import /
-    // quick-add) into a group that lacks a row would make them reappear there.
-    // Snapshot the existing archive state once; only relevant when NOT
-    // reactivating (a real submission clears the archive everywhere instead).
-    let inheritedArchiveFields: {
-      isActive: boolean;
-      archivedAt: number | undefined;
-    } | null = null;
-    if (!args.reactivate) {
-      const archivedSibling = await ctx.db
-        .query("communityPeople")
-        .withIndex("by_community_user", (q: any) =>
-          q.eq("communityId", args.communityId).eq("userId", args.userId),
-        )
-        .filter((q: any) => q.eq(q.field("isActive"), false))
-        .first();
-      if (archivedSibling) {
-        inheritedArchiveFields = {
-          isActive: false,
-          archivedAt: (archivedSibling as any).archivedAt ?? nowTs,
-        };
-      }
-    }
-
     // 6. Find all active group memberships for this user in this community
     const allMemberships = await ctx.db
       .query("groupMembers")
@@ -2663,6 +2638,41 @@ export const upsertFromSubmission = internalMutation({
       const group = await ctx.db.get(membership.groupId);
       if (group && group.communityId === args.communityId) {
         communityGroupIds.push(group._id);
+      }
+    }
+    const communityGroupIdSet = new Set(
+      communityGroupIds.map((id) => id.toString()),
+    );
+
+    // Archiving is community-wide, so a new per-group row for an already-archived
+    // person must start archived too — otherwise a generic upsert (CSV import /
+    // quick-add) into a group that lacks a row would make them reappear there.
+    // Snapshot the existing archive state once; only relevant when NOT
+    // reactivating (a real submission clears the archive everywhere instead).
+    //
+    // Only rows for groups the user is STILL an active member of are
+    // authoritative: a left-group row stays archived until the daily prune even
+    // after a reactivation, and must not re-archive the user's current rows.
+    let inheritedArchiveFields: {
+      isActive: boolean;
+      archivedAt: number | undefined;
+    } | null = null;
+    if (!args.reactivate) {
+      const archivedSiblings = await ctx.db
+        .query("communityPeople")
+        .withIndex("by_community_user", (q: any) =>
+          q.eq("communityId", args.communityId).eq("userId", args.userId),
+        )
+        .filter((q: any) => q.eq(q.field("isActive"), false))
+        .collect();
+      const authoritative = archivedSiblings.find((row) =>
+        communityGroupIdSet.has((row as any).groupId.toString()),
+      );
+      if (authoritative) {
+        inheritedArchiveFields = {
+          isActive: false,
+          archivedAt: (authoritative as any).archivedAt ?? nowTs,
+        };
       }
     }
 

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -2626,6 +2626,31 @@ export const upsertFromSubmission = internalMutation({
       ? { isActive: true, archivedAt: undefined, reactivatedAt: nowTs }
       : {};
 
+    // Archiving is community-wide, so a new per-group row for an already-archived
+    // person must start archived too — otherwise a generic upsert (CSV import /
+    // quick-add) into a group that lacks a row would make them reappear there.
+    // Snapshot the existing archive state once; only relevant when NOT
+    // reactivating (a real submission clears the archive everywhere instead).
+    let inheritedArchiveFields: {
+      isActive: boolean;
+      archivedAt: number | undefined;
+    } | null = null;
+    if (!args.reactivate) {
+      const archivedSibling = await ctx.db
+        .query("communityPeople")
+        .withIndex("by_community_user", (q: any) =>
+          q.eq("communityId", args.communityId).eq("userId", args.userId),
+        )
+        .filter((q: any) => q.eq(q.field("isActive"), false))
+        .first();
+      if (archivedSibling) {
+        inheritedArchiveFields = {
+          isActive: false,
+          archivedAt: (archivedSibling as any).archivedAt ?? nowTs,
+        };
+      }
+    }
+
     // 6. Find all active group memberships for this user in this community
     const allMemberships = await ctx.db
       .query("groupMembers")
@@ -2662,6 +2687,9 @@ export const upsertFromSubmission = internalMutation({
         cpId = await ctx.db.insert("communityPeople", {
           ...canonicalFields,
           ...reactivationFields,
+          // Inherit the person's community-wide archive state on new rows
+          // (no-op when reactivating, since the archive is being cleared).
+          ...(inheritedArchiveFields ?? {}),
           groupId,
           createdAt: nowTs,
         });

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -2676,10 +2676,16 @@ export const upsertFromSubmission = internalMutation({
         .first();
 
       let cpId: Id<"communityPeople">;
+      // Inherit the person's community-wide archive state on both branches
+      // (no-op when reactivating, since the archive is being cleared). On
+      // inserts this archives brand-new rows; on patches it archives active
+      // placeholders — e.g. a quick-add row created just before this runs — so
+      // an archived person never reappears in another group's People table.
       if (existing) {
         await ctx.db.patch(existing._id, {
           ...canonicalFields,
           ...reactivationFields,
+          ...(inheritedArchiveFields ?? {}),
           groupId,
         });
         cpId = existing._id;
@@ -2687,8 +2693,6 @@ export const upsertFromSubmission = internalMutation({
         cpId = await ctx.db.insert("communityPeople", {
           ...canonicalFields,
           ...reactivationFields,
-          // Inherit the person's community-wide archive state on new rows
-          // (no-op when reactivating, since the archive is being cleared).
           ...(inheritedArchiveFields ?? {}),
           groupId,
           createdAt: nowTs,

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -72,37 +72,52 @@ export function mostRecentTimestamp(
  * - A manual or automatic archive sticks. The daily job never resurrects an
  *   archived person on its own.
  * - The ONE thing that reactivates an archived person is fresh activity after
- *   the archive: if `lastActivityTs` is newer than the moment they were archived,
+ *   the archive: if their activity is newer than the moment they were archived,
  *   clear the flag. (For records archived before `archivedAt` was tracked, fall
  *   back to "active within the inactivity window".)
+ * - A manual unarchive or a form submission records `reactivatedAt`. It counts
+ *   as activity, so the clock restarts from that moment: a reactivated person
+ *   stays active unless BOTH their last real activity AND the reactivation date
+ *   are past the 60-day threshold.
  * - An active person is auto-archived once they go quiet for the threshold.
- *   People with no recorded activity have no `lastActivityTs`, so we fall back to
+ *   People with no recorded activity have no activity signal, so we fall back to
  *   `addedAt` (date added).
  */
 export function computePersonActiveState(params: {
   nowTs: number;
   lastActivityTs?: number;
+  reactivatedAt?: number;
   addedAt?: number;
   currentIsActive?: boolean;
   currentArchivedAt?: number;
 }): { isActive: boolean; archivedAt: number | undefined } {
-  const { nowTs, lastActivityTs, addedAt, currentIsActive, currentArchivedAt } =
-    params;
+  const {
+    nowTs,
+    lastActivityTs,
+    reactivatedAt,
+    addedAt,
+    currentIsActive,
+    currentArchivedAt,
+  } = params;
+
+  // A manual unarchive (or a form submission) counts as activity for the
+  // auto-archive clock, alongside the person's own engagement signals.
+  const activitySignal = mostRecentTimestamp(lastActivityTs, reactivatedAt);
 
   if (currentIsActive === false) {
     // Archived. Only activity that happened AFTER archiving brings them back.
     const activeSinceArchive =
-      lastActivityTs != null &&
+      activitySignal != null &&
       (currentArchivedAt != null
-        ? lastActivityTs > currentArchivedAt
-        : nowTs - lastActivityTs <= INACTIVITY_THRESHOLD_MS);
+        ? activitySignal > currentArchivedAt
+        : nowTs - activitySignal <= INACTIVITY_THRESHOLD_MS);
     return activeSinceArchive
       ? { isActive: true, archivedAt: undefined }
       : { isActive: false, archivedAt: currentArchivedAt };
   }
 
   // Active (or brand new). Auto-archive once activity goes stale.
-  const activityTs = lastActivityTs ?? addedAt;
+  const activityTs = activitySignal ?? addedAt;
   if (activityTs != null && nowTs - activityTs > INACTIVITY_THRESHOLD_MS) {
     return { isActive: false, archivedAt: nowTs };
   }
@@ -636,6 +651,7 @@ export const upsertCommunityPeopleBatch = internalMutation({
             member.lastAttendedAt,
             member.lastServedAt,
           ),
+          reactivatedAt: (existing as any).reactivatedAt,
           addedAt: member.addedAt,
           currentIsActive: (existing as any).isActive,
           currentArchivedAt: (existing as any).archivedAt,
@@ -671,6 +687,7 @@ export const upsertCommunityPeopleBatch = internalMutation({
                   member.lastAttendedAt,
                   member.lastServedAt,
                 ),
+                reactivatedAt: (siblingRecord as any)?.reactivatedAt,
                 addedAt: member.addedAt,
                 currentIsActive: (siblingRecord as any)?.isActive,
                 currentArchivedAt: (siblingRecord as any)?.archivedAt,
@@ -679,6 +696,9 @@ export const upsertCommunityPeopleBatch = internalMutation({
           ...scoreDoc,
           isActive: activeState.isActive,
           archivedAt: activeState.archivedAt,
+          // Carry the community-wide reactivation timestamp onto the new
+          // per-group record so the manual-unarchive clock survives.
+          reactivatedAt: (siblingRecord as any)?.reactivatedAt,
           // Copy leader-set fields from sibling if exists
           status: siblingRecord?.status,
           assigneeIds: siblingRecord?.assigneeIds,

--- a/apps/convex/functions/memberArchiveNotice.ts
+++ b/apps/convex/functions/memberArchiveNotice.ts
@@ -62,21 +62,28 @@ const CANDIDATE_PAGE_SIZE = 100;
  * person did anything — so we stay quiet. If they engage again (which bumps
  * `activityTs` past the old `noticeSentAt`) and later go quiet, a fresh notice
  * is allowed. Activity signals mirror the archive logic: app opens, attendance,
- * serving — falling back to `addedAt` for members who never engaged.
+ * serving, plus a manual unarchive / form reactivation (`reactivatedAt`) —
+ * falling back to `addedAt` for members who never engaged.
  */
 export function shouldSendPreArchiveNotice(params: {
   nowTs: number;
   isActive?: boolean;
   lastActivityTs?: number;
+  reactivatedAt?: number;
   addedAt?: number;
   noticeSentAt?: number;
 }): boolean {
-  const { nowTs, isActive, lastActivityTs, addedAt, noticeSentAt } = params;
+  const { nowTs, isActive, lastActivityTs, reactivatedAt, addedAt, noticeSentAt } =
+    params;
 
   // Already archived — nothing to pre-warn about.
   if (isActive === false) return false;
 
-  const activityTs = lastActivityTs ?? addedAt;
+  // A reactivation restarts the inactivity clock just like in
+  // computePersonActiveState, so it must count here too — otherwise a freshly
+  // reactivated person could get a misleading "about to be archived" nudge, or a
+  // stale notice could suppress a correct one later.
+  const activityTs = mostRecentTimestamp(lastActivityTs, reactivatedAt) ?? addedAt;
   if (activityTs == null) return false;
 
   const age = nowTs - activityTs;
@@ -121,6 +128,7 @@ export const getPreArchiveCandidatesPage = internalQuery({
             row.lastAttendedAt,
             row.lastServedAt,
           ),
+          reactivatedAt: row.reactivatedAt,
           addedAt: row.addedAt,
           noticeSentAt: row.preArchiveNoticeSentAt,
         }),

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2438,6 +2438,13 @@ export default defineSchema({
     isActive: v.optional(v.boolean()),
     archivedAt: v.optional(v.number()),
 
+    // When the person was last manually unarchived or reactivated by a form
+    // submission. Counts as activity for the 60-day auto-archive clock, so a
+    // manual unarchive sticks until the person is quiet for the full window
+    // measured from this moment (not from their stale last activity). See
+    // computePersonActiveState in communityScoreComputation.ts.
+    reactivatedAt: v.optional(v.number()),
+
     // When the "approaching auto-archive" check-in notice was last sent to the
     // person's leaders/assignees. Used to send that notice once per inactivity
     // spell (see shouldSendPreArchiveNotice in functions/memberArchiveNotice.ts).

--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -90,6 +90,8 @@ type FollowupMember = {
   latestNote?: string;
   latestNoteAt?: number;
   isLeader: boolean;
+  // Archived state. `isActive === false` = archived; undefined/true = active.
+  isActive?: boolean;
   score1: number;
   score2: number;
   score3?: number;
@@ -161,7 +163,12 @@ type ColumnDef = {
 };
 
 // Built-in editable columns that get a visual highlight
-const BUILTIN_EDITABLE_COLUMNS = new Set(["assignee", "status", "zipCode"]);
+const BUILTIN_EDITABLE_COLUMNS = new Set([
+  "assignee",
+  "status",
+  "zipCode",
+  "archived",
+]);
 
 type DropdownPosition = {
   top: number;
@@ -623,6 +630,9 @@ export function FollowupDesktopTable({
         serverSortKey: "lastActiveAt",
       },
       { key: "alerts", label: "Alerts", defaultWidth: 120, sortable: false },
+      // Clickable cell to archive/unarchive a person inline. Pair with the
+      // `archived:true` / `archived:only` search to surface archived people.
+      { key: "archived", label: "Archived", defaultWidth: 110, sortable: false },
     );
 
     // Custom field columns
@@ -687,6 +697,7 @@ export function FollowupDesktopTable({
     map["lastFollowupAt"] = "Last Contact";
     map["lastActiveAt"] = "Date Active";
     map["alerts"] = "Alerts";
+    map["archived"] = "Archived";
     for (const cf of customFields) {
       map[cf.slot] = cf.name;
     }
@@ -715,6 +726,7 @@ export function FollowupDesktopTable({
       "lastFollowupAt",
       "lastActiveAt",
       "alerts",
+      "archived",
     );
     for (const cf of customFields) keys.push(cf.slot);
     return keys;
@@ -1091,6 +1103,10 @@ export function FollowupDesktopTable({
   const setZipCodeMut = useAuthenticatedMutation(
     api.functions.communityPeople.setZipCode,
   );
+  // Archive / unarchive mutation
+  const setActiveMut = useAuthenticatedMutation(
+    api.functions.communityPeople.setActive,
+  );
   const assigneeMutationQueueRef = useRef<Record<string, Promise<void>>>({});
 
   // Bulk remove mutations
@@ -1291,6 +1307,32 @@ export function FollowupDesktopTable({
         const next = { ...prev };
         if (next[memberId]) {
           delete next[memberId].status;
+          if (Object.keys(next[memberId]).length === 0) delete next[memberId];
+        }
+        return next;
+      });
+    }
+  };
+
+  // Archive (hide from the table) or unarchive (reactivate) a person inline.
+  // Unarchiving records a server-side reactivation timestamp so the daily score
+  // job keeps them active for the full inactivity window. See setActive.
+  const handleToggleArchived = async (memberId: string, nextActive: boolean) => {
+    setOptimistic((prev) => ({
+      ...prev,
+      [memberId]: { ...prev[memberId], isActive: nextActive },
+    }));
+    try {
+      await setActiveMut({
+        communityPeopleId: memberId as any,
+        isActive: nextActive,
+      });
+    } catch (err) {
+      console.error("[setActive] failed:", err);
+      setOptimistic((prev) => {
+        const next = { ...prev };
+        if (next[memberId]) {
+          delete next[memberId].isActive;
           if (Object.keys(next[memberId]).length === 0) delete next[memberId];
         }
         return next;
@@ -1640,6 +1682,7 @@ export function FollowupDesktopTable({
         overrides.assigneeId = nextIds[0];
       }
       if (opt.status !== undefined) overrides.status = opt.status ?? undefined;
+      if (opt.isActive !== undefined) overrides.isActive = opt.isActive;
       // Apply custom field overrides
       for (const [key, val] of Object.entries(opt)) {
         if (key.startsWith("custom")) overrides[key] = val ?? undefined;
@@ -1918,6 +1961,44 @@ export function FollowupDesktopTable({
                 ? item.status.charAt(0).toUpperCase() + item.status.slice(1)
                 : "\u2014"}
             </Text>
+          </TouchableOpacity>
+        );
+      }
+
+      case "archived": {
+        const isArchived = item.isActive === false;
+        return (
+          <TouchableOpacity
+            style={s.editableCellTouchable}
+            data-archived="true"
+            onPress={() =>
+              handleToggleArchived(item.groupMemberId, isArchived)
+            }
+          >
+            <View
+              style={[
+                s.archivedBadge,
+                {
+                  backgroundColor: isArchived
+                    ? colors.warning
+                    : colors.surfaceSecondary,
+                },
+              ]}
+            >
+              <Ionicons
+                name={isArchived ? "archive" : "archive-outline"}
+                size={14}
+                color={isArchived ? colors.text : colors.iconSecondary}
+              />
+              <Text
+                style={[
+                  s.archivedBadgeText,
+                  { color: isArchived ? colors.text : colors.textSecondary },
+                ]}
+              >
+                {isArchived ? "Archived" : "Active"}
+              </Text>
+            </View>
           </TouchableOpacity>
         );
       }
@@ -2672,6 +2753,7 @@ export function FollowupDesktopTable({
                         if (e.target?.closest?.("[data-checkbox]")) return;
                         if (e.target?.closest?.("[data-notes]")) return;
                         if (e.target?.closest?.("[data-tasks]")) return;
+                        if (e.target?.closest?.("[data-archived]")) return;
                         setShowSettingsPanel(false);
                         setShowQuickAddPanel(false);
                         setSelectedMemberId(item.groupMemberId);
@@ -3591,6 +3673,21 @@ const s = StyleSheet.create({
   assigneeMoreText: {
     fontSize: 11,
     fontWeight: "600" as const,
+  },
+
+  // Archived badge — clickable archive/unarchive cell
+  archivedBadge: {
+    flexDirection: "row" as const,
+    alignItems: "center" as const,
+    alignSelf: "flex-start" as const,
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    gap: 4,
+  },
+  archivedBadgeText: {
+    fontSize: 12,
+    fontWeight: "500" as const,
   },
 
   // Notes cell

--- a/apps/mobile/features/leader-tools/components/__tests__/followupCsvExportHelpers.test.ts
+++ b/apps/mobile/features/leader-tools/components/__tests__/followupCsvExportHelpers.test.ts
@@ -76,6 +76,18 @@ describe("followupCsvExportHelpers", () => {
     ).toBe("");
   });
 
+  it("cellValueForColumn renders archived state from isActive", () => {
+    const ctx = { leaderMap, tasksByMember: new Map(), customFields };
+    expect(
+      cellValueForColumn("archived", { ...baseMember, isActive: false }, ctx),
+    ).toBe("Archived");
+    expect(
+      cellValueForColumn("archived", { ...baseMember, isActive: true }, ctx),
+    ).toBe("Active");
+    // Missing isActive (undefined) is treated as active, matching the table.
+    expect(cellValueForColumn("archived", baseMember, ctx)).toBe("Active");
+  });
+
   it("generateFollowupPeopleCsv escapes quotes in notes", () => {
     const csv = generateFollowupPeopleCsv(
       [baseMember],

--- a/apps/mobile/features/leader-tools/components/followupCsvExportHelpers.ts
+++ b/apps/mobile/features/leader-tools/components/followupCsvExportHelpers.ts
@@ -25,6 +25,8 @@ export type FollowupCsvExportMember = {
   lastActiveAt?: number;
   addedAt?: number;
   alerts?: string[];
+  // Archived state. `isActive === false` = archived; undefined/true = active.
+  isActive?: boolean;
   customText1?: string;
   customText2?: string;
   customText3?: string;
@@ -184,6 +186,8 @@ export function cellValueForColumn(
       return formatTimestampMs(member.lastActiveAt);
     case "alerts":
       return (member.alerts ?? []).join("; ");
+    case "archived":
+      return member.isActive === false ? "Archived" : "Active";
     default:
       if (colKey.startsWith("custom")) {
         return formatCustomSlotValue(member, colKey, customFields);

--- a/apps/mobile/features/leader-tools/components/followupShared.ts
+++ b/apps/mobile/features/leader-tools/components/followupShared.ts
@@ -203,5 +203,7 @@ export function adaptCommunityPerson(cp: any) {
     latestNote: cp.latestNote,
     latestNoteAt: cp.latestNoteAt,
     isLeader: cp.isLeader ?? false,
+    // Archived state. `isActive === false` = archived; undefined/true = active.
+    isActive: cp.isActive,
   };
 }


### PR DESCRIPTION
## Summary

Enables reactivating community people **automatically on form submission** and **manually via an inline "Archived" column** in the desktop people table, with correct handling of the interaction between manual unarchiving and the daily 60-day auto-archive job.

People are auto-archived after 60 days of inactivity by the daily score job (`computePersonActiveState`). Previously there was no durable way to keep a manually-unarchived or form-reactivated person active — the next daily run would re-archive them because their *last real activity* was still stale. This adds a `reactivatedAt` timestamp that counts as activity, so the clock restarts from the reactivation moment.

### Behavior
- **Form submission** reactivates the person across all their groups and restarts the auto-archive clock (survives the daily refresh).
- **Manual unarchive** (new Archived column, or the existing detail screen) records `reactivatedAt`. The person stays active unless **both** their last activity **and** the unarchive date are past the 60-day threshold — exactly the requested interaction.
- The Archived column pairs with the existing `archived:true` / `archived:only` search so leaders can surface archived people and reactivate them inline without opening each detail screen.

## Changes

**Backend (`apps/convex`)**
- `schema.ts`: add `reactivatedAt` to `communityPeople`.
- `communityScoreComputation.ts`: fold `reactivatedAt` into the activity signal used by `computePersonActiveState`, and thread it through the daily refresh for existing and sibling records.
- `communityPeople.ts`: `setActive` records `reactivatedAt` on unarchive / clears it on archive (synced to sibling group records); `upsertFromSubmission` reactivates on form submission.

**Frontend (`apps/mobile/features/leader-tools`)**
- New clickable **Archived** column in `FollowupDesktopTable` (optimistic toggle via the existing `setActive` mutation), carried through `adaptCommunityPerson` / `FollowupMember`.
- Row-click guard so toggling the cell doesn't also open the detail panel.

## Testing
- New unit tests in `person-active-state.test.ts` cover: manual unarchive keeps a long-inactive person active, re-archive once the unarchive itself goes stale, form-submission reactivation of an archived person, and that a stale `reactivatedAt` can't resurrect a later archive.
- `apps/convex` vitest suite green (incl. archive-notice / refresh-state / admin-people).
- `apps/mobile` Jest suite green (1108 passed); `npx convex typecheck` passes; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLd6YVZJYgc7J8pY91FzPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLd6YVZJYgc7J8pY91FzPY)_