### PR TITLE
feat(rostering): inline role rename + previous-dates stepper in roster grid

### DIFF
--- a/apps/convex/__tests__/scheduling/roster.test.ts
+++ b/apps/convex/__tests__/scheduling/roster.test.ts
@@ -126,6 +126,46 @@ describe("rosterMatrix", () => {
     expect(adminRow?.availableCount).toBe(1);
   });
 
+  it("windows columns: upcoming by default, pastLimit leads with recent past", async () => {
+    const { t, world } = await setup();
+    const leader = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Two past plans (older + recent) and two upcoming plans.
+    await createPlan(t, leader, world.groupId, "Past old", Date.now() - 21 * DAY);
+    await createPlan(t, leader, world.groupId, "Past recent", Date.now() - 7 * DAY);
+    await createPlan(t, leader, world.groupId, "Soon", Date.now() + 7 * DAY);
+    await createPlan(t, leader, world.groupId, "Later", Date.now() + 21 * DAY);
+
+    // Default: upcoming only, chronological.
+    const def = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+    });
+    expect(def.events.map((e) => e.title)).toEqual(["Soon", "Later"]);
+
+    // pastLimit 1: lead with the single most-recent past plan, then upcoming.
+    const one = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+      pastLimit: 1,
+    });
+    expect(one.events.map((e) => e.title)).toEqual(["Past recent", "Soon", "Later"]);
+
+    // pastLimit beyond the available past plans includes them all (recent-first
+    // order preserved chronologically), never duplicating or erroring.
+    const many = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leader,
+      groupId: world.groupId,
+      pastLimit: 5,
+    });
+    expect(many.events.map((e) => e.title)).toEqual([
+      "Past old",
+      "Past recent",
+      "Soon",
+      "Later",
+    ]);
+  });
+
   it("pendingCount counts assignments orphaned by a removed needed role", async () => {
     const { t, world } = await setup();
     const leader = (await generateTokens(world.groupLeaderId)).accessToken;

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -48,7 +48,12 @@ export const rosterMatrix = query({
     groupId: v.id("groups"),
     /** Event-column cap; clamped to [1, MAX_EVENTS]. */
     limit: v.optional(v.number()),
-    includePast: v.optional(v.boolean()),
+    /**
+     * How many previous plans to lead the grid with (most-recent first),
+     * clamped to [0, MAX_EVENTS]. The roster shows upcoming dates by default;
+     * the grid's "Previous dates" stepper bumps this to reveal past plans.
+     */
+    pastLimit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -58,16 +63,30 @@ export const rosterMatrix = query({
       1,
       Math.min(Math.floor(args.limit ?? MAX_EVENTS), MAX_EVENTS),
     );
+    // How many previous plans (most-recent first) to lead the grid with. The
+    // roster leads with upcoming dates; the "Previous dates" stepper bumps this
+    // to reveal past plans for review/copy. The column cap below still bounds
+    // the total, so adding previous dates trims the furthest-future ones.
+    const pastCount = Math.max(
+      0,
+      Math.min(Math.floor(args.pastLimit ?? 0), MAX_EVENTS),
+    );
     const cutoff = startOfTodayMs();
-    const plans = (
+    const allPlans = (
       await ctx.db
         .query("eventPlans")
         .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
         .collect()
-    )
-      .filter((p) => args.includePast || p.eventDate >= cutoff)
-      .sort((a, b) => a.eventDate - b.eventDate)
-      .slice(0, cap);
+    ).sort((a, b) => a.eventDate - b.eventDate);
+    const upcoming = allPlans.filter((p) => p.eventDate >= cutoff);
+    const past = allPlans.filter((p) => p.eventDate < cutoff);
+    // Lead with the `pastCount` most-recent past plans (kept in chronological
+    // order), then the upcoming plans, trimmed to the column cap from the
+    // oldest-shown end.
+    const plans = [
+      ...past.slice(Math.max(0, past.length - pastCount)),
+      ...upcoming,
+    ].slice(0, cap);
 
     // --- Fan out the three per-plan reads. ---
     const perPlan = await Promise.all(

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -65,6 +65,14 @@ import { TeamChannelToggle } from "./TeamChannelToggle";
 // ---------------------------------------------------------------------------
 // Backend contract (mirrors scheduling.roster.rosterMatrix)
 // ---------------------------------------------------------------------------
+
+/**
+ * Upper bound for the "Previous dates" stepper. Mirrors the backend's
+ * MAX_EVENTS column cap so the stepper can't ask for more past columns than the
+ * grid will ever render.
+ */
+const MAX_PAST_DATES = 10;
+
 type Availability = "available" | "unavailable" | "no_response";
 type AssignmentStatus = "confirmed" | "unconfirmed" | "declined";
 
@@ -294,13 +302,14 @@ export function RosterGridScreen() {
   const MIN_CELL_W = isWide ? 150 : 76;
 
   // Past dates are normally hidden (the grid leads with upcoming). The ⋯
-  // overflow's "Include past" toggle flips this so leaders can reach and
-  // re-run past plans — replacing the old Schedule list's "Past plans" section.
-  const [includePast, setIncludePast] = useState(false);
+  // overflow's "Previous dates" stepper bumps how many past plans lead the grid
+  // so leaders can reach and re-run them — replacing the old Schedule list's
+  // "Past plans" section. 0 = upcoming only.
+  const [pastLimit, setPastLimit] = useState(0);
 
   const data = useAuthenticatedQuery(
     api.functions.scheduling.roster.rosterMatrix,
-    groupId ? { groupId, includePast } : "skip",
+    groupId ? { groupId, pastLimit } : "skip",
   ) as RosterMatrix | undefined;
 
   const assignRole = useAuthenticatedMutation(
@@ -1617,14 +1626,14 @@ export function RosterGridScreen() {
               },
             ]}
           >
-            <View style={styles.nameTextWrap}>
-              <Text style={[styles.nameText, { color: colors.text }]} numberOfLines={1}>
-                {role.roleName}
-              </Text>
-              <Text style={[styles.subCount, { color: colors.textTertiary }]}>
-                covered {coveredCount}/{events.length}
-              </Text>
-            </View>
+            <RoleNameCell
+              roleId={role.roleId}
+              roleName={role.roleName}
+              coveredCount={coveredCount}
+              total={events.length}
+              colors={colors}
+              onRename={updateRole}
+            />
           </Pressable>
         );
       })}
@@ -2241,7 +2250,7 @@ export function RosterGridScreen() {
       {overflowOpen && (
         <OverflowMenu
           colors={colors}
-          includePast={includePast}
+          pastLimit={pastLimit}
           sharingLink={sharingLink}
           onTeams={() => {
             setOverflowOpen(false);
@@ -2255,7 +2264,9 @@ export function RosterGridScreen() {
             setOverflowOpen(false);
             void handleShareLink();
           }}
-          onToggleIncludePast={() => setIncludePast((v) => !v)}
+          onChangePastLimit={(delta) =>
+            setPastLimit((n) => Math.max(0, Math.min(n + delta, MAX_PAST_DATES)))
+          }
           onClose={() => setOverflowOpen(false)}
         />
       )}
@@ -3112,26 +3123,27 @@ function PublishMenu({
 
 /**
  * ⋯ overflow menu — secondary rostering surfaces that no longer have a tab:
- * Teams, Cross-team, Collect availability, plus the "Include past" toggle that
- * flips the grid's rosterMatrix({ includePast }) arg.
+ * Teams, Cross-team, Collect availability, plus the "Previous dates" stepper
+ * that sets the grid's rosterMatrix({ pastLimit }) arg.
  */
 function OverflowMenu({
   colors,
-  includePast,
+  pastLimit,
   sharingLink,
   onTeams,
   onCrossTeam,
   onCollectAvailability,
-  onToggleIncludePast,
+  onChangePastLimit,
   onClose,
 }: {
   colors: Colors;
-  includePast: boolean;
+  pastLimit: number;
   sharingLink: boolean;
   onTeams: () => void;
   onCrossTeam: () => void;
   onCollectAvailability: () => void;
-  onToggleIncludePast: () => void;
+  /** Step the number of previous dates shown by ±1 (clamped by the caller). */
+  onChangePastLimit: (delta: number) => void;
   onClose: () => void;
 }) {
   return (
@@ -3174,22 +3186,173 @@ function OverflowMenu({
             Collect availability
           </Text>
         </Pressable>
-        <Pressable
-          onPress={onToggleIncludePast}
-          style={[styles.menuRow, { borderBottomColor: colors.border }]}
-          accessibilityRole="button"
-        >
-          <Ionicons
-            name={includePast ? "checkbox" : "square-outline"}
-            size={20}
-            color={includePast ? colors.link : colors.text}
-          />
+        <View style={[styles.menuRow, { borderBottomColor: colors.border }]}>
+          <Ionicons name="time-outline" size={20} color={colors.text} />
           <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
-            Include past dates
+            Previous dates
           </Text>
-        </Pressable>
+          <View style={styles.stepper}>
+            <TouchableOpacity
+              onPress={() => onChangePastLimit(-1)}
+              disabled={pastLimit <= 0}
+              hitSlop={8}
+              style={styles.stepperBtn}
+              accessibilityRole="button"
+              accessibilityLabel="Show fewer previous dates"
+            >
+              <Ionicons
+                name="remove"
+                size={18}
+                color={pastLimit <= 0 ? colors.textTertiary : colors.link}
+              />
+            </TouchableOpacity>
+            <Text style={[styles.stepperValue, { color: colors.text }]}>
+              {pastLimit}
+            </Text>
+            <TouchableOpacity
+              onPress={() => onChangePastLimit(1)}
+              disabled={pastLimit >= MAX_PAST_DATES}
+              hitSlop={8}
+              style={styles.stepperBtn}
+              accessibilityRole="button"
+              accessibilityLabel="Show more previous dates"
+            >
+              <Ionicons
+                name="add"
+                size={18}
+                color={pastLimit >= MAX_PAST_DATES ? colors.textTertiary : colors.link}
+              />
+            </TouchableOpacity>
+          </View>
+        </View>
       </View>
     </ModalShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Frozen-column role label
+// ---------------------------------------------------------------------------
+
+/**
+ * The frozen-column role label — tap the name to rename it inline (debounced
+ * auto-save + blur/unmount flush, mirroring the date-column header's title
+ * editor so an in-flight rename is never lost). The "covered X/Y" tally sits
+ * beneath. Long-press / right-click the row still opens the Rename · Delete
+ * menu (handled by the parent Pressable), so the menu rename stays as a
+ * fallback.
+ */
+function RoleNameCell({
+  roleId,
+  roleName,
+  coveredCount,
+  total,
+  colors,
+  onRename,
+}: {
+  roleId: Id<"teamRoles">;
+  roleName: string;
+  coveredCount: number;
+  total: number;
+  colors: Colors;
+  onRename: (args: { roleId: Id<"teamRoles">; name: string }) => Promise<unknown>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(roleName);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pending = useRef<string | null>(null);
+
+  const flush = useCallback(async () => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+    const next = pending.current;
+    pending.current = null;
+    if (next == null) return;
+    const trimmed = next.trim();
+    // Never persist an empty role name (the backend rejects it) or a no-op;
+    // snap back to the last saved value so the row keeps its label.
+    if (!trimmed || trimmed === roleName) {
+      setDraft(roleName);
+      return;
+    }
+    try {
+      await onRename({ roleId, name: trimmed });
+    } catch (e) {
+      setDraft(roleName);
+      const err = e as { data?: { message?: string }; message?: string };
+      notify("Couldn't rename role", err?.data?.message ?? err?.message ?? "Please try again.");
+    }
+  }, [roleName, roleId, onRename]);
+
+  const handleChange = useCallback(
+    (text: string) => {
+      setDraft(text);
+      pending.current = text;
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => void flush(), 600);
+    },
+    [flush],
+  );
+
+  // Keep the draft synced with upstream when we're not mid-edit (e.g. another
+  // device renamed the role).
+  useEffect(() => {
+    if (pending.current == null && !editing) setDraft(roleName);
+  }, [roleName, editing]);
+
+  // Flush any pending rename on unmount (row reorder/removal, screen swap).
+  const flushRef = useRef(flush);
+  flushRef.current = flush;
+  useEffect(() => () => void flushRef.current(), []);
+
+  return (
+    <View style={styles.nameTextWrap}>
+      {editing ? (
+        <TextInput
+          value={draft}
+          onChangeText={handleChange}
+          onBlur={() => {
+            setEditing(false);
+            void flush();
+          }}
+          onSubmitEditing={() => {
+            setEditing(false);
+            void flush();
+          }}
+          autoFocus
+          maxLength={80}
+          autoCapitalize="words"
+          autoCorrect={false}
+          returnKeyType="done"
+          placeholder="Role name"
+          placeholderTextColor={colors.textTertiary}
+          accessibilityLabel="Role name"
+          style={[
+            styles.nameText,
+            styles.nameInput,
+            { color: colors.text, borderColor: colors.inputBorder },
+          ]}
+        />
+      ) : (
+        <Pressable
+          onPress={() => {
+            setDraft(roleName);
+            setEditing(true);
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={`Rename ${roleName}`}
+        >
+          <Text style={[styles.nameText, { color: colors.text }]} numberOfLines={1}>
+            {roleName}
+          </Text>
+        </Pressable>
+      )}
+      <Text style={[styles.subCount, { color: colors.textTertiary }]}>
+        covered {coveredCount}/{total}
+      </Text>
+    </View>
   );
 }
 
@@ -3759,6 +3922,12 @@ const styles = StyleSheet.create({
   nameTextWrap: { flex: 1, minWidth: 0 },
   nameInline: { flexDirection: "row", alignItems: "center", gap: 6 },
   nameText: { fontSize: 14, fontWeight: "500", flexShrink: 1 },
+  nameInput: {
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
   leaderTag: { fontSize: 10 },
   subCount: { fontSize: 11, fontWeight: "600", marginTop: 1 },
   cell: {
@@ -3871,6 +4040,14 @@ const styles = StyleSheet.create({
   menuRowText: { flex: 1, minWidth: 0 },
   menuRowSub: { fontSize: 11, marginTop: 1 },
   menuRowCount: { fontSize: 13, fontWeight: "600" },
+  stepper: { flexDirection: "row", alignItems: "center", gap: 12 },
+  stepperBtn: { width: 28, height: 28, alignItems: "center", justifyContent: "center" },
+  stepperValue: {
+    fontSize: 15,
+    fontWeight: "600",
+    minWidth: 16,
+    textAlign: "center",
+  },
   publishBar: {
     paddingHorizontal: 16,
     paddingTop: 12,

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -317,6 +317,15 @@ export function EventPlans() {
           whether they've since confirmed, declined, or been removed — and{" "}
           <Term>Resend</Term> from there too.
         </P>
+
+        <P>
+          Tap a role's name in the left column to rename it right there in the
+          grid — the edit saves on its own, no menu or separate screen. The grid
+          leads with upcoming plans, but the <Term>⋯</Term> menu's{" "}
+          <Term>Previous dates</Term> stepper brings past plans back in as extra
+          columns on the left, so you can review or copy how a role was staffed
+          on earlier weeks.
+        </P>
       </Section>
 
       <Section id="crossteam" title="Cross-team channels">


### PR DESCRIPTION
## What & why

Two leader-facing improvements to the **roster grid** (`RosterGridScreen`), from the rostering view request:

### 1. Inline role-name editing
Tap a role's name in the frozen left column to rename it **right there in the grid** — no menu, no separate screen. The edit auto-saves with the same debounce + blur/unmount flush discipline the date-column header title editor uses, so an in-flight rename is never lost. Reuses the existing `scheduling.roles.updateRole` mutation. Long-press / right-click still opens the **Rename · Delete** menu, so the menu rename remains as a fallback.

### 2. Adjustable previous-event-plan visibility
The grid leads with upcoming plans. The `⋯` overflow menu's old binary **"Include past dates"** toggle becomes a **−  N  +** stepper that controls how many *previous* event plans appear as extra columns on the left. Bumping it lets a leader review or copy how a role was staffed on earlier weeks.

## How

- **Backend** (`scheduling/roster.ts`): replaced `rosterMatrix`'s `includePast: boolean` arg with `pastLimit: number` (most-recent-first, clamped `[0, MAX_EVENTS]`). The window now leads with the `pastLimit` most-recent past plans (kept chronological) followed by upcoming plans, trimmed to the existing column cap — so adding previous dates trims the furthest-future ones rather than uncapping the grid. `includePast` had no other callers (`AssignmentDetailScreen` uses a different query).
- **Mobile** (`RosterGridScreen.tsx`): new `RoleNameCell` inline editor; `includePast` state → `pastLimit` state; `OverflowMenu` toggle → stepper (clamped to `MAX_PAST_DATES`).
- **Docs**: updated the roster-grid section of the `EventPlans` onboarding guide to describe both behaviors.

## Tests

- Added `rosterMatrix` windowing tests (default upcoming-only, `pastLimit: 1` leads with the most-recent past plan, over-large `pastLimit` includes all past without duplicating/erroring).
- `apps/convex` scheduling suite: 251 passing. `apps/mobile` suite: 1137 passing (pre-push hook). Convex + mobile typecheck clean for the changed files; lint clean.

## Screens affected

Leader **Roster grid** → frozen role column (tap to rename) and the `⋯` overflow menu (Previous dates stepper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjYZ3t4XzWrANic7BQLdu1)_