### PR TITLE
feat(android): relabel Android CTAs to "Join Android testers"

### DIFF
--- a/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
+++ b/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
@@ -376,7 +376,7 @@ export default function CommunityLandingPageClient() {
               }}
             >
               <Ionicons name="logo-android" size={20} color="#fff" />
-              <Text style={styles.appStoreButtonText}>Get the app (Android)</Text>
+              <Text style={styles.appStoreButtonText}>Join Android testers</Text>
             </TouchableOpacity>
           </View>
           </View>

--- a/apps/mobile/app/index+api.ts
+++ b/apps/mobile/app/index+api.ts
@@ -341,9 +341,9 @@ ul, ol { list-style: none; }
             </a>
             <a href="${landingUrl}/android" class="btn btn-secondary btn-lg">
               <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M12 5v14M5 12l7 7 7-7"/>
+                <path d="M5 12h14M12 5l7 7-7 7"/>
               </svg>
-              Get the app (Android)
+              Join Android testers
             </a>
           </div>
 
@@ -719,11 +719,11 @@ ul, ol { list-style: none; }
                 <text x="60" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">App Store</text>
               </svg>
             </a>
-            <a href="${landingUrl}/android" class="store-badge" aria-label="Get the app for Android">
+            <a href="${landingUrl}/android" class="store-badge" aria-label="Join Android testers">
               <svg viewBox="0 0 135 40" fill="currentColor">
                 <rect width="135" height="40" rx="6"/>
-                <text x="67" y="14" text-anchor="middle" fill="white" font-size="8" font-family="Inter, sans-serif">Get the app</text>
-                <text x="67" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">Android</text>
+                <text x="67" y="14" text-anchor="middle" fill="white" font-size="8" font-family="Inter, sans-serif">Join the</text>
+                <text x="67" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">Android test</text>
               </svg>
             </a>
           </div>

--- a/apps/mobile/components/ui/TestFlightBanner.tsx
+++ b/apps/mobile/components/ui/TestFlightBanner.tsx
@@ -74,7 +74,7 @@ export function TestFlightBanner() {
 
   const isIOS = isIOSBrowser();
   const downloadUrl = isIOS ? APP_STORE_URL : ANDROID_URL;
-  const bannerText = isIOS ? 'Get the app on the App Store' : 'Get the app for Android';
+  const bannerText = isIOS ? 'Get the app on the App Store' : 'Join Android testers';
 
   const handlePress = () => {
     Linking.openURL(downloadUrl);

--- a/apps/web/changelog.html
+++ b/apps/web/changelog.html
@@ -254,11 +254,11 @@
                 <text x="60" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">App Store</text>
               </svg>
             </a>
-            <a href="https://togather.nyc/android" class="store-badge" aria-label="Download for Android">
+            <a href="https://togather.nyc/android" class="store-badge" aria-label="Join Android testers">
               <svg viewBox="0 0 135 40" fill="currentColor">
                 <rect width="135" height="40" rx="6"/>
-                <text x="67" y="14" text-anchor="middle" fill="white" font-size="8" font-family="Inter, sans-serif">Download for</text>
-                <text x="67" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">Android</text>
+                <text x="67" y="14" text-anchor="middle" fill="white" font-size="8" font-family="Inter, sans-serif">Join the</text>
+                <text x="67" y="28" text-anchor="middle" fill="white" font-size="14" font-weight="600" font-family="Inter, sans-serif">Android test</text>
               </svg>
             </a>
           </div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -457,8 +457,8 @@ function HeroSection() {
                 >
                   <IconAndroid className="w-6 h-6" />
                   <div className="flex flex-col leading-tight">
-                    <span className="text-[10px] font-medium text-white/70 uppercase tracking-wide">Download</span>
-                    <span className="text-base font-semibold -mt-0.5">APK for Android</span>
+                    <span className="text-[10px] font-medium text-white/70 uppercase tracking-wide">Join</span>
+                    <span className="text-base font-semibold -mt-0.5">Android testers</span>
                   </div>
                 </Link>
               </div>
@@ -733,7 +733,7 @@ function FAQSection() {
     {
       question: "What platforms does Togather support?",
       answer:
-        "Togather is available on iOS (App Store), Android (APK download), and the web. Your data syncs seamlessly across all devices.",
+        "Togather is available on iOS (App Store), Android (Google Play closed testing), and the web. Your data syncs seamlessly across all devices.",
     },
     {
       question: "Can I import members from Planning Center?",
@@ -865,8 +865,8 @@ function CTASection() {
               >
                 <IconAndroid className="w-5 h-5" />
                 <div className="flex flex-col leading-tight">
-                  <span className="text-[9px] font-medium text-white/70 uppercase tracking-wide">Download</span>
-                  <span className="text-sm font-semibold -mt-0.5">APK for Android</span>
+                  <span className="text-[9px] font-medium text-white/70 uppercase tracking-wide">Join</span>
+                  <span className="text-sm font-semibold -mt-0.5">Android testers</span>
                 </div>
               </Link>
             </div>


### PR DESCRIPTION
Android is in Google Play **closed testing**, so the entry-point CTAs that funnel to `/android` should say it's a tester signup, not an APK download.

Relabels **all** Android funnel CTAs across both web surfaces → **"Join Android testers"** / **"Join the Android test"**:

**togather.nyc (apps/web)** — the main marketing site:
- `apps/web/src/App.tsx` — home **hero** + secondary CTA (was "Download / APK for Android"), and the platforms FAQ ("Android (APK download)" → "Android (Google Play closed testing)")
- `apps/web/changelog.html` — Android badge (dated changelog *entry* left as historical record)

**app.togather.nyc + community + mobile (apps/mobile)**:
- `apps/mobile/app/index+api.ts` — Expo landing hero + store badge (also swaps download-arrow → forward-arrow)
- `apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx` — community landing button
- `apps/mobile/components/ui/TestFlightBanner.tsx` — get-the-app banner (Android only; iOS unchanged)

All point at the `/android` closed-testing page (from #506). Label/text-only. Web app type-checks + builds; home hero verified rendering ("JOIN / Android testers").

🤖 Generated with [Claude Code](https://claude.com/claude-code)