### PR TITLE
feat(chat): filled active tab + configurable per-channel composer hints

### DIFF
--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -773,6 +773,30 @@ describe("Channel Updates", () => {
     channel = await t.run(async (ctx) => ctx.db.get(channelId));
     expect(channel?.hint).toBeUndefined();
   });
+
+  test("should reject a composer hint longer than 100 characters", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, communityId } = await seedTestData(t);
+    const { accessToken: leaderToken } = await createLeaderUser(t, communityId, groupId);
+
+    const channelId = await t.mutation(api.functions.messaging.channels.createChannel, {
+      token: leaderToken,
+      groupId,
+      channelType: "main",
+      name: "General",
+    });
+
+    await expect(
+      t.mutation(api.functions.messaging.channels.updateChannel, {
+        token: leaderToken,
+        channelId,
+        hint: "x".repeat(101),
+      }),
+    ).rejects.toThrow(/100 characters or fewer/);
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.hint).toBeUndefined();
+  });
 });
 
 // ============================================================================

--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -740,6 +740,39 @@ describe("Channel Updates", () => {
 
     expect(afterUpdate?.updatedAt).toBeGreaterThan(beforeUpdate?.updatedAt || 0);
   });
+
+  test("should set and clear the composer hint", async () => {
+    const t = convexTest(schema, modules);
+    const { groupId, communityId } = await seedTestData(t);
+    const { accessToken: leaderToken } = await createLeaderUser(t, communityId, groupId);
+
+    const channelId = await t.mutation(api.functions.messaging.channels.createChannel, {
+      token: leaderToken,
+      groupId,
+      channelType: "main",
+      name: "General",
+    });
+
+    // Set a hint (and confirm surrounding whitespace is trimmed).
+    await t.mutation(api.functions.messaging.channels.updateChannel, {
+      token: leaderToken,
+      channelId,
+      hint: "  put experience updates here  ",
+    });
+
+    let channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.hint).toBe("put experience updates here");
+
+    // An empty/whitespace value clears the hint back to undefined.
+    await t.mutation(api.functions.messaging.channels.updateChannel, {
+      token: leaderToken,
+      channelId,
+      hint: "   ",
+    });
+
+    channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.hint).toBeUndefined();
+  });
 });
 
 // ============================================================================

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -2041,6 +2041,13 @@ export const createChannel = mutation({
 });
 
 /**
+ * Max length for a channel's composer hint. Mirrors the `maxLength` on the
+ * channel info editor so a modified client can't persist an oversized
+ * placeholder that `listGroupChannels` would then ship to every member.
+ */
+const CHANNEL_HINT_MAX_LENGTH = 100;
+
+/**
  * Update channel details.
  */
 export const updateChannel = mutation({
@@ -2104,8 +2111,13 @@ export const updateChannel = mutation({
       updates.description = args.description;
     }
     if (args.hint !== undefined) {
-      // Empty string clears the hint so it falls back to the default placeholder.
       const trimmedHint = args.hint.trim();
+      if (trimmedHint.length > CHANNEL_HINT_MAX_LENGTH) {
+        throw new Error(
+          `Hint must be ${CHANNEL_HINT_MAX_LENGTH} characters or fewer`,
+        );
+      }
+      // Empty string clears the hint so it falls back to the default placeholder.
       updates.hint = trimmedHint.length > 0 ? trimmedHint : undefined;
     }
 

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1203,6 +1203,7 @@ export const listGroupChannels = query({
     channelType: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
+    hint: v.optional(v.string()),
     memberCount: v.number(),
     isArchived: v.boolean(),
     isMember: v.boolean(),
@@ -1392,6 +1393,7 @@ export const listGroupChannels = query({
           channelType: channel.channelType,
           name: channel.name,
           description: channel.description,
+          hint: channel.hint,
           memberCount: channel.memberCount,
           isArchived: channel.isArchived,
           isMember,
@@ -2047,6 +2049,8 @@ export const updateChannel = mutation({
     channelId: v.id("chatChannels"),
     name: v.optional(v.string()),
     description: v.optional(v.string()),
+    /** Composer placeholder hint. Pass "" to clear it. */
+    hint: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -2087,6 +2091,7 @@ export const updateChannel = mutation({
     const updates: Partial<{
       name: string;
       description: string;
+      hint: string | undefined;
       updatedAt: number;
     }> = {
       updatedAt: Date.now(),
@@ -2097,6 +2102,11 @@ export const updateChannel = mutation({
     }
     if (args.description !== undefined) {
       updates.description = args.description;
+    }
+    if (args.hint !== undefined) {
+      // Empty string clears the hint so it falls back to the default placeholder.
+      const trimmedHint = args.hint.trim();
+      updates.hint = trimmedHint.length > 0 ? trimmedHint : undefined;
     }
 
     await ctx.db.patch(args.channelId, updates);

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1582,6 +1582,12 @@ export default defineSchema({
     channelType: v.string(), // "main" | "leaders" | "dm" | "group_dm" | "custom" | "pco_services" | "event" | "reach_out" | "announcements" | "cross_team"
     name: v.string(),
     description: v.optional(v.string()),
+    /**
+     * Optional per-channel hint shown as the composer placeholder (e.g.
+     * "put experience updates here"). Guides members to post the right kind of
+     * content in this thread. Editable by leaders on the channel info screen.
+     */
+    hint: v.optional(v.string()),
     createdById: v.id("users"),
     createdAt: v.number(), // Unix timestamp ms
     updatedAt: v.number(), // Unix timestamp ms

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -226,6 +226,10 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
   const [renameValue, setRenameValue] = useState("");
   const [renameSubmitting, setRenameSubmitting] = useState(false);
   const [renameError, setRenameError] = useState<string | null>(null);
+  const [hintVisible, setHintVisible] = useState(false);
+  const [hintValue, setHintValue] = useState("");
+  const [hintSubmitting, setHintSubmitting] = useState(false);
+  const [hintError, setHintError] = useState<string | null>(null);
   const [leaveVisible, setLeaveVisible] = useState(false);
   const [archiveVisible, setArchiveVisible] = useState(false);
   const [pendingResponding, setPendingResponding] = useState<
@@ -618,6 +622,24 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
       setRenameSubmitting(false);
     }
   }, [renameValue, channel?._id, updateChannelMutation]);
+
+  const handleSaveHint = useCallback(async () => {
+    if (!channel?._id) return;
+    setHintSubmitting(true);
+    try {
+      // Empty value clears the hint (composer falls back to "Message...").
+      await updateChannelMutation({
+        channelId: channel._id,
+        hint: hintValue.trim(),
+      });
+      setHintVisible(false);
+      setHintError(null);
+    } catch (e: any) {
+      setHintError(e?.message || "Could not save hint");
+    } finally {
+      setHintSubmitting(false);
+    }
+  }, [hintValue, channel?._id, updateChannelMutation]);
 
   if (channel === undefined) {
     return (
@@ -1327,6 +1349,44 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                   the Rostering hub via `createServingTeam`, and a team's
                   roster is managed there, not from its chat channel. */}
 
+              {/* Composer hint — guidance text shown as the message-box
+                  placeholder (e.g. "put experience updates here"). Available
+                  on any group channel; the backend gates edits to leaders. */}
+              <Pressable
+                onPress={() => {
+                  setHintValue(channel?.hint ?? "");
+                  setHintError(null);
+                  setHintVisible(true);
+                }}
+                style={({ pressed }) => [
+                  styles.actionRowFlat,
+                  {
+                    borderTopWidth: StyleSheet.hairlineWidth,
+                    borderTopColor: colors.border,
+                  },
+                  pressed && { backgroundColor: colors.selectedBackground },
+                ]}
+              >
+                <Ionicons name="bulb-outline" size={20} color={colors.icon} />
+                <Text style={[styles.actionLabel, { color: colors.text }]}>
+                  Composer hint
+                </Text>
+                {channel?.hint ? (
+                  <Text
+                    style={[styles.actionRowValue, { color: colors.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    {channel.hint}
+                  </Text>
+                ) : null}
+                <Ionicons
+                  name="chevron-forward"
+                  size={18}
+                  color={colors.textTertiary}
+                  style={{ marginLeft: channel?.hint ? 0 : "auto" }}
+                />
+              </Pressable>
+
               {/* Rename — custom channels only (backend gates the rest). */}
               {isCustom && (
                 <Pressable
@@ -1506,6 +1566,77 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
               ]}
             >
               {renameSubmitting ? (
+                <ActivityIndicator size="small" color="#ffffff" />
+              ) : (
+                <Text style={[styles.modalButtonText, { color: "#ffffff" }]}>
+                  Save
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </CustomModal>
+
+      {/* Composer hint modal */}
+      <CustomModal
+        visible={hintVisible}
+        onClose={() => {
+          if (!hintSubmitting) {
+            setHintVisible(false);
+            setHintError(null);
+          }
+        }}
+        title="Composer hint"
+      >
+        <View>
+          <Text style={[styles.helperText, { color: colors.textSecondary, marginBottom: 12 }]}>
+            Shown as the message-box placeholder to guide what people post here.
+            Leave empty to use the default.
+          </Text>
+          <TextInput
+            value={hintValue}
+            onChangeText={setHintValue}
+            placeholder="e.g. put experience updates here"
+            placeholderTextColor={colors.textSecondary}
+            maxLength={100}
+            autoFocus
+            style={[
+              styles.renameInput,
+              {
+                color: colors.text,
+                backgroundColor: colors.inputBackground,
+                borderColor: colors.inputBorder,
+              },
+            ]}
+          />
+          {hintError ? (
+            <Text style={[styles.errorText, { color: colors.destructive, marginTop: 8 }]}>
+              {hintError}
+            </Text>
+          ) : null}
+          <View style={styles.modalButtonRow}>
+            <TouchableOpacity
+              onPress={() => {
+                setHintVisible(false);
+                setHintError(null);
+              }}
+              disabled={hintSubmitting}
+              style={[styles.modalButton, { backgroundColor: colors.surfaceSecondary }]}
+            >
+              <Text style={[styles.modalButtonText, { color: colors.text }]}>
+                Cancel
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={handleSaveHint}
+              disabled={hintSubmitting}
+              style={[
+                styles.modalButton,
+                { backgroundColor: primaryColor },
+                hintSubmitting && { opacity: 0.6 },
+              ]}
+            >
+              {hintSubmitting ? (
                 <ActivityIndicator size="small" color="#ffffff" />
               ) : (
                 <Text style={[styles.modalButtonText, { color: "#ffffff" }]}>

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -1350,42 +1350,47 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                   roster is managed there, not from its chat channel. */}
 
               {/* Composer hint — guidance text shown as the message-box
-                  placeholder (e.g. "put experience updates here"). Available
-                  on any group channel; the backend gates edits to leaders. */}
-              <Pressable
-                onPress={() => {
-                  setHintValue(channel?.hint ?? "");
-                  setHintError(null);
-                  setHintVisible(true);
-                }}
-                style={({ pressed }) => [
-                  styles.actionRowFlat,
-                  {
-                    borderTopWidth: StyleSheet.hairlineWidth,
-                    borderTopColor: colors.border,
-                  },
-                  pressed && { backgroundColor: colors.selectedBackground },
-                ]}
-              >
-                <Ionicons name="bulb-outline" size={20} color={colors.icon} />
-                <Text style={[styles.actionLabel, { color: colors.text }]}>
-                  Composer hint
-                </Text>
-                {channel?.hint ? (
-                  <Text
-                    style={[styles.actionRowValue, { color: colors.textSecondary }]}
-                    numberOfLines={1}
-                  >
-                    {channel.hint}
+                  placeholder (e.g. "put experience updates here"). Editing is
+                  authorized by `updateChannel` against the owning group, so we
+                  hide it for secondary-share viewers (a linked group's leader
+                  would otherwise open the modal only to hit "Not authorized").
+                  The owning group's leaders manage the shared hint. */}
+              {!isSecondaryShare && (
+                <Pressable
+                  onPress={() => {
+                    setHintValue(channel?.hint ?? "");
+                    setHintError(null);
+                    setHintVisible(true);
+                  }}
+                  style={({ pressed }) => [
+                    styles.actionRowFlat,
+                    {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Ionicons name="bulb-outline" size={20} color={colors.icon} />
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>
+                    Composer hint
                   </Text>
-                ) : null}
-                <Ionicons
-                  name="chevron-forward"
-                  size={18}
-                  color={colors.textTertiary}
-                  style={{ marginLeft: channel?.hint ? 0 : "auto" }}
-                />
-              </Pressable>
+                  {channel?.hint ? (
+                    <Text
+                      style={[styles.actionRowValue, { color: colors.textSecondary }]}
+                      numberOfLines={1}
+                    >
+                      {channel.hint}
+                    </Text>
+                  ) : null}
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={colors.textTertiary}
+                    style={{ marginLeft: channel?.hint ? 0 : "auto" }}
+                  />
+                </Pressable>
+              )}
 
               {/* Rename — custom channels only (backend gates the rest). */}
               {isCustom && (

--- a/apps/mobile/features/chat/components/ChatNavigation.tsx
+++ b/apps/mobile/features/chat/components/ChatNavigation.tsx
@@ -26,6 +26,13 @@ import {
 } from "../constants/toolbarTools";
 
 /**
+ * Text/icon color for the active (filled) tab. The active tab background is the
+ * community primary color, so its label/icons render in white for contrast —
+ * the same pairing used by primary buttons across the app.
+ */
+const ACTIVE_TAB_CONTENT_COLOR = "#ffffff";
+
+/**
  * Represents a channel tab that can be displayed in the tab bar.
  * This structure matches the output from listGroupChannels query.
  */
@@ -89,12 +96,16 @@ export const ChatTabBar = memo(function ChatTabBar({
           // most of a phone-width tab bar. Accessibility label still reads
           // the channel name for screen readers.
           const isAnnouncements = channel.channelType === "announcements";
-          const tabColor = isActive ? primaryColor : themeColors.textSecondary;
+          // Active tab is a filled pill (primary color background) so it stands
+          // out clearly from inactive tabs even when many teams are listed.
+          // Content sits on the brand color, so it switches to white — matching
+          // how primary buttons render their label elsewhere in the app.
+          const tabColor = isActive ? ACTIVE_TAB_CONTENT_COLOR : themeColors.textSecondary;
 
           return (
             <TouchableOpacity
               key={channel.slug}
-              style={[styles.tab, isActive && { borderBottomColor: primaryColor }]}
+              style={[styles.tab, isActive && { backgroundColor: primaryColor }]}
               onPress={() => onTabChange(channel.slug)}
               onLongPress={() => onTabLongPress?.(channel)}
               delayLongPress={300}
@@ -106,7 +117,7 @@ export const ChatTabBar = memo(function ChatTabBar({
                   <Ionicons
                     name="link"
                     size={12}
-                    color={isActive ? primaryColor : "#8B5CF6"}
+                    color={isActive ? ACTIVE_TAB_CONTENT_COLOR : "#8B5CF6"}
                     style={styles.sharedTabIcon}
                   />
                 )}
@@ -118,7 +129,7 @@ export const ChatTabBar = memo(function ChatTabBar({
                   />
                 ) : (
                   <Text
-                    style={[styles.tabText, { color: themeColors.textSecondary }, isActive && { color: primaryColor }]}
+                    style={[styles.tabText, { color: tabColor }]}
                     numberOfLines={1}
                   >
                     {displayName}
@@ -432,11 +443,10 @@ const styles = StyleSheet.create({
     flexGrow: 1,
   },
   tab: {
-    paddingVertical: 12,
-    paddingHorizontal: 20,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
     marginRight: 8,
-    borderBottomWidth: 2,
-    borderBottomColor: "transparent",
+    borderRadius: 18,
   },
   tabContent: {
     flexDirection: "row",

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -339,6 +339,19 @@ const ConvexChatRoomScreenInner: React.FC = () => {
       ? defaultChannelFallback.slug
       : routeActiveSlug;
 
+  // Per-channel composer hint (e.g. "put experience updates here"), configured
+  // by leaders on the channel info screen. Resolve from the active channel doc;
+  // custom channels come through channelBySlug, the rest through the group list.
+  const activeChannelHint = useMemo(() => {
+    if (isCustomChannel && channelBySlug?._id === activeChannelId) {
+      return channelBySlug?.hint ?? undefined;
+    }
+    const active = effectiveGroupChannels?.find(
+      (ch: any) => ch._id === activeChannelId
+    );
+    return active?.hint ?? undefined;
+  }, [isCustomChannel, channelBySlug, activeChannelId, effectiveGroupChannels]);
+
   // Fetch group details for display (with token to get user's role)
   const groupDetailsRaw = useQuery(
     api.functions.groups.index.getById,
@@ -1255,6 +1268,7 @@ const ConvexChatRoomScreenInner: React.FC = () => {
                 onCancelReply={handleCancelReply}
                 externalSendMessage={sendMessage}
                 externalIsSending={isSending}
+                placeholder={activeChannelHint}
                 // Ad-hoc DM where recipient hasn't accepted yet — strip
                 // attachment UI client-side. Backend rejects (messages.ts);
                 // hiding here means the user never triggers the failure path

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -79,6 +79,12 @@ interface MessageInputProps {
    * still sends. Sourced from `channels.getChannel` → `recipientPending`.
    */
   recipientPending?: boolean;
+  /**
+   * Composer placeholder text. Defaults to "Message...". Channels can set a
+   * custom hint (e.g. "put experience updates here") on the channel info screen
+   * to guide members on what to post in this thread.
+   */
+  placeholder?: string;
 }
 
 interface ChannelMember {
@@ -130,7 +136,7 @@ const filterMembers = (members: ChannelMember[], searchText: string): ChannelMem
   );
 };
 
-export function MessageInput({ channelId, replyToMessage, onCancelReply, hideReplyPreview, externalSendMessage, externalIsSending, recipientPending = false }: MessageInputProps) {
+export function MessageInput({ channelId, replyToMessage, onCancelReply, hideReplyPreview, externalSendMessage, externalIsSending, recipientPending = false, placeholder }: MessageInputProps) {
   const { colors: themeColors } = useTheme();
   const { isKnicksMode } = useCommunityTheme();
   const { getDraft, setDraft: saveDraft, clearDraft } = useDraftStore();
@@ -1224,7 +1230,7 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, hideRep
             const maxContentHeight = LINE_HEIGHT * MAX_INPUT_LINES;
             setNativeScrollEnabled(contentHeight >= maxContentHeight);
           }}
-          placeholder="Message..."
+          placeholder={placeholder || "Message..."}
           placeholderTextColor={themeColors.textTertiary}
           multiline
           scrollEnabled={isWeb ? true : nativeScrollEnabled}

--- a/apps/web/src/pages/guides/GroupsAndChannels.tsx
+++ b/apps/web/src/pages/guides/GroupsAndChannels.tsx
@@ -502,6 +502,16 @@ export function GroupsAndChannels() {
           working immediately. Use that if a link was shared too widely — make a
           new one and the old one can&rsquo;t be used to join.
         </Callout>
+
+        <P>
+          Every channel also has an optional <Term>composer hint</Term>. From a
+          channel&rsquo;s info screen, under <strong>Leader controls</strong>,
+          tap <strong>Composer hint</strong> to set the placeholder text that
+          shows in the message box — for example &ldquo;put experience updates
+          here.&rdquo; It&rsquo;s a gentle nudge that steers people toward
+          posting the right kind of message in each thread. Leave it empty to
+          fall back to the default &ldquo;Message…&rdquo; placeholder.
+        </P>
       </Section>
 
       <Section id="leaders" title="Members & leaders">
@@ -523,7 +533,8 @@ export function GroupsAndChannels() {
             Post in the Announcements channel (members can only read it).
           </Step>
           <Step n={3}>
-            Manage channel invite links and approve or decline join requests.
+            Manage channel invite links and approve or decline join requests,
+            and set a composer hint to guide what members post in each channel.
           </Step>
           <Step n={4}>
             Add, remove, and promote members within the group.


### PR DESCRIPTION
## Summary

Two related chat improvements:

### 1. Filled active channel tab
The active tab used a thin underline, which was easy to miss once a group had
many team tabs. The active tab now renders as a **filled pill** in the community
primary color with white label/icons, so the current channel reads clearly at a
glance. Inactive tabs are unchanged (secondary text, no fill).

- `apps/mobile/features/chat/components/ChatNavigation.tsx` — active tab background fill + white content; tab style switched from bottom-border to a rounded pill.

### 2. Configurable per-channel composer hints
Leaders can set a per-channel **hint** (e.g. "put experience updates here") to
steer members toward posting the right kind of content in each thread. The hint
renders as the message composer's placeholder; clearing it falls back to the
default `Message...`.

- **Schema** — optional `hint` field on `chatChannels`.
- **`updateChannel` mutation** — accepts and trims `hint`; an empty string clears it (back to `undefined`).
- **`listGroupChannels`** — surfaces `hint` so the active channel can feed the composer placeholder.
- **Channel info screen** — new "Composer hint" row under Leader controls + an edit modal (mirrors the existing Rename pattern). Shows the current hint inline.
- **`MessageInput`** — new optional `placeholder` prop, wired from the active channel's hint in `ConvexChatRoomScreen`.
- **Guide** — documented composer hints in `GroupsAndChannels.tsx`.

## Testing
- `apps/convex`: `npx convex typecheck` ✅, full `vitest` suite ✅ (1870 tests, incl. a new test covering setting/trimming/clearing the hint).
- `apps/mobile`: full jest suite ✅ (123 suites), native fingerprint / native-import / navigator-screen checks ✅, and `expo export` (Metro import resolution) ✅.

## Notes
- White-on-primary content for the active tab matches the app's existing primary-button text pairing (`buttonPrimaryText: '#ffffff'`); no new contrast token was introduced.
- The hint is editable on any group channel from its info screen; the backend gates edits to channel admins / group leaders, same as rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXevFgWmuzED9rmaaEbDRV)_