### PR TITLE
feat(scheduling): request history, per-person re-send, and leader notifications

### DIFF
--- a/apps/convex/__tests__/scheduling/requestHistory.test.ts
+++ b/apps/convex/__tests__/scheduling/requestHistory.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for the serving-request history + per-person re-send, and the new
+ * leader notification when a volunteer accepts/declines.
+ *
+ * - `assignmentRequestLog` is append-only: the request fan-out logs an
+ *   `initial` row per recipient, then a `resend` row on any later send. The log
+ *   outlives the assignment, so a removed assignment still shows in history with
+ *   `currentStatus: "removed"`.
+ * - `assignmentRequestHistory` joins those rows with each recipient's current
+ *   assignment status; it is scheduler-gated.
+ * - `respondToAssignment` schedules `notifyLeadersOfResponse`, which notifies the
+ *   event's leaders (inbox + push). The responder is never notified about their
+ *   own response.
+ *
+ * convex-test does not auto-run `scheduler.runAfter` jobs, so — exactly like
+ * reminders.test.ts — we invoke the internal fan-out actions directly and assert
+ * the DB side effects (`assignmentRequestLog` and inbox `notifications` rows).
+ * There are no `pushTokens` in the fixture world and the Twilio path is
+ * best-effort, so push/SMS delivery is not mocked.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api, internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld, type SchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+const DAY = 86400000;
+
+async function makeEvent(
+  t: ReturnType<typeof convexTest>,
+  world: SchedulingWorld,
+  leaderToken: string,
+  dayOffset = 10,
+  title = "Sunday Service",
+): Promise<Id<"eventPlans">> {
+  const eventDate = Date.now() + dayOffset * DAY;
+  const { planId } = await t.mutation(
+    api.functions.scheduling.events.createEvent,
+    {
+      token: leaderToken,
+      groupId: world.groupId,
+      title,
+      eventDate,
+      times: [{ label: "9 AM", startsAt: eventDate }],
+    },
+  );
+  return planId;
+}
+
+async function assign(
+  t: ReturnType<typeof convexTest>,
+  world: SchedulingWorld,
+  leaderToken: string,
+  planId: Id<"eventPlans">,
+  userId: Id<"users">,
+): Promise<Id<"roleAssignments">> {
+  const { assignmentId } = await t.mutation(
+    api.functions.scheduling.assignments.assignRole,
+    { token: leaderToken, planId, teamId: world.teamId, roleId: world.roleId, userId },
+  );
+  return assignmentId;
+}
+
+/**
+ * Run the initial request fan-out directly. convex-test doesn't auto-run the
+ * `scheduler.runAfter` job that `publishEvent` enqueues — and chaining a second
+ * action would drain it nondeterministically — so we invoke the fan-out action
+ * itself (which is all `publishEvent` ultimately does, minus the status flip
+ * that none of these code paths depend on). Mirrors reminders.test.ts.
+ */
+async function sendInitialRequests(
+  t: ReturnType<typeof convexTest>,
+  world: SchedulingWorld,
+  planId: Id<"eventPlans">,
+) {
+  await t.action(
+    internal.functions.scheduling.assignments.sendAssignmentRequests,
+    { planId, publisherId: world.groupLeaderId },
+  );
+}
+
+/** All request-log rows for an assignment, oldest first. */
+async function logRowsForAssignment(
+  t: ReturnType<typeof convexTest>,
+  assignmentId: Id<"roleAssignments">,
+) {
+  return t.run(async (ctx) => {
+    const rows = await ctx.db
+      .query("assignmentRequestLog")
+      .withIndex("by_assignment", (q) => q.eq("assignmentId", assignmentId))
+      .collect();
+    rows.sort((a, b) => a._creationTime - b._creationTime);
+    return rows;
+  });
+}
+
+/** Count inbox notifications of a given type for a user. */
+async function inboxCount(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  notificationType: string,
+): Promise<number> {
+  return t.run(async (ctx) => {
+    const rows = await ctx.db
+      .query("notifications")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("userId"), userId),
+          q.eq(q.field("notificationType"), notificationType),
+        ),
+      )
+      .collect();
+    return rows.length;
+  });
+}
+
+/** Newest inbox notification of a type for a user (or null). */
+async function latestInbox(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  notificationType: string,
+) {
+  return t.run(async (ctx) => {
+    const rows = await ctx.db
+      .query("notifications")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("userId"), userId),
+          q.eq(q.field("notificationType"), notificationType),
+        ),
+      )
+      .collect();
+    if (rows.length === 0) return null;
+    rows.sort((a, b) => b.createdAt - a.createdAt);
+    return rows[0];
+  });
+}
+
+describe("request history + per-person re-send", () => {
+  it("logs an `initial` row then a `resend` row for later sends", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    await sendInitialRequests(t, world, planId);
+
+    let rows = await logRowsForAssignment(t, assignmentId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("initial");
+    expect(rows[0].userId).toBe(world.channelMemberId);
+    expect(rows[0].channels).toContain("sms"); // fixture user has a phone
+
+    // A targeted re-send to the one assignment logs a `resend` row.
+    await t.action(
+      internal.functions.scheduling.assignments.sendAssignmentRequests,
+      { planId, publisherId: world.groupLeaderId, assignmentIds: [assignmentId] },
+    );
+
+    rows = await logRowsForAssignment(t, assignmentId);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.kind)).toEqual(["initial", "resend"]);
+  });
+
+  it("resendAssignmentRequest is scheduler-gated and skips declined volunteers", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const volunteer = (await generateTokens(world.channelMemberId)).accessToken;
+    const outsider = (await generateTokens(world.outsiderId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    await sendInitialRequests(t, world, planId);
+
+    // A non-scheduler cannot re-send.
+    await expect(
+      t.action(api.functions.scheduling.assignments.resendAssignmentRequest, {
+        token: outsider,
+        assignmentId,
+      }),
+    ).rejects.toThrow(ConvexError);
+
+    // A scheduler can re-send to an awaiting volunteer.
+    const ok = await t.action(
+      api.functions.scheduling.assignments.resendAssignmentRequest,
+      { token: leader, assignmentId },
+    );
+    expect(ok.scheduled).toBe(true);
+
+    // …but not to one who has declined.
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: volunteer,
+      assignmentId,
+      status: "declined",
+    });
+    const declined = await t.action(
+      api.functions.scheduling.assignments.resendAssignmentRequest,
+      { token: leader, assignmentId },
+    );
+    expect(declined.scheduled).toBe(false);
+  });
+
+  it("assignmentRequestHistory reflects the current assignment status", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const volunteer = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    await sendInitialRequests(t, world, planId);
+
+    // Before responding: history shows the request as still awaiting.
+    let history = await t.query(
+      api.functions.scheduling.assignments.assignmentRequestHistory,
+      { token: leader, planId },
+    );
+    expect(history).toHaveLength(1);
+    expect(history[0].currentStatus).toBe("unconfirmed");
+    expect(history[0].kind).toBe("initial");
+    expect(history[0].userName).toContain("Memberly");
+
+    // Volunteer declines with a note → history reflects it.
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: volunteer,
+      assignmentId,
+      status: "declined",
+      declineNote: "Out of town",
+    });
+
+    history = await t.query(
+      api.functions.scheduling.assignments.assignmentRequestHistory,
+      { token: leader, planId },
+    );
+    expect(history[0].currentStatus).toBe("declined");
+    expect(history[0].declineNote).toBe("Out of town");
+    expect(history[0].respondedAt).toBeTruthy();
+  });
+
+  it("keeps history after the assignment is removed (currentStatus: removed)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    await sendInitialRequests(t, world, planId);
+
+    await t.mutation(api.functions.scheduling.assignments.unassign, {
+      token: leader,
+      assignmentId,
+    });
+
+    const history = await t.query(
+      api.functions.scheduling.assignments.assignmentRequestHistory,
+      { token: leader, planId },
+    );
+    expect(history).toHaveLength(1);
+    expect(history[0].currentStatus).toBe("removed");
+  });
+
+  it("assignmentRequestHistory is scheduler-gated", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const outsider = (await generateTokens(world.outsiderId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    await assign(t, world, leader, planId, world.channelMemberId);
+
+    await expect(
+      t.query(api.functions.scheduling.assignments.assignmentRequestHistory, {
+        token: outsider,
+        planId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("leader notification on accept/decline", () => {
+  it("notifies the event's leaders when a volunteer accepts, excluding the responder", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const volunteer = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: volunteer,
+      assignmentId,
+      status: "confirmed",
+    });
+    // Run the scheduled fan-out directly (convex-test doesn't auto-run it).
+    await t.action(
+      internal.functions.scheduling.assignments.notifyLeadersOfResponse,
+      { assignmentId, responderId: world.channelMemberId, status: "confirmed" },
+    );
+
+    // The group leader gets a response notification…
+    const leaderNote = await latestInbox(
+      t,
+      world.groupLeaderId,
+      "scheduling_assignment_response",
+    );
+    expect(leaderNote).not.toBeNull();
+    expect(leaderNote!.title).toContain("accepted");
+    expect((leaderNote!.data as { url?: string }).url).toBe(
+      `/rostering/${world.groupId}`,
+    );
+
+    // …and the responding volunteer is NOT notified about their own response.
+    expect(
+      await inboxCount(t, world.channelMemberId, "scheduling_assignment_response"),
+    ).toBe(0);
+  });
+
+  it("includes the decline note in the leader notification", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const volunteer = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: volunteer,
+      assignmentId,
+      status: "declined",
+      declineNote: "Out of town",
+    });
+    await t.action(
+      internal.functions.scheduling.assignments.notifyLeadersOfResponse,
+      {
+        assignmentId,
+        responderId: world.channelMemberId,
+        status: "declined",
+        declineNote: "Out of town",
+      },
+    );
+
+    const leaderNote = await latestInbox(
+      t,
+      world.groupLeaderId,
+      "scheduling_assignment_response",
+    );
+    expect(leaderNote).not.toBeNull();
+    expect(leaderNote!.title).toContain("declined");
+    expect(leaderNote!.body).toContain("Out of town");
+  });
+
+  it("never self-notifies a leader who responds to their own assignment", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    // Assign the leader to their own role, then have the leader respond.
+    const assignmentId = await assign(t, world, leader, planId, world.groupLeaderId);
+
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: leader,
+      assignmentId,
+      status: "declined",
+      declineNote: "Traveling",
+    });
+    await t.action(
+      internal.functions.scheduling.assignments.notifyLeadersOfResponse,
+      {
+        assignmentId,
+        responderId: world.groupLeaderId,
+        status: "declined",
+        declineNote: "Traveling",
+      },
+    );
+
+    // The only leader is also the responder → no self-notification.
+    expect(
+      await inboxCount(t, world.groupLeaderId, "scheduling_assignment_response"),
+    ).toBe(0);
+  });
+});

--- a/apps/convex/__tests__/scheduling/requestHistory.test.ts
+++ b/apps/convex/__tests__/scheduling/requestHistory.test.ts
@@ -422,6 +422,43 @@ describe("leader notification on accept/decline", () => {
     ).toBe(0);
   });
 
+  it("only notifies leaders on an actual status change, not on duplicate responses", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const volunteer = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    // Count notify-leaders jobs ever scheduled (pending or completed), by name.
+    const notifyJobCount = () =>
+      t.run(async (ctx) => {
+        const jobs = await ctx.db.system
+          .query("_scheduled_functions")
+          .collect();
+        return jobs.filter((j) => j.name.includes("notifyLeadersOfResponse"))
+          .length;
+      });
+
+    const respond = (status: "confirmed" | "declined") =>
+      t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+        token: volunteer,
+        assignmentId,
+        status,
+      });
+
+    // First real response → one notification scheduled.
+    await respond("confirmed");
+    expect(await notifyJobCount()).toBe(1);
+
+    // Duplicate same-status response (stale client / double-tap) → no new one.
+    await respond("confirmed");
+    expect(await notifyJobCount()).toBe(1);
+
+    // Genuine change of heart → notify again.
+    await respond("declined");
+    expect(await notifyJobCount()).toBe(2);
+  });
+
   it("never self-notifies a leader who responds to their own assignment", async () => {
     const { t, world } = await setupSchedulingWorld();
     const leader = (await generateTokens(world.groupLeaderId)).accessToken;

--- a/apps/convex/__tests__/scheduling/requestHistory.test.ts
+++ b/apps/convex/__tests__/scheduling/requestHistory.test.ts
@@ -364,6 +364,43 @@ describe("leader notification on accept/decline", () => {
     expect(leaderNote!.body).toContain("Out of town");
   });
 
+  it("does not notify a former scheduler who has since left the group", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+    const volunteer = (await generateTokens(world.channelMemberId)).accessToken;
+    const planId = await makeEvent(t, world, leader);
+    // groupLeader is both the assigner and the plan creator here.
+    const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
+
+    // The leader leaves the group — they can no longer access the event, so they
+    // must not receive volunteer names / decline notes for it.
+    await t.run(async (ctx) => {
+      const m = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", world.groupLeaderId),
+        )
+        .first();
+      if (m) await ctx.db.patch(m._id, { leftAt: Date.now() });
+    });
+
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: volunteer,
+      assignmentId,
+      status: "confirmed",
+    });
+    await t.action(
+      internal.functions.scheduling.assignments.notifyLeadersOfResponse,
+      { assignmentId, responderId: world.channelMemberId, status: "confirmed" },
+    );
+
+    // No current scheduler remains → nobody is notified (in particular not the
+    // departed assigner/creator).
+    expect(
+      await inboxCount(t, world.groupLeaderId, "scheduling_assignment_response"),
+    ).toBe(0);
+  });
+
   it("never self-notifies a leader who responds to their own assignment", async () => {
     const { t, world } = await setupSchedulingWorld();
     const leader = (await generateTokens(world.groupLeaderId)).accessToken;

--- a/apps/convex/__tests__/scheduling/requestHistory.test.ts
+++ b/apps/convex/__tests__/scheduling/requestHistory.test.ts
@@ -183,10 +183,11 @@ describe("request history + per-person re-send", () => {
     expect(rows.map((r) => r.kind)).toEqual(["initial", "resend"]);
   });
 
-  it("resendAssignmentRequest is scheduler-gated and skips declined volunteers", async () => {
+  it("resendAssignmentRequest is scheduler-gated and only re-sends to awaiting volunteers", async () => {
     const { t, world } = await setupSchedulingWorld();
     const leader = (await generateTokens(world.groupLeaderId)).accessToken;
     const volunteer = (await generateTokens(world.channelMemberId)).accessToken;
+    const confirmer = (await generateTokens(world.channelAdminId)).accessToken;
     const outsider = (await generateTokens(world.outsiderId)).accessToken;
     const planId = await makeEvent(t, world, leader);
     const assignmentId = await assign(t, world, leader, planId, world.channelMemberId);
@@ -219,6 +220,26 @@ describe("request history + per-person re-send", () => {
       { token: leader, assignmentId },
     );
     expect(declined.scheduled).toBe(false);
+
+    // …and not to one who has already confirmed (stale history modal): the
+    // fan-out only targets unconfirmed, so report scheduled:false honestly.
+    const confirmedAssignmentId = await assign(
+      t,
+      world,
+      leader,
+      planId,
+      world.channelAdminId,
+    );
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: confirmer,
+      assignmentId: confirmedAssignmentId,
+      status: "confirmed",
+    });
+    const confirmed = await t.action(
+      api.functions.scheduling.assignments.resendAssignmentRequest,
+      { token: leader, assignmentId: confirmedAssignmentId },
+    );
+    expect(confirmed.scheduled).toBe(false);
   });
 
   it("assignmentRequestHistory reflects the current assignment status", async () => {

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -809,6 +809,8 @@ export const respondToAssignment = mutation({
       throw new ConvexError("You can only respond to your own assignments");
     }
 
+    const previousStatus = assignment.status;
+
     await ctx.db.patch(args.assignmentId, {
       status: args.status,
       declineNote:
@@ -832,20 +834,26 @@ export const respondToAssignment = mutation({
       { sourceTeamId: assignment.teamId },
     );
 
-    // Let the schedulers know the volunteer responded. Fanned out via the job
-    // worker (push + in-app inbox) so a slow notification path never blocks the
-    // volunteer's accept/decline.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.functions.scheduling.assignments.notifyLeadersOfResponse,
-      {
-        assignmentId: args.assignmentId,
-        responderId: userId,
-        status: args.status,
-        declineNote:
-          args.status === "declined" ? args.declineNote : undefined,
-      },
-    );
+    // Let the schedulers know the volunteer responded — but only on an actual
+    // state change. A stale client or a double-tap can re-`respondToAssignment`
+    // with the same answer; without this guard each call would re-notify
+    // leaders, spamming duplicate accepted/declined messages for one response.
+    // A genuine change of heart (confirmed → declined, or vice-versa) still
+    // notifies. Fanned out via the job worker so a slow notification path never
+    // blocks the volunteer's accept/decline.
+    if (previousStatus !== args.status) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.scheduling.assignments.notifyLeadersOfResponse,
+        {
+          assignmentId: args.assignmentId,
+          responderId: userId,
+          status: args.status,
+          declineNote:
+            args.status === "declined" ? args.declineNote : undefined,
+        },
+      );
+    }
 
     return { assignmentId: args.assignmentId, status: args.status };
   },

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -35,7 +35,11 @@ import {
 import { COMMUNITY_ROLES } from "../../lib/permissions";
 import { isLeaderRole } from "../../lib/helpers";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
-import { requireTeamGroupMember, requirePlanScheduler } from "./permissions";
+import {
+  requireTeamGroupMember,
+  requirePlanScheduler,
+  isGroupScheduler,
+} from "./permissions";
 
 /** Assignment statuses, for reference and validation. */
 const ASSIGNMENT_STATUSES = ["unconfirmed", "confirmed", "declined"] as const;
@@ -1835,6 +1839,7 @@ export const getResponseNotificationTargets = internalQuery({
       ctx.db.get(args.responderId),
     ]);
     if (!plan) return null;
+    const group = await ctx.db.get(plan.groupId);
 
     // Active group leaders of the plan's group.
     const groupMembers = await ctx.db
@@ -1847,9 +1852,19 @@ export const getResponseNotificationTargets = internalQuery({
       if (isLeaderRole(m.role)) leaderIds.add(m.userId.toString());
     }
     // Plus the scheduler who assigned them and the publisher — they may not be
-    // group leaders (e.g. a team channel admin), but they own this request.
-    leaderIds.add(assignment.assignedById.toString());
-    if (plan.createdById) leaderIds.add(plan.createdById.toString());
+    // group leaders (e.g. a community admin), but they own this request. Only
+    // include them if they STILL have scheduler access to the group: the
+    // notification carries volunteer names + decline notes, so a former
+    // scheduler who has left the group or lost admin must not receive it.
+    if (group) {
+      for (const ownerId of [assignment.assignedById, plan.createdById]) {
+        const key = ownerId.toString();
+        if (leaderIds.has(key)) continue;
+        if (await isGroupScheduler(ctx, group, ownerId)) {
+          leaderIds.add(key);
+        }
+      }
+    }
     // Never notify the responder about their own response.
     leaderIds.delete(args.responderId.toString());
 

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -33,6 +33,7 @@ import {
   normalizePhone,
 } from "../../lib/utils";
 import { COMMUNITY_ROLES } from "../../lib/permissions";
+import { isLeaderRole } from "../../lib/helpers";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { requireTeamGroupMember, requirePlanScheduler } from "./permissions";
 
@@ -827,6 +828,21 @@ export const respondToAssignment = mutation({
       { sourceTeamId: assignment.teamId },
     );
 
+    // Let the schedulers know the volunteer responded. Fanned out via the job
+    // worker (push + in-app inbox) so a slow notification path never blocks the
+    // volunteer's accept/decline.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.assignments.notifyLeadersOfResponse,
+      {
+        assignmentId: args.assignmentId,
+        responderId: userId,
+        status: args.status,
+        declineNote:
+          args.status === "declined" ? args.declineNote : undefined,
+      },
+    );
+
     return { assignmentId: args.assignmentId, status: args.status };
   },
 });
@@ -1294,6 +1310,10 @@ export const getAssignmentRequestTargets = internalQuery({
     planId: v.id("eventPlans"),
     publisherId: v.id("users"),
     includeConfirmed: v.optional(v.boolean()),
+    // When set, restrict the fan-out to these specific assignments (powers the
+    // per-person "Re-send request" action). Any non-matching status filter
+    // below still applies.
+    assignmentIds: v.optional(v.array(v.id("roleAssignments"))),
   },
   handler: async (ctx, args) => {
     const plan = await ctx.db.get(args.planId);
@@ -1303,14 +1323,19 @@ export const getAssignmentRequestTargets = internalQuery({
       .query("roleAssignments")
       .withIndex("by_plan", (q) => q.eq("planId", args.planId))
       .collect();
+    const onlyIds = args.assignmentIds
+      ? new Set(args.assignmentIds.map((id) => id.toString()))
+      : null;
     // Always nudge the unconfirmed; for the 1-day pass also include those
     // who've already confirmed (a serving-tomorrow heads-up). Declined and
-    // removed assignments are never notified.
-    const targeted = assignments.filter((a) =>
-      args.includeConfirmed
+    // removed assignments are never notified. A targeted re-send additionally
+    // narrows to the requested assignment ids.
+    const targeted = assignments.filter((a) => {
+      if (onlyIds && !onlyIds.has(a._id.toString())) return false;
+      return args.includeConfirmed
         ? a.status === "unconfirmed" || a.status === "confirmed"
-        : a.status === "unconfirmed",
-    );
+        : a.status === "unconfirmed";
+    });
 
     const [community, publisher] = await Promise.all([
       ctx.db.get(plan.communityId),
@@ -1327,6 +1352,9 @@ export const getAssignmentRequestTargets = internalQuery({
         return {
           assignmentId: assignment._id,
           userId: assignment.userId,
+          roleId: assignment.roleId,
+          teamId: assignment.teamId,
+          eventDate: assignment.eventDate,
           status: assignment.status,
           phone: user?.phone ?? null,
           roleName: role?.name ?? "a role",
@@ -1402,11 +1430,17 @@ export const sendAssignmentRequests = internalAction({
   args: {
     planId: v.id("eventPlans"),
     publisherId: v.id("users"),
+    // When set, only (re-)send to these assignments — the per-person re-send.
+    assignmentIds: v.optional(v.array(v.id("roleAssignments"))),
   },
   handler: async (ctx, args) => {
     const targets = await ctx.runQuery(
       internal.functions.scheduling.assignments.getAssignmentRequestTargets,
-      { planId: args.planId, publisherId: args.publisherId },
+      {
+        planId: args.planId,
+        publisherId: args.publisherId,
+        assignmentIds: args.assignmentIds,
+      },
     );
     if (!targets || targets.recipients.length === 0) {
       return { pushSent: 0, smsSent: 0 };
@@ -1539,7 +1573,418 @@ export const sendAssignmentRequests = internalAction({
       },
     );
 
+    // --- Request history log ---------------------------------------------
+    // Append-only record of every recipient we just asked, so leaders can
+    // review the request trail and re-send to one person. Records both real
+    // and placeholder recipients (placeholders got an SMS invite). Push is
+    // best-effort, so we only claim the "push" channel when a token existed.
+    await ctx.runMutation(
+      internal.functions.scheduling.assignments.recordRequestLog,
+      {
+        planId: args.planId,
+        groupId: targets.groupId,
+        communityId: targets.communityId,
+        sentById: args.publisherId,
+        entries: targets.recipients.map((recipient) => ({
+          assignmentId: recipient.assignmentId,
+          userId: recipient.userId,
+          roleId: recipient.roleId,
+          teamId: recipient.teamId,
+          eventDate: recipient.eventDate,
+          channels: [
+            ...((tokensByUser.get(recipient.userId)?.length ?? 0) > 0
+              ? ["push"]
+              : []),
+            ...(recipient.phone ? ["sms"] : []),
+          ],
+        })),
+      },
+    );
+
     return { pushSent, smsSent };
+  },
+});
+
+/**
+ * Internal: append rows to `assignmentRequestLog`, one per recipient. The
+ * `kind` ("initial" | "resend") is derived per assignment by checking whether
+ * an earlier log row already exists for it, so callers don't have to track
+ * publish-vs-republish state.
+ */
+export const recordRequestLog = internalMutation({
+  args: {
+    planId: v.id("eventPlans"),
+    groupId: v.id("groups"),
+    communityId: v.id("communities"),
+    sentById: v.id("users"),
+    entries: v.array(
+      v.object({
+        assignmentId: v.id("roleAssignments"),
+        userId: v.id("users"),
+        roleId: v.id("teamRoles"),
+        teamId: v.id("teams"),
+        eventDate: v.number(),
+        channels: v.array(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const sentAt = Date.now();
+    for (const entry of args.entries) {
+      const prior = await ctx.db
+        .query("assignmentRequestLog")
+        .withIndex("by_assignment", (q) =>
+          q.eq("assignmentId", entry.assignmentId),
+        )
+        .first();
+      await ctx.db.insert("assignmentRequestLog", {
+        planId: args.planId,
+        groupId: args.groupId,
+        communityId: args.communityId,
+        assignmentId: entry.assignmentId,
+        userId: entry.userId,
+        roleId: entry.roleId,
+        teamId: entry.teamId,
+        eventDate: entry.eventDate,
+        sentById: args.sentById,
+        sentAt,
+        kind: prior ? "resend" : "initial",
+        channels: entry.channels,
+      });
+    }
+  },
+});
+
+// ============================================================================
+// Request history + per-person re-send
+// ============================================================================
+
+/**
+ * Re-send the serving request for a single assignment (the per-person re-send
+ * from the request-history view). Reuses the same push + SMS + in-app fan-out
+ * as publish, scoped to one assignment, and appends a `resend` history row.
+ *
+ * Auth: group leader or community admin for the assignment's event.
+ */
+export const resendAssignmentRequest = action({
+  args: {
+    token: v.string(),
+    assignmentId: v.id("roleAssignments"),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ scheduled: boolean }> => {
+    const callerId = await requireAuthFromTokenAction(ctx, args.token);
+
+    const planId: Id<"eventPlans"> | null = await ctx.runQuery(
+      internal.functions.scheduling.assignments.getAssignmentPlanForResend,
+      { assignmentId: args.assignmentId, callerId: callerId as Id<"users"> },
+    );
+    if (!planId) {
+      return { scheduled: false };
+    }
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.assignments.sendAssignmentRequests,
+      {
+        planId,
+        publisherId: callerId as Id<"users">,
+        assignmentIds: [args.assignmentId],
+      },
+    );
+    return { scheduled: true };
+  },
+});
+
+/**
+ * Internal: validate scheduler permission for a re-send and resolve the
+ * assignment's plan. Returns `null` when the assignment no longer exists or is
+ * already declined (a declined volunteer is never re-pinged automatically).
+ */
+export const getAssignmentPlanForResend = internalQuery({
+  args: {
+    assignmentId: v.id("roleAssignments"),
+    callerId: v.id("users"),
+  },
+  handler: async (ctx, args): Promise<Id<"eventPlans"> | null> => {
+    const assignment = await ctx.db.get(args.assignmentId);
+    if (!assignment) {
+      throw new ConvexError("Assignment not found");
+    }
+    await requirePlanScheduler(ctx, assignment.planId, args.callerId);
+    // Only re-send to people who haven't declined — getAssignmentRequestTargets
+    // also excludes declined, but bail early so the caller gets honest feedback.
+    if (assignment.status === "declined") {
+      return null;
+    }
+    return assignment.planId;
+  },
+});
+
+/**
+ * Request-history for an event plan — the full append-only trail of serving
+ * requests sent to volunteers, newest first, joined with each recipient's name,
+ * role, and *current* assignment status (so the view can show "asked 2× · still
+ * awaiting"). Optionally narrowed to a single role for the per-role-cell view.
+ *
+ * Auth: group leader or community admin for the plan's group (same gate as the
+ * roster grid) — the response lists volunteer names.
+ */
+export const assignmentRequestHistory = query({
+  args: {
+    token: v.string(),
+    planId: v.id("eventPlans"),
+    roleId: v.optional(v.id("teamRoles")),
+  },
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+    await requirePlanScheduler(ctx, args.planId, callerId);
+
+    const rows = args.roleId
+      ? await ctx.db
+          .query("assignmentRequestLog")
+          .withIndex("by_plan_role", (q) =>
+            q.eq("planId", args.planId).eq("roleId", args.roleId!),
+          )
+          .collect()
+      : await ctx.db
+          .query("assignmentRequestLog")
+          .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+          .collect();
+
+    rows.sort((a, b) => b.sentAt - a.sentAt);
+
+    // Small per-query caches so a plan with many sends to the same person /
+    // role doesn't re-fetch the same docs.
+    const userCache = new Map<string, Doc<"users"> | null>();
+    const roleCache = new Map<string, Doc<"teamRoles"> | null>();
+    const assignmentCache = new Map<string, Doc<"roleAssignments"> | null>();
+    const getUser = async (id: Id<"users">) => {
+      const key = id.toString();
+      if (!userCache.has(key)) userCache.set(key, await ctx.db.get(id));
+      return userCache.get(key) ?? null;
+    };
+    const getRole = async (id: Id<"teamRoles">) => {
+      const key = id.toString();
+      if (!roleCache.has(key)) roleCache.set(key, await ctx.db.get(id));
+      return roleCache.get(key) ?? null;
+    };
+    const getAssignment = async (id: Id<"roleAssignments">) => {
+      const key = id.toString();
+      if (!assignmentCache.has(key))
+        assignmentCache.set(key, await ctx.db.get(id));
+      return assignmentCache.get(key) ?? null;
+    };
+
+    return Promise.all(
+      rows.map(async (row) => {
+        const [user, role, assignment] = await Promise.all([
+          getUser(row.userId),
+          getRole(row.roleId),
+          getAssignment(row.assignmentId),
+        ]);
+        return {
+          id: row._id,
+          assignmentId: row.assignmentId,
+          userId: row.userId,
+          userName:
+            `${user?.firstName ?? ""} ${user?.lastName ?? ""}`.trim() ||
+            "Someone",
+          roleId: row.roleId,
+          roleName: role?.name ?? "a role",
+          sentAt: row.sentAt,
+          kind: row.kind,
+          channels: row.channels,
+          eventDate: row.eventDate,
+          // Current state of the assignment this request was for. `removed`
+          // means the volunteer was unassigned after being asked (the log row
+          // outlives the assignment row).
+          currentStatus: assignment ? assignment.status : "removed",
+          respondedAt: assignment?.respondedAt ?? null,
+          declineNote: assignment?.declineNote ?? null,
+        };
+      }),
+    );
+  },
+});
+
+// ============================================================================
+// Notify leaders when a volunteer accepts / declines
+// ============================================================================
+
+/**
+ * Internal: gather everything `notifyLeadersOfResponse` needs — the leaders to
+ * notify (group leaders of the plan's group, plus the person who assigned the
+ * volunteer and the plan's publisher), the responder's name, and the event /
+ * role context. The responder is never notified about their own response.
+ */
+export const getResponseNotificationTargets = internalQuery({
+  args: {
+    assignmentId: v.id("roleAssignments"),
+    responderId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const assignment = await ctx.db.get(args.assignmentId);
+    if (!assignment) return null;
+
+    const [plan, role, responder] = await Promise.all([
+      ctx.db.get(assignment.planId),
+      ctx.db.get(assignment.roleId),
+      ctx.db.get(args.responderId),
+    ]);
+    if (!plan) return null;
+
+    // Active group leaders of the plan's group.
+    const groupMembers = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", plan.groupId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+    const leaderIds = new Set<string>();
+    for (const m of groupMembers) {
+      if (isLeaderRole(m.role)) leaderIds.add(m.userId.toString());
+    }
+    // Plus the scheduler who assigned them and the publisher — they may not be
+    // group leaders (e.g. a team channel admin), but they own this request.
+    leaderIds.add(assignment.assignedById.toString());
+    if (plan.createdById) leaderIds.add(plan.createdById.toString());
+    // Never notify the responder about their own response.
+    leaderIds.delete(args.responderId.toString());
+
+    return {
+      recipientIds: [...leaderIds] as Id<"users">[],
+      groupId: plan.groupId,
+      communityId: plan.communityId,
+      planTitle: plan.title,
+      eventDate: plan.eventDate,
+      roleName: role?.name ?? "a role",
+      responderName:
+        `${responder?.firstName ?? ""} ${responder?.lastName ?? ""}`.trim() ||
+        "A volunteer",
+    };
+  },
+});
+
+/**
+ * Internal: write the leader-facing "volunteer responded" rows into the
+ * in-app `notifications` inbox.
+ */
+export const recordResponseNotifications = internalMutation({
+  args: {
+    recipientIds: v.array(v.id("users")),
+    communityId: v.id("communities"),
+    groupId: v.id("groups"),
+    title: v.string(),
+    body: v.string(),
+    url: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const nowMs = Date.now();
+    for (const userId of args.recipientIds) {
+      await ctx.db.insert("notifications", {
+        userId,
+        communityId: args.communityId,
+        groupId: args.groupId,
+        notificationType: "scheduling_assignment_response",
+        title: args.title,
+        body: args.body,
+        data: { url: args.url },
+        status: "sent",
+        isRead: false,
+        createdAt: nowMs,
+        sentAt: nowMs,
+      });
+    }
+  },
+});
+
+/**
+ * Internal: notify the schedulers/leaders that a volunteer accepted or declined
+ * their serving request. Push + in-app inbox, mirroring the request fan-out.
+ */
+export const notifyLeadersOfResponse = internalAction({
+  args: {
+    assignmentId: v.id("roleAssignments"),
+    responderId: v.id("users"),
+    status: v.union(v.literal("confirmed"), v.literal("declined")),
+    declineNote: v.optional(v.string()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ pushSent: number; recorded: number }> => {
+    const targets = await ctx.runQuery(
+      internal.functions.scheduling.assignments
+        .getResponseNotificationTargets,
+      { assignmentId: args.assignmentId, responderId: args.responderId },
+    );
+    if (!targets || targets.recipientIds.length === 0) {
+      return { pushSent: 0, recorded: 0 };
+    }
+
+    const eventDate = new Date(targets.eventDate).toLocaleDateString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+    const verb = args.status === "confirmed" ? "accepted" : "declined";
+    const title =
+      args.status === "confirmed"
+        ? `${targets.responderName} accepted`
+        : `${targets.responderName} declined`;
+    const noteSuffix =
+      args.status === "declined" && args.declineNote
+        ? ` "${args.declineNote}"`
+        : "";
+    const body =
+      `${targets.responderName} ${verb} ${targets.roleName} for ` +
+      `${targets.planTitle} on ${eventDate}.${noteSuffix}`;
+    // Relative path for in-app routing; the leader lands on the roster grid.
+    const url = `/rostering/${targets.groupId}`;
+
+    // --- Push -------------------------------------------------------------
+    const tokenResults: Array<{ userId: string; tokens: string[] }> =
+      await ctx.runQuery(
+        internal.functions.notifications.tokens.getActiveTokensForUsers,
+        { userIds: targets.recipientIds },
+      );
+    const pushNotifications = tokenResults.flatMap((r) =>
+      r.tokens.map((token) => ({
+        token,
+        title,
+        body,
+        data: {
+          type: "scheduling_assignment_response",
+          assignmentId: args.assignmentId,
+          url,
+        },
+      })),
+    );
+    let pushSent = 0;
+    if (pushNotifications.length > 0) {
+      const pushResult = await ctx.runAction(
+        internal.functions.notifications.internal.sendBatchPushNotifications,
+        { notifications: pushNotifications },
+      );
+      pushSent = pushResult.success ? pushNotifications.length : 0;
+    }
+
+    // --- In-app inbox -----------------------------------------------------
+    await ctx.runMutation(
+      internal.functions.scheduling.assignments.recordResponseNotifications,
+      {
+        recipientIds: targets.recipientIds,
+        communityId: targets.communityId,
+        groupId: targets.groupId,
+        title,
+        body,
+        url,
+      },
+    );
+
+    return { pushSent, recorded: targets.recipientIds.length };
   },
 });
 

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -1704,8 +1704,9 @@ export const resendAssignmentRequest = action({
 
 /**
  * Internal: validate scheduler permission for a re-send and resolve the
- * assignment's plan. Returns `null` when the assignment no longer exists or is
- * already declined (a declined volunteer is never re-pinged automatically).
+ * assignment's plan. Returns `null` when the assignment no longer exists or has
+ * already been answered (confirmed or declined) — only an `unconfirmed`
+ * volunteer is re-pinged, matching the fan-out's recipient filter.
  */
 export const getAssignmentPlanForResend = internalQuery({
   args: {
@@ -1718,9 +1719,13 @@ export const getAssignmentPlanForResend = internalQuery({
       throw new ConvexError("Assignment not found");
     }
     await requirePlanScheduler(ctx, assignment.planId, args.callerId);
-    // Only re-send to people who haven't declined — getAssignmentRequestTargets
-    // also excludes declined, but bail early so the caller gets honest feedback.
-    if (assignment.status === "declined") {
+    // Only re-send to volunteers who haven't answered yet. The fan-out
+    // (`getAssignmentRequestTargets`) targets `unconfirmed` assignments only, so
+    // returning a plan id for a confirmed *or* declined assignment would report
+    // `scheduled: true` while actually sending/logging nothing — bail here so the
+    // caller (and the mobile toast) gets honest feedback. Guards against a stale
+    // history modal where the volunteer has since responded.
+    if (assignment.status !== "unconfirmed") {
       return null;
     }
     return assignment.planId;

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -111,6 +111,30 @@ export async function requireTeamScheduler(
 }
 
 /**
+ * Whether `userId` currently has scheduler permission for `group` — an active
+ * group leader, or a community admin. Boolean sibling of
+ * `requireGroupScheduler`; use it to filter (rather than gate) — e.g. to drop
+ * a stale recipient who has since left the group before notifying them.
+ */
+export async function isGroupScheduler(
+  ctx: QueryCtx | MutationCtx,
+  group: Doc<"groups">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const groupMembership = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", group._id).eq("userId", userId),
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+  if (groupMembership && isLeaderRole(groupMembership.role)) {
+    return true;
+  }
+  return isCommunityAdmin(ctx, group.communityId, userId);
+}
+
+/**
  * Require scheduler permission for the campus group that owns an event plan.
  * Used by event/assignment mutations that are scoped to a `groupId` rather
  * than a single team — group leader or community admin.
@@ -127,18 +151,7 @@ export async function requireGroupScheduler(
     throw new ConvexError("Group not found");
   }
 
-  const groupMembership = await ctx.db
-    .query("groupMembers")
-    .withIndex("by_group_user", (q) =>
-      q.eq("groupId", groupId).eq("userId", userId),
-    )
-    .filter((q) => q.eq(q.field("leftAt"), undefined))
-    .first();
-  if (groupMembership && isLeaderRole(groupMembership.role)) {
-    return group;
-  }
-
-  if (await isCommunityAdmin(ctx, group.communityId, userId)) {
+  if (await isGroupScheduler(ctx, group, userId)) {
     return group;
   }
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2756,6 +2756,35 @@ export default defineSchema({
     .index("by_team_eventDate", ["teamId", "eventDate"]),
 
   /**
+   * History of serving requests SENT to volunteers (one row per recipient per
+   * send). Unlike `roleAssignments` — which is mutated in place and hard-deleted
+   * on `unassign` — these rows are append-only, so a leader can review the full
+   * "who was asked, when, and how many times" trail and re-send a request to a
+   * single person from it. Written by `sendAssignmentRequests` (publish +
+   * re-send) and the per-person `resendAssignmentRequest` action.
+   */
+  assignmentRequestLog: defineTable({
+    planId: v.id("eventPlans"),
+    groupId: v.id("groups"),
+    communityId: v.id("communities"),
+    // The assignment the request was for. The assignment may later be removed
+    // (`unassign` hard-deletes), so this id can dangle — readers tolerate a
+    // missing target. The log row itself is never deleted.
+    assignmentId: v.id("roleAssignments"),
+    userId: v.id("users"), // recipient (the volunteer who was asked)
+    roleId: v.id("teamRoles"),
+    teamId: v.id("teams"),
+    eventDate: v.number(), // denormalized from the plan for display/sorting
+    sentById: v.id("users"), // the scheduler who triggered the send
+    sentAt: v.number(),
+    kind: v.string(), // "initial" | "resend"
+    channels: v.array(v.string()), // delivery channels used, e.g. ["push","sms"]
+  })
+    .index("by_plan", ["planId"])
+    .index("by_assignment", ["assignmentId"])
+    .index("by_plan_role", ["planId", "roleId"]),
+
+  /**
    * A single ordered item on an event plan's run sheet (ADR-026). The native
    * replacement for the PCO-derived order-of-items. One run sheet = many rows,
    * keyed by `planId` and ordered by `sequence`; the same run sheet is shared

--- a/apps/mobile/features/notifications/utils/notificationDisplay.ts
+++ b/apps/mobile/features/notifications/utils/notificationDisplay.ts
@@ -34,6 +34,8 @@ export function iconForNotificationType(type: string): IoniconName {
       return "hand-left";
     case "followup_assigned":
       return "clipboard";
+    case "scheduling_assignment_response":
+      return "checkmark-done-outline";
     case "admin_broadcast":
       return "megaphone";
     default:

--- a/apps/mobile/features/scheduling/components/AssignSheet.tsx
+++ b/apps/mobile/features/scheduling/components/AssignSheet.tsx
@@ -171,6 +171,7 @@ export function AssignSheet({
   neededCount,
   assignedCount,
   onSetNeeded,
+  onShowHistory,
   onClose,
 }: {
   visible: boolean;
@@ -235,6 +236,12 @@ export function AssignSheet({
    * When omitted, the Needed stepper is not rendered.
    */
   onSetNeeded?: (count: number) => void;
+  /**
+   * Open the role/event request-history modal. Provided by the roster grid so
+   * the request trail stays reachable even for empty/open cells (which route
+   * here instead of the occupant popover). Omit to hide the affordance.
+   */
+  onShowHistory?: () => void;
   onClose: () => void;
 }) {
   const { colors } = useTheme();
@@ -835,6 +842,17 @@ export function AssignSheet({
             {timeLabel ? ` · ${timeLabel}` : ""}
           </Text>
         </View>
+        {onShowHistory && (
+          <TouchableOpacity
+            onPress={onShowHistory}
+            hitSlop={12}
+            style={styles.headerClose}
+            accessibilityRole="button"
+            accessibilityLabel="Request history"
+          >
+            <Ionicons name="time-outline" size={22} color={colors.textSecondary} />
+          </TouchableOpacity>
+        )}
         <TouchableOpacity onPress={onClose} hitSlop={12} style={styles.headerClose}>
           <Ionicons name="close" size={24} color={colors.textSecondary} />
         </TouchableOpacity>

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -536,6 +536,21 @@ export function RosterGridScreen() {
     setPlanPanel({ planId });
   }, []);
 
+  // Open the request-history modal from the assign panel — the entry point for
+  // empty/open role cells, which route straight to AssignSheet (skipping the
+  // occupant popover). Resolves the full role/event rows from `data` by the
+  // assign target's ids so the same RequestHistoryModal can be reused.
+  const openHistoryForTarget = useCallback(
+    (target: AssignTarget) => {
+      const role = data?.roles.find((r) => r.roleId === target.roleId);
+      const event = data?.events.find((e) => e._id === target.planId);
+      if (!role || !event) return;
+      setAssignTarget(null);
+      setHistoryModal({ role, event });
+    },
+    [data],
+  );
+
   const surfaceError = useCallback((title: string, e: unknown) => {
     const err = e as { data?: { message?: string }; message?: string };
     Alert.alert(title, err?.data?.message ?? err?.message ?? "Something went wrong");
@@ -1941,6 +1956,7 @@ export function RosterGridScreen() {
                 count,
               )
             }
+            onShowHistory={() => openHistoryForTarget(assignTarget)}
             onClose={() => setAssignTarget(null)}
           />
         )}
@@ -2067,6 +2083,7 @@ export function RosterGridScreen() {
               count,
             )
           }
+          onShowHistory={() => openHistoryForTarget(assignTarget)}
           onClose={() => setAssignTarget(null)}
         />
       )}

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -54,6 +54,8 @@ import {
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { confirmAsync, notify } from "@/utils/platformAlert";
+import { formatRelativeTime } from "@features/notifications";
+import { assignmentStatusLabel } from "../utils/format";
 import { AssignSheet } from "./AssignSheet";
 import { GridPresenceBar } from "./GridPresenceBar";
 import { EventEditorPanel } from "./EventEditorPanel";
@@ -443,6 +445,11 @@ export function RosterGridScreen() {
     role: RosterRole;
     event: RosterEvent;
   } | null>(null);
+  // Request-history modal for a role-cell (initial + re-sends + resend action).
+  const [historyModal, setHistoryModal] = useState<{
+    role: RosterRole;
+    event: RosterEvent;
+  } | null>(null);
   // People-view: a member's assignments for an event (manage + add role).
   const [memberCellModal, setMemberCellModal] = useState<{
     member: RosterMember;
@@ -494,6 +501,7 @@ export function RosterGridScreen() {
   const openAssign = useCallback((target: AssignTarget) => {
     setRoleCellModal(null);
     setMemberCellModal(null);
+    setHistoryModal(null);
     setPlanPanel(null);
     setAssignTarget(target);
   }, []);
@@ -501,6 +509,7 @@ export function RosterGridScreen() {
     (payload: { role: RosterRole; event: RosterEvent }) => {
       setAssignTarget(null);
       setMemberCellModal(null);
+      setHistoryModal(null);
       setPlanPanel(null);
       setRoleCellModal(payload);
     },
@@ -510,6 +519,7 @@ export function RosterGridScreen() {
     (payload: { member: RosterMember; event: RosterEvent }) => {
       setAssignTarget(null);
       setRoleCellModal(null);
+      setHistoryModal(null);
       setPlanPanel(null);
       setMemberCellModal(payload);
     },
@@ -522,6 +532,7 @@ export function RosterGridScreen() {
     setAssignTarget(null);
     setRoleCellModal(null);
     setMemberCellModal(null);
+    setHistoryModal(null);
     setPlanPanel({ planId });
   }, []);
 
@@ -1962,7 +1973,23 @@ export function RosterGridScreen() {
                 assignedCount: cell.filled,
               });
             }}
+            onShowHistory={() => {
+              const role = roleCellModal.role;
+              const ev = roleCellModal.event;
+              setRoleCellModal(null);
+              setHistoryModal({ role, event: ev });
+            }}
             onClose={() => setRoleCellModal(null)}
+          />
+        )}
+
+        {isWide && historyModal && (
+          <RequestHistoryModal
+            role={historyModal.role}
+            event={historyModal.event}
+            colors={colors}
+            docked
+            onClose={() => setHistoryModal(null)}
           />
         )}
 
@@ -2070,7 +2097,22 @@ export function RosterGridScreen() {
               assignedCount: cell.filled,
             });
           }}
+          onShowHistory={() => {
+            const role = roleCellModal.role;
+            const ev = roleCellModal.event;
+            setRoleCellModal(null);
+            setHistoryModal({ role, event: ev });
+          }}
           onClose={() => setRoleCellModal(null)}
+        />
+      )}
+
+      {!isWide && historyModal && (
+        <RequestHistoryModal
+          role={historyModal.role}
+          event={historyModal.event}
+          colors={colors}
+          onClose={() => setHistoryModal(null)}
         />
       )}
 
@@ -2501,6 +2543,7 @@ function RoleCellPopover({
   docked = false,
   onRemove,
   onAddSomeone,
+  onShowHistory,
   onClose,
 }: {
   role: RosterRole;
@@ -2510,6 +2553,7 @@ function RoleCellPopover({
   docked?: boolean;
   onRemove: (id: Id<"roleAssignments">) => void;
   onAddSomeone: (cell: RoleCell) => void;
+  onShowHistory: () => void;
   onClose: () => void;
 }) {
   if (!cell) return null;
@@ -2543,6 +2587,151 @@ function RoleCellPopover({
           <Ionicons name="add" size={18} color={colors.link} />
           <Text style={[styles.addBtnText, { color: colors.link }]}>Add someone</Text>
         </Pressable>
+      )}
+      <Pressable
+        onPress={onShowHistory}
+        style={[styles.addBtn, { borderColor: colors.border }]}
+        accessibilityRole="button"
+      >
+        <Ionicons name="time-outline" size={18} color={colors.textSecondary} />
+        <Text style={[styles.addBtnText, { color: colors.textSecondary }]}>
+          Request history
+        </Text>
+      </Pressable>
+    </ModalShell>
+  );
+}
+
+/**
+ * Request-history modal for a role+event cell. Shows every assignment request
+ * sent for the role on the plan (initial + re-sends), newest first, with the
+ * volunteer's current status, and a Resend action for anyone still awaiting a
+ * response. Mirrors the docked-on-desktop / modal-on-mobile pattern of the
+ * other cell popovers via ModalShell.
+ */
+function RequestHistoryModal({
+  role,
+  event,
+  colors,
+  docked = false,
+  onClose,
+}: {
+  role: RosterRole;
+  event: RosterEvent;
+  colors: Colors;
+  docked?: boolean;
+  onClose: () => void;
+}) {
+  const history = useAuthenticatedQuery(
+    api.functions.scheduling.assignments.assignmentRequestHistory,
+    { planId: event._id, roleId: role.roleId },
+  );
+  const resend = useAuthenticatedAction(
+    api.functions.scheduling.assignments.resendAssignmentRequest,
+  );
+  const [resending, setResending] = useState<string | null>(null);
+
+  const handleResend = useCallback(
+    async (assignmentId: Id<"roleAssignments">) => {
+      setResending(assignmentId as string);
+      try {
+        const result = await resend({ assignmentId });
+        if (result.scheduled) {
+          notify("Request re-sent", `${role.roleName} request was sent again.`);
+        } else {
+          notify(
+            "Couldn't re-send",
+            "This volunteer already declined, or the assignment was removed.",
+          );
+        }
+      } catch {
+        notify("Couldn't re-send", "Something went wrong. Please try again.");
+      } finally {
+        setResending(null);
+      }
+    },
+    [resend, role.roleName],
+  );
+
+  return (
+    <ModalShell
+      title="Request history"
+      subtitle={`${role.roleName} · ${monthDay(event.eventDate)}`}
+      colors={colors}
+      docked={docked}
+      onClose={onClose}
+    >
+      {history === undefined ? (
+        <ActivityIndicator style={{ paddingVertical: 20 }} color={colors.link} />
+      ) : history.length === 0 ? (
+        <Text style={[styles.menuEmpty, { color: colors.textSecondary }]}>
+          No requests sent yet.
+        </Text>
+      ) : (
+        <ScrollView style={docked ? styles.popoverListDocked : styles.popoverList}>
+          {history.map((h) => {
+            const removed = h.currentStatus === "removed";
+            const statusLabel = removed
+              ? "Removed"
+              : assignmentStatusLabel(h.currentStatus);
+            const verb = h.kind === "resend" ? "Re-sent" : "Requested";
+            return (
+              <View
+                key={h.id}
+                style={[styles.occupantRow, { borderBottomColor: colors.border }]}
+              >
+                <Ionicons
+                  name={
+                    removed
+                      ? "close-circle-outline"
+                      : statusIcon(h.currentStatus as AssignmentStatus)
+                  }
+                  size={16}
+                  color={
+                    removed
+                      ? colors.textSecondary
+                      : statusColor(h.currentStatus as AssignmentStatus, colors)
+                  }
+                />
+                <View style={styles.menuRowText}>
+                  <Text
+                    style={[styles.occupantName, { color: colors.text }]}
+                    numberOfLines={1}
+                  >
+                    {h.userName}
+                  </Text>
+                  <Text
+                    style={[styles.menuRowSub, { color: colors.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    {`${verb} · ${formatRelativeTime(h.sentAt)} · ${statusLabel}`}
+                  </Text>
+                  {h.declineNote ? (
+                    <Text
+                      style={[styles.menuRowSub, { color: colors.textSecondary }]}
+                      numberOfLines={2}
+                    >
+                      {`“${h.declineNote}”`}
+                    </Text>
+                  ) : null}
+                </View>
+                {h.currentStatus === "unconfirmed" ? (
+                  <TouchableOpacity
+                    onPress={() => handleResend(h.assignmentId)}
+                    disabled={resending === (h.assignmentId as string)}
+                    hitSlop={8}
+                  >
+                    <Text style={[styles.removeText, { color: colors.link }]}>
+                      {resending === (h.assignmentId as string)
+                        ? "Sending…"
+                        : "Resend"}
+                    </Text>
+                  </TouchableOpacity>
+                ) : null}
+              </View>
+            );
+          })}
+        </ScrollView>
       )}
     </ModalShell>
   );

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -215,6 +215,12 @@ export function EventPlans() {
             request once more to volunteers with an open slot (handy after
             you've edited the roster).
           </p>
+          <p>
+            And you don't have to keep checking back: when a volunteer confirms
+            or declines, the plan's leaders get a notification (push and in-app)
+            so you find out the moment someone responds — a decline even carries
+            their note, so you know why and can backfill the slot.
+          </p>
         </Callout>
 
         <Figure caption="The plan editor's bottom bar sends the requests; volunteers confirm or decline from the push/SMS.">
@@ -297,6 +303,15 @@ export function EventPlans() {
           A segmented <Term>Roles</Term> / <Term>People</Term> control flips the
           grid to a per-person view when you'd rather see one volunteer's whole
           schedule.
+        </P>
+
+        <P>
+          Tap a role cell and choose <Term>Request history</Term> to see the full
+          trail for that slot: who was asked, when, and how many times, alongside
+          whether they've since confirmed, declined, or been removed. From there
+          you can <Term>Resend</Term> the confirm-or-decline request to a single
+          person who's still awaiting — a precise nudge when you don't want to
+          re-send to the whole plan.
         </P>
       </Section>
 


### PR DESCRIPTION
## What & why

Implements two leader-facing roster features from the bug report:

1. **Request history + re-send.** Leaders can now review the full trail of serving requests sent for a role slot — who was asked, when, and how many times — and re-send the confirm/decline request to a single person, rather than only re-sending to the whole event.
2. **Leader notifications on accept/decline.** When a volunteer confirms or declines, the event's leaders are notified (push + in-app inbox) so they find out the moment someone responds, instead of having to keep re-checking the grid.

The roster already had a bulk **Re-send requests** button (per the screenshots); this adds the *history* view and *per-person* re-send on top of it.

## Backend (`apps/convex`)

- New append-only table **`assignmentRequestLog`** — one row per recipient per send. Unlike `roleAssignments` (mutated in place, hard-deleted on `unassign`), the log survives removal, so the trail is always reviewable.
- `sendAssignmentRequests` now writes a log row per fan-out and accepts an optional `assignmentIds` filter; `kind` (`initial`/`resend`) is derived from whether a prior log row exists.
- **`resendAssignmentRequest`** action — re-sends to a single assignment (scheduler-gated; skips volunteers who already declined).
- **`assignmentRequestHistory`** query — returns the trail joined with each recipient's *current* status (`unconfirmed`/`confirmed`/`declined`/`removed`), decline note, and timestamps.
- `respondToAssignment` now schedules **`notifyLeadersOfResponse`** — push + in-app inbox to the event's leaders (group leaders, the assigner, the publisher), excluding the responder. New notification type `scheduling_assignment_response`, deep-linking to the roster grid.
- Reuses the existing push/SMS/inbox infrastructure throughout — no new delivery plumbing.

## Mobile (`apps/mobile`)

- Role-cell popover gains a **Request history** action opening a new `RequestHistoryModal` (built on the existing `ModalShell`): status icon + name + "Requested/Re-sent · {time} · {status}" + decline note, with a **Resend** button on still-awaiting rows.
- The new `scheduling_assignment_response` notification type maps to a checkmark icon in the feed; tapping routes to the roster grid via `data.url`.

## Docs

- Updated the **Event Plans** onboarding guide (publishing section + roster grid section) to match the new behavior.

## Scope note: web

`apps/web` is a marketing/onboarding site with **no authenticated roster surface**, so these features are inherently mobile-only. Building a roster UI on web would mean a brand-new authenticated app surface (a significant architectural decision), which is out of scope here. Flagging explicitly since the request mentioned "both mobile and web."

## Testing

- New `__tests__/scheduling/requestHistory.test.ts` (8 tests): log `initial`→`resend`, history reflects current status incl. `removed`, scheduler gating, declined-skip on re-send, and leader notifications (accept, decline-with-note, self-exclusion).
- Full Convex suite green: **116 files / 1839 tests**.
- `convex typecheck` clean; mobile `tsc` clean for changed files; mobile Jest **1121 tests pass**; Metro export succeeds; native-import and navigator-screen checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GT2WsBxanHkxGpHynRwZH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GT2WsBxanHkxGpHynRwZH)_