### PR TITLE
fix(deploy): set git identity before persisting the OTA forced-floor tag

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -504,6 +504,10 @@ jobs:
         run: |
           # Only forced deploys advance the floor; move the tag to this commit so
           # the next deploy (silent or forced) carries the new value forward.
+          # An annotated tag needs a committer identity, which the runner lacks
+          # by default — set the github-actions bot identity before tagging.
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           git tag -f -a production-forced-floor -m "$FLOOR" "$GITHUB_SHA"
           git push -f origin refs/tags/production-forced-floor
           echo "✓ Persisted forced floor $FLOOR"


### PR DESCRIPTION
## Problem

A real `forced` production deploy (from #503's new mechanism) failed at the **Persist forced floor** step:

```
*** Please tell me who you are.
fatal: unable to auto-detect email address (got 'runner@runnervmmklqx.(none)')
Error: Process completed with exit code 128
```

The annotated `git tag -a production-forced-floor` requires a committer identity, which the Actions runner doesn't have by default. The OTA itself published fine (`Publish OTA Update` ✅), but the floor tag wasn't written — so the **next** deploy would read no floor and the forced-update stickiness would be lost.

(The `tag-deploy` job's `production-latest` tag survived because it's a *lightweight* tag, which carries no tagger and needs no identity. Only the annotated forced-floor tag, which stores the serial in its message, needs one.)

## Fix

Set the `github-actions[bot]` identity in the step before creating the annotated tag:

```bash
git config user.email "github-actions[bot]@users.noreply.github.com"
git config user.name "github-actions[bot]"
git tag -f -a production-forced-floor -m "$FLOOR" "$GITHUB_SHA"
```

## Note on current prod state

The forced OTA from that run already shipped and reached online devices (they saw serial > 0 and force-reloaded). Only the floor *tag* is missing, so until the next `forced` deploy runs with this fix, the floor reads 0 — which just means a future silent deploy won't retroactively force devices that missed that one forced release. The next forced deploy re-establishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012REXXEEQsqeSLUEyu1XGxG)_