### PR TITLE
feat(scheduling): compact section-grouped Run sheet + Tasks with segmented tab

### DIFF
--- a/apps/mobile/components/ui/SegmentedTabs.tsx
+++ b/apps/mobile/components/ui/SegmentedTabs.tsx
@@ -1,0 +1,119 @@
+/**
+ * SegmentedTabs
+ *
+ * A small, reusable segmented control / tab switcher for swapping between
+ * 2–4 options (e.g. "Run sheet" / "Tasks"). Pill-shaped track with an
+ * elevated "thumb" behind the active option.
+ *
+ * Layout pattern: each option's Pressable wraps a static-styled inner View —
+ * RN-Web silently drops layout styles on a Pressable's function-style `style`
+ * prop, so all padding/flex lives on the inner View's StyleSheet style.
+ * See features/scheduling/components/TeamChannelToggle.tsx for the same idiom.
+ */
+import React from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+import { useTheme } from "@hooks/useTheme";
+
+export type SegmentedTabOption<T extends string = string> = {
+  key: T;
+  label: string;
+};
+
+export interface SegmentedTabsProps<T extends string = string> {
+  options: SegmentedTabOption<T>[];
+  value: T;
+  onChange: (key: T) => void;
+  style?: StyleProp<ViewStyle>;
+  accessibilityLabel?: string;
+}
+
+export function SegmentedTabs<T extends string>({
+  options,
+  value,
+  onChange,
+  style,
+  accessibilityLabel,
+}: SegmentedTabsProps<T>) {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.track,
+        { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+        style,
+      ]}
+      accessibilityRole="tablist"
+      accessibilityLabel={accessibilityLabel}
+    >
+      {options.map((option) => {
+        const selected = option.key === value;
+        return (
+          <Pressable
+            key={option.key}
+            onPress={() => onChange(option.key)}
+            accessibilityRole="tab"
+            accessibilityState={{ selected }}
+            accessibilityLabel={option.label}
+          >
+            {/* Inner View holds all layout — see file header re: RN-Web. */}
+            <View
+              style={[
+                styles.option,
+                selected && [styles.optionActive, { backgroundColor: colors.surface }],
+              ]}
+            >
+              <Text
+                style={[
+                  styles.label,
+                  {
+                    color: selected ? colors.text : colors.textSecondary,
+                    fontWeight: selected ? "700" : "600",
+                  },
+                ]}
+                numberOfLines={1}
+              >
+                {option.label}
+              </Text>
+            </View>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  track: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    padding: 3,
+    borderRadius: 11,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  option: {
+    paddingHorizontal: 15,
+    paddingVertical: 7,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  optionActive: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.12,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  label: {
+    fontSize: 13,
+  },
+});

--- a/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
@@ -24,7 +24,12 @@ import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import type { Id } from "@services/api/convex";
 import { InlineText } from "./InlineText";
-import { GridScrollList, OptionTag, type GridColumn } from "./GridScrollList";
+import {
+  GridScrollList,
+  OptionTag,
+  type GridColumn,
+  type GridSection,
+} from "./GridScrollList";
 import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
 import {
   EventTasksHowToCell,
@@ -101,6 +106,23 @@ export type TaskPatch = {
   segment?: Segment;
 } & HowToPatch;
 
+/**
+ * Chrome for one Pre/During/Post section when the grid is rendered grouped. The
+ * grid supplies the sorted rows itself (from its team→role sort of `tasks`),
+ * keyed by `segment`; the screen owns the title/meta/collapse/footer.
+ */
+export type TaskSection = {
+  /** Globally-unique section key (the segment works). */
+  key: string;
+  /** Which segment's (sorted) rows this section shows. */
+  segment: Segment;
+  title: string;
+  meta?: string;
+  collapsed?: boolean;
+  onToggle?: () => void;
+  footer?: React.ReactNode;
+};
+
 export function EventTasksGrid({
   tasks,
   teams,
@@ -115,6 +137,7 @@ export function EventTasksGrid({
   onOpenDoc,
   listHeader,
   listFooter,
+  sections,
 }: {
   tasks: PlanTask[];
   teams: TeamOption[];
@@ -134,6 +157,12 @@ export function EventTasksGrid({
   onOpenDoc: (task: PlanTask) => void;
   listHeader?: React.ReactElement | null;
   listFooter?: React.ReactElement | null;
+  /**
+   * OPTIONAL Pre/During/Post grouping. When provided, the grid renders its rows
+   * under collapsible section headers (each with a per-section Add footer) using
+   * its own team→role sort per segment, instead of one flat table.
+   */
+  sections?: TaskSection[];
 }) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
@@ -331,22 +360,40 @@ export function EventTasksGrid({
     }
   };
 
-  // Add-task bar below the table. Sections are gone, so a new task starts in Pre
-  // and the leader reassigns its phase via the Phase column.
+  // Pair each section's chrome (from the screen) with the grid's own sorted rows
+  // for that segment. `data`/`renderCell`/`columns` are shared with the flat path.
+  const gridSections = useMemo<GridSection<PlanTask>[] | undefined>(() => {
+    if (!sections) return undefined;
+    return sections.map((s) => ({
+      key: s.key,
+      title: s.title,
+      meta: s.meta,
+      collapsed: s.collapsed,
+      onToggle: s.onToggle,
+      rows: tasksBySegment[s.segment] ?? [],
+      footer: s.footer,
+    }));
+  }, [sections, tasksBySegment]);
+
+  // Add-task bar below the table. In flat mode a new task starts in Pre (the
+  // leader reassigns its phase via the Phase column); in sectioned mode each
+  // section owns its own Add footer, so we render only the bottom padding here.
   const footer = (
     <View style={{ paddingBottom: insets.bottom + 8 }}>
-      <Pressable
-        onPress={() => onAdd("before")}
-        style={[
-          styles.addTaskBar,
-          { borderColor: primaryColor, backgroundColor: primaryColor + "0D" },
-        ]}
-        accessibilityRole="button"
-        accessibilityLabel="Add a task"
-      >
-        <Ionicons name="add" size={18} color={primaryColor} />
-        <Text style={[styles.addTaskText, { color: primaryColor }]}>Add task</Text>
-      </Pressable>
+      {sections ? null : (
+        <Pressable
+          onPress={() => onAdd("before")}
+          style={[
+            styles.addTaskBar,
+            { borderColor: primaryColor, backgroundColor: primaryColor + "0D" },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Add a task"
+        >
+          <Ionicons name="add" size={18} color={primaryColor} />
+          <Text style={[styles.addTaskText, { color: primaryColor }]}>Add task</Text>
+        </Pressable>
+      )}
       {listFooter}
     </View>
   );
@@ -360,6 +407,7 @@ export function EventTasksGrid({
     <>
       <GridScrollList
         data={flatTasks}
+        sections={gridSections}
         keyExtractor={(t) => t._id as string}
         onReorder={handleReorder}
         columns={columns}
@@ -457,9 +505,15 @@ function ChipCell({
   const addRef = React.useRef<View>(null);
   // Empty + a placeholder label => the team-level dashed chip (role column).
   const showPlaceholder = chips.length === 0 && !!emptyPlaceholder;
+  // Keep the cell to a single line: show the first chip (truncated) and, when
+  // there are more, a compact "+N" count rather than letting many chips wrap and
+  // blow out the row's width/height. Removal of the hidden chips still happens
+  // through the multi-select picker the "+" opens.
+  const visibleChips = chips.slice(0, 1);
+  const overflowCount = chips.length - visibleChips.length;
   return (
     <View style={styles.chipWrap}>
-      {chips.map((chip) => (
+      {visibleChips.map((chip) => (
         <View
           key={chip.id}
           style={[
@@ -489,6 +543,21 @@ function ChipCell({
           ) : null}
         </View>
       ))}
+      {overflowCount > 0 ? (
+        // Compact "+N" count for the remaining chips. The adjacent "+" opens the
+        // multi-select picker (which lists every team/role), so the hidden ones
+        // stay reachable without letting the cell wrap onto a second line.
+        <View
+          style={[
+            styles.chipCount,
+            { borderColor: colors.border, backgroundColor: colors.surfaceSecondary },
+          ]}
+        >
+          <Text style={[styles.chipCountText, { color: colors.textSecondary }]}>
+            +{overflowCount}
+          </Text>
+        </View>
+      ) : null}
       {showPlaceholder ? (
         // Team-level: a single dashed placeholder chip that opens the role picker.
         <Pressable
@@ -607,8 +676,18 @@ const styles = StyleSheet.create({
     borderStyle: "dashed",
   },
   addTaskText: { fontSize: 15, fontWeight: "600" },
-  // Multi-chip team/role cells.
-  chipWrap: { flexDirection: "row", flexWrap: "wrap", alignItems: "center", gap: 4 },
+  // Multi-chip team/role cells. Constrained to the cell width and clipped so a
+  // long chip (or several) never bleeds into the neighbouring How-To column; the
+  // single visible chip truncates while the "+N"/add controls hold their size.
+  chipWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    width: "100%",
+    maxWidth: "100%",
+    minWidth: 0,
+    overflow: "hidden",
+  },
   chip: {
     flexDirection: "row",
     alignItems: "center",
@@ -619,9 +698,20 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     borderWidth: StyleSheet.hairlineWidth,
     maxWidth: "100%",
+    minWidth: 0,
+    flexShrink: 1,
   },
-  chipDot: { width: 8, height: 8, borderRadius: 4 },
-  chipText: { fontSize: 13, fontWeight: "600", flexShrink: 1 },
+  chipDot: { width: 8, height: 8, borderRadius: 4, flexShrink: 0 },
+  chipText: { fontSize: 13, fontWeight: "600", flexShrink: 1, minWidth: 0 },
+  // "+N" overflow count — never shrinks, so it stays legible next to the chip.
+  chipCount: {
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexShrink: 0,
+  },
+  chipCountText: { fontSize: 12, fontWeight: "700" },
   chipAdd: {
     flexDirection: "row",
     alignItems: "center",
@@ -631,8 +721,10 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     borderWidth: StyleSheet.hairlineWidth,
     borderStyle: "dashed",
+    flexShrink: 0,
+    maxWidth: "100%",
   },
-  chipAddText: { fontSize: 12, fontWeight: "600" },
+  chipAddText: { fontSize: 12, fontWeight: "600", flexShrink: 1, minWidth: 0 },
   // Compact icon-only add: a small muted circle that hugs the chip on one line.
   // Visually ~24px; hitSlop widens the touch target to a comfortable size.
   chipAddCompact: {
@@ -642,6 +734,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     borderWidth: StyleSheet.hairlineWidth,
+    flexShrink: 0,
   },
   optionScroll: { maxHeight: 360 },
   optionRow: {

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -39,6 +39,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { SegmentedTabs } from "@components/ui/SegmentedTabs";
 import { useAuth } from "@providers/AuthProvider";
 import {
   useAuthenticatedQuery,
@@ -52,6 +53,7 @@ import {
   type PlanTask,
   type Segment,
   type TaskPatch,
+  type TaskSection,
   type TeamOption,
   type RoleOption,
 } from "./EventTasksGrid";
@@ -313,6 +315,14 @@ export function EventTasksScreen() {
   const [teamFilter, setTeamFilter] = useState<Id<"teams"> | null>(null);
   const [roleFilter, setRoleFilter] = useState<Id<"teamRoles"> | null>(null);
 
+  // Per-phase section collapse state (default: all expanded). Owned here; the
+  // grid's section headers flip these via `onToggle`.
+  const [collapsed, setCollapsed] = useState<Record<Segment, boolean>>({
+    before: false,
+    during: false,
+    after: false,
+  });
+
   // Changing the team filter resets the role filter — a role belongs to one team.
   const handleSetTeamFilter = useCallback((id: Id<"teams"> | null) => {
     setTeamFilter(id);
@@ -443,6 +453,49 @@ export function EventTasksScreen() {
     [reorderTasks, planId, phaseFilter, teamFilter, roleFilter],
   );
 
+  // Group the visible tasks into Pre / During / Post sections for the grid. A
+  // phase filter narrows to that one section; otherwise all three show. The grid
+  // supplies each section's sorted rows itself (keyed by `segment`), so we only
+  // own the chrome: title, readiness meta, collapse, and a per-section Add.
+  const taskSections = useMemo<TaskSection[]>(() => {
+    const defs: Array<{ segment: Segment; title: string }> = [
+      { segment: "before", title: "PRE" },
+      { segment: "during", title: "DURING" },
+      { segment: "after", title: "POST" },
+    ];
+    return defs
+      .filter((d) => !phaseFilter || d.segment === phaseFilter)
+      .map((d) => {
+        const seg = readiness?.bySegment[d.segment];
+        const count = filteredTasks.filter((t) => t.segment === d.segment).length;
+        return {
+          key: d.segment,
+          segment: d.segment,
+          title: d.title,
+          meta: seg ? `${seg.done}/${seg.total} ready` : `${count} tasks`,
+          collapsed: collapsed[d.segment],
+          onToggle: () =>
+            setCollapsed((c) => ({ ...c, [d.segment]: !c[d.segment] })),
+          footer: (
+            <TouchableOpacity
+              onPress={() => void handleAdd(d.segment)}
+              style={[
+                styles.sectionAdd,
+                { borderColor: primaryColor, backgroundColor: primaryColor + "0D" },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Add a ${d.title.toLowerCase()} task`}
+            >
+              <Ionicons name="add" size={16} color={primaryColor} />
+              <Text style={[styles.sectionAddText, { color: primaryColor }]}>
+                Add task
+              </Text>
+            </TouchableOpacity>
+          ),
+        };
+      });
+  }, [phaseFilter, readiness, filteredTasks, collapsed, handleAdd, primaryColor]);
+
   // Teams and roles are now multi-select edits via `updateTask` (a task can
   // belong to several teams/roles). Toggling a team on/off keeps at least one
   // team; toggling a role on/off freely (empty roles => a team-level task).
@@ -527,6 +580,19 @@ export function EventTasksScreen() {
 
   const listHeader = (
     <View>
+      <SegmentedTabs
+        options={[
+          { key: "run", label: "Run sheet" },
+          { key: "tasks", label: "Tasks" },
+        ]}
+        value="tasks"
+        onChange={(k) => {
+          if (k === "run")
+            router.push(`/rostering/${group_id}/run-sheet/${planId}`);
+        }}
+        style={styles.viewTabs}
+        accessibilityLabel="Switch between run sheet and tasks"
+      />
       <Text style={[styles.planTitle, { color: colors.text }]}>
         {event?.title ?? "Event plan"}
       </Text>
@@ -623,6 +689,7 @@ export function EventTasksScreen() {
           onPickRole={(task, anchor) => setRolePicker({ task, anchor })}
           onOpenDoc={setDocEditorTask}
           listHeader={listHeader}
+          sections={taskSections}
         />
       )}
 
@@ -1041,8 +1108,23 @@ const styles = StyleSheet.create({
   headerTitle: { flex: 1, fontSize: 17, fontWeight: "600", textAlign: "center" },
   centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24, gap: 12 },
   gateText: { fontSize: 15, textAlign: "center", lineHeight: 22 },
+  viewTabs: { alignSelf: "flex-start", marginBottom: 12 },
   planTitle: { fontSize: 22, fontWeight: "700" },
   planDate: { fontSize: 13, marginTop: 4 },
+  // Per-section "+ Add task" footer button (dashed, community accent).
+  sectionAdd: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    alignSelf: "flex-start",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginVertical: 6,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: "dashed",
+  },
+  sectionAddText: { fontSize: 14, fontWeight: "600" },
   readiness: {
     marginTop: 16,
     width: "100%",

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -297,16 +297,20 @@ export function GridScrollList<T>({
         ? `${FOOTER_KEY_PREFIX}${it.section.key}`
         : keyExtractor(it.item);
 
-  // Rebuild the COMPLETE row order before handing it to the caller.
+  // Turn the drag list's post-drop order into a COMPLETE, section-safe order.
   //
-  // Only expanded sections contribute rows to the drag list, so `orderedKeys`
-  // omits collapsed sections' rows. Forwarding that partial list would make the
-  // run-sheet reorder mutation reject a stale order and would let Event Tasks
-  // rewrite sort orders for only the visible rows. To stay complete (and match
-  // flat mode), we re-emit every row: expanded sections in their new relative
-  // order, collapsed sections in their original order, spliced back at their
-  // section position. Grouping by owning section also makes an accidental
-  // cross-section drag a no-op (the row stays in its own segment).
+  // Two hazards to handle, both because all sections share one drag list:
+  //  1. Collapsed sections contribute no rows, so `orderedKeys` omits them —
+  //     forwarding that partial list would make the run-sheet mutation reject a
+  //     stale order and let Event Tasks rewrite sort orders for only visible rows.
+  //  2. A row can be dropped across a section boundary. We don't support segment
+  //     changes via drag (that's the row's ⋯ menu), so such a drop must be a
+  //     full no-op — not a silent within-section reshuffle of the landing section.
+  //
+  // A within-section reorder never moves a row out of its section's contiguous
+  // block, so the sequence of section indices stays non-decreasing. Any
+  // inversion means the row crossed a boundary → snap back by not persisting.
+  // Otherwise re-emit every row (collapsed sections keep their original rows).
   const handleSectionReorder = (orderedKeys: string[]) => {
     if (!sections) return onReorder(orderedKeys);
     const visibleOrder = orderedKeys.filter(
@@ -317,25 +321,30 @@ export function GridScrollList<T>({
     sections.forEach((section, i) =>
       section.rows.forEach((row) => sectionOf.set(keyExtractor(row), i)),
     );
-    const reorderedBySection = new Map<number, string[]>();
-    for (const key of visibleOrder) {
-      const i = sectionOf.get(key);
-      if (i === undefined) continue;
-      const list = reorderedBySection.get(i);
-      if (list) list.push(key);
-      else reorderedBySection.set(i, [key]);
+    const seq = visibleOrder
+      .map((k) => sectionOf.get(k))
+      .filter((i): i is number => i !== undefined);
+    if (seq.length !== visibleOrder.length) return; // unknown key → no-op
+    for (let i = 1; i < seq.length; i++) {
+      if (seq[i] < seq[i - 1]) return; // cross-section drop → no-op
     }
+    const expandedCount = sections.reduce(
+      (n, s) => n + (s.collapsed ? 0 : s.rows.length),
+      0,
+    );
+    if (visibleOrder.length !== expandedCount) return; // defensive → no-op
+    // `visibleOrder` is now guaranteed grouped by section in ascending order,
+    // so walk it straight through, splicing collapsed rows back at their spot.
     const fullOrder: string[] = [];
-    sections.forEach((section, i) => {
-      const reordered = reorderedBySection.get(i);
-      // Expanded section with every row accounted for → use the new order;
-      // otherwise (collapsed, or a defensive count mismatch) keep original.
-      if (!section.collapsed && reordered?.length === section.rows.length) {
-        fullOrder.push(...reordered);
+    let vi = 0;
+    for (const section of sections) {
+      if (section.collapsed) {
+        for (const row of section.rows) fullOrder.push(keyExtractor(row));
       } else {
-        section.rows.forEach((row) => fullOrder.push(keyExtractor(row)));
+        for (let n = 0; n < section.rows.length; n++)
+          fullOrder.push(visibleOrder[vi++]);
       }
-    });
+    }
     onReorder(fullOrder);
   };
 

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -297,14 +297,47 @@ export function GridScrollList<T>({
         ? `${FOOTER_KEY_PREFIX}${it.section.key}`
         : keyExtractor(it.item);
 
-  // Strip the synthetic header/footer keys so the caller only sees row keys.
-  const handleSectionReorder = (orderedKeys: string[]) =>
-    onReorder(
-      orderedKeys.filter(
-        (k) =>
-          !k.startsWith(SECTION_KEY_PREFIX) && !k.startsWith(FOOTER_KEY_PREFIX),
-      ),
+  // Rebuild the COMPLETE row order before handing it to the caller.
+  //
+  // Only expanded sections contribute rows to the drag list, so `orderedKeys`
+  // omits collapsed sections' rows. Forwarding that partial list would make the
+  // run-sheet reorder mutation reject a stale order and would let Event Tasks
+  // rewrite sort orders for only the visible rows. To stay complete (and match
+  // flat mode), we re-emit every row: expanded sections in their new relative
+  // order, collapsed sections in their original order, spliced back at their
+  // section position. Grouping by owning section also makes an accidental
+  // cross-section drag a no-op (the row stays in its own segment).
+  const handleSectionReorder = (orderedKeys: string[]) => {
+    if (!sections) return onReorder(orderedKeys);
+    const visibleOrder = orderedKeys.filter(
+      (k) =>
+        !k.startsWith(SECTION_KEY_PREFIX) && !k.startsWith(FOOTER_KEY_PREFIX),
     );
+    const sectionOf = new Map<string, number>();
+    sections.forEach((section, i) =>
+      section.rows.forEach((row) => sectionOf.set(keyExtractor(row), i)),
+    );
+    const reorderedBySection = new Map<number, string[]>();
+    for (const key of visibleOrder) {
+      const i = sectionOf.get(key);
+      if (i === undefined) continue;
+      const list = reorderedBySection.get(i);
+      if (list) list.push(key);
+      else reorderedBySection.set(i, [key]);
+    }
+    const fullOrder: string[] = [];
+    sections.forEach((section, i) => {
+      const reordered = reorderedBySection.get(i);
+      // Expanded section with every row accounted for → use the new order;
+      // otherwise (collapsed, or a defensive count mismatch) keep original.
+      if (!section.collapsed && reordered?.length === section.rows.length) {
+        fullOrder.push(...reordered);
+      } else {
+        section.rows.forEach((row) => fullOrder.push(keyExtractor(row)));
+      }
+    });
+    onReorder(fullOrder);
+  };
 
   const renderSectionHeader = (section: GridSection<T>) => (
     <Pressable

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -26,6 +26,8 @@ import {
   Text,
   ScrollView,
   StyleSheet,
+  Pressable,
+  Platform,
   type LayoutChangeEvent,
   type StyleProp,
   type ViewStyle,
@@ -49,6 +51,32 @@ export type GridColumn = {
   align?: "left" | "center";
 };
 
+/**
+ * An optional collapsible group of rows. When the `sections` prop is supplied,
+ * `GridScrollList` renders each section as a full-width header row (chevron +
+ * uppercase title + right-aligned muted `meta`), followed by its `rows` (via the
+ * SAME row renderer as the flat API — drag grip, columns, cells, dense sizing
+ * all identical) and an optional full-width `footer` (typically a "+ Add" button).
+ *
+ * `GridRow` is the caller's own row item type (the generic `T`); a section's
+ * `rows` are exactly the same items the flat `data`/`rows` prop accepts.
+ */
+export type GridSection<T> = {
+  key: string;
+  /** Uppercased, letter-spaced group label, e.g. "BEFORE EVENT" / "PRE". */
+  title: string;
+  /** Right-aligned muted text, e.g. "11 items · 7:30–9:59a" or "0/23 ready". */
+  meta?: string;
+  /** Collapse state is owned by the caller; flip it inside `onToggle`. */
+  collapsed?: boolean;
+  /** Called when the header is tapped so the caller can flip `collapsed`. */
+  onToggle?: () => void;
+  /** The section's row items — same type the flat `data`/`rows` prop accepts. */
+  rows: T[];
+  /** Full-width node rendered below the rows (e.g. a per-section Add button). */
+  footer?: React.ReactNode;
+};
+
 /** Left gutter that holds the drag grip (header has a matching spacer). */
 const GRIP_W = 34;
 // Roomier events-os spacing: a comfortable row that lets 1–2 line cells breathe,
@@ -59,6 +87,11 @@ const ROW_MIN_HEIGHT = 46;
 // this when a cell wraps, so wrapped content is never clipped.
 const DENSE_ROW_MIN_HEIGHT = 38;
 const HEADER_MIN_HEIGHT = 38;
+/** Full-width collapsible section header row (only used when `sections` is set). */
+const SECTION_MIN_HEIGHT = 32;
+/** Key prefixes for the synthetic header/footer rows woven into the drag list. */
+const SECTION_KEY_PREFIX = "__gridSectionHeader__:";
+const FOOTER_KEY_PREFIX = "__gridSectionFooter__:";
 
 interface Props<T> {
   data: T[];
@@ -83,6 +116,18 @@ interface Props<T> {
    * so this never clips multi-line content — it only lowers the floor.
    */
   dense?: boolean;
+  /**
+   * OPTIONAL section grouping. When provided, rows are rendered grouped under
+   * collapsible section headers (each with an optional footer), instead of the
+   * flat `data` list. `data`/`keyExtractor`/`columns`/`renderCell` are still
+   * required — the section rows reuse `keyExtractor`, `columns` and `renderCell`
+   * exactly as the flat path does. When omitted, rendering is unchanged.
+   *
+   * Reordering stays within the drag list; `onReorder` is called with the
+   * reordered row keys (synthetic header/footer keys stripped). Cross-section
+   * drag is not specially handled.
+   */
+  sections?: GridSection<T>[];
 }
 
 export function GridScrollList<T>({
@@ -95,6 +140,7 @@ export function GridScrollList<T>({
   ListFooterComponent,
   contentContainerStyle,
   dense = false,
+  sections,
 }: Props<T>) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
@@ -174,6 +220,137 @@ export function GridScrollList<T>({
     ? { height: size.h }
     : { flexGrow: 1 };
 
+  // The shared data-row renderer — identical for the flat list and for the rows
+  // inside a section, so drag grip, columns, cells and dense sizing stay the same.
+  const renderDataRow = ({
+    item,
+    Handle,
+    isActive,
+  }: {
+    item: T;
+    Handle: React.ComponentType<{ children: React.ReactNode }>;
+    isActive: boolean;
+  }) => (
+    <View
+      style={[
+        styles.row,
+        {
+          minHeight: rowMinHeight,
+          borderBottomColor: colors.border,
+          backgroundColor: isActive ? colors.surfaceSecondary : colors.surface,
+        },
+      ]}
+    >
+      <Handle>
+        <View
+          style={styles.gripCell}
+          accessibilityLabel="Drag to reorder"
+          hitSlop={8}
+        >
+          <Ionicons name="reorder-three" size={18} color={colors.textTertiary} />
+        </View>
+      </Handle>
+      {columns.map((col, i) => (
+        <View key={col.key} style={cellFrame(i)}>
+          {renderCell(item, col.key, { isActive })}
+        </View>
+      ))}
+    </View>
+  );
+
+  // ── Section rendering (only when `sections` is provided) ────────────────────
+  // The header/footer are woven into a SINGLE drag list as synthetic rows so
+  // there is exactly one vertical scroll container (same as the flat path). On
+  // web the header/footer content is pinned to the visible left edge via
+  // position:sticky so the title/Add button stay visible while scrolling
+  // horizontally; on native it scrolls with the content (acceptable fallback —
+  // this component has no frozen column region to pin to).
+  const stickyLeft: ViewStyle =
+    Platform.OS === "web"
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ({ position: "sticky", left: 0 } as any)
+      : {};
+  const pinnedWidth = size.w || innerWidth;
+
+  type SectionItem =
+    | { _kind: "header"; section: GridSection<T> }
+    | { _kind: "footer"; section: GridSection<T> }
+    | { _kind: "row"; item: T };
+
+  const sectionItems: SectionItem[] = [];
+  if (sections) {
+    for (const section of sections) {
+      sectionItems.push({ _kind: "header", section });
+      if (!section.collapsed) {
+        for (const row of section.rows)
+          sectionItems.push({ _kind: "row", item: row });
+        if (section.footer != null)
+          sectionItems.push({ _kind: "footer", section });
+      }
+    }
+  }
+
+  const sectionKeyExtractor = (it: SectionItem) =>
+    it._kind === "header"
+      ? `${SECTION_KEY_PREFIX}${it.section.key}`
+      : it._kind === "footer"
+        ? `${FOOTER_KEY_PREFIX}${it.section.key}`
+        : keyExtractor(it.item);
+
+  // Strip the synthetic header/footer keys so the caller only sees row keys.
+  const handleSectionReorder = (orderedKeys: string[]) =>
+    onReorder(
+      orderedKeys.filter(
+        (k) =>
+          !k.startsWith(SECTION_KEY_PREFIX) && !k.startsWith(FOOTER_KEY_PREFIX),
+      ),
+    );
+
+  const renderSectionHeader = (section: GridSection<T>) => (
+    <Pressable
+      onPress={section.onToggle}
+      style={[
+        styles.sectionHeader,
+        {
+          backgroundColor: colors.surfaceSecondary,
+          borderBottomColor: colors.border,
+        },
+      ]}
+    >
+      <View
+        style={[styles.sectionHeaderInner, { width: pinnedWidth }, stickyLeft]}
+      >
+        <Ionicons
+          name={section.collapsed ? "chevron-forward" : "chevron-down"}
+          size={14}
+          color={colors.textSecondary}
+        />
+        <Text
+          style={[styles.sectionTitle, { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
+          {section.title}
+        </Text>
+        {section.meta ? (
+          <Text
+            style={[styles.sectionMeta, { color: colors.textTertiary }]}
+            numberOfLines={1}
+          >
+            {section.meta}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+
+  const renderSectionFooter = (section: GridSection<T>) => (
+    <View style={styles.sectionFooter}>
+      <View style={[styles.sectionFooterInner, { width: pinnedWidth }, stickyLeft]}>
+        {section.footer}
+      </View>
+    </View>
+  );
+
   return (
     <View style={styles.root}>
       {ListHeaderComponent}
@@ -192,45 +369,31 @@ export function GridScrollList<T>({
           <View style={[{ width: innerWidth }, innerHeightStyle]}>
             {headerRow}
             <View style={styles.listWrap}>
-              <RunSheetDragList
-                data={data}
-                keyExtractor={keyExtractor}
-                onReorder={onReorder}
-                contentContainerStyle={contentContainerStyle}
-                renderRow={({ item, Handle, isActive }) => (
-                  <View
-                    style={[
-                      styles.row,
-                      {
-                        minHeight: rowMinHeight,
-                        borderBottomColor: colors.border,
-                        backgroundColor: isActive
-                          ? colors.surfaceSecondary
-                          : colors.surface,
-                      },
-                    ]}
-                  >
-                    <Handle>
-                      <View
-                        style={styles.gripCell}
-                        accessibilityLabel="Drag to reorder"
-                        hitSlop={8}
-                      >
-                        <Ionicons
-                          name="reorder-three"
-                          size={18}
-                          color={colors.textTertiary}
-                        />
-                      </View>
-                    </Handle>
-                    {columns.map((col, i) => (
-                      <View key={col.key} style={cellFrame(i)}>
-                        {renderCell(item, col.key, { isActive })}
-                      </View>
-                    ))}
-                  </View>
-                )}
-              />
+              {sections ? (
+                <RunSheetDragList<SectionItem>
+                  data={sectionItems}
+                  keyExtractor={sectionKeyExtractor}
+                  onReorder={handleSectionReorder}
+                  contentContainerStyle={contentContainerStyle}
+                  renderRow={({ item: it, Handle, isActive }) =>
+                    it._kind === "header"
+                      ? renderSectionHeader(it.section)
+                      : it._kind === "footer"
+                        ? renderSectionFooter(it.section)
+                        : renderDataRow({ item: it.item, Handle, isActive })
+                  }
+                />
+              ) : (
+                <RunSheetDragList
+                  data={data}
+                  keyExtractor={keyExtractor}
+                  onReorder={onReorder}
+                  contentContainerStyle={contentContainerStyle}
+                  renderRow={({ item, Handle, isActive }) =>
+                    renderDataRow({ item, Handle, isActive })
+                  }
+                />
+              )}
             </View>
           </View>
         </ScrollView>
@@ -380,5 +543,39 @@ const styles = StyleSheet.create({
     width: GRIP_W,
     alignItems: "center",
     justifyContent: "center",
+  },
+  sectionHeader: {
+    minHeight: SECTION_MIN_HEIGHT,
+    justifyContent: "center",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  sectionHeaderInner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    minHeight: SECTION_MIN_HEIGHT,
+    paddingHorizontal: 10,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    flexShrink: 1,
+  },
+  sectionMeta: {
+    fontSize: 11,
+    fontWeight: "500",
+    marginLeft: "auto",
+    paddingLeft: 8,
+  },
+  sectionFooter: {
+    minHeight: SECTION_MIN_HEIGHT,
+    justifyContent: "center",
+  },
+  sectionFooterInner: {
+    paddingLeft: GRIP_W,
+    paddingRight: 10,
+    paddingVertical: 4,
   },
 });

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -8,12 +8,14 @@
  * toggle: rows show clock times from the earliest start, and the header shows
  * every service as a start–end range that grows as items/durations change.
  *
- * Editing is spreadsheet-style: the run sheet is one continuous `GridScrollList`
- * table (Item / When / Time / Dur / Owner-Role / Notes / Song / actions) modelled
- * on the events-os Run of Show. There are no segment-heading rows — a row's phase
- * is the "When" column. Duration and title edit inline; When, Who, Notes, and Song
- * open focused modals. Reordering is drag-and-drop from a grip in the first cell
- * (web + native). Each row can be duplicated or deleted from the actions column.
+ * Editing is spreadsheet-style: the run sheet is one dense `GridScrollList`
+ * table (Item / Time / Dur / Owner-Role / Notes / Song / ⋯) modelled on the
+ * events-os Run of Show. Rows are grouped into collapsible Before / During /
+ * After sections — a row's phase is its section (there is no "When" column).
+ * Duration and title edit inline; Who, Notes, and Song open focused modals.
+ * Reordering is drag-and-drop from a grip in the first cell (web + native).
+ * The per-row "⋯" menu moves an item to another segment, duplicates, or deletes
+ * it, and each section's footer adds a new item into that segment.
  *
  * Route: /rostering/[group_id]/run-sheet/[plan_id]
  */
@@ -22,7 +24,6 @@ import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
   Pressable,
   TouchableOpacity,
   ActivityIndicator,
@@ -49,8 +50,14 @@ import {
 } from "../utils/runSheetTiming";
 import { useAuth } from "@providers/AuthProvider";
 import { InlineText } from "./InlineText";
-import { GridScrollList, OptionTag, type GridColumn } from "./GridScrollList";
-import { AnchoredMenu, type AnchorRect } from "./AnchoredMenu";
+import {
+  GridScrollList,
+  OptionTag,
+  type GridColumn,
+  type GridSection,
+} from "./GridScrollList";
+import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
+import { SegmentedTabs } from "@components/ui/SegmentedTabs";
 import { CustomModal } from "@components/ui/Modal";
 import { PlanTemplateToolbar } from "./PlanTemplateToolbar";
 import { listRunSheetTemplatesRef } from "../api/eventTemplates";
@@ -65,7 +72,6 @@ import {
 } from "../api/planTemplates";
 import type { Song } from "@features/songs/types";
 import {
-  WhenPill,
   AddButton,
   DurationCell,
   WhoModalBody,
@@ -123,6 +129,33 @@ type EventDoc = {
   times: Array<{ label: string; startsAt: number }>;
   roles: EventRole[];
 };
+
+/**
+ * The per-row "⋯" trigger. Measures its own window rect on press so the parent
+ * can anchor the actions dropdown next to it (the table card clips overflow, so
+ * the menu can't live inside the row). Mirrors `WhenPill`'s measure pattern.
+ */
+function RowActionsButton({
+  colors,
+  onOpen,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  onOpen: (anchor: AnchorRect) => void;
+}) {
+  const ref = React.useRef<View>(null);
+  return (
+    <Pressable
+      ref={ref}
+      onPress={() => measureAnchor(ref.current, onOpen)}
+      hitSlop={8}
+      style={styles.actionsTrigger}
+      accessibilityRole="button"
+      accessibilityLabel="Item actions"
+    >
+      <Ionicons name="ellipsis-horizontal" size={18} color={colors.textTertiary} />
+    </Pressable>
+  );
+}
 
 export function RunSheetScreen() {
   const { colors } = useTheme();
@@ -281,8 +314,13 @@ export function RunSheetScreen() {
 
   // The just-created item to autofocus its title for immediate editing.
   const [focusId, setFocusId] = useState<string | null>(null);
-  // Which phase the "Add" buttons create into.
-  const [addSegment, setAddSegment] = useState<Segment>("during");
+  // Per-segment collapse state (all expanded by default). Owned here; the
+  // section header's onToggle flips the matching flag.
+  const [collapsed, setCollapsed] = useState<Record<Segment, boolean>>({
+    before: false,
+    during: false,
+    after: false,
+  });
 
   // Cell-tap modals. Each holds the item whose Who / Notes / Song is being
   // edited; the live item is re-derived from `items` at render so a deleted or
@@ -290,9 +328,10 @@ export function RunSheetScreen() {
   const [whoItem, setWhoItem] = useState<RunSheetItem | null>(null);
   const [notesItem, setNotesItem] = useState<RunSheetItem | null>(null);
   const [songItem, setSongItem] = useState<RunSheetItem | null>(null);
-  // The "When" picker is an anchored dropdown next to its pill (not a modal), so
-  // it tracks both the item and the pill's measured window rect.
-  const [whenMenu, setWhenMenu] = useState<{
+  // The per-row actions menu (move-between-segments / duplicate / delete) is an
+  // anchored dropdown next to the row's "⋯" trigger, so it tracks both the item
+  // and the trigger's measured window rect.
+  const [actionsMenu, setActionsMenu] = useState<{
     item: RunSheetItem;
     anchor: AnchorRect;
   } | null>(null);
@@ -303,13 +342,12 @@ export function RunSheetScreen() {
   const columns: GridColumn[] = useMemo(
     () => [
       { key: "item", label: "Item", width: 220, flex: 3 },
-      { key: "when", label: "When", width: 104 },
       { key: "time", label: "Time", width: 96, align: "center" },
       { key: "dur", label: "Dur", width: 84, align: "center" },
       { key: "who", label: "Owner / Role", width: 176 },
       { key: "notes", label: "Notes", width: 240, flex: 3 },
       { key: "song", label: "Song", width: 150 },
-      { key: "actions", label: "", width: 64, align: "center" },
+      { key: "actions", label: "", width: 48, align: "center" },
     ],
     [],
   );
@@ -384,21 +422,21 @@ export function RunSheetScreen() {
     [updateItem],
   );
 
-  const handleAdd = useCallback(
-    async (type: string) => {
+  const handleAddTo = useCallback(
+    async (type: string, segment: Segment) => {
       try {
         const { itemId } = await createItem({
           planId,
           type,
           title: type === "header" ? "New section" : "New item",
-          segment: addSegment,
+          segment,
         });
         setFocusId(itemId as string);
       } catch (e: any) {
         notifyError("Couldn't add item", e?.message ?? "Please try again.");
       }
     },
-    [createItem, planId, addSegment],
+    [createItem, planId],
   );
 
   const handleDuplicate = useCallback(
@@ -434,12 +472,33 @@ export function RunSheetScreen() {
   );
 
   // Flat rows for the single table, ordered by phase (before → during → after)
-  // then existing sequence. There are no heading rows: a row's phase lives in the
-  // "When" column and is changed there, not by dragging.
+  // then existing sequence. Kept for `data`/reorder; the visual grouping is now
+  // driven by the `sections` prop below, so a row's phase is its section.
   const rows = useMemo(
     () =>
       itemsBySegment.before.concat(itemsBySegment.during, itemsBySegment.after),
     [itemsBySegment],
+  );
+
+  // A compact per-segment summary for the section header, e.g. "6 items ·
+  // 7:30–9:59 AM". The span is the earliest–latest clock time of the segment's
+  // items (headers have no clock time and are skipped); when it can't be
+  // computed we fall back to just the item count.
+  const segmentMeta = useCallback(
+    (seg: Segment): string => {
+      const segItems = itemsBySegment[seg];
+      const n = segItems.length;
+      const countLabel = `${n} item${n === 1 ? "" : "s"}`;
+      const stamps = segItems
+        .map((it) => clockTimes[it._id])
+        .filter((ms): ms is number => ms != null);
+      if (stamps.length === 0) return countLabel;
+      const start = formatClockTime(Math.min(...stamps));
+      const end = formatClockTime(Math.max(...stamps));
+      const span = start === end ? start : `${start}–${end}`;
+      return `${countLabel} · ${span}`;
+    },
+    [itemsBySegment, clockTimes],
   );
 
   // Drag only reorders within the existing phases — each row keeps its current
@@ -475,8 +534,8 @@ export function RunSheetScreen() {
   const songLive = songItem
     ? (items?.find((i) => i._id === songItem._id) ?? null)
     : null;
-  const whenLive = whenMenu
-    ? (items?.find((i) => i._id === whenMenu.item._id) ?? null)
+  const actionsLive = actionsMenu
+    ? (items?.find((i) => i._id === actionsMenu.item._id) ?? null)
     : null;
 
   return (
@@ -496,21 +555,23 @@ export function RunSheetScreen() {
           <Ionicons name="chevron-back" size={28} color={colors.text} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text }]}>Run sheet</Text>
-        {/* Entry point to the leader Event Tasks "database view" for this plan.
-            Shown only when the community has opted into Event Tasks; the Tasks
-            screen itself re-checks the flag + leader role. */}
+        {/* Run sheet ⇄ Tasks switcher — the entry point to the leader Event Tasks
+            "database view" for this plan. Shown only when the community has opted
+            into Event Tasks; the Tasks screen itself re-checks the flag + leader
+            role. When the flag is off, keep a spacer so the title stays centered. */}
         {eventTasksEnabled ? (
-          <TouchableOpacity
-            onPress={() =>
-              router.push(`/rostering/${group_id}/tasks/${planId}` as never)
-            }
-            hitSlop={12}
-            style={styles.headerBtn}
-            accessibilityRole="button"
-            accessibilityLabel="Event tasks"
-          >
-            <Ionicons name="checkbox-outline" size={24} color={colors.text} />
-          </TouchableOpacity>
+          <SegmentedTabs
+            options={[
+              { key: "run", label: "Run sheet" },
+              { key: "tasks", label: "Tasks" },
+            ]}
+            value="run"
+            onChange={(key) => {
+              if (key === "tasks")
+                router.push(`/rostering/${group_id}/tasks/${planId}` as never);
+            }}
+            accessibilityLabel="View"
+          />
         ) : (
           <View style={styles.headerBtn} />
         )}
@@ -557,81 +618,59 @@ export function RunSheetScreen() {
             </View>
           );
 
-          const listFooter = (
-            <View>
-              {/* Add controls — choose the phase, then add. */}
-              <View style={styles.addToRow}>
-                <Text style={[styles.addToLabel, { color: colors.textSecondary }]}>
-                  Add to:
-                </Text>
-                {SEGMENT_OPTIONS.map((seg) => {
-                  const active = addSegment === seg.key;
-                  return (
-                    <Pressable
-                      key={seg.key}
-                      onPress={() => setAddSegment(seg.key)}
-                      style={styles.addToChipPressable}
-                      accessibilityRole="button"
-                      accessibilityState={{ selected: active }}
-                    >
-                      <View
-                        style={[
-                          styles.addToChip,
-                          {
-                            borderColor: active ? primaryColor : colors.border,
-                            backgroundColor: active
-                              ? primaryColor + "18"
-                              : "transparent",
-                          },
-                        ]}
-                      >
-                        <Text
-                          style={[
-                            styles.addToChipText,
-                            { color: active ? primaryColor : colors.textSecondary },
-                          ]}
-                        >
-                          {seg.label}
-                        </Text>
-                      </View>
-                    </Pressable>
-                  );
-                })}
-              </View>
-              <View style={styles.addBar}>
-                <AddButton label="Add item" icon="add" onPress={() => handleAdd("item")} primaryColor={primaryColor} colors={colors} />
-                <AddButton label="Song" icon="musical-notes" onPress={() => handleAdd("song")} primaryColor={primaryColor} colors={colors} />
-                <AddButton label="Header" icon="bookmark" onPress={() => handleAdd("header")} primaryColor={primaryColor} colors={colors} />
-              </View>
+          // Per-section add controls. Every segment gets "Add item"; the
+          // "during" segment also carries Song / Header so those types stay
+          // reachable now that the flat bottom add-bar is gone. A newly-added
+          // item takes the section's segment.
+          const footerFor = (seg: Segment): React.ReactNode => (
+            <View style={styles.addBar}>
+              <AddButton
+                label="Add item"
+                icon="add"
+                onPress={() => handleAddTo("item", seg)}
+                primaryColor={primaryColor}
+                colors={colors}
+              />
+              {seg === "during" ? (
+                <>
+                  <AddButton
+                    label="Song"
+                    icon="musical-notes"
+                    onPress={() => handleAddTo("song", seg)}
+                    primaryColor={primaryColor}
+                    colors={colors}
+                  />
+                  <AddButton
+                    label="Header"
+                    icon="bookmark"
+                    onPress={() => handleAddTo("header", seg)}
+                    primaryColor={primaryColor}
+                    colors={colors}
+                  />
+                </>
+              ) : null}
             </View>
           );
 
-          const contentStyle = [
-            styles.scrollContent,
-            { paddingBottom: insets.bottom + 96 },
-          ];
+          const sections: GridSection<RunSheetItem>[] = SEGMENT_OPTIONS.map(
+            (seg) => ({
+              key: seg.key,
+              title: seg.label.toUpperCase(),
+              meta: segmentMeta(seg.key),
+              collapsed: collapsed[seg.key],
+              onToggle: () =>
+                setCollapsed((prev) => ({
+                  ...prev,
+                  [seg.key]: !prev[seg.key],
+                })),
+              rows: itemsBySegment[seg.key],
+              footer: footerFor(seg.key),
+            }),
+          );
 
-          if (items.length === 0) {
-            return (
-              <ScrollView
-                contentContainerStyle={contentStyle}
-                keyboardShouldPersistTaps="handled"
-              >
-                {listHeader}
-                <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-                  No items yet. Pick a phase under "Add to" below, then add songs,
-                  headers, and other moments. Drag the grip to reorder — drag
-                  across a phase heading to move an item before, during, or after
-                  the event.
-                </Text>
-                {listFooter}
-              </ScrollView>
-            );
-          }
-
-          // One continuous events-os-style table. Each row's phase is the "When"
-          // column (no heading rows). renderCell returns cell CONTENT only — the
-          // primitive draws the sized, padded cell frame.
+          // One continuous events-os-style table, grouped into before / during /
+          // after sections. A row's phase is its section; renderCell returns cell
+          // CONTENT only — the primitive draws the sized, padded cell frame.
           const renderCell = (
             item: RunSheetItem,
             key: string,
@@ -658,19 +697,6 @@ export function RunSheetScreen() {
                     ]}
                   />
                 );
-              case "when": {
-                const short =
-                  SEGMENT_OPTIONS.find((s) => s.key === item.segment)?.short ??
-                  "During";
-                return (
-                  <WhenPill
-                    label={short}
-                    colors={colors}
-                    primaryColor={primaryColor}
-                    onOpen={(anchor) => setWhenMenu({ item, anchor })}
-                  />
-                );
-              }
               case "time": {
                 if (isHeader) return null;
                 const ms = clockTimes[item._id];
@@ -784,25 +810,14 @@ export function RunSheetScreen() {
                 );
               }
               case "actions":
+                // A single "⋯" that opens an anchored menu: move-between-segments
+                // (the When column is gone), Duplicate, Delete. Keeps the row
+                // compact while preserving every action.
                 return (
-                  <View style={styles.actionsRow}>
-                    <Pressable
-                      onPress={() => handleDuplicate(item._id)}
-                      hitSlop={6}
-                      style={styles.actionBtn}
-                      accessibilityLabel="Duplicate"
-                    >
-                      <Ionicons name="copy-outline" size={16} color={colors.textTertiary} />
-                    </Pressable>
-                    <Pressable
-                      onPress={() => handleDelete(item)}
-                      hitSlop={6}
-                      style={styles.actionBtn}
-                      accessibilityLabel="Delete"
-                    >
-                      <Ionicons name="trash-outline" size={16} color={colors.destructive} />
-                    </Pressable>
-                  </View>
+                  <RowActionsButton
+                    colors={colors}
+                    onOpen={(anchor) => setActionsMenu({ item, anchor })}
+                  />
                 );
               default:
                 return null;
@@ -816,13 +831,13 @@ export function RunSheetScreen() {
               onReorder={handleReorder}
               columns={columns}
               renderCell={renderCell}
+              sections={sections}
+              dense
               ListHeaderComponent={listHeader}
-              // The add controls are fixed below the table card, so they carry
-              // the bottom safe-area inset here (the rows scroll inside the card).
+              // Add controls now live in each section's footer, so the list footer
+              // only carries the bottom safe-area inset.
               ListFooterComponent={
-                <View style={{ paddingBottom: insets.bottom + 8 }}>
-                  {listFooter}
-                </View>
+                <View style={{ paddingBottom: insets.bottom + 8 }} />
               }
               // Vertical padding only — horizontal padding would shift the rows
               // out of alignment with the pinned header.
@@ -882,18 +897,35 @@ export function RunSheetScreen() {
         ) : null}
       </CustomModal>
 
-      {/* When picker — an anchored dropdown next to the pill that moves the row
-          between the before / during / after phases. */}
-      {whenMenu && whenLive ? (
+      {/* Row actions — an anchored dropdown next to the "⋯" trigger: move the row
+          to another segment (the When column is gone), duplicate, or delete. */}
+      {actionsMenu && actionsLive ? (
         <AnchoredMenu
-          anchor={whenMenu.anchor}
-          options={SEGMENT_OPTIONS.map((s) => ({ id: s.key, name: s.label }))}
-          selectedId={whenLive.segment}
+          anchor={actionsMenu.anchor}
+          options={[
+            ...SEGMENT_OPTIONS.filter((s) => s.key !== actionsLive.segment).map(
+              (s) => ({
+                id: `move:${s.key}`,
+                name: `Move to ${s.label}`,
+                icon: "swap-horizontal" as const,
+              }),
+            ),
+            { id: "duplicate", name: "Duplicate", icon: "copy-outline" as const },
+            { id: "delete", name: "Delete", icon: "trash-outline" as const },
+          ]}
           onSelect={(id) => {
-            if (id) patchItem(whenLive._id, { segment: id as Segment });
-            setWhenMenu(null);
+            if (id?.startsWith("move:")) {
+              patchItem(actionsLive._id, {
+                segment: id.slice("move:".length) as Segment,
+              });
+            } else if (id === "duplicate") {
+              void handleDuplicate(actionsLive._id);
+            } else if (id === "delete") {
+              handleDelete(actionsLive);
+            }
+            setActionsMenu(null);
           }}
-          onClose={() => setWhenMenu(null)}
+          onClose={() => setActionsMenu(null)}
         />
       ) : null}
     </View>
@@ -913,41 +945,22 @@ const styles = StyleSheet.create({
   headerTitle: { flex: 1, fontSize: 17, fontWeight: "600", textAlign: "center" },
   centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
   errorText: { fontSize: 14 },
-  scrollContent: { padding: 16 },
   gridContent: { paddingBottom: 8 },
   planTitle: { fontSize: 22, fontWeight: "700" },
   planDate: { fontSize: 13, marginTop: 4 },
   ranges: { fontSize: 14, fontWeight: "600", marginTop: 8 },
-  emptyText: { fontSize: 14, lineHeight: 20, marginTop: 24 },
-  addToRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    flexWrap: "wrap",
-    gap: 8,
-    marginTop: 24,
-  },
-  addToLabel: { fontSize: 13, fontWeight: "600" },
-  addToChipPressable: { borderRadius: 999 },
-  addToChip: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 999,
-    borderWidth: 1,
-  },
-  addToChipText: { fontSize: 13, fontWeight: "600" },
   titleInput: { fontSize: 15, fontWeight: "600", width: "100%" },
   headerTitleInput: { fontSize: 12, fontWeight: "800", letterSpacing: 0.5, textTransform: "uppercase" },
-  actionBtn: { padding: 4 },
-  addBar: { flexDirection: "row", gap: 8, marginTop: 16, flexWrap: "wrap" },
+  // Section footer add controls — a compact row of dashed AddButtons.
+  addBar: { flexDirection: "row", gap: 8, flexWrap: "wrap" },
   // Grid cell content. The primitive draws the padded cell frame; these only
   // style the content that sits inside it.
   cellPressable: { flex: 1, justifyContent: "center" },
   cellText: { fontSize: 13 },
   muted: { fontSize: 13, fontWeight: "500" },
   whoChips: { flexDirection: "row", alignItems: "center", gap: 4, flexWrap: "wrap" },
-  // Wraps an OptionTag that opens an anchored menu (self-aligned so it hugs its
-  // content and can be measured for the dropdown anchor).
   // "Time" — a quiet, contained read-only clock value ("9:00 AM").
   timeText: { fontSize: 13, fontVariant: ["tabular-nums"] },
-  actionsRow: { flexDirection: "row", alignItems: "center", gap: 4 },
+  // The per-row "⋯" actions trigger — centered in its compact cell.
+  actionsTrigger: { flex: 1, alignItems: "center", justifyContent: "center" },
 });


### PR DESCRIPTION
## What

Compact redesign of the **Run sheet** and **Event Tasks** screens for density and clearer UX, rendered through existing theme tokens + community `primaryColor` (no new palette — the accent follows each community's color).

Approved via interactive prototypes; this ports the density/interaction model into the real screens.

## Changes

**Shared**
- `GridScrollList`: new optional `sections` prop — collapsible section headers (title + meta + chevron) with an optional per-section footer, woven into the existing single drag list. The flat `data` API is **unchanged** (template editor etc. unaffected).
- New `SegmentedTabs` primitive (`components/ui`) — swaps between Run sheet / Tasks. Uses the RN-Web static-inner-`View` idiom to avoid dropped `Pressable` styles.

**Run sheet** (`RunSheetScreen.tsx`)
- Dense rows (46→38px).
- Group items into **Before / During / After** sections with per-section **Add** buttons (During also exposes Song/Header).
- **Remove the redundant `When` column and bottom "Add to" toggle** — a row's section *is* its segment. Segment changes move to a compact **`⋯` row menu** (Move to …, Duplicate, Delete).
- Replace the ☑ nav icon with the **segmented `[Run sheet | Tasks]` tab**.

**Event tasks** (`EventTasksScreen.tsx`, `EventTasksGrid.tsx`)
- Group tasks into **Pre / During / Post** sections with per-section **Add task** + readiness meta; add the segmented tab.
- **Fix role/team chips overflowing into the How-To column**: clip the chip cell, truncate the first chip, show a compact `+N` instead of wrapping.

## Verification

`tsc` clean (no new errors; 13 pre-existing errors in unrelated chat/tasks/hooks files untouched). Driven in-browser with Playwright against a real published plan:
- Sections render with counts/time-spans; per-section Add present.
- Segmented tab navigates both directions.
- `⋯` → **Move to During** persists via `updateItem` and recomputes clock times (Before 3→2 items, During 3→4).
- Section collapse works.
- Role chips truncate and no longer bleed into How-To.

## Notes
- Direct replace, no feature flag (per repo "Remove, don't deprecate").
- No onboarding-guide updates needed (rostering run sheet/tasks aren't in the public guides map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)