### PR TITLE
feat(scheduling): send a serving request to one person from the role cell

### DIFF
--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -2574,10 +2574,13 @@ function RoleCellPopover({
   onClose: () => void;
 }) {
   // Per-person serving request, straight from the occupant row. After assigning
-  // or reassigning one volunteer, a leader can ping just that person instead of
-  // re-sending the whole plan via Publish. Reuses the same scheduler-gated
-  // action as the request-history "Resend"; the backend only (re-)sends to an
-  // `unconfirmed` assignment, so the action is shown only for awaiting people.
+  // or reassigning one volunteer on a PUBLISHED plan, a leader can ping just that
+  // person instead of re-sending the whole plan via Publish. Reuses the same
+  // scheduler-gated action as the request-history "Resend"; the backend only
+  // (re-)sends to an `unconfirmed` assignment, so the action is shown only for
+  // awaiting people. Gated to published plans (see the occupant row): on a draft
+  // the first send is "Publish & send requests", so a stray tap can't text a
+  // volunteer about an unpublished roster the leader is still building.
   const resend = useAuthenticatedAction(
     api.functions.scheduling.assignments.resendAssignmentRequest,
   );
@@ -2621,7 +2624,7 @@ function RoleCellPopover({
             <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
               {o.userName}
             </Text>
-            {o.status === "unconfirmed" ? (
+            {event.status === "published" && o.status === "unconfirmed" ? (
               <TouchableOpacity
                 onPress={() => handleSendOne(o.assignmentId, o.userName)}
                 disabled={resending === (o.assignmentId as string)}

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -2573,6 +2573,38 @@ function RoleCellPopover({
   onShowHistory: () => void;
   onClose: () => void;
 }) {
+  // Per-person serving request, straight from the occupant row. After assigning
+  // or reassigning one volunteer, a leader can ping just that person instead of
+  // re-sending the whole plan via Publish. Reuses the same scheduler-gated
+  // action as the request-history "Resend"; the backend only (re-)sends to an
+  // `unconfirmed` assignment, so the action is shown only for awaiting people.
+  const resend = useAuthenticatedAction(
+    api.functions.scheduling.assignments.resendAssignmentRequest,
+  );
+  const [resending, setResending] = useState<string | null>(null);
+
+  const handleSendOne = useCallback(
+    async (assignmentId: Id<"roleAssignments">, userName: string) => {
+      setResending(assignmentId as string);
+      try {
+        const result = await resend({ assignmentId });
+        if (result.scheduled) {
+          notify("Request sent", `Sent a serving request to ${userName}.`);
+        } else {
+          notify(
+            "Couldn't send",
+            "This volunteer already responded, or the assignment was removed.",
+          );
+        }
+      } catch {
+        notify("Couldn't send", "Something went wrong. Please try again.");
+      } finally {
+        setResending(null);
+      }
+    },
+    [resend],
+  );
+
   if (!cell) return null;
   return (
     <ModalShell
@@ -2589,6 +2621,19 @@ function RoleCellPopover({
             <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
               {o.userName}
             </Text>
+            {o.status === "unconfirmed" ? (
+              <TouchableOpacity
+                onPress={() => handleSendOne(o.assignmentId, o.userName)}
+                disabled={resending === (o.assignmentId as string)}
+                hitSlop={8}
+              >
+                <Text style={[styles.removeText, { color: colors.link }]}>
+                  {resending === (o.assignmentId as string)
+                    ? "Sending…"
+                    : "Send request"}
+                </Text>
+              </TouchableOpacity>
+            ) : null}
             <TouchableOpacity onPress={() => onRemove(o.assignmentId)} hitSlop={8}>
               <Text style={[styles.removeText, { color: colors.destructive }]}>Remove</Text>
             </TouchableOpacity>

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -306,10 +306,12 @@ export function EventPlans() {
         </P>
 
         <P>
-          Tap a role cell to manage who's in it. Next to anyone still awaiting a
-          response is <Term>Send request</Term> — it pings just that one person,
-          so after you assign or reassign a single volunteer you can request them
-          on their own instead of re-sending to the whole plan. Choose{" "}
+          Tap a role cell to manage who's in it. Once the plan is published, next
+          to anyone still awaiting a response is <Term>Send request</Term> — it
+          pings just that one person, so after you assign or reassign a single
+          volunteer you can request them on their own instead of re-sending to the
+          whole plan. (On a still-draft plan you publish first, which is what
+          sends the initial requests.) Choose{" "}
           <Term>Request history</Term> on the same popover to see the full trail
           for that slot: who was asked, when, and how many times, alongside
           whether they've since confirmed, declined, or been removed — and{" "}

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -306,12 +306,14 @@ export function EventPlans() {
         </P>
 
         <P>
-          Tap a role cell and choose <Term>Request history</Term> to see the full
-          trail for that slot: who was asked, when, and how many times, alongside
-          whether they've since confirmed, declined, or been removed. From there
-          you can <Term>Resend</Term> the confirm-or-decline request to a single
-          person who's still awaiting — a precise nudge when you don't want to
-          re-send to the whole plan.
+          Tap a role cell to manage who's in it. Next to anyone still awaiting a
+          response is <Term>Send request</Term> — it pings just that one person,
+          so after you assign or reassign a single volunteer you can request them
+          on their own instead of re-sending to the whole plan. Choose{" "}
+          <Term>Request history</Term> on the same popover to see the full trail
+          for that slot: who was asked, when, and how many times, alongside
+          whether they've since confirmed, declined, or been removed — and{" "}
+          <Term>Resend</Term> from there too.
         </P>
       </Section>
 


### PR DESCRIPTION
## What

Adds a **"Send request"** action to each *awaiting* occupant row in the roster role-cell popover, so a leader can ping a single volunteer right after assigning or reassigning them — instead of re-sending the whole plan.

## Why

A volunteer filed this from the app:

> "I should be able to send a request just to one person after assigning them or reassigning their schedule instead of having to send a request to everyone."

Today the only ways to send a serving request are:
1. **Publish / "Re-send requests"** — notifies *every* unconfirmed assignment on the plan (the "send to everyone" the user is complaining about).
2. **Request history** modal — has a per-person *Resend*, but it's two taps deep and only lists people who already have a request trail.

There was no direct "request just this person" affordance where a leader actually assigns people: the role-cell popover (the popup in the bug screenshots showing the role, the assigned person, and *Remove* / *Request history*).

## How

- In `RoleCellPopover` (the role-cell popup, rendered identically on mobile and desktop), each occupant whose status is `unconfirmed` now shows a **Send request** link next to **Remove**.
- It reuses the existing, already-tested, scheduler-gated `resendAssignmentRequest` action from #510 (single-assignment push + SMS + in-app fan-out, plus a history-log row). No backend changes.
- The action is shown only for `unconfirmed` occupants — matching the backend's recipient filter, which only (re-)sends to awaiting assignments — so confirmed/declined people are never re-pinged. Mirrors the existing *Resend* affordance in the Request history modal (label/loading/toast behavior).

## Docs

- Updated the **Event Plans** onboarding guide (`apps/web/src/pages/guides/EventPlans.tsx`) to document the direct per-person send alongside the existing Request history / Resend trail.

## Testing

- `tsc --noEmit` — the changed file is type-clean (remaining repo errors are pre-existing in unrelated files).
- ESLint — 0 errors on both changed files.
- `apps/convex` scheduling suite — **37/37 pass** (`requestHistory.test.ts` + `assignments.test.ts`), covering the per-person `resendAssignmentRequest` path this UI reuses (scheduler-gated, awaiting-only, logs `initial` then `resend`).

UI-only surfacing of an existing tested backend action; there is no component-test harness for `RosterGridScreen`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6ENyQv6g5EK4uH87bVnpe)_