### PR TITLE
fix(events): clarify guest-list leader badge wording

### DIFF
--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -681,7 +681,7 @@ export default defineSchema({
       ),
     ),
     // When true, attendees can RSVP but the count is hidden from non-leaders.
-    // Leaders/host still see the count with a "Leaders only" badge.
+    // Leaders/host still see the count with a "Visible to leaders only" badge.
     hideRsvpCount: v.optional(v.boolean()),
 
     // Visibility

--- a/apps/mobile/features/events/components/EventCard.tsx
+++ b/apps/mobile/features/events/components/EventCard.tsx
@@ -176,7 +176,7 @@ export function EventCard({ event, onPress }: EventCardProps) {
             )}
             {event.hideRsvpCount && event.viewerIsLeader && (
               <View style={styles.leaderBadge}>
-                <Text style={styles.leaderBadgeText}>Leaders only</Text>
+                <Text style={styles.leaderBadgeText}>Visible to leaders only</Text>
               </View>
             )}
           </View>

--- a/apps/mobile/features/events/components/EventGuestList.tsx
+++ b/apps/mobile/features/events/components/EventGuestList.tsx
@@ -42,7 +42,7 @@ interface GuestListPreviewProps {
   onViewAll: () => void;
   /** When true, the RSVP count is considered private. */
   hideRsvpCount?: boolean;
-  /** When true, the viewer is a leader/host and sees the count + "Leaders only" badge. */
+  /** When true, the viewer is a leader/host and sees the count + "Visible to leaders only" badge. */
   canSeeCount?: boolean;
 }
 
@@ -128,7 +128,7 @@ export function GuestListPreview({
             <Text style={[styles.title, { color: colors.text }]}>Guest List</Text>
             {hideRsvpCount && canSeeCount && (
               <View style={[styles.leaderBadge, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
-                <Text style={[styles.leaderBadgeText, { color: colors.textSecondary }]}>Leaders only</Text>
+                <Text style={[styles.leaderBadgeText, { color: colors.textSecondary }]}>Visible to leaders only</Text>
               </View>
             )}
           </View>

--- a/apps/mobile/features/events/hooks/useCommunityEvents.ts
+++ b/apps/mobile/features/events/hooks/useCommunityEvents.ts
@@ -54,7 +54,7 @@ export interface CommunityEvent {
       profileImage: string | null;
     }>;
   };
-  /** When true, RSVP count is hidden from non-leaders. Leaders still see it with a "Leaders only" badge. */
+  /** When true, RSVP count is hidden from non-leaders. Leaders still see it with a "Visible to leaders only" badge. */
   hideRsvpCount: boolean;
   createdById: string | null;
   /** True when the viewer is a leader of the hosting group or the event creator. */

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -161,7 +161,7 @@ export function CreateEventScreen() {
   const [rsvpOptions, setRsvpOptions] =
     useState<RsvpOption[]>(DEFAULT_RSVP_OPTIONS);
   // When true, RSVP count/list is hidden from non-leaders on the event page
-  // and in chat cards. Leaders still see the count with a "Leaders only" badge.
+  // and in chat cards. Leaders still see the count with a "Visible to leaders only" badge.
   const [hideRsvpCount, setHideRsvpCount] = useState(false);
   // Hosts own the event for notifications / chat admin. Defaults to the
   // current user on create (can be edited); in edit mode we read it from


### PR DESCRIPTION
## Summary

Users were confused by the **"Leaders only"** badge shown next to the **Guest List** header. As reported, it reads as though the guest list is restricted to leaders, when it actually means the list/count is *hidden from general attendees but still visible to leaders*.

This reworks the badge text to **"Visible to leaders only"**, which states the meaning directly.

## Changes

- `EventGuestList.tsx` — badge next to the **Guest List** preview header (the exact spot in the report).
- `EventCard.tsx` — the same badge on the event card's RSVP avatar stack, updated for consistency (identical concept and wording).
- Updated the code comments in `useCommunityEvents.ts`, `CreateEventScreen.tsx`, and `schema.ts` that quote the badge label so they stay accurate.

## Context

Reported via the dev-assistant bug flow. Screenshot: an attendee asked *"Do you know why it says 'leaders only' next to Guest List?"* — this is a wording-only clarity fix, no behavior change.

## Testing

Text-only change to JSX string literals and comments; no logic touched. CI typecheck/lint covers the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZtqTr9DJgp1wvUoM1x3Zu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZtqTr9DJgp1wvUoM1x3Zu)_