### PR TITLE
fix(messaging): email DM request recipients in conjunction with push

### DIFF
--- a/apps/convex/__tests__/messaging/events.test.ts
+++ b/apps/convex/__tests__/messaging/events.test.ts
@@ -1094,3 +1094,202 @@ describe("onThreadReply Event", () => {
     expect(parent?.threadReplyCount).toBe(3);
   });
 });
+
+// ============================================================================
+// DM message-request email notifications
+// ============================================================================
+//
+// A new direct-message request should email the recipient *in conjunction
+// with* the push (not only as a fallback when push is unreachable), so users
+// hear about message requests even when they aren't actively using the app.
+
+const RESEND_EMAIL_URL = "https://api.resend.com/emails";
+const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
+
+/** Seed a pending 1:1 DM request from `sender` to `recipient`. */
+async function seedDmRequest(
+  t: ReturnType<typeof convexTest>,
+  opts: {
+    communityId: Id<"communities">;
+    senderId: Id<"users">;
+    recipientId: Id<"users">;
+  },
+): Promise<Id<"chatChannels">> {
+  const now = Date.now();
+  return await t.run(async (ctx) => {
+    const channelId = await ctx.db.insert("chatChannels", {
+      communityId: opts.communityId,
+      channelType: "dm",
+      name: "",
+      isAdHoc: true,
+      createdById: opts.senderId,
+      createdAt: now,
+      updatedAt: now,
+      isArchived: false,
+      memberCount: 2,
+    });
+    // Sender is an accepted member; recipient's request is still pending.
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: opts.senderId,
+      role: "member",
+      joinedAt: now,
+      isMuted: false,
+      requestState: "accepted",
+    });
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: opts.recipientId,
+      role: "member",
+      joinedAt: now,
+      isMuted: false,
+      requestState: "pending",
+      invitedById: opts.senderId,
+    });
+    await ctx.db.insert("chatReadState", {
+      channelId,
+      userId: opts.recipientId,
+      lastReadAt: 0,
+      unreadCount: 0,
+    });
+    return channelId;
+  });
+}
+
+describe("DM request email notifications", () => {
+  test("emails the recipient in conjunction with push when a DM request is sent", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+    const now = Date.now();
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "ticket-dm-req", status: "ok" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Recipient has an email + an active push token, so push succeeds. The
+    // email must still be sent (in conjunction), not skipped as a fallback.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(user2Id, {
+        email: "recipient@example.com",
+        emailNotificationsEnabled: true,
+      });
+      await ctx.db.insert("pushTokens", {
+        userId: user2Id,
+        token: "ExponentPushToken[dm-request-test]",
+        platform: "ios",
+        environment: "staging",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+        lastUsedAt: now,
+      });
+    });
+
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    const messageId = await t.run(async (ctx) => {
+      return await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: userId,
+        content: "Hey, would love to connect!",
+        contentType: "text",
+        createdAt: now,
+        isDeleted: false,
+        senderName: "Test User",
+      });
+    });
+
+    await t.mutation(internal.functions.messaging.events.onMessageSent, {
+      messageId,
+      channelId,
+      senderId: userId,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const calls = fetchMock.mock.calls;
+    const pushCall = calls.find((c) => c?.[0] === EXPO_PUSH_URL);
+    const emailCall = calls.find((c) => c?.[0] === RESEND_EMAIL_URL);
+
+    // Push landed AND the email was sent alongside it — not as a fallback.
+    expect(pushCall).toBeDefined();
+    expect(emailCall).toBeDefined();
+
+    const emailBody = JSON.parse(String(emailCall?.[1]?.body));
+    expect(emailBody.to).toBe("recipient@example.com");
+    expect(emailBody.subject).toBe("Test User would like to chat");
+    expect(emailBody.html).toContain("would like to chat with you");
+  });
+
+  test("does not email when the recipient disabled email notifications", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+    const now = Date.now();
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "ticket-dm-req-2", status: "ok" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(user2Id, {
+        email: "optout@example.com",
+        emailNotificationsEnabled: false,
+      });
+      await ctx.db.insert("pushTokens", {
+        userId: user2Id,
+        token: "ExponentPushToken[dm-request-optout]",
+        platform: "ios",
+        environment: "staging",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+        lastUsedAt: now,
+      });
+    });
+
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    const messageId = await t.run(async (ctx) => {
+      return await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: userId,
+        content: "Hello there",
+        contentType: "text",
+        createdAt: now,
+        isDeleted: false,
+        senderName: "Test User",
+      });
+    });
+
+    await t.mutation(internal.functions.messaging.events.onMessageSent, {
+      messageId,
+      channelId,
+      senderId: userId,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const emailCall = fetchMock.mock.calls.find(
+      (c) => c?.[0] === RESEND_EMAIL_URL,
+    );
+    expect(emailCall).toBeUndefined();
+  });
+});

--- a/apps/convex/__tests__/messaging/events.test.ts
+++ b/apps/convex/__tests__/messaging/events.test.ts
@@ -1292,4 +1292,81 @@ describe("DM request email notifications", () => {
     );
     expect(emailCall).toBeUndefined();
   });
+
+  test("does not email on follow-up messages sent while the recipient is still pending", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+    const now = Date.now();
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "ticket-dm-followup", status: "ok" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(user2Id, {
+        email: "recipient@example.com",
+        emailNotificationsEnabled: true,
+      });
+      await ctx.db.insert("pushTokens", {
+        userId: user2Id,
+        token: "ExponentPushToken[dm-followup-test]",
+        platform: "ios",
+        environment: "staging",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+        lastUsedAt: now,
+      });
+    });
+
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    // The opening request message already exists (and would have emailed).
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: userId,
+        content: "Hey, would love to connect!",
+        contentType: "text",
+        createdAt: now,
+        isDeleted: false,
+        senderName: "Test User",
+      });
+    });
+
+    // A follow-up sent while the recipient is still pending must not email.
+    const followUpId = await t.run(async (ctx) => {
+      return await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: userId,
+        content: "Still hoping to chat!",
+        contentType: "text",
+        createdAt: now + 1000,
+        isDeleted: false,
+        senderName: "Test User",
+      });
+    });
+
+    await t.mutation(internal.functions.messaging.events.onMessageSent, {
+      messageId: followUpId,
+      channelId,
+      senderId: userId,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const emailCall = fetchMock.mock.calls.find(
+      (c) => c?.[0] === RESEND_EMAIL_URL,
+    );
+    expect(emailCall).toBeUndefined();
+  });
 });

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -333,6 +333,21 @@ export const onMessageSent = internalMutation({
           `[onMessageSent] Scheduling ad-hoc notifications: ${pendingRecipients.length} pending, ${acceptedRecipients.length} accepted`,
         );
 
+        // The request email is "first-message-of-request" copy, so it should
+        // only fire for the message that opened the request. Senders can send
+        // legitimate follow-ups while the recipient is still pending, and each
+        // of those re-runs this fanout — without this guard every follow-up
+        // would email a pending recipient again. The opening message is the
+        // earliest in the channel.
+        const firstMessage = await ctx.db
+          .query("chatMessages")
+          .withIndex("by_channel_createdAt", (q) =>
+            q.eq("channelId", args.channelId),
+          )
+          .order("asc")
+          .first();
+        const isInitialRequestMessage = firstMessage?._id === args.messageId;
+
         await ctx.scheduler.runAfter(
           0,
           internal.functions.messaging.events.sendAdHocMessageNotifications,
@@ -345,6 +360,7 @@ export const onMessageSent = internalMutation({
             communityId: channel.communityId,
             pendingRecipients,
             acceptedRecipients,
+            isInitialRequestMessage,
           },
         );
       } else {
@@ -530,6 +546,13 @@ export const sendAdHocMessageNotifications = internalAction({
     pendingRecipients: v.array(v.id("users")),
     /** Members whose membership row is `accepted` (or legacy/undefined). */
     acceptedRecipients: v.array(v.id("users")),
+    /**
+     * True when this is the opening message of the request (the earliest in
+     * the channel). Only then do pending recipients get the request email —
+     * follow-up messages before acceptance stay push-only so a pending
+     * conversation doesn't email on every message.
+     */
+    isInitialRequestMessage: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     console.log(
@@ -585,41 +608,51 @@ export const sendAdHocMessageNotifications = internalAction({
     };
 
     // Pending recipients: first-message-of-a-request copy.
-    // For each recipient, build a personalized email payload that is sent in
-    // conjunction with the push so users hear about a new message request even
-    // when they aren't actively using the app.
+    // On the opening message of the request, build a personalized email payload
+    // that is sent in conjunction with the push so users hear about a new
+    // message request even when they aren't actively using the app. Follow-up
+    // messages sent while the recipient is still pending stay push-only.
     if (args.pendingRecipients.length > 0) {
       const pendingTitle = args.senderName;
       const pendingBody = `would like to chat: ${previewBody}`;
       const isGroupChat = channelType === "group_dm";
       for (const userId of args.pendingRecipients) {
-        const userInfo = await ctx.runQuery(
-          internal.functions.notifications.internal.getUserEmailInfo,
-          { userId },
-        );
-        const emailHtml = chatRequestEmail({
-          senderName: args.senderName,
-          isGroupChat,
-          channelName: isGroupChat ? channelName : undefined,
-          messagePreview: args.messagePreview,
-          firstName: userInfo?.firstName,
-        });
-        const emailSubject = isGroupChat
-          ? channelName.trim().length > 0
-            ? `${args.senderName} added you to ${channelName.trim()}`
-            : `${args.senderName} added you to a group chat`
-          : `${args.senderName} would like to chat`;
+        // Only the opening message of the request carries an email — build the
+        // personalized payload just for that case so follow-ups skip the extra
+        // lookup and HTML render entirely.
+        let requestEmail:
+          | { subject: string; htmlBody: string; notificationType: string }
+          | undefined;
+        if (args.isInitialRequestMessage) {
+          const userInfo = await ctx.runQuery(
+            internal.functions.notifications.internal.getUserEmailInfo,
+            { userId },
+          );
+          const emailHtml = chatRequestEmail({
+            senderName: args.senderName,
+            isGroupChat,
+            channelName: isGroupChat ? channelName : undefined,
+            messagePreview: args.messagePreview,
+            firstName: userInfo?.firstName,
+          });
+          const emailSubject = isGroupChat
+            ? channelName.trim().length > 0
+              ? `${args.senderName} added you to ${channelName.trim()}`
+              : `${args.senderName} added you to a group chat`
+            : `${args.senderName} would like to chat`;
+          requestEmail = {
+            subject: emailSubject,
+            htmlBody: emailHtml,
+            notificationType: "chat_request",
+          };
+        }
         await sendAdHocPushToUser(ctx, {
           userId,
           title: pendingTitle,
           body: pendingBody,
           data: { ...baseData, requestState: "pending" },
           communityId: args.communityId,
-          requestEmail: {
-            subject: emailSubject,
-            htmlBody: emailHtml,
-            notificationType: "chat_request",
-          },
+          requestEmail,
         });
       }
     }

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -585,8 +585,9 @@ export const sendAdHocMessageNotifications = internalAction({
     };
 
     // Pending recipients: first-message-of-a-request copy.
-    // For each recipient, build a personalized email-fallback payload so that
-    // recipients without a live push token still hear about the request.
+    // For each recipient, build a personalized email payload that is sent in
+    // conjunction with the push so users hear about a new message request even
+    // when they aren't actively using the app.
     if (args.pendingRecipients.length > 0) {
       const pendingTitle = args.senderName;
       const pendingBody = `would like to chat: ${previewBody}`;
@@ -614,7 +615,7 @@ export const sendAdHocMessageNotifications = internalAction({
           body: pendingBody,
           data: { ...baseData, requestState: "pending" },
           communityId: args.communityId,
-          emailFallback: {
+          requestEmail: {
             subject: emailSubject,
             htmlBody: emailHtml,
             notificationType: "chat_request",
@@ -683,11 +684,14 @@ async function sendAdHocPushToUser(
     data: Record<string, unknown>;
     communityId?: Id<"communities">;
     /**
-     * Optional email fallback fired when the recipient has no active push
-     * tokens, OR when the push send fails. Used for chat requests so a
-     * recipient who isn't reachable via push still hears about the request.
+     * Optional email sent in conjunction with the push. Used for chat requests
+     * so the recipient hears about a new message request by email even when
+     * they aren't actively using the app — independent of whether push lands.
+     * Respects the recipient's `emailNotificationsEnabled` preference. Only
+     * requests pass this; accepted-chat messages stay push-only so the inbox
+     * doesn't double-notify on every reply.
      */
-    emailFallback?: {
+    requestEmail?: {
       subject: string;
       htmlBody: string;
       notificationType: string;
@@ -729,10 +733,11 @@ async function sendAdHocPushToUser(
     );
   }
 
-  // Cascade to email when push is unreachable (no tokens or send failed).
-  // Only requests get an email fallback — accepted-chat messages stay
+  // Email the recipient in conjunction with the push (not only as a fallback)
+  // so a new message request reaches them even when they aren't actively using
+  // the app. Only requests pass `requestEmail` — accepted-chat messages stay
   // push-only so the inbox doesn't double-notify on every reply.
-  if (!pushOk && args.emailFallback) {
+  if (args.requestEmail) {
     const userInfo = await ctx.runQuery(
       internal.functions.notifications.internal.getUserEmailInfo,
       { userId: args.userId },
@@ -742,13 +747,13 @@ async function sendAdHocPushToUser(
         internal.functions.notifications.internal.sendEmailNotification,
         {
           to: userInfo.email,
-          subject: args.emailFallback.subject,
-          htmlBody: args.emailFallback.htmlBody,
-          notificationType: args.emailFallback.notificationType,
+          subject: args.requestEmail.subject,
+          htmlBody: args.requestEmail.htmlBody,
+          notificationType: args.requestEmail.notificationType,
         },
       );
       console.log(
-        `[sendAdHocMessageNotifications] Email fallback sent to ${userInfo.email} (push unreachable)`,
+        `[sendAdHocMessageNotifications] Request email sent to ${userInfo.email}`,
       );
     }
   }
@@ -762,7 +767,7 @@ async function sendAdHocPushToUser(
       title: args.title,
       body: args.body,
       data: notificationData,
-      status: pushOk || args.emailFallback ? "sent" : "failed",
+      status: pushOk || args.requestEmail ? "sent" : "failed",
       trackingId,
     },
   );


### PR DESCRIPTION
## What & why

When a direct-message **request** is sent, the recipient should also be emailed so they hear about it even when they aren't actively in the app.

That mostly existed already — but the email only fired as a **push fallback**: the code gated it behind `if (!pushOk && args.emailFallback)`, so a recipient who had a live push token (i.e. most active users) got the push and **never** received an email. Users not currently in the app could miss message requests entirely.

This sends the request email **in conjunction with** the push instead of only when push is unreachable.

## Changes

- `apps/convex/functions/messaging/events.ts` — in `sendAdHocPushToUser`, drop the `!pushOk` gate so the request email is always attempted for pending DM-request recipients. Renamed the misleadingly-named `emailFallback` payload to `requestEmail` (and updated its call site + doc comments) to reflect the new semantics.
- The email still:
  - respects the recipient's `emailNotificationsEnabled` preference (and requires an email on file);
  - is scoped to **requests only** — accepted-chat replies stay push-only so the inbox doesn't double-notify on every message.

## Tests

Added two tests in `apps/convex/__tests__/messaging/events.test.ts`:
1. A DM request emails the recipient **in conjunction with** a successful push (the email fetch fires even though push landed).
2. The email is suppressed when the recipient has `emailNotificationsEnabled: false`.

## Verification

- `pnpm test` (convex): messaging + notification suites green (455 tests).
- `npx convex typecheck`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164FKD3a6MjDVX557FhXJeK)_