### PR TITLE
feat(events): templates library UI + item editors (Phase 2)

### DIFF
--- a/apps/mobile/app/rostering/[group_id]/templates/index.tsx
+++ b/apps/mobile/app/rostering/[group_id]/templates/index.tsx
@@ -1,0 +1,10 @@
+import { TemplatesLibraryScreen } from "@features/scheduling";
+
+/**
+ * Per-group event templates library — task templates + run-sheet templates
+ * (event templates Phase 2). Leader-gated inside the screen.
+ * Route: /rostering/[group_id]/templates
+ */
+export default function TemplatesLibraryPage() {
+  return <TemplatesLibraryScreen />;
+}

--- a/apps/mobile/app/rostering/[group_id]/templates/runsheet/[template_id].tsx
+++ b/apps/mobile/app/rostering/[group_id]/templates/runsheet/[template_id].tsx
@@ -1,0 +1,10 @@
+import { RunSheetTemplateEditorScreen } from "@features/scheduling";
+
+/**
+ * Item editor for one run-sheet template — reuses the run sheet editor grid
+ * wired to the run-sheet-template-item mutations (event templates Phase 2).
+ * Leader-gated. Route: /rostering/[group_id]/templates/runsheet/[template_id]
+ */
+export default function RunSheetTemplateEditorPage() {
+  return <RunSheetTemplateEditorScreen />;
+}

--- a/apps/mobile/app/rostering/[group_id]/templates/task/[template_id].tsx
+++ b/apps/mobile/app/rostering/[group_id]/templates/task/[template_id].tsx
@@ -1,0 +1,10 @@
+import { TaskTemplateEditorScreen } from "@features/scheduling";
+
+/**
+ * Item editor for one task template — reuses the plan Event Tasks grid wired to
+ * the task-template-item mutations (event templates Phase 2). Leader-gated.
+ * Route: /rostering/[group_id]/templates/task/[template_id]
+ */
+export default function TaskTemplateEditorPage() {
+  return <TaskTemplateEditorScreen />;
+}

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -2260,6 +2260,10 @@ export function RosterGridScreen() {
             setOverflowOpen(false);
             router.push(`/rostering/${groupId}/cross-team` as never);
           }}
+          onTemplates={() => {
+            setOverflowOpen(false);
+            router.push(`/rostering/${groupId}/templates` as never);
+          }}
           onCollectAvailability={() => {
             setOverflowOpen(false);
             void handleShareLink();
@@ -3132,6 +3136,7 @@ function OverflowMenu({
   sharingLink,
   onTeams,
   onCrossTeam,
+  onTemplates,
   onCollectAvailability,
   onChangePastLimit,
   onClose,
@@ -3141,6 +3146,7 @@ function OverflowMenu({
   sharingLink: boolean;
   onTeams: () => void;
   onCrossTeam: () => void;
+  onTemplates: () => void;
   onCollectAvailability: () => void;
   /** Step the number of previous dates shown by ±1 (clamped by the caller). */
   onChangePastLimit: (delta: number) => void;
@@ -3168,6 +3174,17 @@ function OverflowMenu({
           <Ionicons name="git-merge-outline" size={20} color={colors.text} />
           <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
             Cross-team
+          </Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+        </Pressable>
+        <Pressable
+          onPress={onTemplates}
+          style={[styles.menuRow, { borderBottomColor: colors.border }]}
+          accessibilityRole="button"
+        >
+          <Ionicons name="documents-outline" size={20} color={colors.text} />
+          <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+            Templates
           </Text>
           <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
         </Pressable>

--- a/apps/mobile/features/scheduling/components/RunSheetItemEditors.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetItemEditors.tsx
@@ -1,0 +1,601 @@
+/**
+ * RunSheetItemEditors
+ *
+ * The presentational, plan-agnostic building blocks of the run sheet editor —
+ * extracted from RunSheetScreen so BOTH the per-plan run sheet
+ * (`RunSheetScreen`) and the per-group run-sheet TEMPLATE editor
+ * (`RunSheetTemplateEditorScreen`) render identical row/cell UI (ADR-026 /
+ * event templates Phase 2).
+ *
+ * These components read only from a minimal `RunSheetItemLike` shape and write
+ * through an `ItemPatch` callback, so they are unaware of whether the row is a
+ * plan `eventItems` row or a `runSheetTemplateItems` row. Anything genuinely
+ * plan-specific (clock times, service ranges, event roster) stays in the
+ * containers.
+ */
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Platform,
+  type TextStyle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import type { Id } from "@services/api/convex";
+import { DEFAULT_ROLE_COLOR } from "../utils/format";
+import { InlineText } from "./InlineText";
+import { OptionTag } from "./GridScrollList";
+import { measureAnchor, type AnchorRect } from "./AnchoredMenu";
+import { SongPicker } from "./SongPicker";
+import type { Song } from "@features/songs/types";
+
+/** When an item happens relative to the event's service times. */
+export type Segment = "before" | "during" | "after";
+
+export const SEGMENT_OPTIONS: Array<{
+  key: Segment;
+  label: string;
+  short: string;
+}> = [
+  { key: "before", label: "Before event", short: "Before" },
+  { key: "during", label: "During event", short: "During" },
+  { key: "after", label: "After event", short: "After" },
+];
+
+export type ItemAssignment = {
+  roleId: Id<"teamRoles">;
+  roleName: string;
+  roleColor: string | null;
+};
+
+export type RoleOption = {
+  roleId: Id<"teamRoles">;
+  roleName: string;
+  roleColor?: string;
+  people: string[];
+};
+
+/** Item field patch shape sent to the container's update mutation. */
+export type ItemPatch = {
+  type?: string;
+  title?: string;
+  segment?: Segment;
+  durationSec?: number;
+  description?: string;
+  notes?: Array<{ category: string; content: string }>;
+  assignments?: Array<{ roleId: Id<"teamRoles"> }>;
+  songDetails?: { key?: string; bpm?: number };
+  // Link / unlink a library song. `null` clears the link (ADR-027).
+  songId?: Id<"songs"> | null;
+};
+
+/**
+ * The minimal read surface the row editors need. Both `RunSheetItem` (plan) and
+ * a mapped `runSheetTemplateItems` row satisfy this structurally.
+ */
+export type RunSheetItemLike = {
+  segment: string;
+  description: string | null;
+  durationSec: number;
+  notes: Array<{ category: string; content: string }>;
+  songDetails: { key?: string; bpm?: number; author?: string } | null;
+  songId: Id<"songs"> | null;
+  song: Song | null;
+  assignments: ItemAssignment[];
+};
+
+/**
+ * The "When" phase pill. Measures its own window rect on press so the parent can
+ * anchor the dropdown next to it (the pill can't hold the menu itself — the
+ * table card clips overflow).
+ */
+export function WhenPill({
+  label,
+  colors,
+  primaryColor,
+  onOpen,
+}: {
+  label: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onOpen: (anchor: AnchorRect) => void;
+}) {
+  const ref = React.useRef<View>(null);
+  return (
+    <Pressable
+      ref={ref}
+      onPress={() => measureAnchor(ref.current, onOpen)}
+      style={styles.tagPressable}
+      accessibilityRole="button"
+      accessibilityLabel={`When: ${label}. Tap to change.`}
+    >
+      <OptionTag
+        label={label}
+        colors={colors}
+        primaryColor={primaryColor}
+        tinted
+        chevron
+      />
+    </Pressable>
+  );
+}
+
+export function AddButton({
+  label,
+  icon,
+  onPress,
+  primaryColor,
+  colors,
+}: {
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  onPress: () => void;
+  primaryColor: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  return (
+    <Pressable onPress={onPress} style={styles.addPressable}>
+      <View style={[styles.addRow, { borderColor: colors.border }]}>
+        <Ionicons name={icon} size={18} color={primaryColor} />
+        <Text style={[styles.addText, { color: primaryColor }]}>{label}</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+// RN-Web draws a browser focus ring on the underlying <input> that visually
+// bleeds past this tiny cell; suppress it so the input stays fully contained.
+const webNoOutline: TextStyle | undefined =
+  Platform.OS === "web"
+    ? ({ outlineStyle: "none" } as unknown as TextStyle)
+    : undefined;
+
+/** Inline m:ss duration cell. Parses "5", "5:30", or "330s"-style minute input. */
+export function DurationCell({
+  durationSec,
+  onSave,
+  colors,
+}: {
+  durationSec: number;
+  onSave: (sec: number) => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  const mm = Math.floor(durationSec / 60);
+  const ss = durationSec % 60;
+  const display = `${mm}:${String(ss).padStart(2, "0")}`;
+  return (
+    <InlineText
+      value={display}
+      onSave={(text) => onSave(parseDuration(text))}
+      placeholder="0:00"
+      keyboardType="numbers-and-punctuation"
+      maxLength={6}
+      accessibilityLabel="Duration (minutes:seconds)"
+      style={[
+        styles.durationInput,
+        { color: colors.text, borderColor: colors.border },
+        webNoOutline,
+      ]}
+    />
+  );
+}
+
+/** Parse "m:ss" or plain minutes into seconds. */
+export function parseDuration(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.includes(":")) {
+    const [m, s] = trimmed.split(":");
+    return Math.max(0, (parseInt(m, 10) || 0) * 60 + (parseInt(s, 10) || 0));
+  }
+  return Math.max(0, Math.round((parseFloat(trimmed) || 0) * 60));
+}
+
+/**
+ * Who's-involved editor body (roles multi-select).
+ *
+ * Seeds a local Set from the item's current assignments so rapid toggles
+ * compound instead of each restarting from the last server-synced value (which
+ * lags a mutation round-trip). Remounted per item via a `key` at the call site,
+ * so it re-seeds whenever a different row's modal opens.
+ */
+export function WhoModalBody({
+  item,
+  roleOptions,
+  onPatch,
+}: {
+  item: RunSheetItemLike;
+  roleOptions: RoleOption[];
+  onPatch: (patch: ItemPatch) => void;
+}) {
+  const { colors } = useTheme();
+  const [linked, setLinked] = useState<Set<string>>(
+    () => new Set(item.assignments.map((a) => a.roleId as string)),
+  );
+
+  const toggle = (roleId: string) => {
+    const next = new Set(linked);
+    if (next.has(roleId)) next.delete(roleId);
+    else next.add(roleId);
+    setLinked(next);
+    onPatch({
+      assignments: [...next].map((id) => ({ roleId: id as Id<"teamRoles"> })),
+    });
+  };
+
+  if (roleOptions.length === 0) {
+    return (
+      <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+        No roles are defined for this group yet.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.roleWrap}>
+      {roleOptions.map((r) => {
+        const selected = linked.has(r.roleId as string);
+        const swatch = r.roleColor ?? DEFAULT_ROLE_COLOR;
+        return (
+          <Pressable
+            key={r.roleId}
+            onPress={() => toggle(r.roleId as string)}
+            style={styles.rolePressable}
+          >
+            <View
+              style={[
+                styles.roleChip,
+                {
+                  backgroundColor: selected ? swatch + "22" : colors.surface,
+                  borderColor: selected ? swatch : colors.border,
+                },
+              ]}
+            >
+              <View style={[styles.roleSwatch, { backgroundColor: swatch }]} />
+              <Text
+                style={[styles.roleChipText, { color: colors.text }]}
+                numberOfLines={1}
+              >
+                {r.roleName}
+                {r.people.length > 0 ? `: ${r.people.join(", ")}` : ""}
+              </Text>
+              {selected ? (
+                <Ionicons name="checkmark-circle" size={15} color={swatch} />
+              ) : null}
+            </View>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+/**
+ * Notes editor body — the item's timing phase, free-text description, and the
+ * role-categorized cue notes.
+ */
+export function NotesModalBody({
+  item,
+  onPatch,
+}: {
+  item: RunSheetItemLike;
+  onPatch: (patch: ItemPatch) => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.modalStack}>
+      {/* Timing phase — before / during / after the event (PCO's position). */}
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+        Timing
+      </Text>
+      <View style={styles.timingToggle}>
+        {SEGMENT_OPTIONS.map((seg) => {
+          const active = (item.segment as Segment) === seg.key;
+          return (
+            <Pressable
+              key={seg.key}
+              onPress={() => onPatch({ segment: seg.key })}
+              style={styles.timingPressable}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+            >
+              <View
+                style={[
+                  styles.timingChip,
+                  {
+                    borderColor: active ? colors.buttonPrimary : colors.border,
+                    backgroundColor: active
+                      ? colors.buttonPrimary + "1F"
+                      : "transparent",
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.timingChipText,
+                    {
+                      color: active
+                        ? colors.buttonPrimary
+                        : colors.textSecondary,
+                    },
+                  ]}
+                >
+                  {seg.label}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+        Description
+      </Text>
+      <InlineText
+        value={item.description ?? ""}
+        onSave={(d) => onPatch({ description: d })}
+        placeholder="Optional details for this moment"
+        multiline
+        accessibilityLabel="Item description"
+        style={[
+          styles.descInput,
+          { color: colors.text, borderColor: colors.border },
+        ]}
+      />
+
+      <NotesEditor
+        notes={item.notes}
+        onChange={(notes) => onPatch({ notes })}
+        colors={colors}
+      />
+    </View>
+  );
+}
+
+/**
+ * Song editor body — links the row to a library song (ADR-027) and edits the
+ * per-service Key / BPM overrides. When a song is linked, Key/BPM show only the
+ * override (blank if none), placeholder is the song's default.
+ */
+export function SongModalBody({
+  item,
+  communityId,
+  groupId,
+  onPatch,
+}: {
+  item: RunSheetItemLike;
+  communityId: string;
+  groupId: string;
+  onPatch: (patch: ItemPatch) => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.modalStack}>
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+        Song
+      </Text>
+      <SongPicker
+        communityId={communityId}
+        groupId={groupId}
+        songId={item.songId}
+        song={item.song}
+        onSelect={(songId) => onPatch({ songId: songId as Id<"songs"> | null })}
+      />
+
+      <View style={styles.songRow}>
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+          Key
+        </Text>
+        <InlineText
+          value={item.songDetails?.key ?? ""}
+          onSave={(key) =>
+            onPatch({
+              songDetails: {
+                key: key.trim() || undefined,
+                bpm: item.songDetails?.bpm,
+              },
+            })
+          }
+          placeholder={item.song?.defaultKey ?? "—"}
+          maxLength={8}
+          accessibilityLabel="Song key"
+          style={[
+            styles.songInput,
+            { color: colors.text, borderColor: colors.border },
+          ]}
+        />
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+          BPM
+        </Text>
+        <InlineText
+          value={item.songDetails?.bpm ? String(item.songDetails.bpm) : ""}
+          onSave={(bpm) =>
+            onPatch({
+              songDetails: {
+                key: item.songDetails?.key,
+                bpm: parseInt(bpm, 10) || undefined,
+              },
+            })
+          }
+          placeholder={item.song?.bpm ? String(item.song.bpm) : "—"}
+          keyboardType="number-pad"
+          maxLength={3}
+          accessibilityLabel="Song BPM"
+          style={[
+            styles.songInput,
+            { color: colors.text, borderColor: colors.border },
+          ]}
+        />
+      </View>
+    </View>
+  );
+}
+
+/** Inline role-categorized notes editor. */
+export function NotesEditor({
+  notes,
+  onChange,
+  colors,
+}: {
+  notes: Array<{ category: string; content: string }>;
+  onChange: (notes: Array<{ category: string; content: string }>) => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  const setNote = (
+    idx: number,
+    patch: Partial<{ category: string; content: string }>,
+  ) => onChange(notes.map((n, i) => (i === idx ? { ...n, ...patch } : n)));
+  const removeNote = (idx: number) =>
+    onChange(notes.filter((_, i) => i !== idx));
+
+  return (
+    <>
+      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+        Notes
+      </Text>
+      {notes.map((note, idx) => (
+        <View key={idx} style={styles.noteRow}>
+          <InlineText
+            value={note.category}
+            onSave={(v) => setNote(idx, { category: v })}
+            placeholder="Role"
+            maxLength={30}
+            accessibilityLabel="Note role"
+            style={[
+              styles.noteCategory,
+              { color: colors.text, borderColor: colors.border },
+            ]}
+          />
+          <InlineText
+            value={note.content}
+            onSave={(v) => setNote(idx, { content: v })}
+            placeholder="Cue or instruction"
+            accessibilityLabel="Note content"
+            style={[
+              styles.noteContent,
+              { color: colors.text, borderColor: colors.border },
+            ]}
+          />
+          <Pressable
+            onPress={() => removeNote(idx)}
+            hitSlop={8}
+            style={styles.actionBtn}
+            accessibilityLabel="Remove note"
+          >
+            <Ionicons name="close" size={16} color={colors.textTertiary} />
+          </Pressable>
+        </View>
+      ))}
+      <Pressable
+        onPress={() => onChange([...notes, { category: "", content: "" }])}
+        style={styles.addNotePressable}
+      >
+        <View style={styles.addNoteRow}>
+          <Ionicons name="add" size={16} color={colors.buttonPrimary} />
+          <Text style={[styles.addNoteText, { color: colors.buttonPrimary }]}>
+            Add a note
+          </Text>
+        </View>
+      </Pressable>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
+  timingToggle: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 4 },
+  timingPressable: { borderRadius: 999 },
+  timingChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  timingChipText: { fontSize: 12, fontWeight: "600" },
+  durationInput: {
+    width: 60,
+    alignSelf: "center",
+    fontSize: 13,
+    textAlign: "center",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 6,
+    paddingVertical: 3,
+    paddingHorizontal: 4,
+  },
+  actionBtn: { padding: 4 },
+  fieldLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    marginTop: 8,
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  songRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  songInput: {
+    minWidth: 52,
+    fontSize: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  descInput: {
+    fontSize: 14,
+    minHeight: 40,
+    textAlignVertical: "top",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  roleWrap: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  rolePressable: { borderRadius: 999, maxWidth: "100%" },
+  roleChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  roleSwatch: { width: 9, height: 9, borderRadius: 5 },
+  roleChipText: { fontSize: 12, fontWeight: "500", flexShrink: 1 },
+  noteRow: { flexDirection: "row", alignItems: "center", gap: 6, marginTop: 6 },
+  noteCategory: {
+    width: 88,
+    fontSize: 13,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  noteContent: {
+    flex: 1,
+    fontSize: 13,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  addNotePressable: { marginTop: 6 },
+  addNoteRow: { flexDirection: "row", alignItems: "center", gap: 4 },
+  addNoteText: { fontSize: 13, fontWeight: "600" },
+  addPressable: { flexGrow: 1, borderRadius: 12 },
+  addRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: "dashed",
+  },
+  addText: { fontSize: 14, fontWeight: "600" },
+  modalStack: { gap: 4 },
+  tagPressable: { alignSelf: "flex-start", maxWidth: "100%" },
+});

--- a/apps/mobile/features/scheduling/components/RunSheetItemEditors.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetItemEditors.tsx
@@ -20,6 +20,7 @@ import {
   StyleSheet,
   Pressable,
   Platform,
+  ActivityIndicator,
   type TextStyle,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
@@ -205,10 +206,17 @@ export function WhoModalBody({
   item,
   roleOptions,
   onPatch,
+  emptyStateText = "No roles are defined yet.",
+  loading = false,
 }: {
   item: RunSheetItemLike;
   roleOptions: RoleOption[];
   onPatch: (patch: ItemPatch) => void;
+  /** Message shown when there are no roles to pick — worded per surface. */
+  emptyStateText?: string;
+  /** While the role sources are still loading, show a spinner instead of the
+   *  empty message so it doesn't flash "no roles" before they resolve. */
+  loading?: boolean;
 }) {
   const { colors } = useTheme();
   const [linked, setLinked] = useState<Set<string>>(
@@ -226,9 +234,16 @@ export function WhoModalBody({
   };
 
   if (roleOptions.length === 0) {
+    if (loading) {
+      return (
+        <View style={styles.rolesLoading}>
+          <ActivityIndicator size="small" color={colors.textSecondary} />
+        </View>
+      );
+    }
     return (
       <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-        No roles are defined for this group yet.
+        {emptyStateText}
       </Text>
     );
   }
@@ -505,6 +520,7 @@ export function NotesEditor({
 
 const styles = StyleSheet.create({
   emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
+  rolesLoading: { paddingVertical: 24, alignItems: "center" },
   timingToggle: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 4 },
   timingPressable: { borderRadius: 999 },
   timingChip: {

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -28,7 +28,6 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
-  type TextStyle,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -51,18 +50,22 @@ import {
 import { useAuth } from "@providers/AuthProvider";
 import { InlineText } from "./InlineText";
 import { GridScrollList, OptionTag, type GridColumn } from "./GridScrollList";
-import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
-import { SongPicker } from "./SongPicker";
+import { AnchoredMenu, type AnchorRect } from "./AnchoredMenu";
 import { CustomModal } from "@components/ui/Modal";
 import type { Song } from "@features/songs/types";
-
-/** When an item happens relative to the event's service times. */
-type Segment = "before" | "during" | "after";
-const SEGMENT_OPTIONS: Array<{ key: Segment; label: string; short: string }> = [
-  { key: "before", label: "Before event", short: "Before" },
-  { key: "during", label: "During event", short: "During" },
-  { key: "after", label: "After event", short: "After" },
-];
+import {
+  WhenPill,
+  AddButton,
+  DurationCell,
+  WhoModalBody,
+  NotesModalBody,
+  SongModalBody,
+  SEGMENT_OPTIONS,
+  type Segment,
+  type ItemAssignment,
+  type RoleOption,
+  type ItemPatch,
+} from "./RunSheetItemEditors";
 
 /**
  * Show a one-button error. React Native's Alert.alert is a no-op on web in this
@@ -76,12 +79,6 @@ function notifyError(title: string, message: string) {
   }
   Alert.alert(title, message);
 }
-
-type ItemAssignment = {
-  roleId: Id<"teamRoles">;
-  roleName: string;
-  roleColor: string | null;
-};
 
 type RunSheetItem = {
   _id: Id<"eventItems">;
@@ -114,27 +111,6 @@ type EventDoc = {
   eventDate: number;
   times: Array<{ label: string; startsAt: number }>;
   roles: EventRole[];
-};
-
-type RoleOption = {
-  roleId: Id<"teamRoles">;
-  roleName: string;
-  roleColor?: string;
-  people: string[];
-};
-
-/** Item field patch shape sent to updateItem. */
-type ItemPatch = {
-  type?: string;
-  title?: string;
-  segment?: Segment;
-  durationSec?: number;
-  description?: string;
-  notes?: Array<{ category: string; content: string }>;
-  assignments?: Array<{ roleId: Id<"teamRoles"> }>;
-  songDetails?: { key?: string; bpm?: number };
-  // Link / unlink a library song. `null` clears the link (ADR-027).
-  songId?: Id<"songs"> | null;
 };
 
 export function RunSheetScreen() {
@@ -790,383 +766,6 @@ export function RunSheetScreen() {
   );
 }
 
-/**
- * The "When" phase pill. Measures its own window rect on press so the parent can
- * anchor the dropdown next to it (the pill can't hold the menu itself — the
- * table card clips overflow).
- */
-function WhenPill({
-  label,
-  colors,
-  primaryColor,
-  onOpen,
-}: {
-  label: string;
-  colors: ReturnType<typeof useTheme>["colors"];
-  primaryColor: string;
-  onOpen: (anchor: AnchorRect) => void;
-}) {
-  const ref = React.useRef<View>(null);
-  return (
-    <Pressable
-      ref={ref}
-      onPress={() => measureAnchor(ref.current, onOpen)}
-      style={styles.tagPressable}
-      accessibilityRole="button"
-      accessibilityLabel={`When: ${label}. Tap to change.`}
-    >
-      <OptionTag
-        label={label}
-        colors={colors}
-        primaryColor={primaryColor}
-        tinted
-        chevron
-      />
-    </Pressable>
-  );
-}
-
-function AddButton({
-  label,
-  icon,
-  onPress,
-  primaryColor,
-  colors,
-}: {
-  label: string;
-  icon: keyof typeof Ionicons.glyphMap;
-  onPress: () => void;
-  primaryColor: string;
-  colors: ReturnType<typeof useTheme>["colors"];
-}) {
-  return (
-    <Pressable onPress={onPress} style={styles.addPressable}>
-      <View style={[styles.addRow, { borderColor: colors.border }]}>
-        <Ionicons name={icon} size={18} color={primaryColor} />
-        <Text style={[styles.addText, { color: primaryColor }]}>{label}</Text>
-      </View>
-    </Pressable>
-  );
-}
-
-/**
- * Who's-involved editor body (roles multi-select).
- *
- * Seeds a local Set from the item's current assignments so rapid toggles
- * compound instead of each restarting from the last server-synced value (which
- * lags a mutation round-trip). Remounted per item via a `key` at the call site,
- * so it re-seeds whenever a different row's modal opens.
- */
-function WhoModalBody({
-  item,
-  roleOptions,
-  onPatch,
-}: {
-  item: RunSheetItem;
-  roleOptions: RoleOption[];
-  onPatch: (patch: ItemPatch) => void;
-}) {
-  const { colors } = useTheme();
-  const [linked, setLinked] = useState<Set<string>>(
-    () => new Set(item.assignments.map((a) => a.roleId as string)),
-  );
-
-  const toggle = (roleId: string) => {
-    const next = new Set(linked);
-    if (next.has(roleId)) next.delete(roleId);
-    else next.add(roleId);
-    setLinked(next);
-    onPatch({
-      assignments: [...next].map((id) => ({ roleId: id as Id<"teamRoles"> })),
-    });
-  };
-
-  if (roleOptions.length === 0) {
-    return (
-      <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-        No roles are defined for this event yet.
-      </Text>
-    );
-  }
-
-  return (
-    <View style={styles.roleWrap}>
-      {roleOptions.map((r) => {
-        const selected = linked.has(r.roleId as string);
-        const swatch = r.roleColor ?? DEFAULT_ROLE_COLOR;
-        return (
-          <Pressable
-            key={r.roleId}
-            onPress={() => toggle(r.roleId as string)}
-            style={styles.rolePressable}
-          >
-            <View
-              style={[
-                styles.roleChip,
-                {
-                  backgroundColor: selected ? swatch + "22" : colors.surface,
-                  borderColor: selected ? swatch : colors.border,
-                },
-              ]}
-            >
-              <View style={[styles.roleSwatch, { backgroundColor: swatch }]} />
-              <Text
-                style={[styles.roleChipText, { color: colors.text }]}
-                numberOfLines={1}
-              >
-                {r.roleName}
-                {r.people.length > 0 ? `: ${r.people.join(", ")}` : ""}
-              </Text>
-              {selected ? (
-                <Ionicons name="checkmark-circle" size={15} color={swatch} />
-              ) : null}
-            </View>
-          </Pressable>
-        );
-      })}
-    </View>
-  );
-}
-
-/**
- * Notes editor body — the item's timing phase, free-text description, and the
- * role-categorized cue notes. This is where the old expanded "Timing",
- * "Description", and "Notes" fields now live.
- */
-function NotesModalBody({
-  item,
-  onPatch,
-}: {
-  item: RunSheetItem;
-  onPatch: (patch: ItemPatch) => void;
-}) {
-  const { colors } = useTheme();
-  return (
-    <View style={styles.modalStack}>
-      {/* Timing phase — before / during / after the event (PCO's position). */}
-      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
-        Timing
-      </Text>
-      <View style={styles.timingToggle}>
-        {SEGMENT_OPTIONS.map((seg) => {
-          const active = (item.segment as Segment) === seg.key;
-          return (
-            <Pressable
-              key={seg.key}
-              onPress={() => onPatch({ segment: seg.key })}
-              style={styles.timingPressable}
-              accessibilityRole="button"
-              accessibilityState={{ selected: active }}
-            >
-              <View
-                style={[
-                  styles.timingChip,
-                  {
-                    borderColor: active ? colors.buttonPrimary : colors.border,
-                    backgroundColor: active
-                      ? colors.buttonPrimary + "1F"
-                      : "transparent",
-                  },
-                ]}
-              >
-                <Text
-                  style={[
-                    styles.timingChipText,
-                    { color: active ? colors.buttonPrimary : colors.textSecondary },
-                  ]}
-                >
-                  {seg.label}
-                </Text>
-              </View>
-            </Pressable>
-          );
-        })}
-      </View>
-
-      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
-        Description
-      </Text>
-      <InlineText
-        value={item.description ?? ""}
-        onSave={(d) => onPatch({ description: d })}
-        placeholder="Optional details for this moment"
-        multiline
-        accessibilityLabel="Item description"
-        style={[styles.descInput, { color: colors.text, borderColor: colors.border }]}
-      />
-
-      <NotesEditor
-        notes={item.notes}
-        onChange={(notes) => onPatch({ notes })}
-        colors={colors}
-      />
-    </View>
-  );
-}
-
-/**
- * Song editor body — links the row to a library song (ADR-027) and edits the
- * per-service Key / BPM overrides. When a song is linked, Key/BPM show only the
- * override (blank if none), placeholder is the song's default.
- */
-function SongModalBody({
-  item,
-  communityId,
-  groupId,
-  onPatch,
-}: {
-  item: RunSheetItem;
-  communityId: string;
-  groupId: string;
-  onPatch: (patch: ItemPatch) => void;
-}) {
-  const { colors } = useTheme();
-  return (
-    <View style={styles.modalStack}>
-      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Song</Text>
-      <SongPicker
-        communityId={communityId}
-        groupId={groupId}
-        songId={item.songId}
-        song={item.song}
-        onSelect={(songId) => onPatch({ songId: songId as Id<"songs"> | null })}
-      />
-
-      <View style={styles.songRow}>
-        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Key</Text>
-        <InlineText
-          value={item.songDetails?.key ?? ""}
-          onSave={(key) =>
-            onPatch({
-              songDetails: { key: key.trim() || undefined, bpm: item.songDetails?.bpm },
-            })
-          }
-          placeholder={item.song?.defaultKey ?? "—"}
-          maxLength={8}
-          accessibilityLabel="Song key"
-          style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
-        />
-        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>BPM</Text>
-        <InlineText
-          value={item.songDetails?.bpm ? String(item.songDetails.bpm) : ""}
-          onSave={(bpm) =>
-            onPatch({
-              songDetails: {
-                key: item.songDetails?.key,
-                bpm: parseInt(bpm, 10) || undefined,
-              },
-            })
-          }
-          placeholder={item.song?.bpm ? String(item.song.bpm) : "—"}
-          keyboardType="number-pad"
-          maxLength={3}
-          accessibilityLabel="Song BPM"
-          style={[styles.songInput, { color: colors.text, borderColor: colors.border }]}
-        />
-      </View>
-    </View>
-  );
-}
-
-// RN-Web draws a browser focus ring on the underlying <input> that visually
-// bleeds past this tiny cell; suppress it so the input stays fully contained.
-const webNoOutline: TextStyle | undefined =
-  Platform.OS === "web"
-    ? ({ outlineStyle: "none" } as unknown as TextStyle)
-    : undefined;
-
-/** Inline m:ss duration cell. Parses "5", "5:30", or "330s"-style minute input. */
-function DurationCell({
-  durationSec,
-  onSave,
-  colors,
-}: {
-  durationSec: number;
-  onSave: (sec: number) => void;
-  colors: ReturnType<typeof useTheme>["colors"];
-}) {
-  const mm = Math.floor(durationSec / 60);
-  const ss = durationSec % 60;
-  const display = `${mm}:${String(ss).padStart(2, "0")}`;
-  return (
-    <InlineText
-      value={display}
-      onSave={(text) => onSave(parseDuration(text))}
-      placeholder="0:00"
-      keyboardType="numbers-and-punctuation"
-      maxLength={6}
-      accessibilityLabel="Duration (minutes:seconds)"
-      style={[
-        styles.durationInput,
-        { color: colors.text, borderColor: colors.border },
-        webNoOutline,
-      ]}
-    />
-  );
-}
-
-/** Parse "m:ss" or plain minutes into seconds. */
-function parseDuration(text: string): number {
-  const trimmed = text.trim();
-  if (trimmed.includes(":")) {
-    const [m, s] = trimmed.split(":");
-    return Math.max(0, (parseInt(m, 10) || 0) * 60 + (parseInt(s, 10) || 0));
-  }
-  return Math.max(0, Math.round((parseFloat(trimmed) || 0) * 60));
-}
-
-/** Inline role-categorized notes editor. */
-function NotesEditor({
-  notes,
-  onChange,
-  colors,
-}: {
-  notes: Array<{ category: string; content: string }>;
-  onChange: (notes: Array<{ category: string; content: string }>) => void;
-  colors: ReturnType<typeof useTheme>["colors"];
-}) {
-  const setNote = (idx: number, patch: Partial<{ category: string; content: string }>) =>
-    onChange(notes.map((n, i) => (i === idx ? { ...n, ...patch } : n)));
-  const removeNote = (idx: number) => onChange(notes.filter((_, i) => i !== idx));
-
-  return (
-    <>
-      <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Notes</Text>
-      {notes.map((note, idx) => (
-        <View key={idx} style={styles.noteRow}>
-          <InlineText
-            value={note.category}
-            onSave={(v) => setNote(idx, { category: v })}
-            placeholder="Role"
-            maxLength={30}
-            accessibilityLabel="Note role"
-            style={[styles.noteCategory, { color: colors.text, borderColor: colors.border }]}
-          />
-          <InlineText
-            value={note.content}
-            onSave={(v) => setNote(idx, { content: v })}
-            placeholder="Cue or instruction"
-            accessibilityLabel="Note content"
-            style={[styles.noteContent, { color: colors.text, borderColor: colors.border }]}
-          />
-          <Pressable onPress={() => removeNote(idx)} hitSlop={8} style={styles.actionBtn} accessibilityLabel="Remove note">
-            <Ionicons name="close" size={16} color={colors.textTertiary} />
-          </Pressable>
-        </View>
-      ))}
-      <Pressable
-        onPress={() => onChange([...notes, { category: "", content: "" }])}
-        style={styles.addNotePressable}
-      >
-        <View style={styles.addNoteRow}>
-          <Ionicons name="add" size={16} color={colors.buttonPrimary} />
-          <Text style={[styles.addNoteText, { color: colors.buttonPrimary }]}>Add a note</Text>
-        </View>
-      </Pressable>
-    </>
-  );
-}
-
 const styles = StyleSheet.create({
   container: { flex: 1 },
   header: {
@@ -1202,94 +801,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   addToChipText: { fontSize: 13, fontWeight: "600" },
-  timingToggle: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 4 },
-  timingPressable: { borderRadius: 999 },
-  timingChip: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 999,
-    borderWidth: 1,
-  },
-  timingChipText: { fontSize: 12, fontWeight: "600" },
   titleInput: { fontSize: 15, fontWeight: "600", width: "100%" },
   headerTitleInput: { fontSize: 12, fontWeight: "800", letterSpacing: 0.5, textTransform: "uppercase" },
-  durationInput: {
-    width: 60,
-    alignSelf: "center",
-    fontSize: 13,
-    textAlign: "center",
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 6,
-    paddingVertical: 3,
-    paddingHorizontal: 4,
-  },
   actionBtn: { padding: 4 },
-  fieldLabel: { fontSize: 11, fontWeight: "700", marginTop: 8, textTransform: "uppercase", letterSpacing: 0.4 },
-  songRow: { flexDirection: "row", alignItems: "center", gap: 8 },
-  songInput: {
-    minWidth: 52,
-    fontSize: 14,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 6,
-    paddingVertical: 4,
-    paddingHorizontal: 8,
-  },
-  descInput: {
-    fontSize: 14,
-    minHeight: 40,
-    textAlignVertical: "top",
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 8,
-    paddingVertical: 6,
-    paddingHorizontal: 8,
-  },
-  roleWrap: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
-  rolePressable: { borderRadius: 999, maxWidth: "100%" },
-  roleChip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 999,
-    borderWidth: 1,
-  },
-  roleSwatch: { width: 9, height: 9, borderRadius: 5 },
-  roleChipText: { fontSize: 12, fontWeight: "500", flexShrink: 1 },
-  noteRow: { flexDirection: "row", alignItems: "center", gap: 6, marginTop: 6 },
-  noteCategory: {
-    width: 88,
-    fontSize: 13,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 6,
-    paddingVertical: 4,
-    paddingHorizontal: 8,
-  },
-  noteContent: {
-    flex: 1,
-    fontSize: 13,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 6,
-    paddingVertical: 4,
-    paddingHorizontal: 8,
-  },
-  addNotePressable: { marginTop: 6 },
-  addNoteRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-  addNoteText: { fontSize: 13, fontWeight: "600" },
   addBar: { flexDirection: "row", gap: 8, marginTop: 16, flexWrap: "wrap" },
-  addPressable: { flexGrow: 1, borderRadius: 12 },
-  addRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 6,
-    paddingVertical: 12,
-    paddingHorizontal: 12,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderStyle: "dashed",
-  },
-  addText: { fontSize: 14, fontWeight: "600" },
   // Grid cell content. The primitive draws the padded cell frame; these only
   // style the content that sits inside it.
   cellPressable: { flex: 1, justifyContent: "center" },
@@ -1298,9 +813,7 @@ const styles = StyleSheet.create({
   whoChips: { flexDirection: "row", alignItems: "center", gap: 4, flexWrap: "wrap" },
   // Wraps an OptionTag that opens an anchored menu (self-aligned so it hugs its
   // content and can be measured for the dropdown anchor).
-  tagPressable: { alignSelf: "flex-start", maxWidth: "100%" },
   // "Time" — a quiet, contained read-only clock value ("9:00 AM").
   timeText: { fontSize: 13, fontVariant: ["tabular-nums"] },
   actionsRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-  modalStack: { gap: 4 },
 });

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -712,6 +712,7 @@ export function RunSheetScreen() {
             item={whoLive}
             roleOptions={roleOptions}
             onPatch={(patch) => patchItem(whoLive._id, patch)}
+            emptyStateText="No roles are defined for this event yet."
           />
         ) : null}
       </CustomModal>

--- a/apps/mobile/features/scheduling/components/RunSheetTemplateEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetTemplateEditorScreen.tsx
@@ -1,0 +1,909 @@
+/**
+ * RunSheetTemplateEditorScreen
+ *
+ * The item editor for one run-sheet TEMPLATE (event templates Phase 2). It
+ * reuses the run sheet editor's row/cell building blocks (`RunSheetItemEditors`)
+ * plus the shared `GridScrollList`, so the table reads identically to the
+ * plan-level `RunSheetScreen` — wired to the `*RunSheetTemplateItem*` mutations.
+ *
+ * Templates hold durations only, never clock times (a plan concern), so the
+ * "Time" column is omitted; everything else — When, Dur, Owner/Role, Notes,
+ * Song, duplicate/delete, drag-reorder — matches the plan run sheet.
+ *
+ * Route: /rostering/[group_id]/templates/runsheet/[template_id]
+ * Backend: scheduling.runSheetTemplates.*
+ *
+ * Auth: leaders / community admins only.
+ */
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TouchableOpacity,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useAuth } from "@providers/AuthProvider";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import type { Song } from "@features/songs/types";
+import { DEFAULT_ROLE_COLOR } from "../utils/format";
+import { InlineText } from "./InlineText";
+import { GridScrollList, OptionTag, type GridColumn } from "./GridScrollList";
+import { AnchoredMenu, type AnchorRect } from "./AnchoredMenu";
+import { CustomModal } from "@components/ui/Modal";
+import {
+  WhenPill,
+  AddButton,
+  DurationCell,
+  WhoModalBody,
+  NotesModalBody,
+  SongModalBody,
+  SEGMENT_OPTIONS,
+  type Segment,
+  type RoleOption,
+  type ItemPatch,
+  type RunSheetItemLike,
+} from "./RunSheetItemEditors";
+import {
+  listRunSheetTemplatesRef,
+  renameRunSheetTemplateRef,
+  listRunSheetTemplateItemsRef,
+  addRunSheetTemplateItemRef,
+  updateRunSheetTemplateItemRef,
+  deleteRunSheetTemplateItemRef,
+  duplicateRunSheetTemplateItemRef,
+  reorderRunSheetTemplateItemsRef,
+  type RunSheetTemplateItem,
+  type RunSheetTemplateSummary,
+} from "../api/eventTemplates";
+
+function notifyError(title: string, message: string) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);
+    return;
+  }
+  Alert.alert(title, message);
+}
+
+const errMsg = (e: unknown) => {
+  const err = e as { data?: { message?: string } | string; message?: string };
+  const data = err?.data;
+  if (typeof data === "string") return data;
+  return data?.message ?? err?.message ?? "Please try again.";
+};
+
+/** Adapt a template item to the shared editor's `RunSheetItemLike` shape. */
+function toItemLike(it: RunSheetTemplateItem): RunSheetItemLike {
+  return {
+    segment: it.segment,
+    description: it.description,
+    durationSec: it.durationSec,
+    notes: it.notes,
+    songDetails: it.songDetails,
+    songId: it.songId,
+    song: it.song as Song | null,
+    assignments: it.assignments,
+  };
+}
+
+export function RunSheetTemplateEditorScreen() {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { user, community } = useAuth();
+  const { group_id, template_id } = useLocalSearchParams<{
+    group_id: string;
+    template_id: string;
+  }>();
+  const groupId = group_id as Id<"groups">;
+  const templateId = template_id as Id<"runSheetTemplates">;
+  const communityId = community?.id ?? "";
+
+  const groupData = useAuthenticatedQuery(
+    api.functions.groups.queries.getById,
+    group_id ? { groupId } : "skip",
+  ) as { userRole?: string } | null | undefined;
+  const isLeader =
+    groupData?.userRole === "leader" ||
+    groupData?.userRole === "admin" ||
+    user?.is_admin === true;
+
+  const templates = useAuthenticatedQuery(
+    listRunSheetTemplatesRef,
+    isLeader && groupId ? { groupId } : "skip",
+  ) as RunSheetTemplateSummary[] | undefined;
+  const template = useMemo(
+    () => (templates ?? []).find((t) => t._id === templateId) ?? null,
+    [templates, templateId],
+  );
+
+  const items = useAuthenticatedQuery(
+    listRunSheetTemplateItemsRef,
+    isLeader && templateId ? { templateId } : "skip",
+  ) as RunSheetTemplateItem[] | undefined;
+
+  const teamsData = useAuthenticatedQuery(
+    api.functions.scheduling.teams.listTeams,
+    isLeader && groupId ? { groupId } : "skip",
+  ) as Array<{ _id: Id<"teams">; name: string }> | undefined;
+
+  const addItem = useAuthenticatedMutation(addRunSheetTemplateItemRef);
+  const updateItem = useAuthenticatedMutation(updateRunSheetTemplateItemRef);
+  const deleteItem = useAuthenticatedMutation(deleteRunSheetTemplateItemRef);
+  const duplicateItem = useAuthenticatedMutation(
+    duplicateRunSheetTemplateItemRef,
+  );
+  const reorderItems = useAuthenticatedMutation(reorderRunSheetTemplateItemsRef);
+  const renameTemplate = useAuthenticatedMutation(renameRunSheetTemplateRef);
+
+  // Group roles for the "Who" picker — gathered across the group's teams. There
+  // is no roster on a template, so `people` is always empty.
+  const [rolesByTeam, setRolesByTeam] = useState<
+    Record<string, RunSheetRoleInfo[]>
+  >({});
+  const setRolesForTeam = useCallback(
+    (teamId: string, roles: RunSheetRoleInfo[]) => {
+      setRolesByTeam((prev) => {
+        const existing = prev[teamId];
+        if (
+          existing &&
+          existing.length === roles.length &&
+          existing.every(
+            (r, i) => r.roleId === roles[i].roleId && r.roleName === roles[i].roleName,
+          )
+        ) {
+          return prev;
+        }
+        return { ...prev, [teamId]: roles };
+      });
+    },
+    [],
+  );
+  const roleOptions = useMemo<RoleOption[]>(() => {
+    const byId = new Map<string, RoleOption>();
+    for (const roles of Object.values(rolesByTeam)) {
+      for (const r of roles) {
+        byId.set(r.roleId as string, {
+          roleId: r.roleId,
+          roleName: r.roleName,
+          roleColor: r.roleColor,
+          people: [],
+        });
+      }
+    }
+    return [...byId.values()];
+  }, [rolesByTeam]);
+
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const [addSegment, setAddSegment] = useState<Segment>("during");
+  const [whoItem, setWhoItem] = useState<RunSheetTemplateItem | null>(null);
+  const [notesItem, setNotesItem] = useState<RunSheetTemplateItem | null>(null);
+  const [songItem, setSongItem] = useState<RunSheetTemplateItem | null>(null);
+  const [whenMenu, setWhenMenu] = useState<{
+    item: RunSheetTemplateItem;
+    anchor: AnchorRect;
+  } | null>(null);
+  const [renaming, setRenaming] = useState(false);
+
+  const columns: GridColumn[] = useMemo(
+    () => [
+      { key: "item", label: "Item", width: 220, flex: 3 },
+      { key: "when", label: "When", width: 104 },
+      { key: "dur", label: "Dur", width: 84, align: "center" },
+      { key: "who", label: "Owner / Role", width: 176 },
+      { key: "notes", label: "Notes", width: 240, flex: 3 },
+      { key: "song", label: "Song", width: 150 },
+      { key: "actions", label: "", width: 64, align: "center" },
+    ],
+    [],
+  );
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+  }, [router]);
+
+  // `listRunSheetTemplateItems` already returns items sorted by (segment,
+  // sequence); the flat row order is before → during → after.
+  const rows = useMemo(() => {
+    const groups: Record<Segment, RunSheetTemplateItem[]> = {
+      before: [],
+      during: [],
+      after: [],
+    };
+    for (const it of items ?? []) {
+      const seg = (it.segment as Segment) ?? "during";
+      (groups[seg] ?? groups.during).push(it);
+    }
+    return groups.before.concat(groups.during, groups.after);
+  }, [items]);
+
+  const patchItem = useCallback(
+    (itemId: Id<"runSheetTemplateItems">, patch: ItemPatch) =>
+      updateItem({ itemId, ...patch }).catch((e) =>
+        notifyError("Couldn't save", errMsg(e)),
+      ),
+    [updateItem],
+  );
+
+  const handleAdd = useCallback(
+    async (type: string) => {
+      try {
+        const { itemId } = await addItem({
+          templateId,
+          type,
+          title: type === "header" ? "New section" : "New item",
+          segment: addSegment,
+        });
+        setFocusId(itemId as string);
+      } catch (e) {
+        notifyError("Couldn't add item", errMsg(e));
+      }
+    },
+    [addItem, templateId, addSegment],
+  );
+
+  const handleDuplicate = useCallback(
+    (itemId: Id<"runSheetTemplateItems">) =>
+      duplicateItem({ itemId }).catch((e) =>
+        notifyError("Couldn't duplicate", errMsg(e)),
+      ),
+    [duplicateItem],
+  );
+
+  const handleDelete = useCallback(
+    (item: RunSheetTemplateItem) => {
+      const doDelete = () =>
+        deleteItem({ itemId: item._id }).catch((e) =>
+          notifyError("Couldn't delete", errMsg(e)),
+        );
+      const prompt = `Remove "${item.title}" from the run sheet?`;
+      if (Platform.OS === "web") {
+        if (typeof window !== "undefined" && window.confirm(prompt)) {
+          void doDelete();
+        }
+        return;
+      }
+      Alert.alert("Delete item?", prompt, [
+        { text: "Cancel", style: "cancel" },
+        { text: "Delete", style: "destructive", onPress: () => void doDelete() },
+      ]);
+    },
+    [deleteItem],
+  );
+
+  const handleReorder = useCallback(
+    (orderedKeys: string[]) => {
+      const byId = new Map(rows.map((it) => [it._id as string, it]));
+      const orderedItems = orderedKeys
+        .map((id) => byId.get(id))
+        .filter((it): it is RunSheetTemplateItem => it != null)
+        .map((it) => ({
+          id: it._id,
+          segment: (it.segment as Segment) ?? "during",
+        }));
+      return reorderItems({ templateId, orderedItems }).catch((e) =>
+        notifyError("Couldn't reorder", errMsg(e)),
+      );
+    },
+    [reorderItems, templateId, rows],
+  );
+
+  const referencedTeamIds = useMemo(
+    () => (teamsData ?? []).map((t) => t._id as string),
+    [teamsData],
+  );
+
+  const whoLive = whoItem
+    ? (items?.find((i) => i._id === whoItem._id) ?? null)
+    : null;
+  const notesLive = notesItem
+    ? (items?.find((i) => i._id === notesItem._id) ?? null)
+    : null;
+  const songLive = songItem
+    ? (items?.find((i) => i._id === songItem._id) ?? null)
+    : null;
+  const whenLive = whenMenu
+    ? (items?.find((i) => i._id === whenMenu.item._id) ?? null)
+    : null;
+
+  const templateName = template?.name ?? "Run-sheet template";
+
+  const renderHeaderBar = () => (
+    <View
+      style={[
+        styles.header,
+        { backgroundColor: colors.surface, borderBottomColor: colors.border },
+      ]}
+    >
+      <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBtn}>
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <Pressable
+        onPress={() => template && setRenaming(true)}
+        style={styles.headerTitleWrap}
+        accessibilityRole="button"
+        accessibilityLabel="Rename template"
+      >
+        <Text
+          style={[styles.headerTitle, { color: colors.text }]}
+          numberOfLines={1}
+        >
+          {templateName}
+        </Text>
+        {template ? (
+          <Ionicons name="pencil" size={13} color={colors.textTertiary} />
+        ) : null}
+      </Pressable>
+      <View style={styles.headerBtn} />
+    </View>
+  );
+
+  const loading = isLeader && items === undefined;
+
+  if (groupData === undefined || loading) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      </View>
+    );
+  }
+
+  if (!isLeader) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <Ionicons name="people-outline" size={40} color={colors.iconSecondary} />
+          <Text style={[styles.gateText, { color: colors.textSecondary }]}>
+            Only leaders can edit templates.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const listHeader = (
+    <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+      Build a reusable order of items — songs, headers, and moments with
+      durations. Clock times are set on the plan when you apply this template.
+    </Text>
+  );
+
+  const listFooter = (
+    <View>
+      <View style={styles.addToRow}>
+        <Text style={[styles.addToLabel, { color: colors.textSecondary }]}>
+          Add to:
+        </Text>
+        {SEGMENT_OPTIONS.map((seg) => {
+          const active = addSegment === seg.key;
+          return (
+            <Pressable
+              key={seg.key}
+              onPress={() => setAddSegment(seg.key)}
+              style={styles.addToChipPressable}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+            >
+              <View
+                style={[
+                  styles.addToChip,
+                  {
+                    borderColor: active ? primaryColor : colors.border,
+                    backgroundColor: active ? primaryColor + "18" : "transparent",
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.addToChipText,
+                    { color: active ? primaryColor : colors.textSecondary },
+                  ]}
+                >
+                  {seg.label}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+      <View style={styles.addBar}>
+        <AddButton
+          label="Add item"
+          icon="add"
+          onPress={() => handleAdd("item")}
+          primaryColor={primaryColor}
+          colors={colors}
+        />
+        <AddButton
+          label="Song"
+          icon="musical-notes"
+          onPress={() => handleAdd("song")}
+          primaryColor={primaryColor}
+          colors={colors}
+        />
+        <AddButton
+          label="Header"
+          icon="bookmark"
+          onPress={() => handleAdd("header")}
+          primaryColor={primaryColor}
+          colors={colors}
+        />
+      </View>
+    </View>
+  );
+
+  const renderCell = (
+    item: RunSheetTemplateItem,
+    key: string,
+  ): React.ReactNode => {
+    const isHeader = item.type === "header";
+    const isSong = item.type === "song";
+    const song = item.song as Song | null;
+    switch (key) {
+      case "item":
+        return (
+          <InlineText
+            value={item.title}
+            onSave={(t) => {
+              void patchItem(item._id, { title: t });
+            }}
+            placeholder={isHeader ? "Section name" : "Item title"}
+            autoFocus={focusId === (item._id as string)}
+            maxLength={120}
+            required
+            accessibilityLabel="Item title"
+            style={[
+              styles.titleInput,
+              isHeader && styles.headerTitleInput,
+              { color: colors.text },
+            ]}
+          />
+        );
+      case "when": {
+        const short =
+          SEGMENT_OPTIONS.find((s) => s.key === item.segment)?.short ?? "During";
+        return (
+          <WhenPill
+            label={short}
+            colors={colors}
+            primaryColor={primaryColor}
+            onOpen={(anchor) => setWhenMenu({ item, anchor })}
+          />
+        );
+      }
+      case "dur":
+        if (isHeader) return null;
+        return (
+          <DurationCell
+            durationSec={item.durationSec}
+            onSave={(sec) => void patchItem(item._id, { durationSec: sec })}
+            colors={colors}
+          />
+        );
+      case "who":
+        return (
+          <Pressable
+            onPress={() => setWhoItem(item)}
+            style={styles.cellPressable}
+            accessibilityLabel="Edit owner / role"
+          >
+            {item.assignments.length > 0 ? (
+              <View style={styles.whoChips}>
+                {item.assignments.slice(0, 2).map((a) => (
+                  <OptionTag
+                    key={a.roleId}
+                    label={a.roleName}
+                    colors={colors}
+                    primaryColor={primaryColor}
+                    color={a.roleColor ?? DEFAULT_ROLE_COLOR}
+                  />
+                ))}
+                {item.assignments.length > 2 ? (
+                  <Text style={[styles.muted, { color: colors.textTertiary }]}>
+                    +{item.assignments.length - 2}
+                  </Text>
+                ) : null}
+              </View>
+            ) : (
+              <OptionTag
+                label="＋"
+                colors={colors}
+                primaryColor={primaryColor}
+                placeholder
+              />
+            )}
+          </Pressable>
+        );
+      case "notes":
+        return (
+          <Pressable
+            onPress={() => setNotesItem(item)}
+            style={styles.cellPressable}
+            accessibilityLabel="Edit notes"
+          >
+            <Text
+              numberOfLines={2}
+              style={[
+                styles.cellText,
+                {
+                  color: item.description ? colors.text : colors.textTertiary,
+                },
+              ]}
+            >
+              {item.description && item.description.length > 0
+                ? item.description
+                : "Add notes"}
+              {item.notes.length > 0 ? ` · ${item.notes.length} cues` : ""}
+            </Text>
+          </Pressable>
+        );
+      case "song": {
+        if (!isSong) {
+          return (
+            <Text style={[styles.muted, { color: colors.textTertiary }]}>—</Text>
+          );
+        }
+        const resolvedKey = item.songDetails?.key ?? song?.defaultKey;
+        return (
+          <Pressable
+            onPress={() => setSongItem(item)}
+            style={styles.cellPressable}
+            accessibilityLabel="Edit song"
+          >
+            {song ? (
+              <Text
+                numberOfLines={1}
+                style={[styles.cellText, { color: colors.text }]}
+              >
+                {song.title}
+                {resolvedKey ? ` · ${resolvedKey}` : ""}
+              </Text>
+            ) : (
+              <Text style={[styles.muted, { color: colors.textTertiary }]}>
+                ＋ Song
+              </Text>
+            )}
+          </Pressable>
+        );
+      }
+      case "actions":
+        return (
+          <View style={styles.actionsRow}>
+            <Pressable
+              onPress={() => handleDuplicate(item._id)}
+              hitSlop={6}
+              style={styles.actionBtn}
+              accessibilityLabel="Duplicate"
+            >
+              <Ionicons name="copy-outline" size={16} color={colors.textTertiary} />
+            </Pressable>
+            <Pressable
+              onPress={() => handleDelete(item)}
+              hitSlop={6}
+              style={styles.actionBtn}
+              accessibilityLabel="Delete"
+            >
+              <Ionicons name="trash-outline" size={16} color={colors.destructive} />
+            </Pressable>
+          </View>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      {renderHeaderBar()}
+
+      {/* Load every team's roles so the Who picker has group-wide options. */}
+      {referencedTeamIds.map((tid) => (
+        <RoleLoader
+          key={tid}
+          teamId={tid as Id<"teams">}
+          onLoaded={setRolesForTeam}
+        />
+      ))}
+
+      {(items ?? []).length === 0 ? (
+        <ScrollView
+          contentContainerStyle={[
+            styles.scrollContent,
+            { paddingBottom: insets.bottom + 96 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          {listHeader}
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            No items yet. Pick a phase under "Add to" below, then add songs,
+            headers, and other moments.
+          </Text>
+          {listFooter}
+        </ScrollView>
+      ) : (
+        <GridScrollList<RunSheetTemplateItem>
+          data={rows}
+          keyExtractor={(it) => it._id as string}
+          onReorder={handleReorder}
+          columns={columns}
+          renderCell={renderCell}
+          ListHeaderComponent={listHeader}
+          ListFooterComponent={
+            <View style={{ paddingBottom: insets.bottom + 8 }}>{listFooter}</View>
+          }
+          contentContainerStyle={styles.gridContent}
+        />
+      )}
+
+      {/* Who's-involved (roles) editor. */}
+      <CustomModal
+        visible={whoLive !== null}
+        onClose={() => setWhoItem(null)}
+        title="Who's involved"
+      >
+        {whoLive ? (
+          <WhoModalBody
+            key={whoLive._id}
+            item={toItemLike(whoLive)}
+            roleOptions={roleOptions}
+            onPatch={(patch) => void patchItem(whoLive._id, patch)}
+          />
+        ) : null}
+      </CustomModal>
+
+      {/* Notes editor — timing phase, description, and role-categorized cues. */}
+      <CustomModal
+        visible={notesLive !== null}
+        onClose={() => setNotesItem(null)}
+        title="Notes"
+      >
+        {notesLive ? (
+          <NotesModalBody
+            key={notesLive._id}
+            item={toItemLike(notesLive)}
+            onPatch={(patch) => void patchItem(notesLive._id, patch)}
+          />
+        ) : null}
+      </CustomModal>
+
+      {/* Song editor — library link plus per-service key / BPM overrides. */}
+      <CustomModal
+        visible={songLive !== null}
+        onClose={() => setSongItem(null)}
+        title="Song"
+      >
+        {songLive ? (
+          <SongModalBody
+            key={songLive._id}
+            item={toItemLike(songLive)}
+            communityId={communityId}
+            groupId={group_id ?? ""}
+            onPatch={(patch) => void patchItem(songLive._id, patch)}
+          />
+        ) : null}
+      </CustomModal>
+
+      {/* When picker — moves the row between before / during / after phases. */}
+      {whenMenu && whenLive ? (
+        <AnchoredMenu
+          anchor={whenMenu.anchor}
+          options={SEGMENT_OPTIONS.map((s) => ({ id: s.key, name: s.label }))}
+          selectedId={whenLive.segment}
+          onSelect={(id) => {
+            if (id) void patchItem(whenLive._id, { segment: id as Segment });
+            setWhenMenu(null);
+          }}
+          onClose={() => setWhenMenu(null)}
+        />
+      ) : null}
+
+      {/* Rename the template. */}
+      <CustomModal
+        visible={renaming}
+        onClose={() => setRenaming(false)}
+        title="Rename template"
+      >
+        <RenameBody
+          key={templateName}
+          initialValue={templateName}
+          colors={colors}
+          primaryColor={primaryColor}
+          onSave={(name) => {
+            setRenaming(false);
+            void renameTemplate({ templateId, name }).catch((e) =>
+              notifyError("Couldn't rename", errMsg(e)),
+            );
+          }}
+        />
+      </CustomModal>
+    </View>
+  );
+}
+
+type RunSheetRoleInfo = {
+  roleId: Id<"teamRoles">;
+  roleName: string;
+  roleColor?: string;
+};
+
+/** Loads a team's roles and reports them up for the group-wide Who picker. */
+function RoleLoader({
+  teamId,
+  onLoaded,
+}: {
+  teamId: Id<"teams">;
+  onLoaded: (teamId: string, roles: RunSheetRoleInfo[]) => void;
+}) {
+  const roles = useAuthenticatedQuery(
+    api.functions.scheduling.roles.listRoles,
+    { teamId },
+  ) as Array<{ _id: Id<"teamRoles">; name: string; color?: string }> | undefined;
+
+  React.useEffect(() => {
+    if (roles) {
+      onLoaded(
+        teamId as string,
+        roles.map((r) => ({ roleId: r._id, roleName: r.name, roleColor: r.color })),
+      );
+    }
+  }, [roles, teamId, onLoaded]);
+
+  return null;
+}
+
+function RenameBody({
+  initialValue,
+  colors,
+  primaryColor,
+  onSave,
+}: {
+  initialValue: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onSave: (name: string) => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const canSave = value.trim().length > 0;
+  return (
+    <View style={styles.renameBody}>
+      <TextInput
+        value={value}
+        onChangeText={setValue}
+        placeholder="Template name"
+        placeholderTextColor={colors.textTertiary}
+        autoFocus
+        maxLength={50}
+        returnKeyType="done"
+        onSubmitEditing={() => canSave && onSave(value.trim())}
+        accessibilityLabel="Template name"
+        style={[
+          styles.renameInput,
+          { color: colors.text, borderColor: colors.border },
+        ]}
+      />
+      <Pressable
+        onPress={() => canSave && onSave(value.trim())}
+        disabled={!canSave}
+        style={[
+          styles.saveBtn,
+          { backgroundColor: primaryColor, opacity: canSave ? 1 : 0.5 },
+        ]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.saveBtnText}>Save</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBtn: { width: 36, padding: 4, alignItems: "center" },
+  headerTitleWrap: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+  },
+  headerTitle: { fontSize: 17, fontWeight: "600", flexShrink: 1 },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    gap: 12,
+  },
+  gateText: { fontSize: 15, textAlign: "center", lineHeight: 22 },
+  subtitle: { fontSize: 13, lineHeight: 19, marginBottom: 4 },
+  scrollContent: { padding: 16 },
+  gridContent: { paddingBottom: 8 },
+  emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
+  addToRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 8,
+    marginTop: 24,
+  },
+  addToLabel: { fontSize: 13, fontWeight: "600" },
+  addToChipPressable: { borderRadius: 999 },
+  addToChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  addToChipText: { fontSize: 13, fontWeight: "600" },
+  titleInput: { fontSize: 15, fontWeight: "600", width: "100%" },
+  headerTitleInput: {
+    fontSize: 12,
+    fontWeight: "800",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+  },
+  actionBtn: { padding: 4 },
+  addBar: { flexDirection: "row", gap: 8, marginTop: 16, flexWrap: "wrap" },
+  cellPressable: { flex: 1, justifyContent: "center" },
+  cellText: { fontSize: 13 },
+  muted: { fontSize: 13, fontWeight: "500" },
+  whoChips: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    flexWrap: "wrap",
+  },
+  actionsRow: { flexDirection: "row", alignItems: "center", gap: 4 },
+  renameBody: { gap: 12, paddingTop: 4 },
+  renameInput: {
+    fontSize: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+  },
+  saveBtn: { borderRadius: 10, paddingVertical: 13, alignItems: "center" },
+  saveBtnText: { fontSize: 15, fontWeight: "700", color: "#fff" },
+});

--- a/apps/mobile/features/scheduling/components/RunSheetTemplateEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetTemplateEditorScreen.tsx
@@ -190,6 +190,14 @@ export function RunSheetTemplateEditorScreen() {
     return [...byId.values()];
   }, [rolesByTeam]);
 
+  // Roles are fetched per team via RoleLoader; until every team has reported
+  // (or there are no teams), treat the (empty) role list as still loading so the
+  // Who picker doesn't flash "no roles" before the loaders resolve.
+  const rolesLoading =
+    teamsData === undefined ||
+    (teamsData.length > 0 &&
+      Object.keys(rolesByTeam).length < teamsData.length);
+
   const [focusId, setFocusId] = useState<string | null>(null);
   const [addSegment, setAddSegment] = useState<Segment>("during");
   const [whoItem, setWhoItem] = useState<RunSheetTemplateItem | null>(null);
@@ -682,6 +690,8 @@ export function RunSheetTemplateEditorScreen() {
             item={toItemLike(whoLive)}
             roleOptions={roleOptions}
             onPatch={(patch) => void patchItem(whoLive._id, patch)}
+            emptyStateText="No roles are defined for this template yet."
+            loading={rolesLoading}
           />
         ) : null}
       </CustomModal>

--- a/apps/mobile/features/scheduling/components/TaskTemplateEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TaskTemplateEditorScreen.tsx
@@ -1,0 +1,658 @@
+/**
+ * TaskTemplateEditorScreen
+ *
+ * The item editor for one task TEMPLATE (event templates Phase 2). It reuses the
+ * plan-level `EventTasksGrid` verbatim — the grid is presentational and never
+ * reads `planId`, so template items are adapted to its `PlanTask` shape and the
+ * grid's callbacks are wired to the `*TaskTemplateItem*` mutations instead of
+ * the plan's `eventTasks` mutations. The id-brand mismatch (template item vs
+ * plan task) is bridged with localized casts at this boundary so the shared grid
+ * stays untouched.
+ *
+ * Route: /rostering/[group_id]/templates/task/[template_id]
+ * Backend: scheduling.taskTemplates.{listTaskTemplateItems,addTaskTemplateItem,
+ *          updateTaskTemplateItem,deleteTaskTemplateItem,reorderTaskTemplateItems,
+ *          listTaskTemplates,renameTaskTemplate}
+ *
+ * Auth: leaders / community admins only — mirrors EventTasksScreen's gate.
+ */
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TouchableOpacity,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useAuth } from "@providers/AuthProvider";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { CustomModal } from "@components/ui/Modal";
+import {
+  EventTasksGrid,
+  type PlanTask,
+  type Segment,
+  type TaskPatch,
+  type TeamOption,
+  type RoleOption,
+} from "./EventTasksGrid";
+import { AnchoredMenu, type AnchorRect } from "./AnchoredMenu";
+import { EventTasksHowToDocEditor } from "./EventTasksHowToDocEditor";
+import {
+  listTaskTemplatesRef,
+  renameTaskTemplateRef,
+  listTaskTemplateItemsRef,
+  addTaskTemplateItemRef,
+  updateTaskTemplateItemRef,
+  deleteTaskTemplateItemRef,
+  reorderTaskTemplateItemsRef,
+  type TaskTemplateItem,
+  type TaskTemplateSummary,
+} from "../api/eventTemplates";
+
+function notifyError(title: string, message: string) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);
+    return;
+  }
+  Alert.alert(title, message);
+}
+
+function confirmDelete(prompt: string, onConfirm: () => void) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined" && window.confirm(prompt)) onConfirm();
+    return;
+  }
+  Alert.alert("Delete task?", prompt, [
+    { text: "Cancel", style: "cancel" },
+    { text: "Delete", style: "destructive", onPress: onConfirm },
+  ]);
+}
+
+const errMsg = (e: unknown) => {
+  const err = e as { data?: { message?: string } | string; message?: string };
+  const data = err?.data;
+  if (typeof data === "string") return data;
+  return data?.message ?? err?.message ?? "Please try again.";
+};
+
+// The grid is typed to the plan's `eventTasks` ids; template items carry
+// `eventTaskTemplateItems` ids. These branded strings are structurally the same
+// value, so we cast at the boundary rather than fork the shared grid.
+const asTaskId = (id: string) => id as unknown as Id<"eventTasks">;
+const asItemId = (id: Id<"eventTasks">) =>
+  id as unknown as Id<"eventTaskTemplateItems">;
+
+export function TaskTemplateEditorScreen() {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { user } = useAuth();
+  const { group_id, template_id } = useLocalSearchParams<{
+    group_id: string;
+    template_id: string;
+  }>();
+  const groupId = group_id as Id<"groups">;
+  const templateId = template_id as Id<"eventTaskTemplates">;
+
+  const groupData = useAuthenticatedQuery(
+    api.functions.groups.queries.getById,
+    group_id ? { groupId } : "skip",
+  ) as { userRole?: string } | null | undefined;
+  const isLeader =
+    groupData?.userRole === "leader" ||
+    groupData?.userRole === "admin" ||
+    user?.is_admin === true;
+
+  const templates = useAuthenticatedQuery(
+    listTaskTemplatesRef,
+    isLeader && groupId ? { groupId } : "skip",
+  ) as TaskTemplateSummary[] | undefined;
+  const template = useMemo(
+    () => (templates ?? []).find((t) => t._id === templateId) ?? null,
+    [templates, templateId],
+  );
+
+  const items = useAuthenticatedQuery(
+    listTaskTemplateItemsRef,
+    isLeader && templateId ? { templateId } : "skip",
+  ) as TaskTemplateItem[] | undefined;
+
+  const teamsData = useAuthenticatedQuery(
+    api.functions.scheduling.teams.listTeams,
+    isLeader && groupId ? { groupId } : "skip",
+  ) as Array<{ _id: Id<"teams">; name: string }> | undefined;
+
+  const addItem = useAuthenticatedMutation(addTaskTemplateItemRef);
+  const updateItem = useAuthenticatedMutation(updateTaskTemplateItemRef);
+  const deleteItem = useAuthenticatedMutation(deleteTaskTemplateItemRef);
+  const reorderItems = useAuthenticatedMutation(reorderTaskTemplateItemsRef);
+  const renameTemplate = useAuthenticatedMutation(renameTaskTemplateRef);
+
+  const teams: TeamOption[] = useMemo(
+    () => (teamsData ?? []).map((t) => ({ _id: t._id, name: t.name })),
+    [teamsData],
+  );
+
+  // Roles loaded per referenced team (same lazy pattern as EventTasksScreen).
+  const [rolesByTeam, setRolesByTeam] = useState<Record<string, RoleOption[]>>(
+    {},
+  );
+  const setRolesForTeam = useCallback((teamId: string, roles: RoleOption[]) => {
+    setRolesByTeam((prev) => {
+      const existing = prev[teamId];
+      if (
+        existing &&
+        existing.length === roles.length &&
+        existing.every(
+          (r, i) => r._id === roles[i]._id && r.name === roles[i].name,
+        )
+      ) {
+        return prev;
+      }
+      return { ...prev, [teamId]: roles };
+    });
+  }, []);
+
+  // Adapt template items to the grid's PlanTask shape.
+  const tasks = useMemo<PlanTask[]>(
+    () =>
+      (items ?? []).map((it) => ({
+        _id: asTaskId(it._id as string),
+        planId: templateId as unknown as Id<"eventPlans">,
+        teamIds: it.teamIds.map((id) => id as Id<"teams">),
+        teamNames: it.teamNames,
+        roleIds: it.roleIds.map((id) => id as Id<"teamRoles">),
+        roleNames: it.roleNames,
+        segment: it.segment,
+        title: it.title,
+        howToType: it.howToType,
+        howToText: it.howToText,
+        howToUrl: it.howToUrl,
+        howToMediaPath: it.howToMediaPath,
+        howToDoc: it.howToDoc,
+      })),
+    [items, templateId],
+  );
+
+  const referencedTeamIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const t of tasks) for (const id of t.teamIds) ids.add(id as string);
+    return [...ids];
+  }, [tasks]);
+
+  const [teamPicker, setTeamPicker] = useState<{
+    task: PlanTask;
+    anchor: AnchorRect;
+  } | null>(null);
+  const [rolePicker, setRolePicker] = useState<{
+    task: PlanTask;
+    anchor: AnchorRect;
+  } | null>(null);
+  const [docEditorTask, setDocEditorTask] = useState<PlanTask | null>(null);
+  const [renaming, setRenaming] = useState(false);
+
+  const handlePatch = useCallback(
+    (taskId: Id<"eventTasks">, patch: TaskPatch) => {
+      void updateItem({ itemId: asItemId(taskId), ...patch }).catch((e) =>
+        notifyError("Couldn't save", errMsg(e)),
+      );
+    },
+    [updateItem],
+  );
+
+  const handleAdd = useCallback(
+    async (segment: Segment) => {
+      const teamId = teams[0]?._id;
+      if (!teamId) {
+        notifyError(
+          "Add a team first",
+          "Create a serving team for this group before adding tasks.",
+        );
+        return;
+      }
+      try {
+        await addItem({
+          templateId,
+          teamIds: [teamId],
+          roleIds: [],
+          segment,
+          title: "New task",
+          howToType: "none",
+        });
+      } catch (e) {
+        notifyError("Couldn't add task", errMsg(e));
+      }
+    },
+    [addItem, templateId, teams],
+  );
+
+  const handleDelete = useCallback(
+    (task: PlanTask) => {
+      confirmDelete(`Remove "${task.title}"?`, () => {
+        void deleteItem({ itemId: asItemId(task._id) }).catch((e) =>
+          notifyError("Couldn't delete", errMsg(e)),
+        );
+      });
+    },
+    [deleteItem],
+  );
+
+  const handleDuplicate = useCallback(
+    async (task: PlanTask) => {
+      try {
+        await addItem({
+          templateId,
+          teamIds: task.teamIds,
+          roleIds: task.roleIds,
+          segment: task.segment,
+          title: task.title,
+          howToType: task.howToType,
+          howToText: task.howToText,
+          howToUrl: task.howToUrl,
+          howToMediaPath: task.howToMediaPath,
+          howToDoc: task.howToDoc,
+        });
+      } catch (e) {
+        notifyError("Couldn't duplicate", errMsg(e));
+      }
+    },
+    [addItem, templateId],
+  );
+
+  const handleReorder = useCallback(
+    (orderedIds: Array<Id<"eventTasks">>) => {
+      void reorderItems({
+        templateId,
+        orderedIds: orderedIds.map(asItemId),
+      }).catch((e) => notifyError("Couldn't reorder", errMsg(e)));
+    },
+    [reorderItems, templateId],
+  );
+
+  const handleToggleTeam = useCallback(
+    (task: PlanTask, teamId: Id<"teams">) => {
+      const has = task.teamIds.includes(teamId);
+      const next = has
+        ? task.teamIds.filter((t) => t !== teamId)
+        : [...task.teamIds, teamId];
+      if (next.length === 0) return;
+      handlePatch(task._id, { teamIds: next });
+    },
+    [handlePatch],
+  );
+
+  const handleToggleRole = useCallback(
+    (task: PlanTask, roleId: Id<"teamRoles">) => {
+      const has = task.roleIds.includes(roleId);
+      const next = has
+        ? task.roleIds.filter((r) => r !== roleId)
+        : [...task.roleIds, roleId];
+      handlePatch(task._id, { roleIds: next });
+    },
+    [handlePatch],
+  );
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+  }, [router]);
+
+  const templateName = template?.name ?? "Task template";
+
+  const renderHeaderBar = () => (
+    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+      <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBtn}>
+        <Ionicons name="chevron-back" size={28} color={colors.text} />
+      </TouchableOpacity>
+      <Pressable
+        onPress={() => template && setRenaming(true)}
+        style={styles.headerTitleWrap}
+        accessibilityRole="button"
+        accessibilityLabel="Rename template"
+      >
+        <Text
+          style={[styles.headerTitle, { color: colors.text }]}
+          numberOfLines={1}
+        >
+          {templateName}
+        </Text>
+        {template ? (
+          <Ionicons name="pencil" size={13} color={colors.textTertiary} />
+        ) : null}
+      </Pressable>
+      <View style={styles.headerBtn} />
+    </View>
+  );
+
+  if (groupData === undefined || (isLeader && items === undefined)) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      </View>
+    );
+  }
+
+  if (!isLeader) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { paddingTop: insets.top, backgroundColor: colors.surface },
+        ]}
+      >
+        {renderHeaderBar()}
+        <View style={styles.centered}>
+          <Ionicons name="people-outline" size={40} color={colors.iconSecondary} />
+          <Text style={[styles.gateText, { color: colors.textSecondary }]}>
+            Only leaders can edit templates.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const listHeader = (
+    <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+      Define the tasks each team and role is accountable for. These seed a plan's
+      Event Tasks when you apply this template.
+    </Text>
+  );
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surface },
+      ]}
+    >
+      {renderHeaderBar()}
+
+      {/* Load roles for every referenced team + the team currently in the role
+          picker, so role labels/pickers resolve without a big join. */}
+      {referencedTeamIds.map((tid) => (
+        <RoleLoader
+          key={tid}
+          teamId={tid as Id<"teams">}
+          onLoaded={setRolesForTeam}
+        />
+      ))}
+      {rolePicker
+        ? rolePicker.task.teamIds.map((tid) => (
+            <RoleLoader
+              key={`picker-${tid}`}
+              teamId={tid}
+              onLoaded={setRolesForTeam}
+            />
+          ))
+        : null}
+
+      {(items ?? []).length === 0 ? (
+        <ScrollView contentContainerStyle={styles.emptyScroll}>
+          {listHeader}
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            No tasks yet. Use "Add task" to define what each team and role is
+            accountable for, then attach a How-To for each.
+          </Text>
+          <View style={styles.emptyAddRow}>
+            {(["before", "during", "after"] as Segment[]).map((seg) => (
+              <TouchableOpacity
+                key={seg}
+                onPress={() => handleAdd(seg)}
+                style={[styles.emptyAddBtn, { borderColor: colors.border }]}
+              >
+                <Ionicons name="add" size={16} color={primaryColor} />
+                <Text style={[styles.emptyAddText, { color: primaryColor }]}>
+                  {seg === "before" ? "Pre" : seg === "during" ? "During" : "Post"}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </ScrollView>
+      ) : (
+        <EventTasksGrid
+          tasks={tasks}
+          teams={teams}
+          rolesByTeam={rolesByTeam}
+          onPatch={handlePatch}
+          onDelete={handleDelete}
+          onDuplicate={handleDuplicate}
+          onAdd={handleAdd}
+          onReorder={handleReorder}
+          onPickTeam={(task, anchor) => setTeamPicker({ task, anchor })}
+          onPickRole={(task, anchor) => setRolePicker({ task, anchor })}
+          onOpenDoc={setDocEditorTask}
+          listHeader={listHeader}
+        />
+      )}
+
+      {/* Team picker — multi-select; reads the LIVE task so checkmarks reflect
+          each toggle. */}
+      {teamPicker
+        ? (() => {
+            const live =
+              tasks.find((t) => t._id === teamPicker.task._id) ?? teamPicker.task;
+            return (
+              <AnchoredMenu
+                anchor={teamPicker.anchor}
+                options={teams.map((t) => ({ id: t._id as string, name: t.name }))}
+                selectedIds={live.teamIds as string[]}
+                onToggle={(id) => handleToggleTeam(live, id as Id<"teams">)}
+                onSelect={() => {}}
+                onClose={() => setTeamPicker(null)}
+              />
+            );
+          })()
+        : null}
+
+      {/* Role picker — union of roles across the task's teams. */}
+      {rolePicker
+        ? (() => {
+            const live =
+              tasks.find((t) => t._id === rolePicker.task._id) ?? rolePicker.task;
+            const roleOptions = new Map<
+              string,
+              { id: string; name: string; color?: string }
+            >();
+            for (const tid of live.teamIds) {
+              for (const r of rolesByTeam[tid as string] ?? []) {
+                roleOptions.set(r._id as string, {
+                  id: r._id as string,
+                  name: r.name,
+                  color: r.color,
+                });
+              }
+            }
+            return (
+              <AnchoredMenu
+                anchor={rolePicker.anchor}
+                options={[...roleOptions.values()]}
+                selectedIds={live.roleIds as string[]}
+                onToggle={(id) => handleToggleRole(live, id as Id<"teamRoles">)}
+                onSelect={() => {}}
+                onClose={() => setRolePicker(null)}
+              />
+            );
+          })()
+        : null}
+
+      {/* Full-screen How-To doc editor. */}
+      <EventTasksHowToDocEditor
+        visible={docEditorTask !== null}
+        taskTitle={docEditorTask?.title ?? ""}
+        initialDoc={docEditorTask?.howToDoc ?? ""}
+        onSave={(doc) => {
+          if (docEditorTask) handlePatch(docEditorTask._id, { howToDoc: doc });
+        }}
+        onClose={() => setDocEditorTask(null)}
+      />
+
+      {/* Rename the template. */}
+      <CustomModal
+        visible={renaming}
+        onClose={() => setRenaming(false)}
+        title="Rename template"
+      >
+        <RenameBody
+          key={templateName}
+          initialValue={templateName}
+          colors={colors}
+          primaryColor={primaryColor}
+          onSave={(name) => {
+            setRenaming(false);
+            void renameTemplate({ templateId, name }).catch((e) =>
+              notifyError("Couldn't rename", errMsg(e)),
+            );
+          }}
+        />
+      </CustomModal>
+    </View>
+  );
+}
+
+/**
+ * Loads a team's roles and reports them up. Rendered once per referenced team so
+ * the grid can show role names and the role picker has options.
+ */
+function RoleLoader({
+  teamId,
+  onLoaded,
+}: {
+  teamId: Id<"teams">;
+  onLoaded: (teamId: string, roles: RoleOption[]) => void;
+}) {
+  const roles = useAuthenticatedQuery(
+    api.functions.scheduling.roles.listRoles,
+    { teamId },
+  ) as Array<{ _id: Id<"teamRoles">; name: string; color?: string }> | undefined;
+
+  React.useEffect(() => {
+    if (roles) {
+      onLoaded(
+        teamId as string,
+        roles.map((r) => ({ _id: r._id, name: r.name, color: r.color })),
+      );
+    }
+  }, [roles, teamId, onLoaded]);
+
+  return null;
+}
+
+function RenameBody({
+  initialValue,
+  colors,
+  primaryColor,
+  onSave,
+}: {
+  initialValue: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onSave: (name: string) => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const canSave = value.trim().length > 0;
+  return (
+    <View style={styles.renameBody}>
+      <TextInput
+        value={value}
+        onChangeText={setValue}
+        placeholder="Template name"
+        placeholderTextColor={colors.textTertiary}
+        autoFocus
+        maxLength={50}
+        returnKeyType="done"
+        onSubmitEditing={() => canSave && onSave(value.trim())}
+        accessibilityLabel="Template name"
+        style={[
+          styles.renameInput,
+          { color: colors.text, borderColor: colors.border },
+        ]}
+      />
+      <Pressable
+        onPress={() => canSave && onSave(value.trim())}
+        disabled={!canSave}
+        style={[
+          styles.saveBtn,
+          { backgroundColor: primaryColor, opacity: canSave ? 1 : 0.5 },
+        ]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.saveBtnText}>Save</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBtn: { width: 44, padding: 4, alignItems: "center" },
+  headerTitleWrap: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+  },
+  headerTitle: { fontSize: 17, fontWeight: "600", flexShrink: 1 },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    gap: 12,
+  },
+  gateText: { fontSize: 15, textAlign: "center", lineHeight: 22 },
+  subtitle: { fontSize: 13, lineHeight: 19, marginBottom: 8 },
+  emptyScroll: { padding: 16 },
+  emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
+  emptyAddRow: { flexDirection: "row", gap: 8, marginTop: 16 },
+  emptyAddBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  emptyAddText: { fontSize: 14, fontWeight: "600" },
+  renameBody: { gap: 12, paddingTop: 4 },
+  renameInput: {
+    fontSize: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+  },
+  saveBtn: { borderRadius: 10, paddingVertical: 13, alignItems: "center" },
+  saveBtnText: { fontSize: 15, fontWeight: "700", color: "#fff" },
+});

--- a/apps/mobile/features/scheduling/components/TaskTemplateEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TaskTemplateEditorScreen.tsx
@@ -218,6 +218,15 @@ export function TaskTemplateEditorScreen() {
 
   const handleAdd = useCallback(
     async (segment: Segment) => {
+      // Distinguish "teams still loading" from "genuinely no teams" so a tap
+      // before listTeams resolves doesn't wrongly claim there are none.
+      if (teamsData === undefined) {
+        notifyError(
+          "Just a moment",
+          "Teams are still loading — try again in a second.",
+        );
+        return;
+      }
       const teamId = teams[0]?._id;
       if (!teamId) {
         notifyError(
@@ -239,7 +248,7 @@ export function TaskTemplateEditorScreen() {
         notifyError("Couldn't add task", errMsg(e));
       }
     },
-    [addItem, templateId, teams],
+    [addItem, templateId, teams, teamsData],
   );
 
   const handleDelete = useCallback(

--- a/apps/mobile/features/scheduling/components/TemplatesLibraryScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TemplatesLibraryScreen.tsx
@@ -1,0 +1,650 @@
+/**
+ * TemplatesLibraryScreen
+ *
+ * The per-GROUP (per-location) library of reusable event templates (event
+ * templates Phase 2). Two sections — "Task templates" and "Run-sheet templates"
+ * — each list the group's saved templates with their item count, a "+ New …"
+ * row, and per-row rename / delete. Tapping a template opens its item editor,
+ * which reuses the same grids as the plan-level Event Tasks / Run sheet screens.
+ *
+ * This screen is library CRUD only. Applying a template to a plan (linkage,
+ * propagation, save-to-template, plan-side pickers) lands in later phases.
+ *
+ * Route: /rostering/[group_id]/templates
+ * Backend: scheduling.taskTemplates.* / scheduling.runSheetTemplates.*
+ *
+ * Auth: leaders / community admins only — mirrors EventTasksScreen's gate.
+ */
+import React, { useCallback, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useAuth } from "@providers/AuthProvider";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { CustomModal } from "@components/ui/Modal";
+import { CenteredColumn } from "./CenteredColumn";
+import { RosteringBackHeader } from "./RosteringBackHeader";
+import {
+  createTaskTemplateRef,
+  renameTaskTemplateRef,
+  deleteTaskTemplateRef,
+  listTaskTemplatesRef,
+  createRunSheetTemplateRef,
+  renameRunSheetTemplateRef,
+  deleteRunSheetTemplateRef,
+  listRunSheetTemplatesRef,
+  type TaskTemplateSummary,
+  type RunSheetTemplateSummary,
+} from "../api/eventTemplates";
+
+/** Show a one-button error (Alert.alert is a no-op on web in this codebase). */
+function notifyError(title: string, message: string) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);
+    return;
+  }
+  Alert.alert(title, message);
+}
+
+/** Confirm a destructive action, cross-platform. */
+function confirmDelete(prompt: string, onConfirm: () => void) {
+  if (Platform.OS === "web") {
+    if (typeof window !== "undefined" && window.confirm(prompt)) onConfirm();
+    return;
+  }
+  Alert.alert("Delete template?", prompt, [
+    { text: "Cancel", style: "cancel" },
+    { text: "Delete", style: "destructive", onPress: onConfirm },
+  ]);
+}
+
+const errMsg = (e: unknown) => {
+  const err = e as { data?: { message?: string } | string; message?: string };
+  const data = err?.data;
+  if (typeof data === "string") return data;
+  return data?.message ?? err?.message ?? "Please try again.";
+};
+
+type EditingRow = {
+  kind: "task" | "runsheet";
+  id: string;
+  name: string;
+};
+
+export function TemplatesLibraryScreen() {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { user } = useAuth();
+  const { group_id } = useLocalSearchParams<{ group_id: string }>();
+  const groupId = group_id as Id<"groups">;
+
+  // Leader gate — mirrors EventTasksScreen. Community admins manage templates
+  // even when they aren't a member/leader of this group (backend scheduler
+  // permission), so `getById` may return no `userRole` for them.
+  const groupData = useAuthenticatedQuery(
+    api.functions.groups.queries.getById,
+    group_id ? { groupId } : "skip",
+  ) as { userRole?: string } | null | undefined;
+  const isLeader =
+    groupData?.userRole === "leader" ||
+    groupData?.userRole === "admin" ||
+    user?.is_admin === true;
+
+  const taskTemplates = useAuthenticatedQuery(
+    listTaskTemplatesRef,
+    isLeader && groupId ? { groupId } : "skip",
+  ) as TaskTemplateSummary[] | undefined;
+
+  const runSheetTemplates = useAuthenticatedQuery(
+    listRunSheetTemplatesRef,
+    isLeader && groupId ? { groupId } : "skip",
+  ) as RunSheetTemplateSummary[] | undefined;
+
+  const createTaskTemplate = useAuthenticatedMutation(createTaskTemplateRef);
+  const renameTaskTemplate = useAuthenticatedMutation(renameTaskTemplateRef);
+  const deleteTaskTemplate = useAuthenticatedMutation(deleteTaskTemplateRef);
+  const createRunSheetTemplate = useAuthenticatedMutation(
+    createRunSheetTemplateRef,
+  );
+  const renameRunSheetTemplate = useAuthenticatedMutation(
+    renameRunSheetTemplateRef,
+  );
+  const deleteRunSheetTemplate = useAuthenticatedMutation(
+    deleteRunSheetTemplateRef,
+  );
+
+  // Name modal — used for both "New …" (no `editing`) and rename (with the row).
+  const [nameModal, setNameModal] = useState<
+    | { mode: "create"; kind: "task" | "runsheet" }
+    | { mode: "rename"; row: EditingRow }
+    | null
+  >(null);
+  // Row action sheet (Rename · Delete) for a single template.
+  const [actionRow, setActionRow] = useState<EditingRow | null>(null);
+
+  const openTaskEditor = useCallback(
+    (templateId: string) => {
+      router.push(
+        `/rostering/${groupId}/templates/task/${templateId}` as never,
+      );
+    },
+    [router, groupId],
+  );
+  const openRunSheetEditor = useCallback(
+    (templateId: string) => {
+      router.push(
+        `/rostering/${groupId}/templates/runsheet/${templateId}` as never,
+      );
+    },
+    [router, groupId],
+  );
+
+  const handleSaveName = useCallback(
+    async (name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const modal = nameModal;
+      setNameModal(null);
+      try {
+        if (modal?.mode === "create") {
+          if (modal.kind === "task") {
+            const { templateId } = await createTaskTemplate({
+              groupId,
+              name: trimmed,
+            });
+            openTaskEditor(templateId as string);
+          } else {
+            const { templateId } = await createRunSheetTemplate({
+              groupId,
+              name: trimmed,
+            });
+            openRunSheetEditor(templateId as string);
+          }
+        } else if (modal?.mode === "rename") {
+          if (modal.row.kind === "task") {
+            await renameTaskTemplate({
+              templateId: modal.row.id as Id<"eventTaskTemplates">,
+              name: trimmed,
+            });
+          } else {
+            await renameRunSheetTemplate({
+              templateId: modal.row.id as Id<"runSheetTemplates">,
+              name: trimmed,
+            });
+          }
+        }
+      } catch (e) {
+        notifyError("Couldn't save template", errMsg(e));
+      }
+    },
+    [
+      nameModal,
+      groupId,
+      createTaskTemplate,
+      createRunSheetTemplate,
+      renameTaskTemplate,
+      renameRunSheetTemplate,
+      openTaskEditor,
+      openRunSheetEditor,
+    ],
+  );
+
+  const handleDelete = useCallback(
+    (row: EditingRow) => {
+      setActionRow(null);
+      confirmDelete(`Delete "${row.name}" and all its items?`, () => {
+        const run =
+          row.kind === "task"
+            ? deleteTaskTemplate({
+                templateId: row.id as Id<"eventTaskTemplates">,
+              })
+            : deleteRunSheetTemplate({
+                templateId: row.id as Id<"runSheetTemplates">,
+              });
+        void run.catch((e: unknown) =>
+          notifyError("Couldn't delete template", errMsg(e)),
+        );
+      });
+    },
+    [deleteTaskTemplate, deleteRunSheetTemplate],
+  );
+
+  // --- Gating states ---------------------------------------------------------
+  if (groupData === undefined) {
+    return (
+      <View style={[styles.root, { backgroundColor: colors.surface }]}>
+        <RosteringBackHeader title="Templates" />
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      </View>
+    );
+  }
+  if (!isLeader) {
+    return (
+      <View style={[styles.root, { backgroundColor: colors.surface }]}>
+        <RosteringBackHeader title="Templates" />
+        <View style={styles.centered}>
+          <Ionicons
+            name="people-outline"
+            size={40}
+            color={colors.iconSecondary}
+          />
+          <Text style={[styles.gateText, { color: colors.textSecondary }]}>
+            Only leaders can manage templates.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const loading = taskTemplates === undefined || runSheetTemplates === undefined;
+
+  return (
+    <View style={[styles.root, { backgroundColor: colors.surface }]}>
+      <RosteringBackHeader title="Templates" />
+      {loading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      ) : (
+        <ScrollView
+          style={{ backgroundColor: colors.surface }}
+          contentContainerStyle={[
+            styles.content,
+            { paddingBottom: insets.bottom + 24 },
+          ]}
+        >
+          <CenteredColumn style={styles.column}>
+            <Text style={[styles.intro, { color: colors.textSecondary }]}>
+              Reusable checklists and run sheets for this location. Save one once,
+              then apply it when you plan an event.
+            </Text>
+
+            <Section
+              title="Task templates"
+              icon="checkbox-outline"
+              colors={colors}
+            >
+              {(taskTemplates ?? []).map((t) => (
+                <TemplateRow
+                  key={t._id}
+                  name={t.name}
+                  itemCount={t.itemCount}
+                  itemNoun="task"
+                  colors={colors}
+                  onOpen={() => openTaskEditor(t._id as string)}
+                  onMenu={() =>
+                    setActionRow({
+                      kind: "task",
+                      id: t._id as string,
+                      name: t.name,
+                    })
+                  }
+                />
+              ))}
+              <NewRow
+                label="New task template"
+                colors={colors}
+                primaryColor={primaryColor}
+                onPress={() => setNameModal({ mode: "create", kind: "task" })}
+              />
+            </Section>
+
+            <Section
+              title="Run-sheet templates"
+              icon="list-outline"
+              colors={colors}
+            >
+              {(runSheetTemplates ?? []).map((t) => (
+                <TemplateRow
+                  key={t._id}
+                  name={t.name}
+                  itemCount={t.itemCount}
+                  itemNoun="item"
+                  colors={colors}
+                  onOpen={() => openRunSheetEditor(t._id as string)}
+                  onMenu={() =>
+                    setActionRow({
+                      kind: "runsheet",
+                      id: t._id as string,
+                      name: t.name,
+                    })
+                  }
+                />
+              ))}
+              <NewRow
+                label="New run-sheet template"
+                colors={colors}
+                primaryColor={primaryColor}
+                onPress={() =>
+                  setNameModal({ mode: "create", kind: "runsheet" })
+                }
+              />
+            </Section>
+          </CenteredColumn>
+        </ScrollView>
+      )}
+
+      {/* Name modal — create or rename. */}
+      <NameModal
+        visible={nameModal !== null}
+        title={nameModal?.mode === "rename" ? "Rename template" : "New template"}
+        initialValue={
+          nameModal?.mode === "rename" ? nameModal.row.name : ""
+        }
+        colors={colors}
+        primaryColor={primaryColor}
+        onSave={handleSaveName}
+        onClose={() => setNameModal(null)}
+      />
+
+      {/* Per-row action sheet: Rename · Delete. */}
+      <CustomModal
+        visible={actionRow !== null}
+        onClose={() => setActionRow(null)}
+        title={actionRow?.name}
+      >
+        {actionRow ? (
+          <View>
+            <Pressable
+              onPress={() => {
+                const row = actionRow;
+                setActionRow(null);
+                setNameModal({ mode: "rename", row });
+              }}
+              style={[styles.menuRow, { borderBottomColor: colors.border }]}
+              accessibilityRole="button"
+            >
+              <Ionicons name="pencil-outline" size={20} color={colors.text} />
+              <Text style={[styles.menuLabel, { color: colors.text }]}>
+                Rename
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={() => handleDelete(actionRow)}
+              style={styles.menuRow}
+              accessibilityRole="button"
+            >
+              <Ionicons
+                name="trash-outline"
+                size={20}
+                color={colors.destructive}
+              />
+              <Text style={[styles.menuLabel, { color: colors.destructive }]}>
+                Delete
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+      </CustomModal>
+    </View>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  colors,
+  children,
+}: {
+  title: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  colors: ReturnType<typeof useTheme>["colors"];
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <View style={styles.sectionHeader}>
+        <Ionicons name={icon} size={16} color={colors.textSecondary} />
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+          {title.toUpperCase()}
+        </Text>
+      </View>
+      <View style={styles.sectionBody}>{children}</View>
+    </View>
+  );
+}
+
+function TemplateRow({
+  name,
+  itemCount,
+  itemNoun,
+  colors,
+  onOpen,
+  onMenu,
+}: {
+  name: string;
+  itemCount: number;
+  itemNoun: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  onOpen: () => void;
+  onMenu: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onOpen}
+      onLongPress={onMenu}
+      style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}
+      accessibilityRole="button"
+    >
+      <View style={styles.cardMain}>
+        <Text
+          style={[styles.cardTitle, { color: colors.text }]}
+          numberOfLines={1}
+        >
+          {name}
+        </Text>
+        <Text style={[styles.cardMeta, { color: colors.textSecondary }]}>
+          {itemCount} {itemCount === 1 ? itemNoun : `${itemNoun}s`}
+        </Text>
+      </View>
+      <Pressable
+        onPress={onMenu}
+        hitSlop={10}
+        style={styles.menuBtn}
+        accessibilityRole="button"
+        accessibilityLabel={`Options for ${name}`}
+      >
+        <Ionicons
+          name="ellipsis-horizontal"
+          size={20}
+          color={colors.textSecondary}
+        />
+      </Pressable>
+    </Pressable>
+  );
+}
+
+function NewRow({
+  label,
+  colors,
+  primaryColor,
+  onPress,
+}: {
+  label: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.newRow, { borderColor: primaryColor }]}
+      accessibilityRole="button"
+    >
+      <Ionicons name="add" size={20} color={primaryColor} />
+      <Text style={[styles.newLabel, { color: primaryColor }]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+/**
+ * A small name-entry modal used for both creating and renaming a template.
+ * Remounted per open via `key` so it re-seeds `initialValue`.
+ */
+function NameModal({
+  visible,
+  title,
+  initialValue,
+  colors,
+  primaryColor,
+  onSave,
+  onClose,
+}: {
+  visible: boolean;
+  title: string;
+  initialValue: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onSave: (name: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <CustomModal visible={visible} onClose={onClose} title={title}>
+      <NameModalBody
+        key={`${title}:${initialValue}`}
+        initialValue={initialValue}
+        colors={colors}
+        primaryColor={primaryColor}
+        onSave={onSave}
+      />
+    </CustomModal>
+  );
+}
+
+function NameModalBody({
+  initialValue,
+  colors,
+  primaryColor,
+  onSave,
+}: {
+  initialValue: string;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onSave: (name: string) => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const canSave = value.trim().length > 0;
+  return (
+    <View style={styles.modalBody}>
+      <TextInput
+        value={value}
+        onChangeText={setValue}
+        placeholder="Template name"
+        placeholderTextColor={colors.textTertiary}
+        autoFocus
+        maxLength={50}
+        returnKeyType="done"
+        onSubmitEditing={() => canSave && onSave(value)}
+        accessibilityLabel="Template name"
+        style={[
+          styles.nameInput,
+          { color: colors.text, borderColor: colors.border },
+        ]}
+      />
+      <Pressable
+        onPress={() => canSave && onSave(value)}
+        disabled={!canSave}
+        style={[
+          styles.saveBtn,
+          { backgroundColor: primaryColor, opacity: canSave ? 1 : 0.5 },
+        ]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.saveBtnText}>Save</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    gap: 12,
+  },
+  gateText: { fontSize: 15, textAlign: "center", lineHeight: 22 },
+  content: { padding: 16, gap: 20 },
+  column: { gap: 20 },
+  intro: { fontSize: 14, lineHeight: 20 },
+  section: { gap: 10 },
+  sectionHeader: { flexDirection: "row", alignItems: "center", gap: 6 },
+  sectionTitle: { fontSize: 11, fontWeight: "800", letterSpacing: 0.6 },
+  sectionBody: { gap: 10 },
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingLeft: 14,
+    paddingRight: 6,
+    gap: 8,
+  },
+  cardMain: { flex: 1, gap: 2 },
+  cardTitle: { fontSize: 16, fontWeight: "600" },
+  cardMeta: { fontSize: 13 },
+  menuBtn: {
+    width: 40,
+    height: 40,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  newRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    borderWidth: 1.5,
+    borderStyle: "dashed",
+    borderRadius: 12,
+    paddingVertical: 14,
+  },
+  newLabel: { fontSize: 15, fontWeight: "600" },
+  menuRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  menuLabel: { fontSize: 16, fontWeight: "500" },
+  modalBody: { gap: 12, paddingTop: 4 },
+  nameInput: {
+    fontSize: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+  },
+  saveBtn: {
+    borderRadius: 10,
+    paddingVertical: 13,
+    alignItems: "center",
+  },
+  saveBtnText: { fontSize: 15, fontWeight: "700", color: "#fff" },
+});

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -35,3 +35,4 @@ export { RosteringTeamsScreen } from "./components/RosteringTeamsScreen";
 export { RosteringCrossTeamScreen } from "./components/RosteringCrossTeamScreen";
 export { TemplatesLibraryScreen } from "./components/TemplatesLibraryScreen";
 export { TaskTemplateEditorScreen } from "./components/TaskTemplateEditorScreen";
+export { RunSheetTemplateEditorScreen } from "./components/RunSheetTemplateEditorScreen";

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -34,3 +34,4 @@ export { AssignmentDetailScreen } from "./components/AssignmentDetailScreen";
 export { RosteringTeamsScreen } from "./components/RosteringTeamsScreen";
 export { RosteringCrossTeamScreen } from "./components/RosteringCrossTeamScreen";
 export { TemplatesLibraryScreen } from "./components/TemplatesLibraryScreen";
+export { TaskTemplateEditorScreen } from "./components/TaskTemplateEditorScreen";

--- a/apps/mobile/features/scheduling/index.ts
+++ b/apps/mobile/features/scheduling/index.ts
@@ -33,3 +33,4 @@ export { RosterGridScreen } from "./components/RosterGridScreen";
 export { AssignmentDetailScreen } from "./components/AssignmentDetailScreen";
 export { RosteringTeamsScreen } from "./components/RosteringTeamsScreen";
 export { RosteringCrossTeamScreen } from "./components/RosteringCrossTeamScreen";
+export { TemplatesLibraryScreen } from "./components/TemplatesLibraryScreen";


### PR DESCRIPTION
## Event templates — Phase 2 (frontend)

Builds the **frontend** for the per-location (per-GROUP) event templates
feature on top of the Phase 1 model + CRUD (no backend changes). Leaders can
create/rename/delete **task templates** and **run-sheet templates** and edit
each template's items — reusing the existing Event Tasks grid and run-sheet
editor rather than duplicating them.

### What's included
- **Templates library** (`TemplatesLibraryScreen`, route
  `/rostering/[group_id]/templates`): two sections (Task templates / Run-sheet
  templates), each listing templates with item counts, a "+ New …" row, and
  per-row rename/delete (⋯ / long-press). Leader-gated.
- **Task-template editor** (route `.../templates/task/[template_id]`): renders
  the plan **`EventTasksGrid`** wired to the task-template-item mutations, with
  the same phase/segment + multi-select team/role editing and a tap-to-rename
  header.
- **Run-sheet-template editor** (route `.../templates/runsheet/[template_id]`):
  reuses the run sheet editor's row/cell building blocks + shared
  `GridScrollList`, wired to the run-sheet-template-item mutations
  (add/edit/delete/duplicate/reorder, When/Dur/Owner-Role/Notes/Song). Clock
  times are omitted (templates hold durations only).
- **Entry point**: a "Templates" item in the roster grid's ⋯ overflow (beside
  Cross-team).

### How grids were reused vs extracted
- **Event Tasks grid — reused verbatim.** `EventTasksGrid` never reads `planId`,
  so template items are adapted to its `PlanTask` shape and its callbacks wired
  to the template mutations. The id-brand mismatch (template item vs plan task)
  is bridged with localized casts at the container boundary — **zero change to
  the shared grid**, so plan Event Tasks is untouched.
- **Run sheet editor — extracted shared parts (DRY).** The presentational,
  plan-agnostic row/cell editors (`WhenPill`, `DurationCell`, `NotesEditor`,
  Who/Notes/Song modal bodies, `AddButton`, segment types/`ItemPatch`) moved
  from `RunSheetScreen` into a new `RunSheetItemEditors` module used by **both**
  the plan run sheet and the template editor. `RunSheetScreen` now imports them
  — same props, no behavior change; plan-specific clock times / service ranges
  stay in the screen.

### Regression risk
- Main risk is the `RunSheetScreen` extraction. The move is mechanical and
  `tsc` is clean; the plan run sheet uses the extracted components with
  identical props. **Not runtime-verified** (no simulator) — worth a quick
  manual smoke of the plan run sheet.

### Explicitly deferred to Phase 3/4
Plan↔template linkage, propagation, save-to-template, and plan-side pickers —
this phase is library + item editors only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSwZmWmrY1LisZYjSZYx49