### PR TITLE
Show cohost names and tappable host photos on event details

### DIFF
--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -838,6 +838,18 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
               // rest into "+ N others"; see formatHostLine for the rules.
               const hostLine = formatHostLine(hosts);
 
+              // The profile route scopes to the viewer's *active* community and
+              // skips entirely without an auth token, so tapping a host only
+              // resolves correctly for an authenticated viewer whose active
+              // community is this event's community. On public share pages and
+              // cross-community views we still show the avatars (photo + crown)
+              // but leave them non-interactive rather than route to a broken
+              // "Profile unavailable" / wrong-community screen.
+              const canViewHostProfiles =
+                isAuthenticated &&
+                !!community?.id &&
+                String(community.id) === String((eventData as any).communityId);
+
               return (
                 <View style={styles.organizerColumn}>
                   <View style={styles.organizerHeader}>
@@ -857,15 +869,8 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                   >
                     {hosts.map((host) => {
                       const name = hostDisplayName(host);
-                      return (
-                        <TouchableOpacity
-                          key={host.id}
-                          style={styles.hostAvatarItem}
-                          activeOpacity={0.7}
-                          onPress={() => router.push(`/(user)/profile/${host.id}`)}
-                          accessibilityRole="button"
-                          accessibilityLabel={`View ${name || "host"}'s profile`}
-                        >
+                      const avatar = (
+                        <>
                           <Avatar imageUrl={host.profilePhoto} name={name} size={56} />
                           <View
                             style={[
@@ -875,6 +880,27 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                           >
                             <MaterialCommunityIcons name="crown" size={11} color={colors.surface} />
                           </View>
+                        </>
+                      );
+
+                      if (!canViewHostProfiles) {
+                        return (
+                          <View key={host.id} style={styles.hostAvatarItem}>
+                            {avatar}
+                          </View>
+                        );
+                      }
+
+                      return (
+                        <TouchableOpacity
+                          key={host.id}
+                          style={styles.hostAvatarItem}
+                          activeOpacity={0.7}
+                          onPress={() => router.push(`/(user)/profile/${host.id}`)}
+                          accessibilityRole="button"
+                          accessibilityLabel={`View ${name || "host"}'s profile`}
+                        >
+                          {avatar}
                         </TouchableOpacity>
                       );
                     })}

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -60,10 +60,15 @@ function TextWithLinks({ text, style }: { text: string; style?: any }) {
   );
 }
 
-import { Ionicons } from "@expo/vector-icons";
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
-import { AppImage } from "@components/ui";
+import { AppImage, Avatar } from "@components/ui";
 import { getMediaUrl } from "@/utils/media";
+import {
+  formatHostLine,
+  hostDisplayName,
+  type HostRow,
+} from "@/features/events/utils/hostAttribution";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useTheme } from "@hooks/useTheme";
 import {
@@ -794,26 +799,25 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
         />
 
         <View style={styles.content}>
-          {/* Host Attribution. Shows "Hosted by {primary host} + N others"
-              when the event has explicit hosts; otherwise attributes to the
+          {/* Host Attribution. Shows the host/cohost names alongside a
+              horizontal, tappable row of host avatars (each badged with a
+              crown). Tapping an avatar opens that host's profile. When the
+              event has no explicit hosts it falls back to attributing the
               group. Creator is never surfaced — hosts are the canonical
               owner per the host-decoupling change. */}
           <View style={[styles.organizerRow, { borderBottomColor: colors.surfaceSecondary }]}>
             {(() => {
-              type HostRow = {
-                id: string;
-                firstName: string | null;
-                lastName: string | null;
-                profilePhoto: string | null;
-              };
               const hosts =
                 ((eventData as any).hosts as HostRow[] | undefined) ?? [];
-              const primary = hosts[0];
-              const extraHostCount = Math.max(0, hosts.length - 1);
 
-              if (!primary) {
+              const groupSubtitle = (eventData as any).isAnnouncementGroup
+                ? eventData.communityName
+                : `${eventData.groupName}${eventData.communityName ? ' · ' + eventData.communityName : ''}`;
+
+              // No explicit hosts: attribute the event to the group.
+              if (hosts.length === 0) {
                 return (
-                  <>
+                  <View style={styles.organizerHeader}>
                     <AppImage
                       source={eventData.groupImage}
                       style={styles.groupAvatar}
@@ -826,38 +830,56 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                       <Text style={[styles.organizerName, { color: colors.text }]}>{eventData.groupName}</Text>
                       <Text style={[styles.communityName, { color: colors.textSecondary }]}>{eventData.communityName}</Text>
                     </View>
-                  </>
+                  </View>
                 );
               }
 
-              const firstName = primary.firstName || "";
-              const lastInitial = primary.lastName?.[0] ? `${primary.lastName[0]}.` : "";
-              const display = [firstName, lastInitial].filter(Boolean).join(" ").trim();
-              const hostLine = display
-                ? extraHostCount > 0
-                  ? `Hosted by ${display} + ${extraHostCount} other${extraHostCount === 1 ? "" : "s"}`
-                  : `Hosted by ${display}`
-                : "Hosted";
+              // Name up to two hosts (host + cohost) before collapsing the
+              // rest into "+ N others"; see formatHostLine for the rules.
+              const hostLine = formatHostLine(hosts);
 
               return (
-                <>
-                  <AppImage
-                    source={primary.profilePhoto ?? undefined}
-                    style={styles.groupAvatar}
-                    placeholder={{
-                      type: 'initials',
-                      name: display || (eventData.groupName ?? undefined),
-                    }}
-                  />
-                  <View style={styles.organizerInfo}>
-                    <Text style={[styles.organizerName, { color: colors.text }]}>{hostLine}</Text>
-                    <Text style={[styles.communityName, { color: colors.textSecondary }]}>
-                      {(eventData as any).isAnnouncementGroup
-                        ? eventData.communityName
-                        : `${eventData.groupName}${eventData.communityName ? ' · ' + eventData.communityName : ''}`}
-                    </Text>
+                <View style={styles.organizerColumn}>
+                  <View style={styles.organizerHeader}>
+                    <MaterialCommunityIcons name="crown" size={20} color={colors.text} />
+                    <View style={styles.organizerInfo}>
+                      <Text style={[styles.organizerName, { color: colors.text }]}>{hostLine}</Text>
+                      <Text style={[styles.communityName, { color: colors.textSecondary }]}>
+                        {groupSubtitle}
+                      </Text>
+                    </View>
                   </View>
-                </>
+
+                  <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    contentContainerStyle={styles.hostAvatarRow}
+                  >
+                    {hosts.map((host) => {
+                      const name = hostDisplayName(host);
+                      return (
+                        <TouchableOpacity
+                          key={host.id}
+                          style={styles.hostAvatarItem}
+                          activeOpacity={0.7}
+                          onPress={() => router.push(`/(user)/profile/${host.id}`)}
+                          accessibilityRole="button"
+                          accessibilityLabel={`View ${name || "host"}'s profile`}
+                        >
+                          <Avatar imageUrl={host.profilePhoto} name={name} size={56} />
+                          <View
+                            style={[
+                              styles.hostCrownBadge,
+                              { backgroundColor: colors.text, borderColor: colors.surface },
+                            ]}
+                          >
+                            <MaterialCommunityIcons name="crown" size={11} color={colors.surface} />
+                          </View>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </ScrollView>
+                </View>
               );
             })()}
           </View>
@@ -1250,12 +1272,17 @@ const styles = StyleSheet.create({
 
   // Organizer
   organizerRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
     marginBottom: 20,
     paddingBottom: 20,
     borderBottomWidth: 1,
+  },
+  organizerColumn: {
+    gap: 12,
+  },
+  organizerHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
   },
   groupAvatar: {
     width: 40,
@@ -1264,6 +1291,26 @@ const styles = StyleSheet.create({
   },
   organizerInfo: {
     flex: 1,
+  },
+  hostAvatarRow: {
+    flexDirection: "row",
+    gap: 12,
+    paddingVertical: 2,
+  },
+  hostAvatarItem: {
+    width: 56,
+    height: 56,
+  },
+  hostCrownBadge: {
+    position: "absolute",
+    right: -2,
+    bottom: -2,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    alignItems: "center",
+    justifyContent: "center",
   },
   organizerName: {
     fontSize: 16,

--- a/apps/mobile/features/events/__tests__/hostAttribution.test.ts
+++ b/apps/mobile/features/events/__tests__/hostAttribution.test.ts
@@ -1,0 +1,74 @@
+import { hostDisplayName, formatHostLine } from "../utils/hostAttribution";
+
+describe("hostDisplayName", () => {
+  it("combines first name and last initial", () => {
+    expect(hostDisplayName({ firstName: "Jane", lastName: "Doe" })).toBe("Jane D.");
+  });
+
+  it("uses first name only when last name is missing", () => {
+    expect(hostDisplayName({ firstName: "Jane", lastName: null })).toBe("Jane");
+  });
+
+  it("uses last initial only when first name is missing", () => {
+    expect(hostDisplayName({ firstName: null, lastName: "Doe" })).toBe("D.");
+  });
+
+  it("returns empty string when the host has no name", () => {
+    expect(hostDisplayName({ firstName: null, lastName: null })).toBe("");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(hostDisplayName({ firstName: "  Jane  ", lastName: "  Doe  " })).toBe("Jane D.");
+  });
+});
+
+describe("formatHostLine", () => {
+  it("returns a bare label when there are no hosts", () => {
+    expect(formatHostLine([])).toBe("Hosted");
+  });
+
+  it("returns a bare label when no host has a usable name", () => {
+    expect(formatHostLine([{ firstName: null, lastName: null }])).toBe("Hosted");
+  });
+
+  it("names a single host", () => {
+    expect(formatHostLine([{ firstName: "Jane", lastName: "Doe" }])).toBe("Hosted by Jane D.");
+  });
+
+  it("names both hosts when there are exactly two (host + cohost)", () => {
+    expect(
+      formatHostLine([
+        { firstName: "Jane", lastName: "Doe" },
+        { firstName: "Mark", lastName: "King" },
+      ])
+    ).toBe("Hosted by Jane D. & Mark K.");
+  });
+
+  it("names the first two and collapses the rest with correct pluralization", () => {
+    expect(
+      formatHostLine([
+        { firstName: "Jane", lastName: "Doe" },
+        { firstName: "Mark", lastName: "King" },
+        { firstName: "Rosa", lastName: "Smith" },
+      ])
+    ).toBe("Hosted by Jane D., Mark K. + 1 other");
+
+    expect(
+      formatHostLine([
+        { firstName: "Jane", lastName: "Doe" },
+        { firstName: "Mark", lastName: "King" },
+        { firstName: "Rosa", lastName: "Smith" },
+        { firstName: "Tom", lastName: "Lee" },
+      ])
+    ).toBe("Hosted by Jane D., Mark K. + 2 others");
+  });
+
+  it("ignores unnamed hosts when counting", () => {
+    expect(
+      formatHostLine([
+        { firstName: "Jane", lastName: "Doe" },
+        { firstName: null, lastName: null },
+      ])
+    ).toBe("Hosted by Jane D.");
+  });
+});

--- a/apps/mobile/features/events/utils/hostAttribution.ts
+++ b/apps/mobile/features/events/utils/hostAttribution.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers for rendering event host attribution (the "Hosted by …" line and the
+ * row of host avatars) on the public event page. Kept pure so the formatting
+ * rules can be unit-tested without mounting the screen.
+ */
+
+export type HostRow = {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  profilePhoto: string | null;
+};
+
+/**
+ * Display name for a single host: first name plus last initial when both are
+ * present (e.g. "Jane D."). Falls back to whichever part exists, or "" when the
+ * host has no name at all.
+ */
+export function hostDisplayName(host: Pick<HostRow, "firstName" | "lastName">): string {
+  const first = host.firstName?.trim() || "";
+  const lastInitial = host.lastName?.trim()?.[0]
+    ? `${host.lastName.trim()[0]}.`
+    : "";
+  return [first, lastInitial].filter(Boolean).join(" ").trim();
+}
+
+/**
+ * The "Hosted by …" headline. Names up to two hosts (host + cohost) explicitly
+ * so a cohost's name is always surfaced, then collapses any remainder into
+ * "+ N others". Empty names (hosts with no name) are ignored. Returns a bare
+ * "Hosted" when no host has a usable name.
+ */
+export function formatHostLine(hosts: Array<Pick<HostRow, "firstName" | "lastName">>): string {
+  const names = hosts.map(hostDisplayName).filter(Boolean);
+
+  if (names.length === 0) return "Hosted";
+  if (names.length === 1) return `Hosted by ${names[0]}`;
+  if (names.length === 2) return `Hosted by ${names[0]} & ${names[1]}`;
+
+  const extra = names.length - 2;
+  return `Hosted by ${names[0]}, ${names[1]} + ${extra} other${extra === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
## What & why

The public event page (`/e/[shortId]`) previously attributed every event to a single primary host — **"Hosted by Jane D. + N others"** — which hid cohost names and gave no way to see who the other hosts were.

This PR updates the event details host attribution to surface cohosts and match the provided reference design (crowned host avatars in a horizontal row).

## Changes

- **Cohost names are now shown.** The "Hosted by …" line names up to two hosts (host + cohost) explicitly before collapsing the remainder into "+ N others".
- **Horizontal row of host avatars.** Each host is rendered as a circular avatar badged with a crown. Tapping an avatar opens that host's profile (`/(user)/profile/[userId]`).
- **Crown attribution.** The "Hosted by …" line is prefixed with a crown icon, matching the reference.
- **No-host fallback preserved.** When an event has no explicit hosts it still attributes to the group, unchanged.
- **Pure, tested helper.** The name/host-line formatting was extracted into `features/events/utils/hostAttribution.ts` with unit tests (`features/events/__tests__/hostAttribution.test.ts`, 11 cases).

## Implementation notes

- The backend `getByShortId` query already returns the full `hosts` array (`id`, `firstName`, `lastName`, `profilePhoto`), so this is a frontend-only change — no backend/schema changes.
- The crown uses `MaterialCommunityIcons` from `@expo/vector-icons`, which is classified as a **`core`** native dep in `native-deps.json` — **no new native dependency** is introduced, and the native-import gating check passes.

## Verification

- `hostAttribution` unit tests: 11/11 pass.
- ESLint on changed files: 0 errors (only the file's pre-existing `(eventData as any)` warnings remain).
- Native import gating check: passes.

## Reference design

The cohost row mirrors the supplied mock: "Hosted by …" with a crown, followed by a horizontal row of host avatars each carrying a small crown badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZFPWozL2x8QRzWjLpeRyU)_