### PR TITLE
Enable server-side search for cohosts in large groups

### DIFF
--- a/apps/convex/__tests__/groupMembers-list-search.test.ts
+++ b/apps/convex/__tests__/groupMembers-list-search.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the server-side `search` argument on `groupMembers.list` — the
+ * backend behind the mobile Hosts picker's "Search members" field.
+ *
+ * Before this argument existed the picker fetched a single capped page and
+ * filtered it client-side, so in large groups any member beyond the first page
+ * was unsearchable. These tests pin down that:
+ *
+ *  - a member who sorts beyond the first page is NOT in the un-searched page,
+ *    but IS found when `search` is provided (search spans the whole group)
+ *  - search matches first name, last name, full name, and email
+ *  - the member-list security check still applies to searched requests
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/groupMembers-list-search.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+
+// JWT secret must be at least 32 characters
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+vi.useFakeTimers();
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+interface ListSearchTestData {
+  groupId: Id<"groups">;
+  callerUserId: Id<"users">;
+  callerToken: string;
+  outsiderToken: string;
+  // A member who joins last, so they sort to the end of a large group and fall
+  // beyond the first page when listing without a search term.
+  farawayUserId: Id<"users">;
+}
+
+const PAGE_SIZE = 100;
+const MEMBER_COUNT = 120;
+
+async function seedLargeGroup(
+  t: ReturnType<typeof convexTest>,
+): Promise<ListSearchTestData> {
+  const ids = await t.run(async (ctx) => {
+    const now = Date.now();
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Big Community",
+      slug: "big-community",
+      isPublic: true,
+      timezone: "America/New_York",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Group",
+      slug: "group",
+      isActive: true,
+      createdAt: now,
+      displayOrder: 1,
+    });
+
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Big Group",
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Caller is a leader so they pass the member-list security check.
+    const callerUserId = await ctx.db.insert("users", {
+      firstName: "Caller",
+      lastName: "Leader",
+      email: "caller@test.com",
+      phone: "+15551110000",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: callerUserId,
+      role: "leader",
+      joinedAt: now,
+      notificationsEnabled: true,
+    });
+
+    // A pile of ordinary members, joined in sequence so they sort by joinedAt.
+    for (let i = 0; i < MEMBER_COUNT; i++) {
+      const userId = await ctx.db.insert("users", {
+        firstName: `Member${i}`,
+        lastName: "Test",
+        email: `member${i}@test.com`,
+        phone: `+1555200${String(i).padStart(4, "0")}`,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId,
+        role: "member",
+        joinedAt: now + i + 1,
+        notificationsEnabled: true,
+      });
+    }
+
+    // The faraway member joins last, so they land beyond the first page.
+    const farawayUserId = await ctx.db.insert("users", {
+      firstName: "Zelda",
+      lastName: "Faraway",
+      email: "zelda@test.com",
+      phone: "+15559990000",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: farawayUserId,
+      role: "member",
+      joinedAt: now + MEMBER_COUNT + 1000,
+      notificationsEnabled: true,
+    });
+
+    // A user who is NOT in the group — used to assert the security check.
+    const outsiderUserId = await ctx.db.insert("users", {
+      firstName: "Olivia",
+      lastName: "Outsider",
+      email: "olivia@test.com",
+      phone: "+15558880000",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { groupId, callerUserId, farawayUserId, outsiderUserId };
+  });
+
+  const { accessToken: callerToken } = await generateTokens(ids.callerUserId);
+  const { accessToken: outsiderToken } = await generateTokens(
+    ids.outsiderUserId,
+  );
+
+  return {
+    groupId: ids.groupId,
+    callerUserId: ids.callerUserId,
+    farawayUserId: ids.farawayUserId,
+    callerToken,
+    outsiderToken,
+  };
+}
+
+describe("groupMembers.list server-side search", () => {
+  test("a member beyond the first page is absent without search but found with it", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroup(t);
+
+    // Without a search term, the first page does not include the faraway member.
+    const page = await t.query(api.functions.groupMembers.list, {
+      groupId: data.groupId,
+      token: data.callerToken,
+      limit: PAGE_SIZE,
+    });
+    const pageIds = page.items.map((i) => i.user?.id);
+    expect(page.items.length).toBe(PAGE_SIZE);
+    expect(pageIds).not.toContain(data.farawayUserId);
+
+    // Searching finds them even though they are beyond the first page.
+    const searched = await t.query(api.functions.groupMembers.list, {
+      groupId: data.groupId,
+      token: data.callerToken,
+      search: "zelda",
+      limit: PAGE_SIZE,
+    });
+    const searchedIds = searched.items.map((i) => i.user?.id);
+    expect(searchedIds).toContain(data.farawayUserId);
+  });
+
+  test("search matches last name, full name, and email", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroup(t);
+
+    for (const term of ["faraway", "zelda faraway", "zelda@test.com"]) {
+      const res = await t.query(api.functions.groupMembers.list, {
+        groupId: data.groupId,
+        token: data.callerToken,
+        search: term,
+        limit: PAGE_SIZE,
+      });
+      const ids = res.items.map((i) => i.user?.id);
+      expect(ids, `term "${term}"`).toContain(data.farawayUserId);
+    }
+  });
+
+  test("non-members get an empty result even when searching", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroup(t);
+
+    const res = await t.query(api.functions.groupMembers.list, {
+      groupId: data.groupId,
+      token: data.outsiderToken,
+      search: "zelda",
+      limit: PAGE_SIZE,
+    });
+
+    expect(res.items).toEqual([]);
+  });
+});

--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -22,7 +22,7 @@
 import { v } from "convex/values";
 import { query, mutation } from "../_generated/server";
 import { internal } from "../_generated/api";
-import { Id } from "../_generated/dataModel";
+import { Id, Doc } from "../_generated/dataModel";
 import { now, normalizePagination, getDisplayName, getMediaUrl } from "../lib/utils";
 import { paginationArgs, groupRoleValidator, memberStatusValidator } from "../lib/validators";
 import { requireAuth, getOptionalAuth } from "../lib/auth";
@@ -107,6 +107,10 @@ export const search = query({
 /**
  * List members of a group with pagination
  *
+ * When `search` is provided, members are filtered server-side across the entire
+ * group (by name or email) before pagination, so large groups aren't limited to
+ * the first page of results.
+ *
  * SECURITY: Only returns members if the caller is a group member or community admin.
  * Non-members receive an empty response to prevent member list data leakage.
  */
@@ -116,6 +120,9 @@ export const list = query({
     token: v.optional(v.string()),
     includeInactive: v.optional(v.boolean()),
     role: v.optional(groupRoleValidator),
+    // When set, members are searched server-side across the whole group by
+    // name (and email), so large groups aren't limited to the first page.
+    search: v.optional(v.string()),
     ...paginationArgs,
   },
   handler: async (ctx, args) => {
@@ -188,6 +195,37 @@ export const list = query({
       return a.joinedAt - b.joinedAt;
     });
 
+    // userId -> user cache, reused for the final response below. We only fetch
+    // every user eagerly when we need their names to search; otherwise we fetch
+    // just the paginated page to avoid loading the whole group.
+    const userMap = new Map<string, Doc<"users"> | null>();
+
+    // Server-side search across the ENTIRE group, not just the current page.
+    // The mobile Hosts picker used to filter a single page client-side, so in
+    // large groups any member beyond the first page was unsearchable. Filtering
+    // here lets the picker find any member by name (or email) regardless of size.
+    const searchTerm = args.search?.trim().toLowerCase();
+    if (searchTerm) {
+      const allUserIds = members.map((m) => m.userId);
+      const allUsers = await Promise.all(allUserIds.map((id) => ctx.db.get(id)));
+      allUsers.forEach((user, i) => userMap.set(allUserIds[i], user));
+
+      members = members.filter((m) => {
+        const user = userMap.get(m.userId);
+        if (!user) return false;
+        const firstName = (user.firstName || "").toLowerCase();
+        const lastName = (user.lastName || "").toLowerCase();
+        const fullName = `${firstName} ${lastName}`.trim();
+        const email = (user.email || "").toLowerCase();
+        return (
+          fullName.includes(searchTerm) ||
+          firstName.includes(searchTerm) ||
+          lastName.includes(searchTerm) ||
+          email.includes(searchTerm)
+        );
+      });
+    }
+
     // Get total count before pagination
     const totalCount = members.length;
 
@@ -196,17 +234,14 @@ export const list = query({
     const hasMore = cursorIndex + limit < totalCount;
     const nextCursor = hasMore ? String(cursorIndex + limit) : undefined;
 
-    // Batch fetch all users upfront
+    // Batch fetch users for the page we're returning. When searching we already
+    // cached every user above, so only fetch the ones we don't have yet.
     const userIds = paginatedMembers.map((m) => m.userId);
-    const users = await Promise.all(userIds.map((id) => ctx.db.get(id)));
-
-    // Build userId -> user map for O(1) lookup
-    const userMap = new Map<string, typeof users[0]>();
-    users.forEach((user, i) => {
-      if (user) {
-        userMap.set(userIds[i], user);
-      }
-    });
+    const missingUserIds = userIds.filter((id) => !userMap.has(id));
+    const fetchedUsers = await Promise.all(
+      missingUserIds.map((id) => ctx.db.get(id)),
+    );
+    missingUserIds.forEach((id, i) => userMap.set(id, fetchedUsers[i]));
 
     const notifsDisabled = await getUsersWithNotificationsDisabled(ctx, userIds);
 

--- a/apps/mobile/features/leader-tools/components/HostsPicker.tsx
+++ b/apps/mobile/features/leader-tools/components/HostsPicker.tsx
@@ -6,7 +6,7 @@
  * meetingPermissions.ts). When the viewer removes themselves and isn't a
  * leader, we confirm — they'd lose edit rights on save.
  */
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -47,6 +47,18 @@ type MemberRow = {
   profileImage: string | null;
 };
 
+/** Map raw `groupMembers.list` items (browse or search) to picker rows. */
+function mapMembers(items: any[]): MemberRow[] {
+  return items
+    .filter((item) => item.user != null)
+    .map((item) => ({
+      id: String(item.user.id),
+      firstName: item.user.firstName ?? "",
+      lastName: item.user.lastName ?? "",
+      profileImage: item.user.profileImage ?? null,
+    }));
+}
+
 export function HostsPicker({
   groupId,
   token,
@@ -60,26 +72,36 @@ export function HostsPicker({
   const { colors } = useTheme();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
 
-  // Higher limit: announcement groups can have hundreds of community members,
-  // and the current user may be outside a 200-row page. Convex queries are
-  // reactive, so the full page only loads once.
+  // Debounce the search input so we don't fire a query on every keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Browse list: the first page of members, also used to resolve the names of
+  // already-selected host chips. Convex queries are reactive, so this only
+  // loads once. Searching is handled server-side by a separate query below so
+  // large groups can find any member, not just those on this page.
   const membersData = useQuery(
     api.functions.groupMembers.list,
     groupId && token ? { groupId, limit: 1000, token } : "skip",
   );
 
-  const members: MemberRow[] = useMemo(() => {
-    const items = membersData?.items ?? [];
-    return items
-      .filter((item: any) => item.user != null)
-      .map((item: any) => ({
-        id: String(item.user.id),
-        firstName: item.user.firstName ?? "",
-        lastName: item.user.lastName ?? "",
-        profileImage: item.user.profileImage ?? null,
-      }));
-  }, [membersData]);
+  // Server-side search across the ENTIRE group. Only runs once the user types,
+  // so large announcement groups can find members beyond the browse page.
+  const searchData = useQuery(
+    api.functions.groupMembers.list,
+    groupId && token && debouncedSearch
+      ? { groupId, token, search: debouncedSearch, limit: 100 }
+      : "skip",
+  );
+
+  const members: MemberRow[] = useMemo(
+    () => mapMembers(membersData?.items ?? []),
+    [membersData],
+  );
 
   const membersById = useMemo(() => {
     const map = new Map<string, MemberRow>();
@@ -92,13 +114,20 @@ export function HostsPicker({
     [hostUserIds],
   );
 
-  const filteredMembers = useMemo(() => {
-    const needle = search.trim().toLowerCase();
-    if (!needle) return members;
-    return members.filter((m) =>
-      `${m.firstName} ${m.lastName}`.toLowerCase().includes(needle),
-    );
-  }, [members, search]);
+  // When the user has typed a search, show the server-side results (which span
+  // the whole group); otherwise show the browse list.
+  const isSearching = debouncedSearch.length > 0;
+  const searchResults: MemberRow[] = useMemo(
+    () => mapMembers(searchData?.items ?? []),
+    [searchData],
+  );
+  const displayedMembers = isSearching ? searchResults : members;
+  // Distinguish "still loading results" from "no matches". While the debounce
+  // is catching up (search text set but debounced value not yet), or the search
+  // query is in flight, treat it as loading so we don't flash "no members".
+  const isListLoading = isSearching
+    ? search.trim() !== debouncedSearch || searchData === undefined
+    : membersData === undefined;
 
   const toggleMember = (memberId: string) => {
     const asUserId = memberId as Id<"users">;
@@ -239,13 +268,13 @@ export function HostsPicker({
             />
           </View>
 
-          {membersData === undefined ? (
+          {isListLoading ? (
             <View style={styles.loading}>
               <ActivityIndicator color={colors.textSecondary} />
             </View>
           ) : (
             <FlatList
-              data={filteredMembers}
+              data={displayedMembers}
               keyExtractor={(item) => item.id}
               keyboardShouldPersistTaps="handled"
               renderItem={({ item }) => {


### PR DESCRIPTION
## Problem

When adding hosts/cohosts to an event, the "Search members" field in the Hosts picker could only find members on the first fetched page. The picker requested `groupMembers.list` with a high limit, but the backend caps a page at 100 members and the search was then performed **client-side** over that single page. In large groups (e.g. announcement groups with hundreds of community members), any member beyond the first page was effectively invisible to search.

Repro:
1. Open a large group in the app.
2. Attempt to add a cohost.
3. Use the search bar to find a member not in the initial list.
4. The search returns nothing for members beyond the first page.

## Fix

Move the search server-side so it spans the **entire** group regardless of size:

- **Backend** (`apps/convex/functions/groupMembers.ts`): add an optional `search` argument to the `list` query. When provided, members are filtered server-side across the whole group (by first name, last name, full name, or email) *before* pagination. The existing member-list security check (only group members / community admins) and the response shape are preserved, and users are fetched only when needed (eagerly when searching, otherwise just the returned page).
- **Frontend** (`apps/mobile/.../HostsPicker.tsx`): wire a debounced (300ms) search query to `groupMembers.list` with the `search` argument and render its results, replacing the old client-side `.filter()`. The original browse query is kept to resolve the names of already-selected host chips, so selecting/searching never blanks out existing chips.

## Design notes

I extended the existing `list` query rather than repurposing the separate `groupMembers.search` helper, because `list` already enforces member-list authorization and returns the exact shape the picker consumes — `search` lacks the auth check. This keeps a single query, a single response shape, and a minimal frontend diff. This mirrors the established pattern in the codebase (`admin.stats.getActiveMembersList` already takes a server-side `search` arg with a debounced input in `MemberListModal`).

## Testing

- New `apps/convex/__tests__/groupMembers-list-search.test.ts` (3 tests): a member who sorts beyond the first page is absent from an un-searched page but found when `search` is set; search matches last name, full name, and email; non-members still get an empty result when searching.
- `pnpm test` (Convex): **1852 passed**.
- `npx convex typecheck`: passes.
- `pnpm test` (mobile): **1126 passed / 122 suites**; native-import gating and navigator-screen checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNTfr26FhqV99UmP9pGYw)_