### PR TITLE
feat(android): /android page → Google Play closed-testing instructions

### DIFF
--- a/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
+++ b/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
@@ -376,7 +376,7 @@ export default function CommunityLandingPageClient() {
               }}
             >
               <Ionicons name="logo-android" size={20} color="#fff" />
-              <Text style={styles.appStoreButtonText}>Android APK</Text>
+              <Text style={styles.appStoreButtonText}>Get the app (Android)</Text>
             </TouchableOpacity>
           </View>
           </View>

--- a/apps/mobile/app/index+api.ts
+++ b/apps/mobile/app/index+api.ts
@@ -343,7 +343,7 @@ ul, ol { list-style: none; }
               <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M12 5v14M5 12l7 7 7-7"/>
               </svg>
-              Download for Android
+              Get the app (Android)
             </a>
           </div>
 
@@ -719,10 +719,10 @@ ul, ol { list-style: none; }
                 <text x="60" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">App Store</text>
               </svg>
             </a>
-            <a href="${landingUrl}/android" class="store-badge" aria-label="Download for Android">
+            <a href="${landingUrl}/android" class="store-badge" aria-label="Get the app for Android">
               <svg viewBox="0 0 135 40" fill="currentColor">
                 <rect width="135" height="40" rx="6"/>
-                <text x="67" y="14" text-anchor="middle" fill="white" font-size="8" font-family="Inter, sans-serif">Download for</text>
+                <text x="67" y="14" text-anchor="middle" fill="white" font-size="8" font-family="Inter, sans-serif">Get the app</text>
                 <text x="67" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">Android</text>
               </svg>
             </a>

--- a/apps/web/src/pages/AndroidDownload.tsx
+++ b/apps/web/src/pages/AndroidDownload.tsx
@@ -1,12 +1,151 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
-const R2_BASE = `${import.meta.env.VITE_IMAGE_CDN_URL || "https://images.togather.nyc"}/releases/android`;
+// Closed-testing links. The opt-in URL is where a tester enrolls their Google
+// account ("Become a tester"); the store URL only works once they're enrolled
+// and access has propagated. The group is the tester allowlist.
+const TESTERS_GROUP_URL = "https://groups.google.com/a/supa.media/g/togather-testers";
+const PLAY_OPT_IN_URL = "https://play.google.com/apps/testing/app.gatherful.mobile";
+const PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=app.gatherful.mobile";
 
-const LATEST_APK_URL: Record<string, string> = {
-  production: `${R2_BASE}/production/togather-latest.apk`,
-  staging: `${R2_BASE}/staging/togather-staging-latest.apk`,
-};
+const R2_BASE = `${import.meta.env.VITE_IMAGE_CDN_URL || "https://images.togather.nyc"}/releases/android`;
+const STAGING_APK_URL = `${R2_BASE}/staging/togather-staging-latest.apk`;
+
+/**
+ * Android install page.
+ *
+ * Production (`/android`) is invite-only Google Play closed testing — no
+ * sideloaded APK. Staging (`/android-staging`) is internal-only and still
+ * distributes the staging APK from R2. The Cloudflare worker rewrites
+ * /android → /android-staging on the staging environment.
+ */
+export function AndroidDownload({ variant = "production" }: { variant?: "production" | "staging" }) {
+  return variant === "staging" ? <StagingSideloadPage /> : <ClosedTestingPage />;
+}
+
+function BackToHome() {
+  return (
+    <Link
+      to="/"
+      className="inline-flex items-center gap-2 text-neutral-600 hover:text-neutral-900 mb-10"
+    >
+      <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M19 12H5M12 19l-7-7 7-7" />
+      </svg>
+      Back to Home
+    </Link>
+  );
+}
+
+function AndroidIcon() {
+  return (
+    <div className="w-20 h-20 bg-[#3ddc84]/10 rounded-2xl flex items-center justify-center mx-auto mb-6">
+      <svg className="w-10 h-10 text-[#3ddc84]" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M17.6 9.48l1.84-3.18c.16-.31.04-.69-.27-.86a.64.64 0 0 0-.87.26l-1.88 3.24a11.43 11.43 0 0 0-8.84 0L5.73 5.7a.64.64 0 0 0-.87-.26c-.31.17-.43.55-.27.86L6.43 9.48A10.28 10.28 0 0 0 1.58 17h20.84A10.28 10.28 0 0 0 17.6 9.48zM7 14.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm10 0a1 1 0 1 1 0-2 1 1 0 0 1 0 2z" />
+      </svg>
+    </div>
+  );
+}
+
+// ── Production: Google Play closed testing ──────────────────────────────────
+
+function ClosedTestingPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-xl mx-auto px-6 py-12">
+        <BackToHome />
+
+        <div className="text-center mb-10">
+          <AndroidIcon />
+          <h1 className="text-3xl font-bold text-neutral-900 mb-2">
+            Togather for Android
+          </h1>
+          <span className="inline-block text-sm font-semibold text-[#1f9c5c] bg-[#3ddc84]/10 px-3 py-1 rounded-full">
+            Closed testing
+          </span>
+          <p className="text-neutral-500 mt-4">
+            Togather is in invite-only testing on Google Play. You can&rsquo;t find it
+            by searching the Play Store yet &mdash; follow these 3 steps to get it.
+          </p>
+        </div>
+
+        <ol className="space-y-4 mb-8">
+          <StepCard
+            number={1}
+            title="Join the testers group"
+            body="Use the same Google account you're signed into on your phone."
+            cta="Join the testers group"
+            href={TESTERS_GROUP_URL}
+          />
+          <StepCard
+            number={2}
+            title="Become a tester"
+            body="Open the opt-in link and tap “Become a tester” to enroll your account."
+            cta="Become a tester"
+            href={PLAY_OPT_IN_URL}
+          />
+          <StepCard
+            number={3}
+            title="Install Togather"
+            body="Install from Google Play. If it says “not available” or “item not found,” your tester access is still activating — wait about 30 minutes and try again."
+            cta="Get it on Google Play"
+            href={PLAY_STORE_URL}
+          />
+        </ol>
+
+        <div className="bg-blue-50 border border-blue-100 rounded-xl p-4 text-sm text-blue-800">
+          <p>
+            <strong>Why can&rsquo;t I search for it?</strong> Togather is in Google&rsquo;s
+            closed testing program, so it&rsquo;s only visible to approved testers
+            through these links &mdash; not in public Play Store search. Once we pass
+            Google&rsquo;s testing requirements, it&rsquo;ll be available to everyone.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StepCard({
+  number,
+  title,
+  body,
+  cta,
+  href,
+}: {
+  number: number;
+  title: string;
+  body: string;
+  cta: string;
+  href: string;
+}) {
+  return (
+    <li className="bg-neutral-50 rounded-2xl border border-neutral-200 p-5">
+      <div className="flex gap-4">
+        <span className="flex-shrink-0 w-8 h-8 bg-neutral-900 text-white rounded-full flex items-center justify-center text-sm font-semibold">
+          {number}
+        </span>
+        <div className="flex-1">
+          <h2 className="text-base font-semibold text-neutral-900 mb-1">{title}</h2>
+          <p className="text-neutral-500 text-sm mb-4">{body}</p>
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-neutral-900 text-white text-sm font-medium rounded-xl hover:bg-neutral-800 transition-colors"
+          >
+            {cta}
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M5 12h14M12 5l7 7-7 7" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+// ── Staging: internal-only sideloaded APK from R2 ───────────────────────────
 
 interface ManifestData {
   version: string;
@@ -16,6 +155,11 @@ interface ManifestData {
   latestUrl: string;
   minSupportedVersion: string;
 }
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "success"; manifest: ManifestData };
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024) {
@@ -36,24 +180,10 @@ function formatDate(isoDate: string): string {
   }
 }
 
-/**
- * Android download page.
- *
- * Fetches the release manifest from R2 and shows a download button
- * with version info and sideloading instructions.
- *
- * The `variant` prop controls whether to show production or staging APK.
- * The Cloudflare worker rewrites /android → /android-staging for staging.
- */
-type FetchState =
-  | { status: "loading" }
-  | { status: "error" }
-  | { status: "success"; manifest: ManifestData };
-
-export function AndroidDownload({ variant = "production" }: { variant?: "production" | "staging" }) {
+function StagingSideloadPage() {
   const [state, setState] = useState<FetchState>({ status: "loading" });
 
-  const manifestUrl = `${R2_BASE}/${variant}/manifest.json`;
+  const manifestUrl = `${R2_BASE}/staging/manifest.json`;
 
   useEffect(() => {
     let stale = false;
@@ -82,43 +212,16 @@ export function AndroidDownload({ variant = "production" }: { variant?: "product
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-xl mx-auto px-6 py-12">
-        {/* Back link */}
-        <Link
-          to="/"
-          className="inline-flex items-center gap-2 text-neutral-600 hover:text-neutral-900 mb-10"
-        >
-          <svg
-            className="w-5 h-5"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <path d="M19 12H5M12 19l-7-7 7-7" />
-          </svg>
-          Back to Home
-        </Link>
+        <BackToHome />
 
-        {/* Header */}
         <div className="text-center mb-10">
-          {/* Android icon */}
-          <div className="w-20 h-20 bg-[#3ddc84]/10 rounded-2xl flex items-center justify-center mx-auto mb-6">
-            <svg className="w-10 h-10 text-[#3ddc84]" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M17.6 9.48l1.84-3.18c.16-.31.04-.69-.27-.86a.64.64 0 0 0-.87.26l-1.88 3.24a11.43 11.43 0 0 0-8.84 0L5.73 5.7a.64.64 0 0 0-.87-.26c-.31.17-.43.55-.27.86L6.43 9.48A10.28 10.28 0 0 0 1.58 17h20.84A10.28 10.28 0 0 0 17.6 9.48zM7 14.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm10 0a1 1 0 1 1 0-2 1 1 0 0 1 0 2z" />
-            </svg>
-          </div>
-
+          <AndroidIcon />
           <h1 className="text-3xl font-bold text-neutral-900 mb-2">
             Download Togather for Android
           </h1>
-          <p className="text-neutral-500">
-            {variant === "staging"
-              ? "Staging build for testing"
-              : "Get the latest version directly"}
-          </p>
+          <p className="text-neutral-500">Staging build for testing</p>
         </div>
 
-        {/* Download card */}
         <div className="bg-neutral-50 rounded-2xl border border-neutral-200 p-6 mb-8">
           {state.status === "loading" && (
             <div className="text-center py-8">
@@ -129,11 +232,9 @@ export function AndroidDownload({ variant = "production" }: { variant?: "product
 
           {state.status === "error" && (
             <div className="text-center py-6">
-              <p className="text-neutral-600 mb-4">
-                Could not load release information.
-              </p>
+              <p className="text-neutral-600 mb-4">Could not load release information.</p>
               <a
-                href={LATEST_APK_URL[variant]}
+                href={STAGING_APK_URL}
                 className="inline-flex items-center gap-2 px-6 py-3 bg-neutral-900 text-white font-medium rounded-xl hover:bg-neutral-800 transition-colors"
               >
                 <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -148,7 +249,6 @@ export function AndroidDownload({ variant = "production" }: { variant?: "product
 
           {state.status === "success" && (
             <>
-              {/* Version info */}
               <div className="flex items-center justify-between mb-5 text-sm">
                 <div>
                   <span className="text-neutral-400">Version</span>
@@ -170,7 +270,6 @@ export function AndroidDownload({ variant = "production" }: { variant?: "product
                 </p>
               )}
 
-              {/* Download button */}
               <button
                 onClick={handleDownload}
                 className="w-full flex items-center justify-center gap-2 px-6 py-3.5 bg-neutral-900 text-white font-medium rounded-xl hover:bg-neutral-800 transition-colors cursor-pointer"
@@ -186,49 +285,35 @@ export function AndroidDownload({ variant = "production" }: { variant?: "product
           )}
         </div>
 
-        {/* Installation instructions */}
         <div className="mb-8">
-          <h2 className="text-lg font-semibold text-neutral-900 mb-4">
-            How to install
-          </h2>
+          <h2 className="text-lg font-semibold text-neutral-900 mb-4">How to install</h2>
           <ol className="space-y-3 text-neutral-600 text-sm">
             <li className="flex gap-3">
-              <span className="flex-shrink-0 w-6 h-6 bg-neutral-100 rounded-full flex items-center justify-center text-xs font-semibold text-neutral-500">
-                1
-              </span>
+              <span className="flex-shrink-0 w-6 h-6 bg-neutral-100 rounded-full flex items-center justify-center text-xs font-semibold text-neutral-500">1</span>
               <span>
                 Tap <strong>Download APK</strong> above. Your browser may show a warning — tap{" "}
                 <strong>Download anyway</strong>.
               </span>
             </li>
             <li className="flex gap-3">
-              <span className="flex-shrink-0 w-6 h-6 bg-neutral-100 rounded-full flex items-center justify-center text-xs font-semibold text-neutral-500">
-                2
-              </span>
+              <span className="flex-shrink-0 w-6 h-6 bg-neutral-100 rounded-full flex items-center justify-center text-xs font-semibold text-neutral-500">2</span>
               <span>
                 Open the downloaded file. If prompted, enable{" "}
-                <strong>Install from unknown sources</strong> for your browser in
-                Settings.
+                <strong>Install from unknown sources</strong> for your browser in Settings.
               </span>
             </li>
             <li className="flex gap-3">
-              <span className="flex-shrink-0 w-6 h-6 bg-neutral-100 rounded-full flex items-center justify-center text-xs font-semibold text-neutral-500">
-                3
-              </span>
-              <span>
-                Tap <strong>Install</strong> and open Togather once installation is
-                complete.
-              </span>
+              <span className="flex-shrink-0 w-6 h-6 bg-neutral-100 rounded-full flex items-center justify-center text-xs font-semibold text-neutral-500">3</span>
+              <span>Tap <strong>Install</strong> and open Togather once installation is complete.</span>
             </li>
           </ol>
         </div>
 
-        {/* Note about updates */}
         <div className="bg-blue-50 border border-blue-100 rounded-xl p-4 text-sm text-blue-800">
           <p>
-            <strong>About updates:</strong> Most updates are delivered automatically
-            when you open the app. You only need to download a new APK when there is a
-            major update that requires reinstallation.
+            <strong>About updates:</strong> Most updates are delivered automatically when
+            you open the app. You only need to download a new APK when there is a major
+            update that requires reinstallation.
           </p>
         </div>
       </div>

--- a/docs/architecture/ADR-021-android-distribution.md
+++ b/docs/architecture/ADR-021-android-distribution.md
@@ -1,7 +1,7 @@
 # ADR-021: Android Distribution via Direct APK Download
 
 ## Status
-Accepted — **amended 2026-06-22** (see [Amendment](#amendment-2026-06-22-adding-google-play-alongside-r2) below: Google Play is being added *alongside* R2 sideload, not replacing it).
+Accepted — **amended 2026-06-22** (see [Amendment](#amendment-2026-06-22-adding-google-play-alongside-r2) below: Google Play is being added *alongside* R2 sideload, not replacing it) — **amended again 2026-06-26** (see [Amendment](#amendment-2026-06-26-production-moves-to-google-play-closed-testing) below: **production** Android distribution has moved from R2 sideload to Google Play closed testing; the public `/android` page no longer offers an APK).
 
 ## Date
 2025-01-17
@@ -158,3 +158,30 @@ existing EAS key as the Play signing key.
 The personal developer account hits Google's **12-tester / 14-day closed-testing**
 gate before production access. Full step-by-step:
 [`docs/launch/google-play-launch-runbook.md`](../../launch/google-play-launch-runbook.md).
+
+## Amendment (2026-06-26): Production moves to Google Play closed testing
+
+**Production** Android distribution has moved **off** the R2 sideload and onto
+**Google Play closed testing**. The original decision above (and the 2026-06-22
+amendment's "Play *alongside* R2") described the production APK and Play builds
+shipping side by side; that is no longer the case for production.
+
+### What changed
+- The public **`togather.nyc/android`** page **no longer offers an APK**. It now
+  serves **closed-testing instructions**: testers (1) join the Google Group
+  `https://groups.google.com/a/supa.media/g/togather-testers`, (2) open the opt-in
+  link `https://play.google.com/apps/testing/app.gatherful.mobile` and tap
+  "Become a tester", then (3) install from the Play Store listing
+  `https://play.google.com/store/apps/details?id=app.gatherful.mobile`.
+- The app is **not searchable** in the Play Store (closed testing) — testers reach
+  it only via the links above. Until access propagates the listing can return
+  "item not found"; the wait is ~30 minutes.
+- See [`docs/launch/tester-instructions.md`](../../launch/tester-instructions.md)
+  for the tester-facing flow.
+
+### What is retained
+- The **staging** APK sideload via R2 (**`togather.nyc/android-staging`**) is
+  **kept** for internal testing. Only the public/production sideload page changed.
+
+This supersedes the production sideload path of the original decision and the
+2026-06-22 amendment. Historical content above is preserved for context.

--- a/docs/architecture/ADR-021-android-distribution.md
+++ b/docs/architecture/ADR-021-android-distribution.md
@@ -176,7 +176,7 @@ shipping side by side; that is no longer the case for production.
 - The app is **not searchable** in the Play Store (closed testing) — testers reach
   it only via the links above. Until access propagates the listing can return
   "item not found"; the wait is ~30 minutes.
-- See [`docs/launch/tester-instructions.md`](../../launch/tester-instructions.md)
+- See [`docs/launch/tester-instructions.md`](../launch/tester-instructions.md)
   for the tester-facing flow.
 
 ### What is retained

--- a/docs/launch/google-play-launch-runbook.md
+++ b/docs/launch/google-play-launch-runbook.md
@@ -15,7 +15,11 @@ prep work above it is already done in the `feat/google-play-prep` branch.
 See [ADR-021](../architecture/ADR-021-android-distribution.md) — the team
 deliberately shipped Android as a **sideloaded APK** from `togather.nyc/android`
 (Cloudflare R2) and deferred Play Store to "future". This runbook reverses that
-deferral. The R2 sideload path stays in place; Play Store is added alongside it.
+deferral. As of 2026-06-26 the public **`togather.nyc/android`** page no longer
+offers a production APK — it now serves **Google Play closed-testing
+instructions** (join the testers group → opt in → install from Play). Only the
+**staging** sideload (**`togather.nyc/android-staging`**, Cloudflare R2) remains,
+and it is internal-only. See ADR-021's 2026-06-26 amendment for the rationale.
 
 The app is **managed/prebuild** (the `android/` dir is gitignored build output).
 EAS already builds a production **AAB** (`production` profile in

--- a/docs/launch/tester-instructions.md
+++ b/docs/launch/tester-instructions.md
@@ -10,11 +10,18 @@ minutes to join, then just keep the app installed and open it now and then.
   into the Play Store on your phone**. This is the #1 thing people get wrong.
 
 ## How to join (2 minutes)
-1. Tap this link on your phone: **`<OPT-IN LINK — paste from Play Console>`**
-2. Tap **"Become a tester."**
-3. It opens the Togather page in the Play Store — tap **Install**.
-   - ⏳ It can take a few minutes (sometimes up to a couple hours) to show up.
-     If it's not there yet, don't worry — check back later.
+1. **Join the testers group** — open this link and tap **Join group**:
+   **https://groups.google.com/a/supa.media/g/togather-testers**
+   (Use the same Google account that's signed into your Play Store.)
+2. **Opt in to the test** — tap this link on your phone:
+   **https://play.google.com/apps/testing/app.gatherful.mobile**
+   then tap **"Become a tester."**
+3. **Install from the Play Store** — open this link and tap **Install**:
+   **https://play.google.com/store/apps/details?id=app.gatherful.mobile**
+   - Togather is a **closed test**, so it **won't show up if you search** the
+     Play Store — you have to use the link above.
+   - ⏳ If you see **"item not found"** or the page won't load, your access is
+     still propagating. Wait **~30 minutes** and try the link again.
 4. Open the app and sign in like normal.
 
 ## What we need from you for 14 days


### PR DESCRIPTION
## What & why
Android is moving to **invite-only Google Play closed testing**, so the public `/android` page (togather.nyc) should no longer hand out a sideloaded APK. It now walks testers through the real flow.

### `/android` (production) — rewritten
1. **Join the testers group** → `https://groups.google.com/a/supa.media/g/togather-testers`
2. **Become a tester** (opt-in) → `https://play.google.com/apps/testing/app.gatherful.mobile`
3. **Install from Google Play** → `https://play.google.com/store/apps/details?id=app.gatherful.mobile`
   + explains why it isn't searchable in the store yet, and that "item not found" means access is still propagating (wait ~30 min).

All APK download / "unknown sources" steps removed. **`/android-staging` keeps the R2 sideload** (internal-only, not on Play).

### Also
- Relabel funnel CTAs `Android APK` / `Download for Android` → `Get the app (Android)` (CommunityLandingPageClient, index landing) so they don't promise a direct download.
- Docs updated: `tester-instructions.md`, `ADR-021` amendment (2026-06-26), launch runbook.

## Verification
- `apps/web` type-check + build pass; pre-commit eslint clean.
- Rendered & screenshotted the new page (mobile + desktop) — renders as designed.

## Deploy note
`togather.nyc` (production landing) requires a manual `deploy-landing.yml` workflow_dispatch (environment=production) after merge — push-to-main only deploys staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)