### PR TITLE
feat(messaging): admin view access to group channels without joining

### DIFF
--- a/apps/convex/__tests__/messaging/adminChannelViewAccess.test.ts
+++ b/apps/convex/__tests__/messaging/adminChannelViewAccess.test.ts
@@ -350,6 +350,46 @@ describe("Admin view access — reading messages", () => {
     expect(result.messages).toEqual([]);
   });
 
+  test("admin can read a poll in a channel without joining; outsider cannot", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+    const outsider = await createOutsider(t, f.communityId);
+
+    const pollId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("polls", {
+        channelId: f.mainChannelId,
+        authorId: f.leaderUserId,
+        question: "Favorite night?",
+        options: [
+          { id: "a", text: "Tuesday" },
+          { id: "b", text: "Thursday" },
+        ],
+        allowMultiple: false,
+        isAnonymous: false,
+        status: "active",
+        voteCount: 0,
+        voterCount: 0,
+        editCount: 0,
+        createdAt: now,
+      });
+    });
+
+    const adminPoll = await t.query(api.functions.messaging.polls.getPoll, {
+      token: admin.token,
+      pollId,
+    });
+    const outsiderPoll = await t.query(api.functions.messaging.polls.getPoll, {
+      token: outsider.token,
+      pollId,
+    });
+
+    expect(adminPoll).not.toBeNull();
+    expect(adminPoll?.question).toBe("Favorite night?");
+    expect(outsiderPoll).toBeNull();
+  });
+
   test("admin from a DIFFERENT community cannot read messages", async () => {
     const t = convexTest(schema, modules);
     const f = await seedCommunity(t);

--- a/apps/convex/__tests__/messaging/adminChannelViewAccess.test.ts
+++ b/apps/convex/__tests__/messaging/adminChannelViewAccess.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Admin View Access Tests
+ *
+ * Community admins can VIEW any group's channels and read their conversations
+ * without joining the group (read-only oversight). They never get a
+ * `groupMembers` or `chatChannelMembers` row from viewing, so they don't appear
+ * in rosters or pick up inbox / notification entries, and write paths
+ * (`sendMessage`) still reject them.
+ *
+ * See `isCommunityAdminForGroup` / `isCommunityAdminForChannel`
+ * (functions/messaging/helpers.ts) and the gates in channels.ts / messages.ts.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import type { Id } from "../../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+
+interface Fixture {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  leaderUserId: Id<"users">;
+  mainChannelId: Id<"chatChannels">;
+  customChannelId: Id<"chatChannels">;
+  leadersChannelId: Id<"chatChannels">;
+}
+
+/**
+ * Builds a community with one group, a leader member, and main / custom /
+ * leaders channels — each seeded with a message authored by the leader.
+ */
+async function seedCommunity(t: ReturnType<typeof convexTest>): Promise<Fixture> {
+  const now = Date.now();
+
+  const communityId = await t.run(async (ctx) =>
+    ctx.db.insert("communities", {
+      name: "Test Community",
+      subdomain: "test",
+      slug: "test",
+      timezone: "America/New_York",
+      createdAt: now,
+      updatedAt: now,
+    }),
+  );
+
+  const groupTypeId = await t.run(async (ctx) =>
+    ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Groups",
+      slug: "small-groups",
+      isActive: true,
+      displayOrder: 1,
+      createdAt: now,
+    }),
+  );
+
+  const groupId = await t.run(async (ctx) =>
+    ctx.db.insert("groups", {
+      name: "Test Group",
+      communityId,
+      groupTypeId,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    }),
+  );
+
+  const leaderUserId = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("users", {
+      firstName: "Group",
+      lastName: "Leader",
+      phone: "+15555550010",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ctx.db.insert("groupMembers", {
+      userId: id,
+      groupId,
+      role: "leader",
+      joinedAt: now,
+      notificationsEnabled: true,
+    });
+    return id;
+  });
+
+  async function makeChannel(
+    channelType: string,
+    slug: string,
+    name: string,
+  ): Promise<Id<"chatChannels">> {
+    const channelId = await t.run(async (ctx) =>
+      ctx.db.insert("chatChannels", {
+        groupId,
+        channelType,
+        name,
+        slug,
+        createdById: leaderUserId,
+        createdAt: now,
+        updatedAt: now,
+        isArchived: false,
+        memberCount: 1,
+      }),
+    );
+    // Leader is the channel member so member-gated paths behave normally.
+    await t.run(async (ctx) =>
+      ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: leaderUserId,
+        role: "admin",
+        joinedAt: now,
+        isMuted: false,
+      }),
+    );
+    await t.run(async (ctx) =>
+      ctx.db.insert("chatMessages", {
+        channelId,
+        communityId,
+        senderId: leaderUserId,
+        senderName: "Group Leader",
+        content: `Hello from ${name}`,
+        contentType: "text",
+        createdAt: now,
+        lastActivityAt: now,
+        isDeleted: false,
+      }),
+    );
+    return channelId;
+  }
+
+  const mainChannelId = await makeChannel("main", "general", "General");
+  const customChannelId = await makeChannel("custom", "planning", "Planning");
+  const leadersChannelId = await makeChannel("leaders", "leaders", "Leaders");
+
+  return {
+    communityId,
+    groupId,
+    leaderUserId,
+    mainChannelId,
+    customChannelId,
+    leadersChannelId,
+  };
+}
+
+/** Community admin with NO membership in the seeded group. */
+async function createAdminViewer(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+): Promise<{ userId: Id<"users">; token: string }> {
+  const userId = await t.run(async (ctx) => {
+    const now = Date.now();
+    const id = await ctx.db.insert("users", {
+      firstName: "Community",
+      lastName: "Admin",
+      phone: "+15555550020",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ctx.db.insert("userCommunities", {
+      userId: id,
+      communityId,
+      roles: 3, // Admin
+      status: 1, // Active
+      createdAt: now,
+      updatedAt: now,
+    });
+    return id;
+  });
+  const { accessToken } = await generateTokens(userId);
+  return { userId, token: accessToken };
+}
+
+/** Plain community member with NO admin role and NO group membership. */
+async function createOutsider(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+): Promise<{ userId: Id<"users">; token: string }> {
+  const userId = await t.run(async (ctx) => {
+    const now = Date.now();
+    return ctx.db.insert("users", {
+      firstName: "Random",
+      lastName: "Outsider",
+      phone: "+15555550030",
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+  const { accessToken } = await generateTokens(userId);
+  return { userId, token: accessToken };
+}
+
+// ============================================================================
+// Channel listing
+// ============================================================================
+
+describe("Admin view access — channel listing", () => {
+  test("admin sees all channels (incl. leaders) via listGroupChannels without joining", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+
+    const channels = await t.query(
+      api.functions.messaging.channels.listGroupChannels,
+      { token: admin.token, groupId: f.groupId },
+    );
+
+    const types = channels.map((c) => c.channelType).sort();
+    expect(types).toEqual(["custom", "leaders", "main"]);
+    // Admin viewer is never recorded as a member.
+    expect(channels.every((c) => c.isMember === false)).toBe(true);
+  });
+
+  test("admin sees channels via getChannelsByGroup without joining", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+
+    const channels = await t.query(
+      api.functions.messaging.channels.getChannelsByGroup,
+      { token: admin.token, groupId: f.groupId },
+    );
+
+    const types = channels.map((c) => c.channelType).sort();
+    expect(types).toContain("main");
+    expect(types).toContain("custom");
+    expect(types).toContain("leaders");
+  });
+
+  test("non-admin outsider sees no channels", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const outsider = await createOutsider(t, f.communityId);
+
+    const viaList = await t.query(
+      api.functions.messaging.channels.listGroupChannels,
+      { token: outsider.token, groupId: f.groupId },
+    );
+    const viaGroup = await t.query(
+      api.functions.messaging.channels.getChannelsByGroup,
+      { token: outsider.token, groupId: f.groupId },
+    );
+
+    expect(viaList).toEqual([]);
+    expect(viaGroup).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Opening a channel
+// ============================================================================
+
+describe("Admin view access — opening channels", () => {
+  test("admin can open main, custom and leaders channels via getChannel", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+
+    for (const channelId of [
+      f.mainChannelId,
+      f.customChannelId,
+      f.leadersChannelId,
+    ]) {
+      const channel = await t.query(api.functions.messaging.channels.getChannel, {
+        token: admin.token,
+        channelId,
+      });
+      expect(channel).not.toBeNull();
+    }
+  });
+
+  test("admin can resolve a channel via getChannelBySlug without joining", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+
+    const channel = await t.query(
+      api.functions.messaging.channels.getChannelBySlug,
+      { token: admin.token, groupId: f.groupId, slug: "general" },
+    );
+
+    expect(channel).not.toBeNull();
+    expect(channel?.isMember).toBe(false);
+  });
+
+  test("non-admin outsider cannot open channels", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const outsider = await createOutsider(t, f.communityId);
+
+    const byId = await t.query(api.functions.messaging.channels.getChannel, {
+      token: outsider.token,
+      channelId: f.mainChannelId,
+    });
+    const bySlug = await t.query(
+      api.functions.messaging.channels.getChannelBySlug,
+      { token: outsider.token, groupId: f.groupId, slug: "general" },
+    );
+
+    expect(byId).toBeNull();
+    expect(bySlug).toBeNull();
+  });
+});
+
+// ============================================================================
+// Reading conversations
+// ============================================================================
+
+describe("Admin view access — reading messages", () => {
+  test("admin can read messages in main and custom channels without joining", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+
+    for (const channelId of [f.mainChannelId, f.customChannelId]) {
+      const result = await t.query(
+        api.functions.messaging.messages.getMessages,
+        { token: admin.token, channelId },
+      );
+      expect(result.messages.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("non-admin outsider gets no messages", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const outsider = await createOutsider(t, f.communityId);
+
+    const result = await t.query(
+      api.functions.messaging.messages.getMessages,
+      { token: outsider.token, channelId: f.mainChannelId },
+    );
+    expect(result.messages).toEqual([]);
+  });
+
+  test("admin from a DIFFERENT community cannot read messages", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+
+    // Spin up a second community and make this user its admin only.
+    const otherCommunityId = await t.run(async (ctx) =>
+      ctx.db.insert("communities", {
+        name: "Other Community",
+        subdomain: "other",
+        slug: "other",
+        timezone: "America/New_York",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const foreignAdmin = await createAdminViewer(t, otherCommunityId);
+
+    const result = await t.query(
+      api.functions.messaging.messages.getMessages,
+      { token: foreignAdmin.token, channelId: f.mainChannelId },
+    );
+    expect(result.messages).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Read-only guarantees
+// ============================================================================
+
+describe("Admin view access — read-only, no side effects", () => {
+  test("viewing does not create membership rows for the admin", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+
+    // Exercise the full read surface.
+    await t.query(api.functions.messaging.channels.listGroupChannels, {
+      token: admin.token,
+      groupId: f.groupId,
+    });
+    await t.query(api.functions.messaging.channels.getChannel, {
+      token: admin.token,
+      channelId: f.customChannelId,
+    });
+    await t.query(api.functions.messaging.messages.getMessages, {
+      token: admin.token,
+      channelId: f.customChannelId,
+    });
+
+    const groupRows = await t.run(async (ctx) =>
+      ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", f.groupId).eq("userId", admin.userId),
+        )
+        .collect(),
+    );
+    const channelRows = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", f.customChannelId).eq("userId", admin.userId),
+        )
+        .collect(),
+    );
+
+    expect(groupRows).toEqual([]);
+    expect(channelRows).toEqual([]);
+  });
+
+  test("admin viewer still cannot post (sendMessage rejects)", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seedCommunity(t);
+    const admin = await createAdminViewer(t, f.communityId);
+
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: admin.token,
+        channelId: f.mainChannelId,
+        content: "admins should not be able to post without joining",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -21,7 +21,10 @@ import { isCommunityAdmin } from "../../lib/permissions";
 import { generateChannelSlug, getChannelSlug } from "../../lib/slugs";
 import { internal } from "../../_generated/api";
 import { syncUserChannelMembershipsLogic } from "../sync/memberships";
-import { updateChannelMemberCount } from "./helpers";
+import {
+  updateChannelMemberCount,
+  isCommunityAdminForGroup,
+} from "./helpers";
 import { matchesSearchTerms, parseSearchTerms } from "../../lib/memberSearch";
 import { canAccessEventChannel } from "./eventChat";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
@@ -440,6 +443,13 @@ export const getChannel = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
+    // Community admins get read-only oversight of any group's channels without
+    // joining (no groupMembers row). Only checked when they aren't already a
+    // member, so normal members never pay for the extra lookup.
+    const isAdminViewer =
+      !groupMembership &&
+      (await isCommunityAdminForGroup(ctx, groupId, userId));
+
     // Cross-team channels draw their members from serving teams that may live
     // on other groups, so a synced member is often NOT in the channel's home
     // group. Their auto-synced membership row IS the authorization — grant
@@ -454,11 +464,13 @@ export const getChannel = query({
           recipientPending: false,
         };
       }
-      // Must be a group member to access any other channel
-      return null;
+      // Must be a group member — or a community admin viewer — for any other channel
+      if (!isAdminViewer) {
+        return null;
+      }
     }
 
-    const isLeaderOrAdmin = isLeaderRole(groupMembership.role);
+    const isLeaderOrAdmin = isAdminViewer || isLeaderRole(groupMembership?.role);
 
     // Leader-disabled custom/PCO: members cannot open the channel
     if (
@@ -476,8 +488,8 @@ export const getChannel = query({
       }
     }
 
-    // For custom channels, must be a channel member
-    if (isCustomChannel(channel.channelType) && !membership) {
+    // For custom channels, must be a channel member (or a community admin viewer)
+    if (isCustomChannel(channel.channelType) && !membership && !isAdminViewer) {
       return null;
     }
 
@@ -679,7 +691,12 @@ export const getChannelBySlug = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
-    if (!groupMembership) {
+    // Community admins get read-only oversight without joining the group.
+    const isAdminViewer =
+      !groupMembership &&
+      (await isCommunityAdminForGroup(ctx, args.groupId, userId));
+
+    if (!groupMembership && !isAdminViewer) {
       return null;
     }
 
@@ -693,7 +710,7 @@ export const getChannelBySlug = query({
       .first();
 
     const isMember = !!channelMembership;
-    const isLeaderOrAdmin = isLeaderRole(groupMembership.role);
+    const isLeaderOrAdmin = isAdminViewer || isLeaderRole(groupMembership?.role);
 
     // Access control based on channel type
     if (resolvedChannel.channelType === "leaders") {
@@ -742,7 +759,7 @@ export const getChannelBySlug = query({
       slug: getChannelSlug(resolvedChannel),
       isMember,
       role: channelMembership?.role,
-      userGroupRole: groupMembership.role,
+      userGroupRole: groupMembership?.role,
       pendingShareForGroup,
       primaryGroupName,
     };
@@ -771,7 +788,13 @@ export const getChannelsByGroup = query({
       .filter((q) => q.eq(q.field("leftAt"), undefined))
       .first();
 
-    if (!groupMembership) {
+    // Community admins can view any group's channels without joining (read-only
+    // oversight). Only looked up when they aren't already a member.
+    const isAdminViewer =
+      !groupMembership &&
+      (await isCommunityAdminForGroup(ctx, args.groupId, userId));
+
+    if (!groupMembership && !isAdminViewer) {
       return [];
     }
 
@@ -797,8 +820,8 @@ export const getChannelsByGroup = query({
       }
     }
 
-    // Filter based on role and membership
-    const isLeader = isLeaderRole(groupMembership.role);
+    // Filter based on role and membership (admin viewers see like a leader)
+    const isLeader = isAdminViewer || isLeaderRole(groupMembership?.role);
 
     const filteredChannels = channels.filter((channel) => {
       // Event channels are scoped to meetings, not surfaced on the group page.

--- a/apps/convex/functions/messaging/helpers.ts
+++ b/apps/convex/functions/messaging/helpers.ts
@@ -4,8 +4,47 @@
  * Shared utilities for messaging functions (channels, messages, etc.)
  */
 
-import type { MutationCtx } from "../../_generated/server";
-import type { Id } from "../../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { isCommunityAdmin } from "../../lib/permissions";
+
+/**
+ * Whether `userId` may view this group's channels purely on community-admin
+ * standing — i.e. without joining the group.
+ *
+ * Community admins get read-only "oversight" access to any group's channels in
+ * their community without a `groupMembers` (or `chatChannelMembers`) row, so
+ * they never show up in rosters or pick up inbox / notification entries. This
+ * grants VIEW access only; the send / manage mutations keep their own
+ * membership gates, so an admin viewer can read but not post or alter a group
+ * they haven't joined.
+ *
+ * Callers fold this into their existing membership checks as an extra escape
+ * hatch. Mirrors the admin bypass already baked into `listGroupChannels`.
+ */
+export async function isCommunityAdminForGroup(
+  ctx: QueryCtx,
+  groupId: Id<"groups">,
+  userId: Id<"users">
+): Promise<boolean> {
+  const group = await ctx.db.get(groupId);
+  if (!group) return false;
+  return isCommunityAdmin(ctx, group.communityId, userId);
+}
+
+/**
+ * Channel-keyed convenience wrapper around {@link isCommunityAdminForGroup}.
+ * Ad-hoc DM/group_dm channels have no owning group, so admin oversight never
+ * applies to them.
+ */
+export async function isCommunityAdminForChannel(
+  ctx: QueryCtx,
+  channel: Doc<"chatChannels">,
+  userId: Id<"users">
+): Promise<boolean> {
+  if (!channel.groupId) return false;
+  return isCommunityAdminForGroup(ctx, channel.groupId, userId);
+}
 
 /**
  * Recomputes and updates the member count for a channel from actual membership records.

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -26,6 +26,7 @@ import {
 import { checkRateLimit } from "../../lib/rateLimit";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { canAccessEventChannel } from "./eventChat";
+import { isCommunityAdminForChannel } from "./helpers";
 import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 
@@ -256,7 +257,12 @@ export const getMessage = query({
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
 
-      if (!membership) {
+      // Community admins may read messages in their community's group channels
+      // without joining (read-only oversight).
+      if (
+        !membership &&
+        !(channel && (await isCommunityAdminForChannel(ctx, channel, userId)))
+      ) {
         return null;
       }
 
@@ -346,13 +352,21 @@ export const getMessages = query({
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
 
-      // If not a channel member, only group leaders/admins may load messages.
-      // Return empty instead of throwing — `getMessages` is a reactive query and
-      // a throw crashes the chat screen via ErrorBoundary when membership is
-      // lost mid-session (e.g. user confirms a Leave Group alert while the
-      // chat screen is still mounted). The screen's own navigation flow handles
-      // the redirect; we just need to stop replying with messages.
-      if (!channelMembership && !isLeaderRole(groupMembership?.role)) {
+      // Community admins get read-only oversight of any group's channels
+      // without joining. Checked only when they aren't a channel member or
+      // group leader, so the common paths skip the extra lookup.
+      const isAdminViewer =
+        !channelMembership &&
+        !isLeaderRole(groupMembership?.role) &&
+        (await isCommunityAdminForChannel(ctx, channel, userId));
+
+      // If not a channel member, only group leaders/admins (or community admins)
+      // may load messages. Return empty instead of throwing — `getMessages` is a
+      // reactive query and a throw crashes the chat screen via ErrorBoundary when
+      // membership is lost mid-session (e.g. user confirms a Leave Group alert
+      // while the chat screen is still mounted). The screen's own navigation flow
+      // handles the redirect; we just need to stop replying with messages.
+      if (!channelMembership && !isLeaderRole(groupMembership?.role) && !isAdminViewer) {
         return { messages: [], hasMore: false, cursor: undefined };
       }
 
@@ -384,7 +398,8 @@ export const getMessages = query({
           channel.channelType === "announcements") &&
         !effectiveEnabled &&
         !isOwningGroupLeader &&
-        !isLinkedGroupLeader
+        !isLinkedGroupLeader &&
+        !isAdminViewer
       ) {
         return { messages: [], hasMore: false, cursor: undefined };
       }
@@ -565,7 +580,12 @@ export const getThreadReplies = query({
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
 
-      if (!membership) {
+      // Community admins may read threads in their community's group channels
+      // without joining (read-only oversight).
+      if (
+        !membership &&
+        !(channel && (await isCommunityAdminForChannel(ctx, channel, userId)))
+      ) {
         throw new Error("Not a member of this channel");
       }
     }

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -27,6 +27,7 @@ import {
 } from "../../lib/helpers";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { canAccessEventChannel } from "./eventChat";
+import { isCommunityAdminForChannel } from "./helpers";
 import { generateMessagePreview } from "./messages";
 import { checkRateLimit } from "../../lib/rateLimit";
 
@@ -794,7 +795,8 @@ export const getPoll = query({
     const channel = await ctx.db.get(poll.channelId);
     if (!channel) return null;
 
-    // Same channel-visibility gate as message reads.
+    // Same channel-visibility gate as message reads: members can read, and so
+    // can community admins (read-only oversight) without joining.
     if (channel.channelType === "event") {
       if (!(await canAccessEventChannel(ctx, userId, channel))) return null;
     } else {
@@ -805,7 +807,9 @@ export const getPoll = query({
         )
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
-      if (!m) return null;
+      if (!m && !(await isCommunityAdminForChannel(ctx, channel, userId))) {
+        return null;
+      }
     }
 
     const allVotes = await ctx.db
@@ -958,7 +962,10 @@ export const getPollVoters = query({
         )
         .filter((q) => q.eq(q.field("leftAt"), undefined))
         .first();
-      if (!m) return null;
+      // Community admins get read-only oversight without joining.
+      if (!m && !(await isCommunityAdminForChannel(ctx, channel, userId))) {
+        return null;
+      }
     }
 
     const isAuthor = poll.authorId === userId;


### PR DESCRIPTION
## What & why

Community admins should be able to **view** any group's channels and conversations to monitor activity **without formally joining** — so they don't clutter their inbox, don't appear in member rosters, and don't disrupt ongoing conversations.

The codebase already had this for the channel **list** (`listGroupChannels` has a community-admin bypass), but the rest of the read paths still required a `groupMembers` row, so an admin could see the channel list yet hit a wall the moment they tried to open a channel or read messages. This PR completes the feature by extending the same admin bypass consistently across the read surface.

## Changes (backend / Convex)

New shared helpers in `apps/convex/functions/messaging/helpers.ts`:
- `isCommunityAdminForGroup(ctx, groupId, userId)` — resolves the group's community and checks `isCommunityAdmin`.
- `isCommunityAdminForChannel(ctx, channel, userId)` — channel-keyed wrapper (ad-hoc DMs have no owning group, so oversight never applies).

Folded into each existing membership gate as an **additive** escape hatch (only checked when the caller is *not* already a member/leader, so normal paths are unchanged):
- `channels.ts`: `getChannel`, `getChannelBySlug`, `getChannelsByGroup`
- `messages.ts`: `getMessages`, `getMessage`, `getThreadReplies`

**Read-only by design.** No mutation is touched — `sendMessage` and the manage paths keep their own `chatChannelMembers` gates, so an admin viewer can read but cannot post or alter a group they haven't joined. Viewing creates **no** `groupMembers` / `chatChannelMembers` rows.

## Tests

New `apps/convex/__tests__/messaging/adminChannelViewAccess.test.ts`:
- Admin lists / opens / reads main, custom, and leaders channels without joining.
- Read-only guarantees: viewing creates no membership rows; `sendMessage` still rejects the admin.
- Negative cases: a plain community member (non-admin, non-member) and an admin **of a different community** are both denied.

Verified locally: `npx convex typecheck` passes; full Convex suite green (482 messaging tests + new file); full `pnpm test` (convex + mobile + shared) green.

## Follow-up (intentionally not in this PR)

The mobile UI wiring to *surface* this read-only browsing is a deliberate follow-up because it involves a UX decision (which CLAUDE.md says to consult on before implementing):
- `GroupDetailScreen.tsx` renders the member view only when `isMember`; an admin non-member currently sees `GroupNonMemberView`. Showing the channels section to admins also means suppressing member-only controls that the member view renders unconditionally (e.g. **Leave Group**) and the chat composer (`ConvexChatRoomScreen.tsx`, which would otherwise show a composer that errors on send), plus adding a "viewing as admin" read-only indicator.
- When that lands, the `GroupsAndChannels` onboarding guide should be updated.

This PR is the backend authorization half — self-contained, fully tested, and consistent with the existing `listGroupChannels` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5emKwfasY8J68dm6v3AMy)_