### PR TITLE
feat(channels): surface rename (custom/cross-team/serving-team) + serving-inbox display names

### DIFF
--- a/apps/convex/__tests__/scheduling/teams.test.ts
+++ b/apps/convex/__tests__/scheduling/teams.test.ts
@@ -251,6 +251,42 @@ describe("updateTeam", () => {
   });
 });
 
+describe("updateChannel on a serving-team channel", () => {
+  it("mirrors the channel rename onto the underlying team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await t.mutation(api.functions.messaging.channels.updateChannel, {
+      token: leaderToken,
+      channelId: world.channelId,
+      name: "  Renamed From Channel  ",
+    });
+
+    await t.run(async (ctx) => {
+      const channel = await ctx.db.get(world.channelId);
+      // Name is trimmed and applied to the channel...
+      expect(channel?.name).toBe("Renamed From Channel");
+
+      // ...and mirrored onto the linked team so the two stay in sync.
+      const team = await ctx.db.get(world.teamId);
+      expect(team?.name).toBe("Renamed From Channel");
+    });
+  });
+
+  it("rejects an empty / whitespace-only name with a ConvexError", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await expect(
+      t.mutation(api.functions.messaging.channels.updateChannel, {
+        token: leaderToken,
+        channelId: world.channelId,
+        name: "   ",
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
 describe("archiveTeam", () => {
   it("archives the team and its channel, purging synced members", async () => {
     const { t, world } = await setupSchedulingWorld();

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -2173,7 +2173,18 @@ export const updateChannel = mutation({
     };
 
     if (args.name !== undefined) {
-      updates.name = args.name;
+      // Validate: trim, 1-50 chars, must contain a letter or number. Mirrors
+      // `createCustomChannel` / `updateTeam` so a rename can't blank out a name.
+      const trimmedName = args.name.trim();
+      if (trimmedName.length < 1 || trimmedName.length > 50) {
+        throw new ConvexError("Channel name must be 1-50 characters.");
+      }
+      if (!/[a-zA-Z0-9]/.test(trimmedName)) {
+        throw new ConvexError(
+          "Channel name must contain at least one letter or number."
+        );
+      }
+      updates.name = trimmedName;
     }
     if (args.description !== undefined) {
       updates.description = args.description;
@@ -2190,6 +2201,22 @@ export const updateChannel = mutation({
     }
 
     await ctx.db.patch(args.channelId, updates);
+
+    // Serving-team channels back a `teams` record. Keep the team name in sync
+    // with the channel name so the roster and the conversation stay labelled
+    // consistently everywhere (mirrors `updateTeam` in scheduling/teams.ts).
+    if (channel.isServingTeam && updates.name !== undefined) {
+      const team = await ctx.db
+        .query("teams")
+        .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+        .first();
+      if (team) {
+        await ctx.db.patch(team._id, {
+          name: updates.name,
+          updatedAt: Date.now(),
+        });
+      }
+    }
   },
 });
 

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -334,6 +334,11 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
   const isReachOut = channelType === "reach_out";
   const isPco = channelType === "pco_services";
   const isCrossTeam = channelType === "cross_team";
+  // Renameable types: plain custom, serving-team (which is a `custom` channel
+  // flagged isServingTeam — renaming it also renames the team, backend-side),
+  // and cross-team. NOT pco_services or system channels (main/leaders/
+  // announcements/reach_out).
+  const isRenameable = isCustom || isCrossTeam;
 
   // This channel's saved cross-team selectors, sourced BY CHANNEL ID from
   // getChannelBySlug (the raw `crossTeamSync.selectors`). Reading it off the
@@ -681,6 +686,12 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
     [channelDisplayName, groupData?.name, groupData?.shortId],
   );
 
+  const openRename = useCallback(() => {
+    setRenameValue(channelDisplayName);
+    setRenameError(null);
+    setRenameVisible(true);
+  }, [channelDisplayName]);
+
   const handleRename = useCallback(async () => {
     const trimmed = renameValue.trim();
     if (!trimmed) {
@@ -791,9 +802,36 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           <View style={[styles.heroIconCircle, { backgroundColor: iconCfg.bg }]}>
             <Ionicons name={iconCfg.icon} size={48} color={iconCfg.color} />
           </View>
-          <Text style={[styles.heroName, { color: colors.text }]} numberOfLines={2}>
-            {isCustom || isPco ? `#${channelDisplayName}` : channelDisplayName}
-          </Text>
+          {isRenameable && isLeader ? (
+            <TouchableOpacity
+              activeOpacity={0.6}
+              onPress={openRename}
+              accessibilityRole="button"
+              accessibilityLabel="Rename channel"
+            >
+              <View style={styles.heroTitleRow}>
+                <Text
+                  style={[styles.heroName, { color: colors.text, marginTop: 0 }]}
+                  numberOfLines={2}
+                >
+                  {isCustom ? `#${channelDisplayName}` : channelDisplayName}
+                </Text>
+                <Ionicons
+                  name="create-outline"
+                  size={18}
+                  color={colors.textSecondary}
+                  style={styles.heroTitlePencil}
+                />
+              </View>
+            </TouchableOpacity>
+          ) : (
+            <Text
+              style={[styles.heroName, { color: colors.text }]}
+              numberOfLines={2}
+            >
+              {isCustom || isPco ? `#${channelDisplayName}` : channelDisplayName}
+            </Text>
+          )}
           <Text style={[styles.heroSubtitle, { color: colors.textSecondary }]}>
             {totalMemberCount} {totalMemberCount === 1 ? "member" : "members"}
           </Text>
@@ -1495,14 +1533,11 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                 </Pressable>
               )}
 
-              {/* Rename — custom channels only (backend gates the rest). */}
-              {isCustom && (
+              {/* Rename — custom, serving-team, and cross-team channels
+                  (backend gates the rest, and mirrors serving-team → team). */}
+              {isRenameable && (
                 <Pressable
-                  onPress={() => {
-                    setRenameValue(channelDisplayName);
-                    setRenameError(null);
-                    setRenameVisible(true);
-                  }}
+                  onPress={openRename}
                   style={({ pressed }) => [
                     styles.actionRowFlat,
                     {
@@ -2257,6 +2292,15 @@ const styles = StyleSheet.create({
     fontSize: 22,
     fontWeight: "700",
     textAlign: "center",
+  },
+  heroTitleRow: {
+    marginTop: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  heroTitlePencil: {
+    marginLeft: 6,
   },
   heroSubtitle: {
     marginTop: 4,

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -87,42 +87,45 @@ export interface GroupedInboxItemProps {
 }
 
 /**
- * Lowercase, hyphenate, and strip a string down to a `#channel-name`-safe slug.
+ * Turn a slug-ish string into a readable, title-cased label
+ * (e.g. "worship-team" → "Worship Team").
  */
-function slugifyChannelLabel(value: string): string {
+function humanize(value: string): string {
   return value
-    .toLowerCase()
     .trim()
-    .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9-]/g, "");
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 /**
- * Build a distinguishing `#team-channel` label for a serving-mode inbox row.
+ * Build a readable DISPLAY NAME for a serving-mode inbox row.
  *
- * Team channels are commonly named after the team, so a raw name can't tell the
- * rows apart. Disambiguate the well-known channel types by their role, and fall
- * back to the channel's own (already meaningful) name for custom channels.
+ * Serving mode flattens each of a team's channels into its own row, so the
+ * title must distinguish them without ever falling back to a raw `#slug`.
+ * Always prefer the channel's own name; for the well-known system channels
+ * (which rarely surface in serving mode) fall back to a humanized team-scoped
+ * label.
  */
 function getServingChannelLabel(teamName: string, channel: ChannelData): string {
-  const teamSlug = slugifyChannelLabel(teamName);
+  const name = channel.name?.trim();
   switch (channel.channelType) {
     case "main":
-      return `#${teamSlug}-general`;
+      return name || `${humanize(teamName)} General`;
     case "leaders":
-      return `#${teamSlug}-leaders`;
+      return name || `${humanize(teamName)} Leaders`;
     case "announcements":
-      return `#${teamSlug}-announcements`;
+      return name || `${humanize(teamName)} Announcements`;
     case "cross_team":
       // Cross-team channels always carry a distinct 1-50 char name; prefer it.
-      // The slug is only a fallback for the rare unnamed channel.
-      return channel.name && channel.name.trim() ? channel.name : `#${teamSlug}-cross-team`;
-    default: {
+      return name || humanize(teamName);
+    default:
       // Custom / pco_services / reach_out channels carry their own distinct
       // name from the backend — prefer it since it's already meaningful.
-      const nameSlug = channel.name ? slugifyChannelLabel(channel.name) : "";
-      return nameSlug ? `#${nameSlug}` : `#${teamSlug}-channel`;
-    }
+      return name || humanize(teamName);
   }
 }
 
@@ -446,6 +449,17 @@ function GroupedInboxItemInner({
             </View>
           </View>
 
+          {/* Serving mode: the title is the channel name, so name the parent
+              group underneath to keep flattened team rows distinguishable. */}
+          {servingMode && (
+            <Text
+              style={[styles.groupSubtext, { color: colors.textTertiary }]}
+              numberOfLines={1}
+            >
+              in {group.name}
+            </Text>
+          )}
+
           {/* Bottom row: Last message preview */}
           <View style={styles.bottomRow}>
             <Text
@@ -682,6 +696,11 @@ const styles = StyleSheet.create({
   },
   groupNameUnread: {
     fontWeight: "700",
+  },
+  groupSubtext: {
+    fontSize: 12,
+    marginTop: 1,
+    marginBottom: 2,
   },
   badge: {
     paddingHorizontal: 8,


### PR DESCRIPTION
## Summary

Two related channel-naming features.

### A. Surface channel rename for custom / cross-team / serving-team channels

- **Widened rename gate.** The rename UI was gated to plain `custom` channels only. It's now gated on a new `isRenameable` (`custom || cross_team`), which also covers **serving-team** channels (they are `custom` + `isServingTeam`). `pco_services` and system channels (main/leaders/announcements/reach_out) stay non-renameable.
- **Tappable hero title.** The channel title on the info screen is now tappable (with a `create-outline` pencil affordance) for leaders on renameable channels, opening the same rename flow as the Rename row. Non-renameable titles stay static.
- **Serving-team → team rename mirroring.** `updateChannel` now trims + validates the name (1-50 chars, must contain a letter or number — matching `createCustomChannel` / `updateTeam`), and when the channel `isServingTeam`, mirrors the rename onto the linked `teams` record via the `by_channel` index. Net effect: renaming a serving-team channel updates **both** `teams.name` and `chatChannels.name`, so the roster and the conversation stay in sync everywhere. The frontend just calls `updateChannel` for every renameable type.

### B. Event-mode (serving) inbox — one naming convention + group subtext

- **Display-name normalization.** `getServingChannelLabel` previously mixed `#slug` labels and display names. It now always returns the humanized display name (the channel's own `name` when present, else a readable team-scoped fallback like `Worship Team General`) and never a raw `#slug`. The now-unused `slugifyChannelLabel` helper was removed.
- **Parent-group subtext.** Each serving row now shows a subtle `in {group.name}` line (textTertiary, single line) under the title so flattened team channels stay distinguishable.
- Non-serving (normal) inbox rendering is unchanged. Serving mode always flattens to one channel per row in `getInboxChannels`, so the multi-channel expanded path is never hit in serving mode and is left as-is.

## Testing

- `apps/convex/__tests__/scheduling/teams.test.ts` extended: renaming a serving-team channel updates both the channel and the team, and an empty/whitespace name is rejected. All 28 tests pass.
- Convex `tsc --noEmit` and mobile `tsc --noEmit` clean for the touched files (only the known repo-wide `@togather/shared` baseline errors remain, on untouched import lines).
- **Not visually verified** — the simulator/browser was not driven for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSwZmWmrY1LisZYjSZYx49