### PR TITLE
fix(inbox): main spot follows channel updates, not always General

### DIFF
--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -470,20 +470,27 @@ export function ChatInboxScreen({
     // Only auto-select if we're on the bare /inbox/ route
     if (pathname !== "/inbox" && pathname !== "/inbox/") return;
 
-    const firstGroup = inboxChannels[0];
-    // Open the channel that actually occupies the group's main spot (which now
-    // follows updates), so the right pane matches the channel highlighted in the row.
-    // Match the row's channel set: the inbox splits event channels into their own
-    // rows and hides disabled ones (see listItems below), so select from the same
-    // enabled, non-event channels — otherwise an unread event channel could be
-    // auto-opened even though it never occupies the visible main spot.
-    const firstChannel =
-      firstGroup &&
-      selectMainChannel(
-        firstGroup.channels.filter(
+    // Auto-select the main-spot channel of the first group that actually renders a
+    // row. The inbox splits event channels into their own rows and hides disabled
+    // ones (see listItems below), so we match that set (enabled, non-event) and run
+    // the same selectMainChannel used by the row. We scan rather than only checking
+    // inboxChannels[0] because the first backend group may contain only event/disabled
+    // channels — in that case it renders no main row, and the pane should fall through
+    // to the next group with a visible conversation instead of staying blank.
+    let firstGroup: (typeof inboxChannels)[number] | undefined;
+    let firstChannel: (typeof inboxChannels)[number]["channels"][number] | undefined;
+    for (const group of inboxChannels) {
+      const candidate = selectMainChannel(
+        group.channels.filter(
           (ch) => ch.isEnabled !== false && ch.channelType !== "event"
         )
       );
+      if (candidate) {
+        firstGroup = group;
+        firstChannel = candidate;
+        break;
+      }
+    }
     if (!firstGroup || !firstChannel) return;
 
     hasAutoSelected.current = true;

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -38,6 +38,7 @@ import { InboxSearchResults } from "./InboxSearchResults";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { GroupedInboxItem } from "./GroupedInboxItem";
+import { selectMainChannel } from "../utils/selectMainChannel";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxCache } from "../../../stores/inboxCache";
 import { Avatar } from "@components/ui/Avatar";
@@ -470,7 +471,9 @@ export function ChatInboxScreen({
     if (pathname !== "/inbox" && pathname !== "/inbox/") return;
 
     const firstGroup = inboxChannels[0];
-    const firstChannel = firstGroup.channels[0];
+    // Open the channel that actually occupies the group's main spot (which now
+    // follows updates), so the right pane matches the channel highlighted in the row.
+    const firstChannel = firstGroup && selectMainChannel(firstGroup.channels);
     if (!firstGroup || !firstChannel) return;
 
     hasAutoSelected.current = true;

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -473,7 +473,17 @@ export function ChatInboxScreen({
     const firstGroup = inboxChannels[0];
     // Open the channel that actually occupies the group's main spot (which now
     // follows updates), so the right pane matches the channel highlighted in the row.
-    const firstChannel = firstGroup && selectMainChannel(firstGroup.channels);
+    // Match the row's channel set: the inbox splits event channels into their own
+    // rows and hides disabled ones (see listItems below), so select from the same
+    // enabled, non-event channels — otherwise an unread event channel could be
+    // auto-opened even though it never occupies the visible main spot.
+    const firstChannel =
+      firstGroup &&
+      selectMainChannel(
+        firstGroup.channels.filter(
+          (ch) => ch.isEnabled !== false && ch.channelType !== "event"
+        )
+      );
     if (!firstGroup || !firstChannel) return;
 
     hasAutoSelected.current = true;

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -354,9 +354,14 @@ function GroupedInboxItemInner({
     return null;
   }
 
-  // Show secondary channels if expanded OR if they have unread messages
+  // Show secondary channels if expanded, if they have unread messages, or if one is
+  // the channel the user is currently viewing. The active check keeps the selected
+  // channel visible when another channel is promoted into the main spot, so the
+  // currently-open channel never silently disappears from the row.
   const secondaryChannels = channels.filter(
-    (ch) => ch._id !== mainChannel._id && (isExpanded || ch.unreadCount > 0)
+    (ch) =>
+      ch._id !== mainChannel._id &&
+      (isExpanded || ch.unreadCount > 0 || (isActiveGroup && activeChannelSlug === ch.slug))
   );
   const mainHasUnread = mainChannel.unreadCount > 0;
 

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -27,6 +27,7 @@ import { useTheme } from "@hooks/useTheme";
 import { getGroupTypeColorScheme } from "../../../constants/groupTypes";
 import type { Id } from "@services/api/convex";
 import { useAwaitPrefetch, useTriggerPrefetch } from "../hooks/usePrefetchChannel";
+import { selectMainChannel } from "../utils/selectMainChannel";
 
 // Type for channel data from getInboxChannels query
 interface ChannelData {
@@ -344,8 +345,9 @@ function GroupedInboxItemInner({
   }
 
   // Multiple channels display - main channel as full card, sub-channels below with L-connector
-  // Find the main channel and secondary channels (only show secondary if unread)
-  const mainChannel = channels.find((ch) => ch.channelType === "main") || channels[0];
+  // The main spot follows updates: a channel with unread messages takes it, and the
+  // General channel reclaims it whenever it has its own update (see selectMainChannel).
+  const mainChannel = selectMainChannel(channels);
 
   // Guard against empty channels array (shouldn't happen, but be safe)
   if (!mainChannel) {

--- a/apps/mobile/features/chat/utils/__tests__/selectMainChannel.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/selectMainChannel.test.ts
@@ -1,0 +1,69 @@
+import { selectMainChannel, type MainSpotChannel } from "../selectMainChannel";
+
+/**
+ * The grouped inbox row shows one channel in the prominent "main spot" and the
+ * rest as secondary sub-rows. These tests pin down which channel wins the main
+ * spot now that selection follows updates instead of always being "General".
+ */
+type TestChannel = MainSpotChannel & { id: string };
+
+const channel = (overrides: Partial<TestChannel> & { id: string }): TestChannel => ({
+  channelType: "custom",
+  unreadCount: 0,
+  lastMessageAt: null,
+  ...overrides,
+});
+
+describe("selectMainChannel", () => {
+  it("returns undefined for an empty channel list", () => {
+    expect(selectMainChannel([])).toBeUndefined();
+  });
+
+  it("falls back to the General channel when nothing has updates", () => {
+    const general = channel({ id: "g", channelType: "main", lastMessageAt: 100 });
+    const leaders = channel({ id: "l", channelType: "leaders", lastMessageAt: 200 });
+
+    expect(selectMainChannel([general, leaders])?.id).toBe("g");
+  });
+
+  it("falls back to the first channel when there is no General channel and no updates", () => {
+    const leaders = channel({ id: "l", channelType: "leaders" });
+    const announcements = channel({ id: "a", channelType: "announcements" });
+
+    expect(selectMainChannel([leaders, announcements])?.id).toBe("l");
+  });
+
+  it("gives the main spot to a secondary channel that has updates when General has none", () => {
+    const general = channel({ id: "g", channelType: "main", unreadCount: 0, lastMessageAt: 500 });
+    const leaders = channel({ id: "l", channelType: "leaders", unreadCount: 3, lastMessageAt: 100 });
+
+    expect(selectMainChannel([general, leaders])?.id).toBe("l");
+  });
+
+  it("lets the General channel reclaim the main spot when it receives an update", () => {
+    const general = channel({ id: "g", channelType: "main", unreadCount: 1, lastMessageAt: 100 });
+    const leaders = channel({ id: "l", channelType: "leaders", unreadCount: 3, lastMessageAt: 999 });
+
+    // Even though leaders is more recent and has more unread, General reclaims the spot.
+    expect(selectMainChannel([general, leaders])?.id).toBe("g");
+  });
+
+  it("picks the most recently updated channel when several secondaries have updates", () => {
+    const general = channel({ id: "g", channelType: "main", unreadCount: 0, lastMessageAt: 50 });
+    const leaders = channel({ id: "l", channelType: "leaders", unreadCount: 2, lastMessageAt: 300 });
+    const announcements = channel({ id: "a", channelType: "announcements", unreadCount: 5, lastMessageAt: 800 });
+
+    expect(selectMainChannel([general, leaders, announcements])?.id).toBe("a");
+  });
+
+  it("does not mutate the input array order", () => {
+    const general = channel({ id: "g", channelType: "main", unreadCount: 0, lastMessageAt: 50 });
+    const leaders = channel({ id: "l", channelType: "leaders", unreadCount: 2, lastMessageAt: 300 });
+    const announcements = channel({ id: "a", channelType: "announcements", unreadCount: 5, lastMessageAt: 800 });
+    const input = [general, leaders, announcements];
+
+    selectMainChannel(input);
+
+    expect(input.map((ch) => ch.id)).toEqual(["g", "l", "a"]);
+  });
+});

--- a/apps/mobile/features/chat/utils/selectMainChannel.ts
+++ b/apps/mobile/features/chat/utils/selectMainChannel.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal channel shape needed to choose the inbox "main spot" channel.
+ * Matches the relevant fields of `ChannelData` from the getInboxChannels query.
+ */
+export interface MainSpotChannel {
+  channelType: string;
+  unreadCount: number;
+  lastMessageAt: number | null;
+}
+
+/**
+ * Chooses which channel occupies the prominent "main spot" of a grouped inbox row.
+ *
+ * Previously the "General" channel (channelType === "main") always held the main
+ * spot, even when it had no updates, pushing channels that *did* have updates into
+ * a secondary position. Now the main spot follows the updates:
+ *
+ * - The General channel reclaims the main spot whenever it has its own unread
+ *   updates — per product requirement, General takes priority when it has an update.
+ * - Otherwise, the most recently updated channel with unread messages takes the spot.
+ * - When no channel has updates, fall back to the General channel (or, if there is
+ *   no General channel, the first channel) so the row still renders as before.
+ */
+export function selectMainChannel<T extends MainSpotChannel>(channels: T[]): T | undefined {
+  if (channels.length === 0) {
+    return undefined;
+  }
+
+  const generalChannel = channels.find((ch) => ch.channelType === "main");
+
+  // General reclaims the main spot when it has its own updates.
+  if (generalChannel && generalChannel.unreadCount > 0) {
+    return generalChannel;
+  }
+
+  // Otherwise the most recently updated channel with unread messages wins.
+  const mostRecentWithUpdates = channels
+    .filter((ch) => ch.unreadCount > 0)
+    .sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0))[0];
+
+  // Fall back to General (or the first channel) when nothing has updates.
+  return mostRecentWithUpdates ?? generalChannel ?? channels[0];
+}


### PR DESCRIPTION
## Problem

In the grouped inbox row, the prominent "main spot" was unconditionally assigned to the **General** channel (`channelType === "main"`), even when it had no updates. Channels that *did* have updates were demoted to a secondary L-connector sub-row.

**Repro:**
1. Have updates in a secondary channel (e.g. Leaders/Announcements) but not in General.
2. The General channel still occupies the main spot, while the channel with the actual update sits below it.

## Fix

`GroupedInboxItem` now selects the main-spot channel by update status instead of always picking General:

- The most recently updated channel **with unread messages** takes the main spot.
- The **General channel reclaims** the main spot whenever it has its own update (per the requirement, General takes priority when it has an update — the other channel moves to a secondary position).
- When **no** channel has updates, it falls back to General (or the first channel), preserving the previous default.

The selection logic is extracted into a pure `selectMainChannel()` helper (`apps/mobile/features/chat/utils/selectMainChannel.ts`) so it can be unit-tested in isolation.

## Tests

Added `selectMainChannel.test.ts` covering: empty list, no-updates fallback to General, no-General fallback to first channel, a secondary channel winning the spot when General is quiet, General reclaiming the spot on its own update, most-recent-wins among multiple updated channels, and input-array non-mutation.

- New suite passes (7/7).
- Full mobile test suite green (1147 passing) via the pre-push hook.
- ESLint clean on changed files (only pre-existing warnings remain).

## Scope

Client-side display only — no backend/query changes. The needed fields (`unreadCount`, `lastMessageAt`, `channelType`) are already present on each channel from `getInboxChannels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Re3jYJkyaJ733PRpFHqbJ)_