### PR TITLE
feat(events): template data model + CRUD (task + run-sheet templates)

### DIFF
--- a/apps/convex/__tests__/scheduling/eventTemplates.test.ts
+++ b/apps/convex/__tests__/scheduling/eventTemplates.test.ts
@@ -1,0 +1,701 @@
+/**
+ * Tests for event templates (Phase 1): reusable, per-group task templates and
+ * run-sheet templates + their CRUD (taskTemplates.ts / runSheetTemplates.ts).
+ *
+ * Covers: create/rename templates; add/list/reorder/update/delete items;
+ * delete-template cascades its items; list*Templates itemCounts; role-belongs-
+ * to-team validation; run-sheet song join; and auth (a non-leader cannot
+ * create or edit).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+/**
+ * Insert a second serving team (+ one role) in the world's group, so multi-team
+ * / cross-team validation can be exercised. Mirrors the eventTasks test helper.
+ */
+async function addSecondTeam(
+  t: ReturnType<typeof convexTest>,
+  world: Awaited<ReturnType<typeof buildSchedulingWorld>>,
+) {
+  return t.run(async (ctx) => {
+    const now = Date.now();
+    const teamId = await ctx.db.insert("teams", {
+      groupId: world.groupId,
+      communityId: world.communityId,
+      name: "Hospitality",
+      isArchived: false,
+      createdAt: now,
+      createdById: world.groupLeaderId,
+      updatedAt: now,
+    });
+    const roleId = await ctx.db.insert("teamRoles", {
+      teamId,
+      communityId: world.communityId,
+      name: "Greeter",
+      sortOrder: 0,
+      defaultNeeded: 1,
+      isArchived: false,
+      createdAt: now,
+      createdById: world.groupLeaderId,
+    });
+    return { teamId, roleId };
+  });
+}
+
+// ============================================================================
+// Task templates
+// ============================================================================
+
+describe("task templates CRUD", () => {
+  it("creates, renames, adds/lists items ordered, and reorders", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.taskTemplates.createTaskTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Sunday Setup" },
+    );
+
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.renameTaskTemplate,
+      { token: leaderToken, templateId, name: "Sunday AM Setup" },
+    );
+
+    // Create in mixed segments to prove before < during < after ordering.
+    const after = await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        teamIds: [world.teamId],
+        segment: "after",
+        title: "Tear down",
+        howToType: "none",
+      },
+    );
+    const before1 = await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        teamIds: [world.teamId],
+        roleIds: [world.roleId],
+        segment: "before",
+        title: "Set up drums",
+        howToType: "text",
+        howToText: "Assemble the kit",
+      },
+    );
+    const before2 = await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        teamIds: [world.teamId],
+        segment: "before",
+        title: "Sound check",
+        howToType: "none",
+      },
+    );
+
+    const list = await t.query(
+      api.functions.scheduling.taskTemplates.listTaskTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list.map((x) => x.title)).toEqual([
+      "Set up drums",
+      "Sound check",
+      "Tear down",
+    ]);
+    // Role names hydrated; team-level item has an empty roleNames array.
+    const setUp = list.find((x) => x.title === "Set up drums")!;
+    expect(setUp.roleNames).toEqual(["Drums"]);
+    expect(setUp.teamNames).toEqual(["Worship Team"]);
+    expect(list.find((x) => x.title === "Sound check")!.roleNames).toEqual([]);
+
+    // Reorder: put "Sound check" before "Set up drums".
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.reorderTaskTemplateItems,
+      {
+        token: leaderToken,
+        templateId,
+        orderedIds: [before2.itemId, before1.itemId, after.itemId],
+      },
+    );
+    const reordered = await t.query(
+      api.functions.scheduling.taskTemplates.listTaskTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(reordered.map((x) => x.title)).toEqual([
+      "Sound check",
+      "Set up drums",
+      "Tear down",
+    ]);
+  });
+
+  it("updates an item and deletes an item", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.taskTemplates.createTaskTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Setup" },
+    );
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        teamIds: [world.teamId],
+        roleIds: [world.roleId],
+        segment: "before",
+        title: "Original",
+        howToType: "none",
+      },
+    );
+
+    // Update title + convert to team-level (empty roleIds).
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.updateTaskTemplateItem,
+      { token: leaderToken, itemId, title: "Renamed", roleIds: [] },
+    );
+    let list = await t.query(
+      api.functions.scheduling.taskTemplates.listTaskTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list[0].title).toBe("Renamed");
+    expect(list[0].roleIds).toEqual([]);
+
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.deleteTaskTemplateItem,
+      { token: leaderToken, itemId },
+    );
+    list = await t.query(
+      api.functions.scheduling.taskTemplates.listTaskTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list).toHaveLength(0);
+  });
+
+  it("rejects a role that does not belong to one of the item's teams", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const team2 = await addSecondTeam(t, world);
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.taskTemplates.createTaskTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "X" },
+    );
+
+    // teamIds = [team1] but roleIds = [team2's role] → cross-team, rejected.
+    await expect(
+      t.mutation(
+        api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+        {
+          token: leaderToken,
+          templateId,
+          teamIds: [world.teamId],
+          roleIds: [team2.roleId],
+          segment: "before",
+          title: "Bad",
+          howToType: "none",
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("cascades items when the template is deleted", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.taskTemplates.createTaskTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Doomed" },
+    );
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        teamIds: [world.teamId],
+        segment: "before",
+        title: "One",
+        howToType: "none",
+      },
+    );
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        teamIds: [world.teamId],
+        segment: "after",
+        title: "Two",
+        howToType: "none",
+      },
+    );
+
+    const { deletedItems } = await t.mutation(
+      api.functions.scheduling.taskTemplates.deleteTaskTemplate,
+      { token: leaderToken, templateId },
+    );
+    expect(deletedItems).toBe(2);
+
+    const remaining = await t.run(async (ctx) =>
+      ctx.db
+        .query("eventTaskTemplateItems")
+        .withIndex("by_template", (q) => q.eq("templateId", templateId))
+        .collect(),
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("listTaskTemplates returns correct itemCounts", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const a = await t.mutation(
+      api.functions.scheduling.taskTemplates.createTaskTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Alpha" },
+    );
+    const b = await t.mutation(
+      api.functions.scheduling.taskTemplates.createTaskTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Bravo" },
+    );
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId: a.templateId,
+        teamIds: [world.teamId],
+        segment: "before",
+        title: "one",
+        howToType: "none",
+      },
+    );
+    await t.mutation(
+      api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+      {
+        token: leaderToken,
+        templateId: a.templateId,
+        teamIds: [world.teamId],
+        segment: "before",
+        title: "two",
+        howToType: "none",
+      },
+    );
+
+    const list = await t.query(
+      api.functions.scheduling.taskTemplates.listTaskTemplates,
+      { token: leaderToken, groupId: world.groupId },
+    );
+    const byId = new Map(list.map((x) => [x._id as string, x.itemCount]));
+    expect(byId.get(a.templateId as string)).toBe(2);
+    expect(byId.get(b.templateId as string)).toBe(0);
+  });
+
+  it("rejects create + edit from a non-leader", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+
+    await expect(
+      t.mutation(
+        api.functions.scheduling.taskTemplates.createTaskTemplate,
+        { token: memberToken, groupId: world.groupId, name: "Nope" },
+      ),
+    ).rejects.toThrow();
+
+    // Leader creates one; a plain member cannot add an item to it.
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.taskTemplates.createTaskTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Real" },
+    );
+    await expect(
+      t.mutation(
+        api.functions.scheduling.taskTemplates.addTaskTemplateItem,
+        {
+          token: memberToken,
+          templateId,
+          teamIds: [world.teamId],
+          segment: "before",
+          title: "Nope",
+          howToType: "none",
+        },
+      ),
+    ).rejects.toThrow();
+
+    // A plain group member CAN read the list (community read gate).
+    const list = await t.query(
+      api.functions.scheduling.taskTemplates.listTaskTemplates,
+      { token: memberToken, groupId: world.groupId },
+    );
+    expect(list).toHaveLength(1);
+  });
+
+  it("rejects an invalid template name", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    await expect(
+      t.mutation(
+        api.functions.scheduling.taskTemplates.createTaskTemplate,
+        { token: leaderToken, groupId: world.groupId, name: "   " },
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ============================================================================
+// Run-sheet templates
+// ============================================================================
+
+describe("run-sheet templates CRUD", () => {
+  it("creates, adds/lists items ordered by segment+sequence, reorders", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Standard Flow" },
+    );
+
+    const opener = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "header",
+        title: "Pre-service",
+        segment: "before",
+        durationSec: 0,
+      },
+    );
+    const song = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "song",
+        title: "Opening Song",
+        segment: "during",
+        durationSec: 300,
+      },
+    );
+    const item2 = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "item",
+        title: "Welcome",
+        segment: "during",
+        durationSec: 120,
+      },
+    );
+
+    let list = await t.query(
+      api.functions.scheduling.runSheetTemplates.listRunSheetTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    // before → during (opening song, then welcome).
+    expect(list.map((x) => x.title)).toEqual([
+      "Pre-service",
+      "Opening Song",
+      "Welcome",
+    ]);
+
+    // Reorder the two during items (Welcome before Opening Song).
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.reorderRunSheetTemplateItems,
+      {
+        token: leaderToken,
+        templateId,
+        orderedItems: [
+          { id: opener.itemId, segment: "before" },
+          { id: item2.itemId, segment: "during" },
+          { id: song.itemId, segment: "during" },
+        ],
+      },
+    );
+    list = await t.query(
+      api.functions.scheduling.runSheetTemplates.listRunSheetTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list.map((x) => x.title)).toEqual([
+      "Pre-service",
+      "Welcome",
+      "Opening Song",
+    ]);
+  });
+
+  it("updates, duplicates, and deletes an item", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Flow" },
+    );
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "song",
+        title: "Song A",
+        segment: "during",
+        durationSec: 200,
+      },
+    );
+
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.updateRunSheetTemplateItem,
+      { token: leaderToken, itemId, title: "Song A (edited)", durationSec: 250 },
+    );
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.duplicateRunSheetTemplateItem,
+      { token: leaderToken, itemId },
+    );
+
+    let list = await t.query(
+      api.functions.scheduling.runSheetTemplates.listRunSheetTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list.map((x) => x.title)).toEqual([
+      "Song A (edited)",
+      "Song A (edited)",
+    ]);
+    expect(list[0].durationSec).toBe(250);
+    // Contiguous sequences within the segment after duplication.
+    expect(list.map((x) => x.sequence)).toEqual([0, 1]);
+
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.deleteRunSheetTemplateItem,
+      { token: leaderToken, itemId },
+    );
+    list = await t.query(
+      api.functions.scheduling.runSheetTemplates.listRunSheetTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list).toHaveLength(1);
+  });
+
+  it("joins a linked library song and validates cross-community songs", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Flow" },
+    );
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "song",
+        title: "Amazing Grace",
+        segment: "during",
+        durationSec: 300,
+      },
+    );
+
+    // A library song in the same community.
+    const songId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("songs", {
+        communityId: world.communityId,
+        title: "Amazing Grace",
+        author: "John Newton",
+        createdAt: now,
+        createdById: world.groupLeaderId,
+        updatedAt: now,
+      });
+    });
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.updateRunSheetTemplateItem,
+      { token: leaderToken, itemId, songId },
+    );
+
+    const list = await t.query(
+      api.functions.scheduling.runSheetTemplates.listRunSheetTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list[0].songId).toBe(songId);
+    expect((list[0].song as { title: string } | null)?.title).toBe(
+      "Amazing Grace",
+    );
+
+    // A song in a DIFFERENT community cannot be linked.
+    const foreignSongId = await t.run(async (ctx) => {
+      const now = Date.now();
+      const otherCommunityId = await ctx.db.insert("communities", {
+        name: "Other",
+        slug: "other",
+        isPublic: true,
+      });
+      return ctx.db.insert("songs", {
+        communityId: otherCommunityId,
+        title: "Foreign",
+        createdAt: now,
+        createdById: world.groupLeaderId,
+        updatedAt: now,
+      });
+    });
+    await expect(
+      t.mutation(
+        api.functions.scheduling.runSheetTemplates.updateRunSheetTemplateItem,
+        { token: leaderToken, itemId, songId: foreignSongId },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("validates run-sheet item role assignments against the template's group", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Flow" },
+    );
+
+    // A role in a different group cannot be assigned.
+    const foreignRoleId = await t.run(async (ctx) => {
+      const now = Date.now();
+      const existingGroup = await ctx.db.get(world.groupId);
+      const otherGroupId = await ctx.db.insert("groups", {
+        communityId: world.communityId,
+        groupTypeId: existingGroup!.groupTypeId,
+        name: "Other Campus",
+        isArchived: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const otherTeamId = await ctx.db.insert("teams", {
+        groupId: otherGroupId,
+        communityId: world.communityId,
+        name: "Other Team",
+        isArchived: false,
+        createdAt: now,
+        createdById: world.groupLeaderId,
+        updatedAt: now,
+      });
+      return ctx.db.insert("teamRoles", {
+        teamId: otherTeamId,
+        communityId: world.communityId,
+        name: "Foreign Role",
+        sortOrder: 0,
+        defaultNeeded: 1,
+        isArchived: false,
+        createdAt: now,
+        createdById: world.groupLeaderId,
+      });
+    });
+
+    await expect(
+      t.mutation(
+        api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+        {
+          token: leaderToken,
+          templateId,
+          type: "item",
+          title: "Bad assignment",
+          segment: "during",
+          assignments: [{ roleId: foreignRoleId }],
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("cascades items when the template is deleted; listRunSheetTemplates itemCounts", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const a = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Alpha" },
+    );
+    const b = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Bravo" },
+    );
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId: a.templateId,
+        type: "song",
+        title: "s1",
+        segment: "during",
+        durationSec: 100,
+      },
+    );
+
+    const counts = await t.query(
+      api.functions.scheduling.runSheetTemplates.listRunSheetTemplates,
+      { token: leaderToken, groupId: world.groupId },
+    );
+    const byId = new Map(counts.map((x) => [x._id as string, x.itemCount]));
+    expect(byId.get(a.templateId as string)).toBe(1);
+    expect(byId.get(b.templateId as string)).toBe(0);
+
+    const { deletedItems } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.deleteRunSheetTemplate,
+      { token: leaderToken, templateId: a.templateId },
+    );
+    expect(deletedItems).toBe(1);
+    const remaining = await t.run(async (ctx) =>
+      ctx.db
+        .query("runSheetTemplateItems")
+        .withIndex("by_template", (q) => q.eq("templateId", a.templateId))
+        .collect(),
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("rejects create + edit from a non-leader", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+
+    await expect(
+      t.mutation(
+        api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+        { token: memberToken, groupId: world.groupId, name: "Nope" },
+      ),
+    ).rejects.toThrow();
+
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Real" },
+    );
+    await expect(
+      t.mutation(
+        api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+        {
+          token: memberToken,
+          templateId,
+          type: "song",
+          title: "Nope",
+          segment: "during",
+          durationSec: 100,
+        },
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/convex/__tests__/scheduling/eventTemplates.test.ts
+++ b/apps/convex/__tests__/scheduling/eventTemplates.test.ts
@@ -567,6 +567,98 @@ describe("run-sheet templates CRUD", () => {
     ).rejects.toThrow();
   });
 
+  it("nulls a template item's songId when the linked song is deleted", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Flow" },
+    );
+    const { itemId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "song",
+        title: "Doxology",
+        segment: "during",
+        durationSec: 120,
+      },
+    );
+
+    const songId = await t.mutation(
+      api.functions.scheduling.songs.createSong,
+      {
+        token: leaderToken,
+        communityId: world.communityId,
+        input: { title: "Doxology" },
+      },
+    );
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.updateRunSheetTemplateItem,
+      { token: leaderToken, itemId, songId },
+    );
+
+    // Deleting the song must null the template item's songId (no dangling ref).
+    const result = await t.mutation(
+      api.functions.scheduling.songs.deleteSong,
+      { token: leaderToken, songId },
+    );
+    expect(result.unlinkedTemplateItems).toBe(1);
+
+    const list = await t.query(
+      api.functions.scheduling.runSheetTemplates.listRunSheetTemplateItems,
+      { token: leaderToken, templateId },
+    );
+    expect(list[0].songId).toBeNull();
+    expect(list[0].song).toBeNull();
+    // The item itself survives, falling back to its title.
+    expect(list[0].title).toBe("Doxology");
+  });
+
+  it("rejects a stale/partial run-sheet reorder set", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { templateId } = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.createRunSheetTemplate,
+      { token: leaderToken, groupId: world.groupId, name: "Flow" },
+    );
+    const a = await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "item",
+        title: "A",
+        segment: "during",
+        durationSec: 60,
+      },
+    );
+    await t.mutation(
+      api.functions.scheduling.runSheetTemplates.addRunSheetTemplateItem,
+      {
+        token: leaderToken,
+        templateId,
+        type: "item",
+        title: "B",
+        segment: "during",
+        durationSec: 60,
+      },
+    );
+
+    // Partial set (only one of two items) is stale → rejected.
+    await expect(
+      t.mutation(
+        api.functions.scheduling.runSheetTemplates.reorderRunSheetTemplateItems,
+        {
+          token: leaderToken,
+          templateId,
+          orderedItems: [{ id: a.itemId, segment: "during" }],
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
   it("validates run-sheet item role assignments against the template's group", async () => {
     const { t, world } = await setupSchedulingWorld();
     const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -149,6 +149,8 @@ import type * as functions_scheduling_events from "../functions/scheduling/event
 import type * as functions_scheduling_index from "../functions/scheduling/index.js";
 import type * as functions_scheduling_mySchedule from "../functions/scheduling/mySchedule.js";
 import type * as functions_scheduling_people from "../functions/scheduling/people.js";
+import type * as functions_scheduling_runSheetTemplates from "../functions/scheduling/runSheetTemplates.js";
+import type * as functions_scheduling_taskTemplates from "../functions/scheduling/taskTemplates.js";
 import type * as functions_scheduling_permissions from "../functions/scheduling/permissions.js";
 import type * as functions_scheduling_presence from "../functions/scheduling/presence.js";
 import type * as functions_scheduling_publicAvailability from "../functions/scheduling/publicAvailability.js";
@@ -371,6 +373,8 @@ declare const fullApi: ApiFromModules<{
   "functions/scheduling/index": typeof functions_scheduling_index;
   "functions/scheduling/mySchedule": typeof functions_scheduling_mySchedule;
   "functions/scheduling/people": typeof functions_scheduling_people;
+  "functions/scheduling/runSheetTemplates": typeof functions_scheduling_runSheetTemplates;
+  "functions/scheduling/taskTemplates": typeof functions_scheduling_taskTemplates;
   "functions/scheduling/permissions": typeof functions_scheduling_permissions;
   "functions/scheduling/presence": typeof functions_scheduling_presence;
   "functions/scheduling/publicAvailability": typeof functions_scheduling_publicAvailability;

--- a/apps/convex/functions/scheduling/index.ts
+++ b/apps/convex/functions/scheduling/index.ts
@@ -63,6 +63,33 @@ export {
 } from "./eventItems";
 
 // ============================================================================
+// Event templates — reusable per-group task + run-sheet templates (Phase 1)
+// ============================================================================
+export {
+  createTaskTemplate,
+  renameTaskTemplate,
+  deleteTaskTemplate,
+  listTaskTemplates,
+  listTaskTemplateItems,
+  addTaskTemplateItem,
+  updateTaskTemplateItem,
+  deleteTaskTemplateItem,
+  reorderTaskTemplateItems,
+} from "./taskTemplates";
+export {
+  createRunSheetTemplate,
+  renameRunSheetTemplate,
+  deleteRunSheetTemplate,
+  listRunSheetTemplates,
+  listRunSheetTemplateItems,
+  addRunSheetTemplateItem,
+  updateRunSheetTemplateItem,
+  deleteRunSheetTemplateItem,
+  duplicateRunSheetTemplateItem,
+  reorderRunSheetTemplateItems,
+} from "./runSheetTemplates";
+
+// ============================================================================
 // Assignments & lifecycle
 // ============================================================================
 export {

--- a/apps/convex/functions/scheduling/runSheetTemplates.ts
+++ b/apps/convex/functions/scheduling/runSheetTemplates.ts
@@ -1,0 +1,637 @@
+/**
+ * Scheduling — Run-sheet templates (Phase 1 of event templates)
+ *
+ * A `runSheetTemplates` row is a reusable, per-GROUP order-of-items a leader
+ * saves for a location and can later apply to a plan's `eventItems`. Its items
+ * (`runSheetTemplateItems`) mirror `eventItems` minus the `planId` (keyed by
+ * `templateId`), with the same segment + `sequence` ordering, notes, role
+ * `assignments`, and library `songId` join. Clock times are never stored
+ * (durations cascade client-side), matching `eventItems`. Plan linkage /
+ * propagation land in later phases.
+ *
+ * Auth mirrors `eventItems`: viewing requires an active group member
+ * (`requireGroupMember`); editing requires `requireGroupScheduler` (group
+ * leader / community admin).
+ */
+
+import { ConvexError, v } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { requireGroupMember, requireGroupScheduler } from "./permissions";
+import { getHydratedSongForJoin } from "./songs";
+
+/** Run sheet item types — mirrors PCO vocabulary. */
+const ITEM_TYPES = new Set(["song", "header", "media", "item"]);
+
+/** When an item happens relative to the event's service times. */
+const SEGMENTS = ["before", "during", "after"] as const;
+type Segment = (typeof SEGMENTS)[number];
+const SEGMENT_SET = new Set<string>(SEGMENTS);
+
+/** An item's segment, defaulting legacy/absent rows to "during". */
+function itemSegment(item: Doc<"runSheetTemplateItems">): Segment {
+  const s = item.segment;
+  return s && SEGMENT_SET.has(s) ? (s as Segment) : "during";
+}
+
+/** Validate a run sheet segment, throwing on an unknown value. */
+function assertSegment(segment: string): void {
+  if (!SEGMENT_SET.has(segment)) {
+    throw new ConvexError(`Unknown run sheet segment: ${segment}`);
+  }
+}
+
+/** Validate a run sheet item type, throwing on an unknown value. */
+function assertItemType(type: string): void {
+  if (!ITEM_TYPES.has(type)) {
+    throw new ConvexError(`Unknown run sheet item type: ${type}`);
+  }
+}
+
+/** Highest `sequence` among a template's items in `segment`, or -1 if none. */
+function lastSequenceInSegment(
+  items: Doc<"runSheetTemplateItems">[],
+  segment: Segment,
+): number {
+  return items.reduce(
+    (max, i) => (itemSegment(i) === segment ? Math.max(max, i.sequence) : max),
+    -1,
+  );
+}
+
+const noteValidator = v.object({
+  category: v.string(),
+  content: v.string(),
+});
+
+const itemAssignmentValidator = v.object({
+  roleId: v.id("teamRoles"),
+});
+
+const songDetailsValidator = v.object({
+  key: v.optional(v.string()),
+  bpm: v.optional(v.number()),
+  author: v.optional(v.string()),
+});
+
+/**
+ * Validate a template name — same rule as `createCrossTeamChannel`: 1–50
+ * characters, at least one letter or number. Returns the trimmed name.
+ */
+function validateTemplateName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < 1 || trimmed.length > 50) {
+    throw new ConvexError("Template name must be 1-50 characters.");
+  }
+  if (!/[a-zA-Z0-9]/.test(trimmed)) {
+    throw new ConvexError(
+      "Template name must contain at least one letter or number.",
+    );
+  }
+  return trimmed;
+}
+
+/** Load a run-sheet template or throw. */
+async function requireRunSheetTemplate(
+  ctx: QueryCtx | MutationCtx,
+  templateId: Id<"runSheetTemplates">,
+): Promise<Doc<"runSheetTemplates">> {
+  const template = await ctx.db.get(templateId);
+  if (!template) {
+    throw new ConvexError("Run sheet template not found");
+  }
+  return template;
+}
+
+/**
+ * Resolve a template and assert the caller may edit its group's schedule.
+ */
+async function requireRunSheetTemplateScheduler(
+  ctx: MutationCtx,
+  templateId: Id<"runSheetTemplates">,
+  userId: Id<"users">,
+): Promise<Doc<"runSheetTemplates">> {
+  const template = await requireRunSheetTemplate(ctx, templateId);
+  await requireGroupScheduler(ctx, template.groupId, userId);
+  return template;
+}
+
+/**
+ * Resolve a run sheet template item, assert the caller may edit its template,
+ * and return both. Mirrors `eventItems.requireItemScheduler`.
+ */
+async function requireItemScheduler(
+  ctx: MutationCtx,
+  itemId: Id<"runSheetTemplateItems">,
+  userId: Id<"users">,
+): Promise<{
+  item: Doc<"runSheetTemplateItems">;
+  template: Doc<"runSheetTemplates">;
+}> {
+  const item = await ctx.db.get(itemId);
+  if (!item) {
+    throw new ConvexError("Run sheet template item not found");
+  }
+  const template = await requireRunSheetTemplateScheduler(
+    ctx,
+    item.templateId,
+    userId,
+  );
+  return { item, template };
+}
+
+/**
+ * Validate that every `assignments` entry references a role belonging to a team
+ * in the template's group. Mirrors `eventItems.validateItemAssignments`.
+ */
+async function validateItemAssignments(
+  ctx: MutationCtx,
+  template: Doc<"runSheetTemplates">,
+  assignments: Array<{ roleId: Id<"teamRoles"> }>,
+): Promise<void> {
+  for (const link of assignments) {
+    const role = await ctx.db.get(link.roleId);
+    if (!role) {
+      throw new ConvexError("Linked role not found");
+    }
+    const team = await ctx.db.get(role.teamId);
+    if (!team || team.groupId !== template.groupId) {
+      throw new ConvexError(
+        "Linked role does not belong to this template's group",
+      );
+    }
+  }
+}
+
+/**
+ * Join a template item's linked assignments with role display info + library
+ * song. Mirrors `eventItems.hydrateItem`.
+ */
+async function hydrateItem(ctx: QueryCtx, item: Doc<"runSheetTemplateItems">) {
+  const assignments = await Promise.all(
+    (item.assignments ?? []).map(async (link) => {
+      const role = await ctx.db.get(link.roleId);
+      return {
+        roleId: link.roleId,
+        roleName: role?.name ?? "Role",
+        roleColor: role?.color ?? null,
+      };
+    }),
+  );
+
+  const song = await getHydratedSongForJoin(ctx, item.songId);
+
+  return {
+    _id: item._id,
+    templateId: item.templateId,
+    segment: itemSegment(item),
+    sequence: item.sequence,
+    type: item.type,
+    title: item.title,
+    description: item.description ?? null,
+    durationSec: item.durationSec,
+    notes: item.notes ?? [],
+    songDetails: item.songDetails ?? null,
+    songId: item.songId ?? null,
+    song,
+    assignments,
+  };
+}
+
+// ============================================================================
+// Templates
+// ============================================================================
+
+/**
+ * Create an empty run-sheet template for a group.
+ *
+ * Auth: group leader / community admin for the group.
+ */
+export const createRunSheetTemplate = mutation({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    name: v.string(),
+  },
+  returns: v.object({ templateId: v.id("runSheetTemplates") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const group = await requireGroupScheduler(ctx, args.groupId, userId);
+
+    const name = validateTemplateName(args.name);
+    const nowMs = Date.now();
+    const templateId = await ctx.db.insert("runSheetTemplates", {
+      groupId: args.groupId,
+      communityId: group.communityId,
+      name,
+      createdById: userId,
+      createdAt: nowMs,
+      updatedAt: nowMs,
+    });
+    return { templateId };
+  },
+});
+
+/**
+ * Rename a run-sheet template.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const renameRunSheetTemplate = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("runSheetTemplates"),
+    name: v.string(),
+  },
+  returns: v.object({ templateId: v.id("runSheetTemplates") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireRunSheetTemplateScheduler(ctx, args.templateId, userId);
+
+    const name = validateTemplateName(args.name);
+    await ctx.db.patch(args.templateId, { name, updatedAt: Date.now() });
+    return { templateId: args.templateId };
+  },
+});
+
+/**
+ * Delete a run-sheet template and cascade all of its items.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const deleteRunSheetTemplate = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("runSheetTemplates"),
+  },
+  returns: v.object({ deletedItems: v.number() }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireRunSheetTemplateScheduler(ctx, args.templateId, userId);
+
+    const items = await ctx.db
+      .query("runSheetTemplateItems")
+      .withIndex("by_template", (q) => q.eq("templateId", args.templateId))
+      .collect();
+    await Promise.all(items.map((i) => ctx.db.delete(i._id)));
+    await ctx.db.delete(args.templateId);
+    return { deletedItems: items.length };
+  },
+});
+
+/**
+ * List a group's run-sheet templates, each with its `itemCount`.
+ *
+ * Auth: an active member of the group (community read gate).
+ */
+export const listRunSheetTemplates = query({
+  args: { token: v.string(), groupId: v.id("groups") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupMember(ctx, args.groupId, userId);
+
+    const templates = await ctx.db
+      .query("runSheetTemplates")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .collect();
+    templates.sort((a, b) => a.createdAt - b.createdAt);
+
+    return Promise.all(
+      templates.map(async (template) => {
+        const items = await ctx.db
+          .query("runSheetTemplateItems")
+          .withIndex("by_template", (q) => q.eq("templateId", template._id))
+          .collect();
+        return {
+          _id: template._id,
+          groupId: template.groupId,
+          name: template.name,
+          itemCount: items.length,
+          createdAt: template.createdAt,
+          updatedAt: template.updatedAt,
+        };
+      }),
+    );
+  },
+});
+
+/**
+ * List a template's items in (segment, sequence) order, hydrated with role +
+ * song display info. Mirrors `eventItems.listItems`.
+ *
+ * Auth: an active member of the template's group.
+ */
+export const listRunSheetTemplateItems = query({
+  args: { token: v.string(), templateId: v.id("runSheetTemplates") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const template = await requireRunSheetTemplate(ctx, args.templateId);
+    await requireGroupMember(ctx, template.groupId, userId);
+
+    const items = await ctx.db
+      .query("runSheetTemplateItems")
+      .withIndex("by_template", (q) => q.eq("templateId", args.templateId))
+      .collect();
+    const segRank = (i: Doc<"runSheetTemplateItems">) =>
+      SEGMENTS.indexOf(itemSegment(i));
+    items.sort((a, b) => segRank(a) - segRank(b) || a.sequence - b.sequence);
+
+    return Promise.all(items.map((item) => hydrateItem(ctx, item)));
+  },
+});
+
+// ============================================================================
+// Template items
+// ============================================================================
+
+/**
+ * Append a new item to the end of a template's given segment. Mirrors
+ * `eventItems.createItem`.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const addRunSheetTemplateItem = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("runSheetTemplates"),
+    type: v.string(),
+    title: v.string(),
+    segment: v.optional(v.string()),
+    durationSec: v.optional(v.number()),
+    description: v.optional(v.string()),
+    notes: v.optional(v.array(noteValidator)),
+    assignments: v.optional(v.array(itemAssignmentValidator)),
+    songDetails: v.optional(songDetailsValidator),
+  },
+  returns: v.object({ itemId: v.id("runSheetTemplateItems") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const template = await requireRunSheetTemplateScheduler(
+      ctx,
+      args.templateId,
+      userId,
+    );
+
+    assertItemType(args.type);
+    const segment: Segment = (args.segment as Segment) ?? "during";
+    assertSegment(segment);
+    const title = args.title.trim();
+    if (!title) {
+      throw new ConvexError("Run sheet item title cannot be empty");
+    }
+    if (args.assignments && args.assignments.length > 0) {
+      await validateItemAssignments(ctx, template, args.assignments);
+    }
+
+    const existing = await ctx.db
+      .query("runSheetTemplateItems")
+      .withIndex("by_template", (q) => q.eq("templateId", args.templateId))
+      .collect();
+    const nextSequence = lastSequenceInSegment(existing, segment) + 1;
+
+    const nowMs = Date.now();
+    const itemId = await ctx.db.insert("runSheetTemplateItems", {
+      templateId: args.templateId,
+      communityId: template.communityId,
+      segment,
+      sequence: nextSequence,
+      type: args.type,
+      title,
+      description: args.description?.trim() || undefined,
+      durationSec: Math.max(0, Math.round(args.durationSec ?? 0)),
+      notes: args.notes,
+      assignments: args.assignments,
+      songDetails: args.songDetails,
+      createdAt: nowMs,
+      createdById: userId,
+      updatedAt: nowMs,
+    });
+    return { itemId };
+  },
+});
+
+/**
+ * Update a template item's editable fields. Only provided fields change; pass an
+ * empty array to clear `notes` / `assignments`. Mirrors `eventItems.updateItem`.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const updateRunSheetTemplateItem = mutation({
+  args: {
+    token: v.string(),
+    itemId: v.id("runSheetTemplateItems"),
+    type: v.optional(v.string()),
+    title: v.optional(v.string()),
+    segment: v.optional(v.string()),
+    durationSec: v.optional(v.number()),
+    description: v.optional(v.string()),
+    notes: v.optional(v.array(noteValidator)),
+    assignments: v.optional(v.array(itemAssignmentValidator)),
+    songDetails: v.optional(songDetailsValidator),
+    /** Link a library song, `null` clears, omitted leaves unchanged. */
+    songId: v.optional(v.union(v.id("songs"), v.null())),
+  },
+  returns: v.object({ itemId: v.id("runSheetTemplateItems") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const { item, template } = await requireItemScheduler(
+      ctx,
+      args.itemId,
+      userId,
+    );
+
+    const patch: Partial<Doc<"runSheetTemplateItems">> = {
+      updatedAt: Date.now(),
+    };
+    if (args.segment !== undefined) {
+      assertSegment(args.segment);
+      // Moving to another phase appends the item to the end of it.
+      if (args.segment !== itemSegment(item)) {
+        const siblings = await ctx.db
+          .query("runSheetTemplateItems")
+          .withIndex("by_template", (q) => q.eq("templateId", item.templateId))
+          .collect();
+        patch.segment = args.segment;
+        patch.sequence =
+          lastSequenceInSegment(siblings, args.segment as Segment) + 1;
+      }
+    }
+    if (args.type !== undefined) {
+      assertItemType(args.type);
+      patch.type = args.type;
+    }
+    if (args.title !== undefined) {
+      const title = args.title.trim();
+      if (!title) {
+        throw new ConvexError("Run sheet item title cannot be empty");
+      }
+      patch.title = title;
+    }
+    if (args.durationSec !== undefined) {
+      patch.durationSec = Math.max(0, Math.round(args.durationSec));
+    }
+    if (args.description !== undefined) {
+      patch.description = args.description.trim() || undefined;
+    }
+    if (args.notes !== undefined) patch.notes = args.notes;
+    if (args.assignments !== undefined) {
+      if (args.assignments.length > 0) {
+        await validateItemAssignments(ctx, template, args.assignments);
+      }
+      patch.assignments = args.assignments;
+    }
+    if (args.songDetails !== undefined) patch.songDetails = args.songDetails;
+    if (args.songId !== undefined) {
+      if (args.songId === null) {
+        patch.songId = undefined;
+      } else {
+        const song = await ctx.db.get(args.songId);
+        if (!song || song.communityId !== template.communityId) {
+          throw new ConvexError("Linked song does not belong to this community");
+        }
+        patch.songId = args.songId;
+      }
+    }
+
+    await ctx.db.patch(args.itemId, patch);
+    return { itemId: args.itemId };
+  },
+});
+
+/**
+ * Delete a single template item. Remaining items keep their `sequence` values
+ * (gaps are harmless); call `reorderRunSheetTemplateItems` to compact. Mirrors
+ * `eventItems.deleteItem`.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const deleteRunSheetTemplateItem = mutation({
+  args: { token: v.string(), itemId: v.id("runSheetTemplateItems") },
+  returns: v.object({ deleted: v.boolean() }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireItemScheduler(ctx, args.itemId, userId);
+    await ctx.db.delete(args.itemId);
+    return { deleted: true };
+  },
+});
+
+/**
+ * Duplicate a template item, placing the copy immediately after the source and
+ * resequencing that segment. Mirrors `eventItems.duplicateItem`.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const duplicateRunSheetTemplateItem = mutation({
+  args: { token: v.string(), itemId: v.id("runSheetTemplateItems") },
+  returns: v.object({ itemId: v.id("runSheetTemplateItems") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const { item, template } = await requireItemScheduler(
+      ctx,
+      args.itemId,
+      userId,
+    );
+
+    const segment = itemSegment(item);
+    const nowMs = Date.now();
+    const newItemId = await ctx.db.insert("runSheetTemplateItems", {
+      templateId: item.templateId,
+      communityId: template.communityId,
+      segment,
+      sequence: item.sequence, // provisional; resequenced below
+      type: item.type,
+      title: item.title,
+      description: item.description,
+      durationSec: item.durationSec,
+      notes: item.notes,
+      assignments: item.assignments,
+      songDetails: item.songDetails,
+      songId: item.songId,
+      createdAt: nowMs,
+      createdById: userId,
+      updatedAt: nowMs,
+    });
+
+    const all = await ctx.db
+      .query("runSheetTemplateItems")
+      .withIndex("by_template", (q) => q.eq("templateId", item.templateId))
+      .collect();
+    const segmentOrder = all
+      .filter((i) => i._id !== newItemId && itemSegment(i) === segment)
+      .sort((a, b) => a.sequence - b.sequence)
+      .map((i) => i._id);
+    const sourceIndex = segmentOrder.findIndex((id) => id === item._id);
+    segmentOrder.splice(sourceIndex + 1, 0, newItemId);
+
+    await Promise.all(
+      segmentOrder.map((id, index) =>
+        ctx.db.patch(id, { sequence: index, updatedAt: nowMs }),
+      ),
+    );
+
+    return { itemId: newItemId };
+  },
+});
+
+/**
+ * Reorder a template's whole run sheet, carrying each item's (possibly changed)
+ * `segment`. Every id must belong to the template and the set must be complete.
+ * Mirrors `eventItems.reorderItems` (without the legacy `orderedIds` shape —
+ * this is a new surface with no deployed older clients).
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const reorderRunSheetTemplateItems = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("runSheetTemplates"),
+    orderedItems: v.array(
+      v.object({ id: v.id("runSheetTemplateItems"), segment: v.string() }),
+    ),
+  },
+  returns: v.object({ reordered: v.number() }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireRunSheetTemplateScheduler(ctx, args.templateId, userId);
+
+    const existing = await ctx.db
+      .query("runSheetTemplateItems")
+      .withIndex("by_template", (q) => q.eq("templateId", args.templateId))
+      .collect();
+
+    const existingIds = new Set(existing.map((i) => i._id as string));
+    const seen = new Set<string>();
+    for (const entry of args.orderedItems) {
+      assertSegment(entry.segment);
+      if (!existingIds.has(entry.id as string)) {
+        throw new ConvexError(
+          "Reorder list references an item not on this template",
+        );
+      }
+      if (seen.has(entry.id as string)) {
+        throw new ConvexError("Reorder list contains a duplicate item");
+      }
+      seen.add(entry.id as string);
+    }
+    if (args.orderedItems.length !== existing.length) {
+      throw new ConvexError(
+        "Reorder list is stale — it does not match the template's current items",
+      );
+    }
+
+    const counters: Record<Segment, number> = { before: 0, during: 0, after: 0 };
+    const nowMs = Date.now();
+    await Promise.all(
+      args.orderedItems.map((entry) => {
+        const segment = entry.segment as Segment;
+        const sequence = counters[segment]++;
+        return ctx.db.patch(entry.id, { segment, sequence, updatedAt: nowMs });
+      }),
+    );
+
+    return { reordered: args.orderedItems.length };
+  },
+});

--- a/apps/convex/functions/scheduling/songs.ts
+++ b/apps/convex/functions/scheduling/songs.ts
@@ -244,7 +244,9 @@ export const updateSong = mutation({
 /**
  * Delete a song. First null out `songId` on every run sheet item that
  * references it — the item survives, falling back to its `songDetails`/title —
- * then delete the song (ADR-027). Uses the `eventItems.by_song` index.
+ * then delete the song (ADR-027). Covers both real run sheets (`eventItems`) and
+ * run-sheet TEMPLATE items (`runSheetTemplateItems`), each via its `by_song`
+ * index, so a deleted song never leaves a dangling reference on either.
  *
  * Auth: community admin for the song's community.
  */
@@ -257,18 +259,34 @@ export const deleteSong = mutation({
     const userId = await requireAuth(ctx, args.token);
     await requireSongAdmin(ctx, args.songId, userId);
 
+    const nowMs = Date.now();
+
     const referencing = await ctx.db
       .query("eventItems")
       .withIndex("by_song", (q) => q.eq("songId", args.songId))
       .collect();
     await Promise.all(
       referencing.map((item) =>
-        ctx.db.patch(item._id, { songId: undefined, updatedAt: Date.now() }),
+        ctx.db.patch(item._id, { songId: undefined, updatedAt: nowMs }),
+      ),
+    );
+
+    const referencingTemplateItems = await ctx.db
+      .query("runSheetTemplateItems")
+      .withIndex("by_song", (q) => q.eq("songId", args.songId))
+      .collect();
+    await Promise.all(
+      referencingTemplateItems.map((item) =>
+        ctx.db.patch(item._id, { songId: undefined, updatedAt: nowMs }),
       ),
     );
 
     await ctx.db.delete(args.songId);
-    return { deleted: true, unlinkedItems: referencing.length };
+    return {
+      deleted: true,
+      unlinkedItems: referencing.length,
+      unlinkedTemplateItems: referencingTemplateItems.length,
+    };
   },
 });
 

--- a/apps/convex/functions/scheduling/taskTemplates.ts
+++ b/apps/convex/functions/scheduling/taskTemplates.ts
@@ -1,0 +1,546 @@
+/**
+ * Scheduling — Task templates (Phase 1 of event templates)
+ *
+ * An `eventTaskTemplates` row is a reusable, per-GROUP checklist a leader saves
+ * for a location and can later apply to a plan's `eventTasks`. Its items
+ * (`eventTaskTemplateItems`) mirror `eventTasks` minus the `planId`, using ONLY the
+ * multi-assign array role model: `teamIds` (>= 1) + `roleIds` (empty => a
+ * team-level task). There is no completion state — a template is never "done";
+ * it seeds a plan's tasks (plan linkage / propagation land in later phases).
+ *
+ * Auth mirrors `eventTasks`: viewing requires an active group member
+ * (`requireGroupMember`); editing requires `requireGroupScheduler` (group
+ * leader / community admin). Like the rest of the backend, every function takes
+ * a JWT `token` and resolves the user via `requireAuth`.
+ */
+
+import { ConvexError, v } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { requireGroupMember, requireGroupScheduler } from "./permissions";
+
+/** When a task happens relative to the event's service times. */
+const segmentValidator = v.union(
+  v.literal("before"),
+  v.literal("during"),
+  v.literal("after"),
+);
+
+/** The kind of "how to" guidance attached to a task. */
+const howToTypeValidator = v.union(
+  v.literal("none"),
+  v.literal("text"),
+  v.literal("link"),
+  v.literal("media"),
+  v.literal("doc"),
+);
+
+/** before < during < after ordering rank for a template item/segment. */
+const SEGMENT_RANK: Record<string, number> = { before: 0, during: 1, after: 2 };
+
+/** Stable-order dedupe for an id array (preserves first-seen order). */
+function dedupeIds<T extends string>(ids: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const id of ids) {
+    if (seen.has(id as string)) continue;
+    seen.add(id as string);
+    out.push(id);
+  }
+  return out;
+}
+
+/**
+ * Validate a template name — same rule as `createCrossTeamChannel` /
+ * `createCustomChannel`: 1–50 characters, at least one letter or number.
+ * Returns the trimmed name.
+ */
+function validateTemplateName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < 1 || trimmed.length > 50) {
+    throw new ConvexError("Template name must be 1-50 characters.");
+  }
+  if (!/[a-zA-Z0-9]/.test(trimmed)) {
+    throw new ConvexError(
+      "Template name must contain at least one letter or number.",
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Load a template or throw. Shared by item functions that key off a
+ * `templateId`.
+ */
+async function requireTaskTemplate(
+  ctx: QueryCtx | MutationCtx,
+  templateId: Id<"eventTaskTemplates">,
+): Promise<Doc<"eventTaskTemplates">> {
+  const template = await ctx.db.get(templateId);
+  if (!template) {
+    throw new ConvexError("Task template not found");
+  }
+  return template;
+}
+
+/**
+ * Resolve a template and assert the caller may edit its group's schedule.
+ * Returns the template (its `groupId` is the edit gate).
+ */
+async function requireTaskTemplateScheduler(
+  ctx: MutationCtx,
+  templateId: Id<"eventTaskTemplates">,
+  userId: Id<"users">,
+): Promise<Doc<"eventTaskTemplates">> {
+  const template = await requireTaskTemplate(ctx, templateId);
+  await requireGroupScheduler(ctx, template.groupId, userId);
+  return template;
+}
+
+/**
+ * Validate a template item's `teamIds` / `roleIds` against the template's
+ * group: every team must belong to the group, and every role must belong to one
+ * of the item's teams. Mirrors the checks in `eventTasks.createTask`. Returns
+ * the deduped arrays.
+ */
+async function validateItemTeamsRoles(
+  ctx: MutationCtx,
+  template: Doc<"eventTaskTemplates">,
+  rawTeamIds: Id<"teams">[],
+  rawRoleIds: Id<"teamRoles">[],
+): Promise<{ teamIds: Id<"teams">[]; roleIds: Id<"teamRoles">[] }> {
+  const teamIds = dedupeIds(rawTeamIds);
+  if (teamIds.length === 0) {
+    throw new ConvexError("A task must belong to at least one team");
+  }
+  const teamIdSet = new Set(teamIds as string[]);
+  for (const teamId of teamIds) {
+    const team = await ctx.db.get(teamId);
+    if (!team || team.groupId !== template.groupId) {
+      throw new ConvexError("Team does not belong to this template's group");
+    }
+  }
+  const roleIds = dedupeIds(rawRoleIds);
+  for (const roleId of roleIds) {
+    const role = await ctx.db.get(roleId);
+    if (!role || !teamIdSet.has(role.teamId as string)) {
+      throw new ConvexError("Role does not belong to one of the task's teams");
+    }
+  }
+  return { teamIds, roleIds };
+}
+
+/**
+ * Next append `sortOrder` within a (template, segment) bucket. Mirrors
+ * `nextTaskSortOrder` for `eventTasks`.
+ */
+async function nextItemSortOrder(
+  ctx: MutationCtx,
+  templateId: Id<"eventTaskTemplates">,
+  segment: "before" | "during" | "after",
+): Promise<number> {
+  const inSegment = await ctx.db
+    .query("eventTaskTemplateItems")
+    .withIndex("by_template_segment", (q) =>
+      q.eq("templateId", templateId).eq("segment", segment),
+    )
+    .collect();
+  if (inSegment.length === 0) return 0;
+  return Math.max(...inSegment.map((i) => i.sortOrder)) + 1;
+}
+
+// ============================================================================
+// Templates
+// ============================================================================
+
+/**
+ * Create an empty task template for a group.
+ *
+ * Auth: group leader / community admin for the group.
+ */
+export const createTaskTemplate = mutation({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    name: v.string(),
+  },
+  returns: v.object({ templateId: v.id("eventTaskTemplates") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const group = await requireGroupScheduler(ctx, args.groupId, userId);
+
+    const name = validateTemplateName(args.name);
+    const nowMs = Date.now();
+    const templateId = await ctx.db.insert("eventTaskTemplates", {
+      groupId: args.groupId,
+      communityId: group.communityId,
+      name,
+      createdById: userId,
+      createdAt: nowMs,
+      updatedAt: nowMs,
+    });
+    return { templateId };
+  },
+});
+
+/**
+ * Rename a task template.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const renameTaskTemplate = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("eventTaskTemplates"),
+    name: v.string(),
+  },
+  returns: v.object({ templateId: v.id("eventTaskTemplates") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireTaskTemplateScheduler(ctx, args.templateId, userId);
+
+    const name = validateTemplateName(args.name);
+    await ctx.db.patch(args.templateId, { name, updatedAt: Date.now() });
+    return { templateId: args.templateId };
+  },
+});
+
+/**
+ * Delete a task template and cascade all of its items.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const deleteTaskTemplate = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("eventTaskTemplates"),
+  },
+  returns: v.object({ deletedItems: v.number() }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireTaskTemplateScheduler(ctx, args.templateId, userId);
+
+    const items = await ctx.db
+      .query("eventTaskTemplateItems")
+      .withIndex("by_template", (q) => q.eq("templateId", args.templateId))
+      .collect();
+    await Promise.all(items.map((i) => ctx.db.delete(i._id)));
+    await ctx.db.delete(args.templateId);
+    return { deletedItems: items.length };
+  },
+});
+
+/**
+ * List a group's task templates, each with its `itemCount`.
+ *
+ * Auth: an active member of the group (community read gate).
+ */
+export const listTaskTemplates = query({
+  args: { token: v.string(), groupId: v.id("groups") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupMember(ctx, args.groupId, userId);
+
+    const templates = await ctx.db
+      .query("eventTaskTemplates")
+      .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+      .collect();
+    templates.sort((a, b) => a.createdAt - b.createdAt);
+
+    return Promise.all(
+      templates.map(async (template) => {
+        const items = await ctx.db
+          .query("eventTaskTemplateItems")
+          .withIndex("by_template", (q) => q.eq("templateId", template._id))
+          .collect();
+        return {
+          _id: template._id,
+          groupId: template.groupId,
+          name: template.name,
+          itemCount: items.length,
+          createdAt: template.createdAt,
+          updatedAt: template.updatedAt,
+        };
+      }),
+    );
+  },
+});
+
+/**
+ * List a template's items, ordered by (segment, then sortOrder), each enriched
+ * with its `teamNames` / `roleNames` — mirrors `listPlanTasks`.
+ *
+ * Auth: an active member of the template's group.
+ */
+export const listTaskTemplateItems = query({
+  args: { token: v.string(), templateId: v.id("eventTaskTemplates") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const template = await requireTaskTemplate(ctx, args.templateId);
+    await requireGroupMember(ctx, template.groupId, userId);
+
+    const items = await ctx.db
+      .query("eventTaskTemplateItems")
+      .withIndex("by_template", (q) => q.eq("templateId", args.templateId))
+      .collect();
+    items.sort(
+      (a, b) =>
+        (SEGMENT_RANK[a.segment] ?? 1) - (SEGMENT_RANK[b.segment] ?? 1) ||
+        a.sortOrder - b.sortOrder,
+    );
+
+    const teamNames = new Map<string, string>();
+    const roleNames = new Map<string, string>();
+    const teamNameFor = async (id: Id<"teams">): Promise<string> => {
+      const key = id as string;
+      if (!teamNames.has(key)) {
+        const team = await ctx.db.get(id);
+        teamNames.set(key, team?.name ?? "Team");
+      }
+      return teamNames.get(key)!;
+    };
+    const roleNameFor = async (id: Id<"teamRoles">): Promise<string> => {
+      const key = id as string;
+      if (!roleNames.has(key)) {
+        const role = await ctx.db.get(id);
+        roleNames.set(key, role?.name ?? "Role");
+      }
+      return roleNames.get(key)!;
+    };
+
+    return Promise.all(
+      items.map(async (item) => ({
+        _id: item._id,
+        templateId: item.templateId,
+        teamIds: item.teamIds as string[],
+        roleIds: item.roleIds as string[],
+        teamNames: await Promise.all(item.teamIds.map(teamNameFor)),
+        roleNames: await Promise.all(item.roleIds.map(roleNameFor)),
+        segment: item.segment,
+        title: item.title,
+        howToType: item.howToType,
+        howToText: item.howToText,
+        howToUrl: item.howToUrl,
+        howToMediaPath: item.howToMediaPath,
+        howToDoc: item.howToDoc,
+        sortOrder: item.sortOrder,
+      })),
+    );
+  },
+});
+
+// ============================================================================
+// Template items
+// ============================================================================
+
+/**
+ * Add an item to a task template. `roleIds` empty (or omitted) => a team-level
+ * task. Mirrors `eventTasks.createTask`.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const addTaskTemplateItem = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("eventTaskTemplates"),
+    teamIds: v.array(v.id("teams")),
+    roleIds: v.optional(v.array(v.id("teamRoles"))),
+    segment: segmentValidator,
+    title: v.string(),
+    howToType: howToTypeValidator,
+    howToText: v.optional(v.string()),
+    howToUrl: v.optional(v.string()),
+    howToMediaPath: v.optional(v.string()),
+    howToDoc: v.optional(v.string()),
+  },
+  returns: v.object({ itemId: v.id("eventTaskTemplateItems") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const template = await requireTaskTemplateScheduler(
+      ctx,
+      args.templateId,
+      userId,
+    );
+
+    const { teamIds, roleIds } = await validateItemTeamsRoles(
+      ctx,
+      template,
+      args.teamIds,
+      args.roleIds ?? [],
+    );
+
+    const title = args.title.trim();
+    if (!title) {
+      throw new ConvexError("Task title cannot be empty");
+    }
+
+    const nowMs = Date.now();
+    const sortOrder = await nextItemSortOrder(ctx, args.templateId, args.segment);
+    const itemId = await ctx.db.insert("eventTaskTemplateItems", {
+      templateId: args.templateId,
+      communityId: template.communityId,
+      teamIds,
+      roleIds,
+      segment: args.segment,
+      title,
+      howToType: args.howToType,
+      howToText: args.howToText,
+      howToUrl: args.howToUrl,
+      howToMediaPath: args.howToMediaPath,
+      howToDoc: args.howToDoc,
+      sortOrder,
+      createdById: userId,
+      createdAt: nowMs,
+      updatedAt: nowMs,
+    });
+    return { itemId };
+  },
+});
+
+/**
+ * Update a template item's editable fields. Only provided fields change; an
+ * empty `roleIds` converts the item to team-level. Mirrors `eventTasks.updateTask`
+ * (minus the completion cleanup — templates have no completions).
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const updateTaskTemplateItem = mutation({
+  args: {
+    token: v.string(),
+    itemId: v.id("eventTaskTemplateItems"),
+    title: v.optional(v.string()),
+    teamIds: v.optional(v.array(v.id("teams"))),
+    roleIds: v.optional(v.array(v.id("teamRoles"))),
+    segment: v.optional(segmentValidator),
+    howToType: v.optional(howToTypeValidator),
+    howToText: v.optional(v.string()),
+    howToUrl: v.optional(v.string()),
+    howToMediaPath: v.optional(v.string()),
+    howToDoc: v.optional(v.string()),
+  },
+  returns: v.object({ itemId: v.id("eventTaskTemplateItems") }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const item = await ctx.db.get(args.itemId);
+    if (!item) {
+      throw new ConvexError("Task template item not found");
+    }
+    const template = await requireTaskTemplateScheduler(
+      ctx,
+      item.templateId,
+      userId,
+    );
+
+    const patch: Partial<Doc<"eventTaskTemplateItems">> = { updatedAt: Date.now() };
+    if (args.title !== undefined) {
+      const title = args.title.trim();
+      if (!title) {
+        throw new ConvexError("Task title cannot be empty");
+      }
+      patch.title = title;
+    }
+
+    // Resolve the effective team/role sets after this update so roles can be
+    // validated against teams and dropped when their team leaves.
+    const nextTeamIds =
+      args.teamIds !== undefined ? dedupeIds(args.teamIds) : item.teamIds;
+    if (nextTeamIds.length === 0) {
+      throw new ConvexError("A task must belong to at least one team");
+    }
+    const teamIdSet = new Set(nextTeamIds as string[]);
+    if (args.teamIds !== undefined) {
+      for (const teamId of nextTeamIds) {
+        const team = await ctx.db.get(teamId);
+        if (!team || team.groupId !== template.groupId) {
+          throw new ConvexError("Team does not belong to this template's group");
+        }
+      }
+      patch.teamIds = nextTeamIds;
+    }
+
+    if (args.roleIds !== undefined) {
+      const nextRoleIds = dedupeIds(args.roleIds);
+      for (const roleId of nextRoleIds) {
+        const role = await ctx.db.get(roleId);
+        if (!role || !teamIdSet.has(role.teamId as string)) {
+          throw new ConvexError("Role does not belong to one of the task's teams");
+        }
+      }
+      patch.roleIds = nextRoleIds;
+    } else if (args.teamIds !== undefined) {
+      // Teams changed but roles weren't explicitly set: drop any role that no
+      // longer belongs to one of the item's teams.
+      const kept: Id<"teamRoles">[] = [];
+      for (const roleId of item.roleIds) {
+        const role = await ctx.db.get(roleId);
+        if (role && teamIdSet.has(role.teamId as string)) kept.push(roleId);
+      }
+      if (kept.length !== item.roleIds.length) {
+        patch.roleIds = kept;
+      }
+    }
+
+    if (args.segment !== undefined) patch.segment = args.segment;
+    if (args.howToType !== undefined) patch.howToType = args.howToType;
+    if (args.howToText !== undefined) patch.howToText = args.howToText;
+    if (args.howToUrl !== undefined) patch.howToUrl = args.howToUrl;
+    if (args.howToMediaPath !== undefined)
+      patch.howToMediaPath = args.howToMediaPath;
+    if (args.howToDoc !== undefined) patch.howToDoc = args.howToDoc;
+
+    await ctx.db.patch(args.itemId, patch);
+    return { itemId: args.itemId };
+  },
+});
+
+/**
+ * Delete a single template item.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const deleteTaskTemplateItem = mutation({
+  args: { token: v.string(), itemId: v.id("eventTaskTemplateItems") },
+  returns: v.object({ deleted: v.boolean() }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const item = await ctx.db.get(args.itemId);
+    if (!item) {
+      throw new ConvexError("Task template item not found");
+    }
+    await requireTaskTemplateScheduler(ctx, item.templateId, userId);
+    await ctx.db.delete(args.itemId);
+    return { deleted: true };
+  },
+});
+
+/**
+ * Reorder a template's items by index over `orderedIds`. Ids that don't belong
+ * to the template are ignored so a stale client list can't rewrite foreign rows.
+ * Mirrors `eventTasks.reorderTasks`.
+ *
+ * Auth: group leader / community admin for the template's group.
+ */
+export const reorderTaskTemplateItems = mutation({
+  args: {
+    token: v.string(),
+    templateId: v.id("eventTaskTemplates"),
+    orderedIds: v.array(v.id("eventTaskTemplateItems")),
+  },
+  returns: v.object({ reordered: v.number() }),
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireTaskTemplateScheduler(ctx, args.templateId, userId);
+
+    const nowMs = Date.now();
+    let index = 0;
+    for (const itemId of args.orderedIds) {
+      const item = await ctx.db.get(itemId);
+      if (!item || item.templateId !== args.templateId) continue;
+      await ctx.db.patch(itemId, { sortOrder: index, updatedAt: nowMs });
+      index += 1;
+    }
+    return { reordered: index };
+  },
+});

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3027,6 +3027,117 @@ export default defineSchema({
     .index("by_plan", ["planId"]),
 
   /**
+   * A reusable, per-GROUP event-task template — a named, saved checklist of
+   * `eventTaskTemplateItems` a leader can keep for a location and later apply to
+   * a plan's `eventTasks`. Named `eventTaskTemplates` (not `taskTemplates`, which
+   * is a separate feature) to avoid a table collision. Scoped to one campus group
+   * (mirrors how cross-team channels / teams are group-scoped); `communityId` is
+   * denormalized for the community read gate. Phase 1 stores the template only —
+   * there is no plan linkage or propagation yet.
+   */
+  eventTaskTemplates: defineTable({
+    groupId: v.id("groups"),
+    communityId: v.id("communities"),
+    name: v.string(),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }).index("by_group", ["groupId"]),
+
+  /**
+   * A single item on an `eventTaskTemplates` template — the template mirror of
+   * `eventTasks` MINUS `planId` (keyed by `templateId` instead) and using ONLY
+   * the multi-assign array model (`teamIds` >= 0, `roleIds` empty => a
+   * team-level task). No legacy single-value `teamId` / `roleId` columns, and no
+   * completion records (templates are never "done" — they seed a plan's tasks).
+   * `sortOrder` orders items WITHIN a segment.
+   */
+  eventTaskTemplateItems: defineTable({
+    templateId: v.id("eventTaskTemplates"),
+    communityId: v.id("communities"),
+    teamIds: v.array(v.id("teams")),
+    roleIds: v.array(v.id("teamRoles")),
+    segment: v.union(
+      v.literal("before"),
+      v.literal("during"),
+      v.literal("after"),
+    ),
+    title: v.string(),
+    howToType: v.union(
+      v.literal("none"),
+      v.literal("text"),
+      v.literal("link"),
+      v.literal("media"),
+      v.literal("doc"),
+    ),
+    howToText: v.optional(v.string()),
+    howToUrl: v.optional(v.string()),
+    howToMediaPath: v.optional(v.string()), // r2: path
+    howToDoc: v.optional(v.string()), // markdown source
+    sortOrder: v.number(),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_template", ["templateId"])
+    .index("by_template_segment", ["templateId", "segment"]),
+
+  /**
+   * A reusable, per-GROUP run-sheet template — a named, saved order-of-items of
+   * `runSheetTemplateItems` a leader can keep for a location and later apply to a
+   * plan's `eventItems`. Group-scoped, with `communityId` denormalized for the
+   * community read gate. Phase 1 stores the template only (no plan linkage or
+   * propagation yet).
+   */
+  runSheetTemplates: defineTable({
+    groupId: v.id("groups"),
+    communityId: v.id("communities"),
+    name: v.string(),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }).index("by_group", ["groupId"]),
+
+  /**
+   * A single item on a `runSheetTemplates` template — the template mirror of
+   * `eventItems` MINUS `planId` (keyed by `templateId` instead). Same segment +
+   * `sequence` ordering, notes, role `assignments`, and library `songId` join as
+   * a real run sheet item. Clock times are never stored (durations cascade
+   * client-side), matching `eventItems`.
+   */
+  runSheetTemplateItems: defineTable({
+    templateId: v.id("runSheetTemplates"),
+    communityId: v.id("communities"),
+    /** "before" | "during" | "after"; optional, treated as "during" if absent. */
+    segment: v.optional(v.string()),
+    /** Ordering within the segment; reordering rewrites these. */
+    sequence: v.number(),
+    /** "song" | "header" | "media" | "item" (mirrors PCO vocabulary). */
+    type: v.string(),
+    title: v.string(),
+    description: v.optional(v.string()),
+    durationSec: v.number(),
+    notes: v.optional(
+      v.array(v.object({ category: v.string(), content: v.string() })),
+    ),
+    assignments: v.optional(v.array(v.object({ roleId: v.id("teamRoles") }))),
+    songDetails: v.optional(
+      v.object({
+        key: v.optional(v.string()),
+        bpm: v.optional(v.number()),
+        author: v.optional(v.string()),
+      }),
+    ),
+    songId: v.optional(v.id("songs")),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_template", ["templateId"])
+    // Scan items referencing a song so deleteSong can null them out (ADR-027).
+    .index("by_song", ["songId"]),
+
+  /**
    * Per-community song library (ADR-027). A song lives once and is referenced
    * by run sheet `eventItems` via `songId`, so editing its charts/metadata
    * updates every plan that uses it (no copied-string drift). `ccliNumber` is

--- a/apps/mobile/features/scheduling/api/eventTemplates.ts
+++ b/apps/mobile/features/scheduling/api/eventTemplates.ts
@@ -1,0 +1,288 @@
+/**
+ * Typed function references for the event-template backend (Phase 1).
+ *
+ * Why this file exists: the Convex backend modules
+ * `functions/scheduling/taskTemplates` and
+ * `functions/scheduling/runSheetTemplates` are deployed, but the committed
+ * `apps/convex/_generated/api.d.ts` in this repo can be stale offline and not
+ * yet list them — so `api.functions.scheduling.taskTemplates.*` would be a type
+ * error until the next `npx convex dev` regenerates the api map.
+ *
+ * Rather than depend on the generated `api` object, we build the references
+ * directly from their function paths with `makeFunctionReference`, asserting the
+ * precise arg/return types — matching the validators in `taskTemplates.ts` /
+ * `runSheetTemplates.ts`. This is fully type-checked at every call site and,
+ * unlike traversing the `api` proxy, evaluates safely under test mocks. Once the
+ * generated api map includes the modules, this file can be deleted and call
+ * sites can use the `api.functions.scheduling.*` paths directly.
+ *
+ * Phase 1 is backend-only — these refs exist so later phases can call the CRUD.
+ */
+import { makeFunctionReference } from "convex/server";
+import type { Id } from "@services/api/convex";
+
+// ============================================================================
+// Shared shapes
+// ============================================================================
+
+/** "when it happens" phase for a task template item. */
+export type TemplateSegment = "before" | "during" | "after";
+
+/** "how to" guidance kind on a task template item. */
+export type TemplateHowToType = "none" | "text" | "link" | "media" | "doc";
+
+/** A saved template (task or run-sheet) with its item count, as listed. */
+export type EventTemplateSummary = {
+  _id: Id<"eventTaskTemplates"> | Id<"runSheetTemplates">;
+  groupId: Id<"groups">;
+  name: string;
+  itemCount: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+// ============================================================================
+// Task templates
+// ============================================================================
+
+export type TaskTemplateSummary = {
+  _id: Id<"eventTaskTemplates">;
+  groupId: Id<"groups">;
+  name: string;
+  itemCount: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+/** A hydrated task template item, as returned by `listTaskTemplateItems`. */
+export type TaskTemplateItem = {
+  _id: Id<"eventTaskTemplateItems">;
+  templateId: Id<"eventTaskTemplates">;
+  teamIds: string[];
+  roleIds: string[];
+  teamNames: string[];
+  roleNames: string[];
+  segment: TemplateSegment;
+  title: string;
+  howToType: TemplateHowToType;
+  howToText?: string;
+  howToUrl?: string;
+  howToMediaPath?: string;
+  howToDoc?: string;
+  sortOrder: number;
+};
+
+export const createTaskTemplateRef = makeFunctionReference<
+  "mutation",
+  { token: string; groupId: Id<"groups">; name: string },
+  { templateId: Id<"eventTaskTemplates"> }
+>("functions/scheduling/taskTemplates:createTaskTemplate");
+
+export const renameTaskTemplateRef = makeFunctionReference<
+  "mutation",
+  { token: string; templateId: Id<"eventTaskTemplates">; name: string },
+  { templateId: Id<"eventTaskTemplates"> }
+>("functions/scheduling/taskTemplates:renameTaskTemplate");
+
+export const deleteTaskTemplateRef = makeFunctionReference<
+  "mutation",
+  { token: string; templateId: Id<"eventTaskTemplates"> },
+  { deletedItems: number }
+>("functions/scheduling/taskTemplates:deleteTaskTemplate");
+
+export const listTaskTemplatesRef = makeFunctionReference<
+  "query",
+  { token: string; groupId: Id<"groups"> },
+  TaskTemplateSummary[]
+>("functions/scheduling/taskTemplates:listTaskTemplates");
+
+export const listTaskTemplateItemsRef = makeFunctionReference<
+  "query",
+  { token: string; templateId: Id<"eventTaskTemplates"> },
+  TaskTemplateItem[]
+>("functions/scheduling/taskTemplates:listTaskTemplateItems");
+
+export const addTaskTemplateItemRef = makeFunctionReference<
+  "mutation",
+  {
+    token: string;
+    templateId: Id<"eventTaskTemplates">;
+    teamIds: Id<"teams">[];
+    roleIds?: Id<"teamRoles">[];
+    segment: TemplateSegment;
+    title: string;
+    howToType: TemplateHowToType;
+    howToText?: string;
+    howToUrl?: string;
+    howToMediaPath?: string;
+    howToDoc?: string;
+  },
+  { itemId: Id<"eventTaskTemplateItems"> }
+>("functions/scheduling/taskTemplates:addTaskTemplateItem");
+
+export const updateTaskTemplateItemRef = makeFunctionReference<
+  "mutation",
+  {
+    token: string;
+    itemId: Id<"eventTaskTemplateItems">;
+    title?: string;
+    teamIds?: Id<"teams">[];
+    roleIds?: Id<"teamRoles">[];
+    segment?: TemplateSegment;
+    howToType?: TemplateHowToType;
+    howToText?: string;
+    howToUrl?: string;
+    howToMediaPath?: string;
+    howToDoc?: string;
+  },
+  { itemId: Id<"eventTaskTemplateItems"> }
+>("functions/scheduling/taskTemplates:updateTaskTemplateItem");
+
+export const deleteTaskTemplateItemRef = makeFunctionReference<
+  "mutation",
+  { token: string; itemId: Id<"eventTaskTemplateItems"> },
+  { deleted: boolean }
+>("functions/scheduling/taskTemplates:deleteTaskTemplateItem");
+
+export const reorderTaskTemplateItemsRef = makeFunctionReference<
+  "mutation",
+  {
+    token: string;
+    templateId: Id<"eventTaskTemplates">;
+    orderedIds: Id<"eventTaskTemplateItems">[];
+  },
+  { reordered: number }
+>("functions/scheduling/taskTemplates:reorderTaskTemplateItems");
+
+// ============================================================================
+// Run-sheet templates
+// ============================================================================
+
+export type RunSheetTemplateSummary = {
+  _id: Id<"runSheetTemplates">;
+  groupId: Id<"groups">;
+  name: string;
+  itemCount: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+/** A single free-text note on a run-sheet item, categorized by role. */
+export type RunSheetTemplateNote = { category: string; content: string };
+
+/** Lightweight per-occurrence song metadata (override of the library song). */
+export type RunSheetTemplateSongDetails = {
+  key?: string;
+  bpm?: number;
+  author?: string;
+};
+
+/** A hydrated run-sheet template item, as returned by `listRunSheetTemplateItems`. */
+export type RunSheetTemplateItem = {
+  _id: Id<"runSheetTemplateItems">;
+  templateId: Id<"runSheetTemplates">;
+  segment: TemplateSegment;
+  sequence: number;
+  type: string;
+  title: string;
+  description: string | null;
+  durationSec: number;
+  notes: RunSheetTemplateNote[];
+  songDetails: RunSheetTemplateSongDetails | null;
+  songId: Id<"songs"> | null;
+  // The joined library song (client-facing shape) or null. Left as unknown here
+  // to avoid duplicating the Song type; call sites narrow as needed.
+  song: unknown;
+  assignments: Array<{
+    roleId: Id<"teamRoles">;
+    roleName: string;
+    roleColor: string | null;
+  }>;
+};
+
+export const createRunSheetTemplateRef = makeFunctionReference<
+  "mutation",
+  { token: string; groupId: Id<"groups">; name: string },
+  { templateId: Id<"runSheetTemplates"> }
+>("functions/scheduling/runSheetTemplates:createRunSheetTemplate");
+
+export const renameRunSheetTemplateRef = makeFunctionReference<
+  "mutation",
+  { token: string; templateId: Id<"runSheetTemplates">; name: string },
+  { templateId: Id<"runSheetTemplates"> }
+>("functions/scheduling/runSheetTemplates:renameRunSheetTemplate");
+
+export const deleteRunSheetTemplateRef = makeFunctionReference<
+  "mutation",
+  { token: string; templateId: Id<"runSheetTemplates"> },
+  { deletedItems: number }
+>("functions/scheduling/runSheetTemplates:deleteRunSheetTemplate");
+
+export const listRunSheetTemplatesRef = makeFunctionReference<
+  "query",
+  { token: string; groupId: Id<"groups"> },
+  RunSheetTemplateSummary[]
+>("functions/scheduling/runSheetTemplates:listRunSheetTemplates");
+
+export const listRunSheetTemplateItemsRef = makeFunctionReference<
+  "query",
+  { token: string; templateId: Id<"runSheetTemplates"> },
+  RunSheetTemplateItem[]
+>("functions/scheduling/runSheetTemplates:listRunSheetTemplateItems");
+
+export const addRunSheetTemplateItemRef = makeFunctionReference<
+  "mutation",
+  {
+    token: string;
+    templateId: Id<"runSheetTemplates">;
+    type: string;
+    title: string;
+    segment?: string;
+    durationSec?: number;
+    description?: string;
+    notes?: RunSheetTemplateNote[];
+    assignments?: Array<{ roleId: Id<"teamRoles"> }>;
+    songDetails?: RunSheetTemplateSongDetails;
+  },
+  { itemId: Id<"runSheetTemplateItems"> }
+>("functions/scheduling/runSheetTemplates:addRunSheetTemplateItem");
+
+export const updateRunSheetTemplateItemRef = makeFunctionReference<
+  "mutation",
+  {
+    token: string;
+    itemId: Id<"runSheetTemplateItems">;
+    type?: string;
+    title?: string;
+    segment?: string;
+    durationSec?: number;
+    description?: string;
+    notes?: RunSheetTemplateNote[];
+    assignments?: Array<{ roleId: Id<"teamRoles"> }>;
+    songDetails?: RunSheetTemplateSongDetails;
+    songId?: Id<"songs"> | null;
+  },
+  { itemId: Id<"runSheetTemplateItems"> }
+>("functions/scheduling/runSheetTemplates:updateRunSheetTemplateItem");
+
+export const deleteRunSheetTemplateItemRef = makeFunctionReference<
+  "mutation",
+  { token: string; itemId: Id<"runSheetTemplateItems"> },
+  { deleted: boolean }
+>("functions/scheduling/runSheetTemplates:deleteRunSheetTemplateItem");
+
+export const duplicateRunSheetTemplateItemRef = makeFunctionReference<
+  "mutation",
+  { token: string; itemId: Id<"runSheetTemplateItems"> },
+  { itemId: Id<"runSheetTemplateItems"> }
+>("functions/scheduling/runSheetTemplates:duplicateRunSheetTemplateItem");
+
+export const reorderRunSheetTemplateItemsRef = makeFunctionReference<
+  "mutation",
+  {
+    token: string;
+    templateId: Id<"runSheetTemplates">;
+    orderedItems: Array<{ id: Id<"runSheetTemplateItems">; segment: string }>;
+  },
+  { reordered: number }
+>("functions/scheduling/runSheetTemplates:reorderRunSheetTemplateItems");


### PR DESCRIPTION
## Phase 1 of event templates — backend only

Adds reusable, **per-group** task templates and run-sheet templates plus their CRUD. This is the data-model + backend phase only: **no plan linkage, no propagation, and no UI** — those land in later phases.

### What's here
- **Schema** — 4 new tables:
  - `eventTaskTemplates` / `eventTaskTemplateItems` — the template mirror of `eventTasks` minus `planId`, using only the multi-assign array role model (`teamIds` / `roleIds`, no legacy single-value columns) and no completion state.
  - `runSheetTemplates` / `runSheetTemplateItems` — the template mirror of `eventItems` minus `planId` (segment + sequence ordering, notes, role assignments, library `songId` join).
  - Note: the task-template tables are prefixed `event*` because a **separate** `taskTemplates` table already exists in the schema (different feature) — using the bare name collided.
- **Backend CRUD** — `functions/scheduling/taskTemplates.ts` and `functions/scheduling/runSheetTemplates.ts`, mirroring the `eventTasks` / `eventItems` logic (sort/sequence ordering, resequencing, role-belongs-to-team + cross-community-song validation, hydration). Auth: `requireGroupScheduler` on writes, `requireGroupMember` on reads. Exported via `functions/scheduling/index.ts`.
- **Mobile API refs** — `apps/mobile/features/scheduling/api/eventTemplates.ts`, typed `makeFunctionReference` refs (mirrors `crossTeamChannels.ts`) so later phases can call the CRUD.
- **Tests** — `__tests__/scheduling/eventTemplates.test.ts` (13 tests): CRUD, reorder, delete-template cascade, itemCounts, role/song validation, and non-leader auth rejection.

### Verification
- `apps/convex` `tsc --noEmit`: clean (only the pre-existing `@togather/shared/config` baseline errors remain, all in untouched files).
- Scheduling test suite (incl. the new file): **301 passed / 22 files**; new file **13 passed**.
- `npx convex codegen` is not runnable here (no deployment); the generated `api.d.ts` was hand-patched to register the two new modules, and `api.js` resolves via `anyApi` at runtime so tests pass. CI regenerates on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSwZmWmrY1LisZYjSZYx49