### PR TITLE
feat(messaging): surface admin read-only channel browsing in mobile UI

### DIFF
--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -400,13 +400,19 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // Get user role for toolbar visibility
   const userRole = (groupDetails?.userRole || groupData?.userRole) as "admin" | "leader" | "member" | undefined;
 
-  // Community admin browsing a group they haven't joined. The backend grants
-  // read access (PR #525) but no membership row exists, so they must not be
-  // able to post. Members have a role ("member"/"leader"); non-members resolve
-  // to undefined once the role query settles (guarded by !isRoleLoading so we
-  // don't flash read-only while loading).
-  const isAdminViewer =
-    isCommunityAdmin && hasGroup && !isRoleLoading && userRole === undefined;
+  // Community admin viewing a group whose membership isn't confirmed yet. This
+  // covers BOTH the role-loading window and a settled non-member: the channel
+  // lookup can resolve before groups.getById, so if we waited for the role to
+  // settle the composer would briefly mount as sendable for a non-member (whose
+  // send the server then rejects — the exact bug this change removes). Members
+  // have a role ("member"/"leader"), so this flips false the moment that lands.
+  const isCommunityAdminGroupView =
+    isCommunityAdmin && hasGroup && userRole === undefined;
+  // Confirmed admin viewer: role has settled and they're definitely not a
+  // member. Drives the channel-tab expansion and the explanatory banner copy
+  // (kept distinct so we don't show "viewing as admin" to a member-admin during
+  // the brief loading window).
+  const isAdminViewer = isCommunityAdminGroupView && !isRoleLoading;
 
   // Build channel tabs from the query result (or cache). Admin viewers get the
   // group's full enabled channel set so they can browse every channel; members
@@ -480,9 +486,11 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // community-wide announcement group. The announcement group's general
   // channel is open to everyone, just like any other group's general channel.
   // Admin viewers are read-only everywhere (they haven't joined); otherwise
-  // only Announcements restricts posting to leaders.
+  // only Announcements restricts posting to leaders. Gated on the broader
+  // "group view" flag so the composer never mounts for a community admin while
+  // their membership role is still resolving.
   const canSendMessages =
-    !isAdminViewer && (!isAnnouncementsChannel || isUserLeader);
+    !isCommunityAdminGroupView && (!isAnnouncementsChannel || isUserLeader);
 
   // UI state
   const [menuVisible, setMenuVisible] = useState(false);
@@ -1343,8 +1351,10 @@ const ConvexChatRoomScreenInner: React.FC = () => {
             ) : (
               <View style={[styles.readOnlyBanner, { backgroundColor: colors.surfaceSecondary, borderTopColor: colors.border }]}>
                 <Text style={[styles.readOnlyText, { color: colors.textSecondary }]}>
-                  {isAdminViewer
-                    ? "You're viewing as a community admin. Join the group to post."
+                  {isCommunityAdminGroupView
+                    ? isRoleLoading
+                      ? "Checking your access…"
+                      : "You're viewing as a community admin. Join the group to post."
                     : isAnnouncementsChannel
                       ? "Only leaders can post in Announcements. You can react to messages."
                       : "Only admins can post in this channel. You can react to messages."}

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -253,23 +253,9 @@ const ConvexChatRoomScreenInner: React.FC = () => {
     : null;
   const effectiveGroupChannels = groupChannels ?? cachedGroupChannels;
 
-  // Build channel tabs from the query result (or cache) — member + leader-enabled (tab bar)
-  const channelTabs: ChannelTab[] = useMemo(() => {
-    if (!effectiveGroupChannels) return [];
-
-    return effectiveGroupChannels
-      .filter(
-        (channel: any) =>
-          channel.isMember && channel.isEnabled !== false
-      )
-      .map((channel: any) => ({
-        slug: channel.slug,
-        channelType: channel.channelType,
-        name: channel.name,
-        unreadCount: channel.unreadCount,
-        isShared: channel.isShared || undefined,
-      }));
-  }, [effectiveGroupChannels]);
+  // `channelTabs` is defined further down, once `isAdminViewer` has resolved
+  // from the group role — admin browsers are shown the group's full channel
+  // set, regular members only the channels they belong to.
 
   // Get Convex channel IDs for main and leaders
   const mainChannelId = useConvexChannelFromGroup(resolvedGroupId, "main");
@@ -413,6 +399,37 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   const hasGroup = !!resolvedGroupId;
   // Get user role for toolbar visibility
   const userRole = (groupDetails?.userRole || groupData?.userRole) as "admin" | "leader" | "member" | undefined;
+
+  // Community admin browsing a group they haven't joined. The backend grants
+  // read access (PR #525) but no membership row exists, so they must not be
+  // able to post. Members have a role ("member"/"leader"); non-members resolve
+  // to undefined once the role query settles (guarded by !isRoleLoading so we
+  // don't flash read-only while loading).
+  const isAdminViewer =
+    isCommunityAdmin && hasGroup && !isRoleLoading && userRole === undefined;
+
+  // Build channel tabs from the query result (or cache). Admin viewers get the
+  // group's full enabled channel set so they can browse every channel; members
+  // only get the channels they belong to.
+  const channelTabs: ChannelTab[] = useMemo(() => {
+    if (!effectiveGroupChannels) return [];
+
+    return effectiveGroupChannels
+      .filter((channel: any) => {
+        if (channel.isEnabled === false) return false;
+        // Admin viewers browse every readable channel. Skip reach_out — it's a
+        // leader workflow surface (ReachOutScreen), not a conversation to read.
+        if (isAdminViewer) return channel.channelType !== "reach_out";
+        return channel.isMember;
+      })
+      .map((channel: any) => ({
+        slug: channel.slug,
+        channelType: channel.channelType,
+        name: channel.name,
+        unreadCount: channel.unreadCount,
+        isShared: channel.isShared || undefined,
+      }));
+  }, [effectiveGroupChannels, isAdminViewer]);
   // Type for group with visibility settings
   type GroupWithVisibility = typeof groupDetails & {
     showToolbarToMembers?: boolean;
@@ -462,7 +479,10 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // (server-enforced in sendMessage), for every group including the
   // community-wide announcement group. The announcement group's general
   // channel is open to everyone, just like any other group's general channel.
-  const canSendMessages = !isAnnouncementsChannel || isUserLeader;
+  // Admin viewers are read-only everywhere (they haven't joined); otherwise
+  // only Announcements restricts posting to leaders.
+  const canSendMessages =
+    !isAdminViewer && (!isAnnouncementsChannel || isUserLeader);
 
   // UI state
   const [menuVisible, setMenuVisible] = useState(false);
@@ -1323,9 +1343,11 @@ const ConvexChatRoomScreenInner: React.FC = () => {
             ) : (
               <View style={[styles.readOnlyBanner, { backgroundColor: colors.surfaceSecondary, borderTopColor: colors.border }]}>
                 <Text style={[styles.readOnlyText, { color: colors.textSecondary }]}>
-                  {isAnnouncementsChannel
-                    ? "Only leaders can post in Announcements. You can react to messages."
-                    : "Only admins can post in this channel. You can react to messages."}
+                  {isAdminViewer
+                    ? "You're viewing as a community admin. Join the group to post."
+                    : isAnnouncementsChannel
+                      ? "Only leaders can post in Announcements. You can react to messages."
+                      : "Only admins can post in this channel. You can react to messages."}
                 </Text>
               </View>
             )}

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -46,6 +46,14 @@ import { ChannelJoinRequestsBanner } from "./ChannelJoinRequestsBanner";
 interface ChannelsSectionProps {
   groupId: string;
   userRole?: string | null; // 'member', 'leader', or 'admin'
+  /**
+   * Overrides where a channel row navigates. Defaults to the per-channel
+   * info screen (the member/leader management surface). Community admins
+   * browsing a group they haven't joined pass a handler that opens the
+   * read-only chat instead, so "view inside the channel" lands on messages
+   * rather than settings.
+   */
+  onChannelPress?: (slug: string, channelId?: string) => void;
 }
 
 interface Channel {
@@ -66,7 +74,7 @@ interface Channel {
   isEnabled: boolean;
 }
 
-export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
+export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsSectionProps) {
   const router = useRouter();
   const { token } = useAuth();
   const { primaryColor } = useCommunityTheme();
@@ -147,7 +155,13 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
     // channelId disambiguates shared channels: slugs are only unique within the
     // owning group, so a group invited to two same-slug channels needs the id to
     // open the right one. Plain group channels omit it and route by path alone.
-    (slug: string, channelId?: string) =>
+    (slug: string, channelId?: string) => {
+      // Admin browsers (onChannelPress provided) open the read-only chat;
+      // everyone else lands on the per-channel info/management screen.
+      if (onChannelPress) {
+        onChannelPress(slug, channelId);
+        return;
+      }
       router.push(
         channelId
           ? ({
@@ -155,8 +169,9 @@ export function ChannelsSection({ groupId, userRole }: ChannelsSectionProps) {
               params: { channelId },
             } as any)
           : (`/inbox/${groupId}/${slug}/info` as any)
-      ),
-    [router, groupId]
+      );
+    },
+    [router, groupId, onChannelPress]
   );
 
   const handleCreateChannel = useCallback(() => {

--- a/apps/mobile/features/groups/components/GroupNonMemberView.tsx
+++ b/apps/mobile/features/groups/components/GroupNonMemberView.tsx
@@ -20,6 +20,7 @@ import { MembersRow } from "./MembersRow";
 import { HighlightsGrid } from "./HighlightsGrid";
 import { JoinGroupButton } from "./JoinGroupButton";
 import { GroupOptionsModal } from "./GroupOptionsModal";
+import { ChannelsSection } from "./ChannelsSection";
 import { sectionStyles } from "./sectionStyles";
 import { Group } from "../types";
 import { ImageViewerManager } from "@/providers/ImageViewerProvider";
@@ -106,6 +107,22 @@ export function GroupNonMemberView({
   const handleMembersPress = () => {
     if (!group._id) return;
     router.push(`/leader-tools/${group._id}/members`);
+  };
+
+  // Community admins can open any channel read-only without joining (backend
+  // grants the read access; the chat screen hides the composer for them).
+  // Route straight to the chat — not the channel info/settings screen — so
+  // "look inside the channel" lands on the conversation.
+  const handleAdminChannelPress = (slug: string) => {
+    if (!group._id) return;
+    router.push({
+      pathname: `/inbox/${group._id}/${slug}` as any,
+      params: {
+        groupName: group.name || group.title || "",
+        imageUrl: group.preview || "",
+        isAnnouncementGroup: group.is_announcement_group ? "1" : "0",
+      },
+    });
   };
 
   // Resolve a single address string the same way the member view does so
@@ -460,6 +477,23 @@ export function GroupNonMemberView({
           </View>
         )}
 
+        {/* CHANNELS — admin-only. Community admins can browse and read any
+            channel without joining (backend read access from PR #525). Tapping
+            a channel opens the read-only chat. The note flags the asymmetry,
+            mirroring the LOCATION / MEMBERS admin disclaimers above. */}
+        {isAdmin && group._id && (
+          <View>
+            <ChannelsSection
+              groupId={group._id}
+              userRole={group.user_role}
+              onChannelPress={handleAdminChannelPress}
+            />
+            <View style={styles.channelsNoteWrap}>
+              <AdminViewNote text="Channels shown because you're a community admin. You can read but can't post until you join." />
+            </View>
+          </View>
+        )}
+
         {/* HIGHLIGHTS — already a self-contained section component. */}
         {group.highlights && group.highlights.length > 0 && (
           <HighlightsGrid
@@ -535,6 +569,12 @@ const styles = StyleSheet.create({
   },
   adminNoteWrap: {
     marginTop: 8,
+  },
+  // ChannelsSection carries its own horizontal padding; align the note under
+  // it (it sits flush to the section, not inside a section card).
+  channelsNoteWrap: {
+    marginTop: 8,
+    paddingHorizontal: 20,
   },
   // Leaders horizontal scroll lives inside the section card.
   leadersScrollContent: {

--- a/apps/mobile/features/groups/components/__tests__/GroupNonMemberView.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/GroupNonMemberView.test.tsx
@@ -96,6 +96,20 @@ jest.mock("../HighlightsGrid", () => {
   };
 });
 
+// ChannelsSection pulls in Convex query hooks; stub it so this unit test stays
+// focused on GroupNonMemberView's own gating. Expose onChannelPress as a
+// tappable handle so we can assert the admin browse route is wired up.
+jest.mock("../ChannelsSection", () => {
+  const { Text } = require("react-native");
+  return {
+    ChannelsSection: ({ onChannelPress }: any) => (
+      <Text testID="channels-section" onPress={() => onChannelPress?.("general")}>
+        Channels
+      </Text>
+    ),
+  };
+});
+
 jest.mock("../JoinGroupButton", () => {
   const { Text } = require("react-native");
   return {
@@ -183,6 +197,52 @@ describe("GroupNonMemberView", () => {
       login: jest.fn(),
       logout: jest.fn(),
     });
+  });
+
+  it("does NOT show the channels section to non-admin non-members", () => {
+    const onJoinPress = jest.fn();
+
+    render(<GroupNonMemberView group={mockGroup} onJoinPress={onJoinPress} />);
+
+    expect(screen.queryByTestId("channels-section")).toBeNull();
+  });
+
+  it("shows the channels section to community admins and routes taps to chat", () => {
+    const onJoinPress = jest.fn();
+    const push = jest.fn();
+    const { useRouter } = require("expo-router");
+    useRouter.mockReturnValue({ push, back: jest.fn(), replace: jest.fn() });
+
+    const { useAuth } = require("@providers/AuthProvider");
+    useAuth.mockReturnValue({
+      user: { id: 1, first_name: "Admin", last_name: "User", is_admin: true },
+      isAuthenticated: true,
+      isLoading: false,
+      church: null,
+      login: jest.fn(),
+      logout: jest.fn(),
+    });
+
+    render(<GroupNonMemberView group={mockGroup} onJoinPress={onJoinPress} />);
+
+    const channels = screen.getByTestId("channels-section");
+    expect(channels).toBeTruthy();
+
+    // Tapping a channel opens the read-only chat (not the info/settings screen).
+    fireEvent.press(channels);
+    expect(push).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: "/inbox/group_1/general" })
+    );
+
+    useAuth.mockReturnValue({
+      user: { id: 1, first_name: "Test", last_name: "User" },
+      isAuthenticated: true,
+      isLoading: false,
+      church: null,
+      login: jest.fn(),
+      logout: jest.fn(),
+    });
+    useRouter.mockReturnValue({ push: jest.fn(), back: jest.fn(), replace: jest.fn() });
   });
 
   it("calls onJoinPress when join button is pressed", () => {

--- a/apps/web/src/pages/guides/GroupsAndChannels.tsx
+++ b/apps/web/src/pages/guides/GroupsAndChannels.tsx
@@ -463,6 +463,17 @@ export function GroupsAndChannels() {
           Announcements is enabled, its row reads &ldquo;Tap to enable — leaders
           post, members read.&rdquo;
         </Callout>
+
+        <P>
+          <strong>Community admins</strong> can look inside any group&rsquo;s
+          channels — including Leaders — <strong>without joining</strong>. Open a
+          group you&rsquo;re not a member of and a <Term>Channels</Term> section
+          appears; tap any channel to read the conversation. This is{" "}
+          <strong>read-only</strong>: instead of the message box you&rsquo;ll see
+          &ldquo;You&rsquo;re viewing as a community admin. Join the group to
+          post.&rdquo; Browsing this way doesn&rsquo;t add you to the group or its
+          roster, so members aren&rsquo;t notified and your inbox stays clear.
+        </P>
       </Section>
 
       <Section id="custom-channels" title="Custom channels & invite links">


### PR DESCRIPTION
## What & why

Completes the **mobile UI half** of #525. That PR shipped the backend authorization so community admins can read any group's channels and messages **without joining** — but the UI never surfaced it. An admin opening a group they weren't a member of saw `GroupNonMemberView` (which has no channels section), and even a deep link into a channel rendered a composer that errored on send. End result: *"I cannot view any channel of a group that I'm not a member of."*

This PR wires up the read-only browsing experience.

## Changes (mobile)

- **`GroupNonMemberView.tsx`** — Render a **CHANNELS** section for community admins viewing a group they haven't joined, with an admin disclaimer note. Tapping a channel opens the **read-only chat** (the conversation), not the member info/settings screen.
- **`ChannelsSection.tsx`** — Add an optional `onChannelPress` override so admin browsers route to chat while members keep the existing info-screen behavior. Fully backward-compatible (default unchanged).
- **`ConvexChatRoomScreen.tsx`** — Detect an *admin viewer* (community admin + group context + no membership role, once the role query settles) and make the screen read-only:
  - Hide the composer behind a `"You're viewing as a community admin. Join the group to post."` banner.
  - Populate the channel tab bar from the group's full enabled channel set (excluding the `reach_out` leader-workflow surface) so admins can browse every channel, not just ones they belong to.

## Read-only guarantees

Viewing creates **no** membership rows. This is enforced on both ends:
- Composer hidden client-side; `sendMessage` rejects non-members server-side.
- `toggleReaction` rejects non-members; `markAsRead` no-ops for non-members.

(Community-admin message *deletion* remains available — that's a pre-existing moderation capability, unchanged here.)

## Indicators

Both facts are surfaced to the admin: a note under the channels list (*"Channels shown because you're a community admin. You can read but can't post until you join."*) and the in-chat banner above.

## Docs

- Updated the `GroupsAndChannels` onboarding guide to document admin read-only browsing (per the #525 follow-up note and CLAUDE.md's guide-sync rule).

## Tests

- New coverage in `GroupNonMemberView.test.tsx`: channels section hidden for non-admin non-members, shown for admins, and taps route into chat.
- Full mobile suite green (123 suites / 1140 tests) via the pre-push hook; typecheck and eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvqqQaUVATcpK98nHDqGHi)_