### PR TITLE
Paste images into chat on web + fix dev-assistant review link domain

### DIFF
--- a/apps/convex/__tests__/dev-assistant-bugs.test.ts
+++ b/apps/convex/__tests__/dev-assistant-bugs.test.ts
@@ -71,7 +71,7 @@ describe("dev-assistant bug lifecycle", () => {
     activeHandle = t;
     const { communityId, channelId, userId } = await seedContext(t);
 
-    const { bugId, reviewLink } = await t.mutation(
+    const { bugId, reviewLink, reviewUrl } = await t.mutation(
       internal.functions.devAssistant.bugs.createBug,
       {
         communityId,
@@ -82,7 +82,12 @@ describe("dev-assistant bug lifecycle", () => {
       },
     );
 
+    // In-app router path keeps the `(user)` route group for navigation.
     expect(reviewLink).toBe(`/(user)/admin/bugs/${bugId}`);
+    // Chat-facing URL is absolute, on togather.nyc, and drops the route group.
+    expect(reviewUrl).toBe(`https://togather.nyc/admin/bugs/${bugId}`);
+    expect(reviewUrl).not.toContain("togather.com");
+    expect(reviewUrl).not.toContain("(user)");
     const bug = await t.query(internal.functions.devAssistant.bugs.getBug, {
       bugId,
     });

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -22,6 +22,7 @@ import { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getMediaUrl } from "../../lib/utils";
 import { DEV_MAINTAINER_ROLE } from "./maintainers";
+import { DOMAIN_CONFIG } from "@togather/shared/config";
 
 // ============================================================================
 // Status machine
@@ -131,7 +132,10 @@ export const createBug = internalMutation({
     repro: v.optional(v.string()),
     screenshotUrls: v.optional(v.array(v.string())),
   },
-  handler: async (ctx, args): Promise<{ bugId: Id<"devBugs">; reviewLink: string }> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ bugId: Id<"devBugs">; reviewLink: string; reviewUrl: string }> => {
     const now = Date.now();
     const bugId = await ctx.db.insert("devBugs", {
       communityId: args.communityId,
@@ -147,10 +151,17 @@ export const createBug = internalMutation({
       updatedAt: now,
     });
 
+    // In-app router path (used for navigation inside the app, where the
+    // `(user)` route group is meaningful to Expo Router).
     const reviewLink = `/(user)/admin/bugs/${bugId}`;
     await ctx.db.patch(bugId, { reviewLink });
 
-    return { bugId, reviewLink };
+    // Absolute, human-facing URL for the chat reply. Built from the centralized
+    // domain config (togather.nyc) so the bot never fabricates a domain, and
+    // without the `(user)` route group, which is not a real URL segment.
+    const reviewUrl = `${DOMAIN_CONFIG.appUrl}/admin/bugs/${bugId}`;
+
+    return { bugId, reviewLink, reviewUrl };
   },
 });
 

--- a/apps/convex/functions/devAssistant/prompts.ts
+++ b/apps/convex/functions/devAssistant/prompts.ts
@@ -57,6 +57,9 @@ READY_TO_MERGE → MERGED. REJECTED is possible at any point (humans only).
 
 # Replying
 Always respond to the humans with \`reply_in_thread\`. Keep replies short and
-concrete. When you create a bug, include the review link returned by
-\`create_bug\` so they can open the review screen. Use plain text.`;
+concrete. When you create a bug, a native bug card with an "Open review" button
+is posted into the thread automatically, so the team can open the review with a
+tap. In your confirming reply, include the absolute review URL returned by
+\`create_bug\` as its \`reviewUrl\` field — copy it EXACTLY as given, never edit
+or guess the domain. Use plain text.`;
 }

--- a/apps/convex/functions/devAssistant/tools.ts
+++ b/apps/convex/functions/devAssistant/tools.ts
@@ -148,7 +148,7 @@ export async function executeTool(
           bugId: execCtx.currentBugId,
         };
       }
-      const { bugId, reviewLink } = await ctx.runMutation(
+      const { bugId, reviewLink, reviewUrl } = await ctx.runMutation(
         internal.functions.devAssistant.bugs.createBug,
         {
           communityId: execCtx.communityId,
@@ -180,7 +180,7 @@ export async function executeTool(
         sourceKey: `bug:${bugId}:card`,
       });
 
-      return { success: true, bugId, reviewLink };
+      return { success: true, bugId, reviewLink, reviewUrl };
     }
 
     case "update_bug": {

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -326,6 +326,33 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
   /**
    * Pick photos and videos from gallery (supports multi-select for photos)
    */
+  /**
+   * Add image URIs to the composer and upload them in parallel. Shared by the
+   * media picker and the web paste handler so both behave identically.
+   */
+  const uploadAndAttachImages = useCallback(async (imageUris: string[]) => {
+    if (imageUris.length === 0) return;
+    setSelectedImages(prev => [...prev, ...imageUris]);
+
+    const uploadPromises = imageUris.map(async (uri) => {
+      const uploadResult = await uploadImage(uri);
+      if (uploadResult.error) {
+        console.error('[MessageInput] Upload failed for:', uri, uploadResult.error);
+        return null;
+      }
+      return uploadResult.url;
+    });
+
+    const results = await Promise.all(uploadPromises);
+    const successfulUrls = results.filter((url): url is string => url !== null);
+    setUploadedImageUrls(prev => [...prev, ...successfulUrls]);
+
+    const failedCount = imageUris.length - successfulUrls.length;
+    if (failedCount > 0) {
+      console.warn(`[MessageInput] ${failedCount} images failed to upload`);
+    }
+  }, [uploadImage]);
+
   const pickMedia = useCallback(async () => {
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
@@ -342,26 +369,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
 
         // Handle images (existing flow — multi-select, parallel upload)
         if (imageAssets.length > 0) {
-          const imageUris = imageAssets.map(asset => asset.uri);
-          setSelectedImages(prev => [...prev, ...imageUris]);
-
-          const uploadPromises = imageUris.map(async (uri) => {
-            const uploadResult = await uploadImage(uri);
-            if (uploadResult.error) {
-              console.error('[MessageInput] Upload failed for:', uri, uploadResult.error);
-              return null;
-            }
-            return uploadResult.url;
-          });
-
-          const results = await Promise.all(uploadPromises);
-          const successfulUrls = results.filter((url): url is string => url !== null);
-          setUploadedImageUrls(prev => [...prev, ...successfulUrls]);
-
-          const failedCount = imageUris.length - successfulUrls.length;
-          if (failedCount > 0) {
-            console.warn(`[MessageInput] ${failedCount} images failed to upload`);
-          }
+          await uploadAndAttachImages(imageAssets.map(asset => asset.uri));
         }
 
         // Handle video (take first only)
@@ -406,7 +414,43 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
     } catch (error) {
       console.error('[MessageInput] Media picker error:', error);
     }
-  }, [uploadImage, uploadVideoFile, resetVideoUpload]);
+  }, [uploadAndAttachImages, uploadVideoFile, resetVideoUpload]);
+
+  /**
+   * Web only: paste a copied image (e.g. a macOS screenshot via Cmd+V) straight
+   * into the composer. Screenshots arrive on the clipboard as image/* files; we
+   * pull them out, upload them through the normal image flow, and let plain-text
+   * pastes fall through to the default browser behavior untouched.
+   */
+  const handleWebPaste = useCallback((e: any) => {
+    if (Platform.OS !== 'web') return;
+    const clipboard = e?.clipboardData;
+    if (!clipboard) return;
+
+    // Prefer clipboard items (most reliable for pasted images across browsers),
+    // falling back to the files list.
+    const fromItems = clipboard.items
+      ? Array.from(clipboard.items as ArrayLike<DataTransferItem>)
+          .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+          .map((item) => item.getAsFile())
+          .filter((file): file is File => file != null)
+      : [];
+    const fromFiles = clipboard.files
+      ? Array.from(clipboard.files as ArrayLike<File>).filter((file) =>
+          file.type.startsWith('image/'),
+        )
+      : [];
+    const imageFiles = fromItems.length > 0 ? fromItems : fromFiles;
+
+    if (imageFiles.length === 0) return; // nothing to handle — allow normal paste
+
+    // We're taking over the paste, so stop the browser from also dropping the
+    // image (or a data: URL of it) into the text field.
+    e.preventDefault();
+
+    const objectUrls = imageFiles.map((file) => URL.createObjectURL(file));
+    void uploadAndAttachImages(objectUrls);
+  }, [uploadAndAttachImages]);
 
   /**
    * Pick a document file (PDF, DOC, audio, video, etc.)
@@ -1172,6 +1216,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
           scrollEnabled={isWeb ? true : nativeScrollEnabled}
           maxLength={2000}
           editable={!uploading}
+          {...(Platform.OS === 'web' && { onPaste: handleWebPaste })}
         />
 
         {/* Send Button */}

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -424,6 +424,14 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
    */
   const handleWebPaste = useCallback((e: any) => {
     if (Platform.OS !== 'web') return;
+
+    // In a not-yet-accepted DM the attachment affordances are intentionally
+    // hidden — the server rejects attachments until the recipient accepts the
+    // request, and that failure path previously cascaded into a navigator
+    // crash loop (see the `recipientPending` prop docs). Don't let paste stage
+    // an image either; bail so a plain-text paste still works normally.
+    if (recipientPending) return;
+
     const clipboard = e?.clipboardData;
     if (!clipboard) return;
 
@@ -450,7 +458,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
 
     const objectUrls = imageFiles.map((file) => URL.createObjectURL(file));
     void uploadAndAttachImages(objectUrls);
-  }, [uploadAndAttachImages]);
+  }, [uploadAndAttachImages, recipientPending]);
 
   /**
    * Pick a document file (PDF, DOC, audio, video, etc.)

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
@@ -5,7 +5,7 @@ import { MessageInput } from '../MessageInput';
 
 jest.mock('../../hooks/useImageUpload', () => ({
   useImageUpload: () => ({
-    uploadImage: jest.fn(),
+    uploadImage: jest.fn(() => Promise.resolve({ url: 'r2:chat/pasted.png' })),
     uploading: false,
     progress: 0,
     reset: jest.fn(),
@@ -252,6 +252,73 @@ describe('MessageInput', () => {
       );
       const input = getByPlaceholderText('Message...');
       expect(input.props.scrollEnabled).toBe(true);
+    });
+
+    describe('image paste', () => {
+      const originalCreateObjectURL = (global as any).URL?.createObjectURL;
+
+      beforeEach(() => {
+        if (!(global as any).URL) {
+          (global as any).URL = {} as any;
+        }
+        (global as any).URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+      });
+
+      afterEach(() => {
+        if ((global as any).URL) {
+          (global as any).URL.createObjectURL = originalCreateObjectURL;
+        }
+      });
+
+      const makePasteEvent = (
+        files: Array<{ type: string }>,
+      ): { clipboardData: any; preventDefault: jest.Mock } => {
+        const fileList = files.map((f) => ({ type: f.type }));
+        return {
+          preventDefault: jest.fn(),
+          clipboardData: {
+            items: files.map((f) => ({
+              kind: 'file',
+              type: f.type,
+              getAsFile: () => ({ type: f.type }),
+            })),
+            files: fileList,
+          },
+        };
+      };
+
+      it('uploads a pasted image and prevents the default paste', () => {
+        const { getByPlaceholderText } = render(
+          <MessageInput channelId={'test-channel' as any} />
+        );
+        const input = getByPlaceholderText('Message...');
+
+        const event = makePasteEvent([{ type: 'image/png' }]);
+        act(() => {
+          fireEvent(input, 'paste', event);
+        });
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect((global as any).URL.createObjectURL).toHaveBeenCalledTimes(1);
+      });
+
+      it('ignores a text-only paste so default paste still works', () => {
+        const { getByPlaceholderText } = render(
+          <MessageInput channelId={'test-channel' as any} />
+        );
+        const input = getByPlaceholderText('Message...');
+
+        const event = {
+          preventDefault: jest.fn(),
+          clipboardData: { items: [], files: [] },
+        };
+        act(() => {
+          fireEvent(input, 'paste', event);
+        });
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect((global as any).URL.createObjectURL).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
@@ -302,6 +302,23 @@ describe('MessageInput', () => {
         expect((global as any).URL.createObjectURL).toHaveBeenCalledTimes(1);
       });
 
+      it('ignores a pasted image in a not-yet-accepted DM (recipientPending)', () => {
+        const { getByPlaceholderText } = render(
+          <MessageInput channelId={'test-channel' as any} recipientPending />
+        );
+        const input = getByPlaceholderText('Message...');
+
+        const event = makePasteEvent([{ type: 'image/png' }]);
+        act(() => {
+          fireEvent(input, 'paste', event);
+        });
+
+        // Pending DMs reject attachments server-side, so paste must not stage
+        // an image — and it should leave the default paste alone.
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect((global as any).URL.createObjectURL).not.toHaveBeenCalled();
+      });
+
       it('ignores a text-only paste so default paste still works', () => {
         const { getByPlaceholderText } = render(
           <MessageInput channelId={'test-channel' as any} />


### PR DESCRIPTION
## What & why

Implements bug `x97ak2nb6ybfygg7bqej3mnqed89ct3v` — three related fixes around chat input and the dev-assistant's own bug card.

### 1. Direct image paste upload in the composer (macOS/web)
Copying a screenshot and pasting (Cmd+V) into the message input did nothing. Now a web-only `onPaste` handler pulls `image/*` files off the clipboard, uploads them through the existing image flow, and attaches them to the composer. Text-only pastes fall through to the browser untouched.

- The picker's image-upload logic is extracted into a shared `uploadAndAttachImages` helper so the picker and paste paths behave identically (no duplicated upload logic).
- Gated on `Platform.OS === 'web'`, mirroring the existing `onPaste` pattern in `OTPInput`.

### 2. Review link uses the correct domain
The dev-assistant bot posted its review link as `https://togather.com/(user)/admin/bugs/<id>` — wrong domain **and** the `(user)` Expo Router group leaked into a non-routable web URL. This happened because `create_bug` returned a bare path and the LLM fabricated a domain in front of it.

`createBug` now also returns `reviewUrl`, an absolute URL built from the centralized domain config (`togather.nyc`) without the route group, and the prompt instructs the bot to surface it verbatim.

### 3. Native chat card with a native button
The native bug card (`BugCardFromMessage`) with its **Open review** button already renders for `contentType: "bug_card"` (`MessageItem.tsx`) and remains the primary affordance. The prompt now references it explicitly so the bot leans on the card rather than a raw text link.

## Tests
- `apps/convex/__tests__/dev-assistant-bugs.test.ts` — asserts `reviewUrl` is absolute, on `togather.nyc`, and free of `togather.com` / the `(user)` group.
- `apps/mobile/.../MessageInput.test.tsx` — pasting an image uploads + prevents default; a text-only paste is ignored.

## Verification
- Convex: `npx convex typecheck` ✅, dev-assistant test suite ✅
- Mobile: full jest suite (1110 passed) ✅, native-import gating ✅, eslint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WseyQNZCxHqm6VPJ7dx34e)_