### PR TITLE
fix(chat): make web image-paste actually upload (RN-Web drops onPaste)

### DIFF
--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -26,6 +26,7 @@ import { api, useQuery } from '@services/api/convex';
 import { useAuth } from '@/providers/AuthProvider';
 import { useConvexFeatureFlag } from '@hooks/useConvexFeatureFlag';
 import { useImageUpload } from '../hooks/useImageUpload';
+import { getPastedImageFiles } from '../utils/imageUpload';
 import { useWebEnterToSend } from '../hooks/useWebEnterToSend';
 import { useFileUpload, type SelectedFile } from '../hooks/useFileUpload';
 import { useSendMessage } from '../hooks/useConvexSendMessage';
@@ -422,7 +423,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
    * pull them out, upload them through the normal image flow, and let plain-text
    * pastes fall through to the default browser behavior untouched.
    */
-  const handleWebPaste = useCallback((e: any) => {
+  const handleWebPaste = useCallback((e: ClipboardEvent) => {
     if (Platform.OS !== 'web') return;
 
     // In a not-yet-accepted DM the attachment affordances are intentionally
@@ -432,24 +433,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
     // an image either; bail so a plain-text paste still works normally.
     if (recipientPending) return;
 
-    const clipboard = e?.clipboardData;
-    if (!clipboard) return;
-
-    // Prefer clipboard items (most reliable for pasted images across browsers),
-    // falling back to the files list.
-    const fromItems = clipboard.items
-      ? Array.from(clipboard.items as ArrayLike<DataTransferItem>)
-          .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
-          .map((item) => item.getAsFile())
-          .filter((file): file is File => file != null)
-      : [];
-    const fromFiles = clipboard.files
-      ? Array.from(clipboard.files as ArrayLike<File>).filter((file) =>
-          file.type.startsWith('image/'),
-        )
-      : [];
-    const imageFiles = fromItems.length > 0 ? fromItems : fromFiles;
-
+    const imageFiles = getPastedImageFiles(e?.clipboardData);
     if (imageFiles.length === 0) return; // nothing to handle — allow normal paste
 
     // We're taking over the paste, so stop the browser from also dropping the
@@ -459,6 +443,24 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
     const objectUrls = imageFiles.map((file) => URL.createObjectURL(file));
     void uploadAndAttachImages(objectUrls);
   }, [uploadAndAttachImages, recipientPending]);
+
+  /**
+   * Wire up the web paste handler via a real DOM listener.
+   *
+   * react-native-web's <TextInput> only forwards an allowlisted set of props to
+   * the underlying <textarea> (see its `forwardedProps`), and `onPaste` is NOT
+   * on that list — so passing `onPaste` as a JSX prop is silently dropped and
+   * the handler never fires. Attach the listener directly to the host DOM node
+   * instead. The RN-Web ref resolves to the actual <textarea> element on web.
+   */
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const node = textInputRef.current as unknown as HTMLElement | null;
+    if (!node || typeof node.addEventListener !== 'function') return;
+    const listener = (event: Event) => handleWebPaste(event as ClipboardEvent);
+    node.addEventListener('paste', listener);
+    return () => node.removeEventListener('paste', listener);
+  }, [handleWebPaste]);
 
   /**
    * Pick a document file (PDF, DOC, audio, video, etc.)
@@ -1224,7 +1226,6 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
           scrollEnabled={isWeb ? true : nativeScrollEnabled}
           maxLength={2000}
           editable={!uploading}
-          {...(Platform.OS === 'web' && { onPaste: handleWebPaste })}
         />
 
         {/* Send Button */}

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -452,6 +452,10 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
    * on that list — so passing `onPaste` as a JSX prop is silently dropped and
    * the handler never fires. Attach the listener directly to the host DOM node
    * instead. The RN-Web ref resolves to the actual <textarea> element on web.
+   *
+   * `isVoiceRecording` is a dependency because the voice recorder unmounts the
+   * <TextInput> and remounts a fresh one when it closes — mirroring
+   * `useWebEnterToSend` — so the listener must re-attach to the new DOM node.
    */
   useEffect(() => {
     if (Platform.OS !== 'web') return;
@@ -460,7 +464,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
     const listener = (event: Event) => handleWebPaste(event as ClipboardEvent);
     node.addEventListener('paste', listener);
     return () => node.removeEventListener('paste', listener);
-  }, [handleWebPaste]);
+  }, [handleWebPaste, isVoiceRecording]);
 
   /**
    * Pick a document file (PDF, DOC, audio, video, etc.)

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.test.tsx
@@ -254,89 +254,12 @@ describe('MessageInput', () => {
       expect(input.props.scrollEnabled).toBe(true);
     });
 
-    describe('image paste', () => {
-      const originalCreateObjectURL = (global as any).URL?.createObjectURL;
-
-      beforeEach(() => {
-        if (!(global as any).URL) {
-          (global as any).URL = {} as any;
-        }
-        (global as any).URL.createObjectURL = jest.fn(() => 'blob:mock-url');
-      });
-
-      afterEach(() => {
-        if ((global as any).URL) {
-          (global as any).URL.createObjectURL = originalCreateObjectURL;
-        }
-      });
-
-      const makePasteEvent = (
-        files: Array<{ type: string }>,
-      ): { clipboardData: any; preventDefault: jest.Mock } => {
-        const fileList = files.map((f) => ({ type: f.type }));
-        return {
-          preventDefault: jest.fn(),
-          clipboardData: {
-            items: files.map((f) => ({
-              kind: 'file',
-              type: f.type,
-              getAsFile: () => ({ type: f.type }),
-            })),
-            files: fileList,
-          },
-        };
-      };
-
-      it('uploads a pasted image and prevents the default paste', () => {
-        const { getByPlaceholderText } = render(
-          <MessageInput channelId={'test-channel' as any} />
-        );
-        const input = getByPlaceholderText('Message...');
-
-        const event = makePasteEvent([{ type: 'image/png' }]);
-        act(() => {
-          fireEvent(input, 'paste', event);
-        });
-
-        expect(event.preventDefault).toHaveBeenCalledTimes(1);
-        expect((global as any).URL.createObjectURL).toHaveBeenCalledTimes(1);
-      });
-
-      it('ignores a pasted image in a not-yet-accepted DM (recipientPending)', () => {
-        const { getByPlaceholderText } = render(
-          <MessageInput channelId={'test-channel' as any} recipientPending />
-        );
-        const input = getByPlaceholderText('Message...');
-
-        const event = makePasteEvent([{ type: 'image/png' }]);
-        act(() => {
-          fireEvent(input, 'paste', event);
-        });
-
-        // Pending DMs reject attachments server-side, so paste must not stage
-        // an image — and it should leave the default paste alone.
-        expect(event.preventDefault).not.toHaveBeenCalled();
-        expect((global as any).URL.createObjectURL).not.toHaveBeenCalled();
-      });
-
-      it('ignores a text-only paste so default paste still works', () => {
-        const { getByPlaceholderText } = render(
-          <MessageInput channelId={'test-channel' as any} />
-        );
-        const input = getByPlaceholderText('Message...');
-
-        const event = {
-          preventDefault: jest.fn(),
-          clipboardData: { items: [], files: [] },
-        };
-        act(() => {
-          fireEvent(input, 'paste', event);
-        });
-
-        expect(event.preventDefault).not.toHaveBeenCalled();
-        expect((global as any).URL.createObjectURL).not.toHaveBeenCalled();
-      });
-    });
+    // NOTE: Image-paste detection is unit-tested directly against
+    // `getPastedImageFiles` in utils/__tests__/imageUpload.test.ts. The paste
+    // listener is attached to the real <textarea> DOM node via addEventListener
+    // (react-native-web silently drops an `onPaste` JSX prop), which the
+    // react-test-renderer host mock can't drive — so the end-to-end paste flow
+    // is verified manually in the browser rather than here.
   });
 
   // ==========================================================================

--- a/apps/mobile/features/chat/utils/__tests__/imageUpload.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/imageUpload.test.ts
@@ -1,4 +1,57 @@
-import { isValidImageUri } from '../imageUpload';
+import { isValidImageUri, getPastedImageFiles } from '../imageUpload';
+
+describe('getPastedImageFiles', () => {
+  const file = (type: string) => ({ type }) as File;
+  const item = (type: string, asFile: File | null) =>
+    ({ kind: 'file', type, getAsFile: () => asFile }) as unknown as DataTransferItem;
+
+  test('returns image files from clipboard items (preferred path)', () => {
+    const png = file('image/png');
+    const clipboard = {
+      items: [item('image/png', png)],
+      files: [],
+    } as unknown as DataTransfer;
+    expect(getPastedImageFiles(clipboard)).toEqual([png]);
+  });
+
+  test('falls back to clipboard.files when items has no images', () => {
+    const jpg = file('image/jpeg');
+    const clipboard = {
+      items: [],
+      files: [jpg],
+    } as unknown as DataTransfer;
+    expect(getPastedImageFiles(clipboard)).toEqual([jpg]);
+  });
+
+  test('ignores non-image items (e.g. text-only paste)', () => {
+    const clipboard = {
+      items: [item('text/plain', null)],
+      files: [],
+    } as unknown as DataTransfer;
+    expect(getPastedImageFiles(clipboard)).toEqual([]);
+  });
+
+  test('ignores non-image files', () => {
+    const clipboard = {
+      items: [],
+      files: [file('application/pdf')],
+    } as unknown as DataTransfer;
+    expect(getPastedImageFiles(clipboard)).toEqual([]);
+  });
+
+  test('returns [] when clipboard is missing', () => {
+    expect(getPastedImageFiles(null)).toEqual([]);
+    expect(getPastedImageFiles(undefined)).toEqual([]);
+  });
+
+  test('drops items whose getAsFile() yields null', () => {
+    const clipboard = {
+      items: [item('image/png', null)],
+      files: [],
+    } as unknown as DataTransfer;
+    expect(getPastedImageFiles(clipboard)).toEqual([]);
+  });
+});
 
 describe('isValidImageUri', () => {
   // Native URI schemes

--- a/apps/mobile/features/chat/utils/imageUpload.ts
+++ b/apps/mobile/features/chat/utils/imageUpload.ts
@@ -68,6 +68,37 @@ export function getContentTypeFromUri(imageUri: string): string {
 }
 
 /**
+ * Pull image files off a paste/clipboard payload (web only).
+ *
+ * Screenshots and copied images land on the clipboard as `image/*` files.
+ * Browsers expose them two ways and not always consistently, so we prefer
+ * `clipboardData.items` (most reliable for pasted images) and fall back to
+ * `clipboardData.files`. Text-only pastes carry no image files and return [],
+ * which lets the caller leave the default paste behavior untouched.
+ *
+ * @param clipboard - The `clipboardData` from a paste ClipboardEvent
+ * @returns The image `File`s found on the clipboard (empty if none)
+ */
+export function getPastedImageFiles(clipboard: DataTransfer | null | undefined): File[] {
+  if (!clipboard) return [];
+
+  const fromItems = clipboard.items
+    ? Array.from(clipboard.items as ArrayLike<DataTransferItem>)
+        .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => file != null)
+    : [];
+
+  if (fromItems.length > 0) return fromItems;
+
+  return clipboard.files
+    ? Array.from(clipboard.files as ArrayLike<File>).filter((file) =>
+        file.type.startsWith('image/'),
+      )
+    : [];
+}
+
+/**
  * Check if an image extension is supported
  *
  * @param filename - The filename or URI to check


### PR DESCRIPTION
## What & why

Follow-up to #500. That PR added paste-to-upload in the chat composer but it **never worked** — pasting a screenshot did nothing.

**Root cause:** the handler was attached as an `onPaste` JSX prop on the React Native `TextInput`. react-native-web only forwards an allowlisted set of props to the underlying `<textarea>` (its `forwardedProps`: default/accessibility/click/focus/keyboard/mouse/touch/style), and `onPaste` is **not** on that list — so RN-Web silently drops the prop and the handler is never wired to the DOM. (The `OTPInput` "pattern" #500 copied has the same latent dead prop.)

## Fix

- Attach the `paste` listener directly to the host `<textarea>` DOM node via the existing `textInputRef` (on web, RN-Web exposes the DOM node as the ref). Effect is web-gated and cleans up on unmount.
- Remove the dead `onPaste` JSX prop.
- Extract clipboard image-detection into a pure, unit-tested `getPastedImageFiles()` helper. The upload / `blob:` path was already correct (`isValidImageUri` accepts `blob:`), so it's unchanged.

## Tests

- The old component paste tests drove the never-functional `onPaste` prop under the RN jest preset (false confidence — the prop doesn't exist in real web). Replaced with 6 real `getPastedImageFiles` unit tests (items path, files fallback, text-only, non-image, missing clipboard, null `getAsFile`).
- Full chat jest suite passes (123 tests).
- **Verified manually in the browser**: copy screenshot → Cmd+V in composer → uploads and stages the image; text-only paste still pastes text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)