### PR TITLE
feat: add message search to the app inbox

### DIFF
--- a/apps/convex/__tests__/messaging/search.test.ts
+++ b/apps/convex/__tests__/messaging/search.test.ts
@@ -47,6 +47,17 @@ async function createUser(
       updatedAt: Date.now(),
     }),
   );
+  // Active community membership — searchMessages requires the caller to be a
+  // member of the community they're searching (defense-in-depth tenant gate).
+  await t.run(async (ctx) => {
+    await ctx.db.insert("userCommunities", {
+      userId,
+      communityId,
+      status: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
   const { accessToken } = await generateTokens(userId);
   return { userId, accessToken };
 }
@@ -471,6 +482,179 @@ describe("searchMessages", () => {
       query: "picnic",
     });
     expect(after.results).toHaveLength(1);
+  });
+
+  test("finds an event-channel message for an RSVPer with no membership row", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "evt-rsvp");
+    // Host owns the group/meeting; attendee only RSVPs (no chatChannelMembers row).
+    const { userId: hostId } = await createUser(t, communityId, "Host");
+    const { userId: attendeeId, accessToken } = await createUser(
+      t,
+      communityId,
+      "Attendee",
+    );
+
+    const groupTypeId = await t.run(async (ctx) =>
+      ctx.db.insert("groupTypes", {
+        communityId,
+        name: "Small Groups",
+        slug: `sg-${Math.random().toString(36).slice(2, 8)}`,
+        isActive: true,
+        displayOrder: 1,
+        createdAt: Date.now(),
+      }),
+    );
+    const groupId = await t.run(async (ctx) =>
+      ctx.db.insert("groups", {
+        name: "Event Group",
+        communityId,
+        groupTypeId,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const meetingId = await t.run(async (ctx) =>
+      ctx.db.insert("meetings", {
+        groupId,
+        communityId,
+        createdById: hostId,
+        hostUserIds: [hostId],
+        title: "Picnic Event",
+        scheduledAt: Date.now(),
+        status: "scheduled",
+        meetingType: 1,
+        createdAt: Date.now(),
+        shortId: "abc123",
+        rsvpEnabled: true,
+        rsvpOptions: [{ id: 1, label: "Going", enabled: true }],
+      }),
+    );
+
+    const eventChannelId = await t.run(async (ctx) =>
+      ctx.db.insert("chatChannels", {
+        groupId,
+        channelType: "event",
+        name: "Picnic Event",
+        slug: "event-abc123",
+        meetingId,
+        createdById: hostId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        isEnabled: true,
+        memberCount: 1,
+      }),
+    );
+
+    // Attendee RSVPs but has NO chatChannelMembers row — mirrors a "Can't Go"
+    // or not-yet-seated attendee who can still read the chat in-app.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("meetingRsvps", {
+        meetingId,
+        userId: attendeeId,
+        rsvpOptionId: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await insertMessage(t, eventChannelId, "picnic logistics in the event chat");
+
+    const { results } = await t.query(
+      api.functions.messaging.search.searchMessages,
+      { token: accessToken, communityId, query: "picnic" },
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].channelId).toBe(eventChannelId);
+    expect(results[0].channelType).toBe("event");
+  });
+
+  test("does not return an event-channel message for a non-RSVP non-member", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "evt-noaccess");
+    const { userId: hostId } = await createUser(t, communityId, "Host");
+    // Outsider is a community member but has no host/RSVP/membership tie to the event.
+    const { accessToken } = await createUser(t, communityId, "Outsider");
+
+    const groupTypeId = await t.run(async (ctx) =>
+      ctx.db.insert("groupTypes", {
+        communityId,
+        name: "Small Groups",
+        slug: `sg-${Math.random().toString(36).slice(2, 8)}`,
+        isActive: true,
+        displayOrder: 1,
+        createdAt: Date.now(),
+      }),
+    );
+    const groupId = await t.run(async (ctx) =>
+      ctx.db.insert("groups", {
+        name: "Event Group",
+        communityId,
+        groupTypeId,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const meetingId = await t.run(async (ctx) =>
+      ctx.db.insert("meetings", {
+        groupId,
+        communityId,
+        createdById: hostId,
+        hostUserIds: [hostId],
+        title: "Private Picnic",
+        scheduledAt: Date.now(),
+        status: "scheduled",
+        meetingType: 1,
+        createdAt: Date.now(),
+        shortId: "def456",
+        rsvpEnabled: true,
+        rsvpOptions: [{ id: 1, label: "Going", enabled: true }],
+      }),
+    );
+    const eventChannelId = await t.run(async (ctx) =>
+      ctx.db.insert("chatChannels", {
+        groupId,
+        channelType: "event",
+        name: "Private Picnic",
+        slug: "event-def456",
+        meetingId,
+        createdById: hostId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        isEnabled: true,
+        memberCount: 1,
+      }),
+    );
+    await insertMessage(t, eventChannelId, "secret picnic logistics");
+
+    const { results } = await t.query(
+      api.functions.messaging.search.searchMessages,
+      { token: accessToken, communityId, query: "picnic" },
+    );
+
+    expect(results).toHaveLength(0);
+  });
+
+  test("rejects a caller who is not a member of the searched community", async () => {
+    const t = convexTest(schema, modules);
+    const homeCommunity = await createCommunity(t, "home2");
+    const foreignCommunity = await createCommunity(t, "foreign2");
+    // Alice is a member of homeCommunity only.
+    const { accessToken } = await createUser(t, homeCommunity, "Alice");
+
+    await expect(
+      t.query(api.functions.messaging.search.searchMessages, {
+        token: accessToken,
+        communityId: foreignCommunity,
+        query: "picnic",
+      }),
+    ).rejects.toThrow();
   });
 
   test("returns nothing for queries below the minimum length", async () => {

--- a/apps/convex/__tests__/messaging/search.test.ts
+++ b/apps/convex/__tests__/messaging/search.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Inbox message search tests.
+ *
+ * Covers: matching message bodies, community + channel-access scoping,
+ * exclusion of soft-deleted / system / blocked-sender messages, and the
+ * minimum-query-length guard.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import type { Id } from "../../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+type Ctx = ReturnType<typeof convexTest>;
+
+async function createCommunity(t: Ctx, subdomain: string): Promise<Id<"communities">> {
+  return await t.run(async (ctx) =>
+    ctx.db.insert("communities", {
+      name: `Community ${subdomain}`,
+      subdomain,
+      slug: subdomain,
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }),
+  );
+}
+
+async function createUser(
+  t: Ctx,
+  communityId: Id<"communities">,
+  firstName: string,
+): Promise<{ userId: Id<"users">; accessToken: string }> {
+  const userId = await t.run(async (ctx) =>
+    ctx.db.insert("users", {
+      firstName,
+      lastName: "User",
+      phone: `+1555${Math.floor(Math.random() * 10_000_000).toString().padStart(7, "0")}`,
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }),
+  );
+  const { accessToken } = await generateTokens(userId);
+  return { userId, accessToken };
+}
+
+async function createGroupWithChannel(
+  t: Ctx,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+  opts: { role?: string; channelType?: string; channelName?: string } = {},
+): Promise<{ groupId: Id<"groups">; channelId: Id<"chatChannels"> }> {
+  const groupTypeId = await t.run(async (ctx) =>
+    ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Groups",
+      slug: `small-groups-${Math.random().toString(36).slice(2, 8)}`,
+      isActive: true,
+      displayOrder: 1,
+      createdAt: Date.now(),
+    }),
+  );
+
+  const groupId = await t.run(async (ctx) =>
+    ctx.db.insert("groups", {
+      name: "Test Group",
+      communityId,
+      groupTypeId,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }),
+  );
+
+  await t.run(async (ctx) => {
+    await ctx.db.insert("groupMembers", {
+      userId,
+      groupId,
+      role: opts.role ?? "member",
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+  });
+
+  const channelId = await t.run(async (ctx) =>
+    ctx.db.insert("chatChannels", {
+      groupId,
+      channelType: opts.channelType ?? "main",
+      name: opts.channelName ?? "General",
+      slug: `general-${Math.random().toString(36).slice(2, 8)}`,
+      createdById: userId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isArchived: false,
+      memberCount: 1,
+    }),
+  );
+
+  await t.run(async (ctx) => {
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId,
+      role: opts.role ?? "member",
+      joinedAt: Date.now(),
+      isMuted: false,
+    });
+  });
+
+  return { groupId, channelId };
+}
+
+async function insertMessage(
+  t: Ctx,
+  channelId: Id<"chatChannels">,
+  content: string,
+  opts: {
+    senderId?: Id<"users">;
+    senderName?: string;
+    contentType?: string;
+    isDeleted?: boolean;
+  } = {},
+): Promise<Id<"chatMessages">> {
+  return await t.run(async (ctx) =>
+    ctx.db.insert("chatMessages", {
+      channelId,
+      senderId: opts.senderId,
+      senderName: opts.senderName ?? "Sender",
+      content,
+      contentType: opts.contentType ?? "text",
+      createdAt: Date.now(),
+      isDeleted: opts.isDeleted ?? false,
+    }),
+  );
+}
+
+describe("searchMessages", () => {
+  test("returns messages matching the query in the user's channel", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "alpha");
+    const { userId, accessToken } = await createUser(t, communityId, "Alice");
+    const { channelId } = await createGroupWithChannel(t, communityId, userId);
+
+    await insertMessage(t, channelId, "Let's plan the picnic on Saturday");
+    await insertMessage(t, channelId, "Unrelated message about parking");
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toContain("picnic");
+    expect(results[0].channelId).toBe(channelId);
+  });
+
+  test("does not return messages from channels the user cannot access", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "beta");
+    const { accessToken } = await createUser(t, communityId, "Alice");
+    // Another user owns a separate group/channel that Alice is NOT a member of.
+    const { userId: bobId } = await createUser(t, communityId, "Bob");
+    const { channelId: bobChannel } = await createGroupWithChannel(
+      t,
+      communityId,
+      bobId,
+    );
+
+    await insertMessage(t, bobChannel, "secret picnic planning");
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  test("does not return messages from other communities", async () => {
+    const t = convexTest(schema, modules);
+    const homeCommunity = await createCommunity(t, "home");
+    const otherCommunity = await createCommunity(t, "other");
+    const { userId, accessToken } = await createUser(t, homeCommunity, "Alice");
+
+    // Channel in a different community that Alice somehow has a membership row in.
+    const { channelId: otherChannel } = await createGroupWithChannel(
+      t,
+      otherCommunity,
+      userId,
+    );
+    await insertMessage(t, otherChannel, "picnic in the other community");
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId: homeCommunity,
+      query: "picnic",
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  test("excludes deleted and system messages", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "gamma");
+    const { userId, accessToken } = await createUser(t, communityId, "Alice");
+    const { channelId } = await createGroupWithChannel(t, communityId, userId);
+
+    await insertMessage(t, channelId, "deleted picnic note", { isDeleted: true });
+    await insertMessage(t, channelId, "picnic system notice", {
+      contentType: "system",
+    });
+    await insertMessage(t, channelId, "real picnic message");
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("real picnic message");
+  });
+
+  test("excludes messages from blocked senders", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "delta");
+    const { userId, accessToken } = await createUser(t, communityId, "Alice");
+    const { userId: bobId } = await createUser(t, communityId, "Bob");
+    const { channelId } = await createGroupWithChannel(t, communityId, userId);
+
+    await insertMessage(t, channelId, "picnic from blocked bob", {
+      senderId: bobId,
+      senderName: "Bob",
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatUserBlocks", {
+        blockerId: userId,
+        blockedId: bobId,
+        createdAt: Date.now(),
+      });
+    });
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  test("returns nothing for queries below the minimum length", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "epsilon");
+    const { userId, accessToken } = await createUser(t, communityId, "Alice");
+    const { channelId } = await createGroupWithChannel(t, communityId, userId);
+    await insertMessage(t, channelId, "picnic");
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "a",
+    });
+
+    expect(results).toHaveLength(0);
+  });
+});

--- a/apps/convex/__tests__/messaging/search.test.ts
+++ b/apps/convex/__tests__/messaging/search.test.ts
@@ -10,7 +10,7 @@ import { convexTest } from "convex-test";
 import { expect, test, describe } from "vitest";
 import schema from "../../schema";
 import { modules } from "../../test.setup";
-import { api } from "../../_generated/api";
+import { api, internal } from "../../_generated/api";
 import { generateTokens } from "../../lib/auth";
 import type { Id } from "../../_generated/dataModel";
 
@@ -127,17 +127,26 @@ async function insertMessage(
     isDeleted?: boolean;
   } = {},
 ): Promise<Id<"chatMessages">> {
-  return await t.run(async (ctx) =>
-    ctx.db.insert("chatMessages", {
+  return await t.run(async (ctx) => {
+    // Derive communityId from the channel exactly like production writes do, so
+    // the community-scoped search index can find the message.
+    const channel = await ctx.db.get(channelId);
+    let communityId = channel?.communityId;
+    if (!communityId && channel?.groupId) {
+      const group = await ctx.db.get(channel.groupId);
+      communityId = group?.communityId ?? undefined;
+    }
+    return ctx.db.insert("chatMessages", {
       channelId,
+      communityId,
       senderId: opts.senderId,
       senderName: opts.senderName ?? "Sender",
       content,
       contentType: opts.contentType ?? "text",
       createdAt: Date.now(),
       isDeleted: opts.isDeleted ?? false,
-    }),
-  );
+    });
+  });
 }
 
 describe("searchMessages", () => {
@@ -421,6 +430,47 @@ describe("searchMessages", () => {
     });
 
     expect(results).toHaveLength(0);
+  });
+
+  test("backfill populates communityId so legacy messages become searchable", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "theta");
+    const { userId, accessToken } = await createUser(t, communityId, "Alice");
+    const { channelId } = await createGroupWithChannel(t, communityId, userId);
+
+    // Legacy row written before the field existed: no communityId.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatMessages", {
+        channelId,
+        content: "legacy picnic message",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+      });
+    });
+
+    // Not yet searchable — the community-scoped index can't match a null
+    // communityId.
+    const before = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+    expect(before.results).toHaveLength(0);
+
+    // Large batch → completes in a single page (no self-reschedule).
+    const result = await t.mutation(
+      internal.functions.admin.migrations.backfillMessageCommunityId,
+      { batchSize: 1000 },
+    );
+    expect(result.patched).toBe(1);
+
+    const after = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+    expect(after.results).toHaveLength(1);
   });
 
   test("returns nothing for queries below the minimum length", async () => {

--- a/apps/convex/__tests__/messaging/search.test.ts
+++ b/apps/convex/__tests__/messaging/search.test.ts
@@ -258,6 +258,171 @@ describe("searchMessages", () => {
     expect(results).toHaveLength(0);
   });
 
+  test("returns a back-compat slug for legacy channels without a slug", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "zeta");
+    const { userId, accessToken } = await createUser(t, communityId, "Alice");
+
+    // A "main" group channel with no slug set (legacy data).
+    const groupTypeId = await t.run(async (ctx) =>
+      ctx.db.insert("groupTypes", {
+        communityId,
+        name: "Small Groups",
+        slug: "small-groups-zeta",
+        isActive: true,
+        displayOrder: 1,
+        createdAt: Date.now(),
+      }),
+    );
+    const groupId = await t.run(async (ctx) =>
+      ctx.db.insert("groups", {
+        name: "Legacy Group",
+        communityId,
+        groupTypeId,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    await t.run(async (ctx) => {
+      await ctx.db.insert("groupMembers", {
+        userId,
+        groupId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+    const channelId = await t.run(async (ctx) =>
+      ctx.db.insert("chatChannels", {
+        groupId,
+        channelType: "main",
+        name: "General",
+        // no slug
+        createdById: userId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 1,
+      }),
+    );
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    });
+    await insertMessage(t, channelId, "picnic in the legacy channel");
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+
+    expect(results).toHaveLength(1);
+    // "main" channels fall back to the "general" slug, never null.
+    expect(results[0].channelSlug).toBe("general");
+  });
+
+  test("hides a shared channel a linked group has hidden from its members", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "eta");
+    const groupTypeId = await t.run(async (ctx) =>
+      ctx.db.insert("groupTypes", {
+        communityId,
+        name: "Small Groups",
+        slug: "small-groups-eta",
+        isActive: true,
+        displayOrder: 1,
+        createdAt: Date.now(),
+      }),
+    );
+
+    // Owning group (owned by Bob) and a linked group (Alice is a non-leader member).
+    const ownerId = (await createUser(t, communityId, "Bob")).userId;
+    const { userId: aliceId, accessToken } = await createUser(t, communityId, "Alice");
+
+    const ownerGroupId = await t.run(async (ctx) =>
+      ctx.db.insert("groups", {
+        name: "Owner Group",
+        communityId,
+        groupTypeId,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const linkedGroupId = await t.run(async (ctx) =>
+      ctx.db.insert("groups", {
+        name: "Linked Group",
+        communityId,
+        groupTypeId,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    await t.run(async (ctx) => {
+      await ctx.db.insert("groupMembers", {
+        userId: aliceId,
+        groupId: linkedGroupId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+
+    // Shared custom channel owned by ownerGroup, shared (accepted) with the
+    // linked group but hidden from that group's navigation.
+    const channelId = await t.run(async (ctx) =>
+      ctx.db.insert("chatChannels", {
+        groupId: ownerGroupId,
+        channelType: "custom",
+        name: "Shared Hidden",
+        slug: "shared-hidden",
+        createdById: ownerId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        isEnabled: true,
+        isShared: true,
+        sharedGroups: [
+          {
+            groupId: linkedGroupId,
+            status: "accepted",
+            invitedById: ownerId,
+            invitedAt: Date.now(),
+            hiddenFromNavigation: true,
+          },
+        ],
+        memberCount: 1,
+      }),
+    );
+    // Alice has a membership row on the shared channel.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: aliceId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    });
+    await insertMessage(t, channelId, "picnic in a hidden shared channel");
+
+    const { results } = await t.query(api.functions.messaging.search.searchMessages, {
+      token: accessToken,
+      communityId,
+      query: "picnic",
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
   test("returns nothing for queries below the minimum length", async () => {
     const t = convexTest(schema, modules);
     const communityId = await createCommunity(t, "epsilon");

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -100,6 +100,7 @@ import type * as functions_messaging_polls from "../functions/messaging/polls.js
 import type * as functions_messaging_reachOut from "../functions/messaging/reachOut.js";
 import type * as functions_messaging_reactions from "../functions/messaging/reactions.js";
 import type * as functions_messaging_readState from "../functions/messaging/readState.js";
+import type * as functions_messaging_search from "../functions/messaging/search.js";
 import type * as functions_messaging_sharedChannels from "../functions/messaging/sharedChannels.js";
 import type * as functions_messaging_threadSubscriptions from "../functions/messaging/threadSubscriptions.js";
 import type * as functions_messaging_typing from "../functions/messaging/typing.js";
@@ -319,6 +320,7 @@ declare const fullApi: ApiFromModules<{
   "functions/messaging/reachOut": typeof functions_messaging_reachOut;
   "functions/messaging/reactions": typeof functions_messaging_reactions;
   "functions/messaging/readState": typeof functions_messaging_readState;
+  "functions/messaging/search": typeof functions_messaging_search;
   "functions/messaging/sharedChannels": typeof functions_messaging_sharedChannels;
   "functions/messaging/threadSubscriptions": typeof functions_messaging_threadSubscriptions;
   "functions/messaging/typing": typeof functions_messaging_typing;

--- a/apps/convex/functions/admin/migrations.ts
+++ b/apps/convex/functions/admin/migrations.ts
@@ -6,8 +6,11 @@
 
 import { v } from "convex/values";
 import { mutation, internalMutation } from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
 import { now } from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
+import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 
 // ============================================================================
 // Migration Functions (for Supabase to Convex sync)
@@ -90,5 +93,62 @@ export const migrateAdminGroupMembersToLeader = internalMutation({
     }
 
     return { migrated, total: adminMembers.length };
+  },
+});
+
+// ============================================================================
+// chatMessages.communityId backfill
+// ============================================================================
+
+/**
+ * Backfill `chatMessages.communityId` for legacy rows written before the field
+ * existed. New messages set it at write time (see `resolveChannelCommunityId`),
+ * so this only needs to run once after deploy to make historical messages
+ * searchable under the community-scoped `search_content` index.
+ *
+ * Processes one page at a time and reschedules itself until the table is
+ * exhausted, so a single `npx convex run` invocation backfills everything
+ * without exceeding per-mutation limits. Idempotent: rows that already have a
+ * communityId are skipped, so re-running is safe.
+ */
+export const backfillMessageCommunityId = internalMutation({
+  args: {
+    cursor: v.optional(v.union(v.string(), v.null())),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = args.batchSize ?? 200;
+    const page = await ctx.db
+      .query("chatMessages")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    // Cache channel→community lookups within the batch; many messages share a
+    // channel, so this avoids redundant reads.
+    const communityByChannel = new Map<string, Id<"communities"> | undefined>();
+    let patched = 0;
+    for (const message of page.page) {
+      if (message.communityId) continue;
+      if (!communityByChannel.has(message.channelId)) {
+        communityByChannel.set(
+          message.channelId,
+          await resolveChannelCommunityId(ctx, message.channelId),
+        );
+      }
+      const communityId = communityByChannel.get(message.channelId);
+      if (communityId) {
+        await ctx.db.patch(message._id, { communityId });
+        patched++;
+      }
+    }
+
+    if (!page.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.admin.migrations.backfillMessageCommunityId,
+        { cursor: page.continueCursor, batchSize },
+      );
+    }
+
+    return { patched, scanned: page.page.length, isDone: page.isDone };
   },
 });

--- a/apps/convex/functions/cli/messaging.ts
+++ b/apps/convex/functions/cli/messaging.ts
@@ -12,6 +12,7 @@ import { v } from "convex/values";
 import { mutation } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import { requireAuth } from "../../lib/auth";
+import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { checkRateLimit } from "../../lib/rateLimit";
 import {
   isCustomChannel,
@@ -268,6 +269,7 @@ export const sendMessage = mutation({
 
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: args.channelId,
+      communityId: await resolveChannelCommunityId(ctx, args.channelId),
       senderId: userId,
       content: args.content,
       contentType: "text",

--- a/apps/convex/functions/eventBlasts.ts
+++ b/apps/convex/functions/eventBlasts.ts
@@ -10,6 +10,7 @@ import { query, mutation, internalQuery, internalMutation, internalAction } from
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { requireAuth } from "../lib/auth";
+import { resolveChannelCommunityId } from "../lib/messaging/communityScope";
 import { canEditMeeting } from "../lib/meetingPermissions";
 import { NOTIFIED_RSVP_OPTION_IDS, isAttendingRsvpOption } from "../lib/meetingConfig";
 import { now, getMediaUrl } from "../lib/utils";
@@ -408,6 +409,7 @@ export const recordBlast = internalMutation({
 
     const messageId = await ctx.db.insert("chatMessages", {
       channelId,
+      communityId: await resolveChannelCommunityId(ctx, channelId),
       senderId: args.sentById,
       content: args.message,
       contentType: "text",

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -10,6 +10,7 @@ import type { MutationCtx } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { internal } from "../../_generated/api";
 import { now, generateShortId, getDisplayName, getMediaUrl } from "../../lib/utils";
+import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { requireAuth } from "../../lib/auth";
 import { isActiveLeader, isActiveMembership } from "../../lib/helpers";
 import {
@@ -1104,6 +1105,7 @@ export const postToChat = mutation({
     // Insert the chat message
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: targetChannel._id,
+      communityId: await resolveChannelCommunityId(ctx, targetChannel._id),
       senderId: userId,
       content,
       contentType: "text",

--- a/apps/convex/functions/messaging/availabilityRequests.ts
+++ b/apps/convex/functions/messaging/availabilityRequests.ts
@@ -19,6 +19,7 @@ import type { QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { internal } from "../../_generated/api";
 import { requireAuth } from "../../lib/auth";
+import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { getDisplayName, getMediaUrl, generateShortId } from "../../lib/utils";
 import { checkRateLimit } from "../../lib/rateLimit";
 import { requireGroupScheduler, requireGroupMember } from "../scheduling/permissions";
@@ -133,6 +134,7 @@ export const sendAvailabilityRequest = mutation({
     const content = message || "Availability request";
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: args.channelId,
+      communityId: await resolveChannelCommunityId(ctx, args.channelId),
       senderId: userId,
       content,
       contentType: "availability_request",

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -26,6 +26,7 @@ import {
 import { checkRateLimit } from "../../lib/rateLimit";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { canAccessEventChannel } from "./eventChat";
+import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
 /**
@@ -847,6 +848,7 @@ export const sendMessage = mutation({
 
     const messageId = await ctx.db.insert("chatMessages", {
       channelId,
+      communityId: await resolveChannelCommunityId(ctx, channelId),
       senderId: userId,
       content: args.content,
       contentType,
@@ -1088,6 +1090,7 @@ export const sendSystemMessage = internalMutation({
     // Create system message (no senderId = system message)
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: args.channelId,
+      communityId: await resolveChannelCommunityId(ctx, args.channelId),
       // senderId is optional in schema for system/bot messages
       content: args.content,
       contentType: args.contentType || "system",

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -18,6 +18,7 @@ import type { MutationCtx, QueryCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
+import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import {
   channelEffectiveEnabledForGroup,
   channelIsLeaderEnabled,
@@ -273,6 +274,7 @@ export const createPoll = mutation({
     // never observe an inconsistent state.
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: args.channelId,
+      communityId: await resolveChannelCommunityId(ctx, args.channelId),
       senderId: userId,
       content: trimmedQuestion,
       contentType: "poll",

--- a/apps/convex/functions/messaging/reachOut.ts
+++ b/apps/convex/functions/messaging/reachOut.ts
@@ -11,6 +11,7 @@ import { query, mutation } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
+import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { isLeaderRole, isActiveMembership } from "../../lib/helpers";
 
@@ -141,6 +142,7 @@ export const submitTaskRequest = mutation({
     const preview = content.length > 100 ? content.substring(0, 97) + "..." : content;
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: leadersChannel._id,
+      communityId: await resolveChannelCommunityId(ctx, leadersChannel._id),
       senderId: userId,
       senderName: submitterName,
       senderProfilePhoto: submitter ? getMediaUrl(submitter.profilePhoto) : undefined,
@@ -514,6 +516,7 @@ export const submitRequest = mutation({
     const preview = content.length > 100 ? content.substring(0, 97) + "..." : content;
     const messageId = await ctx.db.insert("chatMessages", {
       channelId: leadersChannel._id,
+      communityId: await resolveChannelCommunityId(ctx, leadersChannel._id),
       senderId: userId,
       senderName: submitterName,
       senderProfilePhoto: submitter ? getMediaUrl(submitter.profilePhoto) : undefined,

--- a/apps/convex/functions/messaging/search.ts
+++ b/apps/convex/functions/messaging/search.ts
@@ -23,6 +23,7 @@ import {
 } from "../../lib/helpers";
 import { getChannelSlug } from "../../lib/slugs";
 import { canAccessEventChannel } from "./eventChat";
+import { requireCommunityMember } from "../scheduling/permissions";
 
 /** Below this length a search is a no-op (avoids matching on single letters). */
 const MIN_QUERY_LENGTH = 2;
@@ -74,7 +75,12 @@ type SearchResult = {
  *    per the user's actual group context via `channelEffectiveEnabledForGroup`
  *    so a channel a linked group hid (`sharedGroups[].hiddenFromNavigation`)
  *    isn't exposed to that group's members.
- *  - Event channels additionally go through `canAccessEventChannel`.
+ *  - Event channels are gated SOLELY by `canAccessEventChannel` (host /
+ *    delegated leader / RSVP), with no membership-row requirement — matching
+ *    getMessages, which routes event channels straight through that check.
+ *    They are resolved in a dedicated pass over the caller's hosted / RSVP'd /
+ *    led-group meetings, and group leadership alone never grants access to an
+ *    explicit-host event channel.
  *
  * The set is bounded by the user's memberships + their leader groups' channels,
  * so this stays cheap regardless of total community size.
@@ -111,13 +117,23 @@ async function resolveAccessibleChannelIds(
 
   const accessible = new Set<string>();
 
+  // Led groups, used both for the leader channel pass below and for resolving
+  // delegated-host event-channel access (leaders of the hosting group can read
+  // an event channel that has no explicit host — see canAccessEventChannel).
+  const leaderGroupIds: Id<"groups">[] = [];
+
   // Leaders see every (non-archived) channel in their group, even without a
   // dedicated membership row. Leadership also bypasses the disabled-channel
-  // gate, so these are added unconditionally.
+  // gate, so these are added unconditionally — EXCEPT event channels, which
+  // always gate on meeting-based access (host / delegated leader / RSVP) via
+  // canAccessEventChannel, exactly as getMessages does. Leadership of the
+  // hosting group alone does not grant read access to an explicit-host event,
+  // so event channels are deferred to the canAccessEventChannel pass below.
   for (const [groupId, role] of groupRoleMap) {
     if (!isLeaderRole(role)) continue;
     const group = await getGroup(groupId as Id<"groups">);
     if (!group || group.isArchived || group.communityId !== communityId) continue;
+    leaderGroupIds.push(groupId as Id<"groups">);
     const channels = await ctx.db
       .query("chatChannels")
       .withIndex("by_group", (q) => q.eq("groupId", groupId as Id<"groups">))
@@ -125,6 +141,7 @@ async function resolveAccessibleChannelIds(
       .collect();
     for (const channel of channels) {
       channelCache.set(channel._id, channel);
+      if (channel.channelType === "event") continue;
       accessible.add(channel._id);
     }
   }
@@ -201,6 +218,70 @@ async function resolveAccessibleChannelIds(
     accessible.add(channel._id);
   }
 
+  // Event channels are readable purely via meeting-based access — host,
+  // delegated leader, or RSVP — with NO chatChannelMembers row required (see
+  // getMessages, which routes event channels straight through
+  // canAccessEventChannel). A "Can't Go" RSVPer or a host who never opened the
+  // chat can read it in-app, so search must surface it too. Gather the
+  // meetings the caller could host/attend, resolve their event channels, and
+  // gate each one through canAccessEventChannel exactly like getMessages —
+  // never broader.
+  const candidateMeetingIds = new Set<string>();
+
+  // Meetings the caller created (host access).
+  const createdMeetings = await ctx.db
+    .query("meetings")
+    .withIndex("by_createdBy", (q) => q.eq("createdById", userId))
+    .collect();
+  for (const meeting of createdMeetings) {
+    candidateMeetingIds.add(meeting._id);
+  }
+
+  // Meetings the caller RSVP'd to (RSVP access).
+  const rsvps = await ctx.db
+    .query("meetingRsvps")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+  for (const rsvp of rsvps) {
+    candidateMeetingIds.add(rsvp.meetingId);
+  }
+
+  // Meetings in groups the caller leads (delegated-host access for events with
+  // no explicit host — canAccessEventChannel makes the final call).
+  for (const groupId of leaderGroupIds) {
+    const groupMeetings = await ctx.db
+      .query("meetings")
+      .withIndex("by_group", (q) => q.eq("groupId", groupId))
+      .collect();
+    for (const meeting of groupMeetings) {
+      candidateMeetingIds.add(meeting._id);
+    }
+  }
+
+  for (const meetingId of candidateMeetingIds) {
+    const channel = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_meetingId", (q) =>
+        q.eq("meetingId", meetingId as Id<"meetings">),
+      )
+      .first();
+    if (!channel || channel.isArchived) continue;
+    if (accessible.has(channel._id)) continue;
+
+    // Community scoping: event channels inherit their hosting group's community.
+    if (channel.groupId) {
+      const group = await getGroup(channel.groupId);
+      if (!group || group.isArchived || group.communityId !== communityId) continue;
+    } else if (channel.communityId !== communityId) {
+      continue;
+    }
+
+    if (!(await canAccessEventChannel(ctx, userId, channel))) continue;
+
+    channelCache.set(channel._id, channel);
+    accessible.add(channel._id);
+  }
+
   return accessible;
 }
 
@@ -212,6 +293,14 @@ export const searchMessages = query({
   },
   handler: async (ctx, args): Promise<{ results: SearchResult[]; truncated: boolean }> => {
     const userId = await requireAuth(ctx, args.token);
+
+    // Defense-in-depth: fail fast if the caller isn't a member of the
+    // community they're searching. The per-channel re-scoping below already
+    // prevents cross-tenant leaks (every accessible channel is gated to
+    // args.communityId), so this changes nothing for legitimate callers — it
+    // just makes the tenant boundary self-evident and rejects a foreign
+    // communityId outright instead of silently returning an empty list.
+    await requireCommunityMember(ctx, args.communityId, userId);
 
     const term = args.query.trim();
     if (term.length < MIN_QUERY_LENGTH) {

--- a/apps/convex/functions/messaging/search.ts
+++ b/apps/convex/functions/messaging/search.ts
@@ -1,0 +1,273 @@
+/**
+ * Inbox message search.
+ *
+ * Full-text search over chat message bodies for the app inbox. Results are
+ * scoped to the caller's active community and restricted to channels the caller
+ * can actually read (the same read boundary `getMessages` enforces). Convex
+ * search-index filters can only match a single field value, so they can't OR
+ * across the user's channel set — community/permission scoping is therefore
+ * applied in the handler after pulling the top matches from the index.
+ */
+
+import { v } from "convex/values";
+import { query } from "../../_generated/server";
+import type { QueryCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import {
+  isCustomChannel,
+  channelIsLeaderEnabled,
+  isLeaderRole,
+} from "../../lib/helpers";
+import { canAccessEventChannel } from "./eventChat";
+
+/** Below this length a search is a no-op (avoids matching on single letters). */
+const MIN_QUERY_LENGTH = 2;
+/**
+ * Raw matches pulled from the search index before permission filtering. The
+ * index returns globally relevance-ranked rows; we over-fetch so a reasonable
+ * number survive the per-channel access filter below.
+ */
+const SEARCH_FETCH_LIMIT = 100;
+/** Maximum results returned to the client after filtering. */
+const SEARCH_RESULT_LIMIT = 40;
+
+/**
+ * Content types that aren't user-authored prose. System notices have body text
+ * (e.g. "X joined the group") that would otherwise pollute search results.
+ */
+const NON_SEARCHABLE_CONTENT_TYPES = new Set(["system"]);
+
+type SearchResult = {
+  messageId: Id<"chatMessages">;
+  channelId: Id<"chatChannels">;
+  channelName: string;
+  channelType: string;
+  /** Channel slug — used to build the `/inbox/{groupId}/{slug}` deep link. */
+  channelSlug: string | null;
+  isAdHoc: boolean;
+  groupId: Id<"groups"> | null;
+  groupName: string | null;
+  /** For event channels: the owning meeting's shortId for `/e/{shortId}`. */
+  meetingShortId: string | null;
+  content: string;
+  senderId: Id<"users"> | null;
+  senderName: string | null;
+  createdAt: number;
+};
+
+/**
+ * Resolve the set of channel IDs the caller can read within `communityId`.
+ *
+ * Mirrors the read boundary in `getMessages`:
+ *  - Leaders of a group can read all of that group's channels.
+ *  - Anyone with an active channel-membership row can read that channel
+ *    (covers DMs, group_dm, event, custom, and shared channels).
+ *  - Disabled leader-only channels (custom / pco_services / announcements)
+ *    stay hidden from non-leader members.
+ *  - Event channels additionally go through `canAccessEventChannel`.
+ *
+ * The set is bounded by the user's memberships + their leader groups' channels,
+ * so this stays cheap regardless of total community size.
+ */
+async function resolveAccessibleChannelIds(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+  communityId: Id<"communities">,
+  channelCache: Map<string, Doc<"chatChannels"> | null>,
+  groupCache: Map<string, Doc<"groups"> | null>,
+): Promise<Set<string>> {
+  const getGroup = async (id: Id<"groups">) => {
+    if (!groupCache.has(id)) groupCache.set(id, await ctx.db.get(id));
+    return groupCache.get(id) ?? null;
+  };
+
+  // Active group memberships → which groups the user leads.
+  const groupMemberships = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .filter((q) =>
+      q.and(
+        q.eq(q.field("leftAt"), undefined),
+        q.or(
+          q.eq(q.field("requestStatus"), undefined),
+          q.eq(q.field("requestStatus"), "accepted"),
+        ),
+      ),
+    )
+    .collect();
+  const leaderGroupIds = new Set<string>(
+    groupMemberships
+      .filter((gm) => isLeaderRole(gm.role))
+      .map((gm) => gm.groupId),
+  );
+
+  const accessible = new Set<string>();
+
+  // Leaders see every (non-archived) channel in their group, even without a
+  // dedicated membership row.
+  for (const groupId of leaderGroupIds) {
+    const group = await getGroup(groupId as Id<"groups">);
+    if (!group || group.isArchived || group.communityId !== communityId) continue;
+    const channels = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_group", (q) => q.eq("groupId", groupId as Id<"groups">))
+      .filter((q) => q.eq(q.field("isArchived"), false))
+      .collect();
+    for (const channel of channels) {
+      channelCache.set(channel._id, channel);
+      accessible.add(channel._id);
+    }
+  }
+
+  // Channel-membership rows (DMs, group_dm, event, custom, shared, and group
+  // channels the user explicitly belongs to).
+  const memberships = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .collect();
+
+  for (const membership of memberships) {
+    if (accessible.has(membership.channelId)) continue;
+    if (membership.requestState === "declined") continue;
+
+    if (!channelCache.has(membership.channelId)) {
+      channelCache.set(membership.channelId, await ctx.db.get(membership.channelId));
+    }
+    const channel = channelCache.get(membership.channelId);
+    if (!channel || channel.isArchived) continue;
+
+    // Community scoping: group channels inherit the group's community; ad-hoc
+    // (dm/group_dm) channels carry communityId directly.
+    if (channel.groupId) {
+      const group = await getGroup(channel.groupId);
+      if (!group || group.isArchived || group.communityId !== communityId) continue;
+    } else if (channel.communityId !== communityId) {
+      continue;
+    }
+
+    if (channel.channelType === "event") {
+      if (!(await canAccessEventChannel(ctx, userId, channel))) continue;
+      accessible.add(channel._id);
+      continue;
+    }
+
+    // Disabled leader-only channels are invisible to non-leader members.
+    if (
+      isCustomChannel(channel.channelType) ||
+      channel.channelType === "pco_services" ||
+      channel.channelType === "announcements"
+    ) {
+      const isLeaderHere = channel.groupId
+        ? leaderGroupIds.has(channel.groupId)
+        : false;
+      if (!channelIsLeaderEnabled(channel) && !isLeaderHere) continue;
+    }
+
+    accessible.add(channel._id);
+  }
+
+  return accessible;
+}
+
+export const searchMessages = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    query: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ results: SearchResult[]; truncated: boolean }> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const term = args.query.trim();
+    if (term.length < MIN_QUERY_LENGTH) {
+      return { results: [], truncated: false };
+    }
+
+    const channelCache = new Map<string, Doc<"chatChannels"> | null>();
+    const groupCache = new Map<string, Doc<"groups"> | null>();
+
+    const accessibleChannelIds = await resolveAccessibleChannelIds(
+      ctx,
+      userId,
+      args.communityId,
+      channelCache,
+      groupCache,
+    );
+    if (accessibleChannelIds.size === 0) {
+      return { results: [], truncated: false };
+    }
+
+    // Filter out messages from users the caller has blocked (parity with
+    // getMessages).
+    const blocks = await ctx.db
+      .query("chatUserBlocks")
+      .withIndex("by_blocker", (q) => q.eq("blockerId", userId))
+      .collect();
+    const blockedUserIds = new Set(blocks.map((b) => b.blockedId));
+
+    const matches = await ctx.db
+      .query("chatMessages")
+      .withSearchIndex("search_content", (q) =>
+        q.search("content", term).eq("isDeleted", false),
+      )
+      .take(SEARCH_FETCH_LIMIT);
+
+    const meetingShortIdCache = new Map<string, string | null>();
+    const getMeetingShortId = async (
+      meetingId: Id<"meetings">,
+    ): Promise<string | null> => {
+      if (!meetingShortIdCache.has(meetingId)) {
+        const meeting = await ctx.db.get(meetingId);
+        meetingShortIdCache.set(meetingId, meeting?.shortId ?? null);
+      }
+      return meetingShortIdCache.get(meetingId) ?? null;
+    };
+
+    const results: SearchResult[] = [];
+    for (const message of matches) {
+      if (results.length >= SEARCH_RESULT_LIMIT) break;
+      if (!accessibleChannelIds.has(message.channelId)) continue;
+      if (NON_SEARCHABLE_CONTENT_TYPES.has(message.contentType)) continue;
+      if (message.senderId && blockedUserIds.has(message.senderId)) continue;
+
+      const channel = channelCache.get(message.channelId);
+      if (!channel) continue;
+
+      let groupName: string | null = null;
+      if (channel.groupId) {
+        const group = groupCache.get(channel.groupId);
+        groupName = group?.name ?? null;
+      }
+
+      const meetingShortId =
+        channel.channelType === "event" && channel.meetingId
+          ? await getMeetingShortId(channel.meetingId)
+          : null;
+
+      results.push({
+        messageId: message._id,
+        channelId: message.channelId,
+        channelName: channel.name,
+        channelType: channel.channelType,
+        channelSlug: channel.slug ?? null,
+        isAdHoc: channel.isAdHoc ?? false,
+        groupId: channel.groupId ?? null,
+        groupName,
+        meetingShortId,
+        content: message.content,
+        senderId: message.senderId ?? null,
+        senderName: message.senderName ?? null,
+        createdAt: message.createdAt,
+      });
+    }
+
+    return {
+      results,
+      // True when the index returned the full fetch budget — there may be more
+      // matches beyond what we ranked and filtered.
+      truncated: matches.length >= SEARCH_FETCH_LIMIT,
+    };
+  },
+});

--- a/apps/convex/functions/messaging/search.ts
+++ b/apps/convex/functions/messaging/search.ts
@@ -6,7 +6,7 @@
  * can actually read (the same read boundary `getMessages` enforces). Convex
  * search-index filters can only match a single field value, so they can't OR
  * across the user's channel set — community/permission scoping is therefore
- * applied in the handler after pulling the top matches from the index.
+ * applied in the handler after pulling matches from the index.
  */
 
 import { v } from "convex/values";
@@ -17,20 +17,27 @@ import { requireAuth } from "../../lib/auth";
 import {
   isCustomChannel,
   channelIsLeaderEnabled,
+  channelEffectiveEnabledForGroup,
   isLeaderRole,
 } from "../../lib/helpers";
+import { getChannelSlug } from "../../lib/slugs";
 import { canAccessEventChannel } from "./eventChat";
 
 /** Below this length a search is a no-op (avoids matching on single letters). */
 const MIN_QUERY_LENGTH = 2;
-/**
- * Raw matches pulled from the search index before permission filtering. The
- * index returns globally relevance-ranked rows; we over-fetch so a reasonable
- * number survive the per-channel access filter below.
- */
-const SEARCH_FETCH_LIMIT = 100;
 /** Maximum results returned to the client after filtering. */
 const SEARCH_RESULT_LIMIT = 40;
+/** Page size when scanning the relevance-ranked search index. */
+const SEARCH_PAGE_SIZE = 100;
+/**
+ * Hard cap on how many index rows we scan before giving up. The index returns
+ * globally relevance-ranked rows and we filter to the caller's accessible
+ * channels afterwards, so in a multi-community dataset the top rows may all be
+ * inaccessible. We keep paging past those (rather than `.take(100)` once) until
+ * we fill the result limit, exhaust the index, or hit this scan cap — bounding
+ * cost while avoiding empty results when accessible matches exist deeper down.
+ */
+const MAX_SCAN_DOCS = 600;
 
 /**
  * Content types that aren't user-authored prose. System notices have body text
@@ -43,8 +50,8 @@ type SearchResult = {
   channelId: Id<"chatChannels">;
   channelName: string;
   channelType: string;
-  /** Channel slug — used to build the `/inbox/{groupId}/{slug}` deep link. */
-  channelSlug: string | null;
+  /** Channel slug (with back-compat fallback) for the `/inbox/{groupId}/{slug}` link. */
+  channelSlug: string;
   isAdHoc: boolean;
   groupId: Id<"groups"> | null;
   groupName: string | null;
@@ -63,8 +70,11 @@ type SearchResult = {
  *  - Leaders of a group can read all of that group's channels.
  *  - Anyone with an active channel-membership row can read that channel
  *    (covers DMs, group_dm, event, custom, and shared channels).
- *  - Disabled leader-only channels (custom / pco_services / announcements)
- *    stay hidden from non-leader members.
+ *  - Disabled / per-group-hidden leader-only channels (custom / pco_services /
+ *    announcements) stay hidden from non-leader members. Visibility is checked
+ *    per the user's actual group context via `channelEffectiveEnabledForGroup`
+ *    so a channel a linked group hid (`sharedGroups[].hiddenFromNavigation`)
+ *    isn't exposed to that group's members.
  *  - Event channels additionally go through `canAccessEventChannel`.
  *
  * The set is bounded by the user's memberships + their leader groups' channels,
@@ -82,7 +92,7 @@ async function resolveAccessibleChannelIds(
     return groupCache.get(id) ?? null;
   };
 
-  // Active group memberships → which groups the user leads.
+  // Active group memberships → the user's role in each group.
   const groupMemberships = await ctx.db
     .query("groupMembers")
     .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -96,17 +106,17 @@ async function resolveAccessibleChannelIds(
       ),
     )
     .collect();
-  const leaderGroupIds = new Set<string>(
-    groupMemberships
-      .filter((gm) => isLeaderRole(gm.role))
-      .map((gm) => gm.groupId),
+  const groupRoleMap = new Map<string, string>(
+    groupMemberships.map((gm) => [gm.groupId, gm.role]),
   );
 
   const accessible = new Set<string>();
 
   // Leaders see every (non-archived) channel in their group, even without a
-  // dedicated membership row.
-  for (const groupId of leaderGroupIds) {
+  // dedicated membership row. Leadership also bypasses the disabled-channel
+  // gate, so these are added unconditionally.
+  for (const [groupId, role] of groupRoleMap) {
+    if (!isLeaderRole(role)) continue;
     const group = await getGroup(groupId as Id<"groups">);
     if (!group || group.isArchived || group.communityId !== communityId) continue;
     const channels = await ctx.db
@@ -153,16 +163,40 @@ async function resolveAccessibleChannelIds(
       continue;
     }
 
-    // Disabled leader-only channels are invisible to non-leader members.
+    // Disabled / per-group-hidden leader-only channels are invisible to
+    // non-leader members. Check visibility against each group context the user
+    // actually has for this channel (owning group + any accepted shared group
+    // they belong to), matching the inbox/routing visibility rules.
     if (
       isCustomChannel(channel.channelType) ||
       channel.channelType === "pco_services" ||
       channel.channelType === "announcements"
     ) {
-      const isLeaderHere = channel.groupId
-        ? leaderGroupIds.has(channel.groupId)
-        : false;
-      if (!channelIsLeaderEnabled(channel) && !isLeaderHere) continue;
+      const contextGroupIds: Id<"groups">[] = [];
+      if (channel.groupId && groupRoleMap.has(channel.groupId)) {
+        contextGroupIds.push(channel.groupId);
+      }
+      if (channel.isShared && channel.sharedGroups) {
+        for (const sg of channel.sharedGroups) {
+          if (sg.status === "accepted" && groupRoleMap.has(sg.groupId)) {
+            contextGroupIds.push(sg.groupId);
+          }
+        }
+      }
+
+      let visible: boolean;
+      if (contextGroupIds.length === 0) {
+        // Member of a channel without a tied group context (unusual); fall back
+        // to the channel's global enabled flag.
+        visible = channelIsLeaderEnabled(channel);
+      } else {
+        visible = contextGroupIds.some(
+          (gid) =>
+            channelEffectiveEnabledForGroup(channel, gid) ||
+            isLeaderRole(groupRoleMap.get(gid)),
+        );
+      }
+      if (!visible) continue;
     }
 
     accessible.add(channel._id);
@@ -207,13 +241,6 @@ export const searchMessages = query({
       .collect();
     const blockedUserIds = new Set(blocks.map((b) => b.blockedId));
 
-    const matches = await ctx.db
-      .query("chatMessages")
-      .withSearchIndex("search_content", (q) =>
-        q.search("content", term).eq("isDeleted", false),
-      )
-      .take(SEARCH_FETCH_LIMIT);
-
     const meetingShortIdCache = new Map<string, string | null>();
     const getMeetingShortId = async (
       meetingId: Id<"meetings">,
@@ -226,48 +253,68 @@ export const searchMessages = query({
     };
 
     const results: SearchResult[] = [];
-    for (const message of matches) {
-      if (results.length >= SEARCH_RESULT_LIMIT) break;
-      if (!accessibleChannelIds.has(message.channelId)) continue;
-      if (NON_SEARCHABLE_CONTENT_TYPES.has(message.contentType)) continue;
-      if (message.senderId && blockedUserIds.has(message.senderId)) continue;
+    let scanned = 0;
+    let cursor: string | null = null;
+    let isDone = false;
 
-      const channel = channelCache.get(message.channelId);
-      if (!channel) continue;
+    // Page through relevance-ranked matches, skipping ones in channels the
+    // caller can't read, until we fill the result limit, exhaust the index, or
+    // hit the scan cap.
+    while (results.length < SEARCH_RESULT_LIMIT && scanned < MAX_SCAN_DOCS && !isDone) {
+      const page = await ctx.db
+        .query("chatMessages")
+        .withSearchIndex("search_content", (q) =>
+          q.search("content", term).eq("isDeleted", false),
+        )
+        .paginate({ cursor, numItems: SEARCH_PAGE_SIZE });
 
-      let groupName: string | null = null;
-      if (channel.groupId) {
-        const group = groupCache.get(channel.groupId);
-        groupName = group?.name ?? null;
+      scanned += page.page.length;
+      cursor = page.continueCursor;
+      isDone = page.isDone;
+
+      for (const message of page.page) {
+        if (results.length >= SEARCH_RESULT_LIMIT) break;
+        if (!accessibleChannelIds.has(message.channelId)) continue;
+        if (NON_SEARCHABLE_CONTENT_TYPES.has(message.contentType)) continue;
+        if (message.senderId && blockedUserIds.has(message.senderId)) continue;
+
+        const channel = channelCache.get(message.channelId);
+        if (!channel) continue;
+
+        let groupName: string | null = null;
+        if (channel.groupId) {
+          const group = groupCache.get(channel.groupId);
+          groupName = group?.name ?? null;
+        }
+
+        const meetingShortId =
+          channel.channelType === "event" && channel.meetingId
+            ? await getMeetingShortId(channel.meetingId)
+            : null;
+
+        results.push({
+          messageId: message._id,
+          channelId: message.channelId,
+          channelName: channel.name,
+          channelType: channel.channelType,
+          channelSlug: getChannelSlug(channel),
+          isAdHoc: channel.isAdHoc ?? false,
+          groupId: channel.groupId ?? null,
+          groupName,
+          meetingShortId,
+          content: message.content,
+          senderId: message.senderId ?? null,
+          senderName: message.senderName ?? null,
+          createdAt: message.createdAt,
+        });
       }
-
-      const meetingShortId =
-        channel.channelType === "event" && channel.meetingId
-          ? await getMeetingShortId(channel.meetingId)
-          : null;
-
-      results.push({
-        messageId: message._id,
-        channelId: message.channelId,
-        channelName: channel.name,
-        channelType: channel.channelType,
-        channelSlug: channel.slug ?? null,
-        isAdHoc: channel.isAdHoc ?? false,
-        groupId: channel.groupId ?? null,
-        groupName,
-        meetingShortId,
-        content: message.content,
-        senderId: message.senderId ?? null,
-        senderName: message.senderName ?? null,
-        createdAt: message.createdAt,
-      });
     }
 
     return {
       results,
-      // True when the index returned the full fetch budget — there may be more
-      // matches beyond what we ranked and filtered.
-      truncated: matches.length >= SEARCH_FETCH_LIMIT,
+      // True when matches may exist beyond what we surfaced — we stopped at the
+      // result limit or the scan cap before exhausting the index.
+      truncated: !isDone,
     };
   },
 });

--- a/apps/convex/functions/messaging/search.ts
+++ b/apps/convex/functions/messaging/search.ts
@@ -1,12 +1,13 @@
 /**
  * Inbox message search.
  *
- * Full-text search over chat message bodies for the app inbox. Results are
- * scoped to the caller's active community and restricted to channels the caller
- * can actually read (the same read boundary `getMessages` enforces). Convex
- * search-index filters can only match a single field value, so they can't OR
- * across the user's channel set — community/permission scoping is therefore
- * applied in the handler after pulling matches from the index.
+ * Full-text search over chat message bodies for the app inbox. The search index
+ * is filtered to the caller's active community via the denormalized
+ * `chatMessages.communityId` (so other tenants' messages are never scanned).
+ * Results are then restricted to the channels the caller can actually read (the
+ * same read boundary `getMessages` enforces) — Convex search filters can't OR
+ * across the user's channel set, so that per-channel scoping is applied in the
+ * handler after pulling community-scoped matches from the index.
  */
 
 import { v } from "convex/values";
@@ -30,12 +31,10 @@ const SEARCH_RESULT_LIMIT = 40;
 /** Page size when scanning the relevance-ranked search index. */
 const SEARCH_PAGE_SIZE = 100;
 /**
- * Hard cap on how many index rows we scan before giving up. The index returns
- * globally relevance-ranked rows and we filter to the caller's accessible
- * channels afterwards, so in a multi-community dataset the top rows may all be
- * inaccessible. We keep paging past those (rather than `.take(100)` once) until
- * we fill the result limit, exhaust the index, or hit this scan cap — bounding
- * cost while avoiding empty results when accessible matches exist deeper down.
+ * Hard cap on how many index rows we scan before giving up. The search index is
+ * filtered to the caller's community, so scanned rows are already same-tenant;
+ * we still page past channels the caller can't read (leaders-only channels, etc.)
+ * until we fill the result limit, exhaust the matches, or hit this scan cap.
  */
 const MAX_SCAN_DOCS = 600;
 
@@ -264,7 +263,10 @@ export const searchMessages = query({
       const page = await ctx.db
         .query("chatMessages")
         .withSearchIndex("search_content", (q) =>
-          q.search("content", term).eq("isDeleted", false),
+          q
+            .search("content", term)
+            .eq("communityId", args.communityId)
+            .eq("isDeleted", false),
         )
         .paginate({ cursor, numItems: SEARCH_PAGE_SIZE });
 

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -25,6 +25,7 @@ import {
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { notifyBatch } from "../lib/notifications/send";
+import { resolveChannelCommunityId } from "../lib/messaging/communityScope";
 import { now, getMediaUrlWithTransform, ImagePresets } from "../lib/utils";
 import {
   calculateCommunicationBotNextSchedule,
@@ -1768,6 +1769,7 @@ export const insertBotMessage = internalMutation({
     // Insert bot message (no senderId - it's a system/bot message)
     const messageId = await ctx.db.insert("chatMessages", {
       channelId,
+      communityId: await resolveChannelCommunityId(ctx, channelId),
       // senderId is undefined for bot messages
       content,
       contentType: contentType || "bot",

--- a/apps/convex/lib/messaging/communityScope.ts
+++ b/apps/convex/lib/messaging/communityScope.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolve the community a chat message belongs to.
+ *
+ * `chatMessages.communityId` is denormalized at write time so inbox search can
+ * filter by community directly in the search index (instead of pulling globally
+ * relevance-ranked rows and discarding cross-community hits afterwards). A
+ * message's community is the community of its channel:
+ *   - ad-hoc channels (dm/group_dm) carry `communityId` directly;
+ *   - group channels inherit it from their owning group.
+ */
+
+import type { QueryCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+
+export async function resolveChannelCommunityId(
+  ctx: QueryCtx,
+  channelId: Id<"chatChannels">,
+): Promise<Id<"communities"> | undefined> {
+  const channel = await ctx.db.get(channelId);
+  if (!channel) return undefined;
+  if (channel.communityId) return channel.communityId;
+  if (channel.groupId) {
+    const group = await ctx.db.get(channel.groupId);
+    return group?.communityId ?? undefined;
+  }
+  return undefined;
+}

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1733,6 +1733,14 @@ export default defineSchema({
    */
   chatMessages: defineTable({
     channelId: v.id("chatChannels"),
+    /**
+     * Denormalized community the message belongs to (derived from the channel's
+     * group, or the channel's own communityId for ad-hoc dm/group_dm channels).
+     * Set at write time and backfilled for existing rows; used as a search-index
+     * filter field so inbox search scopes to a community without scanning other
+     * tenants' messages. Optional only for legacy rows pending backfill.
+     */
+    communityId: v.optional(v.id("communities")),
     senderId: v.optional(v.id("users")), // Optional for bot/system messages
     content: v.string(), // Message text
     contentType: v.string(), // "text" | "image" | "file" | "system" | "bot" | "reach_out_request" | "task_card" | "bug_card" | "poll" | "availability_request"
@@ -1794,14 +1802,15 @@ export default defineSchema({
     .index("by_parentMessage", ["parentMessageId"])
     .index("by_createdAt", ["createdAt"])
     .index("by_sourceKey", ["sourceKey"])
-    // Full-text search over message body for inbox search. `isDeleted` is a
-    // filter field so soft-deleted messages don't consume the result budget.
-    // Permission/community scoping is enforced in the query handler against the
-    // user's accessible channels — Convex search filters can't OR across the
-    // user's channel set.
+    // Full-text search over message body for inbox search. `communityId`
+    // scopes the search to a single tenant in the index (so other communities'
+    // messages aren't scanned), and `isDeleted` keeps soft-deleted messages out
+    // of the result budget. Per-channel permission scoping is still enforced in
+    // the query handler against the user's accessible channels — Convex search
+    // filters can't OR across the user's channel set.
     .searchIndex("search_content", {
       searchField: "content",
-      filterFields: ["isDeleted"],
+      filterFields: ["communityId", "isDeleted"],
     }),
 
   /**

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1793,7 +1793,16 @@ export default defineSchema({
     .index("by_sender", ["senderId"])
     .index("by_parentMessage", ["parentMessageId"])
     .index("by_createdAt", ["createdAt"])
-    .index("by_sourceKey", ["sourceKey"]),
+    .index("by_sourceKey", ["sourceKey"])
+    // Full-text search over message body for inbox search. `isDeleted` is a
+    // filter field so soft-deleted messages don't consume the result budget.
+    // Permission/community scoping is enforced in the query handler against the
+    // user's accessible channels — Convex search filters can't OR across the
+    // user's channel set.
+    .searchIndex("search_content", {
+      searchField: "content",
+      filterFields: ["isDeleted"],
+    }),
 
   /**
    * Polls

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -27,7 +27,8 @@ import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@providers/AuthProvider";
 import { useQuery, api, useStoredAuthToken } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
-import { AppImage } from "@components/ui";
+import { AppImage, SearchBar } from "@components/ui";
+import { InboxSearchResults } from "./InboxSearchResults";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { GroupedInboxItem } from "./GroupedInboxItem";
@@ -42,6 +43,10 @@ import { EnableNotificationsBanner } from "@features/notifications/components/En
 // `INBOX_EVENT_HIDE_AFTER_MS` in apps/convex/functions/messaging/channels.ts
 // (channels without a first message or quiet for >2 days are omitted from
 // the payload), so the client no longer duplicates that constant.
+
+// Minimum query length before the inbox search query runs. Mirrors the
+// MIN_QUERY_LENGTH guard in the backend `searchMessages` query.
+const MIN_SEARCH_LENGTH = 2;
 
 // Type for a channel as returned by getInboxChannels
 type InboxChannel = {
@@ -173,6 +178,20 @@ export function ChatInboxScreen({
   const notificationSummary = useQuery(
     api.functions.notifications.queries.inboxSummary,
     token ? { token } : "skip",
+  );
+
+  // Inbox message search. SearchBar debounces input, so `searchTerm` only
+  // updates after the user pauses typing — keeping the reactive query from
+  // firing on every keystroke. A search is only run once the term is long
+  // enough to be meaningful (see MIN_SEARCH_LENGTH).
+  const [searchTerm, setSearchTerm] = useState("");
+  const trimmedSearch = searchTerm.trim();
+  const isSearching = trimmedSearch.length >= MIN_SEARCH_LENGTH;
+  const searchResults = useQuery(
+    api.functions.messaging.search.searchMessages,
+    isSearching && token && communityId
+      ? { token, communityId, query: trimmedSearch }
+      : "skip",
   );
 
   // Cache inbox data for offline use
@@ -594,14 +613,30 @@ export function ChatInboxScreen({
     <Wrapper>
       <View style={[styles.container, { backgroundColor: colors.surface }]}>
         {renderHeader(true)}
-        <EnableNotificationsBanner />
-        <FlatList
-          data={listItemsWithDm}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          contentContainerStyle={styles.listContainer}
-          style={styles.list}
-        />
+        <View style={styles.searchBarContainer}>
+          <SearchBar
+            placeholder="Search messages"
+            onSearch={setSearchTerm}
+            onClear={() => setSearchTerm("")}
+          />
+        </View>
+        {isSearching ? (
+          <InboxSearchResults
+            query={trimmedSearch}
+            results={searchResults?.results}
+          />
+        ) : (
+          <>
+            <EnableNotificationsBanner />
+            <FlatList
+              data={listItemsWithDm}
+              renderItem={renderItem}
+              keyExtractor={keyExtractor}
+              contentContainerStyle={styles.listContainer}
+              style={styles.list}
+            />
+          </>
+        )}
       </View>
     </Wrapper>
   );
@@ -1387,6 +1422,10 @@ const styles = StyleSheet.create({
   },
   listContainer: {
     paddingVertical: 8,
+  },
+  searchBarContainer: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
   },
 
   // Events section

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -624,6 +624,7 @@ export function ChatInboxScreen({
           <InboxSearchResults
             query={trimmedSearch}
             results={searchResults?.results}
+            truncated={searchResults?.truncated}
           />
         ) : (
           <>

--- a/apps/mobile/features/chat/components/InboxSearchResults.tsx
+++ b/apps/mobile/features/chat/components/InboxSearchResults.tsx
@@ -42,6 +42,28 @@ interface InboxSearchResultsProps {
   query: string;
   /** Results from the query; `undefined` while the query is in flight. */
   results: MessageSearchResult[] | undefined;
+  /**
+   * True when the backend stopped before exhausting the index (hit the result
+   * or scan cap). We surface a hint so users on large communities know more
+   * matches may exist beyond what's shown.
+   */
+  truncated?: boolean;
+}
+
+/**
+ * Display label for a result row's header. DMs/group DMs often have an empty
+ * `channelName` (DM titles are computed client-side from members), so fall back
+ * to the sender's name or a generic label rather than rendering a blank header.
+ */
+function resultHeaderLabel(result: MessageSearchResult): string {
+  if (result.groupName) {
+    return `${result.groupName} · ${result.channelName}`;
+  }
+  if (result.channelName) return result.channelName;
+  if (result.isAdHoc || !result.groupId) {
+    return result.senderName ?? "Direct message";
+  }
+  return "Direct message";
 }
 
 /** Compact relative time for a search-result row ("3h", "2d", "Apr 8"). */
@@ -60,7 +82,11 @@ function formatResultTime(timestamp: number, now: number): string {
   });
 }
 
-export function InboxSearchResults({ query, results }: InboxSearchResultsProps) {
+export function InboxSearchResults({
+  query,
+  results,
+  truncated,
+}: InboxSearchResultsProps) {
   const router = useRouter();
   const { colors } = useTheme();
 
@@ -71,11 +97,13 @@ export function InboxSearchResults({ query, results }: InboxSearchResultsProps) 
         router.push(`/e/${result.meetingShortId}?source=app` as any);
         return;
       }
-      // Ad-hoc DMs / group DMs have no owning group.
+      // Ad-hoc DMs / group DMs have no owning group. `channelName` is often
+      // empty for DMs (the title is computed client-side from members), so pass
+      // a sensible header label rather than a blank one.
       if (result.isAdHoc || !result.groupId) {
         router.push({
           pathname: `/inbox/dm/${result.channelId}` as any,
-          params: { groupName: result.channelName },
+          params: { groupName: resultHeaderLabel(result) },
         });
         return;
       }
@@ -124,10 +152,15 @@ export function InboxSearchResults({ query, results }: InboxSearchResultsProps) 
       keyExtractor={(item) => item.messageId}
       keyboardShouldPersistTaps="handled"
       contentContainerStyle={styles.listContent}
+      ListFooterComponent={
+        truncated ? (
+          <Text style={[styles.truncatedFooter, { color: colors.textSecondary }]}>
+            Showing top matches — refine your search to narrow results.
+          </Text>
+        ) : null
+      }
       renderItem={({ item }) => {
-        const location = item.groupName
-          ? `${item.groupName} · ${item.channelName}`
-          : item.channelName || "Direct message";
+        const location = resultHeaderLabel(item);
         const senderPrefix = item.senderName ? `${item.senderName}: ` : "";
         return (
           <Pressable
@@ -199,5 +232,11 @@ const styles = StyleSheet.create({
   snippet: {
     fontSize: 15,
     lineHeight: 20,
+  },
+  truncatedFooter: {
+    fontSize: 13,
+    textAlign: "center",
+    paddingVertical: 16,
+    paddingHorizontal: 24,
   },
 });

--- a/apps/mobile/features/chat/components/InboxSearchResults.tsx
+++ b/apps/mobile/features/chat/components/InboxSearchResults.tsx
@@ -26,7 +26,7 @@ export type MessageSearchResult = {
   channelId: Id<"chatChannels">;
   channelName: string;
   channelType: string;
-  channelSlug: string | null;
+  channelSlug: string;
   isAdHoc: boolean;
   groupId: Id<"groups"> | null;
   groupName: string | null;

--- a/apps/mobile/features/chat/components/InboxSearchResults.tsx
+++ b/apps/mobile/features/chat/components/InboxSearchResults.tsx
@@ -1,0 +1,203 @@
+/**
+ * Inbox message search results.
+ *
+ * Renders the results of `messaging.search.searchMessages` as a tappable list.
+ * Each row deep-links to the channel the message lives in, reusing the same
+ * routes the normal inbox rows use (`/inbox/{groupId}/{slug}`, `/inbox/dm/{id}`,
+ * and `/e/{shortId}` for event channels).
+ */
+
+import React, { useCallback } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import type { Id } from "@services/api/convex";
+
+export type MessageSearchResult = {
+  messageId: Id<"chatMessages">;
+  channelId: Id<"chatChannels">;
+  channelName: string;
+  channelType: string;
+  channelSlug: string | null;
+  isAdHoc: boolean;
+  groupId: Id<"groups"> | null;
+  groupName: string | null;
+  meetingShortId: string | null;
+  content: string;
+  senderId: Id<"users"> | null;
+  senderName: string | null;
+  createdAt: number;
+};
+
+interface InboxSearchResultsProps {
+  /** The active (trimmed) search term, used for the empty-state copy. */
+  query: string;
+  /** Results from the query; `undefined` while the query is in flight. */
+  results: MessageSearchResult[] | undefined;
+}
+
+/** Compact relative time for a search-result row ("3h", "2d", "Apr 8"). */
+function formatResultTime(timestamp: number, now: number): string {
+  const diffMs = now - timestamp;
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "now";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function InboxSearchResults({ query, results }: InboxSearchResultsProps) {
+  const router = useRouter();
+  const { colors } = useTheme();
+
+  const openResult = useCallback(
+    (result: MessageSearchResult) => {
+      // Event channels live on the event page with inline activity.
+      if (result.channelType === "event" && result.meetingShortId) {
+        router.push(`/e/${result.meetingShortId}?source=app` as any);
+        return;
+      }
+      // Ad-hoc DMs / group DMs have no owning group.
+      if (result.isAdHoc || !result.groupId) {
+        router.push({
+          pathname: `/inbox/dm/${result.channelId}` as any,
+          params: { groupName: result.channelName },
+        });
+        return;
+      }
+      // Group channels.
+      router.push({
+        pathname: `/inbox/${result.groupId}/${result.channelSlug}` as any,
+        params: {
+          groupName: result.groupName ?? "",
+          channelId: result.channelId,
+        },
+      });
+    },
+    [router],
+  );
+
+  if (results === undefined) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="small" color={colors.icon} />
+      </View>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Ionicons
+          name="search-outline"
+          size={40}
+          color={colors.iconSecondary}
+          style={{ marginBottom: 12 }}
+        />
+        <Text style={[styles.emptyTitle, { color: colors.text }]}>No messages found</Text>
+        <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+          No messages match “{query}”
+        </Text>
+      </View>
+    );
+  }
+
+  const now = Date.now();
+
+  return (
+    <FlatList
+      data={results}
+      keyExtractor={(item) => item.messageId}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={styles.listContent}
+      renderItem={({ item }) => {
+        const location = item.groupName
+          ? `${item.groupName} · ${item.channelName}`
+          : item.channelName || "Direct message";
+        const senderPrefix = item.senderName ? `${item.senderName}: ` : "";
+        return (
+          <Pressable
+            onPress={() => openResult(item)}
+            style={[styles.row, { borderBottomColor: colors.border }]}
+          >
+            <View style={styles.rowHeader}>
+              <Text
+                style={[styles.location, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                {location}
+              </Text>
+              <Text style={[styles.time, { color: colors.textSecondary }]}>
+                {formatResultTime(item.createdAt, now)}
+              </Text>
+            </View>
+            <Text style={[styles.snippet, { color: colors.text }]} numberOfLines={2}>
+              {senderPrefix}
+              {item.content}
+            </Text>
+          </Pressable>
+        );
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    paddingTop: 48,
+  },
+  emptyTitle: {
+    fontSize: 17,
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  emptySubtext: {
+    fontSize: 14,
+    textAlign: "center",
+  },
+  listContent: {
+    paddingBottom: 24,
+  },
+  row: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  rowHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  location: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: "600",
+    marginRight: 8,
+  },
+  time: {
+    fontSize: 12,
+  },
+  snippet: {
+    fontSize: 15,
+    lineHeight: 20,
+  },
+});


### PR DESCRIPTION
## What

Adds a search bar to the top of the chat **inbox** so users can quickly find messages across all the groups and channels they belong to, scoped to their active community. Built to stay robust for multi-tenant datasets with many messages.

## Why

Requested feature (dev-assistant bug `x971ar5terj56d5gyh62ewjbx589jbhd`): _"Implement a search feature in the app's inbox to allow users to search through their messages quickly and efficiently across all groups and channels, but scoped to their community."_

## How

**Backend** (`apps/convex`)
- New `search_content` full-text search index on `chatMessages` (`searchField: content`, filter fields `communityId` + `isDeleted`).
- **Community is denormalized onto messages**: new `chatMessages.communityId`, set at every message-insert site via a shared `resolveChannelCommunityId(ctx, channelId)` helper (sendMessage, system messages, polls, availability requests, reach-out cards, event blasts, meeting posts, bot/scheduled messages, CLI). Derived from the channel's group, or the channel's own `communityId` for ad-hoc dm/group_dm channels.
- New query `messaging.search.searchMessages(token, communityId, query)`:
  - Filters the search index by `communityId` so other tenants' messages are never scanned (no cross-community dilution), then pages through community-scoped matches.
  - Restricts results to channels the caller can actually read, **mirroring the `getMessages` read boundary**: group-leader access to all of a group's channels, explicit channel-membership rows (DMs, group_dm, event, custom, shared), disabled/per-linked-group-hidden leader-only channels excluded (`channelEffectiveEnabledForGroup`), and event channels gated by `canAccessEventChannel`. Convex search filters can't OR across the user's channel set, so this per-channel scoping runs in the handler.
  - Excludes system messages and messages from blocked senders. Each result carries channel slug (with back-compat fallback via `getChannelSlug`), group, and event shortId for deep-linking.
- New `backfillMessageCommunityId` internal migration populates `communityId` on legacy rows — pages through `chatMessages` and reschedules itself until done; idempotent. Run after deploy: `npx convex run functions/admin/migrations:backfillMessageCommunityId`.

**Frontend** (`apps/mobile`)
- Reuses the existing `SearchBar` UI component at the top of `ChatInboxScreen`. Typing is debounced; once the term reaches the minimum length the inbox list is replaced with results, and clearing returns to the normal inbox.
- New `InboxSearchResults` component renders each match (location, sender, snippet, relative time) and deep-links to the channel using the same routes as normal inbox rows (`/inbox/{groupId}/{slug}`, `/inbox/dm/{id}`, `/e/{shortId}`).

## Testing

- `apps/convex` — `__tests__/messaging/search.test.ts`: matching, channel-access scoping, cross-community isolation, deleted/system exclusion, blocked-sender exclusion, slug fallback, hidden-shared-channel exclusion, min-length guard, and a backfill round-trip (legacy row not searchable → backfill → searchable). Full Convex suite green (1858 tests).
- `apps/mobile` — pre-push jest suite green; changed files lint clean and typecheck clean.

## Notes

- No existing onboarding guide covers inbox/messaging search; happy to add one under `apps/web/src/pages/guides/` if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)