### PR TITLE
fix(messaging): exclude event channels from custom-channel limit + surface the error to the user

### DIFF
--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -971,6 +971,56 @@ describe("createCustomChannel", () => {
     ).rejects.toThrow("Only group leaders can create channels");
   });
 
+  // Regression: event channels (auto-created per meeting, hidden from the
+  // channel list) must NOT count toward the 20-channel creation limit. A group
+  // with many past events would otherwise hit "maximum of 20 channels" while
+  // showing only a few real channels, blocking all manual channel creation.
+  test("event channels do not count toward the 20-channel limit", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId } = await seedTestData(t);
+    const { userId: leaderId, accessToken: leaderToken } = await createLeaderUser(
+      t,
+      communityId,
+      groupId
+    );
+
+    // Seed 25 event channels (more than the limit) plus a couple real ones.
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      for (let i = 0; i < 25; i++) {
+        await ctx.db.insert("chatChannels", {
+          groupId,
+          slug: `event-${i}`,
+          channelType: "event",
+          name: `Event ${i}`,
+          createdById: leaderId,
+          createdAt: now,
+          updatedAt: now,
+          isArchived: false,
+          memberCount: 0,
+        });
+      }
+      await ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "general",
+        channelType: "main",
+        name: "General",
+        createdById: leaderId,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 0,
+      });
+    });
+
+    // Creation should still succeed — only the 1 managed channel counts.
+    const result = await t.mutation(
+      api.functions.messaging.channels.createCustomChannel,
+      { token: leaderToken, groupId, name: "LIC Boys" }
+    );
+    expect(result.slug).toBe("lic-boys");
+  });
+
   test("enforces 20 channel limit", async () => {
     const t = convexTest(schema, modules);
     const { communityId, groupId } = await seedTestData(t);

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -2737,7 +2737,16 @@ export const createCustomChannel = mutation({
       .filter((q) => q.eq(q.field("isArchived"), false))
       .collect();
 
-    if (existingChannels.length >= 20) {
+    // Only channels a leader actually manages count toward the limit. Event
+    // channels are auto-created (one per meeting), hidden from the channel
+    // list, and accumulate without bound — counting them lets a group with
+    // lots of past events hit "maximum of 20 channels" while showing only a
+    // handful of real channels, blocking all manual channel creation.
+    const managedChannelCount = existingChannels.filter(
+      (ch) => ch.channelType !== "event"
+    ).length;
+
+    if (managedChannelCount >= 20) {
       throw new ConvexError(
         "This group has reached the maximum of 20 channels. Archive some channels to create new ones."
       );

--- a/apps/mobile/app/inbox/[groupId]/__tests__/create.test.tsx
+++ b/apps/mobile/app/inbox/[groupId]/__tests__/create.test.tsx
@@ -431,6 +431,42 @@ describe("CreateChannelScreen", () => {
       );
     });
 
+    // Regression: createAutoChannel (Planning Center) throws
+    // ConvexError({ code, message }) — an object payload — so the useful text
+    // lives at error.data.message, not a bare string error.data.
+    it("surfaces an object ConvexError payload from error.data.message", async () => {
+      mockCreateChannel.mockRejectedValueOnce(
+        Object.assign(
+          new Error("[CONVEX M(...)] [Request ID: abc] Server Error"),
+          {
+            data: {
+              code: "NO_INTEGRATION",
+              message: "Planning Center integration is not configured.",
+            },
+          }
+        )
+      );
+
+      const { getByPlaceholderText, getByTestId, findByTestId } = render(
+        <CreateChannelScreen />
+      );
+      const nameInput = getByPlaceholderText("Enter channel name");
+
+      act(() => {
+        fireEvent.changeText(nameInput, "Test Channel");
+      });
+
+      const createButton = getByTestId("create-button");
+      await act(async () => {
+        fireEvent.press(createButton);
+      });
+
+      const toastMessage = await findByTestId("toast-message");
+      expect(toastMessage.props.children).toBe(
+        "Planning Center integration is not configured."
+      );
+    });
+
     it("shows toast with 'character limit' error message", async () => {
       mockCreateChannel.mockRejectedValueOnce(
         new Error("Channel name must be 1-50 characters")

--- a/apps/mobile/app/inbox/[groupId]/__tests__/create.test.tsx
+++ b/apps/mobile/app/inbox/[groupId]/__tests__/create.test.tsx
@@ -399,6 +399,38 @@ describe("CreateChannelScreen", () => {
       );
     });
 
+    // Regression: in production a ConvexError arrives with a generic
+    // "Server Error" `.message` and the real text on `.data`. The handler must
+    // read `.data`, otherwise the friendly message never surfaces and the raw
+    // "Server Error" leaks into the toast.
+    it("surfaces a production ConvexError from error.data, not 'Server Error'", async () => {
+      mockCreateChannel.mockRejectedValueOnce(
+        Object.assign(
+          new Error("[CONVEX M(...)] [Request ID: abc] Server Error"),
+          { data: "This group has reached the maximum of 20 channels" }
+        )
+      );
+
+      const { getByPlaceholderText, getByTestId, findByTestId } = render(
+        <CreateChannelScreen />
+      );
+      const nameInput = getByPlaceholderText("Enter channel name");
+
+      act(() => {
+        fireEvent.changeText(nameInput, "Test Channel");
+      });
+
+      const createButton = getByTestId("create-button");
+      await act(async () => {
+        fireEvent.press(createButton);
+      });
+
+      const toastMessage = await findByTestId("toast-message");
+      expect(toastMessage.props.children).toBe(
+        "This group has reached the maximum of 20 channels. Archive some channels to create new ones."
+      );
+    });
+
     it("shows toast with 'character limit' error message", async () => {
       mockCreateChannel.mockRejectedValueOnce(
         new Error("Channel name must be 1-50 characters")

--- a/apps/mobile/app/inbox/[groupId]/create.tsx
+++ b/apps/mobile/app/inbox/[groupId]/create.tsx
@@ -172,25 +172,33 @@ export default function CreateChannelScreen() {
     } catch (error: any) {
       console.error("Failed to create channel:", error);
 
+      // ConvexError delivers its thrown payload on `error.data`. In production
+      // `error.message` is only a generic "[Request ID: …] Server Error"
+      // string, so prefer `error.data` — otherwise the friendly server
+      // messages below never match and the raw "Server Error" leaks into the
+      // toast (which is exactly what users saw on the 20-channel limit).
+      const convexMessage: string =
+        typeof error?.data === "string" ? error.data : error?.message ?? "";
+
       // Extract user-friendly error message
       let errorMessage = "Failed to create channel. Please try again.";
-      if (error?.message) {
-        // Handle Convex errors which often have the message in error.message
-        if (error.message.includes("Only group leaders")) {
+      if (convexMessage) {
+        if (convexMessage.includes("Only group leaders")) {
           errorMessage = "Only group leaders can create channels.";
-        } else if (error.message.includes("maximum of 20 channels")) {
+        } else if (convexMessage.includes("maximum of 20 channels")) {
           errorMessage =
             "This group has reached the maximum of 20 channels. Archive some channels to create new ones.";
-        } else if (error.message.includes("1-50 characters")) {
+        } else if (convexMessage.includes("1-50 characters")) {
           errorMessage = "Channel name must be between 1 and 50 characters.";
         } else if (
-          error.message.includes("Not authenticated") ||
-          error.message.includes("no auth token")
+          convexMessage.includes("Not authenticated") ||
+          convexMessage.includes("no auth token")
         ) {
           errorMessage = "Please log in again to create a channel.";
-        } else {
-          // Use the error message if it seems user-friendly
-          errorMessage = error.message;
+        } else if (!convexMessage.includes("Server Error")) {
+          // Use the server's message only when it's a real ConvexError
+          // payload, never the opaque production "Server Error" fallback.
+          errorMessage = convexMessage;
         }
       }
 

--- a/apps/mobile/app/inbox/[groupId]/create.tsx
+++ b/apps/mobile/app/inbox/[groupId]/create.tsx
@@ -177,8 +177,16 @@ export default function CreateChannelScreen() {
       // string, so prefer `error.data` — otherwise the friendly server
       // messages below never match and the raw "Server Error" leaks into the
       // toast (which is exactly what users saw on the 20-channel limit).
+      // The payload is a bare string for createCustomChannel's errors but a
+      // `{ code, message }` object for createAutoChannel's (Planning Center),
+      // so handle both shapes before falling back to `error.message`.
+      const convexData = error?.data;
       const convexMessage: string =
-        typeof error?.data === "string" ? error.data : error?.message ?? "";
+        typeof convexData === "string"
+          ? convexData
+          : typeof convexData?.message === "string"
+            ? convexData.message
+            : error?.message ?? "";
 
       // Extract user-friendly error message
       let errorMessage = "Failed to create channel. Please try again.";


### PR DESCRIPTION
## Problem

Creating a **Custom** channel failed with:

> `ConvexError: This group has reached the maximum of 20 channels. Archive some channels to create new ones.`

…even though the group only had a few channels — and that message never reached the user, who instead saw a raw **"Server Error"** toast.

## Root cause

**1. Event channels counted toward the 20-channel limit.**
`createCustomChannel` counted *all* non-archived `chatChannels` for the group against the limit. Event channels (`channelType: "event"`) are auto-created **one per meeting**, are `groupId`-bound + `isArchived: false`, and are **hidden from the channel list** (`listGroupChannels` filters them out). A group with many past events accumulates 20+ hidden event-channel rows, so the limit trips while the UI shows only a handful of real channels — blocking *all* manual channel creation.

**2. The error never surfaced.**
The mobile create screen mapped server errors to friendly toasts by inspecting `error.message`. A Convex `ConvexError` carries its payload on **`error.data`**; in production `error.message` is only a generic `"[Request ID: …] Server Error"`. So every branch missed and the opaque string leaked into the toast.

## Fix

- **Backend** (`apps/convex/functions/messaging/channels.ts`): only leader-managed channels (`channelType !== "event"`) count toward the limit. All channels are still used for slug-collision checks.
- **Mobile** (`apps/mobile/app/inbox/[groupId]/create.tsx`): read `error.data` first (matching the existing pattern in `SongLibraryScreen`), so the limit/leader/validation messages actually surface and the opaque "Server Error" fallback is never shown raw.

## Testing

- `apps/convex` — new test: event channels don't count toward the limit (seed 25 event channels, creation still succeeds). **112 passed.**
- `apps/mobile` — new test: a production-shaped `ConvexError` (generic `.message`, real `.data`) surfaces the friendly message. **Create suite 26 passed; full pre-push suite 1122 passed / 9 skipped.**
- `apps/convex` typecheck: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)