### PR TITLE
style(chat): sharp rectangular active tab highlight

### DIFF
--- a/apps/mobile/features/chat/components/ChatNavigation.tsx
+++ b/apps/mobile/features/chat/components/ChatNavigation.tsx
@@ -96,10 +96,10 @@ export const ChatTabBar = memo(function ChatTabBar({
           // most of a phone-width tab bar. Accessibility label still reads
           // the channel name for screen readers.
           const isAnnouncements = channel.channelType === "announcements";
-          // Active tab is a filled pill (primary color background) so it stands
-          // out clearly from inactive tabs even when many teams are listed.
-          // Content sits on the brand color, so it switches to white — matching
-          // how primary buttons render their label elsewhere in the app.
+          // Active tab is a filled rectangle (primary color background) so it
+          // stands out clearly from inactive tabs even when many teams are
+          // listed. Content sits on the brand color, so it switches to white —
+          // matching how primary buttons render their label elsewhere.
           const tabColor = isActive ? ACTIVE_TAB_CONTENT_COLOR : themeColors.textSecondary;
 
           return (
@@ -446,7 +446,8 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 16,
     marginRight: 8,
-    borderRadius: 18,
+    // Sharp rectangular highlight (no rounding) for the active tab.
+    borderRadius: 0,
   },
   tabContent: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary

Follow-up to #519 (now merged). Per design feedback, the active channel tab's
filled highlight should be a **sharp rectangle** rather than a rounded one.

- `apps/mobile/features/chat/components/ChatNavigation.tsx` — active tab `borderRadius` set from `18` to `0` (sharp corners); updated the now-stale "pill" comment.

Purely cosmetic, single-line style change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXevFgWmuzED9rmaaEbDRV)_