### PR TITLE
feat(bots): add Followup Bot for auto-assigning new members to leaders

### DIFF
--- a/apps/convex/__tests__/followup-bot.test.ts
+++ b/apps/convex/__tests__/followup-bot.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { convexTest } from "convex-test";
-import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import { expect, test, describe } from "vitest";
 import schema from "../schema";
 import { api, internal } from "../_generated/api";
 import { modules } from "../test.setup";
@@ -29,9 +29,12 @@ import type { Id } from "../_generated/dataModel";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
-// Scheduled functions triggered by message inserts (mentions, etc.) can reject
-// in the test environment because external APIs aren't available. Swallow those
-// expected rejections so they don't fail unrelated assertions.
+// Posting a bot message schedules downstream jobs (mention notifications) that
+// drain asynchronously, after the triggering action has resolved. In the
+// convex-test sandbox these reject with "Write outside of transaction" once the
+// test's transaction context is gone. They're a harness artifact, not a product
+// bug, and can fire between/after tests — so the handler stays attached for the
+// whole file rather than per-test. Unexpected rejections still propagate.
 const unhandledRejectionHandler = (reason: unknown) => {
   const errorMessage = String(reason);
   if (
@@ -42,16 +45,9 @@ const unhandledRejectionHandler = (reason: unknown) => {
   }
   throw reason;
 };
+process.on("unhandledRejection", unhandledRejectionHandler);
 
 describe("Followup Bot", () => {
-  beforeEach(() => {
-    process.on("unhandledRejection", unhandledRejectionHandler);
-  });
-
-  afterEach(() => {
-    process.off("unhandledRejection", unhandledRejectionHandler);
-  });
-
   describe("Bot Definition", () => {
     test("is registered as an event bot with a round-robin default", async () => {
       const t = convexTest(schema, modules);
@@ -87,35 +83,78 @@ describe("Followup Bot", () => {
     });
   });
 
-  describe("Config lookup", () => {
-    test("returns the config when enabled", async () => {
+  describe("Assignment preparation (atomic resolve + advance)", () => {
+    test("resolves an assignment when enabled", async () => {
       const t = convexTest(schema, modules);
-      const { groupId, communityName, groupName } = await seedFollowupGroup(t, {
-        enabled: true,
-      });
+      const { groupId, leaderAId, leaderBId, groupName } =
+        await seedFollowupGroup(t, {
+          enabled: true,
+          assignmentMode: "round_robin",
+        });
 
-      const config = await t.query(
-        internal.functions.scheduledJobs.getFollowupBotConfig,
-        { groupId },
+      const newMember = await addUser(t, "Casey", "+15555550100");
+      const result = await t.mutation(
+        internal.functions.scheduledJobs.prepareFollowupAssignment,
+        { groupId, userId: newMember },
       );
 
-      expect(config).not.toBeNull();
-      expect(config?.enabled).toBe(true);
-      expect(config?.groupName).toBe(groupName);
-      expect(config?.communityName).toBe(communityName);
-      expect(config?.assignmentMode).toBe("round_robin");
+      expect(result.skipped).toBe(false);
+      if (!result.skipped) {
+        expect([leaderAId, leaderBId]).toContain(result.assignedLeaderId);
+        expect(result.targetChannelSlug).toBe("leaders");
+        expect(result.message).toContain(groupName);
+      }
     });
 
-    test("returns null when disabled", async () => {
+    test("skips when disabled", async () => {
       const t = convexTest(schema, modules);
       const { groupId } = await seedFollowupGroup(t, { enabled: false });
 
-      const config = await t.query(
-        internal.functions.scheduledJobs.getFollowupBotConfig,
-        { groupId },
+      const newMember = await addUser(t, "Casey", "+15555550101");
+      const result = await t.mutation(
+        internal.functions.scheduledJobs.prepareFollowupAssignment,
+        { groupId, userId: newMember },
       );
 
-      expect(config).toBeNull();
+      expect(result).toMatchObject({
+        skipped: true,
+        reason: "bot_not_enabled",
+      });
+    });
+
+    test("inserts \"$\" sequences in names literally (no replace-pattern bug)", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId, leaderAId } = await seedFollowupGroup(t, {
+        enabled: true,
+        assignmentMode: "specific_leader",
+        specificLeaderId: "A",
+        message: "Hi [[leader_name]], welcome [[member_name]]",
+      });
+
+      // A member whose name contains "$&" — a special String.replace pattern.
+      const trickyMember = await t.run(async (ctx) => {
+        return await ctx.db.insert("users", {
+          firstName: "$&Dollar",
+          lastName: "$1Name",
+          phone: "+15555550102",
+          phoneVerified: true,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+      });
+
+      const result = await t.mutation(
+        internal.functions.scheduledJobs.prepareFollowupAssignment,
+        { groupId, userId: trickyMember },
+      );
+
+      expect(result.skipped).toBe(false);
+      if (!result.skipped) {
+        expect(result.assignedLeaderId).toBe(leaderAId);
+        expect(result.message).toBe(
+          "Hi Alice Leader, welcome $&Dollar $1Name",
+        );
+      }
     });
   });
 

--- a/apps/convex/__tests__/followup-bot.test.ts
+++ b/apps/convex/__tests__/followup-bot.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Followup Bot Tests
+ *
+ * Tests for the Followup Bot, which assigns a leader to follow up with each
+ * new member when they join a group. The assigned leader is chosen by the
+ * configured strategy — a single specific leader, or round-robin across the
+ * group's active leaders — and is notified via an @mention in the target
+ * channel (defaults to the Leaders channel).
+ *
+ * The followup bot:
+ * - Is event-triggered when a NEW member joins a group (mirrors Welcome Bot)
+ * - Is configured per-group via the groupBotConfigs table (botType "followup")
+ * - Uses placeholders [[leader_name]], [[member_name]], [[group_name]],
+ *   [[community_name]]
+ * - Rotates leaders in round-robin mode, advancing a saved pointer each time
+ * - Always assigns to the configured leader in specific-leader mode
+ * - Never assigns a newly-joined leader to follow up with themselves
+ * - Does nothing when disabled or when the group has no other leaders
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/followup-bot.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// Scheduled functions triggered by message inserts (mentions, etc.) can reject
+// in the test environment because external APIs aren't available. Swallow those
+// expected rejections so they don't fail unrelated assertions.
+const unhandledRejectionHandler = (reason: unknown) => {
+  const errorMessage = String(reason);
+  if (
+    errorMessage.includes("Write outside of transaction") ||
+    errorMessage.includes("_scheduled_functions")
+  ) {
+    return;
+  }
+  throw reason;
+};
+
+describe("Followup Bot", () => {
+  beforeEach(() => {
+    process.on("unhandledRejection", unhandledRejectionHandler);
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", unhandledRejectionHandler);
+  });
+
+  describe("Bot Definition", () => {
+    test("is registered as an event bot with a round-robin default", async () => {
+      const t = convexTest(schema, modules);
+
+      const bots = await t.query(api.functions.groupBots.listAvailable, {});
+      const followup = bots.find((bot) => bot.id === "followup");
+
+      expect(followup).toBeDefined();
+      expect(followup?.name).toBe("Followup Bot");
+      expect(followup?.triggerType).toBe("event");
+
+      const assignmentField = followup?.configFields?.find(
+        (field) => field.key === "assignmentMode",
+      );
+      const roundRobinOption = assignmentField?.options?.find(
+        (option) => option.value === "round_robin",
+      );
+      expect(roundRobinOption?.label).toBe("Rotate leaders");
+    });
+
+    test("exposes default config via getConfig", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId } = await seedFollowupGroup(t, { enabled: false });
+
+      const config = await t.query(api.functions.groupBots.getConfig, {
+        groupId,
+        botId: "followup",
+      });
+
+      expect(config.defaultConfig.assignmentMode).toBe("round_robin");
+      expect(config.defaultConfig.targetChannelSlug).toBe("leaders");
+      expect(config.defaultConfig.message).toContain("[[member_name]]");
+    });
+  });
+
+  describe("Config lookup", () => {
+    test("returns the config when enabled", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId, communityName, groupName } = await seedFollowupGroup(t, {
+        enabled: true,
+      });
+
+      const config = await t.query(
+        internal.functions.scheduledJobs.getFollowupBotConfig,
+        { groupId },
+      );
+
+      expect(config).not.toBeNull();
+      expect(config?.enabled).toBe(true);
+      expect(config?.groupName).toBe(groupName);
+      expect(config?.communityName).toBe(communityName);
+      expect(config?.assignmentMode).toBe("round_robin");
+    });
+
+    test("returns null when disabled", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId } = await seedFollowupGroup(t, { enabled: false });
+
+      const config = await t.query(
+        internal.functions.scheduledJobs.getFollowupBotConfig,
+        { groupId },
+      );
+
+      expect(config).toBeNull();
+    });
+  });
+
+  describe("Assignment", () => {
+    test("round-robin rotates leaders and advances the pointer", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId, configId, leaderAId, leaderBId } =
+        await seedFollowupGroup(t, {
+          enabled: true,
+          assignmentMode: "round_robin",
+        });
+
+      // First new member → first leader in rotation.
+      const newMember1 = await addUser(t, "First", "+15555551001");
+      const result1 = await t.action(
+        internal.functions.scheduledJobs.assignNewMemberFollowup,
+        { groupId, userId: newMember1 },
+      );
+      expect(result1).toMatchObject({ success: true });
+
+      const messages1 = await getChannelMessages(t, groupId);
+      expect(messages1).toHaveLength(1);
+      expect(messages1[0].senderName).toBe("Followup Bot 🤝");
+      expect(messages1[0].contentType).toBe("bot");
+      const firstAssignee = messages1[0].mentionedUserIds?.[0];
+      expect([leaderAId, leaderBId]).toContain(firstAssignee);
+
+      // Second new member → the *other* leader (rotation advanced).
+      const newMember2 = await addUser(t, "Second", "+15555551002");
+      await t.action(
+        internal.functions.scheduledJobs.assignNewMemberFollowup,
+        { groupId, userId: newMember2 },
+      );
+
+      const messages2 = await getChannelMessages(t, groupId);
+      expect(messages2).toHaveLength(2);
+      const secondAssignee = messages2[1].mentionedUserIds?.[0];
+      expect(secondAssignee).not.toBe(firstAssignee);
+      expect([leaderAId, leaderBId]).toContain(secondAssignee);
+
+      // The saved pointer advanced to a valid index.
+      const state = await t.run(async (ctx) => {
+        const config = await ctx.db.get(configId);
+        return config?.state as { lastLeaderIndex?: number };
+      });
+      expect(typeof state.lastLeaderIndex).toBe("number");
+    });
+
+    test("specific-leader mode always assigns the chosen leader", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId, leaderBId } = await seedFollowupGroup(t, {
+        enabled: true,
+        assignmentMode: "specific_leader",
+        specificLeaderId: "B",
+      });
+
+      const newMember1 = await addUser(t, "First", "+15555552001");
+      const newMember2 = await addUser(t, "Second", "+15555552002");
+      await t.action(internal.functions.scheduledJobs.assignNewMemberFollowup, {
+        groupId,
+        userId: newMember1,
+      });
+      await t.action(internal.functions.scheduledJobs.assignNewMemberFollowup, {
+        groupId,
+        userId: newMember2,
+      });
+
+      const messages = await getChannelMessages(t, groupId);
+      expect(messages).toHaveLength(2);
+      expect(messages[0].mentionedUserIds?.[0]).toBe(leaderBId);
+      expect(messages[1].mentionedUserIds?.[0]).toBe(leaderBId);
+    });
+
+    test("replaces placeholders in the assignment message", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId, groupName } = await seedFollowupGroup(t, {
+        enabled: true,
+        assignmentMode: "specific_leader",
+        specificLeaderId: "A",
+        message:
+          "Hi [[leader_name]], welcome [[member_name]] to [[group_name]] ([[community_name]])",
+      });
+
+      const newMember = await addUser(t, "Jordan", "+15555553001");
+      await t.action(internal.functions.scheduledJobs.assignNewMemberFollowup, {
+        groupId,
+        userId: newMember,
+      });
+
+      const messages = await getChannelMessages(t, groupId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toContain("Hi Alice Leader");
+      expect(messages[0].content).toContain("welcome Jordan Member to " + groupName);
+      expect(messages[0].content).toContain("(Test Community)");
+      expect(messages[0].content).not.toContain("[[");
+    });
+
+    test("skips silently when the bot is disabled", async () => {
+      const t = convexTest(schema, modules);
+      const { groupId } = await seedFollowupGroup(t, { enabled: false });
+
+      const newMember = await addUser(t, "Nobody", "+15555554001");
+      const result = await t.action(
+        internal.functions.scheduledJobs.assignNewMemberFollowup,
+        { groupId, userId: newMember },
+      );
+
+      expect(result).toMatchObject({ skipped: true, reason: "bot_not_enabled" });
+      expect(await getChannelMessages(t, groupId)).toHaveLength(0);
+    });
+
+    test("never assigns a newly-joined leader to follow up with themselves", async () => {
+      const t = convexTest(schema, modules);
+      // Group whose only leader is the person who just joined.
+      const { groupId, soleLeaderId } = await seedSingleLeaderGroup(t);
+
+      const result = await t.action(
+        internal.functions.scheduledJobs.assignNewMemberFollowup,
+        { groupId, userId: soleLeaderId },
+      );
+
+      expect(result).toMatchObject({ skipped: true, reason: "no_leaders" });
+      expect(await getChannelMessages(t, groupId)).toHaveLength(0);
+    });
+  });
+});
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+async function addUser(
+  t: ReturnType<typeof convexTest>,
+  firstName: string,
+  phone: string,
+): Promise<Id<"users">> {
+  return await t.run(async (ctx) => {
+    return await ctx.db.insert("users", {
+      firstName,
+      lastName: "Member",
+      phone,
+      phoneVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+type SeedOptions = {
+  enabled: boolean;
+  assignmentMode?: string;
+  /** "A" or "B" — which seeded leader to pin in specific-leader mode. */
+  specificLeaderId?: "A" | "B";
+  message?: string;
+};
+
+async function seedFollowupGroup(
+  t: ReturnType<typeof convexTest>,
+  opts: SeedOptions,
+): Promise<{
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  configId: Id<"groupBotConfigs">;
+  leaderAId: Id<"users">;
+  leaderBId: Id<"users">;
+  groupName: string;
+  communityName: string;
+}> {
+  const communityName = "Test Community";
+  const groupName = "Test Followup Group";
+
+  const communityId = await t.run(async (ctx) => {
+    return await ctx.db.insert("communities", {
+      name: communityName,
+      subdomain: "test-followup",
+      slug: "test-followup",
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const groupTypeId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Test Group Type",
+      slug: "test-group-type",
+      isActive: true,
+      displayOrder: 1,
+      createdAt: Date.now(),
+    });
+  });
+
+  const leaderAId = await t.run(async (ctx) => {
+    return await ctx.db.insert("users", {
+      firstName: "Alice",
+      lastName: "Leader",
+      phone: "+15555550001",
+      phoneVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const leaderBId = await t.run(async (ctx) => {
+    return await ctx.db.insert("users", {
+      firstName: "Bob",
+      lastName: "Leader",
+      phone: "+15555550002",
+      phoneVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const groupId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groups", {
+      name: groupName,
+      communityId,
+      groupTypeId,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  await t.run(async (ctx) => {
+    for (const userId of [leaderAId, leaderBId]) {
+      await ctx.db.insert("groupMembers", {
+        userId,
+        groupId,
+        role: "leader",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    }
+  });
+
+  // Leaders channel so the bot message has somewhere to post.
+  await t.run(async (ctx) => {
+    await ctx.db.insert("chatChannels", {
+      groupId,
+      communityId,
+      slug: "leaders",
+      channelType: "leaders",
+      name: "Leaders",
+      createdById: leaderAId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isArchived: false,
+      isEnabled: true,
+      memberCount: 2,
+    });
+  });
+
+  const specificLeaderId =
+    opts.specificLeaderId === "A"
+      ? leaderAId
+      : opts.specificLeaderId === "B"
+        ? leaderBId
+        : undefined;
+
+  const configId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groupBotConfigs", {
+      groupId,
+      botType: "followup",
+      enabled: opts.enabled,
+      config: {
+        message:
+          opts.message ??
+          "🤝 Hey [[leader_name]], please follow up with [[member_name]] who just joined [[group_name]]!",
+        assignmentMode: opts.assignmentMode ?? "round_robin",
+        ...(specificLeaderId ? { specificLeaderId } : {}),
+        targetChannelSlug: "leaders",
+      },
+      state: {},
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  return {
+    communityId,
+    groupId,
+    configId,
+    leaderAId,
+    leaderBId,
+    groupName,
+    communityName,
+  };
+}
+
+/** A group whose only leader is the user we'll pass as the new member. */
+async function seedSingleLeaderGroup(
+  t: ReturnType<typeof convexTest>,
+): Promise<{ groupId: Id<"groups">; soleLeaderId: Id<"users"> }> {
+  const communityId = await t.run(async (ctx) => {
+    return await ctx.db.insert("communities", {
+      name: "Solo Community",
+      subdomain: "solo-followup",
+      slug: "solo-followup",
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const groupTypeId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Solo Group Type",
+      slug: "solo-group-type",
+      isActive: true,
+      displayOrder: 1,
+      createdAt: Date.now(),
+    });
+  });
+
+  const soleLeaderId = await t.run(async (ctx) => {
+    return await ctx.db.insert("users", {
+      firstName: "Solo",
+      lastName: "Leader",
+      phone: "+15555559001",
+      phoneVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const groupId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groups", {
+      name: "Solo Group",
+      communityId,
+      groupTypeId,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  await t.run(async (ctx) => {
+    await ctx.db.insert("groupMembers", {
+      userId: soleLeaderId,
+      groupId,
+      role: "leader",
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupBotConfigs", {
+      groupId,
+      botType: "followup",
+      enabled: true,
+      config: { assignmentMode: "round_robin", targetChannelSlug: "leaders" },
+      state: {},
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  return { groupId, soleLeaderId };
+}
+
+async function getChannelMessages(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+): Promise<
+  Array<{
+    content: string;
+    senderName?: string;
+    contentType?: string;
+    mentionedUserIds?: Id<"users">[];
+    createdAt: number;
+  }>
+> {
+  return await t.run(async (ctx) => {
+    const channels = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_group", (q) => q.eq("groupId", groupId))
+      .collect();
+    const channelIds = new Set(channels.map((c) => c._id));
+    const allMessages = await ctx.db.query("chatMessages").collect();
+    return allMessages
+      .filter((m) => channelIds.has(m.channelId))
+      .sort((a, b) => a.createdAt - b.createdAt)
+      .map((m) => ({
+        content: m.content,
+        senderName: m.senderName,
+        contentType: m.contentType,
+        mentionedUserIds: m.mentionedUserIds,
+        createdAt: m.createdAt,
+      }));
+  });
+}

--- a/apps/convex/functions/admin/requests.ts
+++ b/apps/convex/functions/admin/requests.ts
@@ -256,11 +256,19 @@ export const reviewPendingRequest = mutation({
       // joinedAt is preserved, so joinedAt !== requestedAt indicates a returning member.
       const isReturningMember = request.joinedAt !== request.requestedAt;
 
-      // Only trigger welcome bot for NEW members, not returning members (non-blocking)
+      // Only trigger welcome + followup bots for NEW members, not returning members (non-blocking)
       if (!isReturningMember) {
         await ctx.scheduler.runAfter(
           0,
           internal.functions.scheduledJobs.sendWelcomeMessage,
+          {
+            groupId: request.groupId,
+            userId: request.userId,
+          }
+        );
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.scheduledJobs.assignNewMemberFollowup,
           {
             groupId: request.groupId,
             userId: request.userId,

--- a/apps/convex/functions/groupBots.ts
+++ b/apps/convex/functions/groupBots.ts
@@ -137,6 +137,54 @@ const botDefinitions: Record<string, BotDefinition> = {
       },
     ],
   },
+  followup: {
+    id: "followup",
+    name: "Followup Bot",
+    description: "Assigns a leader to follow up with each new member",
+    icon: "🤝",
+    triggerType: "event",
+    defaultConfig: {
+      message:
+        "🤝 Hey [[leader_name]], please follow up with [[member_name]] who just joined [[group_name]]!",
+      assignmentMode: "round_robin",
+      targetChannelSlug: "leaders",
+    },
+    configFields: [
+      {
+        key: "message",
+        label: "Followup Message",
+        type: "textarea",
+        placeholder:
+          "🤝 Hey [[leader_name]], please follow up with [[member_name]] who just joined [[group_name]]!",
+        helpText:
+          "Available placeholders: [[leader_name]], [[member_name]], [[group_name]], [[community_name]]",
+      },
+      {
+        key: "assignmentMode",
+        label: "Leader Assignment",
+        type: "select",
+        options: [
+          { value: "round_robin", label: "Rotate leaders" },
+          { value: "specific_leader", label: "Specific leader" },
+        ],
+        helpText: "How to choose which leader follows up with new members",
+      },
+      {
+        key: "specificLeaderId",
+        label: "Select Leader",
+        type: "leader_select",
+        helpText: "Choose which leader should follow up with new members",
+        showWhen: { field: "assignmentMode", value: "specific_leader" },
+      },
+      {
+        key: "targetChannelSlug",
+        label: "Target Channel",
+        type: "channel_select",
+        helpText:
+          "Select which channel the assignment is posted to. Defaults to Leaders if not set.",
+      },
+    ],
+  },
   "task-reminder": {
     id: "task-reminder",
     name: "Task Reminder Bot",

--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -555,11 +555,19 @@ export const add = mutation({
       notificationsEnabled: true,
     });
 
-    // Trigger welcome bot for NEW members only (non-blocking)
+    // Trigger welcome + followup bots for NEW members only (non-blocking)
     // Returning members are handled in the if-block above (they don't reach this code)
     await ctx.scheduler.runAfter(
       0,
       internal.functions.scheduledJobs.sendWelcomeMessage,
+      {
+        groupId: args.groupId,
+        userId: args.userId,
+      }
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduledJobs.assignNewMemberFollowup,
       {
         groupId: args.groupId,
         userId: args.userId,
@@ -1162,6 +1170,11 @@ export const addByPcoPersonId = mutation({
     await ctx.scheduler.runAfter(
       0,
       internal.functions.scheduledJobs.sendWelcomeMessage,
+      { groupId: args.groupId, userId }
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduledJobs.assignNewMemberFollowup,
       { groupId: args.groupId, userId }
     );
 

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -3439,10 +3439,18 @@ export const addChannelMembers = mutation({
               notificationsEnabled: true,
             });
 
-            // Trigger welcome message for NEW group members only
+            // Trigger welcome + followup bots for NEW group members only
             await ctx.scheduler.runAfter(
               0,
               internal.functions.scheduledJobs.sendWelcomeMessage,
+              {
+                groupId,
+                userId,
+              }
+            );
+            await ctx.scheduler.runAfter(
+              0,
+              internal.functions.scheduledJobs.assignNewMemberFollowup,
               {
                 groupId,
                 userId,

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -2221,13 +2221,36 @@ export const getUserById = internalQuery({
 // ============================================================================
 
 /**
- * Get the followup bot config for a group, or null when it is missing or
- * disabled. Mirrors getWelcomeBotConfig but also surfaces the assignment
- * strategy and the round-robin pointer from the config's saved state.
+ * Resolve (and persist) the followup assignment for a newly-joined member,
+ * atomically.
+ *
+ * This runs as a single mutation so the read of the round-robin pointer and
+ * the write that advances it happen in one transaction. The bot is
+ * event-triggered, so two members can join almost simultaneously (or a batch
+ * add can schedule many assignments at once); resolving-and-advancing here
+ * lets Convex's serializable mutations rotate leaders correctly instead of
+ * racing on a pointer read/write split across separate transactions.
+ *
+ * Returns a skip reason, or the resolved assignment (message + target channel +
+ * the leader to mention) for the calling action to deliver.
  */
-export const getFollowupBotConfig = internalQuery({
-  args: { groupId: v.id("groups") },
-  handler: async (ctx, { groupId }) => {
+export const prepareFollowupAssignment = internalMutation({
+  args: {
+    groupId: v.id("groups"),
+    userId: v.id("users"),
+  },
+  handler: async (
+    ctx,
+    { groupId, userId },
+  ): Promise<
+    | { skipped: true; reason: string }
+    | {
+        skipped: false;
+        assignedLeaderId: Id<"users">;
+        targetChannelSlug: string;
+        message: string;
+      }
+  > => {
     const config = await ctx.db
       .query("groupBotConfigs")
       .withIndex("by_group_botType", (q) =>
@@ -2236,34 +2259,116 @@ export const getFollowupBotConfig = internalQuery({
       .first();
 
     if (!config || !config.enabled) {
-      return null;
+      return { skipped: true, reason: "bot_not_enabled" };
     }
 
     const group = await ctx.db.get(groupId);
-    if (!group) return null;
+    if (!group) return { skipped: true, reason: "group_not_found" };
+
+    const member = await ctx.db.get(userId);
+    if (!member) return { skipped: true, reason: "member_not_found" };
 
     const community = await ctx.db.get(group.communityId);
 
+    // Active leaders for the group, excluding the new member so a leader who
+    // joins is never assigned to follow up with themselves.
+    const leaderMemberships = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", groupId))
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("leftAt"), undefined),
+          q.eq(q.field("role"), "leader"),
+        ),
+      )
+      .take(100);
+
+    const resolvedLeaders = await Promise.all(
+      leaderMemberships
+        .filter((m) => m.userId !== userId)
+        .map(async (m) => {
+          const user = await ctx.db.get(m.userId);
+          if (!user) return null;
+          const displayName =
+            [user.firstName, user.lastName].filter(Boolean).join(" ") ||
+            "leader";
+          return { userId: m.userId, displayName };
+        }),
+    );
+    const leaders = resolvedLeaders.filter(
+      (leader): leader is BirthdayReminderLeader => leader !== null,
+    );
+
+    if (leaders.length === 0) {
+      return { skipped: true, reason: "no_leaders" };
+    }
+
     const configData = (config.config as Record<string, unknown>) || {};
     const state = (config.state as Record<string, unknown>) || {};
+    const assignmentMode =
+      (configData.assignmentMode as string) || "round_robin";
+    const specificLeaderId =
+      (configData.specificLeaderId as Id<"users"> | undefined) || undefined;
+    const lastLeaderIndex =
+      typeof state.lastLeaderIndex === "number"
+        ? (state.lastLeaderIndex as number)
+        : undefined;
+
+    // Reuse the shared resolver: specific leader when configured & present,
+    // else round-robin from the saved pointer.
+    const assignedLeader = resolveBirthdayReminderLeader({
+      leaders,
+      assignmentMode,
+      specificLeaderId,
+      lastLeaderIndex,
+    });
+
+    if (!assignedLeader) {
+      return { skipped: true, reason: "no_leader_resolved" };
+    }
+
+    // Advance the pointer whenever the assignment came from round-robin — i.e.
+    // unless we actually pinned the configured specific leader. This also keeps
+    // the rotation moving when a specific leader is no longer an active leader
+    // and the resolver falls back to round-robin.
+    const usedSpecificLeader =
+      assignmentMode === "specific_leader" &&
+      !!specificLeaderId &&
+      assignedLeader.userId === specificLeaderId;
+
+    if (!usedSpecificLeader) {
+      const assignedIndex = leaders.findIndex(
+        (leader) => leader.userId === assignedLeader.userId,
+      );
+      await ctx.db.patch(config._id, {
+        state: { ...state, lastLeaderIndex: assignedIndex },
+        updatedAt: now(),
+      });
+    }
+
+    const messageTemplate =
+      (configData.message as string) ||
+      "🤝 Hey [[leader_name]], please follow up with [[member_name]] who just joined [[group_name]]!";
+    const memberName =
+      [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+      member.firstName ||
+      "a new member";
+    const communityName = community?.name || "Community";
+
+    // Use replacer functions so "$" sequences in the substituted values
+    // (names, group, community) are inserted literally — String.replace treats
+    // "$&", "$1", … in a string replacement specially.
+    const message = messageTemplate
+      .replace(/\[\[leader_name\]\]/g, () => assignedLeader.displayName)
+      .replace(/\[\[member_name\]\]/g, () => memberName)
+      .replace(/\[\[group_name\]\]/g, () => group.name)
+      .replace(/\[\[community_name\]\]/g, () => communityName);
 
     return {
-      configId: config._id,
-      groupId,
-      enabled: config.enabled,
-      groupName: group.name,
-      communityName: community?.name || "Community",
-      message:
-        (configData.message as string) ||
-        "🤝 Hey [[leader_name]], please follow up with [[member_name]] who just joined [[group_name]]!",
-      assignmentMode: (configData.assignmentMode as string) || "round_robin",
-      specificLeaderId:
-        (configData.specificLeaderId as Id<"users"> | undefined) || undefined,
-      targetChannelSlug: (configData.targetChannelSlug as string) || undefined,
-      lastLeaderIndex:
-        typeof state.lastLeaderIndex === "number"
-          ? (state.lastLeaderIndex as number)
-          : undefined,
+      skipped: false,
+      assignedLeaderId: assignedLeader.userId,
+      targetChannelSlug: (configData.targetChannelSlug as string) || "leaders",
+      message,
     };
   },
 });
@@ -2272,10 +2377,10 @@ export const getFollowupBotConfig = internalQuery({
  * Assign a leader to follow up with a newly-joined member.
  *
  * Called by the scheduler when a new member joins a group (event-triggered,
- * mirrors the Welcome Bot). The assigned leader is chosen by the configured
- * strategy — a single specific leader, or round-robin across the group's
- * active leaders — and is notified via an @mention in the target channel,
- * which fans out to push/email like any other mention.
+ * mirrors the Welcome Bot). The leader is resolved — and the round-robin
+ * pointer advanced — atomically by prepareFollowupAssignment; this action then
+ * notifies the assigned leader via an @mention in the target channel, which
+ * fans out to push/email like any other mention.
  */
 export const assignNewMemberFollowup = internalAction({
   args: {
@@ -2290,92 +2395,32 @@ export const assignNewMemberFollowup = internalAction({
     | { success: true; assignedLeaderId: Id<"users">; message: string }
     | { success: false; error: string }
   > => {
-    const config = await ctx.runQuery(
-      internal.functions.scheduledJobs.getFollowupBotConfig,
-      { groupId },
+    const assignment = await ctx.runMutation(
+      internal.functions.scheduledJobs.prepareFollowupAssignment,
+      { groupId, userId },
     );
 
-    if (!config) {
-      return { skipped: true, reason: "bot_not_enabled" };
+    if (assignment.skipped) {
+      return { skipped: true, reason: assignment.reason };
     }
-
-    const member = await ctx.runQuery(
-      internal.functions.scheduledJobs.getUserById,
-      { userId },
-    );
-
-    if (!member) {
-      return { skipped: true, reason: "member_not_found" };
-    }
-
-    // Reuse the shared active-leaders query. Exclude the new member so a
-    // leader who joins is never assigned to follow up with themselves.
-    const allLeaders = await ctx.runQuery(
-      internal.functions.scheduledJobs.getBirthdayBotLeaders,
-      { groupId },
-    );
-    const leaders = allLeaders.filter((leader) => leader.userId !== userId);
-
-    if (leaders.length === 0) {
-      return { skipped: true, reason: "no_leaders" };
-    }
-
-    // Reuse the shared resolver: specific leader when configured, else
-    // round-robin from the saved pointer.
-    const assignedLeader = resolveBirthdayReminderLeader({
-      leaders,
-      assignmentMode: config.assignmentMode,
-      specificLeaderId: config.specificLeaderId,
-      lastLeaderIndex: config.lastLeaderIndex,
-    });
-
-    if (!assignedLeader) {
-      return { skipped: true, reason: "no_leader_resolved" };
-    }
-
-    const memberName =
-      [member.firstName, member.lastName].filter(Boolean).join(" ") ||
-      member.firstName ||
-      "a new member";
-
-    const message = config.message
-      .replace(/\[\[leader_name\]\]/g, assignedLeader.displayName)
-      .replace(/\[\[member_name\]\]/g, memberName)
-      .replace(/\[\[group_name\]\]/g, config.groupName)
-      .replace(/\[\[community_name\]\]/g, config.communityName);
 
     try {
       await ctx.runAction(internal.functions.scheduledJobs.sendBotMessage, {
         groupId,
-        message,
-        targetChannelSlug: config.targetChannelSlug || "leaders",
+        message: assignment.message,
+        targetChannelSlug: assignment.targetChannelSlug,
         botType: "followup",
-        mentionedUserIds: [assignedLeader.userId],
+        mentionedUserIds: [assignment.assignedLeaderId],
       });
     } catch (error) {
       console.error(`[FollowupBot] Error sending assignment:`, error);
       return { success: false, error: String(error) };
     }
 
-    // Advance the round-robin pointer only when rotating leaders, so the next
-    // new member is assigned to the following leader. We store the index of the
-    // leader we actually picked; specific-leader mode keeps a fixed assignee.
-    if (config.assignmentMode !== "specific_leader") {
-      const assignedIndex = leaders.findIndex(
-        (leader) => leader.userId === assignedLeader.userId,
-      );
-      if (assignedIndex !== -1) {
-        await ctx.runMutation(internal.functions.scheduledJobs.updateBotState, {
-          configId: config.configId,
-          stateUpdates: { lastLeaderIndex: assignedIndex },
-        });
-      }
-    }
-
     return {
       success: true,
-      assignedLeaderId: assignedLeader.userId,
-      message,
+      assignedLeaderId: assignment.assignedLeaderId,
+      message: assignment.message,
     };
   },
 });

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -1759,6 +1759,7 @@ export const insertBotMessage = internalMutation({
     const botNames: Record<string, string> = {
       birthday: "Birthday Bot 🎂",
       welcome: "Welcome Bot 👋",
+      followup: "Followup Bot 🤝",
       task_reminder: "Task Reminder 📋",
       communication: "Communication Bot 💬",
       dev_assistant: "Togather Bot 🤖",
@@ -2212,6 +2213,170 @@ export const getUserById = internalQuery({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
     return await ctx.db.get(userId);
+  },
+});
+
+// ============================================================================
+// FOLLOWUP BOT
+// ============================================================================
+
+/**
+ * Get the followup bot config for a group, or null when it is missing or
+ * disabled. Mirrors getWelcomeBotConfig but also surfaces the assignment
+ * strategy and the round-robin pointer from the config's saved state.
+ */
+export const getFollowupBotConfig = internalQuery({
+  args: { groupId: v.id("groups") },
+  handler: async (ctx, { groupId }) => {
+    const config = await ctx.db
+      .query("groupBotConfigs")
+      .withIndex("by_group_botType", (q) =>
+        q.eq("groupId", groupId).eq("botType", "followup"),
+      )
+      .first();
+
+    if (!config || !config.enabled) {
+      return null;
+    }
+
+    const group = await ctx.db.get(groupId);
+    if (!group) return null;
+
+    const community = await ctx.db.get(group.communityId);
+
+    const configData = (config.config as Record<string, unknown>) || {};
+    const state = (config.state as Record<string, unknown>) || {};
+
+    return {
+      configId: config._id,
+      groupId,
+      enabled: config.enabled,
+      groupName: group.name,
+      communityName: community?.name || "Community",
+      message:
+        (configData.message as string) ||
+        "🤝 Hey [[leader_name]], please follow up with [[member_name]] who just joined [[group_name]]!",
+      assignmentMode: (configData.assignmentMode as string) || "round_robin",
+      specificLeaderId:
+        (configData.specificLeaderId as Id<"users"> | undefined) || undefined,
+      targetChannelSlug: (configData.targetChannelSlug as string) || undefined,
+      lastLeaderIndex:
+        typeof state.lastLeaderIndex === "number"
+          ? (state.lastLeaderIndex as number)
+          : undefined,
+    };
+  },
+});
+
+/**
+ * Assign a leader to follow up with a newly-joined member.
+ *
+ * Called by the scheduler when a new member joins a group (event-triggered,
+ * mirrors the Welcome Bot). The assigned leader is chosen by the configured
+ * strategy — a single specific leader, or round-robin across the group's
+ * active leaders — and is notified via an @mention in the target channel,
+ * which fans out to push/email like any other mention.
+ */
+export const assignNewMemberFollowup = internalAction({
+  args: {
+    groupId: v.id("groups"),
+    userId: v.id("users"),
+  },
+  handler: async (
+    ctx,
+    { groupId, userId },
+  ): Promise<
+    | { skipped: true; reason: string }
+    | { success: true; assignedLeaderId: Id<"users">; message: string }
+    | { success: false; error: string }
+  > => {
+    const config = await ctx.runQuery(
+      internal.functions.scheduledJobs.getFollowupBotConfig,
+      { groupId },
+    );
+
+    if (!config) {
+      return { skipped: true, reason: "bot_not_enabled" };
+    }
+
+    const member = await ctx.runQuery(
+      internal.functions.scheduledJobs.getUserById,
+      { userId },
+    );
+
+    if (!member) {
+      return { skipped: true, reason: "member_not_found" };
+    }
+
+    // Reuse the shared active-leaders query. Exclude the new member so a
+    // leader who joins is never assigned to follow up with themselves.
+    const allLeaders = await ctx.runQuery(
+      internal.functions.scheduledJobs.getBirthdayBotLeaders,
+      { groupId },
+    );
+    const leaders = allLeaders.filter((leader) => leader.userId !== userId);
+
+    if (leaders.length === 0) {
+      return { skipped: true, reason: "no_leaders" };
+    }
+
+    // Reuse the shared resolver: specific leader when configured, else
+    // round-robin from the saved pointer.
+    const assignedLeader = resolveBirthdayReminderLeader({
+      leaders,
+      assignmentMode: config.assignmentMode,
+      specificLeaderId: config.specificLeaderId,
+      lastLeaderIndex: config.lastLeaderIndex,
+    });
+
+    if (!assignedLeader) {
+      return { skipped: true, reason: "no_leader_resolved" };
+    }
+
+    const memberName =
+      [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+      member.firstName ||
+      "a new member";
+
+    const message = config.message
+      .replace(/\[\[leader_name\]\]/g, assignedLeader.displayName)
+      .replace(/\[\[member_name\]\]/g, memberName)
+      .replace(/\[\[group_name\]\]/g, config.groupName)
+      .replace(/\[\[community_name\]\]/g, config.communityName);
+
+    try {
+      await ctx.runAction(internal.functions.scheduledJobs.sendBotMessage, {
+        groupId,
+        message,
+        targetChannelSlug: config.targetChannelSlug || "leaders",
+        botType: "followup",
+        mentionedUserIds: [assignedLeader.userId],
+      });
+    } catch (error) {
+      console.error(`[FollowupBot] Error sending assignment:`, error);
+      return { success: false, error: String(error) };
+    }
+
+    // Advance the round-robin pointer only when rotating leaders, so the next
+    // new member is assigned to the following leader. We store the index of the
+    // leader we actually picked; specific-leader mode keeps a fixed assignee.
+    if (config.assignmentMode !== "specific_leader") {
+      const assignedIndex = leaders.findIndex(
+        (leader) => leader.userId === assignedLeader.userId,
+      );
+      if (assignedIndex !== -1) {
+        await ctx.runMutation(internal.functions.scheduledJobs.updateBotState, {
+          configId: config.configId,
+          stateUpdates: { lastLeaderIndex: assignedIndex },
+        });
+      }
+    }
+
+    return {
+      success: true,
+      assignedLeaderId: assignedLeader.userId,
+      message,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary

Adds a **Followup Bot** that, when a new member joins a group, automatically assigns a leader to follow up with them. It's configurable like the Birthday Bot, letting groups choose between:

- **Rotate leaders** — round-robin across the group's active leaders, or
- **Specific leader** — always assign the chosen leader.

The assigned leader is notified via an `@mention` in the target channel (defaults to **Leaders**), which fans out to push/email like any other mention — satisfying "the assignment is logged or notified to the relevant parties."

## How it works

The implementation mirrors the existing bot architecture so the feature drops in cleanly:

- **Registry** (`groupBots.ts`): a new `followup` bot definition (event-triggered). Because the bots list and config form are data-driven from this registry, the toggle row and the configuration screen (assignment strategy + leader picker + message + target channel) render automatically — **no mobile code changes needed**.
- **Backend** (`scheduledJobs.ts`): `getFollowupBotConfig` (mirrors `getWelcomeBotConfig`) and `assignNewMemberFollowup` (event action). It reuses the shared active-leaders query and the shared leader resolver used by the Birthday Bot for round-robin / specific-leader selection, advancing a saved `lastLeaderIndex` pointer in round-robin mode.
- **Trigger wiring**: scheduled alongside the Welcome Bot at every new-member join site — `groupMembers.add`, the secondary group-join path, join-request approval (`admin/requests.ts`), and channel-join (`messaging/channels.ts`). It fires for **new members only**, matching the Welcome Bot's gating.

### Notable behavior
- A newly-joined leader is **never** assigned to follow up with themselves (excluded from the pool).
- If the group has no other active leaders, the bot skips silently.
- Disabled / unconfigured groups are a no-op.

## Configuration UI

The new bot appears in the existing **Bots** settings list with an enable toggle and a **Configure** screen offering:
- Followup message (with `[[leader_name]]`, `[[member_name]]`, `[[group_name]]`, `[[community_name]]` placeholders)
- Leader Assignment: *Rotate leaders* / *Specific leader*
- Leader picker (shown for *Specific leader*)
- Target channel (defaults to Leaders)

## Testing

- New suite `apps/convex/__tests__/followup-bot.test.ts` (9 tests): registry defaults, config lookup, round-robin rotation + pointer advance, specific-leader assignment, placeholder replacement, disabled no-op, and self-exclusion.
- `npx convex typecheck` passes.
- Full Convex suite (`pnpm test`) passes: 1880 tests. Mobile suite (pre-push) passes: 1137 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtFPBXPQ2843hQVosp2zqx)_