### PR TITLE
fix(mobile): render people list in roster Assign sheet

### DIFF
--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -1157,7 +1157,12 @@ const styles = StyleSheet.create({
   card: {
     width: "100%",
     maxWidth: 460,
-    maxHeight: "85%",
+    // A *definite* height (not maxHeight) so the candidate FlashList gets a
+    // bounded parent to virtualize into. With a content-sized card the list
+    // area collapses to zero height and only the header + Needed stepper show
+    // — the searchable people list never renders. 85% leaves room to type/scroll
+    // and mirrors the desktop docked panel (which is full height).
+    height: "85%",
     borderRadius: 16,
     borderWidth: StyleSheet.hairlineWidth,
     overflow: "hidden",
@@ -1172,7 +1177,10 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
   cardBody: {
-    flexShrink: 1,
+    // Fill the space below the header + Needed stepper so the FlashList has a
+    // bounded height to virtualize into (both the centered modal card and the
+    // full-height desktop docked panel are definite-height parents).
+    flex: 1,
   },
   header: {
     flexDirection: "row",


### PR DESCRIPTION
## Problem

On mobile, opening the roster **Assign someone** sheet (Roster → assign to a role) showed only the header and the **Needed: N** stepper. The searchable candidate list — **Previously filled by / Group / Community** sections plus the search box — never appeared, so leaders couldn't see available people, browse other group members, or search for someone. The desktop panel already shows all of this; mobile should mirror it.

| Before (reported) | Expected |
| --- | --- |
| "Assign someone" → only `Needed: 1  [−] [+]`, no list, no usable search | Full searchable people list with availability, like desktop |

Repro: open the mobile app → Roster → assign someone to a role → list is missing and there's no search.

## Root cause

The candidate list is rendered with a `FlashList`, which needs a **bounded parent height** to virtualize into. In the mobile (centered modal) path:

- the card was sized to its content (`maxHeight: "85%"`, no definite height), and
- the list wrapper (`cardBody`) used `flexShrink: 1` with no `flexGrow`.

With a content-sized card, the list area resolved to **zero height**, so the FlashList rendered nothing — only the fixed-height header and Needed stepper remained. The desktop docked panel was unaffected because it is full height (`height: "100%"`), giving the same FlashList a bounded parent.

The component already contained the full implementation (search, three sections, availability pills, invite form) — it was purely a layout/height bug, not missing functionality.

## Fix

Give the mobile card a definite height and let the list wrapper fill the space below the header/stepper, so the FlashList has a bounded height in **both** presentations:

- `card`: `maxHeight: "85%"` → `height: "85%"` (definite height)
- `cardBody`: `flexShrink: 1` → `flex: 1`

Only style values changed in `apps/mobile/features/scheduling/components/AssignSheet.tsx` — no behavior, props, or data flow touched.

## Testing

- `eslint` on the changed file — clean
- `tsc --noEmit` — no new errors in the changed file (pre-existing `@togather/shared` workspace-resolution errors are unrelated and present on `main`)
- Mobile Jest suite via the pre-push hook — **1121 passed, 9 skipped, 122 suites green**

A unit test was not added: the bug is a layout/height issue, and React Native's test renderer performs no real layout, so it cannot observe a collapsed FlashList — a test there would only assert StyleSheet literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BN5ZBH6toXwTXJacoZG3rK)_