### PR TITLE
feat(landing): admin camera autofill for community connect cards

### DIFF
--- a/apps/convex/__tests__/landingFormVision.test.ts
+++ b/apps/convex/__tests__/landingFormVision.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the connect-card OCR response parser.
+ *
+ * These cover the pure `parseExtractionResponse` normalizer (no network /
+ * OpenAI). The vision call itself is exercised end-to-end manually; here we
+ * lock down that we only surface clean, expected values to the form and never
+ * leak unexpected or malformed data.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/landingFormVision.test.ts
+ */
+
+import { expect, test, describe } from "vitest";
+import {
+  parseExtractionResponse,
+  buildSystemPrompt,
+  type CustomFieldSpec,
+} from "../lib/landingFormVision";
+
+describe("parseExtractionResponse", () => {
+  test("extracts built-in fields and trims whitespace", () => {
+    const raw = JSON.stringify({
+      firstName: "  Jane ",
+      lastName: "Doe",
+      phone: "(555) 123-4567",
+      email: "jane@example.com",
+      zipCode: "10001",
+      dateOfBirth: "04/12/1990",
+    });
+    expect(parseExtractionResponse(raw, [])).toEqual({
+      firstName: "Jane",
+      lastName: "Doe",
+      phone: "(555) 123-4567",
+      email: "jane@example.com",
+      zipCode: "10001",
+      dateOfBirth: "04/12/1990",
+    });
+  });
+
+  test("omits blank, whitespace-only, and non-string fields", () => {
+    const raw = JSON.stringify({
+      firstName: "Jane",
+      lastName: "",
+      phone: "   ",
+      email: null,
+      zipCode: 10001,
+    });
+    expect(parseExtractionResponse(raw, [])).toEqual({ firstName: "Jane" });
+  });
+
+  test("returns empty object for null, empty, or invalid JSON", () => {
+    expect(parseExtractionResponse(null, [])).toEqual({});
+    expect(parseExtractionResponse(undefined, [])).toEqual({});
+    expect(parseExtractionResponse("", [])).toEqual({});
+    expect(parseExtractionResponse("not json", [])).toEqual({});
+    expect(parseExtractionResponse("[1,2,3]", [])).toEqual({});
+  });
+
+  test("keeps only custom fields matching a configured label", () => {
+    const fields: CustomFieldSpec[] = [
+      { label: "Neighborhood", type: "text" },
+      { label: "How did you hear about us?", type: "text" },
+    ];
+    const raw = JSON.stringify({
+      firstName: "Sam",
+      customFields: [
+        { label: "Neighborhood", value: "Bushwick" },
+        { label: "Unknown Field", value: "should drop" },
+        { label: "How did you hear about us?", value: "A friend" },
+      ],
+    });
+    expect(parseExtractionResponse(raw, fields)).toEqual({
+      firstName: "Sam",
+      customFields: [
+        { label: "Neighborhood", value: "Bushwick" },
+        { label: "How did you hear about us?", value: "A friend" },
+      ],
+    });
+  });
+
+  test("drops custom fields with blank values and dedupes by label", () => {
+    const fields: CustomFieldSpec[] = [{ label: "Neighborhood", type: "text" }];
+    const raw = JSON.stringify({
+      customFields: [
+        { label: "Neighborhood", value: "  " },
+        { label: "Neighborhood", value: "Harlem" },
+        { label: "Neighborhood", value: "Chelsea" },
+      ],
+    });
+    expect(parseExtractionResponse(raw, fields)).toEqual({
+      customFields: [{ label: "Neighborhood", value: "Harlem" }],
+    });
+  });
+
+  test("ignores customFields when none are configured", () => {
+    const raw = JSON.stringify({
+      firstName: "Sam",
+      customFields: [{ label: "Neighborhood", value: "Bushwick" }],
+    });
+    expect(parseExtractionResponse(raw, [])).toEqual({ firstName: "Sam" });
+  });
+});
+
+describe("buildSystemPrompt", () => {
+  test("lists configured custom fields with dropdown options", () => {
+    const fields: CustomFieldSpec[] = [
+      { label: "Neighborhood", type: "text" },
+      { label: "Campus", type: "dropdown", options: ["North", "South"] },
+      { label: "Section", type: "section_header" },
+    ];
+    const prompt = buildSystemPrompt(fields);
+    expect(prompt).toContain('"Neighborhood" (text)');
+    expect(prompt).toContain('"Campus" (dropdown)');
+    expect(prompt).toContain("North, South");
+    // Decorative field types are not extractable and should be excluded.
+    expect(prompt).not.toContain('"Section"');
+    // Always describes the strict JSON contract.
+    expect(prompt).toContain("strict JSON");
+  });
+
+  test("omits the custom-field section when there are no extractable fields", () => {
+    const prompt = buildSystemPrompt([
+      { label: "Header", type: "section_header" },
+    ]);
+    expect(prompt).not.toContain("Also extract these custom fields");
+    expect(prompt).toContain("dateOfBirth");
+  });
+});

--- a/apps/convex/functions/communityLandingPage.ts
+++ b/apps/convex/functions/communityLandingPage.ts
@@ -13,7 +13,7 @@ import { query, mutation, internalMutation, internalQuery } from "../_generated/
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { requireAuth } from "../lib/auth";
-import { requireCommunityAdmin } from "../lib/permissions";
+import { requireCommunityAdmin, isCommunityAdmin } from "../lib/permissions";
 import { VALID_CUSTOM_SLOTS } from "../lib/followupConstants";
 import { normalizePhone, buildSearchText, now } from "../lib/utils";
 import { syncUserChannelMembershipsLogic } from "./sync/memberships";
@@ -109,6 +109,32 @@ export const getConfigBySlugInternal = internalQuery({
     if (!landingPage || !landingPage.isEnabled) return null;
 
     return { community, landingPage };
+  },
+});
+
+/**
+ * Whether `userId` is an admin of the community that owns the landing page at
+ * `slug`. Used by the extractFormFromImage action to gate the OCR autofill
+ * (an OpenAI-billed call) to community admins only.
+ */
+export const isAdminForSlugInternal = internalQuery({
+  args: { slug: v.string(), userId: v.id("users") },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    let community = await ctx.db
+      .query("communities")
+      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
+      .first();
+
+    if (!community) {
+      community = await ctx.db
+        .query("communities")
+        .withIndex("by_subdomain", (q) => q.eq("subdomain", args.slug))
+        .first();
+    }
+
+    if (!community) return false;
+    return await isCommunityAdmin(ctx, community._id, args.userId);
   },
 });
 

--- a/apps/convex/functions/communityLandingPageActions.ts
+++ b/apps/convex/functions/communityLandingPageActions.ts
@@ -5,10 +5,15 @@
  * and follow-up data setup. Queries and mutations live in communityLandingPage.ts.
  */
 
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { action, internalAction, type ActionCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
+import { requireAuthFromTokenAction } from "../lib/auth";
+import {
+  extractLandingFields,
+  type CustomFieldSpec,
+} from "../lib/landingFormVision";
 
 /**
  * Submit the landing page form.
@@ -332,5 +337,67 @@ export const sendAutoReplySmsAndAudit = internalAction({
       );
     }
     return null;
+  },
+});
+
+/**
+ * Extract connect-card fields from a photo (admin-only autofill).
+ *
+ * A community admin photographs a paper connect card; we run OpenAI vision to
+ * read the fields and return suggested values. The client pre-fills the form
+ * for the admin to review — this NEVER submits the form. Gated to admins of the
+ * community that owns the landing page because each call bills OpenAI.
+ */
+export const extractFormFromImage = action({
+  args: {
+    token: v.string(),
+    slug: v.string(),
+    /** Base64-encoded image bytes (no data: prefix). */
+    imageBase64: v.string(),
+    /** Image MIME type, e.g. "image/jpeg". */
+    mimeType: v.string(),
+    /** The community's configured custom fields, so we can read those too. */
+    customFields: v.optional(
+      v.array(
+        v.object({
+          slot: v.optional(v.string()),
+          label: v.string(),
+          type: v.string(),
+          options: v.optional(v.array(v.string())),
+        })
+      )
+    ),
+  },
+  returns: v.object({
+    firstName: v.optional(v.string()),
+    lastName: v.optional(v.string()),
+    phone: v.optional(v.string()),
+    email: v.optional(v.string()),
+    zipCode: v.optional(v.string()),
+    dateOfBirth: v.optional(v.string()),
+    customFields: v.optional(
+      v.array(v.object({ label: v.string(), value: v.string() }))
+    ),
+  }),
+  handler: async (ctx, args) => {
+    // Auth — must be an admin of the community that owns this landing page.
+    const userId = await requireAuthFromTokenAction(ctx, args.token);
+    const isAdmin = await ctx.runQuery(
+      internal.functions.communityLandingPage.isAdminForSlugInternal,
+      { slug: args.slug, userId: userId as Id<"users"> }
+    );
+    if (!isAdmin) {
+      throw new ConvexError("Not authorized: community admin required");
+    }
+
+    const mimeType = args.mimeType.startsWith("image/")
+      ? args.mimeType
+      : "image/jpeg";
+    const imageDataUrl = `data:${mimeType};base64,${args.imageBase64}`;
+
+    return await extractLandingFields(
+      imageDataUrl,
+      (args.customFields ?? []) as CustomFieldSpec[]
+    );
   },
 });

--- a/apps/convex/functions/communityLandingPageActions.ts
+++ b/apps/convex/functions/communityLandingPageActions.ts
@@ -381,10 +381,20 @@ export const extractFormFromImage = action({
   }),
   handler: async (ctx, args) => {
     // Auth — must be an admin of the community that owns this landing page.
-    const userId = await requireAuthFromTokenAction(ctx, args.token);
+    // Resolve the token subject to a real users id first: legacy-migrated
+    // users carry a non-Convex-id subject (a numeric legacyId string), which a
+    // v.id("users") validator would reject.
+    const tokenUserId = await requireAuthFromTokenAction(ctx, args.token);
+    const resolved = await ctx.runQuery(
+      internal.functions.users.resolveUserIdInternal,
+      { tokenUserId }
+    );
+    if (!resolved) {
+      throw new ConvexError("Not authenticated");
+    }
     const isAdmin = await ctx.runQuery(
       internal.functions.communityLandingPage.isAdminForSlugInternal,
-      { slug: args.slug, userId: userId as Id<"users"> }
+      { slug: args.slug, userId: resolved.userId }
     );
     if (!isAdmin) {
       throw new ConvexError("Not authorized: community admin required");

--- a/apps/convex/lib/landingFormVision.ts
+++ b/apps/convex/lib/landingFormVision.ts
@@ -16,6 +16,8 @@
  * read off the card; anything illegible or absent is simply omitted.
  */
 
+import { ConvexError } from "convex/values";
+
 const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_MODEL = "gpt-4o";
 const REQUEST_TIMEOUT_MS = 45_000;
@@ -175,7 +177,10 @@ export async function extractLandingFields(
 ): Promise<ExtractedLandingFields> {
   const apiKey = process.env.OPENAI_SECRET_KEY;
   if (!apiKey) {
-    throw new Error("OPENAI_SECRET_KEY not configured");
+    console.error("[landingFormVision] OPENAI_SECRET_KEY not configured");
+    // ConvexError so the admin sees a real message (plain Errors are redacted
+    // to a generic "Server Error" on the client in production).
+    throw new ConvexError("Photo autofill is unavailable right now.");
   }
 
   const controller = new AbortController();
@@ -210,8 +215,11 @@ export async function extractLandingFields(
 
     if (!response.ok) {
       const errBody = await response.text().catch(() => "");
-      throw new Error(
-        `OpenAI vision error ${response.status}: ${errBody.slice(0, 300)}`
+      console.error(
+        `[landingFormVision] OpenAI vision error ${response.status}: ${errBody.slice(0, 300)}`
+      );
+      throw new ConvexError(
+        "Couldn't read the card. Please try again with a clearer photo."
       );
     }
 

--- a/apps/convex/lib/landingFormVision.ts
+++ b/apps/convex/lib/landingFormVision.ts
@@ -1,0 +1,226 @@
+/**
+ * Community landing page — connect-card OCR via OpenAI vision.
+ *
+ * Admins photograph a paper "connect card" / "gold card" and we extract the
+ * handwritten/printed fields so the landing page form can be pre-filled. The
+ * admin always reviews and confirms before the form is submitted — this only
+ * suggests values, it never submits anything.
+ *
+ * Uses OpenAI's `gpt-4o` (vision) because we already have `OPENAI_SECRET_KEY`
+ * configured (also used by `functions/posters.ts` keywording and the prayer
+ * moderator). gpt-4o reads handwriting noticeably better than gpt-4o-mini,
+ * which matters for hand-filled cards.
+ *
+ * Contract: the caller passes the image as a data URL plus the list of custom
+ * form fields the community has configured. We return only the fields we can
+ * read off the card; anything illegible or absent is simply omitted.
+ */
+
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const OPENAI_MODEL = "gpt-4o";
+const REQUEST_TIMEOUT_MS = 45_000;
+
+/** A community-configured custom field we may be able to read off the card. */
+export interface CustomFieldSpec {
+  /** Stable slot key when present, otherwise the human label is the key. */
+  slot?: string;
+  label: string;
+  /** "text" | "number" | "dropdown" | "multiselect" | "boolean" | ... */
+  type: string;
+  options?: string[];
+}
+
+export interface ExtractedLandingFields {
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  email?: string;
+  zipCode?: string;
+  /** MM/DD/YYYY to match the landing form's birthday input. */
+  dateOfBirth?: string;
+  /** Custom fields keyed by their configured label. */
+  customFields?: Array<{ label: string; value: string }>;
+}
+
+/**
+ * Build the system prompt. Kept as a function so the custom-field section can
+ * describe exactly which labels (and dropdown options) the model may use.
+ */
+export function buildSystemPrompt(customFields: CustomFieldSpec[]): string {
+  const lines: string[] = [
+    "You are an OCR assistant for a community (church) connect card.",
+    "You are given a photo of a paper card a newcomer filled out by hand or that was printed.",
+    "Read the card and extract the visitor's details to pre-fill a digital form.",
+    "",
+    "Extract these built-in fields when present:",
+    "- firstName, lastName: the person's name.",
+    "- phone: their phone number, digits only or in (555) 555-5555 form.",
+    "- email: their email address.",
+    "- zipCode: a US ZIP code (5 digits, optionally ZIP+4).",
+    "- dateOfBirth: their birthday formatted strictly as MM/DD/YYYY.",
+  ];
+
+  const usableCustom = customFields.filter(
+    (f) => f.label && !["section_header", "subtitle", "button"].includes(f.type)
+  );
+  if (usableCustom.length > 0) {
+    lines.push(
+      "",
+      "Also extract these custom fields if their value appears on the card.",
+      'Return them in a "customFields" array of {"label","value"} objects,',
+      "using the EXACT label text shown below:"
+    );
+    for (const f of usableCustom) {
+      let desc = `- "${f.label}" (${f.type})`;
+      if (f.type === "boolean") {
+        desc += ' — value should be "true" or "false"';
+      } else if (
+        (f.type === "dropdown" || f.type === "multiselect") &&
+        f.options?.length
+      ) {
+        desc += ` — choose from: ${f.options.join(", ")}`;
+        if (f.type === "multiselect") {
+          desc += " (separate multiple with a semicolon)";
+        }
+      }
+      lines.push(desc);
+    }
+  }
+
+  lines.push(
+    "",
+    "Rules:",
+    "- Only include a field when you can actually read its value on the card.",
+    "- Omit any field that is blank, illegible, or not present. Do not guess.",
+    "- Do not invent data. An empty form is better than a wrong value.",
+    "",
+    "Respond with strict JSON only, in this shape:",
+    '{"firstName"?:string,"lastName"?:string,"phone"?:string,"email"?:string,"zipCode"?:string,"dateOfBirth"?:string,"customFields"?:[{"label":string,"value":string}]}'
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Parse and normalize the model's JSON response. Pure (no network) so it can be
+ * unit-tested. Unknown/empty values are dropped; custom fields are filtered to
+ * the configured labels.
+ */
+export function parseExtractionResponse(
+  raw: string | null | undefined,
+  customFields: CustomFieldSpec[]
+): ExtractedLandingFields {
+  if (!raw) return {};
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object") return {};
+
+  const result: ExtractedLandingFields = {};
+
+  const str = (v: unknown): string | undefined => {
+    if (typeof v !== "string") return undefined;
+    const t = v.trim();
+    return t.length > 0 ? t : undefined;
+  };
+
+  const firstName = str(parsed.firstName);
+  if (firstName) result.firstName = firstName;
+  const lastName = str(parsed.lastName);
+  if (lastName) result.lastName = lastName;
+  const phone = str(parsed.phone);
+  if (phone) result.phone = phone;
+  const email = str(parsed.email);
+  if (email) result.email = email;
+  const zipCode = str(parsed.zipCode);
+  if (zipCode) result.zipCode = zipCode;
+  const dateOfBirth = str(parsed.dateOfBirth);
+  if (dateOfBirth) result.dateOfBirth = dateOfBirth;
+
+  // Custom fields: keep only entries whose label maps to a configured field.
+  const validLabels = new Set(
+    customFields.map((f) => f.label).filter((l): l is string => !!l)
+  );
+  const rawCustom = parsed.customFields;
+  if (Array.isArray(rawCustom) && validLabels.size > 0) {
+    const seen = new Set<string>();
+    const customFieldsOut: Array<{ label: string; value: string }> = [];
+    for (const entry of rawCustom) {
+      if (!entry || typeof entry !== "object") continue;
+      const label = str((entry as Record<string, unknown>).label);
+      const value = str((entry as Record<string, unknown>).value);
+      if (!label || !value) continue;
+      if (!validLabels.has(label) || seen.has(label)) continue;
+      seen.add(label);
+      customFieldsOut.push({ label, value });
+    }
+    if (customFieldsOut.length > 0) result.customFields = customFieldsOut;
+  }
+
+  return result;
+}
+
+/**
+ * Call OpenAI vision to read a connect card. `imageDataUrl` is a
+ * `data:image/...;base64,...` URL. Throws on a missing key or a non-OK
+ * response so the caller can surface a clear error to the admin.
+ */
+export async function extractLandingFields(
+  imageDataUrl: string,
+  customFields: CustomFieldSpec[]
+): Promise<ExtractedLandingFields> {
+  const apiKey = process.env.OPENAI_SECRET_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_SECRET_KEY not configured");
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(OPENAI_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        response_format: { type: "json_object" },
+        temperature: 0,
+        messages: [
+          { role: "system", content: buildSystemPrompt(customFields) },
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Extract the visitor details from this connect card as JSON.",
+              },
+              { type: "image_url", image_url: { url: imageDataUrl } },
+            ],
+          },
+        ],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      throw new Error(
+        `OpenAI vision error ${response.status}: ${errBody.slice(0, 300)}`
+      );
+    }
+
+    const json = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = json?.choices?.[0]?.message?.content ?? null;
+    return parseExtractionResponse(content, customFields);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
+++ b/apps/mobile/app/c/[slug]/CommunityLandingPageClient.tsx
@@ -14,7 +14,14 @@ import {
   Linking,
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useQuery, useAction, api } from "@services/api/convex";
+import * as ImagePicker from "expo-image-picker";
+import {
+  useQuery,
+  useAction,
+  useAuthenticatedAction,
+  api,
+} from "@services/api/convex";
+import { useAuth } from "@providers/AuthProvider";
 import { Ionicons } from "@expo/vector-icons";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppImage } from "@components/ui";
@@ -50,6 +57,107 @@ const openExternalUrl = async (url: string) => {
   await Linking.openURL(url);
 };
 
+/** Fields the camera autofill returns from the connect-card photo. */
+type ExtractedFields = {
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  email?: string;
+  zipCode?: string;
+  dateOfBirth?: string;
+  customFields?: Array<{ label: string; value: string }>;
+};
+
+/**
+ * Coerce a string the model read off the card into the value shape a given
+ * custom field expects. Returns undefined when the value can't be applied
+ * (e.g. a dropdown value that doesn't match any option) so we never set junk.
+ */
+function coerceCustomFieldValue(
+  field: FormField,
+  rawValue: string
+): string | number | boolean | string[] | undefined {
+  const value = rawValue.trim();
+  if (!value) return undefined;
+
+  switch (field.type) {
+    case "boolean": {
+      const truthy = ["true", "yes", "y", "1", "checked", "x"].includes(
+        value.toLowerCase()
+      );
+      // Only check the box on an affirmative read; never uncheck.
+      return truthy ? true : undefined;
+    }
+    case "number": {
+      const num = Number(value);
+      return Number.isFinite(num) ? num : undefined;
+    }
+    case "dropdown": {
+      return (field.options || []).find(
+        (o) => o.toLowerCase() === value.toLowerCase()
+      );
+    }
+    case "multiselect": {
+      const parts = value
+        .split(/[;,]/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const matched = parts
+        .map((p) =>
+          (field.options || []).find((o) => o.toLowerCase() === p.toLowerCase())
+        )
+        .filter((o): o is string => !!o);
+      return matched.length > 0 ? matched : undefined;
+    }
+    default:
+      return value;
+  }
+}
+
+/** Load an image element from a data URL (web only). */
+function loadImageElement(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+/**
+ * Keep the uploaded image small. expo-image-picker compresses via `quality` on
+ * native, but on web it returns the original file, so a phone photo can be many
+ * MB. Downscale large web images with a canvas before sending to the action.
+ */
+async function prepareImageForUpload(
+  base64: string,
+  mimeType: string
+): Promise<{ base64: string; mimeType: string }> {
+  if (Platform.OS !== "web" || typeof document === "undefined") {
+    return { base64, mimeType };
+  }
+  try {
+    const img = await loadImageElement(`data:${mimeType};base64,${base64}`);
+    const MAX_EDGE = 1600;
+    const longest = Math.max(img.width, img.height);
+    if (longest <= MAX_EDGE) return { base64, mimeType };
+
+    const scale = MAX_EDGE / longest;
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(img.width * scale);
+    canvas.height = Math.round(img.height * scale);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return { base64, mimeType };
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    const dataUrl = canvas.toDataURL("image/jpeg", 0.8);
+    const comma = dataUrl.indexOf(",");
+    if (comma === -1) return { base64, mimeType };
+    return { base64: dataUrl.slice(comma + 1), mimeType: "image/jpeg" };
+  } catch {
+    return { base64, mimeType };
+  }
+}
+
 export default function CommunityLandingPageClient() {
   const router = useRouter();
   const { colors, isDark } = useTheme();
@@ -65,6 +173,16 @@ export default function CommunityLandingPageClient() {
   const submitFormAction = useAction(
     api.functions.communityLandingPageActions.submitForm
   );
+
+  // Admin-only camera autofill: photograph a paper connect card and let the
+  // backend OCR it to pre-fill the form (the admin still reviews + submits).
+  const { user } = useAuth();
+  const isAdmin = user?.is_admin === true;
+  const extractFormFromImage = useAuthenticatedAction(
+    api.functions.communityLandingPageActions.extractFormFromImage
+  );
+  const [isExtracting, setIsExtracting] = useState(false);
+  const [autofillNotice, setAutofillNotice] = useState<string | null>(null);
 
   // Form state
   const [firstName, setFirstName] = useState("");
@@ -98,6 +216,121 @@ export default function CommunityLandingPageClient() {
 
   const updateCustomField = (fieldKey: string, value: any) => {
     setCustomFieldValues((prev) => ({ ...prev, [fieldKey]: value }));
+  };
+
+  // Apply extracted values to the form. Only fills fields we actually read;
+  // never clears anything the admin already typed for an unread field.
+  const applyExtractedFields = (extracted: ExtractedFields) => {
+    let filled = 0;
+    if (extracted.firstName) {
+      setFirstName(extracted.firstName);
+      filled++;
+    }
+    if (extracted.lastName) {
+      setLastName(extracted.lastName);
+      filled++;
+    }
+    if (extracted.phone) {
+      setPhone(extracted.phone);
+      filled++;
+    }
+    if (extracted.email) {
+      setEmail(extracted.email);
+      filled++;
+    }
+    if (extracted.zipCode) {
+      setZipCode(extracted.zipCode);
+      filled++;
+    }
+    if (extracted.dateOfBirth) {
+      setDateOfBirth(extracted.dateOfBirth);
+      filled++;
+    }
+
+    if (extracted.customFields?.length) {
+      const updates: Record<string, string | number | boolean | string[]> = {};
+      for (const { label, value } of extracted.customFields) {
+        const field = visibleFormFields.find(
+          (f) => f.label === label && shouldCollectFieldResponse(f)
+        );
+        if (!field) continue;
+        const coerced = coerceCustomFieldValue(field, value);
+        if (coerced !== undefined) {
+          updates[field.slot || field.label] = coerced;
+          filled++;
+        }
+      }
+      if (Object.keys(updates).length > 0) {
+        setCustomFieldValues((prev) => ({ ...prev, ...updates }));
+      }
+    }
+
+    setSubmitError(null);
+    setAutofillNotice(
+      filled > 0
+        ? "Fields autofilled from your photo. Please review everything before submitting."
+        : "We couldn't read any fields from that photo. Try a clearer picture or enter the details manually."
+    );
+  };
+
+  // Pick/take a photo of a connect card and autofill the form from it.
+  const handleAutofillFromPhoto = async () => {
+    if (!slug || !data || isExtracting) return;
+    try {
+      // Native needs library permission; web uses a file input (no prompt).
+      if (Platform.OS !== "web") {
+        const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+        if (!perm.granted) {
+          setSubmitError(
+            "Photo access is required to autofill from a photo. Please enable it in settings."
+          );
+          return;
+        }
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ["images"],
+        base64: true,
+        quality: 0.5,
+        allowsMultipleSelection: false,
+      });
+      if (result.canceled || !result.assets?.[0]?.base64) return;
+
+      setIsExtracting(true);
+      setSubmitError(null);
+      setAutofillNotice(null);
+
+      const asset = result.assets[0];
+      const { base64, mimeType } = await prepareImageForUpload(
+        asset.base64 as string,
+        asset.mimeType ?? "image/jpeg"
+      );
+
+      const customFields = visibleFormFields
+        .filter((f) => shouldCollectFieldResponse(f))
+        .map((f) => ({
+          slot: f.slot || undefined,
+          label: f.label,
+          type: f.type,
+          options: f.options,
+        }));
+
+      const extracted = await extractFormFromImage({
+        slug,
+        imageBase64: base64,
+        mimeType,
+        customFields,
+      });
+
+      applyExtractedFields(extracted);
+    } catch (error: any) {
+      setSubmitError(
+        error?.message ||
+          "Couldn't autofill from that photo. Please try again or enter the details manually."
+      );
+    } finally {
+      setIsExtracting(false);
+    }
   };
 
   // Format birthday input as MM/DD/YYYY with auto-slashes
@@ -409,6 +642,21 @@ export default function CommunityLandingPageClient() {
               <TouchableOpacity style={styles.heroCloseButton} onPress={handleClose}>
                 <Ionicons name="close" size={22} color="#fff" />
               </TouchableOpacity>
+              {isAdmin && (
+                <TouchableOpacity
+                  style={styles.heroCameraButton}
+                  onPress={handleAutofillFromPhoto}
+                  disabled={isExtracting}
+                  accessibilityRole="button"
+                  accessibilityLabel="Autofill form from a photo"
+                >
+                  {isExtracting ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <Ionicons name="camera" size={22} color="#fff" />
+                  )}
+                </TouchableOpacity>
+              )}
             </View>
             {data.community?.logo ? (
               <AppImage
@@ -431,6 +679,21 @@ export default function CommunityLandingPageClient() {
 
           {/* Form Card */}
           <View style={[styles.formCard, { backgroundColor: colors.surface }]}>
+            {/* Admin autofill notice */}
+            {autofillNotice && (
+              <View
+                style={[
+                  styles.autofillBanner,
+                  { backgroundColor: primaryColor + "15" },
+                ]}
+              >
+                <Ionicons name="sparkles" size={16} color={primaryColor} />
+                <Text style={[styles.autofillBannerText, { color: colors.text }]}>
+                  {autofillNotice}
+                </Text>
+              </View>
+            )}
+
             {/* Built-in fields */}
             <View style={styles.fieldRow}>
               <View style={styles.fieldHalf}>
@@ -854,10 +1117,19 @@ const styles = StyleSheet.create({
   heroCloseRow: {
     alignSelf: "stretch",
     flexDirection: "row",
-    justifyContent: "flex-start",
+    justifyContent: "space-between",
+    alignItems: "center",
     paddingBottom: 8,
   },
   heroCloseButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(255, 255, 255, 0.25)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  heroCameraButton: {
     width: 40,
     height: 40,
     borderRadius: 20,
@@ -1019,6 +1291,20 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 16,
     fontWeight: "600",
+  },
+
+  // Admin autofill notice
+  autofillBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 16,
+    gap: 8,
+  },
+  autofillBannerText: {
+    fontSize: 14,
+    flex: 1,
   },
 
   // Error


### PR DESCRIPTION
## Summary

Adds an **admin-only camera icon** to the public community landing page (the `/c/[slug]` "Welcome" connect-card form). An admin photographs a paper connect card; OpenAI vision (`gpt-4o`) reads the fields and **pre-fills the form for review**. It never auto-submits — the admin always confirms before submitting.

Closes the request: _"Add Camera Icon for Admins to Autofill Form Fields on Community Landing Pages."_

## How it works

1. When `user.is_admin` is true, a camera button appears in the hero (top-right of the landing page).
2. Tapping it opens the photo picker (`expo-image-picker`) — on mobile web this offers "Take Photo" or "Photo Library"; on native it uses the media library.
3. Large web images are downscaled with a canvas before upload (keeps the payload small/fast).
4. The image is sent to a new authenticated Convex action which runs OpenAI vision and returns the extracted fields.
5. The form is pre-filled (built-in **and** community-configured custom fields) and a notice asks the admin to review before submitting.

## Changes

**Backend** (`apps/convex`)
- `lib/landingFormVision.ts` — `gpt-4o` vision call + a pure, unit-tested response parser. Mirrors the existing `OPENAI_SECRET_KEY` fetch pattern used by `functions/posters.ts` (vision keywording) and `lib/moderation/prayer.ts`. No new dependency or env var.
- `communityLandingPageActions.extractFormFromImage` — public **authenticated** action. Gated to admins of the slug's community via `requireAuthFromTokenAction` + a new internal query, because each call bills OpenAI.
- `communityLandingPage.isAdminForSlugInternal` — resolves the community by slug (same slug→subdomain fallback as `getBySlug`) and checks `isCommunityAdmin`.

**Frontend** (`apps/mobile`)
- `app/c/[slug]/CommunityLandingPageClient.tsx` — admin camera button, photo pick/downscale, action call, and field autofill with type coercion for custom fields (dropdown/multiselect/boolean/number). Review banner; suggestions only.
- `expo-image-picker` is already a **core** native dep, so no `native-deps.json` / fingerprint changes and no `runtimeVersion` bump.

**Tests**
- `__tests__/landingFormVision.test.ts` — 8 cases covering the parser (trimming, dropping blanks/non-strings, custom-field label filtering, dedupe) and the prompt builder.

## Verification
- `pnpm test __tests__/landingFormVision.test.ts` → 8 passing.
- `tsc --noEmit` on changed convex + mobile files → no new errors.
- `node scripts/check-native-imports.js` → passes (expo-image-picker is core).
- eslint on the changed component → 0 errors.

## Notes / decisions
- **Auth is enforced server-side.** The client gate (`user.is_admin`) is a UI convenience; the action independently verifies the caller is an admin of *that* community. A cross-community admin would see the icon but get a clear "Not authorized" error.
- Image is sent as base64 to the action (no R2 clutter); web images are downscaled to ≤1600px first to stay well within limits.
- No onboarding guide documents this connect-card form, so no guide update was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012WZmUJQPy5xW7gMvmnbNd1)_