### PR TITLE
feat: events-os Run sheet/Event Tasks grid + event/serving-mode overhaul

### DIFF
--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -1364,6 +1364,9 @@ export const getDirectInbox = query({
       lastMessageSenderNotificationsDisabled: boolean;
       unreadCount: number;
       isMuted: boolean;
+      /** Channel creation timestamp — serving-mode inbox filters DMs to those
+       * created on the event day. */
+      createdAt: number;
     }> = [];
 
     for (const row of acceptedRows) {
@@ -1446,6 +1449,7 @@ export const getDirectInbox = query({
           : false,
         unreadCount,
         isMuted: row.isMuted,
+        createdAt: channel.createdAt ?? channel._creationTime,
       });
     }
 

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -3,8 +3,15 @@
  *
  * Event tasks (`eventTasks`) are the shared, leader-authored checklist for a
  * plan: a team (or a specific role on that team) needs to do X "before" /
- * "during" / "after" the event. Completion is per-serving-person
- * (`eventTaskCompletions`); "during" tasks are completed once per service time.
+ * "during" / "after" the event. Completion has two models, keyed on whether the
+ * task is scoped to a role:
+ *   • Role tasks (`roleId != null`) are completed PER-USER
+ *     (`eventTaskCompletions`); "during" tasks are completed once per service
+ *     time. They surface in each assignee's "Mine" list.
+ *   • Team-level tasks (`roleId == null`) are TEAM-WIDE, single-source on
+ *     `sharedTaskCompletions` (one row per task): any confirmed teammate
+ *     completes it for the whole team. They surface on the Shared tab and count
+ *     as one slot in readiness / all-teams rollups.
  *
  * Personal serving tasks (`personalServingTasks`) are ad-hoc, single-user rows
  * a volunteer adds for themselves in serving mode. They never touch the shared
@@ -405,9 +412,14 @@ export const toggleTaskCompletion = mutation({
 
 /**
  * Aggregate readiness for a plan: overall done/total, per-segment, and
- * per-team. "Expected completions" for a task is the number of confirmed
- * assignees of its role (team-level tasks => confirmed assignees of the team).
- * A "during" task multiplies that expectation by the number of service times.
+ * per-team. Two completion models, one per task kind:
+ *   • Role tasks (`roleId != null`): completion is PER-USER
+ *     (`eventTaskCompletions`). "Expected completions" is the number of
+ *     confirmed assignees of the role, × the number of service times for
+ *     "during" tasks; `done` counts valid completions from those assignees.
+ *   • Team-level tasks (`roleId == null`): completion is TEAM-WIDE
+ *     (`sharedTaskCompletions`, surfaced on the Shared tab). Counted as a
+ *     single slot: `total += 1`, `done += 1` iff a shared completion exists.
  * Personal serving tasks are excluded entirely.
  *
  * Auth: an active member of the plan's community.
@@ -419,7 +431,7 @@ export const getPlanTaskReadiness = query({
     const plan = await requirePlan(ctx, args.planId);
     await requireGroupMember(ctx, plan.groupId, userId);
 
-    const [tasks, assignments] = await Promise.all([
+    const [tasks, assignments, sharedRows] = await Promise.all([
       ctx.db
         .query("eventTasks")
         .withIndex("by_plan", (q) => q.eq("planId", args.planId))
@@ -428,7 +440,13 @@ export const getPlanTaskReadiness = query({
         .query("roleAssignments")
         .withIndex("by_plan", (q) => q.eq("planId", args.planId))
         .collect(),
+      ctx.db
+        .query("sharedTaskCompletions")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
     ]);
+    // Team-wide completion for team-level tasks (one row per task).
+    const sharedDoneByTask = new Set(sharedRows.map((r) => r.taskId as string));
 
     const timesCount = Math.max(1, plan.times.length);
     const validTimeLabels = new Set(plan.times.map((t) => t.label));
@@ -445,37 +463,47 @@ export const getPlanTaskReadiness = query({
     >();
 
     for (const task of tasks) {
-      const expected = assigneesForTask(assignments, task);
-      // Distinct users: a volunteer confirmed for two roles on the same team is
-      // one expected completer for a team-level task, not two (and
-      // getMyServingTasks shows it to them once), so dedupe before counting.
-      const expectedUserIds = new Set(expected.map((a) => a.userId as string));
-      const expectedPeople = expectedUserIds.size;
-      const total =
-        task.segment === "during"
-          ? expectedPeople * timesCount
-          : expectedPeople;
+      let total: number;
+      let done: number;
+      if (!task.roleId) {
+        // Team-level task: a single TEAM-WIDE slot, completed once for the whole
+        // team via `sharedTaskCompletions` (the Shared surface), regardless of
+        // how many teammates are confirmed.
+        total = 1;
+        done = sharedDoneByTask.has(task._id as string) ? 1 : 0;
+      } else {
+        // Role task: PER-USER completion via `eventTaskCompletions`.
+        const expected = assigneesForTask(assignments, task);
+        const expectedUserIds = new Set(
+          expected.map((a) => a.userId as string),
+        );
+        const expectedPeople = expectedUserIds.size;
+        total =
+          task.segment === "during"
+            ? expectedPeople * timesCount
+            : expectedPeople;
 
-      // Count only completions from people who are currently expected to do
-      // this task (a since-removed assignee, or anyone calling the mutation
-      // directly, must not push readiness forward), and — for "during" tasks —
-      // only completions tagged with a real service time. Capped at total as a
-      // final guard against duplicate rows.
-      const completions = await ctx.db
-        .query("eventTaskCompletions")
-        .withIndex("by_task", (q) => q.eq("taskId", task._id))
-        .collect();
-      const validCompletions = completions.filter((c) => {
-        if (!expectedUserIds.has(c.userId as string)) return false;
-        if (task.segment === "during") {
-          // No configured times => a single unlabeled slot (mirrors
-          // getMyServingTasks), so accept the null-label completion.
-          if (plan.times.length === 0) return c.timeLabel == null;
-          return c.timeLabel != null && validTimeLabels.has(c.timeLabel);
-        }
-        return true;
-      });
-      const done = Math.min(validCompletions.length, total);
+        // Count only completions from people who are currently expected to do
+        // this task (a since-removed assignee, or anyone calling the mutation
+        // directly, must not push readiness forward), and — for "during" tasks —
+        // only completions tagged with a real service time. Capped at total as a
+        // final guard against duplicate rows.
+        const completions = await ctx.db
+          .query("eventTaskCompletions")
+          .withIndex("by_task", (q) => q.eq("taskId", task._id))
+          .collect();
+        const validCompletions = completions.filter((c) => {
+          if (!expectedUserIds.has(c.userId as string)) return false;
+          if (task.segment === "during") {
+            // No configured times => a single unlabeled slot (mirrors
+            // getMyServingTasks), so accept the null-label completion.
+            if (plan.times.length === 0) return c.timeLabel == null;
+            return c.timeLabel != null && validTimeLabels.has(c.timeLabel);
+          }
+          return true;
+        });
+        done = Math.min(validCompletions.length, total);
+      }
 
       overall.total += total;
       overall.done += done;
@@ -527,9 +555,14 @@ type ServingTaskItem = {
 
 /**
  * The current user's serving tasks for a plan, grouped by segment. Merges:
- *   (a) template tasks (`eventTasks`) whose role the user is confirmed for on
- *       this plan (team-level tasks => any confirmed role on that team), and
+ *   (a) ROLE-assigned template tasks (`eventTasks.roleId` set) whose role the
+ *       user is confirmed for on this plan — completed PER-USER via
+ *       `eventTaskCompletions`, and
  *   (b) the user's personal serving tasks (`personalServingTasks`).
+ *
+ * Team-level tasks (`roleId == null`) are deliberately EXCLUDED here: they are
+ * team-wide (single-source on `sharedTaskCompletions`) and are surfaced on the
+ * Shared tab only, not in this personal "Mine" list.
  *
  * "during" template tasks expand to one entry per service time (timeLabel set),
  * with `completed` resolved per (task, user, timeLabel). Personal "during"
@@ -562,7 +595,6 @@ export const getMyServingTasks = query({
       .collect();
     const myConfirmed = myAssignments.filter((a) => a.status === "confirmed");
     const confirmedRoleIds = new Set(myConfirmed.map((a) => a.roleId as string));
-    const confirmedTeamIds = new Set(myConfirmed.map((a) => a.teamId as string));
 
     // (a) Assigned template tasks.
     const tasks = await ctx.db
@@ -584,10 +616,12 @@ export const getMyServingTasks = query({
     );
 
     for (const task of tasks) {
-      const mine = task.roleId
-        ? confirmedRoleIds.has(task.roleId as string)
-        : confirmedTeamIds.has(task.teamId as string);
-      if (!mine) continue;
+      // Team-level tasks (roleId == null) are team-wide, single-source on
+      // `sharedTaskCompletions`, and belong to the Shared surface only — they
+      // are no longer listed in this personal "Mine" view. Only role-assigned
+      // tasks the user is confirmed for appear here (plus their personal tasks).
+      if (!task.roleId) continue;
+      if (!confirmedRoleIds.has(task.roleId as string)) continue;
 
       const base = {
         title: task.title,
@@ -657,8 +691,9 @@ export const getMyServingTasks = query({
 // semantics:
 //   • Assigned (role) tasks are completed PER-USER via `eventTaskCompletions`
 //     (one row per user, per task, per service time for "during" tasks).
-//   • Team-level tasks (roleId == null) additionally get a TEAM-WIDE shared
-//     completion via `sharedTaskCompletions` (one row per task — see below).
+//   • Team-level tasks (roleId == null) are TEAM-WIDE, single-source on
+//     `sharedTaskCompletions` (one row per task — see below): completing one on
+//     the Shared surface marks it done everywhere it's counted.
 // ============================================================================
 
 /** Resolve a user's display name, matching the roster convention. */
@@ -1073,12 +1108,15 @@ type AllTeamsEntry = {
  * its tasks, so a volunteer can see the whole event's shape and progress.
  *
  * `done`/`total` here use the plan-wide READINESS semantics (same as
- * `getPlanTaskReadiness`): a task's `total` is the number of confirmed
- * assignees expected to complete it (× the number of service times for
- * "during" tasks), and `done` counts valid completions from those assignees. A
- * task's `completed` flag is true when it is fully satisfied (done >= total,
- * total > 0). Team-level tasks additionally count their team-wide shared
- * completion as satisfying the whole task.
+ * `getPlanTaskReadiness`), one model per task kind:
+ *   • Role tasks (`roleId != null`): PER-USER — `total` is the number of
+ *     confirmed assignees expected to complete it (× the number of service
+ *     times for "during" tasks), `done` counts valid completions from those
+ *     assignees, and `completed` is true when fully satisfied (done >= total,
+ *     total > 0).
+ *   • Team-level tasks (`roleId == null`): TEAM-WIDE — a single slot
+ *     (`total = 1`) completed via `sharedTaskCompletions` (the Shared tab), so
+ *     `done`/`completed` reflect whether the team marked it shared-done.
  *
  * Auth: an active member of the plan's group (any serving participant).
  */
@@ -1123,37 +1161,46 @@ export const getAllTeamsTasks = query({
     const byTeam = new Map<string, AllTeamsEntry>();
 
     for (const task of tasks) {
-      // Readiness "expected completers" for this task.
-      const expected = assigneesForTask(assignments, task);
-      const expectedUserIds = new Set(expected.map((a) => a.userId as string));
-      const expectedPeople = expectedUserIds.size;
-      const total =
-        task.segment === "during"
-          ? expectedPeople * timesCount
-          : expectedPeople;
+      let total: number;
+      let doneForEntry: number;
+      let completed: boolean;
+      if (!task.roleId) {
+        // Team-level task: a single TEAM-WIDE slot completed via
+        // `sharedTaskCompletions` (the Shared surface), matching the readiness
+        // semantics — one slot total, done iff the team marked it shared-done.
+        const sharedDone = sharedByTask.has(task._id as string);
+        total = 1;
+        doneForEntry = sharedDone ? 1 : 0;
+        completed = sharedDone;
+      } else {
+        // Role task: PER-USER readiness — confirmed assignees expected to
+        // complete it (× service times for "during"), done counts their valid
+        // completions. `completed` when fully satisfied.
+        const expected = assigneesForTask(assignments, task);
+        const expectedUserIds = new Set(
+          expected.map((a) => a.userId as string),
+        );
+        const expectedPeople = expectedUserIds.size;
+        total =
+          task.segment === "during"
+            ? expectedPeople * timesCount
+            : expectedPeople;
 
-      const completions = await ctx.db
-        .query("eventTaskCompletions")
-        .withIndex("by_task", (q) => q.eq("taskId", task._id))
-        .collect();
-      const validCompletions = completions.filter((c) => {
-        if (!expectedUserIds.has(c.userId as string)) return false;
-        if (task.segment === "during") {
-          if (plan.times.length === 0) return c.timeLabel == null;
-          return c.timeLabel != null && validTimeLabels.has(c.timeLabel);
-        }
-        return true;
-      });
-      const done = Math.min(validCompletions.length, total);
-
-      // A team-level task the team marked shared-done counts as fully complete.
-      const sharedDone = !task.roleId && sharedByTask.has(task._id as string);
-      const completed = sharedDone || (total > 0 && done >= total);
-      // Keep the aggregate consistent with the row's checkmark: a shared-done
-      // team-level task is fully satisfied, so contribute its full slot count to
-      // the team's `done` (not the sparse per-user completions) — otherwise the
-      // row shows done while the team card reads e.g. 0/6.
-      const doneForEntry = sharedDone ? total : done;
+        const completions = await ctx.db
+          .query("eventTaskCompletions")
+          .withIndex("by_task", (q) => q.eq("taskId", task._id))
+          .collect();
+        const validCompletions = completions.filter((c) => {
+          if (!expectedUserIds.has(c.userId as string)) return false;
+          if (task.segment === "during") {
+            if (plan.times.length === 0) return c.timeLabel == null;
+            return c.timeLabel != null && validTimeLabels.has(c.timeLabel);
+          }
+          return true;
+        });
+        doneForEntry = Math.min(validCompletions.length, total);
+        completed = total > 0 && doneForEntry >= total;
+      }
 
       const teamKey = task.teamId as string;
       if (!teamNames.has(teamKey)) {

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -649,7 +649,7 @@ export const getMyServingTasks = query({
  */
 export const getHowToDocChecks = query({
   args: { token: v.string(), taskId: v.id("eventTasks") },
-  handler: async (ctx, args): Promise<number[]> => {
+  handler: async (ctx, args): Promise<string[]> => {
     const userId = await requireAuth(ctx, args.token);
     const task = await ctx.db.get(args.taskId);
     if (!task) return [];
@@ -663,7 +663,7 @@ export const getHowToDocChecks = query({
         q.eq("userId", userId).eq("taskId", args.taskId),
       )
       .unique();
-    return row?.checkedIndices ?? [];
+    return row?.checkedKeys ?? [];
   },
 });
 
@@ -678,7 +678,7 @@ export const setHowToDocCheck = mutation({
   args: {
     token: v.string(),
     taskId: v.id("eventTasks"),
-    itemIndex: v.number(),
+    itemKey: v.string(),
     checked: v.boolean(),
   },
   handler: async (ctx, args) => {
@@ -697,24 +697,24 @@ export const setHowToDocCheck = mutation({
       )
       .unique();
 
-    const current = new Set(row?.checkedIndices ?? []);
-    if (args.checked) current.add(args.itemIndex);
-    else current.delete(args.itemIndex);
-    const checkedIndices = Array.from(current).sort((a, b) => a - b);
+    const current = new Set(row?.checkedKeys ?? []);
+    if (args.checked) current.add(args.itemKey);
+    else current.delete(args.itemKey);
+    const checkedKeys = Array.from(current).sort();
 
     const nowMs = Date.now();
     if (row) {
-      await ctx.db.patch(row._id, { checkedIndices, updatedAt: nowMs });
+      await ctx.db.patch(row._id, { checkedKeys, updatedAt: nowMs });
     } else {
       await ctx.db.insert("howToDocChecks", {
         userId,
         taskId: args.taskId,
-        checkedIndices,
+        checkedKeys,
         updatedAt: nowMs,
       });
     }
 
-    return { taskId: args.taskId, itemIndex: args.itemIndex, checked: args.checked };
+    return { taskId: args.taskId, itemKey: args.itemKey, checked: args.checked };
   },
 });
 

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -301,11 +301,20 @@ export const deleteTask = mutation({
     }
     await requirePlanScheduler(ctx, task.planId, userId);
 
-    const completions = await ctx.db
-      .query("eventTaskCompletions")
-      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
-      .collect();
-    await Promise.all(completions.map((c) => ctx.db.delete(c._id)));
+    const [completions, sharedCompletions] = await Promise.all([
+      ctx.db
+        .query("eventTaskCompletions")
+        .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+        .collect(),
+      ctx.db
+        .query("sharedTaskCompletions")
+        .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+        .collect(),
+    ]);
+    await Promise.all([
+      ...completions.map((c) => ctx.db.delete(c._id)),
+      ...sharedCompletions.map((c) => ctx.db.delete(c._id)),
+    ]);
     await ctx.db.delete(args.taskId);
 
     return { deletedCompletions: completions.length };
@@ -632,6 +641,542 @@ export const getMyServingTasks = query({
     }
 
     return result;
+  },
+});
+
+// ============================================================================
+// Serving-mode read surfaces (Phase 2): Shared / Crew / All-teams.
+//
+// These sit alongside `getMyServingTasks` (the personal "mine" list). Where the
+// personal + readiness views count completion, they reuse the existing
+// semantics:
+//   • Assigned (role) tasks are completed PER-USER via `eventTaskCompletions`
+//     (one row per user, per task, per service time for "during" tasks).
+//   • Team-level tasks (roleId == null) additionally get a TEAM-WIDE shared
+//     completion via `sharedTaskCompletions` (one row per task — see below).
+// ============================================================================
+
+/** Resolve a user's display name, matching the roster convention. */
+async function resolveUserName(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+): Promise<string> {
+  const u = await ctx.db.get(userId);
+  return `${u?.firstName ?? ""} ${u?.lastName ?? ""}`.trim() || "Someone";
+}
+
+/** The current user's confirmed role assignments on a plan. */
+async function myConfirmedAssignments(
+  ctx: QueryCtx | MutationCtx,
+  planId: Id<"eventPlans">,
+  userId: Id<"users">,
+): Promise<Doc<"roleAssignments">[]> {
+  const rows = await ctx.db
+    .query("roleAssignments")
+    .withIndex("by_plan", (q) => q.eq("planId", planId))
+    .filter((q) => q.eq(q.field("userId"), userId))
+    .collect();
+  return rows.filter((a) => a.status === "confirmed");
+}
+
+/**
+ * A team-level (whole-team, no assignee) shared task with its team-wide
+ * completion state. Reuses the `ServingTaskItem` How-To fields.
+ */
+type SharedTeamTaskItem = {
+  taskId: string;
+  teamId: string;
+  teamName: string;
+  title: string;
+  segment: "before" | "during" | "after";
+  howToType: string;
+  howToText?: string;
+  howToUrl?: string;
+  howToMediaPath?: string;
+  howToDoc?: string;
+  /** Team-wide: true if ANY teammate has marked this task done. */
+  completed: boolean;
+  /** Who last flipped it done (only set when `completed`). */
+  completedByName?: string;
+  completedAt?: number;
+};
+
+/**
+ * The "Shared" surface: team-level tasks (roleId == null) for the CURRENT
+ * user's confirmed team(s) on a plan. These are "the whole team is responsible,
+ * no single assignee" — so completion is TEAM-WIDE (`sharedTaskCompletions`),
+ * not per-user: any confirmed teammate marking it done marks it done for
+ * everyone. Returned as a flat array (each item carries its `segment`), ordered
+ * before → during → after, then by the task's sortOrder.
+ *
+ * Auth: an active member of the plan's group (community read gate). Only the
+ * user's own confirmed teams are included.
+ */
+export const getSharedTeamTasks = query({
+  args: { token: v.string(), planId: v.id("eventPlans") },
+  handler: async (ctx, args): Promise<SharedTeamTaskItem[]> => {
+    const userId = await requireAuth(ctx, args.token);
+    const plan = await requirePlan(ctx, args.planId);
+    await requireGroupMember(ctx, plan.groupId, userId);
+
+    const confirmed = await myConfirmedAssignments(ctx, args.planId, userId);
+    const myTeamIds = new Set(confirmed.map((a) => a.teamId as string));
+    if (myTeamIds.size === 0) return [];
+
+    const [tasks, sharedRows] = await Promise.all([
+      ctx.db
+        .query("eventTasks")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+      ctx.db
+        .query("sharedTaskCompletions")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+    ]);
+    const completionByTask = new Map(
+      sharedRows.map((r) => [r.taskId as string, r]),
+    );
+
+    // Team-level tasks (no role) on a team the user is confirmed for.
+    const teamTasks = tasks.filter(
+      (t) => !t.roleId && myTeamIds.has(t.teamId as string),
+    );
+    teamTasks.sort(
+      (a, b) =>
+        (SEGMENT_RANK[a.segment] ?? 1) - (SEGMENT_RANK[b.segment] ?? 1) ||
+        a.sortOrder - b.sortOrder,
+    );
+
+    const teamNames = new Map<string, string>();
+    const userNames = new Map<string, string>();
+    const items: SharedTeamTaskItem[] = [];
+    for (const task of teamTasks) {
+      const teamKey = task.teamId as string;
+      if (!teamNames.has(teamKey)) {
+        const team = await ctx.db.get(task.teamId);
+        teamNames.set(teamKey, team?.name ?? "Team");
+      }
+      const completion = completionByTask.get(task._id as string);
+      let completedByName: string | undefined;
+      if (completion) {
+        const uKey = completion.completedByUserId as string;
+        if (!userNames.has(uKey)) {
+          userNames.set(
+            uKey,
+            await resolveUserName(ctx, completion.completedByUserId),
+          );
+        }
+        completedByName = userNames.get(uKey);
+      }
+      items.push({
+        taskId: task._id as string,
+        teamId: teamKey,
+        teamName: teamNames.get(teamKey)!,
+        title: task.title,
+        segment: task.segment,
+        howToType: task.howToType,
+        howToText: task.howToText,
+        howToUrl: task.howToUrl,
+        howToMediaPath: task.howToMediaPath,
+        howToDoc: task.howToDoc,
+        completed: !!completion,
+        completedByName,
+        completedAt: completion?.completedAt,
+      });
+    }
+    return items;
+  },
+});
+
+/**
+ * Toggle the TEAM-WIDE shared completion of a team-level task. Any confirmed
+ * member of the task's team may flip it; the state is shared (one row per task
+ * in `sharedTaskCompletions`, not per-user). For a "during" team-level task
+ * this is a single whole-task state (it is deliberately NOT split per service
+ * time — the Shared surface tracks "the team handled this", not per-slot).
+ *
+ * Auth: the caller must be a confirmed member of the task's team on the plan.
+ */
+export const toggleSharedTeamTask = mutation({
+  args: {
+    token: v.string(),
+    planId: v.id("eventPlans"),
+    taskId: v.id("eventTasks"),
+    completed: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const task = await ctx.db.get(args.taskId);
+    if (!task || task.planId !== args.planId) {
+      throw new ConvexError("Task not found");
+    }
+    if (task.roleId) {
+      throw new ConvexError(
+        "Only team-level tasks can be completed for the whole team",
+      );
+    }
+    const plan = await requirePlan(ctx, args.planId);
+    await requireGroupMember(ctx, plan.groupId, userId);
+
+    // Gate: the caller must be a confirmed member of THIS task's team.
+    const confirmed = await myConfirmedAssignments(ctx, args.planId, userId);
+    const onTeam = confirmed.some((a) => a.teamId === task.teamId);
+    if (!onTeam) {
+      throw new ConvexError("You must be serving on this team to update it");
+    }
+
+    const existing = await ctx.db
+      .query("sharedTaskCompletions")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .unique();
+
+    if (args.completed) {
+      if (existing) {
+        // Refresh who/when so the "completed by" label reflects the latest tap.
+        await ctx.db.patch(existing._id, {
+          completedByUserId: userId,
+          completedAt: Date.now(),
+        });
+      } else {
+        await ctx.db.insert("sharedTaskCompletions", {
+          taskId: args.taskId,
+          planId: task.planId,
+          communityId: task.communityId,
+          completedByUserId: userId,
+          completedAt: Date.now(),
+        });
+      }
+    } else if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+
+    return { taskId: args.taskId, completed: args.completed };
+  },
+});
+
+/** A teammate (or the current user) and their assigned work, for the Crew tab. */
+type CrewMemberEntry = {
+  userId: string;
+  name: string;
+  roleId: string;
+  roleName: string;
+  teamId: string;
+  teamName: string;
+  /** True for the current viewer's own row. */
+  isCurrentUser: boolean;
+  /** Completed / total completion "slots" (per-user, matching the personal view). */
+  done: number;
+  total: number;
+  tasks: Array<{
+    taskId: string;
+    title: string;
+    segment: "before" | "during" | "after";
+    /** For "during" tasks: true only when every service-time slot is done. */
+    completed: boolean;
+    howToType: string;
+  }>;
+};
+
+/**
+ * The "Crew" surface: the current user's confirmed teammates (and the user
+ * themselves) on a plan, with each person's ROLE-assigned tasks, READ-ONLY.
+ * One entry per (member, role). "Assigned tasks" are the plan's role tasks
+ * (`eventTasks.roleId` set) whose role the member is confirmed for — team-level
+ * tasks live on the Shared surface, not here.
+ *
+ * `done`/`total` count completion the same way the personal `getMyServingTasks`
+ * view does: per-user `eventTaskCompletions`, with "during" tasks counted once
+ * per service time (so a member serving one "during" task across two services
+ * has total 2). A task's `completed` flag is true only when all of its slots
+ * are done.
+ *
+ * Auth: an active member of the plan's group. Only teams the current user is
+ * confirmed for are included.
+ */
+export const getCrewTasks = query({
+  args: { token: v.string(), planId: v.id("eventPlans") },
+  handler: async (ctx, args): Promise<CrewMemberEntry[]> => {
+    const userId = await requireAuth(ctx, args.token);
+    const plan = await requirePlan(ctx, args.planId);
+    await requireGroupMember(ctx, plan.groupId, userId);
+
+    const myConfirmed = await myConfirmedAssignments(ctx, args.planId, userId);
+    const myTeamIds = new Set(myConfirmed.map((a) => a.teamId as string));
+    if (myTeamIds.size === 0) return [];
+
+    const [allAssignments, tasks] = await Promise.all([
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+      ctx.db
+        .query("eventTasks")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+    ]);
+
+    // Role tasks grouped by roleId (team-level tasks excluded — Shared surface).
+    const tasksByRole = new Map<string, Doc<"eventTasks">[]>();
+    for (const t of tasks) {
+      if (!t.roleId) continue;
+      const key = t.roleId as string;
+      const list = tasksByRole.get(key) ?? [];
+      list.push(t);
+      tasksByRole.set(key, list);
+    }
+
+    const timesCount = Math.max(1, plan.times.length);
+
+    // Crew = confirmed assignments on a team the current user is confirmed for.
+    const crew = allAssignments.filter(
+      (a) => a.status === "confirmed" && myTeamIds.has(a.teamId as string),
+    );
+
+    const teamNames = new Map<string, string>();
+    const roleNames = new Map<string, string>();
+    const userNames = new Map<string, string>();
+    // Per-user completion keys ("taskId::timeLabel"), fetched once per member.
+    const completionsByUser = new Map<string, Set<string>>();
+    const completionKey = (taskId: string, timeLabel?: string) =>
+      `${taskId}::${timeLabel ?? ""}`;
+
+    const entries = new Map<string, CrewMemberEntry>();
+    for (const a of crew) {
+      const memberKey = `${a.userId}::${a.roleId}`;
+      if (entries.has(memberKey)) continue; // one entry per (member, role)
+
+      const teamKey = a.teamId as string;
+      if (!teamNames.has(teamKey)) {
+        const team = await ctx.db.get(a.teamId);
+        teamNames.set(teamKey, team?.name ?? "Team");
+      }
+      const roleKey = a.roleId as string;
+      if (!roleNames.has(roleKey)) {
+        const role = await ctx.db.get(a.roleId);
+        roleNames.set(roleKey, role?.name ?? "Role");
+      }
+      const userKey = a.userId as string;
+      if (!userNames.has(userKey)) {
+        userNames.set(userKey, await resolveUserName(ctx, a.userId));
+      }
+      if (!completionsByUser.has(userKey)) {
+        const rows = await ctx.db
+          .query("eventTaskCompletions")
+          .withIndex("by_plan_user", (q) =>
+            q.eq("planId", args.planId).eq("userId", a.userId),
+          )
+          .collect();
+        completionsByUser.set(
+          userKey,
+          new Set(rows.map((r) => completionKey(r.taskId, r.timeLabel))),
+        );
+      }
+      const done = completionsByUser.get(userKey)!;
+
+      const roleTasks = tasksByRole.get(roleKey) ?? [];
+      roleTasks.sort(
+        (x, y) =>
+          (SEGMENT_RANK[x.segment] ?? 1) - (SEGMENT_RANK[y.segment] ?? 1) ||
+          x.sortOrder - y.sortOrder,
+      );
+
+      let doneCount = 0;
+      let totalCount = 0;
+      const taskList: CrewMemberEntry["tasks"] = [];
+      for (const t of roleTasks) {
+        if (t.segment === "during") {
+          const slots: (string | undefined)[] =
+            plan.times.length > 0
+              ? plan.times.map((s) => s.label)
+              : [undefined];
+          let slotDone = 0;
+          for (const label of slots) {
+            if (done.has(completionKey(t._id as string, label))) slotDone += 1;
+          }
+          totalCount += timesCount;
+          doneCount += slotDone;
+          taskList.push({
+            taskId: t._id as string,
+            title: t.title,
+            segment: t.segment,
+            completed: slotDone === slots.length,
+            howToType: t.howToType,
+          });
+        } else {
+          const isDone = done.has(completionKey(t._id as string, undefined));
+          totalCount += 1;
+          if (isDone) doneCount += 1;
+          taskList.push({
+            taskId: t._id as string,
+            title: t.title,
+            segment: t.segment,
+            completed: isDone,
+            howToType: t.howToType,
+          });
+        }
+      }
+
+      entries.set(memberKey, {
+        userId: userKey,
+        name: userNames.get(userKey)!,
+        roleId: roleKey,
+        roleName: roleNames.get(roleKey)!,
+        teamId: teamKey,
+        teamName: teamNames.get(teamKey)!,
+        isCurrentUser: a.userId === userId,
+        done: doneCount,
+        total: totalCount,
+        tasks: taskList,
+      });
+    }
+
+    // Current user first, then by name for a stable, useful ordering.
+    return Array.from(entries.values()).sort((x, y) => {
+      if (x.isCurrentUser !== y.isCurrentUser) return x.isCurrentUser ? -1 : 1;
+      return x.name.localeCompare(y.name);
+    });
+  },
+});
+
+/** A team's task rollup for the All-teams overview. */
+type AllTeamsEntry = {
+  teamId: string;
+  teamName: string;
+  taskCount: number;
+  done: number;
+  total: number;
+  tasks: Array<{
+    taskId: string;
+    title: string;
+    segment: "before" | "during" | "after";
+    roleName: string | null;
+    completed: boolean;
+    howToType: string;
+  }>;
+};
+
+/**
+ * The "All-teams" surface: a READ-ONLY overview of every team on the plan and
+ * its tasks, so a volunteer can see the whole event's shape and progress.
+ *
+ * `done`/`total` here use the plan-wide READINESS semantics (same as
+ * `getPlanTaskReadiness`): a task's `total` is the number of confirmed
+ * assignees expected to complete it (× the number of service times for
+ * "during" tasks), and `done` counts valid completions from those assignees. A
+ * task's `completed` flag is true when it is fully satisfied (done >= total,
+ * total > 0). Team-level tasks additionally count their team-wide shared
+ * completion as satisfying the whole task.
+ *
+ * Auth: an active member of the plan's group (any serving participant).
+ */
+export const getAllTeamsTasks = query({
+  args: { token: v.string(), planId: v.id("eventPlans") },
+  handler: async (ctx, args): Promise<AllTeamsEntry[]> => {
+    const userId = await requireAuth(ctx, args.token);
+    const plan = await requirePlan(ctx, args.planId);
+    await requireGroupMember(ctx, plan.groupId, userId);
+
+    const [tasks, assignments, sharedRows] = await Promise.all([
+      ctx.db
+        .query("eventTasks")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+      ctx.db
+        .query("sharedTaskCompletions")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+    ]);
+    const sharedByTask = new Set(sharedRows.map((r) => r.taskId as string));
+
+    tasks.sort(
+      (a, b) =>
+        (SEGMENT_RANK[a.segment] ?? 1) - (SEGMENT_RANK[b.segment] ?? 1) ||
+        a.sortOrder - b.sortOrder,
+    );
+
+    const timesCount = Math.max(1, plan.times.length);
+    const validTimeLabels = new Set(plan.times.map((t) => t.label));
+
+    const teamNames = new Map<string, string>();
+    const roleNames = new Map<string, string>();
+    const byTeam = new Map<string, AllTeamsEntry>();
+
+    for (const task of tasks) {
+      // Readiness "expected completers" for this task.
+      const expected = assigneesForTask(assignments, task);
+      const expectedUserIds = new Set(expected.map((a) => a.userId as string));
+      const expectedPeople = expectedUserIds.size;
+      const total =
+        task.segment === "during"
+          ? expectedPeople * timesCount
+          : expectedPeople;
+
+      const completions = await ctx.db
+        .query("eventTaskCompletions")
+        .withIndex("by_task", (q) => q.eq("taskId", task._id))
+        .collect();
+      const validCompletions = completions.filter((c) => {
+        if (!expectedUserIds.has(c.userId as string)) return false;
+        if (task.segment === "during") {
+          if (plan.times.length === 0) return c.timeLabel == null;
+          return c.timeLabel != null && validTimeLabels.has(c.timeLabel);
+        }
+        return true;
+      });
+      const done = Math.min(validCompletions.length, total);
+
+      // A team-level task the team marked shared-done counts as fully complete.
+      const sharedDone = !task.roleId && sharedByTask.has(task._id as string);
+      const completed = sharedDone || (total > 0 && done >= total);
+
+      const teamKey = task.teamId as string;
+      if (!teamNames.has(teamKey)) {
+        const team = await ctx.db.get(task.teamId);
+        teamNames.set(teamKey, team?.name ?? "Team");
+      }
+      let entry = byTeam.get(teamKey);
+      if (!entry) {
+        entry = {
+          teamId: teamKey,
+          teamName: teamNames.get(teamKey)!,
+          taskCount: 0,
+          done: 0,
+          total: 0,
+          tasks: [],
+        };
+        byTeam.set(teamKey, entry);
+      }
+
+      let roleName: string | null = null;
+      if (task.roleId) {
+        const roleKey = task.roleId as string;
+        if (!roleNames.has(roleKey)) {
+          const role = await ctx.db.get(task.roleId);
+          roleNames.set(roleKey, role?.name ?? "Role");
+        }
+        roleName = roleNames.get(roleKey)!;
+      }
+
+      entry.taskCount += 1;
+      entry.total += total;
+      entry.done += done;
+      entry.tasks.push({
+        taskId: task._id as string,
+        title: task.title,
+        segment: task.segment,
+        roleName,
+        completed,
+        howToType: task.howToType,
+      });
+    }
+
+    return Array.from(byTeam.values()).sort((a, b) =>
+      a.teamName.localeCompare(b.teamName),
+    );
   },
 });
 

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -636,6 +636,89 @@ export const getMyServingTasks = query({
 });
 
 // ============================================================================
+// Interactive "doc" How-To checklist — per-user checked state.
+// ============================================================================
+
+/**
+ * The current user's checked checklist-item indices for a task's "doc" How-To.
+ * Returns `[]` when nothing is checked, or when the task/plan no longer exists
+ * (so a stale viewer degrades to an all-unchecked checklist rather than
+ * erroring).
+ *
+ * Auth: an active member of the task's plan's group.
+ */
+export const getHowToDocChecks = query({
+  args: { token: v.string(), taskId: v.id("eventTasks") },
+  handler: async (ctx, args): Promise<number[]> => {
+    const userId = await requireAuth(ctx, args.token);
+    const task = await ctx.db.get(args.taskId);
+    if (!task) return [];
+    const plan = await ctx.db.get(task.planId);
+    if (!plan) return [];
+    await requireGroupMember(ctx, plan.groupId, userId);
+
+    const row = await ctx.db
+      .query("howToDocChecks")
+      .withIndex("by_user_task", (q) =>
+        q.eq("userId", userId).eq("taskId", args.taskId),
+      )
+      .unique();
+    return row?.checkedIndices ?? [];
+  },
+});
+
+/**
+ * Toggle a single checklist item in a task's "doc" How-To for the current user.
+ * Upserts the (user, task) row and adds/removes `itemIndex` from its set.
+ *
+ * Auth: an active member of the task's plan's group (same read gate as viewing
+ * the task).
+ */
+export const setHowToDocCheck = mutation({
+  args: {
+    token: v.string(),
+    taskId: v.id("eventTasks"),
+    itemIndex: v.number(),
+    checked: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const task = await ctx.db.get(args.taskId);
+    if (!task) {
+      throw new ConvexError("Task not found");
+    }
+    const plan = await requirePlan(ctx, task.planId);
+    await requireGroupMember(ctx, plan.groupId, userId);
+
+    const row = await ctx.db
+      .query("howToDocChecks")
+      .withIndex("by_user_task", (q) =>
+        q.eq("userId", userId).eq("taskId", args.taskId),
+      )
+      .unique();
+
+    const current = new Set(row?.checkedIndices ?? []);
+    if (args.checked) current.add(args.itemIndex);
+    else current.delete(args.itemIndex);
+    const checkedIndices = Array.from(current).sort((a, b) => a - b);
+
+    const nowMs = Date.now();
+    if (row) {
+      await ctx.db.patch(row._id, { checkedIndices, updatedAt: nowMs });
+    } else {
+      await ctx.db.insert("howToDocChecks", {
+        userId,
+        taskId: args.taskId,
+        checkedIndices,
+        updatedAt: nowMs,
+      });
+    }
+
+    return { taskId: args.taskId, itemIndex: args.itemIndex, checked: args.checked };
+  },
+});
+
+// ============================================================================
 // Personal (ad-hoc, single-user) serving tasks — never part of the template.
 // ============================================================================
 

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -541,7 +541,12 @@ export const getMyServingTasks = query({
   args: { token: v.string(), planId: v.id("eventPlans") },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
-    const plan = await requirePlan(ctx, args.planId);
+    // Tolerate a stale/deleted activePlanId: return the empty shape rather than
+    // throwing, so the serving Tasks tab degrades gracefully (like getEvent)
+    // instead of dropping to the error boundary. Auth is unchanged when the
+    // plan exists.
+    const plan = await ctx.db.get(args.planId);
+    if (!plan) return { before: [], during: [], after: [] };
     await requireGroupMember(ctx, plan.groupId, userId);
 
     const result: Record<
@@ -716,7 +721,11 @@ export const getSharedTeamTasks = query({
   args: { token: v.string(), planId: v.id("eventPlans") },
   handler: async (ctx, args): Promise<SharedTeamTaskItem[]> => {
     const userId = await requireAuth(ctx, args.token);
-    const plan = await requirePlan(ctx, args.planId);
+    // Tolerate a stale/deleted activePlanId: return empty rather than throwing,
+    // so the serving Tasks tab degrades gracefully instead of erroring. Auth is
+    // unchanged when the plan exists.
+    const plan = await ctx.db.get(args.planId);
+    if (!plan) return [];
     await requireGroupMember(ctx, plan.groupId, userId);
 
     const confirmed = await myConfirmedAssignments(ctx, args.planId, userId);
@@ -897,7 +906,11 @@ export const getCrewTasks = query({
   args: { token: v.string(), planId: v.id("eventPlans") },
   handler: async (ctx, args): Promise<CrewMemberEntry[]> => {
     const userId = await requireAuth(ctx, args.token);
-    const plan = await requirePlan(ctx, args.planId);
+    // Tolerate a stale/deleted activePlanId: return empty rather than throwing,
+    // so the serving Tasks tab degrades gracefully instead of erroring. Auth is
+    // unchanged when the plan exists.
+    const plan = await ctx.db.get(args.planId);
+    if (!plan) return [];
     await requireGroupMember(ctx, plan.groupId, userId);
 
     const myConfirmed = await myConfirmedAssignments(ctx, args.planId, userId);
@@ -1073,7 +1086,11 @@ export const getAllTeamsTasks = query({
   args: { token: v.string(), planId: v.id("eventPlans") },
   handler: async (ctx, args): Promise<AllTeamsEntry[]> => {
     const userId = await requireAuth(ctx, args.token);
-    const plan = await requirePlan(ctx, args.planId);
+    // Tolerate a stale/deleted activePlanId: return empty rather than throwing,
+    // so the serving Tasks tab degrades gracefully instead of erroring. Auth is
+    // unchanged when the plan exists.
+    const plan = await ctx.db.get(args.planId);
+    if (!plan) return [];
     await requireGroupMember(ctx, plan.groupId, userId);
 
     const [tasks, assignments, sharedRows] = await Promise.all([
@@ -1132,6 +1149,11 @@ export const getAllTeamsTasks = query({
       // A team-level task the team marked shared-done counts as fully complete.
       const sharedDone = !task.roleId && sharedByTask.has(task._id as string);
       const completed = sharedDone || (total > 0 && done >= total);
+      // Keep the aggregate consistent with the row's checkmark: a shared-done
+      // team-level task is fully satisfied, so contribute its full slot count to
+      // the team's `done` (not the sparse per-user completions) — otherwise the
+      // row shows done while the team card reads e.g. 0/6.
+      const doneForEntry = sharedDone ? total : done;
 
       const teamKey = task.teamId as string;
       if (!teamNames.has(teamKey)) {
@@ -1163,7 +1185,7 @@ export const getAllTeamsTasks = query({
 
       entry.taskCount += 1;
       entry.total += total;
-      entry.done += done;
+      entry.done += doneForEntry;
       entry.tasks.push({
         taskId: task._id as string,
         title: task.title,

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -18,6 +18,10 @@ import type { QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { requireGroupMember } from "./permissions";
+import { ADD_DAYS_BEFORE } from "./teamChannelSync";
+
+/** Milliseconds in one day. */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /** Two hours before the first service time is when serving auto-enters. */
 const AUTO_ENTER_LEAD_MS = 2 * 60 * 60 * 1000;
@@ -242,5 +246,119 @@ export const getServingInboxMeta = query({
     if (!plan) return null;
     await requireGroupMember(ctx, plan.groupId, userId);
     return { eventDate: plan.eventDate };
+  },
+});
+
+/** A channel the user will belong to for a plan but isn't an active member of yet. */
+type UpcomingChannel = {
+  channelId: Id<"chatChannels">;
+  name: string;
+  kind: "team" | "cross_team";
+  availableAt: number;
+};
+
+/**
+ * Serving-mode "coming soon" channels: the team + cross-team channels the
+ * CURRENT user WILL be added to for this plan (via the rotation engine in
+ * `teamChannelSync.ts`) but is NOT yet an active member of. These exist as
+ * `chatChannels` rows already, but the user is only mirrored into
+ * `chatChannelMembers` inside a rotation window starting
+ * `eventDate − ADD_DAYS_BEFORE days`, so before that they don't appear in the
+ * (membership-filtered) serving inbox. The serving inbox renders these as
+ * non-tappable "ghost" cards showing when the channel opens.
+ *
+ * Scope is the user's OWN teams on the plan — their `confirmed` role
+ * assignments — not every team on the plan:
+ *   - team channels: `teams.channelId` for each team the user is confirmed on;
+ *   - cross-team channels (`channelType === "cross_team"`): any whose
+ *     `crossTeamSync.selectors` match one of the user's confirmed assignments
+ *     (same `sourceTeamId`, and matching `roleId` when the selector pins one).
+ * Channels the user is already an active member of (`chatChannelMembers` with
+ * `leftAt === undefined`) are excluded — those render as real rows.
+ *
+ * `availableAt = plan.eventDate − ADD_DAYS_BEFORE * MS_PER_DAY`. Returns `[]`
+ * when there's nothing upcoming. Membership-gated like the rest of the plan
+ * surface.
+ */
+export const getServingUpcomingChannels = query({
+  args: { token: v.string(), planId: v.id("eventPlans") },
+  handler: async (ctx, args): Promise<UpcomingChannel[]> => {
+    const userId = await requireAuth(ctx, args.token);
+    const plan = await ctx.db.get(args.planId);
+    if (!plan) return [];
+    await requireGroupMember(ctx, plan.groupId, userId);
+
+    // The user's confirmed assignments on this plan → the teams they'll be in.
+    const planAssignments = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+      .filter((q) => q.eq(q.field("userId"), userId))
+      .collect();
+    const confirmed = planAssignments.filter((a) => a.status === "confirmed");
+    if (confirmed.length === 0) return [];
+
+    const availableAt = plan.eventDate - ADD_DAYS_BEFORE * MS_PER_DAY;
+
+    // Candidate channels (may include channels the user is already in — those
+    // are filtered out below).
+    const candidates: Array<Omit<UpcomingChannel, "availableAt">> = [];
+
+    // (a) Team channels — one per team the user is confirmed on.
+    const teamIds = new Set<string>(confirmed.map((a) => a.teamId as string));
+    for (const teamId of teamIds) {
+      const team = await ctx.db.get(teamId as Id<"teams">);
+      if (team?.channelId && team.isArchived !== true) {
+        candidates.push({
+          channelId: team.channelId,
+          name: team.name,
+          kind: "team",
+        });
+      }
+    }
+
+    // (b) Cross-team channels whose selectors match one of the user's confirmed
+    // assignments. Cross-team channels are rare, so a filtered scan is fine
+    // (mirrors `reconcileCrossTeamChannelsForSource`).
+    const crossChannels = await ctx.db
+      .query("chatChannels")
+      .filter((q) => q.eq(q.field("channelType"), "cross_team"))
+      .collect();
+    for (const ch of crossChannels) {
+      if (ch.isArchived === true) continue;
+      const selectors = ch.crossTeamSync?.selectors ?? [];
+      const willBeMember = confirmed.some((a) =>
+        selectors.some(
+          (s) =>
+            (s.sourceTeamId as string) === (a.teamId as string) &&
+            (s.roleId === undefined ||
+              (s.roleId as string) === (a.roleId as string)),
+        ),
+      );
+      if (willBeMember) {
+        candidates.push({ channelId: ch._id, name: ch.name, kind: "cross_team" });
+      }
+    }
+
+    // Exclude channels the user is already an active member of, and dedupe.
+    const result: UpcomingChannel[] = [];
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      const key = candidate.channelId as string;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const memberRows = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel_user", (q) =>
+          q.eq("channelId", candidate.channelId).eq("userId", userId),
+        )
+        .collect();
+      const isActiveMember = memberRows.some((r) => r.leftAt === undefined);
+      if (isActiveMember) continue;
+
+      result.push({ ...candidate, availableAt });
+    }
+
+    return result;
   },
 });

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -17,6 +17,7 @@ import { query } from "../../_generated/server";
 import type { QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
+import { requireGroupMember } from "./permissions";
 
 /** Two hours before the first service time is when serving auto-enters. */
 const AUTO_ENTER_LEAD_MS = 2 * 60 * 60 * 1000;
@@ -220,5 +221,26 @@ export const getServingEligibility = query({
       activePlan,
       plans,
     };
+  },
+});
+
+/**
+ * Lightweight serving-inbox metadata for one plan: just its `eventDate`. The
+ * mobile inbox (serving mode) uses this to derive the event's local-day window
+ * and filter direct messages down to those created on the day of the event.
+ *
+ * Unlike `getServingEligibility`, this resolves straight from the plan id, so
+ * it works even outside the ~12h serving window (e.g. a volunteer previewing
+ * their focused inbox early) — mirroring how the runsheet loads the plan via
+ * `getEvent`. Membership-gated like the rest of the plan surface.
+ */
+export const getServingInboxMeta = query({
+  args: { token: v.string(), planId: v.id("eventPlans") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const plan = await ctx.db.get(args.planId);
+    if (!plan) return null;
+    await requireGroupMember(ctx, plan.groupId, userId);
+    return { eventDate: plan.eventDate };
   },
 });

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2969,7 +2969,10 @@ export default defineSchema({
   howToDocChecks: defineTable({
     userId: v.id("users"),
     taskId: v.id("eventTasks"),
-    checkedIndices: v.array(v.number()), // 0-based checklist-item indices, in doc order
+    // Content-based keys for the checked items (a stable hash of the item's
+    // text + its occurrence, so checks survive reordering the doc). Replaces the
+    // old positional-index scheme.
+    checkedKeys: v.array(v.string()),
     updatedAt: v.number(),
   }).index("by_user_task", ["userId", "taskId"]),
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2977,6 +2977,25 @@ export default defineSchema({
   }).index("by_user_task", ["userId", "taskId"]),
 
   /**
+   * Team-WIDE completion of a team-level event task (the "Shared" serving
+   * surface). Unlike `eventTaskCompletions` (per-user), this is a single shared
+   * state per task: any confirmed member of the task's team may mark the task
+   * done for the whole team, and a row's mere existence means "done". Only used
+   * for team-level tasks (`eventTasks.roleId == null`); one row per task, keyed
+   * by `taskId`. `completedByUserId` records who last flipped it done (for a
+   * "completed by …" label). Deleting the row un-completes the task.
+   */
+  sharedTaskCompletions: defineTable({
+    taskId: v.id("eventTasks"),
+    planId: v.id("eventPlans"),
+    communityId: v.id("communities"),
+    completedByUserId: v.id("users"),
+    completedAt: v.number(),
+  })
+    .index("by_task", ["taskId"])
+    .index("by_plan", ["planId"]),
+
+  /**
    * Per-community song library (ADR-027). A song lives once and is referenced
    * by run sheet `eventItems` via `songId`, so editing its charts/metadata
    * updates every plan that uses it (no copied-string drift). `ccliNumber` is

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2960,6 +2960,20 @@ export default defineSchema({
   }).index("by_plan_user", ["planId", "userId"]),
 
   /**
+   * Per-user checked state for the interactive checklist inside a serving
+   * task's "doc" How-To. One row per (user, task) holding the set of checked
+   * checklist-item indices (positional, in document order). This is personal —
+   * each volunteer sees only their own checks — and never mutates the shared
+   * `howToDoc` markdown itself.
+   */
+  howToDocChecks: defineTable({
+    userId: v.id("users"),
+    taskId: v.id("eventTasks"),
+    checkedIndices: v.array(v.number()), // 0-based checklist-item indices, in doc order
+    updatedAt: v.number(),
+  }).index("by_user_task", ["userId", "taskId"]),
+
+  /**
    * Per-community song library (ADR-027). A song lives once and is referenced
    * by run sheet `eventItems` via `songId`, so editing its charts/metadata
    * updates every plan that uses it (no copied-string drift). `ccliNumber` is

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -35,6 +35,13 @@ export default function TabsLayout() {
 
   const tabs = (
     <Tabs
+      // Expo Router's Tabs computes its visible tab set from `href` at mount and
+      // doesn't reliably re-render the bar when hrefs flip at runtime — so
+      // entering/leaving serving mode left the OLD tabs on screen until a
+      // refresh. Keying the navigator on the mode remounts it on that (rare)
+      // transition, recomputing the tab set. Stable within each mode, so normal
+      // navigation is unaffected.
+      key={inServingMode ? 'serving' : 'normal'}
       screenOptions={{
         headerShown: false,
         tabBarActiveTintColor: primaryColor,

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -21,10 +21,10 @@ export default function TabsLayout() {
   // was over-engineered and introduced a stale render frame.
   const hasCommunity = !!community?.id;
 
-  // Serving mode collapses the tab bar to a focused set (Inbox, Runsheet,
-  // Tasks, Profile, Exit) for the duration of an event. Gated on the community
-  // opting into the Event Tasks feature so communities without it never see
-  // serving tabs even if a stale persisted flag lingers.
+  // Serving mode collapses the tab bar to a focused set — ordered
+  // Runsheet · Inbox · Tasks · Exit (no Profile) — for the duration of an event.
+  // Gated on the community opting into the Event Tasks feature so communities
+  // without it never see serving tabs even if a stale persisted flag lingers.
   const eventTasksEnabled =
     (community?.churchFeatures as { eventTasksEnabled?: boolean } | undefined)
       ?.eventTasksEnabled === true;
@@ -123,6 +123,23 @@ export default function TabsLayout() {
           ),
         }}
       />
+      {/* Serving-mode Runsheet sits immediately before Inbox so the serving
+          tab order reads Runsheet · Inbox · Tasks · Exit. Normal mode hides the
+          serving tabs (href: null), so its order is unaffected. */}
+      <Tabs.Screen
+        name="serving-runsheet"
+        options={{
+          title: 'Runsheet',
+          href: inServingMode ? '/(tabs)/serving-runsheet' : null,
+          tabBarIcon: ({ color, focused }) => (
+            <Ionicons
+              name={focused ? 'list' : 'list-outline'}
+              size={24}
+              color={color}
+            />
+          ),
+        }}
+      />
       <Tabs.Screen
         name="chat"
         options={{
@@ -140,6 +157,35 @@ export default function TabsLayout() {
                     ? 'chatbubbles'
                     : 'chatbubbles-outline'
               }
+              size={24}
+              color={color}
+            />
+          ),
+        }}
+      />
+      {/* Serving-mode Tasks + Exit sit immediately after Inbox. */}
+      <Tabs.Screen
+        name="serving-tasks"
+        options={{
+          title: 'Tasks',
+          href: inServingMode ? '/(tabs)/serving-tasks' : null,
+          tabBarIcon: ({ color, focused }) => (
+            <Ionicons
+              name={focused ? 'checkmark-done' : 'checkmark-done-outline'}
+              size={24}
+              color={color}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="serving-exit"
+        options={{
+          title: 'Exit',
+          href: inServingMode ? '/(tabs)/serving-exit' : null,
+          tabBarIcon: ({ color, focused }) => (
+            <Ionicons
+              name={focused ? 'exit' : 'exit-outline'}
               size={24}
               color={color}
             />
@@ -185,54 +231,13 @@ export default function TabsLayout() {
           ),
         }}
       />
-
-      {/* Serving-mode tabs — only visible while serving mode is active. */}
-      <Tabs.Screen
-        name="serving-runsheet"
-        options={{
-          title: 'Runsheet',
-          href: inServingMode ? '/(tabs)/serving-runsheet' : null,
-          tabBarIcon: ({ color, focused }) => (
-            <Ionicons
-              name={focused ? 'list' : 'list-outline'}
-              size={24}
-              color={color}
-            />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="serving-tasks"
-        options={{
-          title: 'Tasks',
-          href: inServingMode ? '/(tabs)/serving-tasks' : null,
-          tabBarIcon: ({ color, focused }) => (
-            <Ionicons
-              name={focused ? 'checkmark-done' : 'checkmark-done-outline'}
-              size={24}
-              color={color}
-            />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="serving-exit"
-        options={{
-          title: 'Exit',
-          href: inServingMode ? '/(tabs)/serving-exit' : null,
-          tabBarIcon: ({ color, focused }) => (
-            <Ionicons
-              name={focused ? 'exit' : 'exit-outline'}
-              size={24}
-              color={color}
-            />
-          ),
-        }}
-      />
       <Tabs.Screen
         name="profile"
         options={{
           title: 'Profile',
+          // Hidden while serving mode is active to keep the serving tab bar to
+          // Runsheet · Inbox · Tasks · Exit.
+          href: inServingMode ? null : '/(tabs)/profile',
           tabBarIcon: ({ color, focused }) => (
             <Ionicons
               name={focused ? 'person' : 'person-outline'}

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { View } from 'react-native';
-import { Tabs } from 'expo-router';
+import { Tabs, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@providers/AuthProvider';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
@@ -29,7 +29,9 @@ export default function TabsLayout() {
     (community?.churchFeatures as { eventTasksEnabled?: boolean } | undefined)
       ?.eventTasksEnabled === true;
   const isServingMode = useEventModeStore((s) => s.isServingMode);
+  const exitServingMode = useEventModeStore((s) => s.exit);
   const inServingMode = isServingMode && eventTasksEnabled;
+  const router = useRouter();
 
   const tabs = (
     <Tabs
@@ -190,6 +192,19 @@ export default function TabsLayout() {
               color={color}
             />
           ),
+        }}
+        listeners={{
+          // Exit is an action, not a destination: intercept the tap so we never
+          // focus the (about-to-be-hidden) serving-exit route. Navigate to Inbox
+          // (visible in both modes) first, then drop serving mode so the tab bar
+          // re-renders to the normal layout. Doing it here avoids the focus/blur
+          // race a screen-side effect hit (its cleanup cancelled the exit).
+          tabPress: (e) => {
+            if (!inServingMode) return;
+            e.preventDefault();
+            router.replace('/(tabs)/chat');
+            requestAnimationFrame(() => exitServingMode());
+          },
         }}
       />
       <Tabs.Screen

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -19,6 +19,7 @@ import {
   Pressable,
   Linking,
   Platform,
+  Alert,
 } from "react-native";
 import Animated, {
   useSharedValue,
@@ -111,6 +112,15 @@ type InboxGroup = {
   };
   channels: InboxChannel[];
   userRole: "leader" | "member";
+};
+
+// A "coming soon" serving channel the user will be added to but isn't yet a
+// member of. Returned by getServingUpcomingChannels; rendered as a ghost card.
+type UpcomingChannel = {
+  channelId: Id<"chatChannels">;
+  name: string;
+  kind: "team" | "cross_team";
+  availableAt: number;
 };
 
 // An event row combines the channel with its owning group (for avatar + nav)
@@ -228,6 +238,17 @@ export function ChatInboxScreen({
       : "skip",
   ) as { eventDate: number } | null | undefined;
 
+  // Serving mode "coming soon" channels: the plan's team + cross-team channels
+  // the user WILL be added to (via the rotation engine) but isn't yet a member
+  // of, so they don't appear as real rows. Rendered as non-tappable ghost cards
+  // at the bottom of the serving inbox showing when each channel opens.
+  const upcomingChannels = useQuery(
+    api.functions.scheduling.serving.getServingUpcomingChannels,
+    inServingMode && activePlanId && token
+      ? { token, planId: activePlanId as Id<"eventPlans"> }
+      : "skip",
+  ) as UpcomingChannel[] | undefined;
+
   // Event-day window (device-local day of `eventDate`, matching how event rows
   // format "Today"). Null outside serving mode or before the plan loads.
   const servingDmWindow = useMemo<{ start: number; end: number } | null>(() => {
@@ -338,6 +359,7 @@ export function ChatInboxScreen({
     | { kind: "event"; item: EventInboxRow }
     | { kind: "dm"; item: DirectInboxRow }
     | { kind: "notifications"; item: NotificationsRow }
+    | { kind: "ghost"; item: UpcomingChannel }
     | { kind: "requests-link"; count: number };
 
   // Render a single inbox row (group, event, dm, section header, or
@@ -403,6 +425,9 @@ export function ChatInboxScreen({
           />
         );
       }
+      if (item.kind === "ghost") {
+        return <GhostChannelCard channel={item.item} />;
+      }
       if (item.kind === "event") {
         return (
           <EventInboxRowItem
@@ -433,6 +458,7 @@ export function ChatInboxScreen({
   const keyExtractor = useCallback((item: InboxListItem) => {
     if (item.kind === "requests-link") return "requests-link";
     if (item.kind === "notifications") return "notifications";
+    if (item.kind === "ghost") return `ghost:${item.item.channelId}`;
     if (item.kind === "dm") return `dm:${item.item.channelId}`;
     return item.kind === "event"
       ? `event:${item.item.channel._id}`
@@ -741,7 +767,15 @@ export function ChatInboxScreen({
         )
         .sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0))
         .map((row) => ({ kind: "dm" as const, item: row }));
-      return [...listItems, ...dayDmItems];
+      // "Coming soon" ghost cards, grouped together at the bottom. Past-due
+      // ghosts (availableAt already elapsed but the user still isn't a member —
+      // a rotation edge case) are hidden to keep the list clean.
+      const now = Date.now();
+      const ghostItems: InboxListItem[] = (upcomingChannels ?? [])
+        .filter((c) => c.availableAt > now)
+        .sort((a, b) => a.availableAt - b.availableAt)
+        .map((c) => ({ kind: "ghost" as const, item: c }));
+      return [...listItems, ...dayDmItems, ...ghostItems];
     }
 
     const dmItems: InboxListItem[] = dmRows.map((row) => ({
@@ -812,6 +846,7 @@ export function ChatInboxScreen({
     notificationsItem,
     inServingMode,
     servingDmWindow,
+    upcomingChannels,
   ]);
   const hasInboxItems = listItemsWithDm.length > 0;
 
@@ -1590,6 +1625,84 @@ function NotificationsInboxRow({
   );
 }
 
+// ============================================================================
+// Ghost (coming-soon) channel card
+// ============================================================================
+
+/**
+ * Format a channel's `availableAt` as "Mon, Aug 26 · 7:00 AM" — the app's
+ * standard weekday + date + time shape.
+ */
+function formatOpensAt(ts: number): string {
+  const d = new Date(ts);
+  const date = d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const time = d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${date} · ${time}`;
+}
+
+/**
+ * A non-tappable "coming soon" inbox card for a serving channel the user will
+ * be added to but isn't a member of yet. Rendered muted/greyed with a dashed
+ * lock avatar and a "Opens {date}" subtitle; tapping just explains when it
+ * opens rather than navigating (there's nothing to open yet).
+ */
+function GhostChannelCard({ channel }: { channel: UpcomingChannel }) {
+  const { colors } = useTheme();
+  const opensLabel = formatOpensAt(channel.availableAt);
+  const tagLabel = channel.kind === "cross_team" ? "Cross-team" : "Team";
+
+  return (
+    <Pressable
+      onPress={() =>
+        Alert.alert(
+          "Not open yet",
+          `${channel.name} opens ${opensLabel}.`,
+        )
+      }
+      style={[styles.ghostRow, { opacity: 0.75 }]}
+      accessibilityRole="button"
+      accessibilityLabel={`${channel.name}, ${tagLabel} channel, opens ${opensLabel}`}
+    >
+      <View style={[styles.ghostAvatar, { borderColor: colors.border }]}>
+        <Ionicons name="lock-closed" size={22} color={colors.textTertiary} />
+      </View>
+      <View style={styles.ghostContent}>
+        <View style={styles.ghostTopLine}>
+          <Text
+            numberOfLines={1}
+            style={[styles.ghostName, { color: colors.textSecondary }]}
+          >
+            {channel.name}
+          </Text>
+          <View
+            style={[styles.ghostTag, { backgroundColor: colors.surfaceSecondary }]}
+          >
+            <Text style={[styles.ghostTagText, { color: colors.textTertiary }]}>
+              {tagLabel}
+            </Text>
+          </View>
+        </View>
+        <View style={styles.ghostSubtitleRow}>
+          <Ionicons name="time-outline" size={13} color={colors.textTertiary} />
+          <Text
+            numberOfLines={1}
+            style={[styles.ghostSubtitle, { color: colors.textTertiary }]}
+          >
+            Opens {opensLabel}
+          </Text>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -1963,5 +2076,58 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 12,
     fontWeight: "700",
+  },
+
+  // --- Ghost (coming-soon) channel card ---
+  ghostRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  // Dashed, empty circle with a lock icon — signals "not yet available".
+  ghostAvatar: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    borderWidth: 1.5,
+    borderStyle: "dashed",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ghostContent: {
+    flex: 1,
+    marginLeft: 12,
+    minWidth: 0,
+  },
+  ghostTopLine: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  ghostName: {
+    fontSize: 16,
+    fontWeight: "600",
+    flexShrink: 1,
+  },
+  ghostTag: {
+    marginLeft: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  ghostTagText: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+  },
+  ghostSubtitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginTop: 3,
+  },
+  ghostSubtitle: {
+    fontSize: 13,
+    flexShrink: 1,
   },
 });

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -867,10 +867,25 @@ export function ChatInboxScreen({
               color={colors.iconSecondary}
               style={{ marginBottom: 16 }}
             />
-            <Text style={[styles.emptyTitle, { color: colors.text }]}>No Groups Yet</Text>
-            <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
-              Join a group to start chatting
-            </Text>
+            {inServingMode ? (
+              <>
+                <Text style={[styles.emptyTitle, { color: colors.text }]}>
+                  Your event inbox
+                </Text>
+                <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+                  This is your inbox for the event. Your team channels and shared
+                  team channels show up here, along with direct messages from the
+                  event day. Nothing yet — check back closer to the event.
+                </Text>
+              </>
+            ) : (
+              <>
+                <Text style={[styles.emptyTitle, { color: colors.text }]}>No Groups Yet</Text>
+                <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+                  Join a group to start chatting
+                </Text>
+              </>
+            )}
           </ScrollView>
         </View>
       </Wrapper>

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -762,9 +762,13 @@ export function ChatInboxScreen({
       const dayDmItems: InboxListItem[] = dmRows
         .filter(
           (row) =>
-            !servingDmWindow ||
-            (row.createdAt >= servingDmWindow.start &&
-              row.createdAt < servingDmWindow.end),
+            // Only surface DMs once the event-day window is KNOWN. While
+            // getServingInboxMeta is loading, or when it returns null (plan
+            // gone / non-member), servingDmWindow is null — show no DMs rather
+            // than falling open to every DM.
+            servingDmWindow != null &&
+            row.createdAt >= servingDmWindow.start &&
+            row.createdAt < servingDmWindow.end,
         )
         .sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0))
         .map((row) => ({ kind: "dm" as const, item: row }));

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -448,10 +448,11 @@ export function ChatInboxScreen({
           activeGroupId={sidebarMode ? activeGroupId : undefined}
           activeChannelSlug={sidebarMode ? activeChannelSlug : undefined}
           resources={resourcesByGroup.get(item.item.group._id)}
+          servingMode={inServingMode}
         />
       );
     },
-    [isGroupExpanded, toggleGroupExpanded, sidebarMode, activeGroupId, activeChannelSlug, primaryColor, colors, router, resourcesByGroup]
+    [isGroupExpanded, toggleGroupExpanded, sidebarMode, activeGroupId, activeChannelSlug, primaryColor, colors, router, resourcesByGroup, inServingMode]
   );
 
   // Key extractor for FlatList

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -215,6 +215,34 @@ export function ChatInboxScreen({
     token ? { token } : "skip",
   );
 
+  // Serving mode focuses the inbox on the active plan: its channels stay
+  // pinned on top (filtered server-side via `servingPlanId`, above), DMs are
+  // narrowed to those created on the event day, and the Notifications row is
+  // hidden. `getServingInboxMeta` returns the plan's `eventDate` (resolved
+  // straight from the plan id, so it works even before the day-of window) from
+  // which we derive the local-day boundaries for the DM filter.
+  const servingInboxMeta = useQuery(
+    api.functions.scheduling.serving.getServingInboxMeta,
+    inServingMode && activePlanId && token
+      ? { token, planId: activePlanId as Id<"eventPlans"> }
+      : "skip",
+  ) as { eventDate: number } | null | undefined;
+
+  // Event-day window (device-local day of `eventDate`, matching how event rows
+  // format "Today"). Null outside serving mode or before the plan loads.
+  const servingDmWindow = useMemo<{ start: number; end: number } | null>(() => {
+    if (!inServingMode) return null;
+    const eventDate = servingInboxMeta?.eventDate;
+    if (typeof eventDate !== "number") return null;
+    const d = new Date(eventDate);
+    const start = new Date(
+      d.getFullYear(),
+      d.getMonth(),
+      d.getDate(),
+    ).getTime();
+    return { start, end: start + 24 * 60 * 60 * 1000 };
+  }, [inServingMode, servingInboxMeta]);
+
   // Resources flagged to show under their group in the inbox. One batched
   // subscription returns them grouped by groupId; we index into it per row.
   const inboxResources = useQuery(
@@ -699,6 +727,23 @@ export function ChatInboxScreen({
   }, [notificationSummary]);
 
   const listItemsWithDm = useMemo<InboxListItem[]>(() => {
+    // Serving mode: a focused inbox. `listItems` is already restricted to the
+    // active plan's serving channels (server-filtered via `servingPlanId`), so
+    // pin those on top and append only the DMs created on the event day. No
+    // Notifications row and no requests-link — everything unrelated is hidden.
+    if (inServingMode) {
+      const dayDmItems: InboxListItem[] = dmRows
+        .filter(
+          (row) =>
+            !servingDmWindow ||
+            (row.createdAt >= servingDmWindow.start &&
+              row.createdAt < servingDmWindow.end),
+        )
+        .sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0))
+        .map((row) => ({ kind: "dm" as const, item: row }));
+      return [...listItems, ...dayDmItems];
+    }
+
     const dmItems: InboxListItem[] = dmRows.map((row) => ({
       kind: "dm" as const,
       item: row,
@@ -760,7 +805,14 @@ export function ChatInboxScreen({
     }
     items.push(...pinned, ...merged);
     return items;
-  }, [requestCount, dmRows, listItems, notificationsItem]);
+  }, [
+    requestCount,
+    dmRows,
+    listItems,
+    notificationsItem,
+    inServingMode,
+    servingDmWindow,
+  ]);
   const hasInboxItems = listItemsWithDm.length > 0;
 
   // Show message when user has no community context

--- a/apps/mobile/features/chat/components/ChatNavigation.tsx
+++ b/apps/mobile/features/chat/components/ChatNavigation.tsx
@@ -2,7 +2,7 @@
  * Chat Navigation Component
  * Contains TabBar (dynamic channel tabs) and Toolbar (quick actions).
  */
-import React, { memo, useMemo } from "react";
+import React, { memo, useMemo, useRef, useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -73,6 +73,29 @@ export const ChatTabBar = memo(function ChatTabBar({
   const { colors: themeColors } = useTheme();
   const externalChatInfo = externalChatLink ? getExternalChatInfo(externalChatLink) : null;
 
+  // Keep the ACTIVE channel tab visible in the horizontal bar no matter how the
+  // room was opened (inbox, notification, deep link, tab tap). We remember each
+  // tab's measured x/width and the viewport width, then scroll the active tab to
+  // center whenever the active slug changes (or its layout first arrives).
+  const scrollRef = useRef<ScrollView>(null);
+  const tabLayoutsRef = useRef<Record<string, { x: number; width: number }>>({});
+  const [viewportW, setViewportW] = useState(0);
+
+  const scrollActiveIntoView = useCallback(
+    (animated: boolean) => {
+      const layout = tabLayoutsRef.current[activeSlug];
+      if (!layout || viewportW === 0) return;
+      // Center it; RN clamps the offset to the scrollable range for us.
+      const x = layout.x - (viewportW - layout.width) / 2;
+      scrollRef.current?.scrollTo({ x: Math.max(0, x), animated });
+    },
+    [activeSlug, viewportW],
+  );
+
+  useEffect(() => {
+    scrollActiveIntoView(true);
+  }, [scrollActiveIntoView]);
+
   // Helper to get display name for a channel
   const getDisplayName = (channel: ChannelTab): string => {
     if (channel.channelType === "main") return "General";
@@ -85,9 +108,11 @@ export const ChatTabBar = memo(function ChatTabBar({
   return (
     <View style={[styles.tabBar, { backgroundColor: themeColors.surface, borderBottomColor: themeColors.border }]}>
       <ScrollView
+        ref={scrollRef}
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.tabBarScrollContent}
+        onLayout={(e) => setViewportW(e.nativeEvent.layout.width)}
       >
         {channels.map((channel) => {
           const isActive = channel.slug === activeSlug;
@@ -113,6 +138,12 @@ export const ChatTabBar = memo(function ChatTabBar({
               delayLongPress={300}
               activeOpacity={0.7}
               accessibilityLabel={displayName}
+              onLayout={(e) => {
+                const { x, width } = e.nativeEvent.layout;
+                tabLayoutsRef.current[channel.slug] = { x, width };
+                // First time the active tab is measured, snap it into view.
+                if (channel.slug === activeSlug) scrollActiveIntoView(false);
+              }}
             >
               <View style={styles.tabContent}>
                 {channel.isShared && (

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -77,6 +77,51 @@ export interface GroupedInboxItemProps {
   activeChannelSlug?: string;
   /** Resources flagged to show under this group in the inbox. */
   resources?: InboxResourceData[];
+  /**
+   * Serving mode flattens each of a team's channels into its own inbox row, so
+   * they'd otherwise all render with the same team name (e.g. three "Worship
+   * Team" rows). When true, the row title becomes a distinguishing
+   * `#team-channel` label derived from the channel's identity instead.
+   */
+  servingMode?: boolean;
+}
+
+/**
+ * Lowercase, hyphenate, and strip a string down to a `#channel-name`-safe slug.
+ */
+function slugifyChannelLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+/**
+ * Build a distinguishing `#team-channel` label for a serving-mode inbox row.
+ *
+ * Team channels are commonly named after the team, so a raw name can't tell the
+ * rows apart. Disambiguate the well-known channel types by their role, and fall
+ * back to the channel's own (already meaningful) name for custom channels.
+ */
+function getServingChannelLabel(teamName: string, channel: ChannelData): string {
+  const teamSlug = slugifyChannelLabel(teamName);
+  switch (channel.channelType) {
+    case "main":
+      return `#${teamSlug}-general`;
+    case "leaders":
+      return `#${teamSlug}-leaders`;
+    case "announcements":
+      return `#${teamSlug}-announcements`;
+    case "cross_team":
+      return `#${teamSlug}-cross-team`;
+    default: {
+      // Custom / pco_services / reach_out channels carry their own distinct
+      // name from the backend — prefer it since it's already meaningful.
+      const nameSlug = channel.name ? slugifyChannelLabel(channel.name) : "";
+      return nameSlug ? `#${nameSlug}` : `#${teamSlug}-channel`;
+    }
+  }
 }
 
 // Helper to get badge colors dynamically for any group type ID
@@ -127,6 +172,7 @@ function GroupedInboxItemInner({
   activeGroupId,
   activeChannelSlug,
   resources,
+  servingMode = false,
 }: GroupedInboxItemProps) {
   const router = useRouter();
   const { user } = useAuth();
@@ -331,6 +377,12 @@ function GroupedInboxItemInner({
   if (isSingleChannel && primaryChannel) {
     const hasUnread = primaryChannel.unreadCount > 0;
     const isActive = isActiveGroup && activeChannelSlug === primaryChannel.slug;
+    // In serving mode a team's channels are flattened into separate rows, so
+    // title each by its own `#team-channel` identity rather than the shared
+    // team name. Normal mode keeps the team name unchanged.
+    const rowTitle = servingMode
+      ? getServingChannelLabel(group.name, primaryChannel)
+      : group.name;
 
     // When the group has inbox resources, wrap the row + resource sub-rows in a
     // container so they read as one inbox item.
@@ -375,7 +427,7 @@ function GroupedInboxItemInner({
           {/* Top row: Name + Badge */}
           <View style={styles.topRow}>
             <Text style={[styles.groupName, { color: colors.text }, hasUnread && styles.groupNameUnread]} numberOfLines={1}>
-              {group.name}
+              {rowTitle}
             </Text>
             {primaryChannel.isShared && (
               <Ionicons name="link" size={14} color="#8B5CF6" style={styles.sharedIcon} />

--- a/apps/mobile/features/scheduling/components/AnchoredMenu.tsx
+++ b/apps/mobile/features/scheduling/components/AnchoredMenu.tsx
@@ -1,0 +1,227 @@
+/**
+ * AnchoredMenu
+ *
+ * A compact single-select dropdown that appears next to the pill/chip that
+ * opened it — the native-select feel the scheduling grids use for their short
+ * enum pickers (run-sheet "When", tasks "Phase" / "Team" / "Role", and the
+ * How-To type). It replaces the full-screen `CustomModal` those pickers used to
+ * open, which took over the whole page on desktop for a three-item choice.
+ *
+ * It renders inside a transparent `Modal` so it overlays the app and is never
+ * clipped by the table card's `overflow: "hidden"`, yet a full-screen
+ * transparent backdrop dismisses it on an outside press. The menu box is
+ * absolutely positioned at the anchor's measured window rect (below by default,
+ * flipped above when near the viewport bottom) and caps its height with an
+ * internal scroll so long Team / Role lists stay usable.
+ *
+ * The caller measures its anchor with `ref.measureInWindow` (see `measureAnchor`)
+ * and passes the resulting `AnchorRect`. Selection semantics mirror the old
+ * `TaskOptionList`: pass `emptyOption` for a leading "clear" row (e.g.
+ * "Team-level (no role)"), which calls `onSelect(null)`.
+ */
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal as RNModal,
+  Pressable,
+  ScrollView,
+  Platform,
+  useWindowDimensions,
+  type GestureResponderEvent,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+
+/** A window-space rectangle, as returned by `measureInWindow`. */
+export type AnchorRect = { x: number; y: number; width: number; height: number };
+
+export type AnchoredMenuOption = {
+  id: string;
+  name: string;
+  /** Optional leading color swatch (roles). */
+  color?: string;
+  /** Optional leading icon (How-To types). */
+  icon?: keyof typeof Ionicons.glyphMap;
+};
+
+/**
+ * Measure a host component (a `ref` on a Pressable/View) into window space and
+ * report its rect. A no-op if the ref isn't mounted yet.
+ */
+export function measureAnchor(
+  ref: { measureInWindow?: (cb: (x: number, y: number, w: number, h: number) => void) => void } | null,
+  cb: (rect: AnchorRect) => void,
+) {
+  if (ref?.measureInWindow) {
+    ref.measureInWindow((x, y, width, height) => cb({ x, y, width, height }));
+  }
+}
+
+const GAP = 4;
+const MENU_MAX_HEIGHT = 320;
+const MIN_MENU_HEIGHT = 120;
+
+export function AnchoredMenu({
+  anchor,
+  options,
+  selectedId,
+  emptyOption,
+  onSelect,
+  onClose,
+  minWidth = 168,
+  maxWidth = 300,
+}: {
+  anchor: AnchorRect;
+  options: AnchoredMenuOption[];
+  selectedId?: string | null;
+  /** Prepend a "clear" row that reports `null` (e.g. "Team-level (no role)"). */
+  emptyOption?: { label: string };
+  onSelect: (id: string | null) => void;
+  onClose: () => void;
+  minWidth?: number;
+  maxWidth?: number;
+}) {
+  const { colors } = useTheme();
+  const { width: winW, height: winH } = useWindowDimensions();
+
+  const menuWidth = Math.min(
+    Math.max(anchor.width, minWidth),
+    maxWidth,
+    Math.max(winW - 16, minWidth),
+  );
+
+  let left = anchor.x;
+  if (left + menuWidth > winW - 8) left = winW - 8 - menuWidth;
+  if (left < 8) left = 8;
+
+  const spaceBelow = winH - (anchor.y + anchor.height);
+  const spaceAbove = anchor.y;
+  const placeAbove = spaceBelow < 220 && spaceAbove > spaceBelow;
+  const maxHeight = Math.max(
+    MIN_MENU_HEIGHT,
+    Math.min(MENU_MAX_HEIGHT, (placeAbove ? spaceAbove : spaceBelow) - 16),
+  );
+
+  const positionStyle = placeAbove
+    ? { bottom: winH - anchor.y + GAP, left }
+    : { top: anchor.y + anchor.height + GAP, left };
+
+  return (
+    <RNModal transparent visible animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable
+          onPress={(e: GestureResponderEvent) => e.stopPropagation()}
+          style={[
+            styles.menu,
+            positionStyle,
+            {
+              width: menuWidth,
+              maxHeight,
+              backgroundColor: colors.surface,
+              borderColor: colors.border,
+            },
+            Platform.select({
+              web: { boxShadow: "0px 6px 24px rgba(0,0,0,0.16)" } as object,
+              default: {
+                shadowColor: "#000",
+                shadowOffset: { width: 0, height: 4 },
+                shadowOpacity: 0.18,
+                shadowRadius: 16,
+                elevation: 6,
+              },
+            }),
+          ]}
+        >
+          <ScrollView
+            style={styles.scroll}
+            bounces={false}
+            keyboardShouldPersistTaps="handled"
+          >
+            {emptyOption ? (
+              <Pressable
+                onPress={() => onSelect(null)}
+                style={[
+                  styles.row,
+                  !selectedId && { backgroundColor: colors.surfaceSecondary },
+                ]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: !selectedId }}
+              >
+                <Text
+                  style={[styles.rowText, { color: colors.textSecondary }]}
+                  numberOfLines={1}
+                >
+                  {emptyOption.label}
+                </Text>
+                {!selectedId ? (
+                  <Ionicons name="checkmark" size={17} color={colors.buttonPrimary} />
+                ) : null}
+              </Pressable>
+            ) : null}
+
+            {options.length === 0 && !emptyOption ? (
+              <Text style={[styles.empty, { color: colors.textTertiary }]}>
+                No options available.
+              </Text>
+            ) : (
+              options.map((o) => {
+                const active = o.id === selectedId;
+                return (
+                  <Pressable
+                    key={o.id}
+                    onPress={() => onSelect(o.id)}
+                    style={[
+                      styles.row,
+                      active && { backgroundColor: colors.surfaceSecondary },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                  >
+                    {o.icon ? (
+                      <Ionicons name={o.icon} size={16} color={colors.textSecondary} />
+                    ) : null}
+                    {o.color ? (
+                      <View style={[styles.swatch, { backgroundColor: o.color }]} />
+                    ) : null}
+                    <Text
+                      style={[styles.rowText, { color: colors.text }]}
+                      numberOfLines={1}
+                    >
+                      {o.name}
+                    </Text>
+                    {active ? (
+                      <Ionicons name="checkmark" size={17} color={colors.buttonPrimary} />
+                    ) : null}
+                  </Pressable>
+                );
+              })
+            )}
+          </ScrollView>
+        </Pressable>
+      </Pressable>
+    </RNModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1 },
+  menu: {
+    position: "absolute",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  scroll: { flexGrow: 0 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+  },
+  rowText: { flex: 1, fontSize: 14, fontWeight: "500" },
+  swatch: { width: 12, height: 12, borderRadius: 6 },
+  empty: { fontSize: 13, padding: 16, fontStyle: "italic" },
+});

--- a/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
@@ -2,30 +2,30 @@
  * EventTasksGrid
  *
  * The database/grid body of the leader Event Tasks screen. Renders one plan's
- * tasks grouped by segment (Pre / During / Post = before / during / after) and,
- * within each segment, ordered by team → role. Each task is a row with inline
- * columns:
+ * tasks as a single continuous bordered table (modelled on the events-os Run of
+ * Show table): a header row of column labels over dividered task rows. There are
+ * NO Pre/During/Post section-heading rows breaking the table up — the phase is
+ * just another column (a pill you tap to change).
  *
- *   - Title  → short high-level description (inline text edit).
- *   - Team   → picker (required).
- *   - Role   → picker (optional; empty = a team-level task).
- *   - How-To → the key column (see EventTasksHowToCell).
- *
- * Rows drag-to-reorder within the whole plan via `RunSheetDragList` (the same
- * cross-platform list the run sheet uses); dragging a row past a segment heading
- * moves it into that segment. Each segment has its own "Add task" affordance,
- * and every row can be deleted.
+ * Columns (after the auto drag-grip): Task, Phase, Team, Role, How-To, and a
+ * delete action. Tasks are still sorted within each segment by team → role, then
+ * flattened in Pre → During → Post order. Rows drag-to-reorder within the whole
+ * plan; the segment now changes via the Phase column, not by dragging past a
+ * heading, so reorder is a plain id reorder.
  *
  * This component is presentational + interaction only — data fetching, the
  * readiness header, and mutation wiring live in EventTasksScreen.
  */
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { View, Text, StyleSheet, Pressable, ScrollView } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import type { Id } from "@services/api/convex";
 import { InlineText } from "./InlineText";
-import { RunSheetDragList } from "./RunSheetDragList";
+import { GridScrollList, OptionTag, type GridColumn } from "./GridScrollList";
+import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
 import {
   EventTasksHowToCell,
   type HowToType,
@@ -40,6 +40,31 @@ export const SEGMENT_OPTIONS: Array<{ key: Segment; label: string }> = [
   { key: "during", label: "During" },
   { key: "after", label: "Post" },
 ];
+
+/**
+ * A small palette of pleasant, distinct hexes for team tags (events-os style —
+ * Flower pink, Food & Bev amber, Welcome blue…). Teams have no color field, so a
+ * team's color is derived by hashing its id into this palette — stable per team.
+ */
+const TEAM_COLORS = [
+  "#EC4899", // pink
+  "#F59E0B", // amber
+  "#3B82F6", // blue
+  "#10B981", // emerald
+  "#8B5CF6", // violet
+  "#EF4444", // red
+  "#14B8A6", // teal
+  "#F97316", // orange
+];
+
+/** Stable color for a team, derived by hashing its id into the palette. */
+function teamColor(teamId: string): string {
+  let hash = 0;
+  for (let i = 0; i < teamId.length; i++) {
+    hash = (hash * 31 + teamId.charCodeAt(i)) >>> 0;
+  }
+  return TEAM_COLORS[hash % TEAM_COLORS.length];
+}
 
 /**
  * A hydrated task row (mirrors `listPlanTasks`). `teamName` / `roleName` are the
@@ -74,16 +99,13 @@ export type TaskPatch = {
   segment?: Segment;
 } & HowToPatch;
 
-type Row =
-  | { kind: "header"; segment: Segment; key: string }
-  | { kind: "task"; task: PlanTask; key: string };
-
 export function EventTasksGrid({
   tasks,
   teams,
   rolesByTeam,
   onPatch,
   onDelete,
+  onDuplicate,
   onAdd,
   onReorder,
   onPickTeam,
@@ -98,18 +120,42 @@ export function EventTasksGrid({
   rolesByTeam: Record<string, RoleOption[] | undefined>;
   onPatch: (taskId: Id<"eventTasks">, patch: TaskPatch) => void;
   onDelete: (task: PlanTask) => void;
+  /** Create a copy of a task (same team/role/segment/title/how-to). */
+  onDuplicate: (task: PlanTask) => void;
   onAdd: (segment: Segment) => void;
   onReorder: (orderedIds: Array<Id<"eventTasks">>) => void;
-  /** Open the team picker for a task (parent owns the modal). */
-  onPickTeam: (task: PlanTask) => void;
-  /** Open the role picker for a task (parent owns the modal). */
-  onPickRole: (task: PlanTask) => void;
+  /** Open the team picker for a task, anchored to its pill (parent owns the menu). */
+  onPickTeam: (task: PlanTask, anchor: AnchorRect) => void;
+  /** Open the role picker for a task, anchored to its pill (parent owns the menu). */
+  onPickRole: (task: PlanTask, anchor: AnchorRect) => void;
   /** Open the full-screen doc editor for a task. */
   onOpenDoc: (task: PlanTask) => void;
   listHeader?: React.ReactElement | null;
   listFooter?: React.ReactElement | null;
 }) {
   const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+
+  // Phase menu (Pre / During / Post) for one task — an anchored dropdown next to
+  // the pill. Held locally; the parent owns the team/role menus, but phase lives
+  // entirely in the grid.
+  const [phaseMenu, setPhaseMenu] = useState<{
+    task: PlanTask;
+    anchor: AnchorRect;
+  } | null>(null);
+
+  const columns = useMemo<GridColumn[]>(
+    () => [
+      { key: "task", label: "Task", width: 220, flex: 3 },
+      { key: "phase", label: "Phase", width: 104 },
+      { key: "team", label: "Team", width: 160 },
+      { key: "role", label: "Role", width: 160 },
+      { key: "howto", label: "How-To", width: 260, flex: 3 },
+      { key: "actions", label: "", width: 84, align: "center" },
+    ],
+    [],
+  );
 
   // Sort tasks within each segment by team → role so the grid reads as a
   // grouped database. Backend order (from reorder) is preserved as the tiebreak
@@ -138,227 +184,253 @@ export function EventTasksGrid({
     return groups;
   }, [tasks, teams]);
 
-  // Flat rows for the drag list: each segment heading followed by its tasks.
-  const rows = useMemo<Row[]>(() => {
-    const out: Row[] = [];
-    for (const seg of SEGMENT_OPTIONS) {
-      out.push({ kind: "header", segment: seg.key, key: `seg:${seg.key}` });
-      for (const t of tasksBySegment[seg.key]) {
-        out.push({ kind: "task", task: t, key: t._id as string });
-      }
-    }
-    return out;
-  }, [tasksBySegment]);
+  // Flat task list for the table, in Pre → During → Post order.
+  const flatTasks = useMemo<PlanTask[]>(
+    () =>
+      tasksBySegment.before.concat(tasksBySegment.during, tasksBySegment.after),
+    [tasksBySegment],
+  );
 
-  // After a drag, walk the new key order: each heading switches the running
-  // segment; each task takes the current one (so dragging past a heading changes
-  // its segment). We emit the flat ordered id list to `reorderTasks` and patch
-  // any task whose segment changed.
+  // Segments now change via the Phase column, so drag is a plain id reorder.
   const handleReorder = (orderedKeys: string[]) => {
-    const orderedIds: Array<Id<"eventTasks">> = [];
-    let current: Segment = "before";
-    const byId = new Map(tasks.map((t) => [t._id as string, t]));
-    for (const key of orderedKeys) {
-      if (key.startsWith("seg:")) {
-        current = key.slice(4) as Segment;
-      } else {
-        orderedIds.push(key as Id<"eventTasks">);
-        const t = byId.get(key);
-        if (t && t.segment !== current) {
-          onPatch(t._id, { segment: current });
-        }
-      }
-    }
+    const byId = new Map(tasks.map((t) => [t._id as string, t._id]));
+    const orderedIds = orderedKeys
+      .map((k) => byId.get(k))
+      .filter((id): id is Id<"eventTasks"> => id !== undefined);
     onReorder(orderedIds);
   };
 
-  const renderHeaderRow = (segment: Segment) => (
-    <View style={styles.segHeaderRow}>
-      <Text style={[styles.segLabel, { color: colors.textSecondary }]}>
-        {SEGMENT_OPTIONS.find((s) => s.key === segment)?.label.toUpperCase()}
-      </Text>
-      <Pressable
-        onPress={() => onAdd(segment)}
-        hitSlop={8}
-        style={styles.addTaskBtn}
-        accessibilityRole="button"
-        accessibilityLabel={`Add a task to ${segment}`}
-      >
-        <Ionicons name="add" size={16} color={colors.buttonPrimary} />
-        <Text style={[styles.addTaskText, { color: colors.buttonPrimary }]}>Add task</Text>
-      </Pressable>
-    </View>
-  );
-
-  return (
-    <RunSheetDragList
-      data={rows}
-      keyExtractor={(r) => r.key}
-      onReorder={handleReorder}
-      ListHeaderComponent={listHeader ?? undefined}
-      ListFooterComponent={listFooter ?? undefined}
-      contentContainerStyle={styles.listContent}
-      renderRow={({ item: row, Handle, isActive }) =>
-        row.kind === "header" ? (
-          renderHeaderRow(row.segment)
-        ) : (
-          <TaskRow
-            task={row.task}
-            teamName={
-              row.task.teamName ??
-              teams.find((t) => t._id === row.task.teamId)?.name
-            }
-            roleOptionsForTeam={rolesByTeam[row.task.teamId as string]}
-            isActive={isActive}
-            Handle={Handle}
-            onPatch={(patch) => onPatch(row.task._id, patch)}
-            onDelete={() => onDelete(row.task)}
-            onPickTeam={() => onPickTeam(row.task)}
-            onPickRole={() => onPickRole(row.task)}
-            onOpenDoc={() => onOpenDoc(row.task)}
-          />
-        )
-      }
-    />
-  );
-}
-
-/** One inline-editable task row. */
-function TaskRow({
-  task,
-  teamName,
-  roleOptionsForTeam,
-  isActive,
-  Handle,
-  onPatch,
-  onDelete,
-  onPickTeam,
-  onPickRole,
-  onOpenDoc,
-}: {
-  task: PlanTask;
-  teamName?: string;
-  roleOptionsForTeam?: RoleOption[];
-  isActive: boolean;
-  Handle: React.ComponentType<{ children: React.ReactNode }>;
-  onPatch: (patch: TaskPatch) => void;
-  onDelete: () => void;
-  onPickTeam: () => void;
-  onPickRole: () => void;
-  onOpenDoc: () => void;
-}) {
-  const { colors } = useTheme();
-
-  const roleLabel =
-    task.roleName ??
-    roleOptionsForTeam?.find((r) => r._id === task.roleId)?.name;
-
-  return (
-    <View
-      style={[
-        styles.row,
-        {
-          backgroundColor: colors.surfaceSecondary,
-          borderColor: colors.border,
-          opacity: isActive ? 0.6 : 1,
-        },
-      ]}
-    >
-      <View style={styles.rowTop}>
-        <Handle>
-          <View style={styles.grip} accessibilityLabel="Drag to reorder" hitSlop={10}>
-            <Ionicons name="reorder-three" size={20} color={colors.textTertiary} />
-          </View>
-        </Handle>
-
-        <View style={styles.titleCol}>
+  const renderCell = (task: PlanTask, key: string) => {
+    switch (key) {
+      case "task":
+        return (
           <InlineText
             value={task.title}
-            onSave={(t) => onPatch({ title: t })}
+            onSave={(t) => onPatch(task._id, { title: t })}
             placeholder="Task title"
             required
             maxLength={140}
             accessibilityLabel="Task title"
             style={[styles.titleInput, { color: colors.text }]}
           />
-        </View>
+        );
+      case "phase": {
+        const label =
+          SEGMENT_OPTIONS.find((s) => s.key === task.segment)?.label ?? "Pre";
+        return (
+          <PhasePill
+            label={label}
+            colors={colors}
+            primaryColor={primaryColor}
+            onOpen={(anchor) => setPhaseMenu({ task, anchor })}
+          />
+        );
+      }
+      case "team": {
+        const teamName =
+          task.teamName ?? teams.find((t) => t._id === task.teamId)?.name;
+        return (
+          <PickerPill
+            value={teamName}
+            placeholder="Pick team"
+            color={teamName ? teamColor(task.teamId as string) : undefined}
+            onPress={(anchor) => onPickTeam(task, anchor)}
+            colors={colors}
+            primaryColor={primaryColor}
+          />
+        );
+      }
+      case "role": {
+        const role = rolesByTeam[task.teamId as string]?.find(
+          (rl) => rl._id === task.roleId,
+        );
+        const roleLabel = task.roleName ?? role?.name;
+        return (
+          <PickerPill
+            value={roleLabel}
+            placeholder="Team-level"
+            dotColor={role?.color}
+            onPress={(anchor) => onPickRole(task, anchor)}
+            colors={colors}
+            primaryColor={primaryColor}
+          />
+        );
+      }
+      case "howto":
+        return (
+          <EventTasksHowToCell
+            howToType={task.howToType}
+            howToText={task.howToText}
+            howToUrl={task.howToUrl}
+            howToMediaPath={task.howToMediaPath}
+            howToDoc={task.howToDoc}
+            onPatch={(patch) => onPatch(task._id, patch)}
+            onOpenDoc={() => onOpenDoc(task)}
+          />
+        );
+      case "actions":
+        return (
+          <View style={styles.actionsCell}>
+            <Pressable
+              onPress={() => onDuplicate(task)}
+              hitSlop={6}
+              style={styles.actionBtn}
+              accessibilityLabel="Duplicate task"
+            >
+              <Ionicons name="copy-outline" size={18} color={colors.textSecondary} />
+            </Pressable>
+            <Pressable
+              onPress={() => onDelete(task)}
+              hitSlop={6}
+              style={styles.actionBtn}
+              accessibilityLabel="Delete task"
+            >
+              <Ionicons name="trash-outline" size={18} color={colors.destructive} />
+            </Pressable>
+          </View>
+        );
+      default:
+        return null;
+    }
+  };
 
-        <Pressable onPress={onDelete} hitSlop={6} style={styles.deleteBtn} accessibilityLabel="Delete task">
-          <Ionicons name="close" size={18} color={colors.textTertiary} />
-        </Pressable>
-      </View>
-
-      {/* Team + Role pickers. */}
-      <View style={styles.pickerRow}>
-        <PickerPill
-          label="Team"
-          value={teamName}
-          placeholder="Pick team"
-          onPress={onPickTeam}
-          colors={colors}
-        />
-        <PickerPill
-          label="Role"
-          value={roleLabel}
-          placeholder="Team-level"
-          onPress={onPickRole}
-          colors={colors}
-        />
-      </View>
-
-      {/* How-To column. */}
-      <View style={styles.howToWrap}>
-        <Text style={[styles.colLabel, { color: colors.textTertiary }]}>HOW-TO</Text>
-        <EventTasksHowToCell
-          howToType={task.howToType}
-          howToText={task.howToText}
-          howToUrl={task.howToUrl}
-          howToMediaPath={task.howToMediaPath}
-          howToDoc={task.howToDoc}
-          onPatch={onPatch}
-          onOpenDoc={onOpenDoc}
-        />
-      </View>
+  // Add-task bar below the table. Sections are gone, so a new task starts in Pre
+  // and the leader reassigns its phase via the Phase column.
+  const footer = (
+    <View style={{ paddingBottom: insets.bottom + 8 }}>
+      <Pressable
+        onPress={() => onAdd("before")}
+        style={[
+          styles.addTaskBar,
+          { borderColor: primaryColor, backgroundColor: primaryColor + "0D" },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel="Add a task"
+      >
+        <Ionicons name="add" size={18} color={primaryColor} />
+        <Text style={[styles.addTaskText, { color: primaryColor }]}>Add task</Text>
+      </Pressable>
+      {listFooter}
     </View>
+  );
+
+  // Re-derive the live task so a deleted row closes the phase menu.
+  const livePhaseTask = phaseMenu
+    ? tasks.find((t) => t._id === phaseMenu.task._id) ?? null
+    : null;
+
+  return (
+    <>
+      <GridScrollList
+        data={flatTasks}
+        keyExtractor={(t) => t._id as string}
+        onReorder={handleReorder}
+        columns={columns}
+        renderCell={(item, columnKey) => renderCell(item, columnKey)}
+        ListHeaderComponent={listHeader ?? undefined}
+        ListFooterComponent={footer}
+        contentContainerStyle={styles.listContent}
+      />
+
+      {/* Phase menu (Pre / During / Post) — an anchored dropdown at the pill. */}
+      {phaseMenu && livePhaseTask ? (
+        <AnchoredMenu
+          anchor={phaseMenu.anchor}
+          options={SEGMENT_OPTIONS.map((s) => ({ id: s.key, name: s.label }))}
+          selectedId={livePhaseTask.segment}
+          onSelect={(id) => {
+            if (id) onPatch(livePhaseTask._id, { segment: id as Segment });
+            setPhaseMenu(null);
+          }}
+          onClose={() => setPhaseMenu(null)}
+        />
+      ) : null}
+    </>
   );
 }
 
-function PickerPill({
+/**
+ * The Phase pill (Pre / During / Post). Measures its own window rect on press so
+ * the parent can anchor the dropdown to it — the table card clips overflow, so
+ * the menu can't live inside the cell.
+ */
+function PhasePill({
   label,
+  colors,
+  primaryColor,
+  onOpen,
+}: {
+  label: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onOpen: (anchor: AnchorRect) => void;
+}) {
+  const ref = React.useRef<View>(null);
+  return (
+    <Pressable
+      ref={ref}
+      onPress={() => measureAnchor(ref.current, onOpen)}
+      style={styles.tagPressable}
+      accessibilityRole="button"
+      accessibilityLabel={`Phase: ${label}. Tap to change.`}
+    >
+      <OptionTag
+        label={label}
+        colors={colors}
+        primaryColor={primaryColor}
+        tinted
+        chevron
+      />
+    </Pressable>
+  );
+}
+
+export function PickerPill({
   value,
   placeholder,
   onPress,
   colors,
+  primaryColor,
+  color,
+  dotColor,
 }: {
-  label: string;
   value?: string;
   placeholder: string;
-  onPress: () => void;
+  /** Called with the pill's measured window rect so the caller can anchor a menu. */
+  onPress: (anchor: AnchorRect) => void;
   colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  /** Full tag color (hex) — soft tinted background + readable text (teams). */
+  color?: string;
+  /** Optional leading swatch (role color). */
+  dotColor?: string;
 }) {
   const filled = !!value;
+  const ref = React.useRef<View>(null);
   return (
     <Pressable
-      onPress={onPress}
-      style={[styles.pickerPill, { borderColor: colors.border }]}
+      ref={ref}
+      onPress={() => measureAnchor(ref.current, onPress)}
+      style={styles.tagPressable}
       accessibilityRole="button"
-      accessibilityLabel={`${label}: ${value ?? placeholder}`}
+      accessibilityLabel={`${value ?? placeholder}. Tap to change.`}
     >
-      <Text style={[styles.pickerPillLabel, { color: colors.textTertiary }]}>{label}</Text>
-      <Text
-        style={[styles.pickerPillValue, { color: filled ? colors.text : colors.textTertiary }]}
-        numberOfLines={1}
-      >
-        {value ?? placeholder}
-      </Text>
-      <Ionicons name="chevron-down" size={12} color={colors.textTertiary} />
+      <OptionTag
+        label={value ?? placeholder}
+        colors={colors}
+        primaryColor={primaryColor}
+        color={filled ? color : undefined}
+        dotColor={filled ? dotColor : undefined}
+        chevron
+        placeholder={!filled}
+      />
     </Pressable>
   );
 }
 
 /**
  * A shared picker modal body — a scrollable option list. The screen renders this
- * inside a CustomModal for both the team and role pickers.
+ * inside a CustomModal for the team, role, and phase pickers.
  */
 export function TaskOptionList({
   options,
@@ -415,44 +487,31 @@ export function TaskOptionList({
 }
 
 const styles = StyleSheet.create({
-  listContent: { padding: 16, paddingBottom: 120 },
-  segHeaderRow: {
+  listContent: { paddingBottom: 24 },
+  titleInput: { fontSize: 15, fontWeight: "600", width: "100%" },
+  actionsCell: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    marginTop: 16,
-    marginBottom: 8,
+    justifyContent: "center",
+    gap: 8,
   },
-  segLabel: { fontSize: 12, fontWeight: "800", letterSpacing: 0.8 },
-  addTaskBtn: { flexDirection: "row", alignItems: "center", gap: 2, padding: 4 },
-  addTaskText: { fontSize: 13, fontWeight: "600" },
-  row: {
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 10,
-    borderWidth: StyleSheet.hairlineWidth,
-    gap: 10,
-  },
-  rowTop: { flexDirection: "row", alignItems: "center", gap: 6 },
-  grip: { paddingHorizontal: 2, paddingVertical: 6, justifyContent: "center" },
-  titleCol: { flex: 1 },
-  titleInput: { fontSize: 15, fontWeight: "600" },
-  deleteBtn: { padding: 4 },
-  pickerRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, paddingLeft: 30 },
-  pickerPill: {
+  actionBtn: { padding: 4, alignItems: "center", justifyContent: "center" },
+  // Wraps an OptionTag that opens an anchored menu (self-aligned so it hugs its
+  // content and can be measured for the dropdown anchor).
+  tagPressable: { alignSelf: "flex-start", maxWidth: "100%" },
+  // Add-task bar below the table card — a clear, tappable dashed button.
+  addTaskBar: {
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "center",
     gap: 6,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 999,
-    borderWidth: 1,
-    maxWidth: "100%",
+    paddingVertical: 12,
+    marginTop: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: "dashed",
   },
-  pickerPillLabel: { fontSize: 10, fontWeight: "700", letterSpacing: 0.4 },
-  pickerPillValue: { fontSize: 13, fontWeight: "500", flexShrink: 1, maxWidth: 160 },
-  howToWrap: { paddingLeft: 30, gap: 4 },
-  colLabel: { fontSize: 10, fontWeight: "700", letterSpacing: 0.4 },
+  addTaskText: { fontSize: 15, fontWeight: "600" },
   optionScroll: { maxHeight: 360 },
   optionRow: {
     flexDirection: "row",

--- a/apps/mobile/features/scheduling/components/EventTasksHowToCell.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksHowToCell.tsx
@@ -7,10 +7,12 @@
  *   - none  → nothing attached.
  *   - text  → a short inline instruction (edited in place).
  *   - link  → a URL (edited in place, opened via the OS on tap).
- *   - media → a media reference. We accept an `r2:` storage path typed/pasted
- *             in place (there is no shared scheduling media picker to reuse yet
- *             — see the screen's header comment). The value is stored verbatim
- *             in `howToMediaPath`.
+ *   - media → an image or video. The leader picks from their library (native
+ *             `expo-image-picker`) or a file dialog (web `<input type=file>`);
+ *             images upload via `useImageUpload`, videos via `useFileUpload`
+ *             (its presigned-URL path accepts video content types). Either way
+ *             the returned `r2:` storage path is stored in `howToMediaPath` and
+ *             previewed as a thumbnail (image) or a compact chip (video).
  *   - doc   → a full Markdown How-To document. Editing opens the full-screen
  *             `EventTasksHowToDocEditor` (rendered by the parent) which saves
  *             back to `howToDoc`.
@@ -18,11 +20,72 @@
  * All edits are surfaced through `onPatch`, which the parent wires to
  * `updateTask`. Only the changed fields are sent.
  */
-import React, { useState } from "react";
-import { View, Text, StyleSheet, Pressable, Linking } from "react-native";
+import React, { useCallback, useRef, useState } from "react";
+import { View, Text, StyleSheet, Pressable, Linking, Image, ActivityIndicator, Platform } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import * as ImagePicker from "expo-image-picker";
 import { useTheme } from "@hooks/useTheme";
+import { useImageUpload } from "@features/chat/hooks/useImageUpload";
+import { useFileUpload } from "@features/chat/hooks/useFileUpload";
+import { getMediaUrl } from "@utils/media";
 import { InlineText } from "./InlineText";
+import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
+
+/** Extensions we treat as video when deciding how to preview a stored media path. */
+const VIDEO_EXT_RE = /\.(mp4|mov|m4v|webm|qt)(\?|$)/i;
+
+/** Whether a stored `howToMediaPath` points at a video (vs an image). */
+function isVideoPath(path: string): boolean {
+  return VIDEO_EXT_RE.test(path);
+}
+
+/**
+ * Derive a short human label for a stored video path. Uploaded R2 keys look
+ * like `chat/<uuidv4>-<original-filename>`, so we strip the leading UUID to
+ * surface the original filename; falls back to "Video" when it can't.
+ */
+function mediaLabelFromPath(path: string): string {
+  const segment = (path.split("/").pop() ?? "").trim();
+  const withoutUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-/i.test(segment)
+    ? segment.slice(37)
+    : segment;
+  return withoutUuid || "Video";
+}
+
+/**
+ * Web-only: open a native file dialog and resolve the picked File (or null if
+ * cancelled/none). Mirrors the DOM `<input type=file>` picking pattern used
+ * elsewhere for web (react-native-web can't render a raw <input> from JSX).
+ */
+function pickMediaFileWeb(): Promise<File | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*,video/*";
+    // Off-screen rather than display:none — Safari refuses to open the file
+    // dialog for a `display:none` input clicked programmatically, which read as
+    // "clicking does nothing". Keep it rendered but invisible.
+    input.style.position = "fixed";
+    input.style.left = "-10000px";
+    input.style.top = "0";
+    input.style.opacity = "0";
+    input.setAttribute("aria-hidden", "true");
+    const cleanup = () => input.remove();
+    input.onchange = () => {
+      const file = input.files?.[0] ?? null;
+      cleanup();
+      resolve(file);
+    };
+    // Resolve (and clean up) if the dialog is dismissed without a selection so
+    // the hidden input doesn't linger in the DOM.
+    input.addEventListener("cancel", () => {
+      cleanup();
+      resolve(null);
+    });
+    document.body.appendChild(input);
+    input.click();
+  });
+}
 
 /** The kind of "how to" guidance attached to a task (mirrors the backend). */
 export type HowToType = "none" | "text" | "link" | "media" | "doc";
@@ -63,57 +126,138 @@ export function EventTasksHowToCell({
   onOpenDoc: () => void;
 }) {
   const { colors } = useTheme();
-  const [typeMenuOpen, setTypeMenuOpen] = useState(false);
+  // Anchored dropdown for the type selector — an inline menu would be clipped by
+  // the grid card's `overflow: "hidden"`, so it renders in an overlay instead.
+  const [typeMenuAnchor, setTypeMenuAnchor] = useState<AnchorRect | null>(null);
+  const chipRef = useRef<View>(null);
 
   const current = HOW_TO_TYPES.find((t) => t.key === howToType) ?? HOW_TO_TYPES[0];
+  const openTypeMenu = () => measureAnchor(chipRef.current, setTypeMenuAnchor);
+
+  // Media upload: images go through the R2 image path, videos through the file
+  // path (which accepts video content types). Both resolve to an `r2:` storage
+  // path stored verbatim in `howToMediaPath`.
+  const { uploadImage, uploading: imageUploading, progress: imageProgress } = useImageUpload();
+  const { uploadFile, uploading: fileUploading, progress: fileProgress } = useFileUpload();
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const mediaUploading = imageUploading || fileUploading;
+  const mediaProgress = imageUploading ? imageProgress : fileProgress;
+
+  const pickAndUploadMedia = useCallback(async () => {
+    setUploadError(null);
+    try {
+      // Pick a URI + metadata, then route image vs video to the right uploader.
+      let source: { uri: string; name: string; size: number; mimeType: string; isVideo: boolean } | null = null;
+
+      if (Platform.OS === "web") {
+        const file = await pickMediaFileWeb();
+        if (!file) return;
+        source = {
+          uri: URL.createObjectURL(file),
+          name: file.name || `media-${Date.now()}`,
+          size: file.size,
+          mimeType: file.type || "application/octet-stream",
+          isVideo: file.type.startsWith("video/"),
+        };
+      } else {
+        const result = await ImagePicker.launchImageLibraryAsync({
+          mediaTypes: ["images", "videos"],
+          quality: 0.8,
+        });
+        if (result.canceled || !result.assets[0]) return;
+        const asset = result.assets[0];
+        source = {
+          uri: asset.uri,
+          name: asset.fileName || `media-${Date.now()}`,
+          size: asset.fileSize ?? 0,
+          mimeType: asset.mimeType || (asset.type === "video" ? "video/mp4" : "image/jpeg"),
+          isVideo: asset.type === "video",
+        };
+      }
+
+      if (source.isVideo) {
+        const res = await uploadFile({
+          uri: source.uri,
+          name: /\.\w+$/.test(source.name) ? source.name : `${source.name}.mp4`,
+          size: source.size,
+          mimeType: source.mimeType,
+        });
+        if (res.error) {
+          setUploadError(res.error);
+          return;
+        }
+        onPatch({ howToMediaPath: res.storagePath });
+      } else {
+        const res = await uploadImage(source.uri);
+        if (res.error) {
+          setUploadError(res.error);
+          return;
+        }
+        onPatch({ howToMediaPath: res.url });
+      }
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : "Upload failed");
+    }
+  }, [onPatch, uploadFile, uploadImage]);
+
+  const menu = typeMenuAnchor ? (
+    <AnchoredMenu
+      anchor={typeMenuAnchor}
+      options={HOW_TO_TYPES.map((t) => ({ id: t.key, name: t.label, icon: t.icon }))}
+      selectedId={howToType}
+      onSelect={(id) => {
+        if (id && id !== howToType) onPatch({ howToType: id as HowToType });
+        setTypeMenuAnchor(null);
+      }}
+      onClose={() => setTypeMenuAnchor(null)}
+    />
+  ) : null;
+
+  // A small trailing chevron button that (re)opens the type dropdown. Sits on
+  // the same line as the value so the cell stays a single compact row.
+  const typeChevron = (
+    <Pressable
+      ref={chipRef}
+      onPress={openTypeMenu}
+      hitSlop={8}
+      style={styles.typeChevron}
+      accessibilityRole="button"
+      accessibilityLabel={`How-to type: ${current.label}. Tap to change.`}
+    >
+      <Ionicons
+        name={typeMenuAnchor ? "chevron-up" : "chevron-down"}
+        size={13}
+        color={colors.textTertiary}
+      />
+    </Pressable>
+  );
+
+  // Empty state: one compact "＋ How-To" chip that opens the type menu.
+  if (howToType === "none") {
+    return (
+      <View style={styles.row}>
+        <Pressable
+          ref={chipRef}
+          onPress={openTypeMenu}
+          style={styles.addChip}
+          accessibilityRole="button"
+          accessibilityLabel="Add how-to"
+        >
+          <Ionicons name="add" size={14} color={colors.textTertiary} />
+          <Text style={[styles.addChipText, { color: colors.textTertiary }]}>How-To</Text>
+          <Ionicons
+            name={typeMenuAnchor ? "chevron-up" : "chevron-down"}
+            size={12}
+            color={colors.textTertiary}
+          />
+        </Pressable>
+        {menu}
+      </View>
+    );
+  }
 
   return (
-    <View style={styles.wrap}>
-      {/* Type selector — a compact chip that expands to a small inline menu. */}
-      <Pressable
-        onPress={() => setTypeMenuOpen((v) => !v)}
-        style={[styles.typeChip, { borderColor: colors.border }]}
-        accessibilityRole="button"
-        accessibilityLabel={`How-to type: ${current.label}. Tap to change.`}
-      >
-        <Ionicons name={current.icon} size={14} color={colors.textSecondary} />
-        <Text style={[styles.typeChipText, { color: colors.textSecondary }]}>
-          {current.label}
-        </Text>
-        <Ionicons
-          name={typeMenuOpen ? "chevron-up" : "chevron-down"}
-          size={12}
-          color={colors.textTertiary}
-        />
-      </Pressable>
-
-      {typeMenuOpen ? (
-        <View style={[styles.typeMenu, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-          {HOW_TO_TYPES.map((t) => {
-            const active = t.key === howToType;
-            return (
-              <Pressable
-                key={t.key}
-                onPress={() => {
-                  setTypeMenuOpen(false);
-                  if (t.key !== howToType) onPatch({ howToType: t.key });
-                }}
-                style={[styles.typeMenuRow, active && { backgroundColor: colors.surfaceSecondary }]}
-                accessibilityRole="button"
-                accessibilityState={{ selected: active }}
-              >
-                <Ionicons name={t.icon} size={15} color={colors.textSecondary} />
-                <Text style={[styles.typeMenuText, { color: colors.text }]}>{t.label}</Text>
-                {active ? (
-                  <Ionicons name="checkmark" size={15} color={colors.buttonPrimary} />
-                ) : null}
-              </Pressable>
-            );
-          })}
-        </View>
-      ) : null}
-
-      {/* Type-specific value editor. */}
+    <View style={styles.row}>
       {howToType === "text" ? (
         <InlineText
           value={howToText ?? ""}
@@ -126,13 +270,13 @@ export function EventTasksHowToCell({
       ) : null}
 
       {howToType === "link" ? (
-        <View style={styles.linkRow}>
+        <>
           <InlineText
             value={howToUrl ?? ""}
             onSave={(t) => onPatch({ howToUrl: t.trim() })}
             placeholder="https://…"
             accessibilityLabel="How-to link URL"
-            style={[styles.valueInput, styles.linkInput, { color: colors.text, borderColor: colors.border }]}
+            style={[styles.valueInput, { color: colors.text, borderColor: colors.border }]}
           />
           {howToUrl ? (
             <Pressable
@@ -142,24 +286,78 @@ export function EventTasksHowToCell({
               accessibilityLabel="Open link"
               style={styles.linkOpenBtn}
             >
-              <Ionicons name="open-outline" size={16} color={colors.buttonPrimary} />
+              <Ionicons name="open-outline" size={15} color={colors.buttonPrimary} />
             </Pressable>
           ) : null}
-        </View>
+        </>
       ) : null}
 
       {howToType === "media" ? (
-        <View>
-          <InlineText
-            value={howToMediaPath ?? ""}
-            onSave={(t) => onPatch({ howToMediaPath: t.trim() })}
-            placeholder="r2:path/to/media"
-            accessibilityLabel="How-to media reference"
-            style={[styles.valueInput, { color: colors.text, borderColor: colors.border }]}
-          />
-          {howToMediaPath ? (
-            <Text style={[styles.mediaHint, { color: colors.textTertiary }]} numberOfLines={1}>
-              {howToMediaPath}
+        <View style={styles.mediaWrap}>
+          {mediaUploading ? (
+            <View style={styles.mediaUploading}>
+              <ActivityIndicator size="small" color={colors.buttonPrimary} />
+              <Text style={[styles.mediaUploadingText, { color: colors.textTertiary }]}>
+                Uploading… {Math.round(mediaProgress)}%
+              </Text>
+            </View>
+          ) : howToMediaPath && howToMediaPath.trim().length > 0 ? (
+            <View style={styles.mediaSetRow}>
+              {isVideoPath(howToMediaPath) ? (
+                <Pressable
+                  onPress={() => {
+                    const url = getMediaUrl(howToMediaPath);
+                    if (url) void Linking.openURL(url).catch(() => {});
+                  }}
+                  style={[styles.videoChip, { borderColor: colors.border }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Open video"
+                >
+                  <Ionicons name="film-outline" size={14} color={colors.buttonPrimary} />
+                  <Text style={[styles.videoChipText, { color: colors.text }]} numberOfLines={1}>
+                    {mediaLabelFromPath(howToMediaPath)}
+                  </Text>
+                </Pressable>
+              ) : (
+                <Pressable
+                  onPress={pickAndUploadMedia}
+                  accessibilityRole="button"
+                  accessibilityLabel="Replace image"
+                >
+                  <Image source={{ uri: getMediaUrl(howToMediaPath) }} style={styles.mediaThumb} />
+                </Pressable>
+              )}
+              <Pressable
+                onPress={pickAndUploadMedia}
+                hitSlop={6}
+                accessibilityRole="button"
+                accessibilityLabel="Replace media"
+              >
+                <Text style={[styles.mediaReplaceText, { color: colors.buttonPrimary }]}>Replace</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => onPatch({ howToMediaPath: "" })}
+                hitSlop={6}
+                accessibilityRole="button"
+                accessibilityLabel="Remove media"
+              >
+                <Ionicons name="close-circle" size={16} color={colors.textTertiary} />
+              </Pressable>
+            </View>
+          ) : (
+            <Pressable
+              onPress={pickAndUploadMedia}
+              style={[styles.uploadBtn, { borderColor: colors.border }]}
+              accessibilityRole="button"
+              accessibilityLabel="Upload media"
+            >
+              <Ionicons name="cloud-upload-outline" size={14} color={colors.buttonPrimary} />
+              <Text style={[styles.uploadBtnText, { color: colors.buttonPrimary }]}>Upload media</Text>
+            </Pressable>
+          )}
+          {uploadError ? (
+            <Text style={[styles.mediaError, { color: colors.error }]} numberOfLines={1}>
+              {uploadError}
             </Text>
           ) : null}
         </View>
@@ -172,67 +370,84 @@ export function EventTasksHowToCell({
           accessibilityRole="button"
           accessibilityLabel="Edit how-to document"
         >
-          <Ionicons name="document-text-outline" size={15} color={colors.buttonPrimary} />
+          <Ionicons name="document-text-outline" size={14} color={colors.buttonPrimary} />
           <Text style={[styles.docBtnText, { color: colors.buttonPrimary }]} numberOfLines={1}>
-            {howToDoc && howToDoc.trim().length > 0 ? "Edit document" : "Write document"}
+            {howToDoc && howToDoc.trim().length > 0 ? "Edit doc" : "Write doc"}
           </Text>
         </Pressable>
       ) : null}
+
+      {typeChevron}
+      {menu}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  wrap: { gap: 6 },
-  typeChip: {
+  // Single compact row: value control + trailing type chevron.
+  row: { flexDirection: "row", alignItems: "center", gap: 4 },
+  addChip: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4,
+    gap: 3,
     alignSelf: "flex-start",
-    paddingHorizontal: 8,
+    paddingHorizontal: 4,
     paddingVertical: 4,
-    borderRadius: 999,
-    borderWidth: 1,
   },
-  typeChipText: { fontSize: 12, fontWeight: "600" },
-  typeMenu: {
-    borderWidth: 1,
-    borderRadius: 10,
-    overflow: "hidden",
-    alignSelf: "flex-start",
-    minWidth: 140,
-  },
-  typeMenuRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-  },
-  typeMenuText: { flex: 1, fontSize: 13, fontWeight: "500" },
+  addChipText: { fontSize: 13, fontWeight: "600" },
   valueInput: {
+    flex: 1,
     fontSize: 13,
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 6,
-    paddingVertical: 5,
+    paddingVertical: 4,
     paddingHorizontal: 8,
-    minHeight: 32,
+    minHeight: 30,
     textAlignVertical: "top",
   },
-  linkRow: { flexDirection: "row", alignItems: "center", gap: 6 },
-  linkInput: { flex: 1 },
-  linkOpenBtn: { padding: 4 },
-  mediaHint: { fontSize: 11, marginTop: 3 },
+  linkOpenBtn: { padding: 3 },
   docBtn: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 6,
-    alignSelf: "flex-start",
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 8,
+    gap: 5,
+    flex: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 6,
     borderWidth: StyleSheet.hairlineWidth,
     borderStyle: "dashed",
   },
-  docBtnText: { fontSize: 13, fontWeight: "600" },
+  docBtnText: { fontSize: 13, fontWeight: "600", flexShrink: 1 },
+  typeChevron: { paddingHorizontal: 2, paddingVertical: 4 },
+  // Media control — kept compact so it shares the single row with the chevron.
+  mediaWrap: { flex: 1 },
+  uploadBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    alignSelf: "flex-start",
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: "dashed",
+  },
+  uploadBtnText: { fontSize: 13, fontWeight: "600" },
+  mediaUploading: { flexDirection: "row", alignItems: "center", gap: 6, paddingVertical: 4 },
+  mediaUploadingText: { fontSize: 12 },
+  mediaSetRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+  mediaThumb: { width: 36, height: 36, borderRadius: 6 },
+  videoChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    flexShrink: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  videoChipText: { fontSize: 13, flexShrink: 1 },
+  mediaReplaceText: { fontSize: 12, fontWeight: "600" },
+  mediaError: { fontSize: 11, marginTop: 2 },
 });

--- a/apps/mobile/features/scheduling/components/EventTasksHowToCell.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksHowToCell.tsx
@@ -34,6 +34,13 @@ import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
 /** Extensions we treat as video when deciding how to preview a stored media path. */
 const VIDEO_EXT_RE = /\.(mp4|mov|m4v|webm|qt)(\?|$)/i;
 
+/**
+ * Cap for inline `text` how-to guidance. Short instructions belong inline; once
+ * a leader needs more room they should switch to a `doc` (which the hint nudges
+ * toward as they approach the limit).
+ */
+const HOW_TO_TEXT_MAX = 140;
+
 /** Whether a stored `howToMediaPath` points at a video (vs an image). */
 function isVideoPath(path: string): boolean {
   return VIDEO_EXT_RE.test(path);
@@ -259,14 +266,22 @@ export function EventTasksHowToCell({
   return (
     <View style={styles.row}>
       {howToType === "text" ? (
-        <InlineText
-          value={howToText ?? ""}
-          onSave={(t) => onPatch({ howToText: t })}
-          placeholder="Short instruction…"
-          multiline
-          accessibilityLabel="How-to text"
-          style={[styles.valueInput, { color: colors.text, borderColor: colors.border }]}
-        />
+        <View style={styles.textWrap}>
+          <InlineText
+            value={howToText ?? ""}
+            onSave={(t) => onPatch({ howToText: t })}
+            placeholder="Short instruction…"
+            multiline
+            maxLength={HOW_TO_TEXT_MAX}
+            accessibilityLabel="How-to text"
+            style={[styles.valueInput, { color: colors.text, borderColor: colors.border }]}
+          />
+          {(howToText?.length ?? 0) >= HOW_TO_TEXT_MAX * 0.8 ? (
+            <Text style={[styles.textHint, { color: colors.textTertiary }]}>
+              Getting long — consider a Doc instead.
+            </Text>
+          ) : null}
+        </View>
       ) : null}
 
       {howToType === "link" ? (
@@ -395,6 +410,8 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
   },
   addChipText: { fontSize: 13, fontWeight: "600" },
+  textWrap: { flex: 1, gap: 2 },
+  textHint: { fontSize: 11, fontStyle: "italic" },
   valueInput: {
     flex: 1,
     fontSize: 13,

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -46,18 +46,16 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
-import { CustomModal } from "@components/ui/Modal";
-import { ProgressBar } from "@components/ui/ProgressBar";
 import { formatEventDateLong } from "../utils/format";
 import {
   EventTasksGrid,
-  TaskOptionList,
   type PlanTask,
   type Segment,
   type TaskPatch,
   type TeamOption,
   type RoleOption,
 } from "./EventTasksGrid";
+import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
 import { EventTasksHowToDocEditor } from "./EventTasksHowToDocEditor";
 
 /** Show a one-button error (Alert.alert is a no-op on web in this codebase). */
@@ -189,10 +187,52 @@ export function EventTasksScreen() {
     return [...ids];
   }, [tasks]);
 
-  // Picker modal state.
-  const [teamPickerTask, setTeamPickerTask] = useState<PlanTask | null>(null);
-  const [rolePickerTask, setRolePickerTask] = useState<PlanTask | null>(null);
+  // Picker state. Team/Role are anchored dropdowns next to their pills, so each
+  // tracks the task plus the pill's measured window rect. Doc editor stays a
+  // full-screen editor.
+  const [teamPicker, setTeamPicker] = useState<{
+    task: PlanTask;
+    anchor: AnchorRect;
+  } | null>(null);
+  const [rolePicker, setRolePicker] = useState<{
+    task: PlanTask;
+    anchor: AnchorRect;
+  } | null>(null);
   const [docEditorTask, setDocEditorTask] = useState<PlanTask | null>(null);
+
+  // View filters (combinable): phase / team / role. `null` = "All". Applied to
+  // derive the task list handed to the grid.
+  const [phaseFilter, setPhaseFilter] = useState<Segment | null>(null);
+  const [teamFilter, setTeamFilter] = useState<Id<"teams"> | null>(null);
+  const [roleFilter, setRoleFilter] = useState<Id<"teamRoles"> | null>(null);
+
+  // Changing the team filter resets the role filter — a role belongs to one team.
+  const handleSetTeamFilter = useCallback((id: Id<"teams"> | null) => {
+    setTeamFilter(id);
+    setRoleFilter(null);
+  }, []);
+
+  // Role filter options: scoped to the filtered team when one is set, else the
+  // union of every loaded team's roles (deduped by id).
+  const roleFilterOptions = useMemo<RoleOption[]>(() => {
+    if (teamFilter) return rolesByTeam[teamFilter as string] ?? [];
+    const byId = new Map<string, RoleOption>();
+    for (const roles of Object.values(rolesByTeam)) {
+      for (const r of roles ?? []) byId.set(r._id as string, r);
+    }
+    return [...byId.values()];
+  }, [teamFilter, rolesByTeam]);
+
+  const filteredTasks = useMemo<PlanTask[]>(
+    () =>
+      (tasks ?? []).filter((t) => {
+        if (phaseFilter && t.segment !== phaseFilter) return false;
+        if (teamFilter && t.teamId !== teamFilter) return false;
+        if (roleFilter && t.roleId !== roleFilter) return false;
+        return true;
+      }),
+    [tasks, phaseFilter, teamFilter, roleFilter],
+  );
 
   const handlePatch = useCallback(
     (taskId: Id<"eventTasks">, patch: TaskPatch) => {
@@ -205,19 +245,38 @@ export function EventTasksScreen() {
 
   const handleAdd = useCallback(
     async (segment: Segment) => {
-      const firstTeam = teams[0];
-      if (!firstTeam) {
+      // Seed the new task from the active view filters so it stays VISIBLE
+      // under the current filter — otherwise it's created with defaults that
+      // don't match, gets filtered out, and "Add task" looks like a no-op.
+      //
+      // Team: explicit team filter → the team that owns the role filter → the
+      // first team. Segment: the phase filter overrides the caller's segment.
+      // Role: only when it belongs to the resolved team.
+      let teamId = (teamFilter ?? undefined) as Id<"teams"> | undefined;
+      if (!teamId && roleFilter) {
+        const owner = Object.entries(rolesByTeam).find(([, roles]) =>
+          (roles ?? []).some((r) => r._id === roleFilter),
+        );
+        if (owner) teamId = owner[0] as Id<"teams">;
+      }
+      teamId = teamId ?? teams[0]?._id;
+      if (!teamId) {
         notifyError(
           "Add a team first",
           "Create a serving team for this group before adding tasks.",
         );
         return;
       }
+      const seg = phaseFilter ?? segment;
+      const roleMatches =
+        roleFilter &&
+        (rolesByTeam[teamId as string] ?? []).some((r) => r._id === roleFilter);
       try {
         await createTask({
           planId,
-          teamId: firstTeam._id,
-          segment,
+          teamId,
+          ...(roleMatches ? { roleId: roleFilter } : {}),
+          segment: seg,
           title: "New task",
           howToType: "none",
         });
@@ -225,7 +284,7 @@ export function EventTasksScreen() {
         notifyError("Couldn't add task", e?.data?.message ?? e?.message ?? "Please try again.");
       }
     },
-    [createTask, planId, teams],
+    [createTask, planId, teams, teamFilter, phaseFilter, roleFilter, rolesByTeam],
   );
 
   const handleDelete = useCallback(
@@ -237,6 +296,33 @@ export function EventTasksScreen() {
       });
     },
     [deleteTask],
+  );
+
+  // Duplicate a task — copy every editable field (team/role/segment/title +
+  // How-To) onto a new task under the same team. Stays within the create API.
+  const handleDuplicate = useCallback(
+    async (task: PlanTask) => {
+      try {
+        await createTask({
+          planId,
+          teamId: task.teamId,
+          // Only include roleId when the source task has a role — the validator
+          // is v.optional(v.id(...)), which rejects an explicit null (a
+          // team-level task).
+          ...(task.roleId ? { roleId: task.roleId } : {}),
+          segment: task.segment,
+          title: task.title,
+          howToType: task.howToType,
+          howToText: task.howToText,
+          howToUrl: task.howToUrl,
+          howToMediaPath: task.howToMediaPath,
+          howToDoc: task.howToDoc,
+        });
+      } catch (e: any) {
+        notifyError("Couldn't duplicate", e?.data?.message ?? e?.message ?? "Please try again.");
+      }
+    },
+    [createTask, planId],
   );
 
   const handleReorder = useCallback(
@@ -343,6 +429,20 @@ export function EventTasksScreen() {
         </Text>
       ) : null}
       <ReadinessHeader readiness={readiness} primaryColor={primaryColor} colors={colors} />
+      {(tasks?.length ?? 0) > 0 ? (
+        <FilterBar
+          phase={phaseFilter}
+          onPhase={setPhaseFilter}
+          teamId={teamFilter}
+          onTeam={handleSetTeamFilter}
+          roleId={roleFilter}
+          onRole={setRoleFilter}
+          teams={teams}
+          roles={roleFilterOptions}
+          colors={colors}
+          primaryColor={primaryColor}
+        />
+      ) : null}
     </View>
   );
 
@@ -355,10 +455,10 @@ export function EventTasksScreen() {
       {referencedTeamIds.map((tid) => (
         <RoleLoader key={tid} teamId={tid as Id<"teams">} onLoaded={setRolesForTeam} />
       ))}
-      {rolePickerTask ? (
+      {rolePicker ? (
         <RoleLoader
-          key={`picker-${rolePickerTask.teamId}`}
-          teamId={rolePickerTask.teamId}
+          key={`picker-${rolePicker.task.teamId}`}
+          teamId={rolePicker.task.teamId}
           onLoaded={setRolesForTeam}
         />
       ) : null}
@@ -392,66 +492,57 @@ export function EventTasksScreen() {
         </ScrollView>
       ) : (
         <EventTasksGrid
-          tasks={tasks ?? []}
+          tasks={filteredTasks}
           teams={teams}
           rolesByTeam={rolesByTeam}
           onPatch={handlePatch}
           onDelete={handleDelete}
+          onDuplicate={handleDuplicate}
           onAdd={handleAdd}
           onReorder={handleReorder}
-          onPickTeam={setTeamPickerTask}
-          onPickRole={setRolePickerTask}
+          onPickTeam={(task, anchor) => setTeamPicker({ task, anchor })}
+          onPickRole={(task, anchor) => setRolePicker({ task, anchor })}
           onOpenDoc={setDocEditorTask}
           listHeader={listHeader}
         />
       )}
 
-      {/* Team picker. */}
-      <CustomModal
-        visible={teamPickerTask !== null}
-        onClose={() => setTeamPickerTask(null)}
-        title="Team"
-      >
-        <TaskOptionList
+      {/* Team picker — anchored dropdown next to the pill. Changing team recreates
+          the task via handleReassignTeam (a task's team is fixed at creation). */}
+      {teamPicker ? (
+        <AnchoredMenu
+          anchor={teamPicker.anchor}
           options={teams.map((t) => ({ id: t._id as string, name: t.name }))}
-          selectedId={teamPickerTask?.teamId as string | undefined}
+          selectedId={teamPicker.task.teamId as string}
           onSelect={(id) => {
-            if (id && teamPickerTask) {
-              void handleReassignTeam(teamPickerTask, id as Id<"teams">);
-            }
-            setTeamPickerTask(null);
+            if (id) void handleReassignTeam(teamPicker.task, id as Id<"teams">);
+            setTeamPicker(null);
           }}
+          onClose={() => setTeamPicker(null)}
         />
-      </CustomModal>
+      ) : null}
 
-      {/* Role picker. */}
-      <CustomModal
-        visible={rolePickerTask !== null}
-        onClose={() => setRolePickerTask(null)}
-        title="Role"
-      >
-        <TaskOptionList
-          options={(rolePickerTask
-            ? rolesByTeam[rolePickerTask.teamId as string] ?? []
-            : []
-          ).map((r) => ({ id: r._id as string, name: r.name, color: r.color }))}
-          selectedId={rolePickerTask?.roleId as string | undefined}
+      {/* Role picker — anchored dropdown with a "Team-level (no role)" clear row. */}
+      {rolePicker ? (
+        <AnchoredMenu
+          anchor={rolePicker.anchor}
+          options={(rolesByTeam[rolePicker.task.teamId as string] ?? []).map(
+            (r) => ({ id: r._id as string, name: r.name, color: r.color }),
+          )}
+          selectedId={rolePicker.task.roleId as string | undefined}
           emptyOption={{ label: "Team-level (no role)" }}
           onSelect={(id) => {
-            if (rolePickerTask) {
-              // "Team-level (no role)" sends no id → clear the role explicitly
-              // (an omitted roleId can't be distinguished from a clear intent).
-              handlePatch(
-                rolePickerTask._id,
-                id
-                  ? { roleId: id as Id<"teamRoles"> }
-                  : { clearRole: true },
-              );
-            }
-            setRolePickerTask(null);
+            // "Team-level (no role)" sends no id → clear the role explicitly
+            // (an omitted roleId can't be distinguished from a clear intent).
+            handlePatch(
+              rolePicker.task._id,
+              id ? { roleId: id as Id<"teamRoles"> } : { clearRole: true },
+            );
+            setRolePicker(null);
           }}
+          onClose={() => setRolePicker(null)}
         />
-      </CustomModal>
+      ) : null}
 
       {/* Full-screen How-To doc editor. */}
       <EventTasksHowToDocEditor
@@ -496,7 +587,39 @@ function RoleLoader({
   return null;
 }
 
-/** Readiness header — Pre/During/Post progress + per-team breakdown. */
+/** A thin fixed-height progress track with a primary-colored fill (no SVG). */
+function MiniBar({
+  ratio,
+  height,
+  trackColor,
+  fillColor,
+}: {
+  ratio: number;
+  height: number;
+  trackColor: string;
+  fillColor: string;
+}) {
+  const clamped = Math.max(0, Math.min(1, ratio));
+  return (
+    <View style={[styles.miniTrack, { height, backgroundColor: trackColor }]}>
+      <View
+        style={{
+          height,
+          width: `${clamped * 100}%`,
+          borderRadius: height / 2,
+          backgroundColor: fillColor,
+        }}
+      />
+    </View>
+  );
+}
+
+/**
+ * Readiness header — a compact row of stat tiles (Overall / Pre / During / Post),
+ * each showing a done/total count and a short primary-colored bar, plus a
+ * wrapping row of per-team chips. Contained to the table's centered max width so
+ * it doesn't stretch edge-to-edge on desktop.
+ */
 function ReadinessHeader({
   readiness,
   primaryColor,
@@ -507,62 +630,260 @@ function ReadinessHeader({
   colors: ReturnType<typeof useTheme>["colors"];
 }) {
   if (!readiness) return null;
-  const segs: Array<{ key: Segment; label: string }> = [
-    { key: "before", label: "Pre" },
-    { key: "during", label: "During" },
-    { key: "after", label: "Post" },
-  ];
   const pct = (d: number, t: number) => (t > 0 ? d / t : 0);
+  const tiles: Array<{ label: string; done: number; total: number }> = [
+    { label: "Overall", ...readiness.overall },
+    { label: "Pre", ...readiness.bySegment.before },
+    { label: "During", ...readiness.bySegment.during },
+    { label: "Post", ...readiness.bySegment.after },
+  ];
 
   return (
-    <View style={[styles.readiness, { borderColor: colors.border }]}>
+    <View style={styles.readiness}>
       <Text style={[styles.readinessTitle, { color: colors.textSecondary }]}>
-        READINESS · {readiness.overall.done}/{readiness.overall.total}
+        READINESS
       </Text>
-      {segs.map((s) => {
-        const seg = readiness.bySegment[s.key];
-        return (
-          <View key={s.key} style={styles.readinessSegRow}>
-            <Text style={[styles.readinessSegLabel, { color: colors.text }]}>{s.label}</Text>
-            <View style={styles.readinessBar}>
-              <ProgressBar
-                progress={pct(seg.done, seg.total)}
-                color={primaryColor}
-                height={6}
-                animated={false}
-              />
-            </View>
-            <Text style={[styles.readinessCount, { color: colors.textSecondary }]}>
-              {seg.done}/{seg.total}
+      <View style={styles.statRow}>
+        {tiles.map((tile) => (
+          <View
+            key={tile.label}
+            style={[
+              styles.statTile,
+              { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+            ]}
+          >
+            <Text style={[styles.statCount, { color: colors.text }]}>
+              {tile.done}/{tile.total}
             </Text>
+            <Text style={[styles.statLabel, { color: colors.textSecondary }]}>
+              {tile.label}
+            </Text>
+            <MiniBar
+              ratio={pct(tile.done, tile.total)}
+              height={4}
+              trackColor={colors.border}
+              fillColor={primaryColor}
+            />
           </View>
-        );
-      })}
+        ))}
+      </View>
 
       {readiness.byTeam.length > 0 ? (
-        <View style={styles.teamBreakdown}>
+        <View style={styles.teamChipRow}>
           {readiness.byTeam.map((t) => (
-            <View key={t.teamId} style={styles.readinessSegRow}>
+            <View
+              key={t.teamId}
+              style={[
+                styles.teamChip,
+                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+            >
               <Text
-                style={[styles.readinessTeamLabel, { color: colors.textSecondary }]}
+                style={[styles.teamChipName, { color: colors.text }]}
                 numberOfLines={1}
               >
                 {t.teamName}
               </Text>
-              <View style={styles.readinessBar}>
-                <ProgressBar
-                  progress={pct(t.done, t.total)}
-                  color={colors.success}
-                  height={5}
-                  animated={false}
-                />
-              </View>
-              <Text style={[styles.readinessCount, { color: colors.textSecondary }]}>
+              <Text style={[styles.teamChipCount, { color: colors.textSecondary }]}>
                 {t.done}/{t.total}
               </Text>
+              <View style={styles.teamChipBar}>
+                <MiniBar
+                  ratio={pct(t.done, t.total)}
+                  height={3}
+                  trackColor={colors.border}
+                  fillColor={primaryColor}
+                />
+              </View>
             </View>
           ))}
         </View>
+      ) : null}
+    </View>
+  );
+}
+
+/**
+ * The view-filter bar above the grid: Phase chips (All / Pre / During / Post)
+ * plus Team and Role dropdowns. Filters are combinable; active filters use the
+ * community accent, and a Clear button resets them all. State lives in the
+ * screen — this is presentational, owning only its own anchored-menu state.
+ */
+function FilterBar({
+  phase,
+  onPhase,
+  teamId,
+  onTeam,
+  roleId,
+  onRole,
+  teams,
+  roles,
+  colors,
+  primaryColor,
+}: {
+  phase: Segment | null;
+  onPhase: (seg: Segment | null) => void;
+  teamId: Id<"teams"> | null;
+  onTeam: (id: Id<"teams"> | null) => void;
+  roleId: Id<"teamRoles"> | null;
+  onRole: (id: Id<"teamRoles"> | null) => void;
+  teams: TeamOption[];
+  roles: RoleOption[];
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+}) {
+  const [menu, setMenu] = useState<{ kind: "team" | "role"; anchor: AnchorRect } | null>(null);
+  const teamRef = React.useRef<View>(null);
+  const roleRef = React.useRef<View>(null);
+
+  const hasActive = phase !== null || teamId !== null || roleId !== null;
+  const teamName = teamId ? teams.find((t) => t._id === teamId)?.name : undefined;
+  const roleName = roleId ? roles.find((r) => r._id === roleId)?.name : undefined;
+
+  const phaseChips: Array<{ key: Segment | null; label: string }> = [
+    { key: null, label: "All" },
+    { key: "before", label: "Pre" },
+    { key: "during", label: "During" },
+    { key: "after", label: "Post" },
+  ];
+
+  const dropdownStyle = (active: boolean) => [
+    styles.filterPill,
+    {
+      borderColor: active ? primaryColor : colors.border,
+      backgroundColor: active ? primaryColor + "1A" : "transparent",
+    },
+  ];
+
+  return (
+    <View style={styles.filterBar}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.filterScroll}
+      >
+        {phaseChips.map((c) => {
+          const active = phase === c.key;
+          return (
+            <TouchableOpacity
+              key={c.label}
+              onPress={() => onPhase(c.key)}
+              style={[
+                styles.filterChip,
+                {
+                  borderColor: active ? primaryColor : colors.border,
+                  backgroundColor: active ? primaryColor + "1A" : "transparent",
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.filterChipText,
+                  { color: active ? primaryColor : colors.textSecondary },
+                ]}
+              >
+                {c.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+
+        <View style={[styles.filterDivider, { backgroundColor: colors.border }]} />
+
+        <View ref={teamRef} collapsable={false}>
+          <TouchableOpacity
+            onPress={() =>
+              measureAnchor(teamRef.current, (a) => setMenu({ kind: "team", anchor: a }))
+            }
+            style={dropdownStyle(teamId !== null)}
+          >
+            <Text
+              style={[
+                styles.filterPillText,
+                { color: teamId ? primaryColor : colors.textSecondary },
+              ]}
+              numberOfLines={1}
+            >
+              {teamName ? `Team: ${teamName}` : "Team: All"}
+            </Text>
+            <Ionicons
+              name="chevron-down"
+              size={12}
+              color={teamId ? primaryColor : colors.textTertiary}
+            />
+          </TouchableOpacity>
+        </View>
+
+        {roles.length > 0 ? (
+          <View ref={roleRef} collapsable={false}>
+            <TouchableOpacity
+              onPress={() =>
+                measureAnchor(roleRef.current, (a) => setMenu({ kind: "role", anchor: a }))
+              }
+              style={dropdownStyle(roleId !== null)}
+            >
+              <Text
+                style={[
+                  styles.filterPillText,
+                  { color: roleId ? primaryColor : colors.textSecondary },
+                ]}
+                numberOfLines={1}
+              >
+                {roleName ? `Role: ${roleName}` : "Role: All"}
+              </Text>
+              <Ionicons
+                name="chevron-down"
+                size={12}
+                color={roleId ? primaryColor : colors.textTertiary}
+              />
+            </TouchableOpacity>
+          </View>
+        ) : null}
+
+        {hasActive ? (
+          <TouchableOpacity
+            onPress={() => {
+              onPhase(null);
+              onTeam(null);
+              onRole(null);
+            }}
+            style={styles.filterClear}
+            accessibilityLabel="Clear filters"
+          >
+            <Ionicons name="close-circle" size={15} color={colors.textSecondary} />
+            <Text style={[styles.filterClearText, { color: colors.textSecondary }]}>
+              Clear
+            </Text>
+          </TouchableOpacity>
+        ) : null}
+      </ScrollView>
+
+      {menu?.kind === "team" ? (
+        <AnchoredMenu
+          anchor={menu.anchor}
+          options={teams.map((t) => ({ id: t._id as string, name: t.name }))}
+          selectedId={teamId as string | undefined}
+          emptyOption={{ label: "All teams" }}
+          onSelect={(id) => {
+            onTeam(id as Id<"teams"> | null);
+            setMenu(null);
+          }}
+          onClose={() => setMenu(null)}
+        />
+      ) : null}
+
+      {menu?.kind === "role" ? (
+        <AnchoredMenu
+          anchor={menu.anchor}
+          options={roles.map((r) => ({ id: r._id as string, name: r.name, color: r.color }))}
+          selectedId={roleId as string | undefined}
+          emptyOption={{ label: "All roles" }}
+          onSelect={(id) => {
+            onRole(id as Id<"teamRoles"> | null);
+            setMenu(null);
+          }}
+          onClose={() => setMenu(null)}
+        />
       ) : null}
     </View>
   );
@@ -585,24 +906,77 @@ const styles = StyleSheet.create({
   planDate: { fontSize: 13, marginTop: 4 },
   readiness: {
     marginTop: 16,
-    padding: 12,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-    gap: 8,
+    width: "100%",
+    maxWidth: 1200,
+    alignSelf: "center",
+    gap: 10,
   },
   readinessTitle: { fontSize: 11, fontWeight: "800", letterSpacing: 0.6 },
-  readinessSegRow: { flexDirection: "row", alignItems: "center", gap: 10 },
-  readinessSegLabel: { width: 52, fontSize: 13, fontWeight: "600" },
-  readinessTeamLabel: { width: 90, fontSize: 12, fontWeight: "500" },
-  readinessBar: { flex: 1 },
-  readinessCount: { width: 44, fontSize: 12, textAlign: "right", fontVariant: ["tabular-nums"] },
-  teamBreakdown: {
-    marginTop: 4,
-    paddingTop: 8,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: "transparent",
-    gap: 6,
+  statRow: { flexDirection: "row", gap: 8 },
+  statTile: {
+    flex: 1,
+    minWidth: 68,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    gap: 4,
   },
+  statCount: { fontSize: 18, fontWeight: "800", fontVariant: ["tabular-nums"] },
+  statLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  miniTrack: { borderRadius: 2, overflow: "hidden", marginTop: 2 },
+  teamChipRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  teamChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  teamChipName: { fontSize: 12, fontWeight: "600", maxWidth: 120 },
+  teamChipCount: { fontSize: 11, fontVariant: ["tabular-nums"] },
+  teamChipBar: { width: 40 },
+  filterBar: { marginTop: 14, width: "100%", maxWidth: 1200, alignSelf: "center" },
+  filterScroll: { flexDirection: "row", alignItems: "center", gap: 8, paddingVertical: 2 },
+  filterChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  filterChipText: { fontSize: 13, fontWeight: "600" },
+  filterDivider: {
+    width: StyleSheet.hairlineWidth,
+    alignSelf: "stretch",
+    marginVertical: 4,
+    marginHorizontal: 2,
+  },
+  filterPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    maxWidth: 220,
+  },
+  filterPillText: { fontSize: 13, fontWeight: "600", flexShrink: 1 },
+  filterClear: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 3,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  filterClearText: { fontSize: 13, fontWeight: "600" },
   emptyScroll: { padding: 16 },
   emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
   emptyAddRow: { flexDirection: "row", gap: 8, marginTop: 16 },

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -327,11 +327,16 @@ export function EventTasksScreen() {
 
   const handleReorder = useCallback(
     (orderedIds: Array<Id<"eventTasks">>) => {
+      // No-op while any view filter is active: the grid only sees the FILTERED
+      // ids, so reordering here would rewrite sortOrder 0..k over just those,
+      // colliding with the hidden tasks' sortOrders and corrupting the global
+      // order. The reactive query snaps the dragged row back.
+      if (phaseFilter || teamFilter || roleFilter) return;
       void reorderTasks({ planId, orderedIds }).catch((e: any) =>
         notifyError("Couldn't reorder", e?.data?.message ?? e?.message ?? "Please try again."),
       );
     },
-    [reorderTasks, planId],
+    [reorderTasks, planId, phaseFilter, teamFilter, roleFilter],
   );
 
   // `updateTask` (final API) has no `teamId` arg — a task's team is fixed at

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -1,0 +1,372 @@
+/**
+ * GridScrollList
+ *
+ * A bordered, spreadsheet-style table with inline-editable cells and
+ * drag-to-reorder — the shared body of the run sheet and event-tasks grids
+ * (the leader's "database view", modelled faithfully on the events-os Run of
+ * Show table).
+ *
+ * Notion-style horizontal scroll: a SINGLE horizontal `ScrollView` wraps BOTH
+ * the column-label header row AND the drag list, so they scroll horizontally in
+ * sync. Columns are FIXED pixel widths (not flex-fill) so they never squish —
+ * when the columns overflow the card, the table keeps its natural width and the
+ * ScrollView scrolls sideways; when they fit, any leftover "slack" is handed to
+ * the `flex` columns so the table fills the card on desktop. The header stays
+ * pinned vertically because it sits above the drag list's own vertical scroll.
+ *
+ * Reordering reuses `RunSheetDragList` unchanged — a grip in a left gutter, the
+ * same cross-platform drag (native `react-native-reorderable-list` / web HTML5).
+ * The screen owns data + mutations and supplies `renderCell(item, columnKey)`;
+ * this component only lays the cells out and draws the divided, padded, sized
+ * cell frame (the table chrome).
+ */
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  type LayoutChangeEvent,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { RunSheetDragList } from "./RunSheetDragList";
+
+/**
+ * One table column. Widths are FIXED pixels (`width`); `flex` is only a weight
+ * for distributing leftover slack when the whole table fits inside the card.
+ */
+export type GridColumn = {
+  key: string;
+  label: string;
+  /** Fixed width in px. */
+  width: number;
+  /** Weight for absorbing leftover slack when the table fits the card (0 = fixed). */
+  flex?: number;
+  align?: "left" | "center";
+};
+
+/** Left gutter that holds the drag grip (header has a matching spacer). */
+const GRIP_W = 34;
+// Roomier events-os spacing: a comfortable row that lets 1–2 line cells breathe,
+// with content top-aligned (not vertically centered) so multi-line cells read
+// cleanly against the shorter ones. The header is compact above it.
+const ROW_MIN_HEIGHT = 46;
+const HEADER_MIN_HEIGHT = 38;
+
+interface Props<T> {
+  data: T[];
+  keyExtractor: (item: T) => string;
+  onReorder: (orderedKeys: string[]) => void;
+  columns: GridColumn[];
+  /** Cell content for a given row + column. The frame/size is drawn here. */
+  renderCell: (
+    item: T,
+    columnKey: string,
+    info: { isActive: boolean },
+  ) => React.ReactNode;
+  /** Fixed content above the table card (e.g. plan title / readiness). */
+  ListHeaderComponent?: React.ReactElement | null;
+  /** Fixed content below the table card (e.g. the add-row bar). */
+  ListFooterComponent?: React.ReactElement | null;
+  /** Vertical padding only — never horizontal, or rows misalign with the header. */
+  contentContainerStyle?: StyleProp<ViewStyle>;
+}
+
+export function GridScrollList<T>({
+  data,
+  keyExtractor,
+  onReorder,
+  columns,
+  renderCell,
+  ListHeaderComponent,
+  ListFooterComponent,
+  contentContainerStyle,
+}: Props<T>) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  // The card's measured inner size. Width drives the slack distribution; height
+  // bounds the inner content so the drag list's vertical scroll works while it
+  // lives inside the horizontal ScrollView.
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setSize((prev) =>
+      prev.w === width && prev.h === height ? prev : { w: width, h: height },
+    );
+  };
+
+  // ── Column width math ──────────────────────────────────────────────────────
+  // baseW = the table's NATURAL width (grip + every fixed column width).
+  // slack  = leftover space when the card is wider than the table; distributed
+  //          to the flex columns by weight. When the table overflows, slack = 0
+  //          and the table keeps its natural width (→ the ScrollView scrolls).
+  // innerWidth = max(baseW, containerWidth) so the inner content fills the card
+  //          when it fits, and keeps its natural width when it overflows.
+  const baseW = GRIP_W + columns.reduce((sum, c) => sum + c.width, 0);
+  const totalFlex = columns.reduce((sum, c) => sum + (c.flex ?? 0), 0);
+  const slack = Math.max(0, size.w - baseW);
+  const effWidths = columns.map((c) =>
+    c.flex && totalFlex > 0 ? c.width + (slack * c.flex) / totalFlex : c.width,
+  );
+  const innerWidth = Math.max(baseW, size.w);
+
+  const cellFrame = (i: number): ViewStyle => ({
+    width: effWidths[i],
+    paddingHorizontal: 10,
+    paddingVertical: 9,
+    // Top-align content (events-os `items-start`) so a 2-line cell doesn't push
+    // its 1-line neighbours off-centre. The row stretches every cell to the same
+    // height, so the vertical dividers still run the full row.
+    justifyContent: "flex-start",
+    alignItems: columns[i].align === "center" ? "center" : "flex-start",
+    borderRightWidth: i < columns.length - 1 ? StyleSheet.hairlineWidth : 0,
+    borderRightColor: colors.border,
+  });
+
+  const headerRow = (
+    <View
+      style={[
+        styles.headerRow,
+        {
+          backgroundColor: primaryColor + "0D",
+          borderBottomColor: primaryColor,
+        },
+      ]}
+    >
+      <View style={styles.gripCell} />
+      {columns.map((col, i) => (
+        <View key={col.key} style={cellFrame(i)}>
+          <Text
+            style={[
+              styles.headerLabel,
+              { color: colors.textTertiary },
+              col.align === "center" && styles.headerLabelCenter,
+            ]}
+            numberOfLines={1}
+          >
+            {col.label}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+
+  // Bound the inner content to the measured card height so the nested vertical
+  // drag list scrolls within the horizontal ScrollView. Before the first layout
+  // pass, fall back to filling available height so nothing renders at zero.
+  const innerHeightStyle: ViewStyle = size.h
+    ? { height: size.h }
+    : { flexGrow: 1 };
+
+  return (
+    <View style={styles.root}>
+      {ListHeaderComponent}
+      <View
+        style={[
+          styles.card,
+          { borderColor: colors.border, backgroundColor: colors.surface },
+        ]}
+        onLayout={onLayout}
+      >
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.hScroll}
+        >
+          <View style={[{ width: innerWidth }, innerHeightStyle]}>
+            {headerRow}
+            <View style={styles.listWrap}>
+              <RunSheetDragList
+                data={data}
+                keyExtractor={keyExtractor}
+                onReorder={onReorder}
+                contentContainerStyle={contentContainerStyle}
+                renderRow={({ item, Handle, isActive }) => (
+                  <View
+                    style={[
+                      styles.row,
+                      {
+                        borderBottomColor: colors.border,
+                        backgroundColor: isActive
+                          ? colors.surfaceSecondary
+                          : colors.surface,
+                      },
+                    ]}
+                  >
+                    <Handle>
+                      <View
+                        style={styles.gripCell}
+                        accessibilityLabel="Drag to reorder"
+                        hitSlop={8}
+                      >
+                        <Ionicons
+                          name="reorder-three"
+                          size={18}
+                          color={colors.textTertiary}
+                        />
+                      </View>
+                    </Handle>
+                    {columns.map((col, i) => (
+                      <View key={col.key} style={cellFrame(i)}>
+                        {renderCell(item, col.key, { isActive })}
+                      </View>
+                    ))}
+                  </View>
+                )}
+              />
+            </View>
+          </View>
+        </ScrollView>
+      </View>
+      {ListFooterComponent}
+    </View>
+  );
+}
+
+/** #RRGGBB (with or without the leading #). Team / role colors are stored as hex. */
+const HEX6 = /^#?[0-9a-fA-F]{6}$/;
+
+/** Append an 8-bit alpha to a #RRGGBB hex, for a soft tinted background. */
+function hexWithAlpha(hex: string, alpha: number): string {
+  const h = hex.startsWith("#") ? hex : `#${hex}`;
+  const a = Math.round(Math.max(0, Math.min(1, alpha)) * 255)
+    .toString(16)
+    .padStart(2, "0");
+  return `${h}${a}`;
+}
+
+/**
+ * Darken a #RRGGBB hex toward black so a colored tag's text reads cleanly on its
+ * own soft tint (mirrors the readable text/bg pairing in events-os optionColor).
+ */
+function darkenHex(hex: string, amount = 0.42): string {
+  const n = parseInt(hex.replace("#", ""), 16);
+  if (Number.isNaN(n)) return hex;
+  const scale = (v: number) => Math.round(v * (1 - amount));
+  const r = scale((n >> 16) & 0xff);
+  const g = scale((n >> 8) & 0xff);
+  const b = scale(n & 0xff);
+  const to2 = (v: number) => v.toString(16).padStart(2, "0");
+  return `#${to2(r)}${to2(g)}${to2(b)}`;
+}
+
+/**
+ * A subtle events-os-style value tag for cells (When / Phase / Team / Role /
+ * Owner). Small, light background, small radius (NOT a fully-round pill), compact
+ * text, with an optional leading color dot (roles/owner) and a trailing chevron
+ * for the ones that open a dropdown. Purely presentational — the screens wrap it
+ * in a Pressable that measures its own anchor for the AnchoredMenu.
+ *
+ * Pass `color` (a hex, e.g. a team/role color) to render a COLORED tag: a soft
+ * tint of that color as the background, its darkened form as the text, and a
+ * matching leading dot. Without `color` it keeps the neutral / primary-tint look.
+ */
+export function OptionTag({
+  label,
+  colors,
+  primaryColor,
+  color,
+  dotColor,
+  chevron,
+  tinted,
+  placeholder,
+}: {
+  label: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  /** A concrete hex (team / role color) → soft tinted background + readable text. */
+  color?: string;
+  /** Leading swatch (role / owner color); defaults to `color` when that is set. */
+  dotColor?: string;
+  /** Trailing chevron-down for dropdown tags. */
+  chevron?: boolean;
+  /** Use a light primary tint background instead of the neutral surface. */
+  tinted?: boolean;
+  /** Render as an empty/placeholder tag (faint text). */
+  placeholder?: boolean;
+}) {
+  const hasColor = !!color && HEX6.test(color);
+  const backgroundColor = hasColor
+    ? hexWithAlpha(color as string, 0.14)
+    : tinted
+      ? primaryColor + "14"
+      : colors.surfaceSecondary;
+  const textColor = placeholder
+    ? colors.textTertiary
+    : hasColor
+      ? darkenHex(color as string)
+      : colors.text;
+  // A colored tag gets a leading dot in its own color unless one is set explicitly.
+  const swatch = dotColor ?? (hasColor ? (color as string) : undefined);
+  return (
+    <View style={[tagStyles.tag, { backgroundColor }]}>
+      {swatch ? (
+        <View style={[tagStyles.dot, { backgroundColor: swatch }]} />
+      ) : null}
+      <Text style={[tagStyles.text, { color: textColor }]} numberOfLines={1}>
+        {label}
+      </Text>
+      {chevron ? (
+        <Ionicons name="chevron-down" size={11} color={colors.textTertiary} />
+      ) : null}
+    </View>
+  );
+}
+
+const tagStyles = StyleSheet.create({
+  tag: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    alignSelf: "flex-start",
+    maxWidth: "100%",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+  },
+  dot: { width: 8, height: 8, borderRadius: 4 },
+  text: { fontSize: 12, fontWeight: "600", flexShrink: 1 },
+});
+
+const styles = StyleSheet.create({
+  root: { flex: 1, paddingHorizontal: 16, paddingTop: 4 },
+  card: {
+    flex: 1,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    overflow: "hidden",
+    marginTop: 12,
+  },
+  hScroll: { flex: 1 },
+  listWrap: { flex: 1 },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    minHeight: HEADER_MIN_HEIGHT,
+    // A 2px accent underline in the community's primary color (events-os look).
+    borderBottomWidth: 2,
+  },
+  headerLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+  },
+  headerLabelCenter: { textAlign: "center" },
+  row: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    minHeight: ROW_MIN_HEIGHT,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  gripCell: {
+    width: GRIP_W,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/apps/mobile/features/scheduling/components/MyScheduleScreen.tsx
+++ b/apps/mobile/features/scheduling/components/MyScheduleScreen.tsx
@@ -283,6 +283,11 @@ export function MyScheduleScreen() {
                   key={a._id}
                   assignment={a}
                   onPress={() => openDetail(a._id)}
+                  onOpenEvent={
+                    eventTasksEnabled
+                      ? () => handleEnterServing(a.planId as string)
+                      : undefined
+                  }
                 />
               ))}
             </View>
@@ -377,43 +382,67 @@ function PendingRow({
 function UpcomingRow({
   assignment,
   onPress,
+  onOpenEvent,
 }: {
   assignment: MyAssignment;
   onPress: () => void;
+  /**
+   * Enter event (serving) mode for this plan. Provided only when Event Tasks is
+   * enabled. Unlike the day-of banner, this is always available on the row so a
+   * leader can open + preview the event view ahead of the serving window.
+   */
+  onOpenEvent?: () => void;
 }) {
   const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
   const isDeclined = assignment.status === "declined";
   const statusColor = isDeclined ? colors.destructive : colors.success;
+  // The row is a View (not one big Pressable) so the "Open event" button and the
+  // main tap target (open assignment detail) don't fire each other.
   return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [
-        styles.upcomingRow,
-        { backgroundColor: colors.surfaceSecondary },
-        pressed && { opacity: 0.8 },
-      ]}
-    >
-      <View
-        style={[
-          styles.dot,
-          { backgroundColor: assignment.roleColor ?? DEFAULT_ROLE_COLOR },
-        ]}
-      />
-      <View style={styles.upcomingTextWrap}>
-        <Text style={[styles.roleName, { color: colors.text }]}>
-          {assignment.roleName}
-        </Text>
-        <Text style={[styles.subLine, { color: colors.textSecondary }]}>
-          {assignment.eventTitle} · {assignment.teamName}
-          {assignment.timeLabel ? ` · ${assignment.timeLabel}` : ""}
-        </Text>
-      </View>
+    <View style={[styles.upcomingRow, { backgroundColor: colors.surfaceSecondary }]}>
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [styles.upcomingMain, pressed && { opacity: 0.7 }]}
+      >
+        <View
+          style={[
+            styles.dot,
+            { backgroundColor: assignment.roleColor ?? DEFAULT_ROLE_COLOR },
+          ]}
+        />
+        <View style={styles.upcomingTextWrap}>
+          <Text style={[styles.roleName, { color: colors.text }]}>
+            {assignment.roleName}
+          </Text>
+          <Text style={[styles.subLine, { color: colors.textSecondary }]}>
+            {assignment.eventTitle} · {assignment.teamName}
+            {assignment.timeLabel ? ` · ${assignment.timeLabel}` : ""}
+          </Text>
+        </View>
+      </Pressable>
+      {onOpenEvent && !isDeclined ? (
+        <Pressable
+          onPress={onOpenEvent}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={`Open event view for ${assignment.eventTitle}`}
+          style={({ pressed }) => [
+            styles.openEventBtn,
+            { borderColor: primaryColor },
+            pressed && { opacity: 0.6 },
+          ]}
+        >
+          <Ionicons name="open-outline" size={14} color={primaryColor} />
+          <Text style={[styles.openEventText, { color: primaryColor }]}>Open event</Text>
+        </Pressable>
+      ) : null}
       <View style={[styles.statusPill, { backgroundColor: statusColor + "22" }]}>
         <Text style={[styles.statusPillText, { color: statusColor }]}>
           {isDeclined ? "Declined" : "Confirmed"}
         </Text>
       </View>
-    </Pressable>
+    </View>
   );
 }
 
@@ -569,8 +598,27 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     marginBottom: 8,
   },
+  upcomingMain: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
   upcomingTextWrap: {
     flex: 1,
+  },
+  openEventBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  openEventText: {
+    fontSize: 12,
+    fontWeight: "600",
   },
   statusPill: {
     paddingHorizontal: 10,

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -8,15 +8,16 @@
  * toggle: rows show clock times from the earliest start, and the header shows
  * every service as a start–end range that grows as items/durations change.
  *
- * Editing is spreadsheet-style and inline: title, duration, description, and
- * song key are edited in place (debounced autosave via `updateItem`); rows
- * expand for role links and notes. Reordering is drag-and-drop from a grip
- * handle (web + native, see `RunSheetDragList`). Each row can be duplicated or
- * deleted. There is no modal sub-page.
+ * Editing is spreadsheet-style: the run sheet is one continuous `GridScrollList`
+ * table (Item / When / Time / Dur / Owner-Role / Notes / Song / actions) modelled
+ * on the events-os Run of Show. There are no segment-heading rows — a row's phase
+ * is the "When" column. Duration and title edit inline; When, Who, Notes, and Song
+ * open focused modals. Reordering is drag-and-drop from a grip in the first cell
+ * (web + native). Each row can be duplicated or deleted from the actions column.
  *
  * Route: /rostering/[group_id]/run-sheet/[plan_id]
  */
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -27,6 +28,7 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
+  type TextStyle,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -43,22 +45,23 @@ import { DEFAULT_ROLE_COLOR, formatEventDateLong } from "../utils/format";
 import {
   computeSegmentedClockTimes,
   formatClockTime,
-  formatDuration,
   formatServiceRanges,
   totalDurationSec,
 } from "../utils/runSheetTiming";
 import { useAuth } from "@providers/AuthProvider";
 import { InlineText } from "./InlineText";
-import { RunSheetDragList } from "./RunSheetDragList";
+import { GridScrollList, OptionTag, type GridColumn } from "./GridScrollList";
+import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
 import { SongPicker } from "./SongPicker";
+import { CustomModal } from "@components/ui/Modal";
 import type { Song } from "@features/songs/types";
 
 /** When an item happens relative to the event's service times. */
 type Segment = "before" | "during" | "after";
-const SEGMENT_OPTIONS: Array<{ key: Segment; label: string }> = [
-  { key: "before", label: "Before event" },
-  { key: "during", label: "During event" },
-  { key: "after", label: "After event" },
+const SEGMENT_OPTIONS: Array<{ key: Segment; label: string; short: string }> = [
+  { key: "before", label: "Before event", short: "Before" },
+  { key: "during", label: "During event", short: "During" },
+  { key: "after", label: "After event", short: "After" },
 ];
 
 /**
@@ -184,6 +187,36 @@ export function RunSheetScreen() {
   // Which phase the "Add" buttons create into.
   const [addSegment, setAddSegment] = useState<Segment>("during");
 
+  // Cell-tap modals. Each holds the item whose Who / Notes / Song is being
+  // edited; the live item is re-derived from `items` at render so a deleted or
+  // moved row closes its modal instead of showing stale data.
+  const [whoItem, setWhoItem] = useState<RunSheetItem | null>(null);
+  const [notesItem, setNotesItem] = useState<RunSheetItem | null>(null);
+  const [songItem, setSongItem] = useState<RunSheetItem | null>(null);
+  // The "When" picker is an anchored dropdown next to its pill (not a modal), so
+  // it tracks both the item and the pill's measured window rect.
+  const [whenMenu, setWhenMenu] = useState<{
+    item: RunSheetItem;
+    anchor: AnchorRect;
+  } | null>(null);
+
+  // One continuous events-os-style table (after the auto drag-grip). Widths are
+  // fixed pixels; the table scrolls horizontally when it overflows the card, and
+  // the flex columns (Item / Notes) absorb any leftover slack when it fits.
+  const columns: GridColumn[] = useMemo(
+    () => [
+      { key: "item", label: "Item", width: 220, flex: 3 },
+      { key: "when", label: "When", width: 104 },
+      { key: "time", label: "Time", width: 96, align: "center" },
+      { key: "dur", label: "Dur", width: 84, align: "center" },
+      { key: "who", label: "Owner / Role", width: 176 },
+      { key: "notes", label: "Notes", width: 240, flex: 3 },
+      { key: "song", label: "Song", width: 150 },
+      { key: "actions", label: "", width: 64, align: "center" },
+    ],
+    [],
+  );
+
   const handleBack = useCallback(() => {
     if (router.canGoBack()) router.back();
   }, [router]);
@@ -242,16 +275,14 @@ export function RunSheetScreen() {
       })),
     [event?.roles],
   );
-  const peopleByRole = useMemo(() => {
-    const map: Record<string, string[]> = {};
-    for (const r of roleOptions) map[r.roleId as string] = r.people;
-    return map;
-  }, [roleOptions]);
 
   const patchItem = useCallback(
     (itemId: Id<"eventItems">, patch: ItemPatch) =>
       updateItem({ itemId, ...patch }).catch((e: any) =>
-        notifyError("Couldn't save", e?.data?.message ?? e?.message ?? "Please try again."),
+        notifyError(
+          "Couldn't save",
+          e?.data?.message ?? e?.message ?? "Please try again.",
+        ),
       ),
     [updateItem],
   );
@@ -305,46 +336,51 @@ export function RunSheetScreen() {
     [deleteItem],
   );
 
-  // The unified list interleaves phase-header rows (keyed `seg:<phase>`) with
-  // item rows. After a drag, walk the new key order: each header switches the
-  // running phase, and every item that follows takes it — so dragging an item
-  // past a header moves it into that phase.
+  // Flat rows for the single table, ordered by phase (before → during → after)
+  // then existing sequence. There are no heading rows: a row's phase lives in the
+  // "When" column and is changed there, not by dragging.
+  const rows = useMemo(
+    () =>
+      itemsBySegment.before.concat(itemsBySegment.during, itemsBySegment.after),
+    [itemsBySegment],
+  );
+
+  // Drag only reorders within the existing phases — each row keeps its current
+  // segment (phase is changed via the When column instead).
   const handleReorder = useCallback(
     (orderedKeys: string[]) => {
-      const orderedItems: Array<{ id: Id<"eventItems">; segment: Segment }> = [];
-      let current: Segment = "before";
-      for (const key of orderedKeys) {
-        if (key.startsWith("seg:")) {
-          current = key.slice(4) as Segment;
-        } else {
-          orderedItems.push({ id: key as Id<"eventItems">, segment: current });
-        }
-      }
+      const byId = new Map(rows.map((it) => [it._id as string, it]));
+      const orderedItems = orderedKeys
+        .map((id) => byId.get(id))
+        .filter((it): it is RunSheetItem => it != null)
+        .map((it) => ({
+          id: it._id,
+          segment: (it.segment as Segment) ?? "during",
+        }));
       return reorderItems({ planId, orderedItems }).catch((e: any) =>
         notifyError("Couldn't reorder", e?.message ?? "Please try again."),
       );
     },
-    [reorderItems, planId],
+    [reorderItems, planId, rows],
   );
 
-  // Flat rows for the single drag list: each phase's header followed by its
-  // items. Phase headers are always present so an empty phase is still a drop
-  // target — you can drag the first item into it.
-  const rows = useMemo(() => {
-    type Row =
-      | { kind: "header"; segment: Segment; key: string }
-      | { kind: "item"; item: RunSheetItem; key: string };
-    const out: Row[] = [];
-    for (const seg of SEGMENT_OPTIONS) {
-      out.push({ kind: "header", segment: seg.key, key: `seg:${seg.key}` });
-      for (const it of itemsBySegment[seg.key]) {
-        out.push({ kind: "item", item: it, key: it._id as string });
-      }
-    }
-    return out;
-  }, [itemsBySegment]);
-
   const loading = event === undefined || items === undefined;
+
+  // Re-derive each modal's live item from the current `items` so a row that was
+  // deleted or reordered elsewhere closes its modal instead of editing a stale
+  // snapshot. `null` when the item is gone → the modal hides.
+  const whoLive = whoItem
+    ? (items?.find((i) => i._id === whoItem._id) ?? null)
+    : null;
+  const notesLive = notesItem
+    ? (items?.find((i) => i._id === notesItem._id) ?? null)
+    : null;
+  const songLive = songItem
+    ? (items?.find((i) => i._id === songItem._id) ?? null)
+    : null;
+  const whenLive = whenMenu
+    ? (items?.find((i) => i._id === whenMenu.item._id) ?? null)
+    : null;
 
   return (
     <View
@@ -484,45 +520,309 @@ export function RunSheetScreen() {
             );
           }
 
-          // One drag list over all phases. Phase headings are drop zones: drag
-          // an item past one to change its phase.
-          return (
-            <RunSheetDragList
-              data={rows}
-              keyExtractor={(r) => r.key}
-              onReorder={handleReorder}
-              ListHeaderComponent={listHeader}
-              ListFooterComponent={listFooter}
-              contentContainerStyle={contentStyle}
-              renderRow={({ item: row, Handle, isActive }) =>
-                row.kind === "header" ? (
-                  <Text
-                    style={[styles.segmentLabel, { color: colors.textSecondary }]}
-                  >
-                    {SEGMENT_OPTIONS.find((s) => s.key === row.segment)?.label.toUpperCase()}
-                  </Text>
-                ) : (
-                  <EditableRow
-                    item={row.item}
-                    clockMs={clockTimes[row.item._id]}
-                    communityId={communityId}
-                    groupId={group_id ?? ""}
-                    roleOptions={roleOptions}
-                    peopleByRole={peopleByRole}
-                    autoFocus={focusId === (row.item._id as string)}
-                    isActive={isActive}
-                    Handle={Handle}
-                    onPatch={(patch) => patchItem(row.item._id, patch)}
-                    onDuplicate={() => handleDuplicate(row.item._id)}
-                    onDelete={() => handleDelete(row.item)}
+          // One continuous events-os-style table. Each row's phase is the "When"
+          // column (no heading rows). renderCell returns cell CONTENT only — the
+          // primitive draws the sized, padded cell frame.
+          const renderCell = (
+            item: RunSheetItem,
+            key: string,
+          ): React.ReactNode => {
+            const isHeader = item.type === "header";
+            const isSong = item.type === "song";
+            switch (key) {
+              case "item":
+                return (
+                  <InlineText
+                    value={item.title}
+                    onSave={(t) => {
+                      patchItem(item._id, { title: t });
+                    }}
+                    placeholder={isHeader ? "Section name" : "Item title"}
+                    autoFocus={focusId === (item._id as string)}
+                    maxLength={120}
+                    required
+                    accessibilityLabel="Item title"
+                    style={[
+                      styles.titleInput,
+                      isHeader && styles.headerTitleInput,
+                      { color: colors.text },
+                    ]}
                   />
-                )
+                );
+              case "when": {
+                const short =
+                  SEGMENT_OPTIONS.find((s) => s.key === item.segment)?.short ??
+                  "During";
+                return (
+                  <WhenPill
+                    label={short}
+                    colors={colors}
+                    primaryColor={primaryColor}
+                    onOpen={(anchor) => setWhenMenu({ item, anchor })}
+                  />
+                );
               }
+              case "time": {
+                if (isHeader) return null;
+                const ms = clockTimes[item._id];
+                // A single, quiet read-only clock value ("9:00 AM") — no boxed
+                // pill, so it stays contained and doesn't compete with the
+                // editable Dur input beside it.
+                return (
+                  <Text
+                    style={[styles.timeText, { color: colors.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    {ms != null ? formatClockTime(ms) : "—"}
+                  </Text>
+                );
+              }
+              case "dur":
+                if (isHeader) return null;
+                return (
+                  <DurationCell
+                    durationSec={item.durationSec}
+                    onSave={(sec) => patchItem(item._id, { durationSec: sec })}
+                    colors={colors}
+                  />
+                );
+              case "who":
+                return (
+                  <Pressable
+                    onPress={() => setWhoItem(item)}
+                    style={styles.cellPressable}
+                    accessibilityLabel="Edit owner / role"
+                  >
+                    {item.assignments.length > 0 ? (
+                      <View style={styles.whoChips}>
+                        {item.assignments.slice(0, 2).map((a) => (
+                          <OptionTag
+                            key={a.roleId}
+                            label={a.roleName}
+                            colors={colors}
+                            primaryColor={primaryColor}
+                            color={a.roleColor ?? DEFAULT_ROLE_COLOR}
+                          />
+                        ))}
+                        {item.assignments.length > 2 ? (
+                          <Text style={[styles.muted, { color: colors.textTertiary }]}>
+                            +{item.assignments.length - 2}
+                          </Text>
+                        ) : null}
+                      </View>
+                    ) : (
+                      <OptionTag
+                        label="＋"
+                        colors={colors}
+                        primaryColor={primaryColor}
+                        placeholder
+                      />
+                    )}
+                  </Pressable>
+                );
+              case "notes":
+                return (
+                  <Pressable
+                    onPress={() => setNotesItem(item)}
+                    style={styles.cellPressable}
+                    accessibilityLabel="Edit notes"
+                  >
+                    <Text
+                      numberOfLines={2}
+                      style={[
+                        styles.cellText,
+                        {
+                          color: item.description
+                            ? colors.text
+                            : colors.textTertiary,
+                        },
+                      ]}
+                    >
+                      {item.description && item.description.length > 0
+                        ? item.description
+                        : "Add notes"}
+                      {item.notes.length > 0 ? ` · ${item.notes.length} cues` : ""}
+                    </Text>
+                  </Pressable>
+                );
+              case "song": {
+                if (!isSong) {
+                  return (
+                    <Text style={[styles.muted, { color: colors.textTertiary }]}>—</Text>
+                  );
+                }
+                const resolvedKey = item.songDetails?.key ?? item.song?.defaultKey;
+                return (
+                  <Pressable
+                    onPress={() => setSongItem(item)}
+                    style={styles.cellPressable}
+                    accessibilityLabel="Edit song"
+                  >
+                    {item.song ? (
+                      <Text
+                        numberOfLines={1}
+                        style={[styles.cellText, { color: colors.text }]}
+                      >
+                        {item.song.title}
+                        {resolvedKey ? ` · ${resolvedKey}` : ""}
+                      </Text>
+                    ) : (
+                      <Text style={[styles.muted, { color: colors.textTertiary }]}>
+                        ＋ Song
+                      </Text>
+                    )}
+                  </Pressable>
+                );
+              }
+              case "actions":
+                return (
+                  <View style={styles.actionsRow}>
+                    <Pressable
+                      onPress={() => handleDuplicate(item._id)}
+                      hitSlop={6}
+                      style={styles.actionBtn}
+                      accessibilityLabel="Duplicate"
+                    >
+                      <Ionicons name="copy-outline" size={16} color={colors.textTertiary} />
+                    </Pressable>
+                    <Pressable
+                      onPress={() => handleDelete(item)}
+                      hitSlop={6}
+                      style={styles.actionBtn}
+                      accessibilityLabel="Delete"
+                    >
+                      <Ionicons name="trash-outline" size={16} color={colors.destructive} />
+                    </Pressable>
+                  </View>
+                );
+              default:
+                return null;
+            }
+          };
+
+          return (
+            <GridScrollList<RunSheetItem>
+              data={rows}
+              keyExtractor={(it) => it._id as string}
+              onReorder={handleReorder}
+              columns={columns}
+              renderCell={renderCell}
+              ListHeaderComponent={listHeader}
+              // The add controls are fixed below the table card, so they carry
+              // the bottom safe-area inset here (the rows scroll inside the card).
+              ListFooterComponent={
+                <View style={{ paddingBottom: insets.bottom + 8 }}>
+                  {listFooter}
+                </View>
+              }
+              // Vertical padding only — horizontal padding would shift the rows
+              // out of alignment with the pinned header.
+              contentContainerStyle={styles.gridContent}
             />
           );
         })()
       )}
+
+      {/* Who's-involved (roles) editor — multi-select, opened from the Who cell.
+          The live item is re-derived so a deleted/moved row closes the modal. */}
+      <CustomModal
+        visible={whoLive !== null}
+        onClose={() => setWhoItem(null)}
+        title="Who's involved"
+      >
+        {whoLive ? (
+          <WhoModalBody
+            key={whoLive._id}
+            item={whoLive}
+            roleOptions={roleOptions}
+            onPatch={(patch) => patchItem(whoLive._id, patch)}
+          />
+        ) : null}
+      </CustomModal>
+
+      {/* Notes editor — timing phase, description, and role-categorized cues. */}
+      <CustomModal
+        visible={notesLive !== null}
+        onClose={() => setNotesItem(null)}
+        title="Notes"
+      >
+        {notesLive ? (
+          <NotesModalBody
+            key={notesLive._id}
+            item={notesLive}
+            onPatch={(patch) => patchItem(notesLive._id, patch)}
+          />
+        ) : null}
+      </CustomModal>
+
+      {/* Song editor — library link plus per-service key / BPM overrides. */}
+      <CustomModal
+        visible={songLive !== null}
+        onClose={() => setSongItem(null)}
+        title="Song"
+      >
+        {songLive ? (
+          <SongModalBody
+            key={songLive._id}
+            item={songLive}
+            communityId={communityId}
+            groupId={group_id ?? ""}
+            onPatch={(patch) => patchItem(songLive._id, patch)}
+          />
+        ) : null}
+      </CustomModal>
+
+      {/* When picker — an anchored dropdown next to the pill that moves the row
+          between the before / during / after phases. */}
+      {whenMenu && whenLive ? (
+        <AnchoredMenu
+          anchor={whenMenu.anchor}
+          options={SEGMENT_OPTIONS.map((s) => ({ id: s.key, name: s.label }))}
+          selectedId={whenLive.segment}
+          onSelect={(id) => {
+            if (id) patchItem(whenLive._id, { segment: id as Segment });
+            setWhenMenu(null);
+          }}
+          onClose={() => setWhenMenu(null)}
+        />
+      ) : null}
     </View>
+  );
+}
+
+/**
+ * The "When" phase pill. Measures its own window rect on press so the parent can
+ * anchor the dropdown next to it (the pill can't hold the menu itself — the
+ * table card clips overflow).
+ */
+function WhenPill({
+  label,
+  colors,
+  primaryColor,
+  onOpen,
+}: {
+  label: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onOpen: (anchor: AnchorRect) => void;
+}) {
+  const ref = React.useRef<View>(null);
+  return (
+    <Pressable
+      ref={ref}
+      onPress={() => measureAnchor(ref.current, onOpen)}
+      style={styles.tagPressable}
+      accessibilityRole="button"
+      accessibilityLabel={`When: ${label}. Tap to change.`}
+    >
+      <OptionTag
+        label={label}
+        colors={colors}
+        primaryColor={primaryColor}
+        tinted
+        chevron
+      />
+    </Pressable>
   );
 }
 
@@ -549,326 +849,231 @@ function AddButton({
   );
 }
 
-/** One inline-editable run sheet row. */
-function EditableRow({
+/**
+ * Who's-involved editor body (roles multi-select).
+ *
+ * Seeds a local Set from the item's current assignments so rapid toggles
+ * compound instead of each restarting from the last server-synced value (which
+ * lags a mutation round-trip). Remounted per item via a `key` at the call site,
+ * so it re-seeds whenever a different row's modal opens.
+ */
+function WhoModalBody({
   item,
-  clockMs,
-  communityId,
-  groupId,
   roleOptions,
-  peopleByRole,
-  autoFocus,
-  isActive,
-  Handle,
   onPatch,
-  onDuplicate,
-  onDelete,
 }: {
   item: RunSheetItem;
-  clockMs: number | null;
-  communityId: string;
-  groupId: string;
   roleOptions: RoleOption[];
-  peopleByRole: Record<string, string[]>;
-  autoFocus: boolean;
-  isActive: boolean;
-  Handle: React.ComponentType<{ children: React.ReactNode }>;
   onPatch: (patch: ItemPatch) => void;
-  onDuplicate: () => void;
-  onDelete: () => void;
 }) {
   const { colors } = useTheme();
-  const [expanded, setExpanded] = useState(false);
-  const isHeader = item.type === "header";
-  const isSong = item.type === "song";
-
-  // Local selection state so rapid toggles compound instead of each starting
-  // from the last server-synced `item.assignments` (which lags a mutation
-  // round-trip and would drop quick successive taps). Re-syncs only when the
-  // server's set genuinely changes (e.g. another device edited it).
-  const serverRoleKey = item.assignments.map((a) => a.roleId).join(",");
-  const [linkedRoleIds, setLinkedRoleIds] = useState<Set<string>>(
+  const [linked, setLinked] = useState<Set<string>>(
     () => new Set(item.assignments.map((a) => a.roleId as string)),
   );
-  useEffect(() => {
-    setLinkedRoleIds(new Set(serverRoleKey ? serverRoleKey.split(",") : []));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [serverRoleKey]);
 
-  const toggleRole = (roleId: string) => {
-    const next = new Set(linkedRoleIds);
+  const toggle = (roleId: string) => {
+    const next = new Set(linked);
     if (next.has(roleId)) next.delete(roleId);
     else next.add(roleId);
-    setLinkedRoleIds(next);
+    setLinked(next);
     onPatch({
       assignments: [...next].map((id) => ({ roleId: id as Id<"teamRoles"> })),
     });
   };
 
+  if (roleOptions.length === 0) {
+    return (
+      <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+        No roles are defined for this event yet.
+      </Text>
+    );
+  }
+
   return (
-    <View
-      style={[
-        styles.row,
-        {
-          backgroundColor: isHeader ? "transparent" : colors.surfaceSecondary,
-          opacity: isActive ? 0.6 : 1,
-          borderColor: colors.border,
-        },
-        isHeader && styles.headerRow,
-      ]}
-    >
-      <View style={styles.rowTop}>
-        {/* Drag grip */}
-        <Handle>
-          <View
-            style={styles.grip}
-            accessibilityLabel="Drag to reorder"
-            hitSlop={10}
+    <View style={styles.roleWrap}>
+      {roleOptions.map((r) => {
+        const selected = linked.has(r.roleId as string);
+        const swatch = r.roleColor ?? DEFAULT_ROLE_COLOR;
+        return (
+          <Pressable
+            key={r.roleId}
+            onPress={() => toggle(r.roleId as string)}
+            style={styles.rolePressable}
           >
-            <Ionicons name="reorder-three" size={20} color={colors.textTertiary} />
-          </View>
-        </Handle>
-
-        {/* Time */}
-        <View style={styles.timeCol}>
-          <Text style={[styles.timeText, { color: isHeader ? colors.textTertiary : colors.text }]}>
-            {clockMs != null ? formatClockTime(clockMs) : "—"}
-          </Text>
-        </View>
-
-        {/* Title (inline) */}
-        <View style={styles.titleCol}>
-          <InlineText
-            value={item.title}
-            onSave={(t) => onPatch({ title: t })}
-            placeholder={isHeader ? "Section name" : "Item title"}
-            autoFocus={autoFocus}
-            maxLength={120}
-            required
-            accessibilityLabel="Item title"
-            style={[
-              styles.titleInput,
-              isHeader && styles.headerTitleInput,
-              { color: colors.text },
-            ]}
-          />
-        </View>
-
-        {/* Duration (inline m:ss) — hidden for headers */}
-        {!isHeader ? (
-          <View style={styles.durationCol}>
-            <DurationCell
-              durationSec={item.durationSec}
-              onSave={(sec) => onPatch({ durationSec: sec })}
-              colors={colors}
-            />
-          </View>
-        ) : null}
-
-        {/* Row actions */}
-        <View style={styles.actions}>
-          {!isHeader ? (
-            <Pressable
-              onPress={() => setExpanded((v) => !v)}
-              hitSlop={6}
-              style={styles.actionBtn}
-              accessibilityLabel={expanded ? "Collapse" : "Expand details"}
+            <View
+              style={[
+                styles.roleChip,
+                {
+                  backgroundColor: selected ? swatch + "22" : colors.surface,
+                  borderColor: selected ? swatch : colors.border,
+                },
+              ]}
             >
-              <Ionicons
-                name={expanded ? "chevron-up" : "chevron-down"}
-                size={18}
-                color={colors.textTertiary}
-              />
-            </Pressable>
-          ) : null}
-          <Pressable onPress={onDuplicate} hitSlop={6} style={styles.actionBtn} accessibilityLabel="Duplicate">
-            <Ionicons name="copy-outline" size={17} color={colors.textTertiary} />
-          </Pressable>
-          <Pressable onPress={onDelete} hitSlop={6} style={styles.actionBtn} accessibilityLabel="Delete">
-            <Ionicons name="close" size={18} color={colors.textTertiary} />
-          </Pressable>
-        </View>
-      </View>
-
-      {/* Linked people (always visible when present) */}
-      {!isHeader && item.assignments.length > 0 ? (
-        <View style={styles.assignWrap}>
-          {item.assignments.map((a) => {
-            const names = peopleByRole[a.roleId as string] ?? [];
-            return (
-              <View
-                key={a.roleId}
-                style={[
-                  styles.assignChip,
-                  { backgroundColor: (a.roleColor ?? DEFAULT_ROLE_COLOR) + "22" },
-                ]}
+              <View style={[styles.roleSwatch, { backgroundColor: swatch }]} />
+              <Text
+                style={[styles.roleChipText, { color: colors.text }]}
+                numberOfLines={1}
               >
-                <View style={[styles.assignSwatch, { backgroundColor: a.roleColor ?? DEFAULT_ROLE_COLOR }]} />
-                <Text style={[styles.assignText, { color: colors.text }]} numberOfLines={1}>
-                  {a.roleName}
-                  {names.length > 0 ? `: ${names.join(", ")}` : ""}
-                </Text>
-              </View>
-            );
-          })}
-        </View>
-      ) : null}
-
-      {/* Expanded inline editors */}
-      {expanded && !isHeader ? (
-        <View style={styles.expanded}>
-          {/* Timing phase — before / during / after the event (PCO's position). */}
-          <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
-            Timing
-          </Text>
-          <View style={styles.timingToggle}>
-            {SEGMENT_OPTIONS.map((seg) => {
-              const active = (item.segment as Segment) === seg.key;
-              return (
-                <Pressable
-                  key={seg.key}
-                  onPress={() => onPatch({ segment: seg.key })}
-                  style={styles.timingPressable}
-                  accessibilityRole="button"
-                  accessibilityState={{ selected: active }}
-                >
-                  <View
-                    style={[
-                      styles.timingChip,
-                      {
-                        borderColor: active ? colors.buttonPrimary : colors.border,
-                        backgroundColor: active
-                          ? colors.buttonPrimary + "1F"
-                          : "transparent",
-                      },
-                    ]}
-                  >
-                    <Text
-                      style={[
-                        styles.timingChipText,
-                        { color: active ? colors.buttonPrimary : colors.textSecondary },
-                      ]}
-                    >
-                      {seg.label}
-                    </Text>
-                  </View>
-                </Pressable>
-              );
-            })}
-          </View>
-
-          {isSong ? (
-            <>
-              {/* Link this row to a library song (ADR-027). Free-typed rows
-                  (no songId) keep working — the picker just stays unlinked. */}
-              <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Song</Text>
-              <SongPicker
-                communityId={communityId}
-                groupId={groupId}
-                songId={item.songId}
-                song={item.song}
-                onSelect={(songId) =>
-                  onPatch({ songId: songId as Id<"songs"> | null })
-                }
-              />
-
-              {/* Key / BPM. When a song is linked these are PER-SERVICE
-                  OVERRIDES: the value is only the override (blank if none),
-                  the placeholder is the song's default, and saving writes
-                  songDetails. Display elsewhere resolves override ?? default. */}
-              <View style={styles.songRow}>
-                <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Key</Text>
-                <InlineText
-                  value={item.songDetails?.key ?? ""}
-                  onSave={(key) =>
-                    onPatch({
-                      songDetails: { key: key.trim() || undefined, bpm: item.songDetails?.bpm },
-                    })
-                  }
-                  placeholder={item.song?.defaultKey ?? "—"}
-                  maxLength={8}
-                  accessibilityLabel="Song key"
-                  style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
-                />
-                <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>BPM</Text>
-                <InlineText
-                  value={item.songDetails?.bpm ? String(item.songDetails.bpm) : ""}
-                  onSave={(bpm) =>
-                    onPatch({
-                      songDetails: {
-                        key: item.songDetails?.key,
-                        bpm: parseInt(bpm, 10) || undefined,
-                      },
-                    })
-                  }
-                  placeholder={item.song?.bpm ? String(item.song.bpm) : "—"}
-                  keyboardType="number-pad"
-                  maxLength={3}
-                  accessibilityLabel="Song BPM"
-                  style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
-                />
-              </View>
-            </>
-          ) : null}
-
-          <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Description</Text>
-          <InlineText
-            value={item.description ?? ""}
-            onSave={(d) => onPatch({ description: d })}
-            placeholder="Optional details for this moment"
-            multiline
-            accessibilityLabel="Item description"
-            style={[styles.descInput, { color: colors.text, borderColor: colors.border }]}
-          />
-
-          {roleOptions.length > 0 ? (
-            <>
-              <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Who's involved</Text>
-              <View style={styles.roleWrap}>
-                {roleOptions.map((r) => {
-                  const selected = linkedRoleIds.has(r.roleId as string);
-                  const swatch = r.roleColor ?? DEFAULT_ROLE_COLOR;
-                  return (
-                    <Pressable
-                      key={r.roleId}
-                      onPress={() => toggleRole(r.roleId as string)}
-                      style={styles.rolePressable}
-                    >
-                      <View
-                        style={[
-                          styles.roleChip,
-                          {
-                            backgroundColor: selected ? swatch + "22" : colors.surface,
-                            borderColor: selected ? swatch : colors.border,
-                          },
-                        ]}
-                      >
-                        <View style={[styles.roleSwatch, { backgroundColor: swatch }]} />
-                        <Text style={[styles.roleChipText, { color: colors.text }]} numberOfLines={1}>
-                          {r.roleName}
-                          {r.people.length > 0 ? `: ${r.people.join(", ")}` : ""}
-                        </Text>
-                        {selected ? (
-                          <Ionicons name="checkmark-circle" size={15} color={swatch} />
-                        ) : null}
-                      </View>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            </>
-          ) : null}
-
-          <NotesEditor
-            notes={item.notes}
-            onChange={(notes) => onPatch({ notes })}
-            colors={colors}
-          />
-        </View>
-      ) : null}
+                {r.roleName}
+                {r.people.length > 0 ? `: ${r.people.join(", ")}` : ""}
+              </Text>
+              {selected ? (
+                <Ionicons name="checkmark-circle" size={15} color={swatch} />
+              ) : null}
+            </View>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
+
+/**
+ * Notes editor body — the item's timing phase, free-text description, and the
+ * role-categorized cue notes. This is where the old expanded "Timing",
+ * "Description", and "Notes" fields now live.
+ */
+function NotesModalBody({
+  item,
+  onPatch,
+}: {
+  item: RunSheetItem;
+  onPatch: (patch: ItemPatch) => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.modalStack}>
+      {/* Timing phase — before / during / after the event (PCO's position). */}
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+        Timing
+      </Text>
+      <View style={styles.timingToggle}>
+        {SEGMENT_OPTIONS.map((seg) => {
+          const active = (item.segment as Segment) === seg.key;
+          return (
+            <Pressable
+              key={seg.key}
+              onPress={() => onPatch({ segment: seg.key })}
+              style={styles.timingPressable}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+            >
+              <View
+                style={[
+                  styles.timingChip,
+                  {
+                    borderColor: active ? colors.buttonPrimary : colors.border,
+                    backgroundColor: active
+                      ? colors.buttonPrimary + "1F"
+                      : "transparent",
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.timingChipText,
+                    { color: active ? colors.buttonPrimary : colors.textSecondary },
+                  ]}
+                >
+                  {seg.label}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+        Description
+      </Text>
+      <InlineText
+        value={item.description ?? ""}
+        onSave={(d) => onPatch({ description: d })}
+        placeholder="Optional details for this moment"
+        multiline
+        accessibilityLabel="Item description"
+        style={[styles.descInput, { color: colors.text, borderColor: colors.border }]}
+      />
+
+      <NotesEditor
+        notes={item.notes}
+        onChange={(notes) => onPatch({ notes })}
+        colors={colors}
+      />
+    </View>
+  );
+}
+
+/**
+ * Song editor body — links the row to a library song (ADR-027) and edits the
+ * per-service Key / BPM overrides. When a song is linked, Key/BPM show only the
+ * override (blank if none), placeholder is the song's default.
+ */
+function SongModalBody({
+  item,
+  communityId,
+  groupId,
+  onPatch,
+}: {
+  item: RunSheetItem;
+  communityId: string;
+  groupId: string;
+  onPatch: (patch: ItemPatch) => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.modalStack}>
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Song</Text>
+      <SongPicker
+        communityId={communityId}
+        groupId={groupId}
+        songId={item.songId}
+        song={item.song}
+        onSelect={(songId) => onPatch({ songId: songId as Id<"songs"> | null })}
+      />
+
+      <View style={styles.songRow}>
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Key</Text>
+        <InlineText
+          value={item.songDetails?.key ?? ""}
+          onSave={(key) =>
+            onPatch({
+              songDetails: { key: key.trim() || undefined, bpm: item.songDetails?.bpm },
+            })
+          }
+          placeholder={item.song?.defaultKey ?? "—"}
+          maxLength={8}
+          accessibilityLabel="Song key"
+          style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
+        />
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>BPM</Text>
+        <InlineText
+          value={item.songDetails?.bpm ? String(item.songDetails.bpm) : ""}
+          onSave={(bpm) =>
+            onPatch({
+              songDetails: {
+                key: item.songDetails?.key,
+                bpm: parseInt(bpm, 10) || undefined,
+              },
+            })
+          }
+          placeholder={item.song?.bpm ? String(item.song.bpm) : "—"}
+          keyboardType="number-pad"
+          maxLength={3}
+          accessibilityLabel="Song BPM"
+          style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
+        />
+      </View>
+    </View>
+  );
+}
+
+// RN-Web draws a browser focus ring on the underlying <input> that visually
+// bleeds past this tiny cell; suppress it so the input stays fully contained.
+const webNoOutline: TextStyle | undefined =
+  Platform.OS === "web"
+    ? ({ outlineStyle: "none" } as unknown as TextStyle)
+    : undefined;
 
 /** Inline m:ss duration cell. Parses "5", "5:30", or "330s"-style minute input. */
 function DurationCell({
@@ -891,7 +1096,11 @@ function DurationCell({
       keyboardType="numbers-and-punctuation"
       maxLength={6}
       accessibilityLabel="Duration (minutes:seconds)"
-      style={[styles.durationInput, { color: colors.text, borderColor: colors.border }]}
+      style={[
+        styles.durationInput,
+        { color: colors.text, borderColor: colors.border },
+        webNoOutline,
+      ]}
     />
   );
 }
@@ -972,18 +1181,11 @@ const styles = StyleSheet.create({
   centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
   errorText: { fontSize: 14 },
   scrollContent: { padding: 16 },
+  gridContent: { paddingBottom: 8 },
   planTitle: { fontSize: 22, fontWeight: "700" },
   planDate: { fontSize: 13, marginTop: 4 },
   ranges: { fontSize: 14, fontWeight: "600", marginTop: 8 },
   emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
-  segmentLabel: {
-    fontSize: 12,
-    fontWeight: "800",
-    letterSpacing: 0.8,
-    marginTop: 14,
-    marginBottom: 8,
-  },
-  list: { marginTop: 10 },
   addToRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -1009,27 +1211,11 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   timingChipText: { fontSize: 12, fontWeight: "600" },
-  row: {
-    borderRadius: 12,
-    padding: 10,
-    marginBottom: 8,
-    borderWidth: StyleSheet.hairlineWidth,
-  },
-  headerRow: {
-    borderWidth: 0,
-    paddingVertical: 4,
-    marginBottom: 4,
-    marginTop: 4,
-  },
-  rowTop: { flexDirection: "row", alignItems: "center", gap: 6 },
-  grip: { paddingHorizontal: 2, paddingVertical: 6, justifyContent: "center" },
-  timeCol: { width: 62 },
-  timeText: { fontSize: 13, fontWeight: "700" },
-  titleCol: { flex: 1 },
-  titleInput: { fontSize: 15, fontWeight: "600" },
+  titleInput: { fontSize: 15, fontWeight: "600", width: "100%" },
   headerTitleInput: { fontSize: 12, fontWeight: "800", letterSpacing: 0.5, textTransform: "uppercase" },
-  durationCol: { width: 56 },
   durationInput: {
+    width: 60,
+    alignSelf: "center",
     fontSize: 13,
     textAlign: "center",
     borderWidth: StyleSheet.hairlineWidth,
@@ -1037,21 +1223,7 @@ const styles = StyleSheet.create({
     paddingVertical: 3,
     paddingHorizontal: 4,
   },
-  actions: { flexDirection: "row", alignItems: "center" },
   actionBtn: { padding: 4 },
-  assignWrap: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginTop: 8, paddingLeft: 30 },
-  assignChip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 5,
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 999,
-    maxWidth: "100%",
-  },
-  assignSwatch: { width: 8, height: 8, borderRadius: 4 },
-  assignText: { fontSize: 12, fontWeight: "500", flexShrink: 1 },
-  expanded: { marginTop: 10, paddingLeft: 30, gap: 4 },
   fieldLabel: { fontSize: 11, fontWeight: "700", marginTop: 8, textTransform: "uppercase", letterSpacing: 0.4 },
   songRow: { flexDirection: "row", alignItems: "center", gap: 8 },
   songInput: {
@@ -1118,4 +1290,17 @@ const styles = StyleSheet.create({
     borderStyle: "dashed",
   },
   addText: { fontSize: 14, fontWeight: "600" },
+  // Grid cell content. The primitive draws the padded cell frame; these only
+  // style the content that sits inside it.
+  cellPressable: { flex: 1, justifyContent: "center" },
+  cellText: { fontSize: 13 },
+  muted: { fontSize: 13, fontWeight: "500" },
+  whoChips: { flexDirection: "row", alignItems: "center", gap: 4, flexWrap: "wrap" },
+  // Wraps an OptionTag that opens an anchored menu (self-aligned so it hugs its
+  // content and can be measured for the dropdown anchor).
+  tagPressable: { alignSelf: "flex-start", maxWidth: "100%" },
+  // "Time" — a quiet, contained read-only clock value ("9:00 AM").
+  timeText: { fontSize: 13, fontVariant: ["tabular-nums"] },
+  actionsRow: { flexDirection: "row", alignItems: "center", gap: 4 },
+  modalStack: { gap: 4 },
 });

--- a/apps/mobile/features/serving/components/HowToViewer.tsx
+++ b/apps/mobile/features/serving/components/HowToViewer.tsx
@@ -203,18 +203,22 @@ const TASK_ITEM_RE = /^\s*[-*]\s+\[([ xX])\]\s+(.*)$/;
 /** A parsed doc segment: either a run of plain markdown, or a checklist item. */
 type DocSegment =
   | { kind: "md"; text: string }
-  | { kind: "item"; index: number; label: string };
+  | { kind: "item"; key: string; label: string };
 
 /**
  * Split a How-To doc into ordered segments: contiguous non-checklist lines
  * become `md` blocks (rendered through the shared `Markdown`), and each
- * `- [ ] …` line becomes an `item` with a 0-based positional `index`.
+ * `- [ ] …` line becomes an `item` with a CONTENT-BASED `key`.
+ *
+ * The key is `${occurrence}:${normalized label}` — so a saved check follows its
+ * item when the doc is reordered, and only detaches if the item's text is
+ * edited. The occurrence prefix disambiguates two identical checklist lines.
  */
 function parseDoc(source: string): DocSegment[] {
   const lines = source.replace(/\r\n/g, "\n").split("\n");
   const segments: DocSegment[] = [];
   let buffer: string[] = [];
-  let itemIndex = 0;
+  const seen = new Map<string, number>();
 
   const flushBuffer = () => {
     if (buffer.length === 0) return;
@@ -227,11 +231,11 @@ function parseDoc(source: string): DocSegment[] {
     const match = line.match(TASK_ITEM_RE);
     if (match) {
       flushBuffer();
-      segments.push({
-        kind: "item",
-        index: itemIndex++,
-        label: match[2].trim(),
-      });
+      const label = match[2].trim();
+      const normalized = label.replace(/\s+/g, " ").toLowerCase();
+      const occ = seen.get(normalized) ?? 0;
+      seen.set(normalized, occ + 1);
+      segments.push({ kind: "item", key: `${occ}:${normalized}`, label });
     } else {
       buffer.push(line);
     }
@@ -247,9 +251,9 @@ function parseDoc(source: string): DocSegment[] {
  * literal `[x]`. Toggling updates optimistically, then the reactive query
  * confirms.
  *
- * NOTE (positional indices): a user's saved checks map to checklist items by
- * position in the document. If a leader later reorders or edits the doc's
- * checklist, previously-saved checks map by position (acceptable for now).
+ * NOTE (content keys): a user's saved checks map to checklist items by their
+ * text (see `parseDoc`). Reordering the doc keeps checks attached; editing an
+ * item's text detaches its check (it becomes a new item).
  */
 function InteractiveDoc({
   taskId,
@@ -268,7 +272,7 @@ function InteractiveDoc({
   const serverChecks = useAuthenticatedQuery(
     api.functions.scheduling.eventTasks.getHowToDocChecks,
     taskId ? { taskId: taskId as Id<"eventTasks"> } : "skip",
-  ) as number[] | undefined;
+  ) as string[] | undefined;
 
   const setCheck = useAuthenticatedMutation(
     api.functions.scheduling.eventTasks.setHowToDocCheck,
@@ -279,9 +283,9 @@ function InteractiveDoc({
     [serverChecks],
   );
 
-  // Pending optimistic overrides, keyed by itemIndex. An entry wins over the
+  // Pending optimistic overrides, keyed by item key. An entry wins over the
   // server value until the reactive query catches up (then it's reconciled).
-  const [pending, setPending] = useState<Record<number, boolean>>({});
+  const [pending, setPending] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     // Drop optimistic entries the server now agrees with.
@@ -289,9 +293,8 @@ function InteractiveDoc({
       let changed = false;
       const next = { ...prev };
       for (const key of Object.keys(next)) {
-        const i = Number(key);
-        if (checkedSet.has(i) === next[i]) {
-          delete next[i];
+        if (checkedSet.has(key) === next[key]) {
+          delete next[key];
           changed = true;
         }
       }
@@ -300,27 +303,26 @@ function InteractiveDoc({
   }, [checkedSet]);
 
   const isChecked = useCallback(
-    (index: number) =>
-      index in pending ? pending[index] : checkedSet.has(index),
+    (key: string) => (key in pending ? pending[key] : checkedSet.has(key)),
     [pending, checkedSet],
   );
 
   const onToggle = useCallback(
-    async (index: number) => {
+    async (key: string) => {
       if (!taskId) return;
-      const next = !isChecked(index);
-      setPending((prev) => ({ ...prev, [index]: next }));
+      const next = !isChecked(key);
+      setPending((prev) => ({ ...prev, [key]: next }));
       try {
         await setCheck({
           taskId: taskId as Id<"eventTasks">,
-          itemIndex: index,
+          itemKey: key,
           checked: next,
         });
       } catch {
         // Revert the optimistic flip on failure.
         setPending((prev) => {
           const revert = { ...prev };
-          delete revert[index];
+          delete revert[key];
           return revert;
         });
       }
@@ -337,12 +339,12 @@ function InteractiveDoc({
         if (segment.kind === "md") {
           return <Markdown key={`md-${i}`} source={segment.text} />;
         }
-        const checked = isChecked(segment.index);
+        const checked = isChecked(segment.key);
         return (
           <TouchableOpacity
-            key={`item-${segment.index}`}
+            key={`item-${segment.key}`}
             activeOpacity={0.6}
-            onPress={() => void onToggle(segment.index)}
+            onPress={() => void onToggle(segment.key)}
             style={styles.checkRow}
             accessibilityRole="checkbox"
             accessibilityState={{ checked }}

--- a/apps/mobile/features/serving/components/HowToViewer.tsx
+++ b/apps/mobile/features/serving/components/HowToViewer.tsx
@@ -1,0 +1,243 @@
+/**
+ * HowToViewer
+ *
+ * A read-only, full-screen viewer for a serving task's "How-To" guidance. Short
+ * `text` guidance is shown inline on the task row itself, so this viewer only
+ * ever presents the heavier kinds that don't belong inline:
+ *
+ *   - doc   → the Markdown How-To document, padded + scrollable.
+ *   - media → a full-bleed image (via `AppImage`), or — for a video path — a
+ *             centered "Play video" affordance that opens the resolved URL.
+ *   - link  → the URL plus an "Open link" button (opened via the OS).
+ *
+ * Presented as a slide-up `Modal` (matching `EventTasksHowToDocEditor`). The
+ * header carries the task title and a close button. Nothing here mutates state.
+ */
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  ScrollView,
+  TouchableOpacity,
+  Pressable,
+  Linking,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { Markdown } from "@components/ui/Markdown";
+import { AppImage } from "@components/ui/AppImage";
+import { getMediaUrl } from "@/utils/media";
+
+/** How-to guidance kind (mirrors the backend `howToType` validator). */
+export type HowToType = "none" | "text" | "link" | "media" | "doc";
+
+/** The how-to fields the viewer renders (a subset of a serving task). */
+export type HowToViewerContent = {
+  title: string;
+  howToType: HowToType;
+  howToUrl?: string | null;
+  howToMediaPath?: string | null;
+  howToDoc?: string | null;
+};
+
+/** Extensions we treat as video when deciding how to present a media path. */
+const VIDEO_EXT_RE = /\.(mp4|mov|m4v|webm|qt)(\?|$)/i;
+
+export function HowToViewer({
+  visible,
+  content,
+  onClose,
+}: {
+  visible: boolean;
+  content: HowToViewerContent | null;
+  onClose: () => void;
+}) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.background },
+        ]}
+      >
+        <View style={[styles.header, { borderBottomColor: colors.border }]}>
+          <TouchableOpacity onPress={onClose} hitSlop={12} style={styles.headerBtn}>
+            <Ionicons name="close" size={26} color={colors.text} />
+          </TouchableOpacity>
+          <Text
+            style={[styles.headerTitle, { color: colors.text }]}
+            numberOfLines={1}
+          >
+            {content?.title || "How-To"}
+          </Text>
+          {/* Spacer to keep the title optically centered against the close btn. */}
+          <View style={styles.headerBtn} />
+        </View>
+
+        <ScrollView
+          style={styles.body}
+          contentContainerStyle={[
+            styles.bodyContent,
+            { paddingBottom: insets.bottom + 32 },
+          ]}
+        >
+          {content ? (
+            <HowToBody
+              content={content}
+              colors={colors}
+              primaryColor={primaryColor}
+            />
+          ) : null}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+type ThemeColors = ReturnType<typeof useTheme>["colors"];
+
+function HowToBody({
+  content,
+  colors,
+  primaryColor,
+}: {
+  content: HowToViewerContent;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  switch (content.howToType) {
+    case "doc":
+      return content.howToDoc && content.howToDoc.trim().length > 0 ? (
+        <Markdown source={content.howToDoc} />
+      ) : (
+        <EmptyState colors={colors} label="No details yet." />
+      );
+
+    case "link": {
+      const url = content.howToUrl?.trim();
+      if (!url) return <EmptyState colors={colors} label="No link." />;
+      return (
+        <View style={styles.linkWrap}>
+          <Text style={[styles.linkUrl, { color: colors.textSecondary }]}>
+            {url}
+          </Text>
+          <Pressable
+            onPress={() => void Linking.openURL(url).catch(() => {})}
+            style={[styles.primaryButton, { backgroundColor: primaryColor }]}
+            accessibilityRole="button"
+            accessibilityLabel="Open link"
+          >
+            <Ionicons name="open-outline" size={18} color="#fff" />
+            <Text style={styles.primaryButtonText}>Open link</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    case "media": {
+      const path = content.howToMediaPath?.trim();
+      if (!path) return <EmptyState colors={colors} label="No attachment." />;
+      if (VIDEO_EXT_RE.test(path)) {
+        return (
+          <Pressable
+            onPress={() => {
+              const url = getMediaUrl(path);
+              if (url) void Linking.openURL(url).catch(() => {});
+            }}
+            style={[styles.videoTile, { borderColor: colors.border }]}
+            accessibilityRole="button"
+            accessibilityLabel="Play video"
+          >
+            <View
+              style={[styles.playCircle, { backgroundColor: primaryColor }]}
+            >
+              <Ionicons name="play" size={26} color="#fff" />
+            </View>
+            <Text style={[styles.videoLabel, { color: colors.textSecondary }]}>
+              Play video
+            </Text>
+          </Pressable>
+        );
+      }
+      return (
+        <AppImage
+          source={path}
+          style={styles.image}
+          resizeMode="contain"
+        />
+      );
+    }
+
+    default:
+      return <EmptyState colors={colors} label="No details." />;
+  }
+}
+
+function EmptyState({
+  colors,
+  label,
+}: {
+  colors: ThemeColors;
+  label: string;
+}) {
+  return (
+    <Text style={[styles.empty, { color: colors.textTertiary }]}>{label}</Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBtn: { minWidth: 52, paddingHorizontal: 8, alignItems: "center" },
+  headerTitle: { flex: 1, fontSize: 17, fontWeight: "600", textAlign: "center" },
+  body: { flex: 1 },
+  bodyContent: { padding: 20 },
+  empty: { fontSize: 15, fontStyle: "italic" },
+  // Link
+  linkWrap: { gap: 16 },
+  linkUrl: { fontSize: 15, lineHeight: 22 },
+  primaryButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    alignSelf: "flex-start",
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  primaryButtonText: { color: "#fff", fontSize: 15, fontWeight: "700" },
+  // Media
+  image: { width: "100%", height: 360, borderRadius: 12 },
+  videoTile: {
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 14,
+    paddingVertical: 48,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  playCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingLeft: 4,
+  },
+  videoLabel: { fontSize: 15, fontWeight: "600" },
+});

--- a/apps/mobile/features/serving/components/HowToViewer.tsx
+++ b/apps/mobile/features/serving/components/HowToViewer.tsx
@@ -13,7 +13,7 @@
  * Presented as a slide-up `Modal` (matching `EventTasksHowToDocEditor`). The
  * header carries the task title and a close button. Nothing here mutates state.
  */
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -31,12 +31,20 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { Markdown } from "@components/ui/Markdown";
 import { AppImage } from "@components/ui/AppImage";
 import { getMediaUrl } from "@/utils/media";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
 
 /** How-to guidance kind (mirrors the backend `howToType` validator). */
 export type HowToType = "none" | "text" | "link" | "media" | "doc";
 
 /** The how-to fields the viewer renders (a subset of a serving task). */
 export type HowToViewerContent = {
+  /** The `eventTasks` id — keys the per-user checklist state for a `doc`. */
+  taskId: string;
   title: string;
   howToType: HowToType;
   howToUrl?: string | null;
@@ -116,7 +124,12 @@ function HowToBody({
   switch (content.howToType) {
     case "doc":
       return content.howToDoc && content.howToDoc.trim().length > 0 ? (
-        <Markdown source={content.howToDoc} />
+        <InteractiveDoc
+          taskId={content.taskId}
+          source={content.howToDoc}
+          colors={colors}
+          primaryColor={primaryColor}
+        />
       ) : (
         <EmptyState colors={colors} label="No details yet." />
       );
@@ -181,6 +194,182 @@ function HowToBody({
   }
 }
 
+/**
+ * A markdown task-list line, e.g. `- [ ] Step 1` or `* [x] Done`.
+ * Capture 1 is the box state (` `, `x`, or `X`); capture 2 is the label text.
+ */
+const TASK_ITEM_RE = /^\s*[-*]\s+\[([ xX])\]\s+(.*)$/;
+
+/** A parsed doc segment: either a run of plain markdown, or a checklist item. */
+type DocSegment =
+  | { kind: "md"; text: string }
+  | { kind: "item"; index: number; label: string };
+
+/**
+ * Split a How-To doc into ordered segments: contiguous non-checklist lines
+ * become `md` blocks (rendered through the shared `Markdown`), and each
+ * `- [ ] …` line becomes an `item` with a 0-based positional `index`.
+ */
+function parseDoc(source: string): DocSegment[] {
+  const lines = source.replace(/\r\n/g, "\n").split("\n");
+  const segments: DocSegment[] = [];
+  let buffer: string[] = [];
+  let itemIndex = 0;
+
+  const flushBuffer = () => {
+    if (buffer.length === 0) return;
+    const text = buffer.join("\n");
+    if (text.trim().length > 0) segments.push({ kind: "md", text });
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    const match = line.match(TASK_ITEM_RE);
+    if (match) {
+      flushBuffer();
+      segments.push({
+        kind: "item",
+        index: itemIndex++,
+        label: match[2].trim(),
+      });
+    } else {
+      buffer.push(line);
+    }
+  }
+  flushBuffer();
+  return segments;
+}
+
+/**
+ * Renders a `doc` How-To as an interactive checklist. Non-checklist prose is
+ * rendered via the shared `Markdown`; each `- [ ]` line is a tappable row whose
+ * checked state is per-user (from `getHowToDocChecks`) and OVERRIDES the doc's
+ * literal `[x]`. Toggling updates optimistically, then the reactive query
+ * confirms.
+ *
+ * NOTE (positional indices): a user's saved checks map to checklist items by
+ * position in the document. If a leader later reorders or edits the doc's
+ * checklist, previously-saved checks map by position (acceptable for now).
+ */
+function InteractiveDoc({
+  taskId,
+  source,
+  colors,
+  primaryColor,
+}: {
+  taskId: string;
+  source: string;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  const segments = useMemo(() => parseDoc(source), [source]);
+  const hasItems = segments.some((s) => s.kind === "item");
+
+  const serverChecks = useAuthenticatedQuery(
+    api.functions.scheduling.eventTasks.getHowToDocChecks,
+    taskId ? { taskId: taskId as Id<"eventTasks"> } : "skip",
+  ) as number[] | undefined;
+
+  const setCheck = useAuthenticatedMutation(
+    api.functions.scheduling.eventTasks.setHowToDocCheck,
+  );
+
+  const checkedSet = useMemo(
+    () => new Set(serverChecks ?? []),
+    [serverChecks],
+  );
+
+  // Pending optimistic overrides, keyed by itemIndex. An entry wins over the
+  // server value until the reactive query catches up (then it's reconciled).
+  const [pending, setPending] = useState<Record<number, boolean>>({});
+
+  useEffect(() => {
+    // Drop optimistic entries the server now agrees with.
+    setPending((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const key of Object.keys(next)) {
+        const i = Number(key);
+        if (checkedSet.has(i) === next[i]) {
+          delete next[i];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [checkedSet]);
+
+  const isChecked = useCallback(
+    (index: number) =>
+      index in pending ? pending[index] : checkedSet.has(index),
+    [pending, checkedSet],
+  );
+
+  const onToggle = useCallback(
+    async (index: number) => {
+      if (!taskId) return;
+      const next = !isChecked(index);
+      setPending((prev) => ({ ...prev, [index]: next }));
+      try {
+        await setCheck({
+          taskId: taskId as Id<"eventTasks">,
+          itemIndex: index,
+          checked: next,
+        });
+      } catch {
+        // Revert the optimistic flip on failure.
+        setPending((prev) => {
+          const revert = { ...prev };
+          delete revert[index];
+          return revert;
+        });
+      }
+    },
+    [taskId, isChecked, setCheck],
+  );
+
+  // No checklist items → nothing interactive to do; render the doc as-is.
+  if (!hasItems) return <Markdown source={source} />;
+
+  return (
+    <View>
+      {segments.map((segment, i) => {
+        if (segment.kind === "md") {
+          return <Markdown key={`md-${i}`} source={segment.text} />;
+        }
+        const checked = isChecked(segment.index);
+        return (
+          <TouchableOpacity
+            key={`item-${segment.index}`}
+            activeOpacity={0.6}
+            onPress={() => void onToggle(segment.index)}
+            style={styles.checkRow}
+            accessibilityRole="checkbox"
+            accessibilityState={{ checked }}
+            accessibilityLabel={segment.label}
+          >
+            <View
+              style={[
+                styles.checkbox,
+                checked
+                  ? { backgroundColor: primaryColor, borderColor: primaryColor }
+                  : { borderColor: colors.border },
+              ]}
+            >
+              {checked ? (
+                <Ionicons name="checkmark" size={16} color="#fff" />
+              ) : null}
+            </View>
+            <Text style={[styles.checkLabel, { color: colors.text }]}>
+              {segment.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
 function EmptyState({
   colors,
   label,
@@ -207,6 +396,23 @@ const styles = StyleSheet.create({
   body: { flex: 1 },
   bodyContent: { padding: 20 },
   empty: { fontSize: 15, fontStyle: "italic" },
+  // Interactive checklist
+  checkRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingVertical: 12,
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderRadius: 6,
+    borderWidth: 1.5,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 1,
+  },
+  checkLabel: { flex: 1, fontSize: 16, lineHeight: 24 },
   // Link
   linkWrap: { gap: 16 },
   linkUrl: { fontSize: 15, lineHeight: 22 },

--- a/apps/mobile/features/serving/components/ServingExitScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingExitScreen.tsx
@@ -23,8 +23,17 @@ export function ServingExitScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      exit();
+      // Navigate off the Exit tab to Inbox — a tab visible in BOTH serving and
+      // normal mode — before dropping serving mode. Flipping the store while
+      // still focused on the Exit tab (which then becomes `href: null`) leaves
+      // the Tabs navigator focused on a now-hidden route and the tab bar stuck
+      // in the serving layout. Deferring the store update to the next tick lets
+      // the navigation commit first, so the store-driven re-render of the tab
+      // bar re-evaluates every href with Inbox already focused and cleanly
+      // restores the normal tab bar.
       router.replace("/(tabs)/chat");
+      const t = setTimeout(() => exit(), 0);
+      return () => clearTimeout(t);
     }, [exit, router]),
   );
 

--- a/apps/mobile/features/serving/components/ServingExitScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingExitScreen.tsx
@@ -31,9 +31,14 @@ export function ServingExitScreen() {
       // the navigation commit first, so the store-driven re-render of the tab
       // bar re-evaluates every href with Inbox already focused and cleanly
       // restores the normal tab bar.
+      // Navigate to Inbox first, then drop serving mode on the next frame so the
+      // tab bar re-renders to normal. Note: no cleanup that clears this — an
+      // earlier version cancelled the exit when `router.replace` blurred the
+      // screen, so serving mode never actually exited. (The Exit tab now also
+      // handles this via a tabPress listener; this stays as a direct-nav
+      // fallback.)
       router.replace("/(tabs)/chat");
-      const t = setTimeout(() => exit(), 0);
-      return () => clearTimeout(t);
+      requestAnimationFrame(() => exit());
     }, [exit, router]),
   );
 

--- a/apps/mobile/features/serving/components/ServingRunsheetScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingRunsheetScreen.tsx
@@ -6,8 +6,10 @@
  * the exact order-of-service their leaders authored in Rostering. It's strictly
  * read-only here (`canEdit={false}`) — editing lives in Rostering.
  *
- * The owning group id comes from `getServingEligibility().activePlan`; the
- * active plan itself is tracked in `useEventModeStore`.
+ * The active plan is tracked in `useEventModeStore.activePlanId`; the owning
+ * group id is resolved directly from that plan via `getEvent`, independent of
+ * the serving-eligibility window (so previewing an event outside the ~12h
+ * window still shows its run sheet).
  */
 import React from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
@@ -26,22 +28,21 @@ export function ServingRunsheetScreen() {
   const isServingMode = useEventModeStore((s) => s.isServingMode);
   const activePlanId = useEventModeStore((s) => s.activePlanId);
 
-  // The owning group id isn't stored client-side; resolve it from serving
-  // eligibility. Prefer the plan the user has switched to (activePlanId), so the
-  // run sheet follows the ServingPlanSwitcher; fall back to the soonest plan.
-  const eligibility = useAuthenticatedQuery(
-    api.functions.scheduling.serving.getServingEligibility,
-    isServingMode ? {} : "skip",
+  // Resolve the owning group directly from the active plan — NOT from the
+  // serving-eligibility window, which only surfaces plans within ~12h of the
+  // event. The volunteer is a confirmed group member, so `getEvent` passes
+  // `requireGroupMember` and returns the plan's `groupId` regardless of window.
+  const event = useAuthenticatedQuery(
+    api.functions.scheduling.events.getEvent,
+    isServingMode && activePlanId
+      ? { planId: activePlanId as Id<"eventPlans"> }
+      : "skip",
   ) as
-    | {
-        activePlan: { groupId: string } | null;
-        plans: { planId: string; groupId: string }[];
-      }
+    | { groupId: string; items: unknown[] }
     | null
     | undefined;
 
-  const groupId = (eligibility?.plans?.find((p) => p.planId === activePlanId)
-    ?.groupId ?? eligibility?.activePlan?.groupId) as Id<"groups"> | undefined;
+  const groupId = event?.groupId as Id<"groups"> | undefined;
 
   if (!isServingMode) {
     return (
@@ -53,7 +54,8 @@ export function ServingRunsheetScreen() {
     );
   }
 
-  if (eligibility === undefined) {
+  // Still loading the plan (only while we actually have a plan to load).
+  if (activePlanId && event === undefined) {
     return (
       <View style={[styles.centered, { backgroundColor: colors.background }]}>
         <ActivityIndicator size="small" color={colors.text} />
@@ -61,7 +63,10 @@ export function ServingRunsheetScreen() {
     );
   }
 
-  if (!groupId) {
+  // Genuinely nothing to show: no active plan, the plan was deleted, or it has
+  // no run sheet items — as opposed to merely being outside the serving window.
+  const hasItems = !!event && event.items.length > 0;
+  if (!groupId || !hasItems) {
     return (
       <View style={[styles.centered, { backgroundColor: colors.background }]}>
         <Ionicons name="list-outline" size={28} color={colors.textTertiary} />

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -12,8 +12,10 @@
  *   - Personal (ad-hoc) tasks the user added — toggled via `togglePersonalTask`,
  *     and editable / deletable. These carry an "added by you" marker.
  *
- * Tapping a task expands its detail: the "How-To" guidance, rendered from
- * `howToDoc` (markdown) / `howToText` / `howToUrl` / media per `howToType`.
+ * How-To guidance: short `text` guidance renders inline (quiet secondary text);
+ * heavier kinds (`link` / `media` / `doc`) show a compact "How-To →" chip that
+ * opens the full-screen read-only `HowToViewer`. Personal tasks show their note
+ * inline and expand (on tap) to Edit / Delete affordances.
  *
  * A "＋ Add task" affordance opens a small inline form (title + optional note +
  * segment; a time label when adding under During) that calls `addPersonalTask`.
@@ -27,7 +29,6 @@ import {
   Pressable,
   TextInput,
   ActivityIndicator,
-  Linking,
   Alert,
   Platform,
 } from "react-native";
@@ -38,11 +39,9 @@ import type { Id } from "@services/api/convex";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { ProgressBar } from "@components/ui/ProgressBar";
-import { Markdown } from "@components/ui/Markdown";
-import { AppImage } from "@components/ui/AppImage";
-import { getMediaUrl } from "@/utils/media";
 import { useEventModeStore } from "@/stores/eventModeStore";
 import { ServingPlanSwitcher } from "./ServingPlanSwitcher";
+import { HowToViewer, type HowToViewerContent } from "./HowToViewer";
 
 type Segment = "before" | "during" | "after";
 
@@ -107,6 +106,14 @@ export function ServingTasksScreen() {
     planId ? { planId } : "skip",
   ) as MyServingTasks | undefined;
 
+  // Header context (event title + when). Reuses the already-cheap serving
+  // eligibility query — no extra fetch specific to this screen.
+  const eligibility = useAuthenticatedQuery(
+    api.functions.scheduling.serving.getServingEligibility,
+    planId ? {} : "skip",
+  ) as { plans: Array<{ planId: string; title: string; startsAt: number }> } | null | undefined;
+  const activePlan = eligibility?.plans.find((p) => p.planId === planId) ?? null;
+
   const toggleTaskCompletion = useAuthenticatedMutation(
     api.functions.scheduling.eventTasks.toggleTaskCompletion,
   );
@@ -128,6 +135,8 @@ export function ServingTasksScreen() {
   const [addingSegment, setAddingSegment] = useState<Segment | null>(null);
   // The personal task currently being edited (null = none).
   const [editingId, setEditingId] = useState<string | null>(null);
+  // The how-to guidance currently open in the full-screen viewer (null = none).
+  const [viewerContent, setViewerContent] = useState<HowToViewerContent | null>(null);
 
   const toggle = useCallback(
     async (task: ServingTask) => {
@@ -176,121 +185,237 @@ export function ServingTasksScreen() {
     );
   }
 
+  // Overall readiness across every segment.
+  const allTasks = tasks
+    ? [...tasks.before, ...tasks.during, ...tasks.after]
+    : [];
+  const overallDone = allTasks.filter((t) => t.completed).length;
+  const overallTotal = allTasks.length;
+
   return (
-    <ScrollView
-      style={[styles.container, { backgroundColor: colors.background }]}
-      contentContainerStyle={{
-        paddingTop: insets.top + 12,
-        paddingBottom: insets.bottom + 32,
-      }}
-    >
-      <ServingPlanSwitcher />
-      <Text style={[styles.screenTitle, { color: colors.text }]}>My tasks</Text>
+    <>
+      <ScrollView
+        style={[styles.container, { backgroundColor: colors.background }]}
+        contentContainerStyle={{
+          paddingTop: insets.top + 12,
+          paddingBottom: insets.bottom + 40,
+        }}
+      >
+        <ServingPlanSwitcher />
 
-      {tasks === undefined ? (
-        <View style={styles.inlineLoading}>
-          <ActivityIndicator size="small" color={colors.text} />
-        </View>
-      ) : (
-        SEGMENTS.map(({ key, label }) => {
-        const segmentTasks = tasks[key] ?? [];
-        const done = segmentTasks.filter((t) => t.completed).length;
-        const total = segmentTasks.length;
-        const progress = total > 0 ? done / total : 0;
+        <ServingHeader
+          title={activePlan?.title ?? "My tasks"}
+          startsAt={activePlan?.startsAt}
+          done={overallDone}
+          total={overallTotal}
+          loading={tasks === undefined}
+          colors={colors}
+          primaryColor={primaryColor}
+        />
 
-        return (
-          <View key={key} style={styles.segment}>
-            <View style={styles.segmentHeader}>
-              <Text style={[styles.segmentTitle, { color: colors.text }]}>
-                {label}
-              </Text>
-              <Text
-                style={[styles.segmentCount, { color: colors.textSecondary }]}
-              >
-                {done}/{total}
-              </Text>
-            </View>
-            <ProgressBar progress={progress} color={primaryColor} />
-
-            <View style={styles.taskList}>
-              {segmentTasks.map((task) => (
-                <TaskRow
-                  key={task.key}
-                  task={task}
-                  colors={colors}
-                  primaryColor={primaryColor}
-                  expanded={expandedId === task.key}
-                  editing={editingId === task.key}
-                  onToggle={() => toggle(task)}
-                  onPress={() =>
-                    setExpandedId((cur) =>
-                      cur === task.key ? null : task.key,
-                    )
-                  }
-                  onEdit={() => setEditingId(task.key)}
-                  onCancelEdit={() => setEditingId(null)}
-                  onSaveEdit={async (patch) => {
-                    try {
-                      await updatePersonalTask({
-                        taskId: task.taskId as Id<"personalServingTasks">,
-                        ...patch,
-                      });
-                      setEditingId(null);
-                    } catch (err) {
-                      notify(
-                        "Couldn't save task",
-                        String((err as Error)?.message ?? err),
-                      );
-                    }
-                  }}
-                  onDelete={() => remove(task.taskId)}
-                />
-              ))}
-            </View>
-
-            {addingSegment === key ? (
-              <AddTaskForm
-                segment={key}
-                colors={colors}
-                primaryColor={primaryColor}
-                onCancel={() => setAddingSegment(null)}
-                onSubmit={async ({ title, note, timeLabel }) => {
-                  if (!planId) return;
-                  try {
-                    await addPersonalTask({
-                      planId,
-                      segment: key,
-                      title,
-                      note: note || undefined,
-                      timeLabel: timeLabel || undefined,
-                    });
-                    setAddingSegment(null);
-                  } catch (err) {
-                    notify(
-                      "Couldn't add task",
-                      String((err as Error)?.message ?? err),
-                    );
-                  }
-                }}
-              />
-            ) : (
-              <Pressable
-                onPress={() => setAddingSegment(key)}
-                style={styles.addButton}
-                accessibilityRole="button"
-                accessibilityLabel={`Add a ${label} task`}
-              >
-                <Ionicons name="add" size={18} color={primaryColor} />
-                <Text style={[styles.addButtonText, { color: primaryColor }]}>
-                  Add task
-                </Text>
-              </Pressable>
-            )}
+        {tasks === undefined ? (
+          <View style={styles.inlineLoading}>
+            <ActivityIndicator size="small" color={colors.text} />
           </View>
-        );
-        })
-      )}
-    </ScrollView>
+        ) : (
+          SEGMENTS.map(({ key, label }) => {
+            const segmentTasks = tasks[key] ?? [];
+            const done = segmentTasks.filter((t) => t.completed).length;
+            const total = segmentTasks.length;
+            const progress = total > 0 ? done / total : 0;
+
+            return (
+              <View key={key} style={styles.segment}>
+                <View style={styles.segmentHeader}>
+                  <Text style={[styles.segmentTitle, { color: colors.textSecondary }]}>
+                    {label.toUpperCase()}
+                  </Text>
+                  <Text
+                    style={[styles.segmentCount, { color: colors.textTertiary }]}
+                  >
+                    {done}/{total}
+                  </Text>
+                </View>
+                <ProgressBar
+                  progress={progress}
+                  color={primaryColor}
+                  height={4}
+                />
+
+                <View
+                  style={[
+                    styles.card,
+                    { backgroundColor: colors.surface, borderColor: colors.border },
+                  ]}
+                >
+                  {segmentTasks.length === 0 ? (
+                    <Text
+                      style={[styles.cardEmpty, { color: colors.textTertiary }]}
+                    >
+                      Nothing here yet.
+                    </Text>
+                  ) : (
+                    segmentTasks.map((task, i) => (
+                      <TaskRow
+                        key={task.key}
+                        task={task}
+                        first={i === 0}
+                        colors={colors}
+                        primaryColor={primaryColor}
+                        expanded={expandedId === task.key}
+                        editing={editingId === task.key}
+                        onToggle={() => toggle(task)}
+                        onOpenHowTo={() =>
+                          setViewerContent({
+                            title: task.title,
+                            howToType: task.howToType ?? "none",
+                            howToUrl: task.howToUrl,
+                            howToMediaPath: task.howToMediaPath,
+                            howToDoc: task.howToDoc,
+                          })
+                        }
+                        onToggleExpand={() =>
+                          setExpandedId((cur) =>
+                            cur === task.key ? null : task.key,
+                          )
+                        }
+                        onEdit={() => setEditingId(task.key)}
+                        onCancelEdit={() => setEditingId(null)}
+                        onSaveEdit={async (patch) => {
+                          try {
+                            await updatePersonalTask({
+                              taskId: task.taskId as Id<"personalServingTasks">,
+                              ...patch,
+                            });
+                            setEditingId(null);
+                          } catch (err) {
+                            notify(
+                              "Couldn't save task",
+                              String((err as Error)?.message ?? err),
+                            );
+                          }
+                        }}
+                        onDelete={() => remove(task.taskId)}
+                      />
+                    ))
+                  )}
+                </View>
+
+                {addingSegment === key ? (
+                  <AddTaskForm
+                    segment={key}
+                    colors={colors}
+                    primaryColor={primaryColor}
+                    onCancel={() => setAddingSegment(null)}
+                    onSubmit={async ({ title, note, timeLabel }) => {
+                      if (!planId) return;
+                      try {
+                        await addPersonalTask({
+                          planId,
+                          segment: key,
+                          title,
+                          note: note || undefined,
+                          timeLabel: timeLabel || undefined,
+                        });
+                        setAddingSegment(null);
+                      } catch (err) {
+                        notify(
+                          "Couldn't add task",
+                          String((err as Error)?.message ?? err),
+                        );
+                      }
+                    }}
+                  />
+                ) : (
+                  <Pressable
+                    onPress={() => setAddingSegment(key)}
+                    style={styles.addButton}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Add a ${label} task`}
+                  >
+                    <Ionicons name="add" size={17} color={primaryColor} />
+                    <Text style={[styles.addButtonText, { color: primaryColor }]}>
+                      Add my own task
+                    </Text>
+                  </Pressable>
+                )}
+              </View>
+            );
+          })
+        )}
+      </ScrollView>
+
+      <HowToViewer
+        visible={viewerContent !== null}
+        content={viewerContent}
+        onClose={() => setViewerContent(null)}
+      />
+    </>
+  );
+}
+
+// ============================================================================
+// Header
+// ============================================================================
+
+/** Format a plan start timestamp as e.g. "Sun, Jul 6 · 9:00 AM". */
+function formatWhen(startsAt: number): string {
+  const d = new Date(startsAt);
+  const day = d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const time = d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${day} · ${time}`;
+}
+
+function ServingHeader({
+  title,
+  startsAt,
+  done,
+  total,
+  loading,
+  colors,
+  primaryColor,
+}: {
+  title: string;
+  startsAt?: number;
+  done: number;
+  total: number;
+  loading: boolean;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  const allDone = total > 0 && done === total;
+  return (
+    <View style={styles.header}>
+      <Text style={[styles.headerTitle, { color: colors.text }]} numberOfLines={2}>
+        {title}
+      </Text>
+      {startsAt ? (
+        <Text style={[styles.headerWhen, { color: colors.textSecondary }]}>
+          {formatWhen(startsAt)}
+        </Text>
+      ) : null}
+
+      {!loading && total > 0 ? (
+        <View style={styles.readiness}>
+          <View style={styles.readinessLabelRow}>
+            <Text style={[styles.readinessLabel, { color: colors.textSecondary }]}>
+              {allDone ? "You're all set" : "Your readiness"}
+            </Text>
+            <Text style={[styles.readinessCount, { color: colors.text }]}>
+              {done} of {total}
+            </Text>
+          </View>
+          <ProgressBar progress={done / total} color={primaryColor} height={8} />
+        </View>
+      ) : null}
+    </View>
   );
 }
 
@@ -302,26 +427,40 @@ type ThemeColors = ReturnType<typeof useTheme>["colors"];
 
 interface TaskRowProps {
   task: ServingTask;
+  first: boolean;
   colors: ThemeColors;
   primaryColor: string;
   expanded: boolean;
   editing: boolean;
   onToggle: () => void;
-  onPress: () => void;
+  onOpenHowTo: () => void;
+  onToggleExpand: () => void;
   onEdit: () => void;
   onCancelEdit: () => void;
   onSaveEdit: (patch: { title?: string; note?: string }) => void;
   onDelete: () => void;
 }
 
+/** How-to kinds that open the full-screen viewer rather than rendering inline. */
+const VIEWER_HOW_TO_ICONS: Record<
+  "link" | "media" | "doc",
+  keyof typeof Ionicons.glyphMap
+> = {
+  link: "link-outline",
+  media: "image-outline",
+  doc: "document-text-outline",
+};
+
 function TaskRow({
   task,
+  first,
   colors,
   primaryColor,
   expanded,
   editing,
   onToggle,
-  onPress,
+  onOpenHowTo,
+  onToggleExpand,
   onEdit,
   onCancelEdit,
   onSaveEdit,
@@ -330,24 +469,54 @@ function TaskRow({
   const [editTitle, setEditTitle] = useState(task.title);
   const [editNote, setEditNote] = useState(task.note ?? "");
 
+  const howToType = task.howToType ?? "none";
+  // Short text guidance renders inline; personal notes render inline too.
+  const inlineText = task.isPersonal
+    ? task.note
+    : howToType === "text"
+      ? task.howToText
+      : null;
+  // link / media / doc open the viewer via a compact affordance.
+  const viewerType =
+    !task.isPersonal && (howToType === "link" || howToType === "media" || howToType === "doc")
+      ? howToType
+      : null;
+
   return (
-    <View style={[styles.taskRow, { borderColor: colors.border }]}>
+    <View
+      style={[
+        styles.taskRow,
+        !first && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
+      ]}
+    >
       <View style={styles.taskRowMain}>
         <Pressable
           onPress={onToggle}
-          hitSlop={8}
+          hitSlop={10}
           accessibilityRole="checkbox"
           accessibilityState={{ checked: task.completed }}
           accessibilityLabel={task.title}
+          style={styles.checkboxPress}
         >
-          <Ionicons
-            name={task.completed ? "checkbox" : "square-outline"}
-            size={24}
-            color={task.completed ? primaryColor : colors.textTertiary}
-          />
+          <View
+            style={[
+              styles.checkbox,
+              task.completed
+                ? { backgroundColor: primaryColor, borderColor: primaryColor }
+                : { borderColor: colors.textTertiary },
+            ]}
+          >
+            {task.completed ? (
+              <Ionicons name="checkmark" size={15} color="#fff" />
+            ) : null}
+          </View>
         </Pressable>
 
-        <Pressable style={styles.taskTitleWrap} onPress={onPress}>
+        <Pressable
+          style={styles.taskBody}
+          onPress={task.isPersonal ? onToggleExpand : undefined}
+          disabled={!task.isPersonal}
+        >
           <Text
             style={[
               styles.taskTitle,
@@ -357,6 +526,7 @@ function TaskRow({
           >
             {task.title}
           </Text>
+
           <View style={styles.taskMetaRow}>
             {task.timeLabel ? (
               <Text style={[styles.taskMeta, { color: colors.textSecondary }]}>
@@ -369,12 +539,45 @@ function TaskRow({
               </Text>
             ) : null}
           </View>
+
+          {inlineText ? (
+            <Text
+              style={[
+                styles.inlineHowTo,
+                { color: colors.textSecondary },
+                task.completed && styles.inlineHowToDone,
+              ]}
+              numberOfLines={2}
+            >
+              {inlineText}
+            </Text>
+          ) : null}
+
+          {viewerType ? (
+            <Pressable
+              onPress={onOpenHowTo}
+              hitSlop={6}
+              style={[styles.howToChip, { borderColor: colors.border }]}
+              accessibilityRole="button"
+              accessibilityLabel={`Open how-to for ${task.title}`}
+            >
+              <Ionicons
+                name={VIEWER_HOW_TO_ICONS[viewerType]}
+                size={13}
+                color={primaryColor}
+              />
+              <Text style={[styles.howToChipText, { color: primaryColor }]}>
+                How-To
+              </Text>
+              <Ionicons name="arrow-forward" size={13} color={primaryColor} />
+            </Pressable>
+          ) : null}
         </Pressable>
       </View>
 
-      {expanded ? (
+      {expanded && task.isPersonal ? (
         <View style={styles.taskDetail}>
-          {editing && task.isPersonal ? (
+          {editing ? (
             <View style={styles.editForm}>
               <TextInput
                 value={editTitle}
@@ -418,109 +621,19 @@ function TaskRow({
               </View>
             </View>
           ) : (
-            <>
-              <HowTo task={task} colors={colors} primaryColor={primaryColor} />
-              {task.isPersonal ? (
-                <View style={styles.personalActions}>
-                  <Pressable onPress={onEdit} style={styles.textButton}>
-                    <Text style={{ color: primaryColor }}>Edit</Text>
-                  </Pressable>
-                  <Pressable onPress={onDelete} style={styles.textButton}>
-                    <Text style={{ color: colors.error ?? "#c00" }}>Delete</Text>
-                  </Pressable>
-                </View>
-              ) : null}
-            </>
+            <View style={styles.personalActions}>
+              <Pressable onPress={onEdit} style={styles.textButton}>
+                <Text style={{ color: primaryColor }}>Edit</Text>
+              </Pressable>
+              <Pressable onPress={onDelete} style={styles.textButton}>
+                <Text style={{ color: colors.error ?? "#c00" }}>Delete</Text>
+              </Pressable>
+            </View>
           )}
         </View>
       ) : null}
     </View>
   );
-}
-
-// ============================================================================
-// How-To detail
-// ============================================================================
-
-function HowTo({
-  task,
-  colors,
-  primaryColor,
-}: {
-  task: ServingTask;
-  colors: ThemeColors;
-  primaryColor: string;
-}) {
-  const howToType = task.howToType ?? "none";
-
-  if (task.isPersonal) {
-    return task.note ? (
-      <Text style={[styles.howToText, { color: colors.textSecondary }]}>
-        {task.note}
-      </Text>
-    ) : (
-      <Text style={[styles.howToEmpty, { color: colors.textTertiary }]}>
-        No note.
-      </Text>
-    );
-  }
-
-  switch (howToType) {
-    case "doc":
-      return task.howToDoc ? (
-        <View style={styles.markdownWrap}>
-          <Markdown source={task.howToDoc} />
-        </View>
-      ) : (
-        <Text style={[styles.howToEmpty, { color: colors.textTertiary }]}>
-          No details.
-        </Text>
-      );
-    case "text":
-      return (
-        <Text style={[styles.howToText, { color: colors.textSecondary }]}>
-          {task.howToText ?? ""}
-        </Text>
-      );
-    case "link":
-      return task.howToUrl ? (
-        <Pressable onPress={() => Linking.openURL(task.howToUrl as string)}>
-          <Text style={[styles.howToLink, { color: primaryColor }]}>
-            {task.howToUrl}
-          </Text>
-        </Pressable>
-      ) : (
-        <Text style={[styles.howToEmpty, { color: colors.textTertiary }]}>
-          No link.
-        </Text>
-      );
-    case "media":
-      return task.howToMediaPath ? (
-        <Pressable
-          onPress={() => {
-            const url = getMediaUrl(task.howToMediaPath as string);
-            if (url) Linking.openURL(url);
-          }}
-        >
-          <AppImage
-            source={task.howToMediaPath}
-            style={styles.howToMedia}
-            resizeMode="cover"
-          />
-        </Pressable>
-      ) : (
-        <Text style={[styles.howToEmpty, { color: colors.textTertiary }]}>
-          No attachment.
-        </Text>
-      );
-    case "none":
-    default:
-      return (
-        <Text style={[styles.howToEmpty, { color: colors.textTertiary }]}>
-          No details.
-        </Text>
-      );
-  }
 }
 
 // ============================================================================
@@ -626,12 +739,21 @@ const styles = StyleSheet.create({
   },
   emptyText: { fontSize: 15, textAlign: "center" },
   inlineLoading: { paddingVertical: 48, alignItems: "center" },
-  screenTitle: {
-    fontSize: 28,
-    fontWeight: "700",
-    paddingHorizontal: 16,
-    marginBottom: 12,
+
+  // Header
+  header: { paddingHorizontal: 16, marginBottom: 20 },
+  headerTitle: { fontSize: 26, fontWeight: "700", letterSpacing: -0.4 },
+  headerWhen: { fontSize: 14, marginTop: 4 },
+  readiness: { marginTop: 16, gap: 8 },
+  readinessLabelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
+  readinessLabel: { fontSize: 13, fontWeight: "500" },
+  readinessCount: { fontSize: 13, fontWeight: "700" },
+
+  // Segments
   segment: { paddingHorizontal: 16, marginBottom: 24 },
   segmentHeader: {
     flexDirection: "row",
@@ -639,39 +761,62 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 6,
   },
-  segmentTitle: { fontSize: 17, fontWeight: "600" },
-  segmentCount: { fontSize: 13 },
-  taskList: { marginTop: 8 },
-  taskRow: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    paddingVertical: 10,
+  segmentTitle: { fontSize: 12, fontWeight: "700", letterSpacing: 0.8 },
+  segmentCount: { fontSize: 12, fontWeight: "600" },
+  card: {
+    marginTop: 10,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: "hidden",
   },
+  cardEmpty: { fontSize: 14, fontStyle: "italic", padding: 16 },
+
+  // Task rows
+  taskRow: { paddingHorizontal: 14, paddingVertical: 12 },
   taskRowMain: { flexDirection: "row", alignItems: "flex-start", gap: 12 },
-  taskTitleWrap: { flex: 1 },
-  taskTitle: { fontSize: 15, lineHeight: 20 },
-  taskTitleDone: { textDecorationLine: "line-through", opacity: 0.6 },
-  taskMetaRow: { flexDirection: "row", gap: 8, marginTop: 2 },
+  checkboxPress: { paddingTop: 1 },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 7,
+    borderWidth: 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  taskBody: { flex: 1 },
+  taskTitle: { fontSize: 15, lineHeight: 20, fontWeight: "500" },
+  taskTitleDone: { textDecorationLine: "line-through", opacity: 0.5 },
+  taskMetaRow: { flexDirection: "row", gap: 8, marginTop: 3 },
   taskMeta: { fontSize: 12 },
-  taskDetail: { paddingLeft: 36, paddingTop: 8 },
-  howToText: { fontSize: 14, lineHeight: 20 },
-  howToLink: { fontSize: 14, textDecorationLine: "underline" },
-  howToMedia: { width: "100%", height: 180, borderRadius: 8, marginTop: 2 },
-  howToEmpty: { fontSize: 13, fontStyle: "italic" },
-  markdownWrap: { marginTop: 2 },
-  personalActions: { flexDirection: "row", gap: 16, marginTop: 10 },
+  inlineHowTo: { fontSize: 13, lineHeight: 18, marginTop: 6 },
+  inlineHowToDone: { opacity: 0.5 },
+  howToChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    gap: 5,
+    marginTop: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  howToChipText: { fontSize: 12, fontWeight: "600" },
+  taskDetail: { paddingLeft: 34, paddingTop: 10 },
+  personalActions: { flexDirection: "row", gap: 16 },
   addButton: {
     flexDirection: "row",
     alignItems: "center",
     gap: 4,
     paddingVertical: 10,
-    marginTop: 4,
+    marginTop: 6,
   },
-  addButtonText: { fontSize: 15, fontWeight: "500" },
+  addButtonText: { fontSize: 14, fontWeight: "600" },
   addForm: {
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 10,
     padding: 12,
-    marginTop: 8,
+    marginTop: 10,
     gap: 8,
   },
   editForm: { gap: 8 },

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -20,7 +20,7 @@
  * A "＋ Add task" affordance opens a small inline form (title + optional note +
  * segment; a time label when adding under During) that calls `addPersonalTask`.
  */
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   View,
   Text,
@@ -86,6 +86,80 @@ type MyServingTasks = {
   after: ServingTask[];
 };
 
+// ----------------------------------------------------------------------------
+// Section switcher
+// ----------------------------------------------------------------------------
+
+/** The four views of the serving Tasks page. */
+type Section = "mine" | "shared" | "crew" | "allTeams";
+
+const SECTIONS: Array<{ key: Section; label: string }> = [
+  { key: "mine", label: "Mine" },
+  { key: "shared", label: "Shared" },
+  { key: "crew", label: "Crew" },
+  { key: "allTeams", label: "All teams" },
+];
+
+/** A whole-team task (from `getSharedTeamTasks`). Completion is team-wide. */
+type SharedTask = {
+  taskId: string;
+  teamId: string;
+  teamName: string;
+  title: string;
+  segment: Segment;
+  howToType: HowToType;
+  howToText?: string | null;
+  howToUrl?: string | null;
+  howToMediaPath?: string | null;
+  howToDoc?: string | null;
+  completed: boolean;
+  completedByName?: string | null;
+  completedAt?: number | null;
+};
+
+/** A single teammate task in the crew view (read-only; content not fetched). */
+type CrewTask = {
+  taskId: string;
+  title: string;
+  segment: Segment;
+  completed: boolean;
+  howToType: HowToType;
+};
+
+/** One entry per member+role from `getCrewTasks` (current user first). */
+type CrewMember = {
+  userId: string;
+  name: string;
+  roleId: string;
+  roleName: string;
+  teamId: string;
+  teamName: string;
+  isCurrentUser: boolean;
+  done: number;
+  total: number;
+  tasks: CrewTask[];
+};
+
+/** A single task in the all-teams overview (read-only). */
+type TeamTask = {
+  taskId: string;
+  title: string;
+  segment: Segment;
+  roleName: string | null;
+  completed: boolean;
+  howToType: HowToType;
+};
+
+/** One row per team from `getAllTeamsTasks` (plan-wide readiness). */
+type AllTeamsTeam = {
+  teamId: string;
+  teamName: string;
+  taskCount: number;
+  done: number;
+  total: number;
+  tasks: TeamTask[];
+};
+
 /** Show a one-button error (Alert.alert is a no-op on web in this codebase). */
 function notify(title: string, message: string) {
   if (Platform.OS === "web") {
@@ -115,6 +189,25 @@ export function ServingTasksScreen() {
   ) as { plans: Array<{ planId: string; title: string; startsAt: number }> } | null | undefined;
   const activePlan = eligibility?.plans.find((p) => p.planId === planId) ?? null;
 
+  // The other three sections. Fetched alongside Mine so the pill badges can
+  // show live counts; only the active section's content is rendered.
+  const sharedTasks = useAuthenticatedQuery(
+    api.functions.scheduling.eventTasks.getSharedTeamTasks,
+    planId ? { planId } : "skip",
+  ) as SharedTask[] | undefined;
+  const crewMembers = useAuthenticatedQuery(
+    api.functions.scheduling.eventTasks.getCrewTasks,
+    planId ? { planId } : "skip",
+  ) as CrewMember[] | undefined;
+  const allTeams = useAuthenticatedQuery(
+    api.functions.scheduling.eventTasks.getAllTeamsTasks,
+    planId ? { planId } : "skip",
+  ) as AllTeamsTeam[] | undefined;
+
+  const toggleSharedTeamTask = useAuthenticatedMutation(
+    api.functions.scheduling.eventTasks.toggleSharedTeamTask,
+  );
+
   const toggleTaskCompletion = useAuthenticatedMutation(
     api.functions.scheduling.eventTasks.toggleTaskCompletion,
   );
@@ -138,6 +231,78 @@ export function ServingTasksScreen() {
   const [editingId, setEditingId] = useState<string | null>(null);
   // The how-to guidance currently open in the full-screen viewer (null = none).
   const [viewerContent, setViewerContent] = useState<HowToViewerContent | null>(null);
+
+  // Which section is showing. Persisted in component state.
+  const [section, setSection] = useState<Section>("mine");
+  // Expanded rows in the read-only Crew / All-teams sections.
+  const [expandedCrewId, setExpandedCrewId] = useState<string | null>(null);
+  const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
+
+  // Optimistic overrides for shared (team-wide) task completion, keyed by
+  // taskId. Cleared once the reactive query catches up to the toggled value.
+  const [sharedOptimistic, setSharedOptimistic] = useState<
+    Record<string, boolean>
+  >({});
+
+  useEffect(() => {
+    if (!sharedTasks) return;
+    setSharedOptimistic((prev) => {
+      if (Object.keys(prev).length === 0) return prev;
+      let changed = false;
+      const next = { ...prev };
+      for (const t of sharedTasks) {
+        if (t.taskId in next && next[t.taskId] === t.completed) {
+          delete next[t.taskId];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [sharedTasks]);
+
+  const toggleShared = useCallback(
+    async (taskId: string, next: boolean) => {
+      if (!planId) return;
+      setSharedOptimistic((o) => ({ ...o, [taskId]: next }));
+      try {
+        await toggleSharedTeamTask({
+          planId,
+          taskId: taskId as Id<"eventTasks">,
+          completed: next,
+        });
+      } catch (err) {
+        // Revert the optimistic value on failure.
+        setSharedOptimistic((o) => {
+          const copy = { ...o };
+          delete copy[taskId];
+          return copy;
+        });
+        notify("Couldn't update task", String((err as Error)?.message ?? err));
+      }
+    },
+    [planId, toggleSharedTeamTask],
+  );
+
+  const openHowTo = useCallback(
+    (t: {
+      taskId: string;
+      title: string;
+      howToType?: HowToType;
+      howToUrl?: string | null;
+      howToMediaPath?: string | null;
+      howToDoc?: string | null;
+    }) => {
+      setViewerContent({
+        taskId: t.taskId,
+        title: t.title,
+        howToType: t.howToType ?? "none",
+        howToUrl: t.howToUrl,
+        howToMediaPath: t.howToMediaPath,
+        howToDoc: t.howToDoc,
+      });
+    },
+    [],
+  );
 
   const toggle = useCallback(
     async (task: ServingTask) => {
@@ -193,6 +358,14 @@ export function ServingTasksScreen() {
   const overallDone = allTasks.filter((t) => t.completed).length;
   const overallTotal = allTasks.length;
 
+  // Small badges on the section pills (null hides the badge).
+  const sectionCounts: Record<Section, string | null> = {
+    mine: overallTotal > 0 ? `${overallDone}/${overallTotal}` : null,
+    shared: sharedTasks && sharedTasks.length > 0 ? String(sharedTasks.length) : null,
+    crew: crewMembers && crewMembers.length > 0 ? String(crewMembers.length) : null,
+    allTeams: allTeams && allTeams.length > 0 ? String(allTeams.length) : null,
+  };
+
   return (
     <>
       <ScrollView
@@ -214,12 +387,21 @@ export function ServingTasksScreen() {
           primaryColor={primaryColor}
         />
 
-        {tasks === undefined ? (
-          <View style={styles.inlineLoading}>
-            <ActivityIndicator size="small" color={colors.text} />
-          </View>
-        ) : (
-          SEGMENTS.map(({ key, label }) => {
+        <SectionPills
+          section={section}
+          counts={sectionCounts}
+          onChange={setSection}
+          colors={colors}
+          primaryColor={primaryColor}
+        />
+
+        {section === "mine" &&
+          (tasks === undefined ? (
+            <View style={styles.inlineLoading}>
+              <ActivityIndicator size="small" color={colors.text} />
+            </View>
+          ) : (
+            SEGMENTS.map(({ key, label }) => {
             const segmentTasks = tasks[key] ?? [];
             const done = segmentTasks.filter((t) => t.completed).length;
             const total = segmentTasks.length;
@@ -341,9 +523,44 @@ export function ServingTasksScreen() {
                     </Text>
                   </Pressable>
                 )}
-              </View>
-            );
-          })
+                </View>
+              );
+            })
+          ))}
+
+        {section === "shared" && (
+          <SharedSection
+            tasks={sharedTasks}
+            optimistic={sharedOptimistic}
+            colors={colors}
+            primaryColor={primaryColor}
+            onToggle={toggleShared}
+            onOpenHowTo={openHowTo}
+          />
+        )}
+
+        {section === "crew" && (
+          <CrewSection
+            members={crewMembers}
+            expandedId={expandedCrewId}
+            onToggleExpand={(id) =>
+              setExpandedCrewId((cur) => (cur === id ? null : id))
+            }
+            colors={colors}
+            primaryColor={primaryColor}
+          />
+        )}
+
+        {section === "allTeams" && (
+          <AllTeamsSection
+            teams={allTeams}
+            expandedId={expandedTeamId}
+            onToggleExpand={(id) =>
+              setExpandedTeamId((cur) => (cur === id ? null : id))
+            }
+            colors={colors}
+            primaryColor={primaryColor}
+          />
         )}
       </ScrollView>
 
@@ -741,6 +958,699 @@ function AddTaskForm({
   );
 }
 
+// ============================================================================
+// Section pills (Mine · Shared · Crew · All teams)
+// ============================================================================
+
+function SectionPills({
+  section,
+  counts,
+  onChange,
+  colors,
+  primaryColor,
+}: {
+  section: Section;
+  counts: Record<Section, string | null>;
+  onChange: (s: Section) => void;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={styles.pillsScroll}
+      contentContainerStyle={styles.pillsRow}
+    >
+      {SECTIONS.map(({ key, label }) => {
+        const active = key === section;
+        const count = counts[key];
+        return (
+          <Pressable
+            key={key}
+            onPress={() => onChange(key)}
+            accessibilityRole="button"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={label}
+            style={[
+              styles.pill,
+              active
+                ? { backgroundColor: primaryColor, borderColor: primaryColor }
+                : { backgroundColor: colors.surface, borderColor: colors.border },
+            ]}
+          >
+            <Text
+              style={[
+                styles.pillText,
+                { color: active ? "#fff" : colors.textSecondary },
+              ]}
+            >
+              {label}
+            </Text>
+            {count != null ? (
+              <View
+                style={[
+                  styles.pillBadge,
+                  {
+                    backgroundColor: active
+                      ? "rgba(255,255,255,0.25)"
+                      : colors.background,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.pillBadgeText,
+                    { color: active ? "#fff" : colors.textTertiary },
+                  ]}
+                >
+                  {count}
+                </Text>
+              </View>
+            ) : null}
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+// ============================================================================
+// Shared (team-wide) tasks
+// ============================================================================
+
+function SharedSection({
+  tasks,
+  optimistic,
+  colors,
+  primaryColor,
+  onToggle,
+  onOpenHowTo,
+}: {
+  tasks: SharedTask[] | undefined;
+  optimistic: Record<string, boolean>;
+  colors: ThemeColors;
+  primaryColor: string;
+  onToggle: (taskId: string, next: boolean) => void;
+  onOpenHowTo: (t: SharedTask) => void;
+}) {
+  if (tasks === undefined) return <SectionLoading colors={colors} />;
+  if (tasks.length === 0) {
+    return (
+      <SectionEmpty
+        icon="people-outline"
+        title="No shared tasks"
+        subtitle="Whole-team tasks show up here."
+        colors={colors}
+      />
+    );
+  }
+
+  const stateOf = (t: SharedTask) => optimistic[t.taskId] ?? t.completed;
+
+  return (
+    <View style={styles.sectionBody}>
+      {SEGMENTS.map(({ key, label }) => {
+        const segTasks = tasks.filter((t) => t.segment === key);
+        if (segTasks.length === 0) return null;
+        const done = segTasks.filter(stateOf).length;
+        const total = segTasks.length;
+        return (
+          <View key={key} style={styles.segment}>
+            <View style={styles.segmentHeader}>
+              <Text style={[styles.segmentTitle, { color: colors.textSecondary }]}>
+                {label.toUpperCase()}
+              </Text>
+              <Text style={[styles.segmentCount, { color: colors.textTertiary }]}>
+                {done}/{total}
+              </Text>
+            </View>
+            <ProgressBar
+              progress={total > 0 ? done / total : 0}
+              color={primaryColor}
+              height={4}
+            />
+            <View
+              style={[
+                styles.card,
+                { backgroundColor: colors.surface, borderColor: colors.border },
+              ]}
+            >
+              {segTasks.map((task, i) => (
+                <SharedTaskRow
+                  key={task.taskId}
+                  task={task}
+                  completed={stateOf(task)}
+                  first={i === 0}
+                  colors={colors}
+                  primaryColor={primaryColor}
+                  onToggle={() => onToggle(task.taskId, !stateOf(task))}
+                  onOpenHowTo={() => onOpenHowTo(task)}
+                />
+              ))}
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function SharedTaskRow({
+  task,
+  completed,
+  first,
+  colors,
+  primaryColor,
+  onToggle,
+  onOpenHowTo,
+}: {
+  task: SharedTask;
+  completed: boolean;
+  first: boolean;
+  colors: ThemeColors;
+  primaryColor: string;
+  onToggle: () => void;
+  onOpenHowTo: () => void;
+}) {
+  const howToType = task.howToType;
+  const inlineText = howToType === "text" ? task.howToText : null;
+  const viewerType =
+    howToType === "link" || howToType === "media" || howToType === "doc"
+      ? howToType
+      : null;
+
+  return (
+    <View
+      style={[
+        styles.taskRow,
+        !first && {
+          borderTopWidth: StyleSheet.hairlineWidth,
+          borderTopColor: colors.border,
+        },
+      ]}
+    >
+      <View style={styles.taskRowMain}>
+        <Pressable
+          onPress={onToggle}
+          hitSlop={10}
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: completed }}
+          accessibilityLabel={task.title}
+          style={styles.checkboxPress}
+        >
+          <View
+            style={[
+              styles.checkbox,
+              completed
+                ? { backgroundColor: primaryColor, borderColor: primaryColor }
+                : { borderColor: colors.textTertiary },
+            ]}
+          >
+            {completed ? (
+              <Ionicons name="checkmark" size={15} color="#fff" />
+            ) : null}
+          </View>
+        </Pressable>
+
+        <View style={styles.taskBody}>
+          <Text
+            style={[
+              styles.taskTitle,
+              { color: colors.text },
+              completed && styles.taskTitleDone,
+            ]}
+          >
+            {task.title}
+          </Text>
+
+          <View style={styles.taskMetaRow}>
+            <View style={styles.teamCue}>
+              <Ionicons name="people" size={12} color={colors.textTertiary} />
+              <Text style={[styles.taskMeta, { color: colors.textTertiary }]}>
+                Team task
+              </Text>
+            </View>
+            {completed && task.completedByName ? (
+              <Text style={[styles.taskMeta, { color: colors.textTertiary }]}>
+                · Done by {task.completedByName}
+              </Text>
+            ) : null}
+          </View>
+
+          {inlineText ? (
+            <Text
+              style={[
+                styles.inlineHowTo,
+                { color: colors.textSecondary },
+                completed && styles.inlineHowToDone,
+              ]}
+              numberOfLines={2}
+            >
+              {inlineText}
+            </Text>
+          ) : null}
+        </View>
+
+        {viewerType ? (
+          <Pressable
+            onPress={() => {
+              if (howToType === "link" && task.howToUrl) {
+                void Linking.openURL(task.howToUrl).catch(() => {});
+              } else {
+                onOpenHowTo();
+              }
+            }}
+            hitSlop={6}
+            style={[styles.howToChip, { borderColor: colors.border }]}
+            accessibilityRole="button"
+            accessibilityLabel={
+              howToType === "link"
+                ? `Open link for ${task.title}`
+                : `Open how-to for ${task.title}`
+            }
+          >
+            <Ionicons
+              name={VIEWER_HOW_TO_ICONS[viewerType]}
+              size={13}
+              color={primaryColor}
+            />
+            <Text style={[styles.howToChipText, { color: primaryColor }]}>
+              How-To
+            </Text>
+            <Ionicons
+              name={howToType === "link" ? "open-outline" : "arrow-forward"}
+              size={13}
+              color={primaryColor}
+            />
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+// ============================================================================
+// Crew (read-only: who's doing what)
+// ============================================================================
+
+function CrewSection({
+  members,
+  expandedId,
+  onToggleExpand,
+  colors,
+  primaryColor,
+}: {
+  members: CrewMember[] | undefined;
+  expandedId: string | null;
+  onToggleExpand: (id: string) => void;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  if (members === undefined) return <SectionLoading colors={colors} />;
+  if (members.length === 0) {
+    return (
+      <SectionEmpty
+        icon="people-outline"
+        title="No crew yet"
+        subtitle="Teammates serving this event will appear here."
+        colors={colors}
+      />
+    );
+  }
+
+  // Group by team, preserving the query's ordering (current user first).
+  const groups: Array<{ teamId: string; teamName: string; members: CrewMember[] }> = [];
+  for (const m of members) {
+    let g = groups.find((x) => x.teamId === m.teamId);
+    if (!g) {
+      g = { teamId: m.teamId, teamName: m.teamName, members: [] };
+      groups.push(g);
+    }
+    g.members.push(m);
+  }
+  const showTeamHeaders = groups.length > 1;
+
+  return (
+    <View style={styles.sectionBody}>
+      {groups.map((g) => (
+        <View key={g.teamId} style={styles.crewGroup}>
+          {showTeamHeaders ? (
+            <Text style={[styles.groupHeader, { color: colors.textSecondary }]}>
+              {g.teamName.toUpperCase()}
+            </Text>
+          ) : null}
+          <View
+            style={[
+              styles.card,
+              { backgroundColor: colors.surface, borderColor: colors.border },
+            ]}
+          >
+            {g.members.map((m, i) => {
+              const rowKey = `${m.userId}:${m.roleId}`;
+              return (
+                <CrewMemberRow
+                  key={rowKey}
+                  member={m}
+                  first={i === 0}
+                  expanded={expandedId === rowKey}
+                  onToggle={() => onToggleExpand(rowKey)}
+                  colors={colors}
+                  primaryColor={primaryColor}
+                />
+              );
+            })}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function CrewMemberRow({
+  member,
+  first,
+  expanded,
+  onToggle,
+  colors,
+  primaryColor,
+}: {
+  member: CrewMember;
+  first: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  const progress = member.total > 0 ? member.done / member.total : 0;
+  const allDone = member.total > 0 && member.done === member.total;
+
+  return (
+    <View
+      style={[
+        styles.expandRow,
+        !first && {
+          borderTopWidth: StyleSheet.hairlineWidth,
+          borderTopColor: colors.border,
+        },
+      ]}
+    >
+      <Pressable
+        onPress={onToggle}
+        style={styles.expandHeader}
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        accessibilityLabel={`${member.name}, ${member.roleName}`}
+      >
+        <View style={styles.expandInfo}>
+          <View style={styles.expandTitleRow}>
+            <Text style={[styles.expandTitle, { color: colors.text }]} numberOfLines={1}>
+              {member.name}
+            </Text>
+            {member.isCurrentUser ? (
+              <View style={[styles.youChip, { backgroundColor: primaryColor }]}>
+                <Text style={styles.youChipText}>You</Text>
+              </View>
+            ) : null}
+          </View>
+          <Text style={[styles.expandSub, { color: colors.textTertiary }]} numberOfLines={1}>
+            {member.roleName}
+          </Text>
+        </View>
+        <View style={styles.expandRight}>
+          <Text
+            style={[
+              styles.expandCount,
+              { color: allDone ? primaryColor : colors.textSecondary },
+            ]}
+          >
+            {member.done}/{member.total}
+          </Text>
+          <Ionicons
+            name={expanded ? "chevron-up" : "chevron-down"}
+            size={16}
+            color={colors.textTertiary}
+          />
+        </View>
+      </Pressable>
+
+      <View style={styles.expandProgress}>
+        <ProgressBar progress={progress} color={primaryColor} height={3} />
+      </View>
+
+      {expanded ? (
+        <View style={styles.readonlyList}>
+          {member.tasks.length === 0 ? (
+            <Text style={[styles.readonlyEmpty, { color: colors.textTertiary }]}>
+              No tasks assigned.
+            </Text>
+          ) : (
+            member.tasks.map((t) => (
+              <ReadOnlyTaskItem
+                key={t.taskId}
+                title={t.title}
+                completed={t.completed}
+                howToType={t.howToType}
+                colors={colors}
+                primaryColor={primaryColor}
+              />
+            ))
+          )}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+// ============================================================================
+// All teams (read-only: whole-event overview)
+// ============================================================================
+
+function AllTeamsSection({
+  teams,
+  expandedId,
+  onToggleExpand,
+  colors,
+  primaryColor,
+}: {
+  teams: AllTeamsTeam[] | undefined;
+  expandedId: string | null;
+  onToggleExpand: (id: string) => void;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  if (teams === undefined) return <SectionLoading colors={colors} />;
+  if (teams.length === 0) {
+    return (
+      <SectionEmpty
+        icon="grid-outline"
+        title="No teams"
+        subtitle="Teams serving this event will appear here."
+        colors={colors}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.sectionBody}>
+      <View
+        style={[
+          styles.card,
+          { backgroundColor: colors.surface, borderColor: colors.border },
+        ]}
+      >
+        {teams.map((team, i) => (
+          <TeamRow
+            key={team.teamId}
+            team={team}
+            first={i === 0}
+            expanded={expandedId === team.teamId}
+            onToggle={() => onToggleExpand(team.teamId)}
+            colors={colors}
+            primaryColor={primaryColor}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function TeamRow({
+  team,
+  first,
+  expanded,
+  onToggle,
+  colors,
+  primaryColor,
+}: {
+  team: AllTeamsTeam;
+  first: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  const progress = team.total > 0 ? team.done / team.total : 0;
+  const allDone = team.total > 0 && team.done === team.total;
+
+  return (
+    <View
+      style={[
+        styles.expandRow,
+        !first && {
+          borderTopWidth: StyleSheet.hairlineWidth,
+          borderTopColor: colors.border,
+        },
+      ]}
+    >
+      <Pressable
+        onPress={onToggle}
+        style={styles.expandHeader}
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        accessibilityLabel={team.teamName}
+      >
+        <View style={styles.expandInfo}>
+          <Text style={[styles.expandTitle, { color: colors.text }]} numberOfLines={1}>
+            {team.teamName}
+          </Text>
+        </View>
+        <View style={styles.expandRight}>
+          <Text
+            style={[
+              styles.expandCount,
+              { color: allDone ? primaryColor : colors.textSecondary },
+            ]}
+          >
+            {team.done}/{team.total}
+          </Text>
+          <Ionicons
+            name={expanded ? "chevron-up" : "chevron-down"}
+            size={16}
+            color={colors.textTertiary}
+          />
+        </View>
+      </Pressable>
+
+      <View style={styles.expandProgress}>
+        <ProgressBar progress={progress} color={primaryColor} height={3} />
+      </View>
+
+      {expanded ? (
+        <View style={styles.readonlyList}>
+          {team.tasks.length === 0 ? (
+            <Text style={[styles.readonlyEmpty, { color: colors.textTertiary }]}>
+              No tasks yet.
+            </Text>
+          ) : (
+            team.tasks.map((t) => (
+              <ReadOnlyTaskItem
+                key={t.taskId}
+                title={t.title}
+                meta={t.roleName ?? undefined}
+                completed={t.completed}
+                howToType={t.howToType}
+                colors={colors}
+                primaryColor={primaryColor}
+              />
+            ))
+          )}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+// ============================================================================
+// Shared bits for the read-only sections
+// ============================================================================
+
+/** A non-interactive task line: done indicator, title, optional meta + quiet
+ *  how-to hint. Used by both Crew and All-teams. */
+function ReadOnlyTaskItem({
+  title,
+  meta,
+  completed,
+  howToType,
+  colors,
+  primaryColor,
+}: {
+  title: string;
+  meta?: string;
+  completed: boolean;
+  howToType: HowToType;
+  colors: ThemeColors;
+  primaryColor: string;
+}) {
+  return (
+    <View style={styles.roItem}>
+      <Ionicons
+        name={completed ? "checkmark-circle" : "ellipse-outline"}
+        size={18}
+        color={completed ? primaryColor : colors.textTertiary}
+      />
+      <View style={styles.roItemBody}>
+        <Text
+          style={[
+            styles.roItemTitle,
+            { color: colors.text },
+            completed && styles.taskTitleDone,
+          ]}
+          numberOfLines={2}
+        >
+          {title}
+        </Text>
+        {meta ? (
+          <Text style={[styles.roItemMeta, { color: colors.textTertiary }]} numberOfLines={1}>
+            {meta}
+          </Text>
+        ) : null}
+      </View>
+      {howToType !== "none" ? (
+        <Ionicons
+          name="help-circle-outline"
+          size={16}
+          color={colors.textTertiary}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+function SectionLoading({ colors }: { colors: ThemeColors }) {
+  return (
+    <View style={styles.inlineLoading}>
+      <ActivityIndicator size="small" color={colors.text} />
+    </View>
+  );
+}
+
+function SectionEmpty({
+  icon,
+  title,
+  subtitle,
+  colors,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  title: string;
+  subtitle?: string;
+  colors: ThemeColors;
+}) {
+  return (
+    <View style={styles.sectionEmpty}>
+      <Ionicons name={icon} size={30} color={colors.textTertiary} />
+      <Text style={[styles.sectionEmptyTitle, { color: colors.textSecondary }]}>
+        {title}
+      </Text>
+      {subtitle ? (
+        <Text style={[styles.sectionEmptySub, { color: colors.textTertiary }]}>
+          {subtitle}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   container: { flex: 1 },
   centered: {
@@ -847,4 +1757,80 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   textButton: { paddingVertical: 6, paddingHorizontal: 4 },
+
+  // Section pills
+  pillsScroll: { marginBottom: 20 },
+  pillsRow: { paddingHorizontal: 16, gap: 8 },
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  pillText: { fontSize: 14, fontWeight: "600" },
+  pillBadge: {
+    minWidth: 18,
+    paddingHorizontal: 5,
+    height: 18,
+    borderRadius: 9,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pillBadgeText: { fontSize: 11, fontWeight: "700" },
+
+  // Shared / read-only section wrappers
+  sectionBody: {},
+  teamCue: { flexDirection: "row", alignItems: "center", gap: 4 },
+
+  // Crew grouping
+  crewGroup: { paddingHorizontal: 16, marginBottom: 20 },
+  groupHeader: {
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.8,
+    marginBottom: 8,
+  },
+
+  // Expandable rows (crew members + teams)
+  expandRow: { paddingHorizontal: 14, paddingTop: 12, paddingBottom: 10 },
+  expandHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  expandInfo: { flex: 1 },
+  expandTitleRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  expandTitle: { fontSize: 15, fontWeight: "600", flexShrink: 1 },
+  expandSub: { fontSize: 13, marginTop: 2 },
+  expandRight: { flexDirection: "row", alignItems: "center", gap: 6 },
+  expandCount: { fontSize: 13, fontWeight: "700" },
+  expandProgress: { marginTop: 10 },
+  youChip: {
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    borderRadius: 999,
+  },
+  youChipText: { fontSize: 10, fontWeight: "700", color: "#fff", letterSpacing: 0.3 },
+
+  // Read-only task lists (inside expanded crew/team rows)
+  readonlyList: { marginTop: 12, gap: 10 },
+  readonlyEmpty: { fontSize: 13, fontStyle: "italic" },
+  roItem: { flexDirection: "row", alignItems: "flex-start", gap: 10 },
+  roItemBody: { flex: 1 },
+  roItemTitle: { fontSize: 14, lineHeight: 19, fontWeight: "500" },
+  roItemMeta: { fontSize: 12, marginTop: 2 },
+
+  // Per-section empty state
+  sectionEmpty: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    paddingVertical: 56,
+    gap: 8,
+  },
+  sectionEmptyTitle: { fontSize: 16, fontWeight: "600" },
+  sectionEmptySub: { fontSize: 14, textAlign: "center", lineHeight: 19 },
 });

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -31,6 +31,7 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
+  Linking,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -267,6 +268,7 @@ export function ServingTasksScreen() {
                         onToggle={() => toggle(task)}
                         onOpenHowTo={() =>
                           setViewerContent({
+                            taskId: task.taskId,
                             title: task.title,
                             howToType: task.howToType ?? "none",
                             howToUrl: task.howToUrl,
@@ -527,18 +529,13 @@ function TaskRow({
             {task.title}
           </Text>
 
-          <View style={styles.taskMetaRow}>
-            {task.timeLabel ? (
-              <Text style={[styles.taskMeta, { color: colors.textSecondary }]}>
-                {task.timeLabel}
-              </Text>
-            ) : null}
-            {task.isPersonal ? (
+          {task.isPersonal ? (
+            <View style={styles.taskMetaRow}>
               <Text style={[styles.taskMeta, { color: colors.textTertiary }]}>
                 Added by you
               </Text>
-            ) : null}
-          </View>
+            </View>
+          ) : null}
 
           {inlineText ? (
             <Text
@@ -552,27 +549,43 @@ function TaskRow({
               {inlineText}
             </Text>
           ) : null}
-
-          {viewerType ? (
-            <Pressable
-              onPress={onOpenHowTo}
-              hitSlop={6}
-              style={[styles.howToChip, { borderColor: colors.border }]}
-              accessibilityRole="button"
-              accessibilityLabel={`Open how-to for ${task.title}`}
-            >
-              <Ionicons
-                name={VIEWER_HOW_TO_ICONS[viewerType]}
-                size={13}
-                color={primaryColor}
-              />
-              <Text style={[styles.howToChipText, { color: primaryColor }]}>
-                How-To
-              </Text>
-              <Ionicons name="arrow-forward" size={13} color={primaryColor} />
-            </Pressable>
-          ) : null}
         </Pressable>
+
+        {/* How-To sits on the same line as the title (row-level, right side).
+            `link` opens the URL directly; `media`/`doc` open the viewer. */}
+        {viewerType ? (
+          <Pressable
+            onPress={() => {
+              if (howToType === "link" && task.howToUrl) {
+                void Linking.openURL(task.howToUrl).catch(() => {});
+              } else {
+                onOpenHowTo();
+              }
+            }}
+            hitSlop={6}
+            style={[styles.howToChip, { borderColor: colors.border }]}
+            accessibilityRole="button"
+            accessibilityLabel={
+              howToType === "link"
+                ? `Open link for ${task.title}`
+                : `Open how-to for ${task.title}`
+            }
+          >
+            <Ionicons
+              name={VIEWER_HOW_TO_ICONS[viewerType]}
+              size={13}
+              color={primaryColor}
+            />
+            <Text style={[styles.howToChipText, { color: primaryColor }]}>
+              How-To
+            </Text>
+            <Ionicons
+              name={howToType === "link" ? "open-outline" : "arrow-forward"}
+              size={13}
+              color={primaryColor}
+            />
+          </Pressable>
+        ) : null}
       </View>
 
       {expanded && task.isPersonal ? (
@@ -794,8 +807,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     alignSelf: "flex-start",
+    flexShrink: 0,
     gap: 5,
-    marginTop: 8,
     paddingHorizontal: 10,
     paddingVertical: 5,
     borderRadius: 999,


### PR DESCRIPTION
Two large, related pieces of work on the event-planning surface: the leader **Run sheet + Event Tasks "database view"** (modelled on events-os), and a full **event/serving-mode overhaul**. All commits typecheck + lint clean; Convex changes are deployed to dev.

## Run sheet + Event Tasks (leader database view)
- **`GridScrollList`** — a bordered, inline-editable table: fixed-width columns inside a single horizontal `ScrollView` (Notion-style horizontal scroll on overflow; fills the card, capped/centered at 1200 on wide desktop), vertical cell dividers, community-accent header, drag-to-reorder (reuses the cross-platform drag list). Column values are subtle tags; dropdowns are inline anchored menus (`AnchoredMenu`), not full-screen.
- **Run sheet**: Item / When / Time / Dur / Owner-Role / Notes / Song; When (Before/During/After) is a column, not a section break.
- **Event Tasks**: Task / Phase / Team / Role / How-To; colored per-team tags, duplicate + delete, "Add task", view filters (Phase/Team/Role, and new tasks are seeded from active filters), a compact readiness header (stat tiles), and a compact single-line **How-To cell** with a real **image/video upload** (reuses the chat R2 upload; no new deps).
- **Per-user How-To doc checklists**: `- [ ]` items in a doc How-To are tappable and saved per-user, keyed by content so they survive reordering (`howToDocChecks`).

## Event / serving mode
- **Bug fixes**: run sheet loads in event mode (resolves the plan from `activePlanId`, window-independent); **Exit** reliably resets the tab bar (Tabs keyed on mode to remount + a `tabPress` action listener — the old focus-effect cleanup was cancelling the exit); team-level tasks surfaced.
- **Tabs** reordered to **Runsheet · Inbox · Tasks · Exit** (Profile dropped).
- **My Schedule**: an always-available "Open event" entry so you can preview event mode before the day-of window.
- **Tasks** redesigned with section navigation: **Mine** (per-user) · **Shared** (team-level, team-wide "anyone can check") · **Crew** (teammates' progress, read-only) · **All teams** (read-only overview) — new backend queries + a `sharedTaskCompletions` table.
- **How-To viewer**: short text inline; link opens directly; media/doc open a dedicated read-only page.
- **Focused inbox** in event mode: no Notifications, the plan's channels pinned (shown early), only day-of DMs, an event-specific empty state, **ghost cards** for upcoming team/cross-team channels ("Opens …", event date − 5 days), and per-channel `#team-general/leaders/announcements` labels.
- **Channel tab bar** auto-scrolls to keep the active channel visible from any entry point.

## Backend / data
- New tables: `howToDocChecks`, `sharedTaskCompletions` (both net-new, no migration risk). New queries/mutations for the grid, serving sections, focused inbox, and ghost channels. Deployed to dev.

## Review
Three adversarial review passes (grid/leader-tasks, serving mode, inbox/chat) — no security or crash-on-normal-path issues; auth gates verified. Four findings fixed in `b6aa1c7f`: filtered-reorder `sortOrder` corruption, a shared-done team task vs its progress bar, the serving inbox falling open to all DMs while the day window loads, and serving Task queries crashing on a deleted `activePlanId`.

### Known follow-ups (not blocking)
- Team-level tasks are completable in **both** Mine (per-user) and Shared (team-wide) via separate stores that don't reconcile — worth unifying so readiness reflects the shared toggle.
- `getServingUpcomingChannels` scans `cross_team` channels unindexed (rare; correct results).
- Serving Tasks header title is generic when previewing a plan outside the day-of window (cosmetic).

## Testing
Typecheck + lint clean across all commits. Verified on dev web across the grid, event mode, tasks sections, How-To viewer/checklists, focused inbox, ghost cards, Exit, and tab auto-scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
