### PR TITLE
feat(channels): permanent members + role-synced breakdown for cross-team channels

### DIFF
--- a/apps/convex/__tests__/scheduling/crossTeamPermanentMembers.test.ts
+++ b/apps/convex/__tests__/scheduling/crossTeamPermanentMembers.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Tests for PERMANENT members of a cross-team channel + the two-section
+ * Channel Info membership query (`crossTeamChannels.ts`).
+ *
+ * A cross-team channel's roster is otherwise entirely auto-synced from event-
+ * plan role assignments. A "permanent" member is a `chatChannelMembers` row a
+ * leader pinned by hand (`isPermanent === true`); the reconcile engine never
+ * removes it. These are keyed by the cross-team `channelId` (which owns no
+ * `teams` row).
+ *
+ *   - `addPermanentMemberToChannel` pins a member (idempotent; converting an
+ *     existing synced member just flags it, no duplicate row),
+ *   - `removePermanentMemberFromChannel` soft-removes a purely-permanent
+ *     member but only unpins one who is also role-synced,
+ *   - `reconcileCrossTeamChannel` never soft-removes a permanent row,
+ *   - `getCrossTeamChannelMembership` returns the permanent list plus one
+ *     "synced by role" card per (user, role), with both-members in both lists.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api, internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { generateTokens } from "../../lib/auth";
+import { buildSchedulingWorld, ts, type SchedulingWorld } from "./fixtures";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+const DAY = 86400000;
+
+/**
+ * A cross-team world: the base scheduling world (the "worship" team, with a
+ * second "Worship Leader" role added), plus a cross-team channel that selects
+ * everyone from the worship team. The channel lives in `base.groupId`, which
+ * `groupLeaderId` leads — so leader-gated mutations and the member-gated query
+ * both authorize for `groupLeaderId`.
+ */
+interface CrossTeamWorld extends SchedulingWorld {
+  worshipRoleId: Id<"teamRoles">;
+  crossChannelId: Id<"chatChannels">;
+  worshipUserId: Id<"users">;
+}
+
+async function setupWorld(): Promise<{
+  t: ReturnType<typeof convexTest>;
+  world: CrossTeamWorld;
+}> {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const base = await buildSchedulingWorld(t);
+
+  const extra = await t.run(
+    async (
+      ctx,
+    ): Promise<{
+      worshipRoleId: Id<"teamRoles">;
+      worshipUserId: Id<"users">;
+    }> => {
+      const worshipRoleId = await ctx.db.insert("teamRoles", {
+        teamId: base.teamId,
+        communityId: base.communityId,
+        name: "Worship Leader",
+        sortOrder: 1,
+        defaultNeeded: 1,
+        isArchived: false,
+        createdAt: ts(),
+        createdById: base.channelAdminId,
+      });
+      const worshipUserId = await ctx.db.insert("users", {
+        firstName: "Worshipper",
+        lastName: "Test",
+        email: "worshipper@example.com",
+        isActive: true,
+        roles: 1,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+      return { worshipRoleId, worshipUserId };
+    },
+  );
+
+  const crossChannelId = await t.run((ctx) =>
+    ctx.db.insert("chatChannels", {
+      groupId: base.groupId,
+      communityId: base.communityId,
+      name: "Service Leads",
+      channelType: "cross_team",
+      memberCount: 0,
+      isArchived: false,
+      createdById: base.channelAdminId,
+      createdAt: ts(),
+      updatedAt: ts(),
+      crossTeamSync: {
+        selectors: [{ sourceTeamId: base.teamId }],
+      },
+    }),
+  );
+
+  return { t, world: { ...base, ...extra, crossChannelId } };
+}
+
+/** Insert a plan + a roleAssignment on the worship team, inside the window. */
+async function roster(
+  t: ReturnType<typeof convexTest>,
+  world: CrossTeamWorld,
+  opts: { userId: Id<"users">; roleId: Id<"teamRoles">; dayOffset?: number },
+): Promise<Id<"roleAssignments">> {
+  const eventDate = Date.now() + (opts.dayOffset ?? 3) * DAY;
+  return t.run(async (ctx) => {
+    const planId = await ctx.db.insert("eventPlans", {
+      groupId: world.groupId,
+      communityId: world.communityId,
+      title: "Sunday Service",
+      eventDate,
+      times: [{ label: "9 AM", startsAt: eventDate }],
+      status: "draft",
+      createdById: world.groupLeaderId,
+      createdAt: ts(),
+      updatedAt: ts(),
+    });
+    return ctx.db.insert("roleAssignments", {
+      planId,
+      teamId: world.teamId,
+      roleId: opts.roleId,
+      userId: opts.userId,
+      eventDate,
+      status: "unconfirmed",
+      assignedById: world.groupLeaderId,
+      assignedAt: Date.now(),
+    });
+  });
+}
+
+/** All rows (active + soft-left) for a user on the cross-team channel. */
+async function rowsFor(
+  t: ReturnType<typeof convexTest>,
+  world: CrossTeamWorld,
+  userId: Id<"users">,
+) {
+  const rows = await t.run((ctx) =>
+    ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", world.crossChannelId).eq("userId", userId),
+      )
+      .collect(),
+  );
+  return rows;
+}
+
+describe("cross-team permanent members — addPermanentMemberToChannel", () => {
+  it("inserts an active manual row flagged isPermanent, no syncSource", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    const res = await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.outsiderId,
+      },
+    );
+    expect(res.added).toBe(true);
+
+    const rows = await rowsFor(t, world, world.outsiderId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].isPermanent).toBe(true);
+    expect(rows[0].syncSource).toBeUndefined();
+    expect(rows[0].role).toBe("member");
+    expect(rows[0].leftAt).toBeUndefined();
+
+    const channel = await t.run((ctx) => ctx.db.get(world.crossChannelId));
+    expect(channel?.memberCount).toBe(1);
+  });
+
+  it("is idempotent — a second call does not duplicate the row", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.outsiderId,
+      },
+    );
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.outsiderId,
+      },
+    );
+
+    const rows = await rowsFor(t, world, world.outsiderId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].isPermanent).toBe(true);
+  });
+
+  it("flags an existing synced member permanent without duplicating rows", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    // Roster the worship user then reconcile so they have a synced row.
+    await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.roleId,
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    let rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].syncSource).toBe("event_plan");
+
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    rows = await rowsFor(t, world, world.worshipUserId);
+    // Same single row, now BOTH synced and permanent.
+    expect(rows.length).toBe(1);
+    expect(rows[0].syncSource).toBe("event_plan");
+    expect(rows[0].isPermanent).toBe(true);
+    expect(rows[0].leftAt).toBeUndefined();
+  });
+
+  it("a plain group member (non-leader) is rejected", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.channelMemberId);
+
+    await expect(
+      t.mutation(
+        api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+        {
+          token: accessToken,
+          channelId: world.crossChannelId,
+          userId: world.outsiderId,
+        },
+      ),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("cross-team permanent members — removePermanentMemberFromChannel", () => {
+  it("soft-removes a purely-permanent member", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.outsiderId,
+      },
+    );
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels
+        .removePermanentMemberFromChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.outsiderId,
+      },
+    );
+
+    const rows = await rowsFor(t, world, world.outsiderId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].leftAt).toBeDefined();
+    expect(rows[0].isPermanent).toBe(false);
+
+    const channel = await t.run((ctx) => ctx.db.get(world.crossChannelId));
+    expect(channel?.memberCount).toBe(0);
+  });
+
+  it("only unpins a member who is also role-synced (row stays active)", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    // Synced + then pinned → one row that is BOTH.
+    await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.roleId,
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels
+        .removePermanentMemberFromChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    const rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows.length).toBe(1);
+    // Still a live synced member — active, just no longer pinned.
+    expect(rows[0].leftAt).toBeUndefined();
+    expect(rows[0].syncSource).toBe("event_plan");
+    expect(rows[0].isPermanent).toBe(false);
+  });
+
+  it("throws when the user is not a permanent member", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    await expect(
+      t.mutation(
+        api.functions.scheduling.crossTeamChannels
+          .removePermanentMemberFromChannel,
+        {
+          token: accessToken,
+          channelId: world.crossChannelId,
+          userId: world.outsiderId,
+        },
+      ),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("cross-team permanent members — reconcile interaction", () => {
+  it("never soft-removes a permanent row when the user drops off the window", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    // Synced + pinned member.
+    const assignmentId = await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.roleId,
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    // Move the event well into the past — out of the removal window.
+    await t.run((ctx) =>
+      ctx.db.patch(assignmentId, { eventDate: Date.now() - 5 * DAY }),
+    );
+    const result = await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    expect(result.removed).toBe(0);
+
+    const rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].leftAt).toBeUndefined();
+    expect(rows[0].isPermanent).toBe(true);
+  });
+});
+
+describe("cross-team permanent members — getCrossTeamChannelMembership", () => {
+  it("returns the permanent list and one synced card per (user, role)", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    // worshipUser matches TWO worship roles → two synced cards.
+    await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.roleId,
+    });
+    await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.worshipRoleId,
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+
+    // outsider is a purely-permanent member (never rostered).
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.outsiderId,
+      },
+    );
+    // worshipUser is BOTH synced and pinned.
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    const membership = await t.query(
+      api.functions.scheduling.crossTeamChannels.getCrossTeamChannelMembership,
+      { token: accessToken, channelId: world.crossChannelId },
+    );
+
+    // Permanent list: outsider + worshipUser.
+    const permIds = membership.permanentMembers.map((m) => m.userId);
+    expect(permIds).toContain(world.outsiderId);
+    expect(permIds).toContain(world.worshipUserId);
+    expect(permIds).not.toContain(world.channelMemberId);
+
+    // Synced list: worshipUser appears twice — once per matched role.
+    const worshipSynced = membership.syncedRoleMembers.filter(
+      (m) => m.userId === world.worshipUserId,
+    );
+    expect(worshipSynced.length).toBe(2);
+    const roleNames = worshipSynced.map((m) => m.roleName).sort();
+    expect(roleNames).toEqual(["Drums", "Worship Leader"]);
+    expect(worshipSynced.every((m) => m.teamName === "Worship Team")).toBe(true);
+
+    // A purely-permanent member is NOT in the synced list.
+    expect(
+      membership.syncedRoleMembers.some((m) => m.userId === world.outsiderId),
+    ).toBe(false);
+
+    // The both-member appears in BOTH lists.
+    expect(permIds).toContain(world.worshipUserId);
+    expect(worshipSynced.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a non-member of the channel's home group", async () => {
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.outsiderId);
+
+    await expect(
+      t.query(
+        api.functions.scheduling.crossTeamChannels
+          .getCrossTeamChannelMembership,
+        { token: accessToken, channelId: world.crossChannelId },
+      ),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/apps/convex/__tests__/scheduling/crossTeamPermanentMembers.test.ts
+++ b/apps/convex/__tests__/scheduling/crossTeamPermanentMembers.test.ts
@@ -335,6 +335,96 @@ describe("cross-team permanent members — removePermanentMemberFromChannel", ()
     expect(rows[0].isPermanent).toBe(false);
   });
 
+  it("soft-removes a synced+pinned member who has dropped off the roster", async () => {
+    // Regression: the decision must come from the LIVE roster, not the stale
+    // syncSource tag. A pinned member keeps syncSource="event_plan" after the
+    // reconcile guard preserves them off-window — removing must still evict.
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    const assignmentId = await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.roleId,
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    // Move the event out of the window — they're no longer role-matched.
+    await t.run((ctx) =>
+      ctx.db.patch(assignmentId, { eventDate: Date.now() - 5 * DAY }),
+    );
+
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels
+        .removePermanentMemberFromChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    const rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].leftAt).toBeDefined();
+    expect(rows[0].isPermanent).toBe(false);
+  });
+
+  it("only unpins a purely-permanent member who is now live-rostered", async () => {
+    // A purely-permanent member (no syncSource) who is later rostered keeps
+    // syncSource=undefined, but is currently role-matched — removing must only
+    // unpin, leaving them in via their role.
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    // Pin first (purely permanent), then roster + reconcile.
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+    await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.roleId,
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    // Reconcile leaves the existing active row untouched — still no syncSource.
+    let rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows[0].syncSource).toBeUndefined();
+
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels
+        .removePermanentMemberFromChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows.length).toBe(1);
+    // Still live-rostered → stays active, just unpinned.
+    expect(rows[0].leftAt).toBeUndefined();
+    expect(rows[0].isPermanent).toBe(false);
+  });
+
   it("throws when the user is not a permanent member", async () => {
     const { t, world } = await setupWorld();
     const { accessToken } = await generateTokens(world.groupLeaderId);

--- a/apps/convex/__tests__/scheduling/crossTeamPermanentMembers.test.ts
+++ b/apps/convex/__tests__/scheduling/crossTeamPermanentMembers.test.ts
@@ -87,6 +87,19 @@ async function setupWorld(): Promise<{
         createdAt: ts(),
         updatedAt: ts(),
       });
+      // `addPermanentMemberToChannel` gates the target on community membership,
+      // so the users these tests pin (worshipUser + the base fixture's
+      // outsider, who otherwise has no memberships) must be community members.
+      for (const userId of [worshipUserId, base.outsiderId]) {
+        await ctx.db.insert("userCommunities", {
+          communityId: base.communityId,
+          userId,
+          roles: 1,
+          status: 1,
+          createdAt: ts(),
+          updatedAt: ts(),
+        });
+      }
       return { worshipRoleId, worshipUserId };
     },
   );
@@ -480,6 +493,80 @@ describe("cross-team permanent members — reconcile interaction", () => {
     expect(rows.length).toBe(1);
     expect(rows[0].leftAt).toBeUndefined();
     expect(rows[0].isPermanent).toBe(true);
+  });
+
+  it("no ghost: unpinning a still-rostered member lets reconcile evict them once the roster ends", async () => {
+    // The regression that finding 1 describes: pin BEFORE rostering (row has
+    // syncSource=undefined), roster, unpin while matched, then let the roster
+    // end. Without the syncSource stamp on unpin the row would be owned by
+    // neither engine and never evicted.
+    const { t, world } = await setupWorld();
+    const { accessToken } = await generateTokens(world.groupLeaderId);
+
+    // 1. Pin before rostering → active manual row, no syncSource.
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels.addPermanentMemberToChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+
+    // 2. Roster + reconcile → row stays active but keeps syncSource=undefined
+    //    (the add-loop skips already-active rows).
+    const assignmentId = await roster(t, world, {
+      userId: world.worshipUserId,
+      roleId: world.roleId,
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    let rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows[0].syncSource).toBeUndefined();
+    expect(rows[0].isPermanent).toBe(true);
+
+    // 3. Unpin while still role-matched → handed to the sync engine.
+    await t.mutation(
+      api.functions.scheduling.crossTeamChannels
+        .removePermanentMemberFromChannel,
+      {
+        token: accessToken,
+        channelId: world.crossChannelId,
+        userId: world.worshipUserId,
+      },
+    );
+    rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows[0].leftAt).toBeUndefined();
+    expect(rows[0].isPermanent).toBe(false);
+    expect(rows[0].syncSource).toBe("event_plan");
+
+    // Still rostered + unpinned → shows in the synced-by-role section only.
+    const membership = await t.query(
+      api.functions.scheduling.crossTeamChannels.getCrossTeamChannelMembership,
+      { token: accessToken, channelId: world.crossChannelId },
+    );
+    expect(
+      membership.syncedRoleMembers.some(
+        (m) => m.userId === world.worshipUserId,
+      ),
+    ).toBe(true);
+    expect(
+      membership.permanentMembers.some((m) => m.userId === world.worshipUserId),
+    ).toBe(false);
+
+    // 4. Roster ends → reconcile evicts the row (no ghost left behind).
+    await t.run((ctx) =>
+      ctx.db.patch(assignmentId, { eventDate: Date.now() - 5 * DAY }),
+    );
+    const result = await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId: world.crossChannelId },
+    );
+    expect(result.removed).toBe(1);
+    rows = await rowsFor(t, world, world.worshipUserId);
+    expect(rows[0].leftAt).toBeDefined();
   });
 });
 

--- a/apps/convex/functions/scheduling/crossTeamChannels.ts
+++ b/apps/convex/functions/scheduling/crossTeamChannels.ts
@@ -602,10 +602,16 @@ export const addPermanentMemberToChannel = mutation({
 /**
  * Unpin a permanent member from a cross-team channel.
  *
- * Clears `isPermanent` on the user's active row. If that row was ONLY
- * permanent (`syncSource === undefined`) it is soft-removed; if it is still a
- * live synced member (`syncSource === "event_plan"`) the row stays active — the
- * person simply stops being pinned and remains in the channel via their role.
+ * Clears `isPermanent` on the user's active row, then decides whether they stay
+ * in the channel based on their LIVE roster status — NOT the stale `syncSource`
+ * tag. If they are still role-matched (`computeCrossTeamRoleMembers`), the row
+ * stays active and they remain via their role; otherwise the row is soft-
+ * removed and they leave the channel.
+ *
+ * (`syncSource` is unreliable here: the reconcile guard preserves a pinned row
+ * with `syncSource === "event_plan"` long after the user left the roster window,
+ * and a purely-permanent member can be live-rostered while keeping
+ * `syncSource === undefined`. Only the live selector pass is authoritative.)
  *
  * Throws `ConvexError` if the user has no active row or is not permanent.
  * Auth: a leader of the channel's home group.
@@ -623,15 +629,24 @@ export const removePermanentMemberFromChannel = mutation({
   }),
   handler: async (ctx, args) => {
     const callerId = await requireAuth(ctx, args.token);
-    await requireCrossTeamChannelLeader(ctx, args.channelId, callerId);
+    const channel = await requireCrossTeamChannelLeader(
+      ctx,
+      args.channelId,
+      callerId,
+    );
 
     const active = await activeMembership(ctx, args.channelId, args.userId);
     if (!active || active.isPermanent !== true) {
       throw new ConvexError("That person is not a permanent member.");
     }
 
-    if (active.syncSource === undefined) {
-      // Purely permanent — unpinning removes them from the channel entirely.
+    const roleMembers = await computeCrossTeamRoleMembers(ctx, channel);
+    const stillRoleMatched = roleMembers.some(
+      (m) => m.userId === args.userId,
+    );
+
+    if (!stillRoleMatched) {
+      // No live role match — unpinning removes them from the channel entirely.
       await ctx.db.patch(active._id, { isPermanent: false, leftAt: Date.now() });
     } else {
       // Still a live synced member — just unpin, leave the row active.

--- a/apps/convex/functions/scheduling/crossTeamChannels.ts
+++ b/apps/convex/functions/scheduling/crossTeamChannels.ts
@@ -28,6 +28,7 @@ import { requireGroupMember, requireGroupScheduler } from "./permissions";
 import {
   computeCrossTeamRoleMembers,
   reconcileCrossTeamChannelImpl,
+  SYNC_SOURCE,
 } from "./teamChannelSync";
 
 /** Validator for a single cross-team membership selector. */
@@ -542,12 +543,34 @@ export const addPermanentMemberToChannel = mutation({
   }),
   handler: async (ctx, args) => {
     const callerId = await requireAuth(ctx, args.token);
-    await requireCrossTeamChannelLeader(ctx, args.channelId, callerId);
+    const channel = await requireCrossTeamChannelLeader(
+      ctx,
+      args.channelId,
+      callerId,
+    );
 
     const user = await ctx.db.get(args.userId);
     if (!user) {
       throw new ConvexError("User not found");
     }
+
+    // Cross-team channels can span multiple groups, so gate on COMMUNITY
+    // membership: a direct call must not pin an arbitrary unrelated user. The
+    // picker already scopes to group members; this closes the direct-call hole.
+    const group = channel.groupId ? await ctx.db.get(channel.groupId) : null;
+    if (!group) {
+      throw new ConvexError("Channel's group not found");
+    }
+    const targetMembership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", args.userId).eq("communityId", group.communityId),
+      )
+      .first();
+    if (!targetMembership || targetMembership.status !== 1) {
+      throw new ConvexError("That person is not a member of this community.");
+    }
+
     const displayName = getDisplayName(user.firstName, user.lastName);
     const profilePhoto = getMediaUrl(user.profilePhoto);
 
@@ -605,13 +628,18 @@ export const addPermanentMemberToChannel = mutation({
  * Clears `isPermanent` on the user's active row, then decides whether they stay
  * in the channel based on their LIVE roster status — NOT the stale `syncSource`
  * tag. If they are still role-matched (`computeCrossTeamRoleMembers`), the row
- * stays active and they remain via their role; otherwise the row is soft-
- * removed and they leave the channel.
+ * is handed back to the auto-sync engine — `isPermanent: false` plus
+ * `syncSource: "event_plan"` — so the reconcile keeps it while rostered and
+ * evicts it normally once the roster ends. If they are NOT role-matched the row
+ * is soft-removed and they leave the channel.
  *
- * (`syncSource` is unreliable here: the reconcile guard preserves a pinned row
- * with `syncSource === "event_plan"` long after the user left the roster window,
- * and a purely-permanent member can be live-rostered while keeping
- * `syncSource === undefined`. Only the live selector pass is authoritative.)
+ * Stamping `syncSource` is what prevents a "ghost" row: a user pinned BEFORE
+ * being rostered keeps `syncSource === undefined` (the reconcile add-loop skips
+ * already-active rows), so without this a still-rostered unpin would leave a row
+ * owned by neither engine — never evicted, invisible to both Channel Info
+ * sections. `syncSource` alone is unreliable for the stay/leave decision (the
+ * reconcile guard preserves a pinned `event_plan` row long after the window),
+ * so only the live selector pass is authoritative.
  *
  * Throws `ConvexError` if the user has no active row or is not permanent.
  * Auth: a leader of the channel's home group.
@@ -649,8 +677,14 @@ export const removePermanentMemberFromChannel = mutation({
       // No live role match — unpinning removes them from the channel entirely.
       await ctx.db.patch(active._id, { isPermanent: false, leftAt: Date.now() });
     } else {
-      // Still a live synced member — just unpin, leave the row active.
-      await ctx.db.patch(active._id, { isPermanent: false });
+      // Still role-matched — hand the row back to the auto-sync engine so it is
+      // reconciled (and eventually evicted) like any synced member. Stamping
+      // syncSource is required: a row pinned before rostering has none, and
+      // leaving it unset would strand it as a ghost owned by neither engine.
+      await ctx.db.patch(active._id, {
+        isPermanent: false,
+        syncSource: SYNC_SOURCE,
+      });
     }
 
     await updateChannelMemberCount(ctx, args.channelId);

--- a/apps/convex/functions/scheduling/crossTeamChannels.ts
+++ b/apps/convex/functions/scheduling/crossTeamChannels.ts
@@ -17,13 +17,18 @@
 
 import { ConvexError, v } from "convex/values";
 import { mutation, query } from "../../_generated/server";
-import type { MutationCtx } from "../../_generated/server";
-import type { Id } from "../../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
 import { generateChannelSlug, getChannelSlug } from "../../lib/slugs";
+import { getDisplayName, getMediaUrl } from "../../lib/utils";
+import { updateChannelMemberCount } from "../messaging/helpers";
 import { requireGroupMember, requireGroupScheduler } from "./permissions";
-import { reconcileCrossTeamChannelImpl } from "./teamChannelSync";
+import {
+  computeCrossTeamRoleMembers,
+  reconcileCrossTeamChannelImpl,
+} from "./teamChannelSync";
 
 /** Validator for a single cross-team membership selector. */
 const selectorValidator = v.object({
@@ -325,5 +330,315 @@ export const listCrossTeamChannels = query({
         };
       }),
     );
+  },
+});
+
+// ============================================================================
+// Permanent members — manually pinned members of a cross-team channel
+// ============================================================================
+//
+// A cross-team channel's roster is otherwise entirely auto-synced from event-
+// plan role assignments (see `computeCrossTeamRoleMembers`). "Permanent"
+// members are `chatChannelMembers` rows a leader pinned by hand
+// (`isPermanent === true`); the reconcile engine never removes them. These
+// mirror the team-keyed `addPermanentMember` / `removePermanentMember` in
+// `teams.ts`, but are keyed on the cross-team `channelId` (which owns no
+// `teams` row).
+
+/**
+ * Resolve a cross-team channel for a group leader, throwing `ConvexError` if
+ * the channel is missing, not a cross-team channel, has no home group, or the
+ * caller does not lead that group. Mirrors `createCrossTeamChannel`'s gate.
+ */
+async function requireCrossTeamChannelLeader(
+  ctx: MutationCtx,
+  channelId: Id<"chatChannels">,
+  userId: Id<"users">,
+): Promise<Doc<"chatChannels">> {
+  const channel = await ctx.db.get(channelId);
+  if (!channel) {
+    throw new ConvexError("Channel not found");
+  }
+  if (channel.channelType !== "cross_team") {
+    throw new ConvexError("Channel is not a cross-team channel");
+  }
+  const groupId = channel.groupId;
+  if (!groupId) {
+    throw new ConvexError(
+      "Cross-team channel is not attached to a campus group.",
+    );
+  }
+  const groupMembership = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", groupId).eq("userId", userId),
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+  if (!groupMembership || !isLeaderRole(groupMembership.role)) {
+    throw new ConvexError(
+      "Only group leaders can manage cross-team channel members.",
+    );
+  }
+  return channel;
+}
+
+/**
+ * The active membership row for `(channelId, userId)`, or null. There is at
+ * most one active (non-left) row per pair by construction.
+ */
+async function activeMembership(
+  ctx: QueryCtx | MutationCtx,
+  channelId: Id<"chatChannels">,
+  userId: Id<"users">,
+): Promise<Doc<"chatChannelMembers"> | null> {
+  return ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_channel_user", (q) =>
+      q.eq("channelId", channelId).eq("userId", userId),
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+}
+
+/**
+ * Channel Info membership for a cross-team channel, split into two sections:
+ *
+ *   - `permanentMembers`: active rows with `isPermanent === true` — the
+ *     manually pinned members ("Added manually", removable).
+ *   - `syncedRoleMembers`: derived live from `computeCrossTeamRoleMembers`,
+ *     ONE entry per (user, role) they currently match ("Team · Role",
+ *     read-only). A user matching two roles yields two entries.
+ *
+ * A member who is both pinned AND currently role-matched appears in BOTH lists
+ * (the UI renders a card in each section). Auth: an active member of the
+ * channel's home group, or a community admin.
+ */
+export const getCrossTeamChannelMembership = query({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+  },
+  returns: v.object({
+    permanentMembers: v.array(
+      v.object({
+        userId: v.id("users"),
+        name: v.string(),
+        avatarUrl: v.optional(v.string()),
+      }),
+    ),
+    syncedRoleMembers: v.array(
+      v.object({
+        userId: v.id("users"),
+        name: v.string(),
+        avatarUrl: v.optional(v.string()),
+        roleId: v.id("teamRoles"),
+        roleName: v.string(),
+        teamId: v.id("teams"),
+        teamName: v.string(),
+      }),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new ConvexError("Channel not found");
+    }
+    if (channel.channelType !== "cross_team") {
+      throw new ConvexError("Channel is not a cross-team channel");
+    }
+    if (!channel.groupId) {
+      throw new ConvexError(
+        "Cross-team channel is not attached to a campus group.",
+      );
+    }
+    await requireGroupMember(ctx, channel.groupId, userId);
+
+    // --- Permanent (manually pinned) members ---------------------------
+    const activeRows = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+
+    const permanentMembers = await Promise.all(
+      activeRows
+        .filter((row) => row.isPermanent === true)
+        .map(async (row) => {
+          const user = await ctx.db.get(row.userId);
+          return {
+            userId: row.userId,
+            name: user
+              ? getDisplayName(user.firstName, user.lastName)
+              : (row.displayName ?? "Unknown"),
+            avatarUrl: user
+              ? getMediaUrl(user.profilePhoto)
+              : row.profilePhoto,
+          };
+        }),
+    );
+
+    // --- Synced-by-role members — one card per (user, role) ------------
+    const assignments = await computeCrossTeamRoleMembers(ctx, channel);
+    const seen = new Set<string>();
+    const syncedRoleMembers: Array<{
+      userId: Id<"users">;
+      name: string;
+      avatarUrl: string | undefined;
+      roleId: Id<"teamRoles">;
+      roleName: string;
+      teamId: Id<"teams">;
+      teamName: string;
+    }> = [];
+    for (const assignment of assignments) {
+      const key = `${assignment.userId}:${assignment.roleId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const [user, role, team] = await Promise.all([
+        ctx.db.get(assignment.userId),
+        ctx.db.get(assignment.roleId),
+        ctx.db.get(assignment.teamId),
+      ]);
+      syncedRoleMembers.push({
+        userId: assignment.userId,
+        name: user
+          ? getDisplayName(user.firstName, user.lastName)
+          : "Unknown",
+        avatarUrl: user ? getMediaUrl(user.profilePhoto) : undefined,
+        roleId: assignment.roleId,
+        roleName: role?.name ?? "Unknown role",
+        teamId: assignment.teamId,
+        teamName: team?.name ?? "Unknown team",
+      });
+    }
+
+    return { permanentMembers, syncedRoleMembers };
+  },
+});
+
+/**
+ * Pin a permanent member on a cross-team channel.
+ *
+ * Idempotent. If the user already has an active row (synced or manual) it is
+ * flagged `isPermanent: true` — a role-synced member becomes ALSO permanent
+ * without duplicating rows. A soft-left row is revived as a plain permanent
+ * member; otherwise a fresh manual row is inserted.
+ *
+ * Auth: a leader of the channel's home group.
+ */
+export const addPermanentMemberToChannel = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    userId: v.id("users"),
+  },
+  returns: v.object({
+    channelId: v.id("chatChannels"),
+    userId: v.id("users"),
+    added: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+    await requireCrossTeamChannelLeader(ctx, args.channelId, callerId);
+
+    const user = await ctx.db.get(args.userId);
+    if (!user) {
+      throw new ConvexError("User not found");
+    }
+    const displayName = getDisplayName(user.firstName, user.lastName);
+    const profilePhoto = getMediaUrl(user.profilePhoto);
+
+    const active = await activeMembership(ctx, args.channelId, args.userId);
+    if (active) {
+      // Already in the channel (synced or manual) — just pin them. Leaves any
+      // `syncSource`/metadata intact so a synced member stays role-matched.
+      await ctx.db.patch(active._id, { isPermanent: true });
+      await updateChannelMemberCount(ctx, args.channelId);
+      return { channelId: args.channelId, userId: args.userId, added: true };
+    }
+
+    // Revive a prior soft-left row as a plain permanent member, else insert.
+    const softLeft = await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", args.channelId).eq("userId", args.userId),
+      )
+      .first();
+    if (softLeft) {
+      await ctx.db.patch(softLeft._id, {
+        leftAt: undefined,
+        isPermanent: true,
+        role: "member",
+        syncSource: undefined,
+        syncEventId: undefined,
+        scheduledRemovalAt: undefined,
+        syncMetadata: undefined,
+        joinedAt: Date.now(),
+        isMuted: false,
+        displayName,
+        profilePhoto,
+      });
+    } else {
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: args.channelId,
+        userId: args.userId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+        isPermanent: true,
+        displayName,
+        profilePhoto,
+      });
+    }
+
+    await updateChannelMemberCount(ctx, args.channelId);
+    return { channelId: args.channelId, userId: args.userId, added: true };
+  },
+});
+
+/**
+ * Unpin a permanent member from a cross-team channel.
+ *
+ * Clears `isPermanent` on the user's active row. If that row was ONLY
+ * permanent (`syncSource === undefined`) it is soft-removed; if it is still a
+ * live synced member (`syncSource === "event_plan"`) the row stays active — the
+ * person simply stops being pinned and remains in the channel via their role.
+ *
+ * Throws `ConvexError` if the user has no active row or is not permanent.
+ * Auth: a leader of the channel's home group.
+ */
+export const removePermanentMemberFromChannel = mutation({
+  args: {
+    token: v.string(),
+    channelId: v.id("chatChannels"),
+    userId: v.id("users"),
+  },
+  returns: v.object({
+    channelId: v.id("chatChannels"),
+    userId: v.id("users"),
+    removed: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+    await requireCrossTeamChannelLeader(ctx, args.channelId, callerId);
+
+    const active = await activeMembership(ctx, args.channelId, args.userId);
+    if (!active || active.isPermanent !== true) {
+      throw new ConvexError("That person is not a permanent member.");
+    }
+
+    if (active.syncSource === undefined) {
+      // Purely permanent — unpinning removes them from the channel entirely.
+      await ctx.db.patch(active._id, { isPermanent: false, leftAt: Date.now() });
+    } else {
+      // Still a live synced member — just unpin, leave the row active.
+      await ctx.db.patch(active._id, { isPermanent: false });
+    }
+
+    await updateChannelMemberCount(ctx, args.channelId);
+    return { channelId: args.channelId, userId: args.userId, removed: true };
   },
 });

--- a/apps/convex/functions/scheduling/teamChannelSync.ts
+++ b/apps/convex/functions/scheduling/teamChannelSync.ts
@@ -53,7 +53,7 @@ export const ADD_DAYS_BEFORE = 5;
 export const REMOVE_DAYS_AFTER = 1;
 
 /** This sync engine's `syncSource` tag on `chatChannelMembers`. */
-const SYNC_SOURCE = "event_plan";
+export const SYNC_SOURCE = "event_plan";
 
 /** Outcome of a reconcile pass. `skipped` marks a channel-less team no-op. */
 type ReconcileResult = {

--- a/apps/convex/functions/scheduling/teamChannelSync.ts
+++ b/apps/convex/functions/scheduling/teamChannelSync.ts
@@ -31,9 +31,9 @@ import {
   internalQuery,
   mutation,
 } from "../../_generated/server";
-import type { MutationCtx } from "../../_generated/server";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
-import type { Id } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { updateChannelMemberCount } from "../messaging/helpers";
@@ -254,6 +254,10 @@ async function reconcileChannelMembership(
   // --- Remove synced members no longer in the window -------------------
   for (const member of syncedMembers) {
     if (member.leftAt !== undefined) continue; // already gone
+    // A manually pinned member stays in the channel even when off-roster. A
+    // row can be BOTH synced (`syncSource === "event_plan"`) and permanent —
+    // never soft-remove it; the member's role cards are derived live.
+    if (member.isPermanent === true) continue;
     if (desired.has(member.userId)) continue; // still wanted
     await ctx.db.patch(member._id, {
       leftAt: now,
@@ -347,33 +351,34 @@ export async function reconcileTeamChannelImpl(
 }
 
 /**
- * Shared cross-team reconcile implementation.
+ * Compute a cross-team channel's role-matched assignments from live
+ * `roleAssignments`. Returns EVERY in-window, non-declined assignment matching
+ * any of the channel's `crossTeamSync.selectors` — each selector pulls everyone
+ * assigned `roleId` on `sourceTeamId`, or every role there when `roleId` is
+ * omitted. Source-team assignments are read via the `by_team_eventDate` index,
+ * bounded to the rotation window; archived source teams are skipped.
  *
- * Reconcile a single cross-team channel (`channelType === "cross_team"`).
- * Desired members come from `roleAssignments` across the source serving teams
- * named in `crossTeamSync.selectors` — each selector pulls everyone assigned
- * `roleId` on `sourceTeamId`, or every role there when `roleId` is omitted.
+ * The result is NOT deduped — a user assigned two matching roles yields two
+ * entries. `reconcileChannelMembership` collapses them per-user for the chat
+ * roster, while `getCrossTeamChannelMembership` dedupes by (userId, roleId) to
+ * render one "Synced by role" card per matched role. Sharing this one selector
+ * pass keeps membership sync and the Channel Info UI in exact agreement.
  *
- * Source-team assignments are read via the `by_team_eventDate` index, bounded
- * to the rotation window and with `declined` assignments excluded.
+ * Read-only, so it accepts a `QueryCtx` or `MutationCtx`.
  */
-export async function reconcileCrossTeamChannelImpl(
-  ctx: MutationCtx,
-  channelId: Id<"chatChannels">,
-): Promise<ReconcileResult> {
-  const channel = await ctx.db.get(channelId);
+export async function computeCrossTeamRoleMembers(
+  ctx: QueryCtx | MutationCtx,
+  channel: Doc<"chatChannels">,
+): Promise<WindowAssignment[]> {
   if (
-    !channel ||
     channel.channelType !== "cross_team" ||
     channel.crossTeamSync === undefined
   ) {
-    return { added: 0, removed: 0, desiredCount: 0, skipped: true };
+    return [];
   }
 
   const { start, end } = rotationWindow(Date.now());
 
-  // Assignments across each selector's source serving team, optionally
-  // filtered to a single role.
   const assignmentsInWindow: WindowAssignment[] = [];
   for (const selector of channel.crossTeamSync.selectors) {
     // Archived source teams are out of rotation — skip them so an archived
@@ -404,6 +409,31 @@ export async function reconcileCrossTeamChannelImpl(
       });
     }
   }
+
+  return assignmentsInWindow;
+}
+
+/**
+ * Shared cross-team reconcile implementation.
+ *
+ * Reconcile a single cross-team channel (`channelType === "cross_team"`).
+ * Desired members come from `computeCrossTeamRoleMembers` — the same live
+ * selector pass the Channel Info page uses.
+ */
+export async function reconcileCrossTeamChannelImpl(
+  ctx: MutationCtx,
+  channelId: Id<"chatChannels">,
+): Promise<ReconcileResult> {
+  const channel = await ctx.db.get(channelId);
+  if (
+    !channel ||
+    channel.channelType !== "cross_team" ||
+    channel.crossTeamSync === undefined
+  ) {
+    return { added: 0, removed: 0, desiredCount: 0, skipped: true };
+  }
+
+  const assignmentsInWindow = await computeCrossTeamRoleMembers(ctx, channel);
 
   return await reconcileChannelMembership(
     ctx,

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1689,6 +1689,15 @@ export default defineSchema({
     // Denormalized user info for display
     displayName: v.optional(v.string()),
     profilePhoto: v.optional(v.string()),
+    /**
+     * Manually pinned member. When true, the auto-sync reconcile
+     * (`teamChannelSync.ts`) never soft-removes this row — a leader added them
+     * by hand and they stay in the channel even when off-roster. Independent of
+     * `syncSource`: a row can be BOTH `isPermanent` and role-synced
+     * (`syncSource === "event_plan"`), in which case they render in both the
+     * "Permanent" and "Synced by role" sections of a cross-team Channel Info page.
+     */
+    isPermanent: v.optional(v.boolean()),
     // Auto-sync tracking (for auto channels like PCO Services)
     syncSource: v.optional(v.string()), // "pco_services" | "event_rsvp" | null (manual)
     syncEventId: v.optional(v.string()), // External event/plan ID that added them

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -100,7 +100,20 @@ type ChannelIconConfig = {
 function getChannelIconConfig(
   channelType: string,
   brand: string,
+  isServingTeam?: boolean,
 ): ChannelIconConfig {
+  // A serving-team channel is a `custom` channel flagged `isServingTeam`. It
+  // gets the green calendar glyph used for serving-team rows in the group
+  // channels list, so the icon persists into Channel Info (plain custom
+  // channels keep the chat bubble).
+  if (channelType === "custom" && isServingTeam) {
+    return {
+      icon: "calendar-outline",
+      color: "#10B981",
+      bg: "#10B98115",
+      defaultName: "Serving Team",
+    };
+  }
   switch (channelType) {
     case "main":
       return { icon: "chatbubbles", color: brand, bg: brand + "15", defaultName: "General" };
@@ -357,7 +370,11 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
     }
   }, [crossTeamEditVisible]);
 
-  const iconCfg = getChannelIconConfig(channelType, primaryColor);
+  const iconCfg = getChannelIconConfig(
+    channelType,
+    primaryColor,
+    (channel as { isServingTeam?: boolean } | undefined)?.isServingTeam,
+  );
   const channelDisplayName = channel?.name?.trim() || iconCfg.defaultName;
 
   const sharedGroupCount = useMemo(() => {

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -46,10 +46,15 @@ import { AdminViewNote } from "@components/ui/AdminViewNote";
 import { ConfirmModal } from "@components/ui/ConfirmModal";
 import { CustomModal } from "@components/ui/Modal";
 import { AutoChannelSettings } from "@features/channels";
+import { MemberSearch, type CommunityMember } from "@components/ui/MemberSearch";
 import {
   CrossTeamSelectorPicker,
   updateCrossTeamChannelRef,
+  getCrossTeamChannelMembershipRef,
+  addPermanentMemberToChannelRef,
+  removePermanentMemberFromChannelRef,
   type CrossTeamSelector,
+  type CrossTeamChannelMembership,
 } from "@features/scheduling";
 import { useAuth } from "@providers/AuthProvider";
 import { useTheme } from "@hooks/useTheme";
@@ -143,6 +148,16 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
       : "skip",
   );
 
+  // Cross-team channels split membership into two sections — manually pinned
+  // "Permanent" members and live "Synced by role" cards (one per matched role).
+  // Backend gates by group membership.
+  const crossTeamMembership = useQuery(
+    getCrossTeamChannelMembershipRef,
+    token && channel?._id && channel.channelType === "cross_team"
+      ? { token, channelId: channel._id }
+      : "skip",
+  );
+
   // Group data — needed to pass communityId into AutoChannelSettings for
   // PCO synced channels.
   const groupData = useQuery(
@@ -209,6 +224,12 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
   const updateCrossTeamChannel = useAuthenticatedMutation(
     updateCrossTeamChannelRef,
   );
+  const addPermanentMemberToChannel = useAuthenticatedMutation(
+    addPermanentMemberToChannelRef,
+  );
+  const removePermanentMemberFromChannel = useAuthenticatedMutation(
+    removePermanentMemberFromChannelRef,
+  );
 
   const [renameVisible, setRenameVisible] = useState(false);
   const [renameValue, setRenameValue] = useState("");
@@ -231,6 +252,12 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
   const [crossTeamEditVisible, setCrossTeamEditVisible] = useState(false);
   const [crossTeamDraft, setCrossTeamDraft] = useState<CrossTeamSelector[]>([]);
   const [crossTeamSaving, setCrossTeamSaving] = useState(false);
+  const [addPermanentVisible, setAddPermanentVisible] = useState(false);
+  const [pendingRemovePermanent, setPendingRemovePermanent] = useState<{
+    userId: Id<"users">;
+    name: string;
+  } | null>(null);
+  const [removingPermanent, setRemovingPermanent] = useState(false);
   const [requestInFlight, setRequestInFlight] = useState<string | null>(null);
   const [unmatchedActionInFlight, setUnmatchedActionInFlight] = useState<
     string | null
@@ -537,6 +564,39 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
       setCrossTeamSaving(false);
     }
   }, [channel?._id, crossTeamSaving, crossTeamDraft, updateCrossTeamChannel]);
+
+  // Pin a permanent member on a cross-team channel. The modal stays open; the
+  // reactive membership query drops the person from the picker once added.
+  const handleAddPermanentMember = useCallback(
+    async (member: CommunityMember) => {
+      if (!channel?._id) return;
+      try {
+        await addPermanentMemberToChannel({
+          channelId: channel._id,
+          userId: member.user_id as Id<"users">,
+        });
+      } catch (e: any) {
+        Alert.alert("Couldn't add member", e?.message || "Please try again.");
+      }
+    },
+    [channel?._id, addPermanentMemberToChannel],
+  );
+
+  const handleRemovePermanentMember = useCallback(async () => {
+    if (!channel?._id || !pendingRemovePermanent) return;
+    setRemovingPermanent(true);
+    try {
+      await removePermanentMemberFromChannel({
+        channelId: channel._id,
+        userId: pendingRemovePermanent.userId,
+      });
+      setPendingRemovePermanent(null);
+    } catch (e: any) {
+      Alert.alert("Couldn't remove member", e?.message || "Please try again.");
+    } finally {
+      setRemovingPermanent(false);
+    }
+  }, [channel?._id, pendingRemovePermanent, removePermanentMemberFromChannel]);
 
   const handleAddUnmatchedToGroup = useCallback(
     async (person: UnsyncedPerson) => {
@@ -910,8 +970,27 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           </>
         )}
 
+        {/* Cross-team members — two sections that distinguish role-synced from
+            manually pinned members. Replaces the flat Members list above for
+            cross-team channels. A person who is both appears in both sections. */}
+        {isCrossTeam && (
+          <CrossTeamMembersSections
+            membership={crossTeamMembership}
+            colors={colors}
+            primaryColor={primaryColor}
+            canManage={isLeader}
+            onAdd={() => setAddPermanentVisible(true)}
+            onRemove={(userId, name) =>
+              setPendingRemovePermanent({ userId, name })
+            }
+            onOpenProfile={(userId) =>
+              router.push(`/profile/${userId}` as any)
+            }
+          />
+        )}
+
         {/* Members */}
-        {memberRows.length > 0 && (
+        {!isCrossTeam && memberRows.length > 0 && (
           <>
             <SectionHeader colors={colors} label="Members" />
             <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
@@ -1131,14 +1210,18 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           </>
         )}
 
-        {/* Add people — for now this routes to the existing manage-members
-            sub-route. TODO: fold the in-screen picker (mirror of DM
-            ChatInfoScreen.AddPeopleModal) inline once we have a
-            channel-scoped search query. General's membership is the group
-            itself, so there's nothing to add here. */}
+        {/* Add people — for a cross-team channel this opens the in-screen
+            people picker to pin a PERMANENT member (its roster is otherwise
+            auto-synced, so there's no manage-members sub-route). Other channel
+            types route to the existing manage-members screen. General's
+            membership is the group itself, so there's nothing to add here. */}
         {isLeader && !isMain && (
           <Pressable
-            onPress={handleManageMembers}
+            onPress={
+              isCrossTeam
+                ? () => setAddPermanentVisible(true)
+                : handleManageMembers
+            }
             style={({ pressed }) => [
               styles.actionCard,
               {
@@ -1777,6 +1860,82 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           </ScrollView>
         </View>
       </Modal>
+
+      {/* Add permanent members — cross-team channels. Tapping a person pins
+          them immediately; the reactive membership query removes them from the
+          list. */}
+      <Modal
+        visible={addPermanentVisible}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setAddPermanentVisible(false)}
+      >
+        <View
+          style={[
+            styles.container,
+            { paddingTop: insets.top, backgroundColor: colors.surface },
+          ]}
+        >
+          <View
+            style={[
+              styles.headerBar,
+              {
+                backgroundColor: colors.surface,
+                borderBottomColor: colors.border,
+              },
+            ]}
+          >
+            <TouchableOpacity
+              onPress={() => setAddPermanentVisible(false)}
+              style={styles.headerBackButton}
+              hitSlop={12}
+            >
+              <Ionicons name="close" size={26} color={colors.text} />
+            </TouchableOpacity>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>
+              Add members
+            </Text>
+            <TouchableOpacity
+              onPress={() => setAddPermanentVisible(false)}
+              style={styles.headerBackButton}
+              hitSlop={12}
+            >
+              <Text style={[styles.crossTeamSaveLabel, { color: primaryColor }]}>
+                Done
+              </Text>
+            </TouchableOpacity>
+          </View>
+          <MemberSearch
+            mode="single"
+            groupId={groupId}
+            excludeUserIds={(crossTeamMembership?.permanentMembers ?? []).map(
+              (m) => m.userId as string,
+            )}
+            onSelect={handleAddPermanentMember}
+            placeholder="Search group members to add..."
+            showEmptyState
+            showActionButton
+            actionIcon="add-circle-outline"
+            clearOnSelect={false}
+            style={styles.scroll}
+          />
+        </View>
+      </Modal>
+
+      <ConfirmModal
+        visible={pendingRemovePermanent !== null}
+        title="Remove member"
+        message={
+          pendingRemovePermanent
+            ? `Remove ${pendingRemovePermanent.name} from this channel? If they're still on the roster they'll stay via their role.`
+            : ""
+        }
+        onConfirm={handleRemovePermanentMember}
+        onCancel={() => setPendingRemovePermanent(null)}
+        confirmText="Remove"
+        destructive
+        isLoading={removingPermanent}
+      />
     </View>
   );
 }
@@ -1818,6 +1977,205 @@ function SectionHeader({
     <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
       {label.toUpperCase()}
     </Text>
+  );
+}
+
+/**
+ * Cross-team channel membership, rendered as two sections:
+ *   - "Synced by role" — one read-only card per (person, role) they currently
+ *     match from the roster (Team · Role), managed via Edit synced roles.
+ *   - "Permanent" — manually pinned members ("Added manually"), each with a
+ *     remove action; a header [+ Add] opens the people picker.
+ * A person who is both pinned AND role-matched appears in both sections.
+ */
+function CrossTeamMembersSections({
+  membership,
+  colors,
+  primaryColor,
+  canManage,
+  onAdd,
+  onRemove,
+  onOpenProfile,
+}: {
+  membership: CrossTeamChannelMembership | undefined;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  canManage: boolean;
+  onAdd: () => void;
+  onRemove: (userId: Id<"users">, name: string) => void;
+  onOpenProfile: (userId: Id<"users">) => void;
+}) {
+  const syncedRoleMembers = membership?.syncedRoleMembers ?? [];
+  const permanentMembers = membership?.permanentMembers ?? [];
+
+  return (
+    <>
+      {syncedRoleMembers.length > 0 && (
+        <>
+          <SectionHeader colors={colors} label="Synced by role" />
+          <View
+            style={[
+              styles.sectionGroup,
+              { backgroundColor: colors.surfaceSecondary },
+            ]}
+          >
+            {syncedRoleMembers.map((m, idx) => (
+              <Pressable
+                key={`${m.userId}:${m.roleId}`}
+                onPress={() => onOpenProfile(m.userId)}
+                style={({ pressed }) => [
+                  styles.memberRow,
+                  idx > 0 && {
+                    borderTopWidth: StyleSheet.hairlineWidth,
+                    borderTopColor: colors.border,
+                  },
+                  pressed && { backgroundColor: colors.selectedBackground },
+                ]}
+              >
+                <Avatar name={m.name} imageUrl={m.avatarUrl} size={40} />
+                <View style={styles.memberRowText}>
+                  <Text
+                    style={[styles.memberRowName, { color: colors.text }]}
+                    numberOfLines={1}
+                  >
+                    {m.name}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.memberRowSubtitle,
+                      {
+                        color: colors.textSecondary,
+                        textTransform: "none",
+                        letterSpacing: 0,
+                        fontWeight: "500",
+                      },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {m.teamName} · {m.roleName}
+                  </Text>
+                </View>
+                <Ionicons name="sync" size={16} color={colors.textTertiary} />
+              </Pressable>
+            ))}
+          </View>
+        </>
+      )}
+
+      {/* Permanent section — always shown for leaders so they can add. */}
+      {(permanentMembers.length > 0 || canManage) && (
+        <>
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              paddingHorizontal: 20,
+              marginTop: 24,
+              marginBottom: 8,
+            }}
+          >
+            <Text
+              style={[styles.sectionHeader, { color: colors.textSecondary, paddingHorizontal: 0, marginTop: 0, marginBottom: 0 }]}
+            >
+              PERMANENT
+            </Text>
+            {canManage && (
+              <TouchableOpacity
+                onPress={onAdd}
+                style={{ flexDirection: "row", alignItems: "center", gap: 2 }}
+                hitSlop={8}
+              >
+                <Ionicons name="add" size={18} color={primaryColor} />
+                <Text
+                  style={{ fontSize: 14, fontWeight: "600", color: primaryColor }}
+                >
+                  Add
+                </Text>
+              </TouchableOpacity>
+            )}
+          </View>
+          {permanentMembers.length > 0 ? (
+            <View
+              style={[
+                styles.sectionGroup,
+                { backgroundColor: colors.surfaceSecondary },
+              ]}
+            >
+              {permanentMembers.map((m, idx) => (
+                <Pressable
+                  key={m.userId}
+                  onPress={() => onOpenProfile(m.userId)}
+                  style={({ pressed }) => [
+                    styles.memberRow,
+                    idx > 0 && {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                    pressed && { backgroundColor: colors.selectedBackground },
+                  ]}
+                >
+                  <Avatar name={m.name} imageUrl={m.avatarUrl} size={40} />
+                  <View style={styles.memberRowText}>
+                    <Text
+                      style={[styles.memberRowName, { color: colors.text }]}
+                      numberOfLines={1}
+                    >
+                      {m.name}
+                    </Text>
+                    <Text
+                      style={[
+                        styles.memberRowSubtitle,
+                        {
+                          color: colors.textSecondary,
+                          textTransform: "none",
+                          letterSpacing: 0,
+                          fontWeight: "500",
+                        },
+                      ]}
+                    >
+                      Added manually
+                    </Text>
+                  </View>
+                  {canManage && (
+                    <TouchableOpacity
+                      onPress={() => onRemove(m.userId, m.name)}
+                      style={{
+                        width: 28,
+                        height: 28,
+                        borderRadius: 14,
+                        alignItems: "center",
+                        justifyContent: "center",
+                        backgroundColor: colors.surface,
+                      }}
+                      hitSlop={8}
+                    >
+                      <Ionicons
+                        name="remove"
+                        size={18}
+                        color={colors.textSecondary}
+                      />
+                    </TouchableOpacity>
+                  )}
+                </Pressable>
+              ))}
+            </View>
+          ) : (
+            <Text
+              style={{
+                paddingHorizontal: 20,
+                paddingVertical: 4,
+                fontSize: 13,
+                color: colors.textTertiary,
+              }}
+            >
+              No permanent members yet. Add people who should always be in this
+              channel.
+            </Text>
+          )}
+        </>
+      )}
+    </>
   );
 }
 

--- a/apps/mobile/features/scheduling/api/crossTeamChannels.ts
+++ b/apps/mobile/features/scheduling/api/crossTeamChannels.ts
@@ -70,3 +70,45 @@ export const listCrossTeamChannelsRef = makeFunctionReference<
   { token: string; groupId: Id<"groups"> },
   CrossTeamChannel[]
 >("functions/scheduling/crossTeamChannels:listCrossTeamChannels");
+
+/** A manually pinned ("Permanent") member of a cross-team channel. */
+export type CrossTeamPermanentMember = {
+  userId: Id<"users">;
+  name: string;
+  avatarUrl?: string;
+};
+
+/** A live role-matched ("Synced by role") member — one per (user, role). */
+export type CrossTeamSyncedRoleMember = {
+  userId: Id<"users">;
+  name: string;
+  avatarUrl?: string;
+  roleId: Id<"teamRoles">;
+  roleName: string;
+  teamId: Id<"teams">;
+  teamName: string;
+};
+
+/** The two-section Channel Info membership for a cross-team channel. */
+export type CrossTeamChannelMembership = {
+  permanentMembers: CrossTeamPermanentMember[];
+  syncedRoleMembers: CrossTeamSyncedRoleMember[];
+};
+
+export const getCrossTeamChannelMembershipRef = makeFunctionReference<
+  "query",
+  { token: string; channelId: Id<"chatChannels"> },
+  CrossTeamChannelMembership
+>("functions/scheduling/crossTeamChannels:getCrossTeamChannelMembership");
+
+export const addPermanentMemberToChannelRef = makeFunctionReference<
+  "mutation",
+  { token: string; channelId: Id<"chatChannels">; userId: Id<"users"> },
+  { channelId: Id<"chatChannels">; userId: Id<"users">; added: boolean }
+>("functions/scheduling/crossTeamChannels:addPermanentMemberToChannel");
+
+export const removePermanentMemberFromChannelRef = makeFunctionReference<
+  "mutation",
+  { token: string; channelId: Id<"chatChannels">; userId: Id<"users"> },
+  { channelId: Id<"chatChannels">; userId: Id<"users">; removed: boolean }
+>("functions/scheduling/crossTeamChannels:removePermanentMemberFromChannel");

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -11,11 +11,17 @@ export type {
   CrossTeamSelector,
   CrossTeamChannel,
   EnrichedCrossTeamSelector,
+  CrossTeamPermanentMember,
+  CrossTeamSyncedRoleMember,
+  CrossTeamChannelMembership,
 } from "./api/crossTeamChannels";
 export {
   createCrossTeamChannelRef,
   updateCrossTeamChannelRef,
   listCrossTeamChannelsRef,
+  getCrossTeamChannelMembershipRef,
+  addPermanentMemberToChannelRef,
+  removePermanentMemberFromChannelRef,
 } from "./api/crossTeamChannels";
 export { EventEditorScreen } from "./components/EventEditorScreen";
 export { EventEditorPanel } from "./components/EventEditorPanel";


### PR DESCRIPTION
## What & why

On a cross-team chat channel's **Channel Info** page, a leader can now add/remove **permanent** members (manually pinned, not role-synced), and the members list is split into two sections that clearly distinguish the two kinds of membership. This also fixes the previously **no-op "Add people" button** for cross-team channels.

### Two-section membership UX
- **Synced by role** — derived live from the roster; one **read-only** card per `(person, role)` they currently match, shown as `Team · Role`. Managed via *Edit synced roles*. A person matching multiple roles gets one card per role.
- **Permanent** — manually pinned members, each shown as *Added manually* with a remove (–) action; a header **[+ Add]** opens an in-screen people picker.
- A person who is **both** permanent **and** currently role-matched appears in **both** sections.

## Data model — `isPermanent`
Adds `isPermanent: v.optional(v.boolean())` to `chatChannelMembers` (additive/optional, existing rows validate). Meaning: this member is manually pinned. It's **independent of `syncSource`** — a single active row can be BOTH `isPermanent` and role-synced (`syncSource === "event_plan"`).

- **Reconcile never removes permanent rows.** The `reconcileChannelMembership` removal loop now skips any row with `isPermanent === true`, so a pinned member stays in the channel even when they drop off the rotation window (including the both-case). The add-guard is unchanged: an existing active row still causes a `continue`, so role cards are derived live rather than from duplicate rows.

## Backend
- **Shared helper `computeCrossTeamRoleMembers(ctx, channel)`** — factors the selector × `roleAssignments` matching out of `reconcileCrossTeamChannelImpl` into one reusable, read-only pass (accepts `QueryCtx | MutationCtx`). Used by the reconcile (behavior unchanged), the new query, and the remove mutation, so all three derive roster status from the exact same data. (It returns the full in-window assignment list, not a deduped `{userId, roleId, teamId}` — the reconcile needs `planId`/`eventDate` for scheduled removal; the query dedupes to one card per `(user, role)` itself.)
- **New query `getCrossTeamChannelMembership(channelId)`** — auth = active member of the channel's home group (or community admin). Returns `permanentMembers` and `syncedRoleMembers` (one entry per `(user, role)`), with a `returns` validator.
- **Channel-keyed mutations** modeled on the team-keyed `addPermanentMember`/`removePermanentMember` in `teams.ts`, gated to cross-team channels and group leaders (`ConvexError`):
  - `addPermanentMemberToChannel` — patches `isPermanent: true` on an existing active row (a synced person becomes also-permanent, no duplicate); revives a soft-left row; else inserts a fresh manual row. Idempotent.
  - `removePermanentMemberFromChannel` — clears `isPermanent`, then decides from the **live roster** (`computeCrossTeamRoleMembers`), not the stale `syncSource` tag: if the user is still role-matched the row stays active (unpin only), otherwise it's soft-removed. This correctly handles an off-roster synced+pinned member (still evicted) and a later-rostered purely-permanent member (only unpinned). Throws if not an active permanent member.
- Typed mobile refs mirror the existing `crossTeamChannels` refs (the generated api map can be stale offline).

## Add-people fix (frontend)
`ChannelInfoScreen` "Add people" previously routed to `/members`, whose add UI is gated to `custom` channels — a dead end for cross-team. For cross-team it now opens an in-screen modal using the existing **`MemberSearch`** picker (candidate list = group members, minus already-pinned), whose selection calls `addPermanentMemberToChannel`. The custom-channel path is unchanged.

## Also: serving-team calendar icon in Channel Info
A serving-team channel (`custom` + `isServingTeam`) now shows the green `calendar-outline` glyph (`#10B981`) as its Channel Info hero avatar — matching the group channels list — instead of the generic chat bubble. Plain custom channels keep the bubble; cross-team keeps its `git-merge` fork. `isServingTeam` comes from `getChannelBySlug` (spreads the raw channel doc).

## Tests
`apps/convex/__tests__/scheduling/crossTeamPermanentMembers.test.ts` (12 tests): add (manual row / idempotent / synced→also-permanent no dup / non-leader rejected), remove (purely-permanent soft-removed; both-case only unpinned; **off-roster synced+pinned soft-removed**; **later-rostered purely-permanent only unpinned**; not-permanent throws), reconcile never removes a permanent row off-roster, and the membership query (permanent list + per-`(user,role)` synced list, both-member in both, non-group-member rejected).

## Verification
- `apps/convex` `tsc --noEmit`: clean (only the pre-existing `@togather/shared/config` baseline in untouched files).
- `apps/mobile` `tsc --noEmit`: my files clean (ChannelInfoScreen only hits the known `@togather/shared` baseline import that predates this PR).
- Scheduling suite green: full `__tests__/scheduling/` = **285 passed** (12 new permanent-member tests).
- Generated `api` types for the new functions resolve via CI's convex typecheck (`npx convex codegen` can't run here without a deployment); tests exercise them at runtime.
- **No visual/simulator verification** — I can't drive the simulator, so the two-section layout, picker UX, and the calendar icon are unverified in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSwZmWmrY1LisZYjSZYx49