### PR TITLE
feat(channels): distinct calendar icon for serving-team channels

### DIFF
--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -2041,6 +2041,73 @@ describe("listGroupChannels", () => {
     expect(customChannel?.isMember).toBe(true);
   });
 
+  test("surfaces isServingTeam so serving-team custom channels are distinguishable", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, communityId, groupId, accessToken } = await seedTestData(t);
+    const { userId: leaderId } = await createLeaderUser(t, communityId, groupId);
+
+    // A plain, manually-created custom channel.
+    const plainId = await t.run(async (ctx) => {
+      const chId = await ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "directors",
+        channelType: "custom",
+        name: "Directors",
+        createdById: leaderId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: chId,
+        userId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+      return chId;
+    });
+
+    // A serving-team custom channel (auto-created from an event plan).
+    const servingId = await t.run(async (ctx) => {
+      const chId = await ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "sunday-band",
+        channelType: "custom",
+        name: "Sunday Band",
+        isServingTeam: true,
+        createdById: leaderId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: chId,
+        userId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+      return chId;
+    });
+
+    const channels = await t.query(api.functions.messaging.channels.listGroupChannels, {
+      token: accessToken,
+      groupId,
+    });
+
+    const plain = channels.find((c) => c._id === plainId);
+    const serving = channels.find((c) => c._id === servingId);
+
+    expect(plain?.channelType).toBe("custom");
+    expect(plain?.isServingTeam).toBeUndefined();
+
+    expect(serving?.channelType).toBe("custom");
+    expect(serving?.isServingTeam).toBe(true);
+  });
+
   test("hides leader-disabled custom channels from members (group page list)", async () => {
     const t = convexTest(schema, modules);
     const { userId, communityId, groupId, accessToken } = await seedTestData(t);

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1237,6 +1237,7 @@ export const listGroupChannels = query({
     lastMessageAt: v.optional(v.number()),
     isShared: v.optional(v.boolean()),
     isEnabled: v.boolean(),
+    isServingTeam: v.optional(v.boolean()),
   })),
   handler: async (ctx, args) => {
     // 1. Authenticate user
@@ -1433,6 +1434,7 @@ export const listGroupChannels = query({
           lastMessageAt: channel.lastMessageAt,
           isShared: channel.isShared || undefined,
           isEnabled: channelEffectiveEnabledForGroup(channel, args.groupId),
+          isServingTeam: channel.isServingTeam ?? undefined,
         };
       })
     );

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -72,6 +72,8 @@ interface Channel {
   isShared?: boolean;
   /** false when leader hid channel; memberships stay (see Convex isEnabled). */
   isEnabled: boolean;
+  /** true for custom channels auto-created from an event plan's serving team. */
+  isServingTeam?: boolean;
 }
 
 export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsSectionProps) {
@@ -366,14 +368,21 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
 
   customChannels.forEach((channel: Channel) => {
     const enabled = channel.isEnabled && !channel.isArchived;
+    // Serving-team channels are auto-created from event plans (channelType
+    // "custom" + isServingTeam). Give them a distinct calendar icon so leaders
+    // can tell them apart from manually-created custom channels.
+    const isServingTeam = channel.isServingTeam === true;
+    const memberSubtitle = `${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""}`;
     rows.push({
       key: channel._id,
-      icon: "chatbubble",
-      iconColor: "#00BCD4",
-      iconBg: "#00BCD415",
+      icon: isServingTeam ? "calendar-outline" : "chatbubble",
+      iconColor: isServingTeam ? "#10B981" : "#00BCD4",
+      iconBg: isServingTeam ? "#10B98115" : "#00BCD415",
       name: channel.name,
       subtitle: enabled
-        ? `${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""}`
+        ? isServingTeam
+          ? `${memberSubtitle} · Serving team`
+          : memberSubtitle
         : "Hidden — visible to leaders",
       enabled,
       onPress: () => navigateToChannelInfo(channel.slug),


### PR DESCRIPTION
## What & why

In the group settings **Channels** list, serving-team channels — the ones auto-created from event plans — were indistinguishable from manually-created custom channels. Both are stored as `channelType: "custom"`, and serving-team channels additionally carry `isServingTeam: true`, but that flag never reached the client, so both rendered with the same chat-bubble / teal icon.

## Changes

**Backend** (`apps/convex/functions/messaging/channels.ts`, `listGroupChannels`)
- Added `isServingTeam: v.optional(v.boolean())` to the return validator.
- Mapped `isServingTeam` through from the raw `chatChannels` doc in the returned object.
- Extended the `listGroupChannels` shape test to assert the flag is surfaced for serving-team channels and absent for plain custom ones.

**Frontend** (`apps/mobile/features/groups/components/ChannelsSection.tsx`)
- Added `isServingTeam?: boolean` to the `Channel` interface.
- Split the custom-channel bucket by `isServingTeam`:
  - Serving-team → `calendar-outline` (Ionicons), green `#10B981` / bg `#10B98115`, subtitle gains a `· Serving team` hint.
  - Plain custom → unchanged (`chatbubble`, teal `#00BCD4`).
- The pre-existing `cross_team` bucket (purple git-merge icon) is untouched.

## Testing

- `apps/convex` `tsc --noEmit`: clean (only the known repo-wide `@togather/shared` resolution baseline remains).
- `apps/mobile` `tsc --noEmit`: `ChannelsSection.tsx` is clean; remaining errors are the same pre-existing `@togather/shared` baseline / unrelated files.
- New Convex test passes.
- Not visually verified — I can't drive the simulator, so the icon/color rendering has not been confirmed on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSwZmWmrY1LisZYjSZYx49