### PR TITLE
fix(followups): persist community-level custom fields when adding a person via side panel

### DIFF
--- a/apps/convex/__tests__/followup-csv-import.test.ts
+++ b/apps/convex/__tests__/followup-csv-import.test.ts
@@ -115,6 +115,81 @@ async function seedGroupWithLeader(
   });
 }
 
+/**
+ * Seeds a group whose custom field definitions live at the community level
+ * (`communities.peopleCustomFields`) rather than the legacy per-group
+ * `followupColumnConfig`. This mirrors communities that have migrated to the
+ * community-level People directory config, which is the source of truth the
+ * Add Person side panel and People directory render from.
+ */
+async function seedGroupWithCommunityCustomFields(
+  t: ReturnType<typeof convexTest>
+): Promise<SeededContext> {
+  return t.run(async (ctx) => {
+    const timestamp = Date.now();
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Leader",
+      lastName: "One",
+      phone: "+12025550100",
+      isActive: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Community Fields Community",
+      slug: "community-fields-community",
+      isPublic: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      peopleCustomFields: [
+        { slot: "customText1", name: "Neighborhood", type: "text" },
+        { slot: "customNum1", name: "Volunteer Level", type: "number" },
+        { slot: "customBool1", name: "Wants Prayer", type: "boolean" },
+      ],
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: "small-group",
+      isActive: true,
+      createdAt: timestamp,
+      displayOrder: 1,
+    });
+
+    await ctx.db.insert("userCommunities", {
+      userId: leaderId,
+      communityId,
+      roles: 4,
+      status: 1,
+      createdAt: timestamp,
+    });
+
+    // Group intentionally has no followupColumnConfig.customFields — the only
+    // source of custom field definitions is the community-level config.
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Community Fields Group",
+      isArchived: false,
+      isPublic: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: leaderId,
+      role: "leader",
+      joinedAt: timestamp,
+      notificationsEnabled: true,
+    });
+
+    return { leaderId, communityId, groupId };
+  });
+}
+
 describe("follow-up CSV import", () => {
   test("preview reports custom field update actions and ignored invalid values", async () => {
     const t = convexTest(schema, modules);
@@ -692,6 +767,56 @@ describe("follow-up CSV import", () => {
 
     expect(snapshot.usersWithPhone).toHaveLength(1);
     expect(snapshot.membership?._id).toBeTruthy();
+  });
+
+  test("quick add persists custom fields defined at the community level", async () => {
+    const t = convexTest(schema, modules);
+    const { leaderId, communityId, groupId } =
+      await seedGroupWithCommunityCustomFields(t);
+    const token = (await generateTokens(leaderId, communityId)).accessToken;
+
+    const result = await t.mutation(api.functions.memberFollowups.quickAddRow, {
+      token,
+      groupId,
+      firstName: "Quick",
+      lastName: "Add",
+      phone: "(202) 555-0701",
+      customFieldValues: {
+        customText1: "South",
+        customNum1: "3",
+        customBool1: "true",
+      },
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(result.createdUser).toBe(true);
+
+    const score = await t.run(async (ctx) => {
+      const user = await ctx.db
+        .query("users")
+        .withIndex("by_phone", (q) => q.eq("phone", "+12025550701"))
+        .first();
+      const membership = user
+        ? await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", groupId).eq("userId", user._id)
+          )
+          .first()
+        : null;
+      return membership
+        ? await ctx.db
+          .query("memberFollowupScores")
+          .withIndex("by_groupMember", (q) =>
+            q.eq("groupMemberId", membership._id)
+          )
+          .first()
+        : null;
+    });
+
+    expect(score?.customText1).toBe("South");
+    expect(score?.customNum1).toBe(3);
+    expect(score?.customBool1).toBe(true);
   });
 
   test("quick add enforces required first name + phone", async () => {

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -2238,21 +2238,30 @@ async function analyzeCsvImportRows(
   rowReports: CsvImportRowReport[];
   preparedRows: PreparedCsvImportRow[];
 }> {
-  const customFieldDefs = ((group.followupColumnConfig as any)?.customFields ?? []) as Array<{
-    slot: string;
-    type: string;
-    options?: string[];
-  }>;
+  // Custom field definitions now live at the community level
+  // (`communities.peopleCustomFields`) — that's the source of truth the People
+  // directory and Add Person side panel render from. Older communities may
+  // still only have the legacy per-group `followupColumnConfig.customFields`,
+  // so merge both with the community config taking precedence. Without this,
+  // community-level fields are dropped as "unknown_custom_field_slot_ignored".
+  type CustomFieldDef = { slot: string; type: string; options?: string[] };
+  const legacyCustomFieldDefs = ((group.followupColumnConfig as any)?.customFields ??
+    []) as CustomFieldDef[];
+  let communityCustomFieldDefs: CustomFieldDef[] = [];
+  if (group.communityId) {
+    const community = await ctx.db.get(group.communityId);
+    communityCustomFieldDefs = ((community as any)?.peopleCustomFields ??
+      []) as CustomFieldDef[];
+  }
   const assigneeLookup = await buildCsvAssigneeLookup(ctx, group._id);
-  const customFieldDefsBySlot = new Map(
-    customFieldDefs.map((field) => [
-      field.slot,
-      {
-        type: field.type,
-        options: field.options,
-      },
-    ])
-  );
+  const customFieldDefsBySlot = new Map<string, { type: string; options?: string[] }>();
+  // Legacy first so community definitions override on slot collisions.
+  for (const field of [...legacyCustomFieldDefs, ...communityCustomFieldDefs]) {
+    customFieldDefsBySlot.set(field.slot, {
+      type: field.type,
+      options: field.options,
+    });
+  }
 
   const normalizedRows = rows.map(getNormalizedRow);
 


### PR DESCRIPTION
## Problem

When adding a person through the **Add Person side panel**, custom fields such as **Neighborhood** were not saved. Adding a person through the public landing page (`togather.nyc/[community-slug]`) worked correctly. The side panel should mirror the landing page behavior for custom fields.

## Root cause

Custom field definitions have migrated from the legacy per-group config (`groups.followupColumnConfig.customFields`) to the **community-level** config (`communities.peopleCustomFields`). The frontend now sources the custom fields it renders — in both the side panel (`FollowupQuickAddPanel`) and the People directory — from the community-level config via `communityPeople.getConfig`.

However, the backend `analyzeCsvImportRows` (used by `quickAddRow` *and* CSV import) still resolved its custom-field definitions **only** from the legacy `group.followupColumnConfig.customFields`. For any community that migrated to the community-level config, the group config no longer contains those slots, so incoming values were dropped during validation as `unknown_custom_field_slot_ignored` and never written to `memberFollowupScores`.

The landing page path (`setCustomFieldsAndNotes`) was unaffected because it validates only against `VALID_CUSTOM_SLOTS` rather than a per-group definition map — which is why that flow kept working.

## Fix

`analyzeCsvImportRows` now resolves custom field definitions from the community-level `peopleCustomFields`, merged with the legacy per-group `followupColumnConfig.customFields` as a fallback (community definitions win on slot collisions). This keeps the side-panel quick add and CSV import consistent with what the frontend renders, and preserves behavior for un-migrated communities.

## Testing

- Added a regression test: `quick add persists custom fields defined at the community level` — seeds custom fields **only** at the community level (`peopleCustomFields`) with no `followupColumnConfig`, calls `quickAddRow`, and asserts text/number/boolean custom values are persisted to `memberFollowupScores`. Fails before the fix, passes after.
- Full Convex test suite passes (1873 tests).
- `npx convex typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaQxU8oBebxNSRUHSm8igA)_