### PR TITLE
feat(tasks): one-line team/role cells in Event Tasks grid for density

### DIFF
--- a/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
@@ -367,6 +367,7 @@ export function EventTasksGrid({
         ListHeaderComponent={listHeader ?? undefined}
         ListFooterComponent={footer}
         contentContainerStyle={styles.listContent}
+        dense
       />
 
       {/* Phase menu (Pre / During / Post) — an anchored dropdown at the pill. */}
@@ -423,10 +424,17 @@ function PhasePill({
 }
 
 /**
- * A cell that renders a wrapping set of removable chips (teams or roles) plus a
- * compact "+ Add" pill that measures its own window rect so the parent can
- * anchor a multi-select menu to it. When there are no chips, an optional
- * `emptyPlaceholder` label renders on the add pill (e.g. "Team-level").
+ * A cell that renders a wrapping set of removable chips (teams or roles) plus an
+ * add affordance that measures its own window rect so the parent can anchor a
+ * multi-select menu to it. The chips and the add control sit INLINE on one row
+ * (wrapping only when they overflow the column), so the common case — a single
+ * team / role — is a single line.
+ *
+ * When there are chips, the add control is a compact icon-only "+" button placed
+ * right after the last chip. When there are none and an `emptyPlaceholder` is
+ * given (the role column's team-level case), it renders as a single dashed
+ * "+ Team-level" chip that opens the same picker — so team-level rows are also
+ * one line and still read as "no role = team-level".
  */
 function ChipCell({
   chips,
@@ -447,6 +455,8 @@ function ChipCell({
   primaryColor: string;
 }) {
   const addRef = React.useRef<View>(null);
+  // Empty + a placeholder label => the team-level dashed chip (role column).
+  const showPlaceholder = chips.length === 0 && !!emptyPlaceholder;
   return (
     <View style={styles.chipWrap}>
       {chips.map((chip) => (
@@ -479,22 +489,36 @@ function ChipCell({
           ) : null}
         </View>
       ))}
-      <Pressable
-        ref={addRef}
-        onPress={() => measureAnchor(addRef.current, onAdd)}
-        style={[styles.chipAdd, { borderColor: primaryColor }]}
-        accessibilityRole="button"
-        accessibilityLabel={
-          chips.length === 0 && emptyPlaceholder
-            ? emptyPlaceholder
-            : `Add ${addLabel.toLowerCase()}`
-        }
-      >
-        <Ionicons name="add" size={13} color={primaryColor} />
-        <Text style={[styles.chipAddText, { color: primaryColor }]}>
-          {chips.length === 0 && emptyPlaceholder ? emptyPlaceholder : addLabel}
-        </Text>
-      </Pressable>
+      {showPlaceholder ? (
+        // Team-level: a single dashed placeholder chip that opens the role picker.
+        <Pressable
+          ref={addRef}
+          onPress={() => measureAnchor(addRef.current, onAdd)}
+          style={[styles.chipAdd, { borderColor: primaryColor }]}
+          accessibilityRole="button"
+          accessibilityLabel={emptyPlaceholder}
+        >
+          <Ionicons name="add" size={13} color={primaryColor} />
+          <Text style={[styles.chipAddText, { color: primaryColor }]}>
+            {emptyPlaceholder}
+          </Text>
+        </Pressable>
+      ) : (
+        // Compact icon-only add, inline after the last chip to keep one line.
+        <Pressable
+          ref={addRef}
+          onPress={() => measureAnchor(addRef.current, onAdd)}
+          hitSlop={8}
+          style={[
+            styles.chipAddCompact,
+            { borderColor: colors.border, backgroundColor: colors.surfaceSecondary },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={`Add ${addLabel.toLowerCase()}`}
+        >
+          <Ionicons name="add" size={15} color={colors.textSecondary} />
+        </Pressable>
+      )}
     </View>
   );
 }
@@ -609,6 +633,16 @@ const styles = StyleSheet.create({
     borderStyle: "dashed",
   },
   chipAddText: { fontSize: 12, fontWeight: "600" },
+  // Compact icon-only add: a small muted circle that hugs the chip on one line.
+  // Visually ~24px; hitSlop widens the touch target to a comfortable size.
+  chipAddCompact: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: StyleSheet.hairlineWidth,
+  },
   optionScroll: { maxHeight: 360 },
   optionRow: {
     flexDirection: "row",

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -55,6 +55,9 @@ const GRIP_W = 34;
 // with content top-aligned (not vertically centered) so multi-line cells read
 // cleanly against the shorter ones. The header is compact above it.
 const ROW_MIN_HEIGHT = 46;
+// Tighter floor for one-line-per-cell grids (Event Tasks). Rows still grow past
+// this when a cell wraps, so wrapped content is never clipped.
+const DENSE_ROW_MIN_HEIGHT = 38;
 const HEADER_MIN_HEIGHT = 38;
 
 interface Props<T> {
@@ -74,6 +77,12 @@ interface Props<T> {
   ListFooterComponent?: React.ReactElement | null;
   /** Vertical padding only — never horizontal, or rows misalign with the header. */
   contentContainerStyle?: StyleProp<ViewStyle>;
+  /**
+   * Tighter row min-height + cell padding for cells that are one line in the
+   * common case (e.g. the Event Tasks grid). Rows still grow when a cell wraps,
+   * so this never clips multi-line content — it only lowers the floor.
+   */
+  dense?: boolean;
 }
 
 export function GridScrollList<T>({
@@ -85,9 +94,11 @@ export function GridScrollList<T>({
   ListHeaderComponent,
   ListFooterComponent,
   contentContainerStyle,
+  dense = false,
 }: Props<T>) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
+  const rowMinHeight = dense ? DENSE_ROW_MIN_HEIGHT : ROW_MIN_HEIGHT;
 
   // The card's measured inner size. Width drives the slack distribution; height
   // bounds the inner content so the drag list's vertical scroll works while it
@@ -118,7 +129,7 @@ export function GridScrollList<T>({
   const cellFrame = (i: number): ViewStyle => ({
     width: effWidths[i],
     paddingHorizontal: 10,
-    paddingVertical: 9,
+    paddingVertical: dense ? 6 : 9,
     // Top-align content (events-os `items-start`) so a 2-line cell doesn't push
     // its 1-line neighbours off-centre. The row stretches every cell to the same
     // height, so the vertical dividers still run the full row.
@@ -191,6 +202,7 @@ export function GridScrollList<T>({
                     style={[
                       styles.row,
                       {
+                        minHeight: rowMinHeight,
                         borderBottomColor: colors.border,
                         backgroundColor: isActive
                           ? colors.surfaceSecondary


### PR DESCRIPTION
## Problem

In the Event Tasks grid, the **TEAM** and **ROLE** cells rendered their chip(s) on line 1 and a full-width **+ Team** / **+ Role** (and **+ Team-level**) text add-button on a *second* line. The `ChipCell` container was already `row` + `flexWrap`, but the wide text add-pill couldn't fit next to a chip in the 160px column, so it wrapped — **doubling every row's height** and cutting how many tasks fit on screen.

## Change

- **One line in the common case.** The chips and the add control now sit inline on one row. A single team/role chip plus a **compact icon-only `+` button** (Ionicons `add`, a small muted 24px circle with `hitSlop` for a comfortable touch target) sit on one line, wrapping only when multiple chips overflow the column.
- The compact `+` opens the **exact same** `onPickTeam` / `onPickRole` anchored picker as before (it still measures its own rect via `measureAnchor`). Keeps an `accessibilityLabel` ("Add team" / "Add role").
- **Team-level (empty role)** stays a single dashed **+ Team-level** chip that opens the role picker — one line, and still reads as "no role = team-level".
- Existing chip rendering (value chips, `×` remove control, colors, dots, picker menus) is unchanged — only the cell **layout** and resulting row height changed.
- **Row density:** `GridScrollList` gains an opt-in `dense` prop (Event Tasks passes it) that lowers the row min-height (46 → 38) and cell vertical padding (9 → 6). Rows still grow past the floor when a cell wraps (`minHeight` + `alignItems: stretch`), so wrapped/multi-line content is **never clipped**, and RunSheet's grid is untouched.

## Scope

Only the TEAM/ROLE cell layout + row height. No data-model, multi-select, picker-content, or backend changes. No `Pressable` function-style `style` (static styles only, RN-Web safe).

## Verification

Mobile `tsc --noEmit`: the two changed files are clean. Remaining errors are the known repo-wide `@togather/shared` module-resolution baseline (untouched import lines) plus a pre-existing unrelated tasks test — none from this change.

**Not visually verified** — I can't drive the simulator; the layout is reasoned from the flex/wrap rules (row + wrap + center + gap; compact 24px `+` fits beside a short chip in the ~140px usable column, wraps only on overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSwZmWmrY1LisZYjSZYx49