### PR TITLE
fix(leader-tools): make event text blast sheet scrollable with tray grabber

### DIFF
--- a/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
@@ -86,9 +86,14 @@ export function EventBlastSheet({
         >
           <TouchableOpacity
             activeOpacity={1}
-            // Tapping anywhere on the sheet outside the input (grabber, header,
-            // padding) dismisses the keyboard without closing the sheet.
-            onPress={() => Keyboard.dismiss()}
+            // Tapping the sheet outside the input (grabber, header, padding)
+            // dismisses the keyboard. Stop propagation so the press doesn't
+            // bubble to the backdrop's onClose (RN Web bubbles press events)
+            // and close the sheet out from under the user.
+            onPress={(e) => {
+              e.stopPropagation();
+              Keyboard.dismiss();
+            }}
             style={[styles.sheet, { backgroundColor: colors.surface }]}
           >
             {/* Grabber — visual affordance that this is a draggable tray */}

--- a/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/EventBlastSheet.tsx
@@ -9,6 +9,8 @@ import {
   Alert,
   Modal,
   KeyboardAvoidingView,
+  Keyboard,
+  ScrollView,
   Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
@@ -84,9 +86,16 @@ export function EventBlastSheet({
         >
           <TouchableOpacity
             activeOpacity={1}
-            onPress={(e) => e.stopPropagation()}
+            // Tapping anywhere on the sheet outside the input (grabber, header,
+            // padding) dismisses the keyboard without closing the sheet.
+            onPress={() => Keyboard.dismiss()}
             style={[styles.sheet, { backgroundColor: colors.surface }]}
           >
+            {/* Grabber — visual affordance that this is a draggable tray */}
+            <View style={styles.grabberContainer}>
+              <View style={[styles.grabber, { backgroundColor: colors.border }]} />
+            </View>
+
             {/* Header */}
             <View style={[styles.header, { borderBottomColor: colors.border }]}>
               <Text style={[styles.title, { color: colors.text }]}>
@@ -97,7 +106,14 @@ export function EventBlastSheet({
               </TouchableOpacity>
             </View>
 
-            <View style={styles.body}>
+            {/* Scrollable body so the Send CTA stays reachable even when a long
+                message expands the input to the sheet's 80% height cap. */}
+            <ScrollView
+              style={styles.scroll}
+              contentContainerStyle={styles.body}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="interactive"
+            >
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 Text everyone going to or interested in {eventTitle}. The message will also post to the event's Activity feed.
               </Text>
@@ -140,7 +156,7 @@ export function EventBlastSheet({
                   <Text style={styles.sendButtonText}>Send Text Blast</Text>
                 )}
               </TouchableOpacity>
-            </View>
+            </ScrollView>
           </TouchableOpacity>
         </TouchableOpacity>
       </KeyboardAvoidingView>
@@ -157,6 +173,21 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     maxHeight: "80%",
+  },
+  grabberContainer: {
+    alignItems: "center",
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  grabber: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+  },
+  scroll: {
+    // Shrink within the sheet's 80% height cap so the body scrolls instead of
+    // pushing the Send CTA off-screen when the message is long.
+    flexShrink: 1,
   },
   header: {
     flexDirection: "row",
@@ -182,6 +213,9 @@ const styles = StyleSheet.create({
     padding: 14,
     fontSize: 16,
     minHeight: 100,
+    // Cap growth so a long message expands the scrollable body rather than an
+    // ever-taller input; the body scrolls to keep the CTA reachable.
+    maxHeight: 200,
   },
   charCount: {
     fontSize: 12,


### PR DESCRIPTION
## Problem

On the event **Text Blast** sheet (`EventBlastSheet.tsx`), a long message expands the multiline input until the sheet hits its `maxHeight: 80%` cap. Because the body wasn't scrollable, the **Send Text Blast** CTA got pushed off-screen with no way to reach it. Tapping outside the input also didn't dismiss the keyboard.

## Fix

- **Scrollable body** — wrap the sheet body in a `ScrollView` (`flexShrink: 1` so it shrinks within the 80% cap and scrolls instead of clipping the CTA). Cap the input at `maxHeight: 200` so a long message grows the scrollable area rather than an ever-taller input.
- **Tray grabber** — add a grabber handle at the top of the sheet, matching the existing `EventCommentSheet` handle affordance.
- **Keyboard dismissal** — tapping the sheet outside the input now calls `Keyboard.dismiss()`; the `ScrollView` uses `keyboardShouldPersistTaps="handled"` (so the Send button still works with the keyboard up) and `keyboardDismissMode="interactive"`.

## Repro (before)

1. Open the event text blast screen.
2. Enter a message long enough to make the sheet cover ~80% of the screen.
3. Before: the sheet doesn't scroll and the "Send Text Blast" CTA is inaccessible; tapping outside the input doesn't dismiss the keyboard.
4. After: the body scrolls to the CTA, the grabber signals the tray affordance, and tapping outside the input dismisses the keyboard.

## Checks

- `eslint` on the changed file: clean (also enforced by pre-commit hook).
- `tsc --noEmit`: no errors in the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhMa2Xntwyd1L7jy44c8G7)_