### PR TITLE
Fix "too many reads" in event-invite picker; cap invites at 20

### DIFF
--- a/apps/convex/__tests__/eventInvites-invite-picker.test.ts
+++ b/apps/convex/__tests__/eventInvites-invite-picker.test.ts
@@ -267,4 +267,62 @@ describe("initiate recipient cap", () => {
 
     expect(result.invited).toBe(20);
   });
+
+  // Locks in the indexed per-recipient validation (no whole-group / whole-
+  // meeting collection): non-members, RSVP'd members, and already-invited
+  // members are each classified correctly.
+  test("validates each requested recipient with indexed lookups", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    const rsvpdMember = data.memberIds[0];
+    const invitedMember = data.memberIds[1];
+    const freshMember = data.memberIds[2];
+
+    const outsiderId = await t.run(async (ctx) => {
+      const ts = Date.now();
+      const group = await ctx.db.get(data.groupId);
+      // A member already RSVP'd — should be skipped, not re-texted.
+      await ctx.db.insert("meetingRsvps", {
+        meetingId: data.meetingId,
+        userId: rsvpdMember,
+        rsvpOptionId: 1,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      // A member already invited — should be counted as alreadyInvited.
+      await ctx.db.insert("eventInvites", {
+        meetingId: data.meetingId,
+        groupId: data.groupId,
+        communityId: group!.communityId,
+        sentById: data.leaderId,
+        recipientUserId: invitedMember,
+        channels: ["push", "sms"],
+        status: "pending",
+        inviteRound: 1,
+        lastSentAt: ts,
+        createdAt: ts,
+      });
+      // A user who is not a member of the group at all.
+      return await ctx.db.insert("users", {
+        firstName: "Not",
+        lastName: "AMember",
+        createdAt: ts,
+        updatedAt: ts,
+      });
+    });
+
+    const result = await t.mutation(api.functions.eventInvites.initiate, {
+      token: data.leaderToken,
+      meetingId: data.meetingId,
+      recipientUserIds: [rsvpdMember, invitedMember, freshMember, outsiderId],
+    });
+
+    expect(result).toEqual({
+      invited: 1,
+      alreadyInvited: 1,
+      skippedNotMember: 1,
+      skippedRsvped: 1,
+    });
+  });
 });

--- a/apps/convex/__tests__/eventInvites-invite-picker.test.ts
+++ b/apps/convex/__tests__/eventInvites-invite-picker.test.ts
@@ -194,6 +194,30 @@ describe("listGroupMembersForInvite (bounded picker query)", () => {
     expect(self?.isSelf).toBe(true);
   });
 
+  test("excludes members who have left the group from the default view", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    // Mark one member as having left the group.
+    const leftMember = data.memberIds[0];
+    await t.run(async (ctx) => {
+      const membership = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", data.groupId).eq("userId", leftMember),
+        )
+        .first();
+      await ctx.db.patch(membership!._id, { leftAt: Date.now() });
+    });
+
+    const rows = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: data.leaderToken, meetingId: data.meetingId },
+    );
+
+    expect(rows.map((r) => r.userId)).not.toContain(leftMember);
+  });
+
   test("a member beyond the first page is absent by default but found via server-side search", async () => {
     const t = convexTest(schema, modules);
     const data = await seedLargeGroupWithMeeting(t);
@@ -324,5 +348,41 @@ describe("initiate recipient cap", () => {
       skippedNotMember: 1,
       skippedRsvped: 1,
     });
+  });
+});
+
+describe("reinvite recipient handling", () => {
+  test("dedupes duplicate ids so a recipient is only re-sent once", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    const target = data.memberIds[0];
+    await t.run(async (ctx) => {
+      const ts = Date.now();
+      const group = await ctx.db.get(data.groupId);
+      // Existing invite, last sent well outside the re-invite cooldown window.
+      await ctx.db.insert("eventInvites", {
+        meetingId: data.meetingId,
+        groupId: data.groupId,
+        communityId: group!.communityId,
+        sentById: data.leaderId,
+        recipientUserId: target,
+        channels: ["push", "sms"],
+        status: "sent",
+        inviteRound: 1,
+        lastSentAt: ts - 25 * 60 * 60 * 1000,
+        createdAt: ts - 25 * 60 * 60 * 1000,
+      });
+    });
+
+    // Same id submitted many times (a direct, non-UI caller) must collapse to
+    // a single re-invite — otherwise the send action texts them once per entry.
+    const result = await t.mutation(api.functions.eventInvites.reinvite, {
+      token: data.leaderToken,
+      meetingId: data.meetingId,
+      recipientUserIds: [target, target, target, target, target],
+    });
+
+    expect(result.reinvited).toBe(1);
   });
 });

--- a/apps/convex/__tests__/eventInvites-invite-picker.test.ts
+++ b/apps/convex/__tests__/eventInvites-invite-picker.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for the event-invite recipient picker backend
+ * (`eventInvites.listGroupMembersForInvite`) and the recipient cap on
+ * `eventInvites.initiate`.
+ *
+ * Background: the picker query used to `.collect()` every group member and then
+ * fire a user-row read + a push-token query for each one. In large groups that
+ * blew past Convex's per-execution read limit (4096) — the production error
+ * "Too many reads in a single function execution" seen in
+ * `listGroupMembersForInvite`. The query now:
+ *
+ *  - returns at most MEMBER_PICKER_LIMIT (50) members per call, so it never
+ *    fans reads out across the whole group;
+ *  - searches server-side against the users full-text index, so a member beyond
+ *    the first page is still findable by name;
+ *  - always surfaces the caller (test-invite-to-self) in the default view.
+ *
+ * And `initiate`/`reinvite` reject more than 20 recipients per call.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/eventInvites-invite-picker.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+
+// JWT secret must be at least 32 characters
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+vi.useFakeTimers();
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+// The picker caps its result at this many members (mirrors MEMBER_PICKER_LIMIT
+// in functions/eventInvites.ts).
+const PICKER_LIMIT = 50;
+// Enough ordinary members to exceed the picker limit and prove bounding.
+const MEMBER_COUNT = 60;
+
+interface PickerTestData {
+  groupId: Id<"groups">;
+  meetingId: Id<"meetings">;
+  leaderId: Id<"users">;
+  leaderToken: string;
+  // A member who joins last, so they fall beyond the default (un-searched) page.
+  farawayId: Id<"users">;
+  memberIds: Id<"users">[];
+}
+
+async function seedLargeGroupWithMeeting(
+  t: ReturnType<typeof convexTest>,
+): Promise<PickerTestData> {
+  const ids = await t.run(async (ctx) => {
+    const ts = Date.now();
+    const future = ts + 86_400_000;
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Big Community",
+      slug: "big-community-invite",
+      isPublic: true,
+      timezone: "America/New_York",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Group",
+      slug: "group",
+      isActive: true,
+      displayOrder: 1,
+      createdAt: ts,
+    });
+
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Big Group",
+      isArchived: false,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    // Caller is a leader so they pass canEditMeeting.
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Caller",
+      lastName: "Leader",
+      email: "caller@test.com",
+      phone: "+15551110000",
+      searchText: "caller leader caller@test.com +15551110000",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: leaderId,
+      role: "leader",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+
+    const memberIds: Id<"users">[] = [];
+    for (let i = 0; i < MEMBER_COUNT; i++) {
+      const userId = await ctx.db.insert("users", {
+        firstName: `Member${i}`,
+        lastName: "Test",
+        email: `member${i}@test.com`,
+        phone: `+1555200${String(i).padStart(4, "0")}`,
+        searchText: `member${i} test member${i}@test.com`,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId,
+        role: "member",
+        joinedAt: ts + i + 1,
+        notificationsEnabled: true,
+      });
+      memberIds.push(userId);
+    }
+
+    // Joins last, so they land beyond the default first page.
+    const farawayId = await ctx.db.insert("users", {
+      firstName: "Zelda",
+      lastName: "Faraway",
+      email: "zelda@test.com",
+      phone: "+15559990000",
+      searchText: "zelda faraway zelda@test.com +15559990000",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: farawayId,
+      role: "member",
+      joinedAt: ts + MEMBER_COUNT + 1000,
+      notificationsEnabled: true,
+    });
+
+    const meetingId = await ctx.db.insert("meetings", {
+      groupId,
+      title: "Big Event",
+      scheduledAt: future,
+      status: "scheduled",
+      meetingType: 1,
+      createdAt: ts,
+      rsvpEnabled: true,
+      rsvpOptions: [{ id: 1, label: "Going", enabled: true }],
+      visibility: "group",
+      shortId: "bigevt01",
+    });
+
+    return { groupId, meetingId, leaderId, farawayId, memberIds };
+  });
+
+  const { accessToken: leaderToken } = await generateTokens(ids.leaderId);
+
+  return { ...ids, leaderToken };
+}
+
+describe("listGroupMembersForInvite (bounded picker query)", () => {
+  test("caps the default result well below the group size", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    const rows = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: data.leaderToken, meetingId: data.meetingId },
+    );
+
+    // Group has MEMBER_COUNT + leader + faraway members, but the query must not
+    // return (or read) the whole group — that was the "too many reads" bug.
+    expect(rows.length).toBeLessThanOrEqual(PICKER_LIMIT);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  test("always includes the caller for a test-invite-to-self", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    const rows = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: data.leaderToken, meetingId: data.meetingId },
+    );
+
+    const self = rows.find((r) => r.userId === data.leaderId);
+    expect(self).toBeDefined();
+    expect(self?.isSelf).toBe(true);
+  });
+
+  test("a member beyond the first page is absent by default but found via server-side search", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    const defaultRows = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: data.leaderToken, meetingId: data.meetingId },
+    );
+    expect(defaultRows.map((r) => r.userId)).not.toContain(data.farawayId);
+
+    const searched = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: data.leaderToken, meetingId: data.meetingId, search: "zelda" },
+    );
+    expect(searched.map((r) => r.userId)).toContain(data.farawayId);
+  });
+
+  test("search only returns members of the meeting's group", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    // An outsider whose name matches the search term but who is not in the group.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        firstName: "Zelda",
+        lastName: "Outsider",
+        email: "zelda-out@test.com",
+        searchText: "zelda outsider zelda-out@test.com",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    const searched = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: data.leaderToken, meetingId: data.meetingId, search: "zelda" },
+    );
+
+    // Only the in-group Zelda comes back.
+    expect(searched.map((r) => r.userId)).toEqual([data.farawayId]);
+  });
+});
+
+describe("initiate recipient cap", () => {
+  test("rejects more than 20 recipients", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    const twentyOne = data.memberIds.slice(0, 21);
+    expect(twentyOne.length).toBe(21);
+
+    await expect(
+      t.mutation(api.functions.eventInvites.initiate, {
+        token: data.leaderToken,
+        meetingId: data.meetingId,
+        recipientUserIds: twentyOne,
+      }),
+    ).rejects.toThrow(/up to 20 people/i);
+  });
+
+  test("accepts exactly 20 recipients", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    const twenty = data.memberIds.slice(0, 20);
+    const result = await t.mutation(api.functions.eventInvites.initiate, {
+      token: data.leaderToken,
+      meetingId: data.meetingId,
+      recipientUserIds: twenty,
+    });
+
+    expect(result.invited).toBe(20);
+  });
+});

--- a/apps/convex/__tests__/eventInvites-invite-picker.test.ts
+++ b/apps/convex/__tests__/eventInvites-invite-picker.test.ts
@@ -218,6 +218,114 @@ describe("listGroupMembersForInvite (bounded picker query)", () => {
     expect(rows.map((r) => r.userId)).not.toContain(leftMember);
   });
 
+  test("finds active members that sort after a wall of departed rows", async () => {
+    const t = convexTest(schema, modules);
+
+    // A group whose by_group index is front-loaded with many left members, with
+    // the only reachable active members inserted last. A fixed small raw page
+    // would miss them; the scan must continue (up to the cap) to surface them.
+    const seeded = await t.run(async (ctx) => {
+      const ts = Date.now();
+      const communityId = await ctx.db.insert("communities", {
+        name: "Churn Community",
+        slug: "churn-community",
+        isPublic: true,
+        timezone: "America/New_York",
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      const groupTypeId = await ctx.db.insert("groupTypes", {
+        communityId,
+        name: "Group",
+        slug: "group",
+        isActive: true,
+        displayOrder: 1,
+        createdAt: ts,
+      });
+      const groupId = await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name: "Churn Group",
+        isArchived: false,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      const leaderId = await ctx.db.insert("users", {
+        firstName: "Churn",
+        lastName: "Leader",
+        phone: "+15551110001",
+        searchText: "churn leader",
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId: leaderId,
+        role: "leader",
+        joinedAt: ts,
+        notificationsEnabled: true,
+      });
+      // 120 members who have LEFT — they precede the active members in the index.
+      for (let i = 0; i < 120; i++) {
+        const uid = await ctx.db.insert("users", {
+          firstName: `Left${i}`,
+          lastName: "Gone",
+          phone: `+1555300${String(i).padStart(4, "0")}`,
+          createdAt: ts,
+          updatedAt: ts,
+        });
+        await ctx.db.insert("groupMembers", {
+          groupId,
+          userId: uid,
+          role: "member",
+          joinedAt: ts + i + 1,
+          notificationsEnabled: true,
+          leftAt: ts + 1000 + i,
+        });
+      }
+      // A single active member inserted last.
+      const activeId = await ctx.db.insert("users", {
+        firstName: "Still",
+        lastName: "Here",
+        phone: "+15559990001",
+        searchText: "still here",
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId: activeId,
+        role: "member",
+        joinedAt: ts + 5000,
+        notificationsEnabled: true,
+      });
+      const meetingId = await ctx.db.insert("meetings", {
+        groupId,
+        title: "Churn Event",
+        scheduledAt: ts + 86_400_000,
+        status: "scheduled",
+        meetingType: 1,
+        createdAt: ts,
+        rsvpEnabled: true,
+        rsvpOptions: [{ id: 1, label: "Going", enabled: true }],
+        visibility: "group",
+        shortId: "churn001",
+      });
+      return { leaderId, activeId, meetingId };
+    });
+
+    const { accessToken: leaderToken } = await generateTokens(seeded.leaderId);
+    const rows = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: leaderToken, meetingId: seeded.meetingId },
+    );
+
+    const ids = rows.map((r) => r.userId);
+    expect(ids).toContain(seeded.activeId);
+    // No left member should appear.
+    expect(rows.every((r) => r.userId === seeded.leaderId || r.userId === seeded.activeId)).toBe(true);
+  });
+
   test("a member beyond the first page is absent by default but found via server-side search", async () => {
     const t = convexTest(schema, modules);
     const data = await seedLargeGroupWithMeeting(t);

--- a/apps/convex/__tests__/eventInvites-invite-picker.test.ts
+++ b/apps/convex/__tests__/eventInvites-invite-picker.test.ts
@@ -326,6 +326,53 @@ describe("listGroupMembersForInvite (bounded picker query)", () => {
     expect(rows.every((r) => r.userId === seeded.leaderId || r.userId === seeded.activeId)).toBe(true);
   });
 
+  test("surfaces invite-eligible members even when the leading rows are all already invited", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedLargeGroupWithMeeting(t);
+
+    // Invite the first 55 members directly, so the leading active rows in the
+    // group index are all already-invited. Only the tail is still eligible.
+    const alreadyInvited = data.memberIds.slice(0, 55);
+    const stillEligible = data.memberIds.slice(55);
+    expect(stillEligible.length).toBeGreaterThan(0);
+
+    await t.run(async (ctx) => {
+      const ts = Date.now();
+      const group = await ctx.db.get(data.groupId);
+      for (const uid of alreadyInvited) {
+        await ctx.db.insert("eventInvites", {
+          meetingId: data.meetingId,
+          groupId: data.groupId,
+          communityId: group!.communityId,
+          sentById: data.leaderId,
+          recipientUserId: uid,
+          channels: ["push", "sms"],
+          status: "sent",
+          inviteRound: 1,
+          lastSentAt: ts,
+          createdAt: ts,
+        });
+      }
+    });
+
+    const rows = await t.query(
+      api.functions.eventInvites.listGroupMembersForInvite,
+      { token: data.leaderToken, meetingId: data.meetingId },
+    );
+
+    // The default picker must still show invitable members, not just a page of
+    // disabled already-invited rows.
+    const eligible = rows.filter(
+      (r) => r.hasPhone && !r.alreadyInvited && !r.alreadyRsvped && !r.isSelf,
+    );
+    expect(eligible.length).toBeGreaterThan(0);
+    // Every still-eligible member should be reachable through the default view.
+    const returnedEligibleIds = new Set(eligible.map((r) => r.userId));
+    for (const id of stillEligible) {
+      expect(returnedEligibleIds.has(id)).toBe(true);
+    }
+  });
+
   test("a member beyond the first page is absent by default but found via server-side search", async () => {
     const t = convexTest(schema, modules);
     const data = await seedLargeGroupWithMeeting(t);

--- a/apps/convex/functions/eventInvites.ts
+++ b/apps/convex/functions/eventInvites.ts
@@ -41,17 +41,19 @@ const MAX_INVITE_RECIPIENTS = 20;
 // single bounded page off the group index — neither fans reads out across the
 // whole group the way the old collect-everything implementation did.
 const MEMBER_PICKER_LIMIT = 50;
-// Hard upper bound on group-member rows scanned for the empty (default) picker
-// view. We iterate the by_group index lazily and stop as soon as `limit`
-// invite-eligible members are found, so the common case reads only a handful of
-// rows; this cap only bites in a high-churn group where many departed/pending
-// rows precede the active ones.
-const DEFAULT_MEMBER_SCAN_LIMIT = 2000;
-// Hard upper bound on members we HYDRATE (user + push-token + invite + RSVP
-// reads) in the default view before giving up on reaching `limit` eligible
-// ones. Bounds reads even when a big group's leading rows are all already
-// invited / RSVP'd / unreachable. Scan + hydration reads stay well under 4096.
-const DEFAULT_MEMBER_HYDRATE_CAP = 200;
+// Read budget for the empty (default) picker view. We iterate the by_group
+// index lazily and stop as soon as `limit` invite-eligible members are found,
+// so the common case reads only a handful of rows. These two caps are the hard
+// backstop for pathological groups and are sized so the WORST case
+// (SCAN rows read + 4 reads per hydrated member) stays comfortably under
+// Convex's 4096-read-per-execution limit: 1500 + 4*350 = 2900.
+//
+// This is a deliberate, bounded scan — not exhaustive. Exhaustive reach into an
+// arbitrarily large group is fundamentally incompatible with the read limit
+// this whole change exists to respect; the picker's search field (server-side,
+// full-text) is the escape hatch for any member past the default window.
+const DEFAULT_MEMBER_SCAN_LIMIT = 1500; // max group-member rows scanned
+const DEFAULT_MEMBER_HYDRATE_CAP = 350; // max members hydrated (user+push+invite+rsvp)
 // How many full-text matches to scan before narrowing to group members. The
 // users search index is global (not group-scoped), so we over-fetch and then
 // filter to members. 500 matches the cap used by admin People search and
@@ -251,9 +253,11 @@ export const listGroupMembersForInvite = query({
       // Empty search: lazily scan the group index, hydrating active members and
       // continuing until we have `limit` INVITE-ELIGIBLE ones — not just active
       // ones. A group whose leading rows are all already-invited / RSVP'd /
-      // unreachable (which happens naturally after a few 20-person invite
-      // batches) would otherwise show an empty picker even though later members
-      // can still be invited. Both caps keep the reads bounded.
+      // unreachable would otherwise show an empty picker even though later
+      // members can still be invited. Both caps keep the reads bounded; a member
+      // past the scan window (e.g. behind hundreds of already-invited rows) is
+      // reached via the search field rather than by scanning the whole group,
+      // which the read limit forbids.
       let scanned = 0;
       let eligibleCount = 0;
       for await (const m of ctx.db

--- a/apps/convex/functions/eventInvites.ts
+++ b/apps/convex/functions/eventInvites.ts
@@ -42,13 +42,16 @@ const MAX_INVITE_RECIPIENTS = 20;
 // whole group the way the old collect-everything implementation did.
 const MEMBER_PICKER_LIMIT = 50;
 // Hard upper bound on group-member rows scanned for the empty (default) picker
-// view. We iterate the by_group index lazily and stop as soon as `limit` active
-// members are found, so the common case reads only a handful of rows; this cap
-// only bites in a high-churn group where many departed/pending rows precede the
-// active ones. Kept well under the 4096 read limit so the per-member hydration
-// below still fits. A DB `.filter()` (or a fixed-size page then filter) would
-// instead read past every leftAt-set row or stop before reaching active members.
+// view. We iterate the by_group index lazily and stop as soon as `limit`
+// invite-eligible members are found, so the common case reads only a handful of
+// rows; this cap only bites in a high-churn group where many departed/pending
+// rows precede the active ones.
 const DEFAULT_MEMBER_SCAN_LIMIT = 2000;
+// Hard upper bound on members we HYDRATE (user + push-token + invite + RSVP
+// reads) in the default view before giving up on reaching `limit` eligible
+// ones. Bounds reads even when a big group's leading rows are all already
+// invited / RSVP'd / unreachable. Scan + hydration reads stay well under 4096.
+const DEFAULT_MEMBER_HYDRATE_CAP = 200;
 // How many full-text matches to scan before narrowing to group members. The
 // users search index is global (not group-scoped), so we over-fetch and then
 // filter to members. 500 matches the cap used by admin People search and
@@ -168,13 +171,62 @@ export const listGroupMembersForInvite = query({
       MEMBER_PICKER_LIMIT,
     );
 
-    // --- Resolve a BOUNDED set of candidate member userIds -------------------
-    // Never touch more than ~limit members. A search hits the users full-text
-    // index (O(matches)) and confirms membership per hit; the empty default
-    // view reads a single bounded page off the group index.
-    const memberIds = new Set<Id<"users">>();
+    // Hydrate one member into a picker row with `.first()` existence checks
+    // (a handful of reads each) rather than collecting whole tables.
+    const environment = getCurrentEnvironment();
+    const hydrate = async (id: Id<"users">) => {
+      const user = await ctx.db.get(id);
+      if (!user) return null;
+
+      const pushToken = await ctx.db
+        .query("pushTokens")
+        .withIndex("by_user", (q) => q.eq("userId", id))
+        .filter((q) => q.eq(q.field("environment"), environment))
+        .first();
+      const existing = await ctx.db
+        .query("eventInvites")
+        .withIndex("by_meeting_recipient", (q) =>
+          q.eq("meetingId", args.meetingId).eq("recipientUserId", id),
+        )
+        .first();
+      const rsvp = await ctx.db
+        .query("meetingRsvps")
+        .withIndex("by_meeting_user", (q) =>
+          q.eq("meetingId", args.meetingId).eq("userId", id),
+        )
+        .first();
+
+      return {
+        userId: id,
+        firstName: user.firstName ?? null,
+        lastName: user.lastName ?? null,
+        profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
+        hasPhone: !!user.phone,
+        hasPushTokens: !!pushToken,
+        alreadyInvited: !!existing,
+        inviteStatus: existing?.status ?? null,
+        inviteRound: existing?.inviteRound ?? 0,
+        lastSentAt: existing?.lastSentAt ?? null,
+        alreadyRsvped: !!rsvp,
+        isSelf: id === userId,
+      };
+    };
+
+    type Row = NonNullable<Awaited<ReturnType<typeof hydrate>>>;
+    // "Eligible" = actually invitable right now (reachable, not already invited,
+    // not RSVP'd, not the caller). This is what the leader can act on.
+    const isEligible = (r: Row) =>
+      (r.hasPhone || r.hasPushTokens) &&
+      !r.alreadyInvited &&
+      !r.alreadyRsvped &&
+      !r.isSelf;
+
+    // --- Resolve + hydrate a BOUNDED set of candidate members ----------------
+    const rowsById = new Map<string, Row>();
 
     if (search) {
+      // Search hits the users full-text index (O(matches)) and confirms
+      // membership per hit.
       const matches = await ctx.db
         .query("users")
         .withSearchIndex("search_users", (q) =>
@@ -182,7 +234,8 @@ export const listGroupMembersForInvite = query({
         )
         .take(USER_SEARCH_SCAN_LIMIT);
       for (const user of matches) {
-        if (memberIds.size >= limit) break;
+        if (rowsById.size >= limit) break;
+        if (rowsById.has(user._id)) continue;
         const membership = await ctx.db
           .query("groupMembers")
           .withIndex("by_group_user", (q) =>
@@ -190,29 +243,35 @@ export const listGroupMembersForInvite = query({
           )
           .first();
         if (membership && isActiveMembership(membership)) {
-          memberIds.add(user._id);
+          const row = await hydrate(user._id);
+          if (row) rowsById.set(user._id, row);
         }
       }
     } else {
-      // Empty search: lazily scan the group index, collecting active members
-      // until we have `limit` of them. Stopping after a fixed raw page could
-      // return a near-empty roster in a high-churn group where departed/pending
-      // rows precede the active ones; iterating with an early break keeps the
-      // common case cheap while DEFAULT_MEMBER_SCAN_LIMIT bounds the reads.
+      // Empty search: lazily scan the group index, hydrating active members and
+      // continuing until we have `limit` INVITE-ELIGIBLE ones — not just active
+      // ones. A group whose leading rows are all already-invited / RSVP'd /
+      // unreachable (which happens naturally after a few 20-person invite
+      // batches) would otherwise show an empty picker even though later members
+      // can still be invited. Both caps keep the reads bounded.
       let scanned = 0;
+      let eligibleCount = 0;
       for await (const m of ctx.db
         .query("groupMembers")
         .withIndex("by_group", (q) => q.eq("groupId", groupId))) {
         scanned++;
-        if (isActiveMembership(m)) {
-          memberIds.add(m.userId);
-          if (memberIds.size >= limit) break;
-        }
-        if (scanned >= DEFAULT_MEMBER_SCAN_LIMIT) break;
+        if (scanned > DEFAULT_MEMBER_SCAN_LIMIT) break;
+        if (!isActiveMembership(m) || rowsById.has(m.userId)) continue;
+        const row = await hydrate(m.userId);
+        if (!row) continue;
+        rowsById.set(m.userId, row);
+        if (isEligible(row)) eligibleCount++;
+        if (eligibleCount >= limit) break;
+        if (rowsById.size >= DEFAULT_MEMBER_HYDRATE_CAP) break;
       }
       // Always surface the caller (test-invite-to-self) even in a group large
-      // enough that they fall outside the first page.
-      if (!memberIds.has(userId)) {
+      // enough that they fall outside the scan window.
+      if (!rowsById.has(userId)) {
         const selfMembership = await ctx.db
           .query("groupMembers")
           .withIndex("by_group_user", (q) =>
@@ -220,69 +279,34 @@ export const listGroupMembersForInvite = query({
           )
           .first();
         if (selfMembership && isActiveMembership(selfMembership)) {
-          memberIds.add(userId);
+          const row = await hydrate(userId);
+          if (row) rowsById.set(userId, row);
         }
       }
     }
 
-    // --- Hydrate each candidate (bounded per-recipient reads) ----------------
-    // `.first()` existence checks instead of collecting whole tables keeps this
-    // to a handful of reads per member.
-    const environment = getCurrentEnvironment();
-    const rows = await Promise.all(
-      [...memberIds].map(async (id) => {
-        const user = await ctx.db.get(id);
-        if (!user) return null;
+    // We may have hydrated more than `limit` rows while scanning past
+    // non-eligible members. Keep the caller and eligible members first so the
+    // returned page is the actionable one, then backfill with the rest.
+    const allRows = [...rowsById.values()];
+    const chosen = [
+      ...allRows.filter((r) => r.isSelf),
+      ...allRows.filter((r) => !r.isSelf && isEligible(r)),
+      ...allRows.filter((r) => !r.isSelf && !isEligible(r)),
+    ].slice(0, limit);
 
-        const pushToken = await ctx.db
-          .query("pushTokens")
-          .withIndex("by_user", (q) => q.eq("userId", id))
-          .filter((q) => q.eq(q.field("environment"), environment))
-          .first();
-        const existing = await ctx.db
-          .query("eventInvites")
-          .withIndex("by_meeting_recipient", (q) =>
-            q.eq("meetingId", args.meetingId).eq("recipientUserId", id),
-          )
-          .first();
-        const rsvp = await ctx.db
-          .query("meetingRsvps")
-          .withIndex("by_meeting_user", (q) =>
-            q.eq("meetingId", args.meetingId).eq("userId", id),
-          )
-          .first();
-
-        return {
-          userId: id,
-          firstName: user.firstName ?? null,
-          lastName: user.lastName ?? null,
-          profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
-          hasPhone: !!user.phone,
-          hasPushTokens: !!pushToken,
-          alreadyInvited: !!existing,
-          inviteStatus: existing?.status ?? null,
-          inviteRound: existing?.inviteRound ?? 0,
-          lastSentAt: existing?.lastSentAt ?? null,
-          alreadyRsvped: !!rsvp,
-          isSelf: id === userId,
-        };
-      }),
-    );
-
-    return rows
-      .filter((m): m is NonNullable<typeof m> => m !== null)
-      .sort((a, b) => {
-        // Self first (for the "test invite to me" workflow), then
-        // already-invited last, then unreachable last, then alphabetical.
-        if (a.isSelf !== b.isSelf) return a.isSelf ? -1 : 1;
-        if (a.alreadyInvited !== b.alreadyInvited) return a.alreadyInvited ? 1 : -1;
-        const aReachable = a.hasPhone || a.hasPushTokens;
-        const bReachable = b.hasPhone || b.hasPushTokens;
-        if (aReachable !== bReachable) return aReachable ? -1 : 1;
-        const an = `${a.firstName || ""} ${a.lastName || ""}`.toLowerCase();
-        const bn = `${b.firstName || ""} ${b.lastName || ""}`.toLowerCase();
-        return an.localeCompare(bn);
-      });
+    return chosen.sort((a, b) => {
+      // Self first (for the "test invite to me" workflow), then already-invited
+      // last, then unreachable last, then alphabetical.
+      if (a.isSelf !== b.isSelf) return a.isSelf ? -1 : 1;
+      if (a.alreadyInvited !== b.alreadyInvited) return a.alreadyInvited ? 1 : -1;
+      const aReachable = a.hasPhone || a.hasPushTokens;
+      const bReachable = b.hasPhone || b.hasPushTokens;
+      if (aReachable !== bReachable) return aReachable ? -1 : 1;
+      const an = `${a.firstName || ""} ${a.lastName || ""}`.toLowerCase();
+      const bn = `${b.firstName || ""} ${b.lastName || ""}`.toLowerCase();
+      return an.localeCompare(bn);
+    });
   },
 });
 

--- a/apps/convex/functions/eventInvites.ts
+++ b/apps/convex/functions/eventInvites.ts
@@ -29,6 +29,31 @@ const REINVITE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 // Twilio SMS hard cap.
 const SMS_MAX_LEN = 1600;
 
+// Max recipients accepted by a single initiate/reinvite call. Keeps Twilio
+// spend bounded and — together with the bounded picker query below — prevents
+// the "too many reads in a single function execution" failures that large
+// groups used to trigger. Keep in sync with MAX_INVITE_RECIPIENTS in
+// apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx.
+const MAX_INVITE_RECIPIENTS = 20;
+
+// The invite picker returns at most this many members per query. A search hits
+// the users full-text index (O(matches)); the empty default view reads a
+// single bounded page off the group index — neither fans reads out across the
+// whole group the way the old collect-everything implementation did.
+const MEMBER_PICKER_LIMIT = 50;
+// How many full-text matches to scan before narrowing to group members.
+const USER_SEARCH_SCAN_LIMIT = 100;
+
+/** An active, fully-joined group membership (not left, not a pending request). */
+function isActiveMembership(m: Doc<"groupMembers">): boolean {
+  return (
+    m.leftAt === undefined &&
+    (!m.requestStatus ||
+      m.requestStatus === "accepted" ||
+      m.requestStatus === "approved")
+  );
+}
+
 // ============================================================================
 // Queries
 // ============================================================================
@@ -94,18 +119,27 @@ export const list = query({
 /**
  * Group member roster for the invite recipient picker.
  *
- * Returns each active member of the meeting's parent group, annotated with:
+ * Returns members of the meeting's parent group, annotated with:
  *   - hasPhone: whether the user has a phone we can SMS
  *   - alreadyInvited: existing eventInvites row for this meeting+user
  *   - alreadyRsvped: existing RSVP for this meeting+user (any option)
  *
- * Includes the caller themselves — handy for sending a test invite to your
- * own number/push token to preview what recipients will see.
+ * The result is bounded to `limit` (<= MEMBER_PICKER_LIMIT) members so the
+ * query stays well under Convex's per-execution read limit no matter how big
+ * the group is — the old implementation fetched a user row and a push-token
+ * query for *every* member, which blew past the 4096-read cap in large groups.
+ *
+ * Search is performed server-side against the users full-text index so the
+ * picker can find any member by name/phone, not just those on the first page.
+ * When there is no search term the caller is always included so a host can
+ * send a test invite to themselves.
  */
 export const listGroupMembersForInvite = query({
   args: {
     token: v.string(),
     meetingId: v.id("meetings"),
+    search: v.optional(v.string()),
+    limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -114,75 +148,110 @@ export const listGroupMembersForInvite = query({
     if (!meeting) return [];
     if (!(await canEditMeeting(ctx, userId, meeting))) return [];
 
-    const members = await ctx.db
-      .query("groupMembers")
-      .withIndex("by_group", (q) => q.eq("groupId", meeting.groupId))
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .collect();
-
-    const accepted = members.filter(
-      (m) => !m.requestStatus || m.requestStatus === "accepted" || m.requestStatus === "approved",
+    const groupId = meeting.groupId;
+    const search = args.search?.trim();
+    const limit = Math.min(
+      Math.max(args.limit ?? MEMBER_PICKER_LIMIT, 1),
+      MEMBER_PICKER_LIMIT,
     );
 
-    const memberUserIds = accepted.map((m) => m.userId);
+    // --- Resolve a BOUNDED set of candidate member userIds -------------------
+    // Never touch more than ~limit members. A search hits the users full-text
+    // index (O(matches)) and confirms membership per hit; the empty default
+    // view reads a single bounded page off the group index.
+    const memberIds = new Set<Id<"users">>();
 
-    // Batch fetch users
-    const users = await Promise.all(memberUserIds.map((id) => ctx.db.get(id)));
+    if (search) {
+      const matches = await ctx.db
+        .query("users")
+        .withSearchIndex("search_users", (q) =>
+          q.search("searchText", search),
+        )
+        .take(USER_SEARCH_SCAN_LIMIT);
+      for (const user of matches) {
+        if (memberIds.size >= limit) break;
+        const membership = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", groupId).eq("userId", user._id),
+          )
+          .first();
+        if (membership && isActiveMembership(membership)) {
+          memberIds.add(user._id);
+        }
+      }
+    } else {
+      // Empty search: a bounded page of active members. Take some slack so
+      // left/pending rows filtered out below don't shrink the page too far.
+      const memberships = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group", (q) => q.eq("groupId", groupId))
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .take(limit * 3);
+      for (const m of memberships) {
+        if (memberIds.size >= limit) break;
+        if (isActiveMembership(m)) memberIds.add(m.userId);
+      }
+      // Always surface the caller (test-invite-to-self) even in a group large
+      // enough that they fall outside the first page.
+      if (!memberIds.has(userId)) {
+        const selfMembership = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_group_user", (q) =>
+            q.eq("groupId", groupId).eq("userId", userId),
+          )
+          .first();
+        if (selfMembership && isActiveMembership(selfMembership)) {
+          memberIds.add(userId);
+        }
+      }
+    }
 
-    // Existing invites & RSVPs (one read each per recipient is fine — group sizes
-    // are bounded; matches the pattern in groupMembers.list).
-    const existingInvites = await ctx.db
-      .query("eventInvites")
-      .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
-      .collect();
-    const inviteByUser = new Map(
-      existingInvites.map((inv) => [inv.recipientUserId, inv]),
-    );
-
-    const rsvps = await ctx.db
-      .query("meetingRsvps")
-      .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
-      .collect();
-    const rsvpUserIds = new Set(rsvps.map((r) => r.userId));
-
-    // Active push tokens per user, scoped to current environment. Mirrors the
-    // `getActiveTokensForUsers` internalQuery so a member with no phone but a
-    // live push token isn't falsely shown as uninvitable.
+    // --- Hydrate each candidate (bounded per-recipient reads) ----------------
+    // `.first()` existence checks instead of collecting whole tables keeps this
+    // to a handful of reads per member.
     const environment = getCurrentEnvironment();
-    const tokenCounts = await Promise.all(
-      memberUserIds.map(async (id) => {
-        const tokens = await ctx.db
+    const rows = await Promise.all(
+      [...memberIds].map(async (id) => {
+        const user = await ctx.db.get(id);
+        if (!user) return null;
+
+        const pushToken = await ctx.db
           .query("pushTokens")
           .withIndex("by_user", (q) => q.eq("userId", id))
           .filter((q) => q.eq(q.field("environment"), environment))
-          .collect();
-        return [id, tokens.length] as const;
-      }),
-    );
-    const hasPushByUser = new Map(
-      tokenCounts.map(([id, n]) => [id, n > 0]),
-    );
+          .first();
+        const existing = await ctx.db
+          .query("eventInvites")
+          .withIndex("by_meeting_recipient", (q) =>
+            q.eq("meetingId", args.meetingId).eq("recipientUserId", id),
+          )
+          .first();
+        const rsvp = await ctx.db
+          .query("meetingRsvps")
+          .withIndex("by_meeting_user", (q) =>
+            q.eq("meetingId", args.meetingId).eq("userId", id),
+          )
+          .first();
 
-    return users
-      .map((user, i) => {
-        if (!user) return null;
-        const id = memberUserIds[i];
-        const existing = inviteByUser.get(id);
         return {
           userId: id,
           firstName: user.firstName ?? null,
           lastName: user.lastName ?? null,
           profilePhoto: getMediaUrl(user.profilePhoto) ?? null,
           hasPhone: !!user.phone,
-          hasPushTokens: hasPushByUser.get(id) ?? false,
+          hasPushTokens: !!pushToken,
           alreadyInvited: !!existing,
           inviteStatus: existing?.status ?? null,
           inviteRound: existing?.inviteRound ?? 0,
           lastSentAt: existing?.lastSentAt ?? null,
-          alreadyRsvped: rsvpUserIds.has(id),
+          alreadyRsvped: !!rsvp,
           isSelf: id === userId,
         };
-      })
+      }),
+    );
+
+    return rows
       .filter((m): m is NonNullable<typeof m> => m !== null)
       .sort((a, b) => {
         // Self first (for the "test invite to me" workflow), then
@@ -229,6 +298,12 @@ export const initiate = mutation({
     if (!(await canEditMeeting(ctx, userId, meeting))) {
       throw new Error(
         "Only the event creator, group leaders, or community admins can invite members",
+      );
+    }
+
+    if (new Set(args.recipientUserIds).size > MAX_INVITE_RECIPIENTS) {
+      throw new Error(
+        `You can invite up to ${MAX_INVITE_RECIPIENTS} people at a time.`,
       );
     }
 
@@ -350,6 +425,12 @@ export const reinvite = mutation({
     if (!(await canEditMeeting(ctx, userId, meeting))) {
       throw new Error(
         "Only the event creator, group leaders, or community admins can re-invite members",
+      );
+    }
+
+    if (new Set(args.recipientUserIds).size > MAX_INVITE_RECIPIENTS) {
+      throw new Error(
+        `You can re-invite up to ${MAX_INVITE_RECIPIENTS} people at a time.`,
       );
     }
 

--- a/apps/convex/functions/eventInvites.ts
+++ b/apps/convex/functions/eventInvites.ts
@@ -41,11 +41,14 @@ const MAX_INVITE_RECIPIENTS = 20;
 // single bounded page off the group index — neither fans reads out across the
 // whole group the way the old collect-everything implementation did.
 const MEMBER_PICKER_LIMIT = 50;
-// How many raw group-member rows to read for the empty (default) picker view
-// before filtering to active members in memory. A DB `.filter()` would still
-// read (and count against the limit) every leftAt-set row it scans past, so a
-// high-churn group could re-trip the read limit; this caps the read instead.
-const DEFAULT_MEMBER_SCAN_LIMIT = 300;
+// Hard upper bound on group-member rows scanned for the empty (default) picker
+// view. We iterate the by_group index lazily and stop as soon as `limit` active
+// members are found, so the common case reads only a handful of rows; this cap
+// only bites in a high-churn group where many departed/pending rows precede the
+// active ones. Kept well under the 4096 read limit so the per-member hydration
+// below still fits. A DB `.filter()` (or a fixed-size page then filter) would
+// instead read past every leftAt-set row or stop before reaching active members.
+const DEFAULT_MEMBER_SCAN_LIMIT = 2000;
 // How many full-text matches to scan before narrowing to group members. The
 // users search index is global (not group-scoped), so we over-fetch and then
 // filter to members. 500 matches the cap used by admin People search and
@@ -191,18 +194,21 @@ export const listGroupMembersForInvite = query({
         }
       }
     } else {
-      // Empty search: read a BOUNDED page of raw rows off the index, then
-      // filter to active members in memory. Filtering in the DB query would
-      // still read every leftAt-set row it scans past (counting against the
-      // read limit), so a group with lots of departed members could re-trip
-      // the exact error this change prevents.
-      const memberships = await ctx.db
+      // Empty search: lazily scan the group index, collecting active members
+      // until we have `limit` of them. Stopping after a fixed raw page could
+      // return a near-empty roster in a high-churn group where departed/pending
+      // rows precede the active ones; iterating with an early break keeps the
+      // common case cheap while DEFAULT_MEMBER_SCAN_LIMIT bounds the reads.
+      let scanned = 0;
+      for await (const m of ctx.db
         .query("groupMembers")
-        .withIndex("by_group", (q) => q.eq("groupId", groupId))
-        .take(DEFAULT_MEMBER_SCAN_LIMIT);
-      for (const m of memberships) {
-        if (memberIds.size >= limit) break;
-        if (isActiveMembership(m)) memberIds.add(m.userId);
+        .withIndex("by_group", (q) => q.eq("groupId", groupId))) {
+        scanned++;
+        if (isActiveMembership(m)) {
+          memberIds.add(m.userId);
+          if (memberIds.size >= limit) break;
+        }
+        if (scanned >= DEFAULT_MEMBER_SCAN_LIMIT) break;
       }
       // Always surface the caller (test-invite-to-self) even in a group large
       // enough that they fall outside the first page.

--- a/apps/convex/functions/eventInvites.ts
+++ b/apps/convex/functions/eventInvites.ts
@@ -41,8 +41,13 @@ const MAX_INVITE_RECIPIENTS = 20;
 // single bounded page off the group index — neither fans reads out across the
 // whole group the way the old collect-everything implementation did.
 const MEMBER_PICKER_LIMIT = 50;
-// How many full-text matches to scan before narrowing to group members.
-const USER_SEARCH_SCAN_LIMIT = 100;
+// How many full-text matches to scan before narrowing to group members. The
+// users search index is global (not group-scoped), so we over-fetch and then
+// filter to members. 500 matches the cap used by admin People search and
+// lib/memberSearch.ts; leaders narrow the query further to reach a member who
+// ranks past it. Bounded so the membership checks below stay well under the
+// per-execution read limit.
+const USER_SEARCH_SCAN_LIMIT = 500;
 
 /** An active, fully-joined group membership (not left, not a pending request). */
 function isActiveMembership(m: Doc<"groupMembers">): boolean {
@@ -317,35 +322,6 @@ export const initiate = mutation({
     if (!group) throw new Error("Group not found");
     const communityId = group.communityId;
 
-    // Active members of the meeting's group
-    const memberships = await ctx.db
-      .query("groupMembers")
-      .withIndex("by_group", (q) => q.eq("groupId", meeting.groupId))
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .collect();
-    const memberSet = new Set(
-      memberships
-        .filter((m) => !m.requestStatus || m.requestStatus === "accepted" || m.requestStatus === "approved")
-        .map((m) => m.userId),
-    );
-
-    const existing = await ctx.db
-      .query("eventInvites")
-      .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
-      .collect();
-    const existingSet = new Set(existing.map((inv) => inv.recipientUserId));
-
-    // Server-side RSVP guard. The picker disables already-RSVP'd rows, but
-    // the seed is computed once and a member can RSVP between sheet open
-    // and confirm; direct API callers also bypass the UI entirely. The
-    // intended path for messaging attendees is Text Blast, so skip them
-    // here rather than silently double-texting.
-    const rsvps = await ctx.db
-      .query("meetingRsvps")
-      .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
-      .collect();
-    const rsvpSet = new Set(rsvps.map((r) => r.userId));
-
     let invited = 0;
     let alreadyInvited = 0;
     let skippedNotMember = 0;
@@ -354,19 +330,49 @@ export const initiate = mutation({
     const ts = now();
     const seen = new Set<string>();
 
+    // Validate each requested recipient with INDEXED point lookups instead of
+    // materializing the whole group / all invites / all RSVPs. Recipients are
+    // capped at MAX_INVITE_RECIPIENTS above, so this is a small, bounded number
+    // of reads even in very large groups — collecting the whole group/meeting
+    // state (the previous approach) could still blow Convex's per-execution
+    // read limit when sending into a group with thousands of members.
     for (const recipientUserId of args.recipientUserIds) {
       if (seen.has(recipientUserId)) continue;
       seen.add(recipientUserId);
 
-      if (!memberSet.has(recipientUserId)) {
+      const membership = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", meeting.groupId).eq("userId", recipientUserId),
+        )
+        .first();
+      if (!membership || !isActiveMembership(membership)) {
         skippedNotMember++;
         continue;
       }
-      if (rsvpSet.has(recipientUserId)) {
+
+      // Server-side RSVP guard. The picker disables already-RSVP'd rows, but a
+      // member can RSVP between sheet open and confirm, and direct API callers
+      // bypass the UI entirely. The intended path for messaging attendees is
+      // Text Blast, so skip them here rather than silently double-texting.
+      const rsvp = await ctx.db
+        .query("meetingRsvps")
+        .withIndex("by_meeting_user", (q) =>
+          q.eq("meetingId", args.meetingId).eq("userId", recipientUserId),
+        )
+        .first();
+      if (rsvp) {
         skippedRsvped++;
         continue;
       }
-      if (existingSet.has(recipientUserId)) {
+
+      const existing = await ctx.db
+        .query("eventInvites")
+        .withIndex("by_meeting_recipient", (q) =>
+          q.eq("meetingId", args.meetingId).eq("recipientUserId", recipientUserId),
+        )
+        .first();
+      if (existing) {
         alreadyInvited++;
         continue;
       }

--- a/apps/convex/functions/eventInvites.ts
+++ b/apps/convex/functions/eventInvites.ts
@@ -41,6 +41,11 @@ const MAX_INVITE_RECIPIENTS = 20;
 // single bounded page off the group index — neither fans reads out across the
 // whole group the way the old collect-everything implementation did.
 const MEMBER_PICKER_LIMIT = 50;
+// How many raw group-member rows to read for the empty (default) picker view
+// before filtering to active members in memory. A DB `.filter()` would still
+// read (and count against the limit) every leftAt-set row it scans past, so a
+// high-churn group could re-trip the read limit; this caps the read instead.
+const DEFAULT_MEMBER_SCAN_LIMIT = 300;
 // How many full-text matches to scan before narrowing to group members. The
 // users search index is global (not group-scoped), so we over-fetch and then
 // filter to members. 500 matches the cap used by admin People search and
@@ -186,13 +191,15 @@ export const listGroupMembersForInvite = query({
         }
       }
     } else {
-      // Empty search: a bounded page of active members. Take some slack so
-      // left/pending rows filtered out below don't shrink the page too far.
+      // Empty search: read a BOUNDED page of raw rows off the index, then
+      // filter to active members in memory. Filtering in the DB query would
+      // still read every leftAt-set row it scans past (counting against the
+      // read limit), so a group with lots of departed members could re-trip
+      // the exact error this change prevents.
       const memberships = await ctx.db
         .query("groupMembers")
         .withIndex("by_group", (q) => q.eq("groupId", groupId))
-        .filter((q) => q.eq(q.field("leftAt"), undefined))
-        .take(limit * 3);
+        .take(DEFAULT_MEMBER_SCAN_LIMIT);
       for (const m of memberships) {
         if (memberIds.size >= limit) break;
         if (isActiveMembership(m)) memberIds.add(m.userId);
@@ -448,8 +455,14 @@ export const reinvite = mutation({
     let onCooldown = 0;
     let notFound = 0;
     const inviteIdsToSend: Id<"eventInvites">[] = [];
+    // Dedupe so a direct caller passing the same id repeatedly (which slips
+    // past the Set-based cap above) can't re-send to one recipient many times.
+    const seen = new Set<string>();
 
     for (const recipientUserId of args.recipientUserIds) {
+      if (seen.has(recipientUserId)) continue;
+      seen.add(recipientUserId);
+
       const existing = await ctx.db
         .query("eventInvites")
         .withIndex("by_meeting_recipient", (q) =>

--- a/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
+++ b/apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx
@@ -34,6 +34,11 @@ interface InviteGroupMembersSheetProps {
 }
 
 const NOTE_MAX = 140;
+// Max recipients per invite. Keep in sync with MAX_INVITE_RECIPIENTS in
+// apps/convex/functions/eventInvites.ts, which enforces the same cap server-side.
+const MAX_INVITE_RECIPIENTS = 20;
+// Debounce for the server-side member search so we don't fire a query per keystroke.
+const SEARCH_DEBOUNCE_MS = 250;
 
 export function InviteGroupMembersSheet({
   visible,
@@ -47,14 +52,32 @@ export function InviteGroupMembersSheet({
   const { colors } = useTheme();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [note, setNote] = useState("");
   const [confirming, setConfirming] = useState(false);
   const [sending, setSending] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
+  // Debounce the search term before hitting the server so typing doesn't fire
+  // a query per keystroke.
+  React.useEffect(() => {
+    const handle = setTimeout(
+      () => setDebouncedSearch(search.trim()),
+      SEARCH_DEBOUNCE_MS,
+    );
+    return () => clearTimeout(handle);
+  }, [search]);
+
+  // Members are searched and paginated server-side (see
+  // listGroupMembersForInvite) so large groups don't blow the read limit.
   const members = useAuthenticatedQuery(
     api.functions.eventInvites.listGroupMembersForInvite,
-    visible ? { meetingId: meetingId as Id<"meetings"> } : "skip",
+    visible
+      ? {
+          meetingId: meetingId as Id<"meetings">,
+          search: debouncedSearch || undefined,
+        }
+      : "skip",
   );
 
   // Fetch the caller from Convex so the preview shows their actual first
@@ -80,11 +103,15 @@ export function InviteGroupMembersSheet({
       setSelectedIds(new Set());
       setNote("");
       setSearch("");
+      setDebouncedSearch("");
       return;
     }
     if (initialized || !members) return;
     const defaultIds = new Set<string>();
     for (const m of members) {
+      // Cap the default selection at the server-enforced limit so a routine
+      // "open the sheet and send" doesn't hit the recipient cap.
+      if (defaultIds.size >= MAX_INVITE_RECIPIENTS) break;
       const reachable = m.hasPhone || m.hasPushTokens;
       // Self is included in the roster (for test sends) but excluded from
       // the default selection so a routine "Invite everyone" tap doesn't
@@ -97,15 +124,9 @@ export function InviteGroupMembersSheet({
     setInitialized(true);
   }, [visible, members, initialized]);
 
-  const filtered = useMemo(() => {
-    if (!members) return [];
-    const q = search.trim().toLowerCase();
-    if (!q) return members;
-    return members.filter((m) => {
-      const name = `${m.firstName || ""} ${m.lastName || ""}`.toLowerCase();
-      return name.includes(q);
-    });
-  }, [members, search]);
+  // Members already arrive filtered by the server-side `search` argument, so
+  // the list is rendered as-is.
+  const filtered = members ?? [];
 
   // "Eligible" = reachable (phone or push), not already invited, not already
   // RSVP'd, and not self. Self stays tappable individually for test sends but
@@ -122,8 +143,13 @@ export function InviteGroupMembersSheet({
     [members],
   );
 
+  const selectionAtCap = selectedIds.size >= MAX_INVITE_RECIPIENTS;
+
   const allEligibleSelected = useMemo(() => {
     if (!members) return false;
+    // At the cap we can't select any more, so treat the row as "all selected"
+    // — a second tap then clears the selection.
+    if (selectionAtCap) return true;
     return members
       .filter(
         (m) =>
@@ -133,13 +159,23 @@ export function InviteGroupMembersSheet({
           !m.isSelf,
       )
       .every((m) => selectedIds.has(m.userId));
-  }, [members, selectedIds]);
+  }, [members, selectedIds, selectionAtCap]);
 
   const toggle = (userId: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(userId)) next.delete(userId);
-      else next.add(userId);
+      if (next.has(userId)) {
+        next.delete(userId);
+        return next;
+      }
+      if (next.size >= MAX_INVITE_RECIPIENTS) {
+        Alert.alert(
+          "Invite limit reached",
+          `You can invite up to ${MAX_INVITE_RECIPIENTS} people at a time.`,
+        );
+        return prev;
+      }
+      next.add(userId);
       return next;
     });
   };
@@ -149,11 +185,22 @@ export function InviteGroupMembersSheet({
     setSelectedIds((prev) => {
       if (allEligibleSelected) return new Set();
       const next = new Set(prev);
+      let hitLimit = false;
       for (const m of members) {
+        if (next.size >= MAX_INVITE_RECIPIENTS) {
+          hitLimit = true;
+          break;
+        }
         const reachable = m.hasPhone || m.hasPushTokens;
         if (reachable && !m.alreadyInvited && !m.alreadyRsvped && !m.isSelf) {
           next.add(m.userId);
         }
+      }
+      if (hitLimit) {
+        Alert.alert(
+          "Invite limit reached",
+          `You can invite up to ${MAX_INVITE_RECIPIENTS} people at a time. The first ${MAX_INVITE_RECIPIENTS} eligible members are selected.`,
+        );
       }
       return next;
     });
@@ -302,6 +349,12 @@ export function InviteGroupMembersSheet({
                     Select all ({eligibleCount} with phone)
                   </Text>
                 </TouchableOpacity>
+
+                {(selectedIds.size > 0 || eligibleCount > MAX_INVITE_RECIPIENTS) && (
+                  <Text style={[styles.limitHint, { color: colors.textSecondary }]}>
+                    {`${selectedIds.size}/${MAX_INVITE_RECIPIENTS} selected · up to ${MAX_INVITE_RECIPIENTS} per invite`}
+                  </Text>
+                )}
 
                 {members === undefined && (
                   <View style={styles.loadingRow}>
@@ -635,6 +688,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   selectAllText: { fontSize: 14, fontWeight: "500" },
+  limitHint: { fontSize: 12, marginTop: 2, marginBottom: 4 },
 
   loadingRow: { paddingVertical: 20, alignItems: "center" },
   emptyText: { fontSize: 14, paddingVertical: 16, textAlign: "center" },


### PR DESCRIPTION
## Problem

Opening the "Invite members" sheet on an event in a large group threw a Convex server error and dropped users onto the "Something went wrong" screen:

```
[CONVEX Q(functions/eventInvites:listGroupMembersForInvite)] Server Error
Uncaught Error: Too many reads in a single function execution (limit: 4096).
  at async handler (apps/convex/functions/eventInvites.ts)
```

`listGroupMembersForInvite` `.collect()`-ed every group member and then fired a user-row read **and** a push-token query for each one (plus full `.collect()`s of the meeting's invites and RSVPs). In a group with a few thousand members that fans out past Convex's 4096-reads-per-execution limit, so the picker never loads.

## Changes

**Backend — `apps/convex/functions/eventInvites.ts`**
- **Bounded picker query.** `listGroupMembersForInvite` now returns at most `MEMBER_PICKER_LIMIT` (50) members per call:
  - **Empty search** reads a single bounded page off the `groupMembers.by_group` index.
  - **Search** hits the `users` full-text `search_users` index (O(matches)) and confirms group membership per hit via `by_group_user` — so members beyond the first page are still findable by name/phone, without scanning the whole group.
  - Per-member push-token / existing-invite / RSVP lookups switched from `.collect()` to `.first()` existence checks against indexed queries.
  - The caller is still always surfaced in the default view (test-invite-to-self).
- **Recipient cap.** `initiate` and `reinvite` reject more than `MAX_INVITE_RECIPIENTS` (20) recipients per call — bounds Twilio spend and the mutation's own reads.

**Mobile — `apps/mobile/features/leader-tools/components/InviteGroupMembersSheet.tsx`**
- Member search moved server-side (debounced) via the new `search` arg, instead of filtering a single client-side page.
- Selection, "Select all", and the default seed are capped at 20, with a clear in-sheet hint and an alert when the cap is hit. Copy mirrors the server-enforced limit.

**Tests — `apps/convex/__tests__/eventInvites-invite-picker.test.ts`**
- Result is bounded below the group size (regression guard for the read blow-up).
- A member beyond the first page is absent by default but found via server-side search; search stays scoped to the meeting's group.
- The caller is always included.
- `initiate` rejects 21 recipients and accepts exactly 20.

## Verification
- `apps/convex`: new test file (6 tests) + `event-blasts.test.ts` pass; `npx convex typecheck` clean.
- `apps/mobile`: full Jest suite (1147 tests) passes via pre-push hook; ESLint clean on the changed component. The remaining repo-wide `tsc` errors are pre-existing on `main` in unrelated files (chat/tasks) and untouched here.

Fixes the Sentry error `listGroupMembersForInvite` — "Too many reads in a single function execution".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5jdqS5LtMhwdFGpPURXnh)_