### PR TITLE
feat(scheduling): match roster / run sheet / tasks to prototype visuals + roster→tasks link

### DIFF
--- a/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
+++ b/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
@@ -54,6 +54,7 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { useAuth } from "@providers/AuthProvider";
 import { confirmAsync, notify } from "@/utils/platformAlert";
 import { NeededRolesModal } from "./NeededRolesModal";
 
@@ -119,6 +120,15 @@ export function DateColumnHeaderEditor({
   onPublish: () => void;
 }) {
   const router = useRouter();
+
+  // Whether to surface the Event Tasks entry point — same community flag the
+  // Tasks screen (EventTasksScreen) and RunSheetScreen gate on. Read
+  // defensively: the mobile Community type only enumerates `prayerEnabled`.
+  const { community } = useAuth();
+  const eventTasksEnabled = Boolean(
+    (community?.churchFeatures as { eventTasksEnabled?: boolean } | undefined)
+      ?.eventTasksEnabled,
+  );
 
   // Run-sheet item count for the header button / menu row.
   const runSheetItems = useAuthenticatedQuery(
@@ -270,6 +280,11 @@ export function DateColumnHeaderEditor({
     router.push(`/rostering/${groupId}/run-sheet/${event._id}` as never);
   }, [router, groupId, event._id]);
 
+  const openTasks = useCallback(() => {
+    setMenuOpen(false);
+    router.push(`/rostering/${groupId}/tasks/${event._id}` as never);
+  }, [router, groupId, event._id]);
+
   const handleDuplicate = useCallback(async () => {
     setMenuOpen(false);
     try {
@@ -418,6 +433,25 @@ export function DateColumnHeaderEditor({
         </TouchableOpacity>
       )}
 
+      {/* Tasks button — mirrors the run-sheet chip; wide columns only, narrow
+          folds it into the menu. Gated on the Event Tasks community flag. */}
+      {!narrow && eventTasksEnabled && (
+        <TouchableOpacity
+          onPress={openTasks}
+          style={[styles.runSheetBtn, { borderColor: colors.border }]}
+          accessibilityRole="button"
+          accessibilityLabel="Open tasks"
+        >
+          <Ionicons name="checkbox-outline" size={12} color={colors.textSecondary} />
+          <Text
+            style={[styles.runSheetText, { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            Tasks
+          </Text>
+        </TouchableOpacity>
+      )}
+
       {/* Context menu — a centered card over a dim backdrop (Modal), matching
           the screen's other menus. A Modal (rather than an absolutely-
           positioned popover) avoids the horizontal header ScrollView clipping
@@ -470,6 +504,14 @@ export function DateColumnHeaderEditor({
                 colors={colors}
                 onPress={openRunSheet}
               />
+              {eventTasksEnabled && (
+                <MenuItem
+                  icon="checkbox-outline"
+                  label="Open tasks"
+                  colors={colors}
+                  onPress={openTasks}
+                />
+              )}
               <MenuItem
                 icon="paper-plane-outline"
                 label={

--- a/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
+++ b/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
@@ -415,41 +415,52 @@ export function DateColumnHeaderEditor({
       {/* Coverage / availability tally (rendered by the caller, view-aware). */}
       <View style={styles.tallyRow}>{tally}</View>
 
-      {/* Run-sheet button — wide columns only; narrow folds it into the menu. */}
+      {/* Run-sheet + Tasks chips share ONE row so adding the Tasks chip never
+          grows the header past HEADER_H (the frozen corner / Add-date cells are
+          fixed at that height). Wide columns only (CELL_W >= 200); narrow folds
+          both into the ⋯ menu. Tasks is gated on the Event Tasks community flag. */}
       {!narrow && (
-        <TouchableOpacity
-          onPress={openRunSheet}
-          style={[styles.runSheetBtn, { borderColor: colors.border }]}
-          accessibilityRole="button"
-          accessibilityLabel="Open run sheet"
-        >
-          <Ionicons name="list-outline" size={12} color={colors.textSecondary} />
-          <Text
-            style={[styles.runSheetText, { color: colors.textSecondary }]}
-            numberOfLines={1}
+        <View style={styles.headerChipRow}>
+          <TouchableOpacity
+            onPress={openRunSheet}
+            style={[styles.runSheetBtn, { borderColor: colors.border }]}
+            accessibilityRole="button"
+            accessibilityLabel="Open run sheet"
           >
-            Run sheet · {runSheetCount}
-          </Text>
-        </TouchableOpacity>
-      )}
+            <Ionicons
+              name="list-outline"
+              size={12}
+              color={colors.textSecondary}
+            />
+            <Text
+              style={[styles.runSheetText, { color: colors.textSecondary }]}
+              numberOfLines={1}
+            >
+              Run sheet · {runSheetCount}
+            </Text>
+          </TouchableOpacity>
 
-      {/* Tasks button — mirrors the run-sheet chip; wide columns only, narrow
-          folds it into the menu. Gated on the Event Tasks community flag. */}
-      {!narrow && eventTasksEnabled && (
-        <TouchableOpacity
-          onPress={openTasks}
-          style={[styles.runSheetBtn, { borderColor: colors.border }]}
-          accessibilityRole="button"
-          accessibilityLabel="Open tasks"
-        >
-          <Ionicons name="checkbox-outline" size={12} color={colors.textSecondary} />
-          <Text
-            style={[styles.runSheetText, { color: colors.textSecondary }]}
-            numberOfLines={1}
-          >
-            Tasks
-          </Text>
-        </TouchableOpacity>
+          {eventTasksEnabled && (
+            <TouchableOpacity
+              onPress={openTasks}
+              style={[styles.runSheetBtn, { borderColor: colors.border }]}
+              accessibilityRole="button"
+              accessibilityLabel="Open tasks"
+            >
+              <Ionicons
+                name="checkbox-outline"
+                size={12}
+                color={colors.textSecondary}
+              />
+              <Text
+                style={[styles.runSheetText, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                Tasks
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
       )}
 
       {/* Context menu — a centered card over a dim backdrop (Modal), matching
@@ -793,18 +804,27 @@ const styles = StyleSheet.create({
     gap: 2,
     minHeight: 14,
   },
+  headerChipRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    alignSelf: "center",
+    maxWidth: "100%",
+  },
   runSheetBtn: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
     gap: 3,
-    alignSelf: "center",
+    flexShrink: 1,
+    minWidth: 0,
     paddingHorizontal: 6,
     paddingVertical: 2,
     borderRadius: 6,
     borderWidth: StyleSheet.hairlineWidth,
   },
-  runSheetText: { fontSize: 9, fontWeight: "600" },
+  runSheetText: { fontSize: 9, fontWeight: "600", flexShrink: 1 },
   menuBackdrop: {
     flex: 1,
     backgroundColor: "rgba(0,0,0,0.4)",

--- a/apps/mobile/features/scheduling/components/EventEditorPanel.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorPanel.tsx
@@ -45,6 +45,7 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { useAuth } from "@providers/AuthProvider";
 import { confirmAsync, notify } from "@/utils/platformAlert";
 import { NeededRolesModal } from "./NeededRolesModal";
 import { TimesEditor } from "./TimesEditor";
@@ -92,6 +93,15 @@ export function EventEditorPanel({
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const router = useRouter();
+
+  // Whether to surface the Event Tasks entry point — same community flag the
+  // Tasks screen (EventTasksScreen) and RunSheetScreen gate on. Read
+  // defensively: the mobile Community type only enumerates `prayerEnabled`.
+  const { community } = useAuth();
+  const eventTasksEnabled = Boolean(
+    (community?.churchFeatures as { eventTasksEnabled?: boolean } | undefined)
+      ?.eventTasksEnabled,
+  );
 
   const event = useAuthenticatedQuery(
     api.functions.scheduling.events.getEvent,
@@ -544,6 +554,29 @@ export function EventEditorPanel({
           </Text>
           <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
         </Pressable>
+
+        {/* Tasks (event checklist) entry — mirrors the Run sheet row. Gated on
+            the Event Tasks community flag. */}
+        {eventTasksEnabled && (
+          <Pressable
+            onPress={() =>
+              router.push(
+                `/rostering/${event.groupId}/tasks/${planId}` as never,
+              )
+            }
+            style={({ pressed }) => [
+              styles.actionRow,
+              { backgroundColor: colors.surfaceSecondary, marginTop: 12 },
+              pressed && { opacity: 0.8 },
+            ]}
+          >
+            <Ionicons name="checkbox-outline" size={20} color={colors.text} />
+            <Text style={[styles.actionLabel, { color: colors.text }]}>
+              Tasks
+            </Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+          </Pressable>
+        )}
 
         {/* Assignment happens on the GRID — this panel intentionally has no
             per-role assign cards. A short pointer keeps that discoverable. */}

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -611,7 +611,7 @@ export function EventTasksScreen() {
         onSaveExisting={handleSaveExistingTemplate}
         onRevert={handleRevertTemplate}
       />
-      <ReadinessHeader readiness={readiness} primaryColor={primaryColor} colors={colors} />
+      <ReadinessHeader readiness={readiness} colors={colors} />
       {(tasks?.length ?? 0) > 0 ? (
         <FilterBar
           phase={phaseFilter}
@@ -793,90 +793,64 @@ function RoleLoader({
   return null;
 }
 
-/** A thin fixed-height progress track with a primary-colored fill (no SVG). */
-function MiniBar({
-  ratio,
-  height,
-  trackColor,
-  fillColor,
-}: {
-  ratio: number;
-  height: number;
-  trackColor: string;
-  fillColor: string;
-}) {
-  const clamped = Math.max(0, Math.min(1, ratio));
-  return (
-    <View style={[styles.miniTrack, { height, backgroundColor: trackColor }]}>
-      <View
-        style={{
-          height,
-          width: `${clamped * 100}%`,
-          borderRadius: height / 2,
-          backgroundColor: fillColor,
-        }}
-      />
-    </View>
-  );
-}
-
 /**
- * Readiness header — a compact row of stat tiles (Overall / Pre / During / Post),
- * each showing a done/total count and a short primary-colored bar, plus a
- * wrapping row of per-team chips. Contained to the table's centered max width so
- * it doesn't stretch edge-to-edge on desktop.
+ * Readiness header — one compact line: a bold done/total count (monospace,
+ * tabular), a "READY" label, a thin progress track (fill in `colors.success`),
+ * and inline per-phase counts (Pre / During / Post). Any per-team breakdown
+ * follows as a small secondary line of compact chips. Contained to the table's
+ * centered max width so it doesn't stretch edge-to-edge on desktop.
  */
 function ReadinessHeader({
   readiness,
-  primaryColor,
   colors,
 }: {
   readiness: Readiness | undefined;
-  primaryColor: string;
   colors: ReturnType<typeof useTheme>["colors"];
 }) {
   if (!readiness) return null;
-  const pct = (d: number, t: number) => (t > 0 ? d / t : 0);
-  const tiles: Array<{ label: string; done: number; total: number }> = [
-    { label: "Overall", ...readiness.overall },
-    { label: "Pre", ...readiness.bySegment.before },
-    { label: "During", ...readiness.bySegment.during },
-    { label: "Post", ...readiness.bySegment.after },
+  const { overall, bySegment, byTeam } = readiness;
+  const ratio = overall.total > 0 ? overall.done / overall.total : 0;
+  const clamped = Math.max(0, Math.min(1, ratio));
+  const phases: Array<{ label: string; done: number; total: number }> = [
+    { label: "Pre", ...bySegment.before },
+    { label: "During", ...bySegment.during },
+    { label: "Post", ...bySegment.after },
   ];
 
   return (
     <View style={styles.readiness}>
-      <Text style={[styles.readinessTitle, { color: colors.textSecondary }]}>
-        READINESS
-      </Text>
-      <View style={styles.statRow}>
-        {tiles.map((tile) => (
+      <View style={styles.readinessMain}>
+        <Text style={[styles.rdCount, { color: colors.text }]}>
+          {overall.done}/{overall.total}
+        </Text>
+        <Text style={[styles.rdLabel, { color: colors.textSecondary }]}>
+          READY
+        </Text>
+        <View style={[styles.rdTrack, { backgroundColor: colors.surfaceSecondary }]}>
           <View
-            key={tile.label}
-            style={[
-              styles.statTile,
-              { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
-            ]}
-          >
-            <Text style={[styles.statCount, { color: colors.text }]}>
-              {tile.done}/{tile.total}
+            style={{
+              height: "100%",
+              width: `${clamped * 100}%`,
+              borderRadius: 6,
+              backgroundColor: colors.success,
+            }}
+          />
+        </View>
+        <View style={styles.rdPhases}>
+          {phases.map((p) => (
+            <Text
+              key={p.label}
+              style={[styles.rdPhase, { color: colors.textSecondary }]}
+            >
+              {p.label} {p.done}/{p.total}
             </Text>
-            <Text style={[styles.statLabel, { color: colors.textSecondary }]}>
-              {tile.label}
-            </Text>
-            <MiniBar
-              ratio={pct(tile.done, tile.total)}
-              height={4}
-              trackColor={colors.border}
-              fillColor={primaryColor}
-            />
-          </View>
-        ))}
+          ))}
+        </View>
       </View>
 
-      {readiness.byTeam.length > 0 ? (
+      {byTeam.length > 0 ? (
         <View style={styles.teamChipRow}>
-          {readiness.byTeam.map((t) => (
+          {byTeam.map((t) => (
             <View
               key={t.teamId}
               style={[
@@ -893,14 +867,6 @@ function ReadinessHeader({
               <Text style={[styles.teamChipCount, { color: colors.textSecondary }]}>
                 {t.done}/{t.total}
               </Text>
-              <View style={styles.teamChipBar}>
-                <MiniBar
-                  ratio={pct(t.done, t.total)}
-                  height={3}
-                  trackColor={colors.border}
-                  fillColor={primaryColor}
-                />
-              </View>
             </View>
           ))}
         </View>
@@ -1095,6 +1061,10 @@ function FilterBar({
   );
 }
 
+// Monospace + tabular figures for the readiness counts (the "broadcast rundown"
+// numeric feel, matching the run-sheet time/duration cells).
+const MONO_FONT = Platform.select({ ios: "Menlo", default: "monospace" });
+
 const styles = StyleSheet.create({
   container: { flex: 1 },
   header: {
@@ -1132,25 +1102,33 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     gap: 10,
   },
-  readinessTitle: { fontSize: 11, fontWeight: "800", letterSpacing: 0.6 },
-  statRow: { flexDirection: "row", gap: 8 },
-  statTile: {
-    flex: 1,
-    minWidth: 68,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 10,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    gap: 4,
+  // The single compact readiness line: count · READY · track · phase counts.
+  readinessMain: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 10,
   },
-  statCount: { fontSize: 18, fontWeight: "800", fontVariant: ["tabular-nums"] },
-  statLabel: {
-    fontSize: 11,
+  rdCount: {
+    fontSize: 15,
+    fontWeight: "700",
+    fontFamily: MONO_FONT,
+    fontVariant: ["tabular-nums"],
+  },
+  rdLabel: {
+    fontSize: 10,
     fontWeight: "600",
+    letterSpacing: 0.8,
     textTransform: "uppercase",
-    letterSpacing: 0.4,
   },
-  miniTrack: { borderRadius: 2, overflow: "hidden", marginTop: 2 },
+  rdTrack: { width: 130, height: 6, borderRadius: 6, overflow: "hidden" },
+  rdPhases: { flexDirection: "row", flexWrap: "wrap", gap: 12 },
+  rdPhase: {
+    fontSize: 12,
+    fontWeight: "600",
+    fontFamily: MONO_FONT,
+    fontVariant: ["tabular-nums"],
+  },
   teamChipRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
   teamChip: {
     flexDirection: "row",
@@ -1162,8 +1140,11 @@ const styles = StyleSheet.create({
     paddingVertical: 5,
   },
   teamChipName: { fontSize: 12, fontWeight: "600", maxWidth: 120 },
-  teamChipCount: { fontSize: 11, fontVariant: ["tabular-nums"] },
-  teamChipBar: { width: 40 },
+  teamChipCount: {
+    fontSize: 11,
+    fontFamily: MONO_FONT,
+    fontVariant: ["tabular-nums"],
+  },
   filterBar: { marginTop: 14, width: "100%", maxWidth: 1200, alignSelf: "center" },
   filterScroll: { flexDirection: "row", alignItems: "center", gap: 8, paddingVertical: 2 },
   filterChip: {

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -526,6 +526,7 @@ export function EventTasksScreen() {
     if (router.canGoBack()) router.back();
   }, [router]);
 
+  // Simple centered bar for gating states (event not loaded yet).
   const renderHeaderBar = () => (
     <View style={[styles.header, { borderBottomColor: colors.border }]}>
       <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBtn}>
@@ -533,6 +534,41 @@ export function EventTasksScreen() {
       </TouchableOpacity>
       <Text style={[styles.headerTitle, { color: colors.text }]}>Event tasks</Text>
       <View style={styles.headerBtn} />
+    </View>
+  );
+
+  // Consolidated top bar: back + event title/date + the Run sheet/Tasks tabs,
+  // all on one row (matches the run sheet and the approved prototype).
+  const renderRichHeader = () => (
+    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+      <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBackBtn}>
+        <Ionicons name="chevron-back" size={26} color={colors.text} />
+      </TouchableOpacity>
+      <View style={styles.headerTitleBlock}>
+        <Text style={[styles.headerEventTitle, { color: colors.text }]} numberOfLines={1}>
+          {event?.title ?? "Event tasks"}
+        </Text>
+        {event ? (
+          <Text
+            style={[styles.headerEventMeta, { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            {formatEventDateLong(event.eventDate)}
+          </Text>
+        ) : null}
+      </View>
+      <SegmentedTabs
+        options={[
+          { key: "run", label: "Run sheet" },
+          { key: "tasks", label: "Tasks" },
+        ]}
+        value="tasks"
+        onChange={(k) => {
+          if (k === "run")
+            router.push(`/rostering/${group_id}/run-sheet/${planId}`);
+        }}
+        accessibilityLabel="Switch between run sheet and tasks"
+      />
     </View>
   );
 
@@ -580,27 +616,6 @@ export function EventTasksScreen() {
 
   const listHeader = (
     <View>
-      <SegmentedTabs
-        options={[
-          { key: "run", label: "Run sheet" },
-          { key: "tasks", label: "Tasks" },
-        ]}
-        value="tasks"
-        onChange={(k) => {
-          if (k === "run")
-            router.push(`/rostering/${group_id}/run-sheet/${planId}`);
-        }}
-        style={styles.viewTabs}
-        accessibilityLabel="Switch between run sheet and tasks"
-      />
-      <Text style={[styles.planTitle, { color: colors.text }]}>
-        {event?.title ?? "Event plan"}
-      </Text>
-      {event ? (
-        <Text style={[styles.planDate, { color: colors.textSecondary }]}>
-          {formatEventDateLong(event.eventDate)}
-        </Text>
-      ) : null}
       <PlanTemplateToolbar
         label="Task template"
         itemNoun="tasks"
@@ -631,7 +646,7 @@ export function EventTasksScreen() {
 
   return (
     <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.surface }]}>
-      {renderHeaderBar()}
+      {renderRichHeader()}
 
       {/* Populate rolesByTeam for every referenced team + the team currently in
           the role picker, so role labels/pickers resolve without a big join. */}
@@ -1076,11 +1091,17 @@ const styles = StyleSheet.create({
   },
   headerBtn: { width: 44, padding: 4, alignItems: "center" },
   headerTitle: { flex: 1, fontSize: 17, fontWeight: "600", textAlign: "center" },
+  headerBackBtn: { padding: 4 },
+  headerTitleBlock: { flex: 1, minWidth: 0, marginLeft: 4, marginRight: 8 },
+  headerEventTitle: { fontSize: 18, fontWeight: "700", letterSpacing: -0.3 },
+  headerEventMeta: {
+    fontSize: 12,
+    marginTop: 2,
+    fontFamily: MONO_FONT,
+    fontVariant: ["tabular-nums"],
+  },
   centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24, gap: 12 },
   gateText: { fontSize: 15, textAlign: "center", lineHeight: 22 },
-  viewTabs: { alignSelf: "flex-start", marginBottom: 12 },
-  planTitle: { fontSize: 22, fontWeight: "700" },
-  planDate: { fontSize: 13, marginTop: 4 },
   // Per-section "+ Add task" footer button (dashed, community accent).
   sectionAdd: {
     flexDirection: "row",

--- a/apps/mobile/features/scheduling/components/InlineText.tsx
+++ b/apps/mobile/features/scheduling/components/InlineText.tsx
@@ -30,6 +30,7 @@ export function InlineText({
   autoFocus,
   accessibilityLabel,
   required,
+  borderless,
 }: {
   value: string;
   onSave: (text: string) => void | Promise<void>;
@@ -47,9 +48,17 @@ export function InlineText({
    * we snap back to the last saved value instead of saving "".
    */
   required?: boolean;
+  /**
+   * Opt-in "reads as text" look (run-sheet numeric cells): the field is
+   * borderless with a transparent background at rest and only reveals a subtle
+   * border + faint fill on focus. Off by default so every other caller keeps
+   * its own bordered styling untouched.
+   */
+  borderless?: boolean;
 }) {
   const { colors } = useTheme();
   const [draft, setDraft] = useState(value);
+  const [focused, setFocused] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pending = useRef<string | null>(null);
 
@@ -103,11 +112,25 @@ export function InlineText({
   flushRef.current = flush;
   useEffect(() => () => flushRef.current(), []);
 
+  // Text-like resting state that only shows its frame on focus. Applied LAST so
+  // it wins over the caller's `style`, but only when `borderless` is opted in.
+  const borderlessStyle: TextStyle | null = borderless
+    ? {
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: focused ? colors.border : "transparent",
+        backgroundColor: focused ? colors.surfaceSecondary : "transparent",
+      }
+    : null;
+
   return (
     <TextInput
       value={draft}
       onChangeText={handleChange}
-      onBlur={() => flush(true)}
+      onFocus={() => setFocused(true)}
+      onBlur={() => {
+        setFocused(false);
+        flush(true);
+      }}
       placeholder={placeholder}
       placeholderTextColor={colors.inputPlaceholder}
       multiline={multiline}
@@ -115,7 +138,7 @@ export function InlineText({
       maxLength={maxLength}
       autoFocus={autoFocus}
       accessibilityLabel={accessibilityLabel}
-      style={[styles.base, { color: colors.text }, style]}
+      style={[styles.base, { color: colors.text }, style, borderlessStyle]}
     />
   );
 }

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -2457,7 +2457,12 @@ function PeopleCellView({
           {extra > 0 ? ` +${extra}` : ""}
         </Text>
         {cell.doubleBooked && (
-          <Ionicons name="warning" size={11} color={colors.warning} style={styles.cellCorner} />
+          <Ionicons
+            name="warning"
+            size={11}
+            color={colors.destructive}
+            style={styles.cellCorner}
+          />
         )}
       </Pressable>
     );
@@ -2853,7 +2858,7 @@ function MemberCellPopover({
       onClose={onClose}
     >
       {cell.doubleBooked && (
-        <Text style={[styles.noteLine, { color: colors.warning }]}>
+        <Text style={[styles.noteLine, { color: colors.destructive }]}>
           ⚠ Double-booked this day
         </Text>
       )}

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -1008,7 +1008,11 @@ export function RosterGridScreen() {
   // -------------------------------------------------------------------------
   // Header
   // -------------------------------------------------------------------------
-  const renderHeaderBar = () => (
+  // `showActions` gates the desktop title-row actions (view toggle / Publish /
+  // overflow). It is only passed by the main render — never by the gating/empty
+  // early returns — because renderPublishButton is declared further down; calling
+  // it from an early return would hit a temporal-dead-zone ReferenceError.
+  const renderHeaderBar = (showActions = false) => (
     <View style={[styles.header, { borderBottomColor: colors.border }]}>
       <TouchableOpacity
         onPress={() => router.canGoBack() && router.back()}
@@ -1043,7 +1047,7 @@ export function RosterGridScreen() {
           />
           {renderOverflowButton()}
         </>
-      ) : data ? (
+      ) : showActions && data ? (
         <View style={styles.headerActions}>
           {renderViewToggle()}
           {renderPublishButton(false)}
@@ -1897,7 +1901,7 @@ export function RosterGridScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
-      {renderHeaderBar()}
+      {renderHeaderBar(true)}
       {isWide ? renderDesktopToolbar() : renderFilterBar()}
       {renderLegend()}
 

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -46,6 +46,7 @@ import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { Avatar } from "@components/ui/Avatar";
 import { Button } from "@components/ui/Button";
+import { SegmentedTabs } from "@components/ui/SegmentedTabs";
 import {
   useAuthenticatedQuery,
   useAuthenticatedMutation,
@@ -248,6 +249,13 @@ function statusColor(status: AssignmentStatus, colors: Colors): string {
 function statusIcon(status: AssignmentStatus): keyof typeof Ionicons.glyphMap {
   if (status === "declined") return "close";
   if (status === "unconfirmed") return "time-outline";
+  return "checkmark";
+}
+
+/** Filled glyph for the tiny avatar corner badge (declined ✕ / awaiting … / confirmed ✓). */
+function statusBadgeIcon(status: AssignmentStatus): keyof typeof Ionicons.glyphMap {
+  if (status === "declined") return "close";
+  if (status === "unconfirmed") return "time";
   return "checkmark";
 }
 
@@ -1022,20 +1030,15 @@ export function RosterGridScreen() {
       {/* On desktop the view toggle moves into the single toolbar row below
           (renderDesktopToolbar); on mobile it stays here in the header. */}
       {!isWide && (
-        <View style={styles.segmented}>
-          <SegBtn
-            label="Roles"
-            active={mode === "roles"}
-            onPress={() => setMode("roles")}
-            colors={colors}
-          />
-          <SegBtn
-            label="People"
-            active={mode === "people"}
-            onPress={() => setMode("people")}
-            colors={colors}
-          />
-        </View>
+        <SegmentedTabs
+          options={[
+            { key: "roles", label: "Roles" },
+            { key: "people", label: "People" },
+          ]}
+          value={mode}
+          onChange={setMode}
+          accessibilityLabel="Roster view"
+        />
       )}
       {!isWide && renderOverflowButton()}
     </View>
@@ -1059,20 +1062,15 @@ export function RosterGridScreen() {
 
   // The shared view toggle, reused by the header (mobile) and toolbar (desktop).
   const renderViewToggle = () => (
-    <View style={styles.segmented}>
-      <SegBtn
-        label="Roles"
-        active={mode === "roles"}
-        onPress={() => setMode("roles")}
-        colors={colors}
-      />
-      <SegBtn
-        label="People"
-        active={mode === "people"}
-        onPress={() => setMode("people")}
-        colors={colors}
-      />
-    </View>
+    <SegmentedTabs
+      options={[
+        { key: "roles", label: "Roles" },
+        { key: "people", label: "People" },
+      ]}
+      value={mode}
+      onChange={setMode}
+      accessibilityLabel="Roster view"
+    />
   );
 
   if (data === undefined) {
@@ -1249,17 +1247,17 @@ export function RosterGridScreen() {
   const renderLegend = () => (
     <View style={styles.legend}>
       <LegendItem icon="checkmark" color={colors.success} label="Confirmed" colors={colors} />
-      <LegendItem icon="time-outline" color={colors.warning} label="Awaiting" colors={colors} />
+      <LegendItem icon="time" color={colors.warning} label="Awaiting" colors={colors} />
       <LegendItem icon="close" color={colors.destructive} label="Declined" colors={colors} />
-      <LegendItem icon="ellipse-outline" color={colors.textTertiary} label="Open" colors={colors} />
-      <LegendItem icon="warning" color={colors.warning} label="Double-booked" colors={colors} />
+      <LegendItem icon="add" color={colors.textTertiary} label="Open" colors={colors} open />
+      <LegendItem icon="warning" color={colors.destructive} label="Double-booked" colors={colors} />
     </View>
   );
 
   // -------------------------------------------------------------------------
   // Header row of event columns (shared by both views)
   // -------------------------------------------------------------------------
-  const renderHeaderRow = (cornerLabel: string) => (
+  const renderHeaderRow = (kicker: string, count: number) => (
     <View style={[styles.matrixHeaderRow, { borderBottomColor: colors.border }]}>
       <View
         style={[
@@ -1267,9 +1265,10 @@ export function RosterGridScreen() {
           { width: NAME_W, height: HEADER_H, backgroundColor: colors.surface },
         ]}
       >
-        <Text style={[styles.cornerText, { color: colors.textSecondary }]}>
-          {cornerLabel}
+        <Text style={[styles.cornerKicker, { color: colors.textSecondary }]}>
+          {kicker.toUpperCase()}
         </Text>
+        <Text style={[styles.cornerCount, { color: colors.text }]}>{count}</Text>
       </View>
       <ScrollView
         ref={headerScrollRef}
@@ -1834,10 +1833,8 @@ export function RosterGridScreen() {
   );
 
   const rows = mode === "roles" ? roleRows.length : visibleMembers.length;
-  const cornerLabel =
-    mode === "roles"
-      ? `${visibleRoles.length} ${visibleRoles.length === 1 ? "role" : "roles"}`
-      : `${visibleMembers.length} ${visibleMembers.length === 1 ? "person" : "people"}`;
+  const cornerKicker = mode === "roles" ? "Roles" : "People";
+  const cornerCount = mode === "roles" ? visibleRoles.length : visibleMembers.length;
 
   // Publish button label (#477 FR-3). One event → name the date; several with
   // drafts left → generic; all published → "Re-send". Anyone who can see this
@@ -1903,7 +1900,7 @@ export function RosterGridScreen() {
           full width and AssignSheet overlays as a modal (below). */}
       <View style={isWide ? styles.contentRowWide : styles.contentColumn}>
         <View style={styles.gridArea}>
-          {renderHeaderRow(cornerLabel)}
+          {renderHeaderRow(cornerKicker, cornerCount)}
           <View
             style={styles.matrixBody}
             onLayout={(e) => {
@@ -2375,6 +2372,16 @@ function RoleCellView({
             ]}
           >
             <Avatar name={o.userName} imageUrl={o.profilePhoto} size={AV} />
+            {/* Corner status disc — mirrors the legend glyphs so the ring's
+                color has a redundant, colorblind-safe icon. */}
+            <View
+              style={[
+                styles.statusBadge,
+                { backgroundColor: statusColor(o.status, colors), borderColor: colors.surface },
+              ]}
+            >
+              <Ionicons name={statusBadgeIcon(o.status)} size={7} color="#fff" />
+            </View>
           </View>
         ))}
         {overflow > 0 && (
@@ -3366,9 +3373,25 @@ function RoleNameCell({
           </Text>
         </Pressable>
       )}
-      <Text style={[styles.subCount, { color: colors.textTertiary }]}>
-        covered {coveredCount}/{total}
-      </Text>
+      <View style={styles.cov}>
+        <View style={[styles.covBar, { backgroundColor: colors.surfaceSecondary }]}>
+          <View
+            style={[
+              styles.covFill,
+              {
+                width: total > 0 ? `${(coveredCount / total) * 100}%` : "0%",
+                backgroundColor: coveredCount >= total ? colors.success : colors.warning,
+              },
+            ]}
+          />
+        </View>
+        <Text style={[styles.covText, { color: colors.textSecondary }]}>
+          {coveredCount}/{total}
+        </Text>
+        {coveredCount < total && (
+          <Ionicons name="warning-outline" size={11} color={colors.warning} />
+        )}
+      </View>
     </View>
   );
 }
@@ -3376,33 +3399,6 @@ function RoleNameCell({
 // ---------------------------------------------------------------------------
 // Small shared UI
 // ---------------------------------------------------------------------------
-function SegBtn({
-  label,
-  active,
-  onPress,
-  colors,
-}: {
-  label: string;
-  active: boolean;
-  onPress: () => void;
-  colors: Colors;
-}) {
-  return (
-    <Pressable
-      onPress={onPress}
-      style={[
-        styles.segBtn,
-        { backgroundColor: active ? colors.surface : "transparent" },
-        active && styles.segBtnActive,
-      ]}
-    >
-      <Text style={[styles.segBtnText, { color: active ? colors.text : colors.textSecondary }]}>
-        {label}
-      </Text>
-    </Pressable>
-  );
-}
-
 function Chip({
   icon,
   trailingIcon,
@@ -3443,15 +3439,26 @@ function LegendItem({
   color,
   label,
   colors,
+  open,
 }: {
   icon: keyof typeof Ionicons.glyphMap;
   color: string;
   label: string;
   colors: Colors;
+  /** "Open" gets a dashed outline circle instead of a filled swatch. */
+  open?: boolean;
 }) {
   return (
     <View style={styles.legendItem}>
-      <Ionicons name={icon} size={12} color={color} />
+      {open ? (
+        <View style={[styles.legendSwatchOpen, { borderColor: color }]}>
+          <Ionicons name={icon} size={8} color={color} />
+        </View>
+      ) : (
+        <View style={[styles.legendSwatch, { backgroundColor: color }]}>
+          <Ionicons name={icon} size={8} color="#fff" />
+        </View>
+      )}
       <Text style={[styles.legendText, { color: colors.textSecondary }]}>{label}</Text>
     </View>
   );
@@ -3799,21 +3806,6 @@ const styles = StyleSheet.create({
   emptyPrimaryButton: { width: "100%" },
   emptySecondary: { minHeight: 24, alignItems: "center", justifyContent: "center" },
   emptySecondaryText: { fontSize: 15, fontWeight: "500" },
-  segmented: {
-    flexDirection: "row",
-    borderRadius: 9,
-    padding: 2,
-    backgroundColor: "rgba(120,120,128,0.12)",
-  },
-  segBtn: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 7 },
-  segBtnActive: {
-    shadowColor: "#000",
-    shadowOpacity: 0.12,
-    shadowRadius: 2,
-    shadowOffset: { width: 0, height: 1 },
-    elevation: 1,
-  },
-  segBtnText: { fontSize: 13, fontWeight: "600" },
   filterBar: {
     paddingHorizontal: 12,
     paddingVertical: 8,
@@ -3862,11 +3854,28 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 7,
   },
-  legendItem: { flexDirection: "row", alignItems: "center", gap: 4 },
+  legendItem: { flexDirection: "row", alignItems: "center", gap: 6 },
+  legendSwatch: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  legendSwatchOpen: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    borderWidth: 1.5,
+    borderStyle: "dashed",
+    alignItems: "center",
+    justifyContent: "center",
+  },
   legendText: { fontSize: 11 },
   matrixHeaderRow: { flexDirection: "row", borderBottomWidth: StyleSheet.hairlineWidth },
-  corner: { justifyContent: "flex-end", paddingHorizontal: 12, paddingBottom: 8 },
-  cornerText: { fontSize: 12, fontWeight: "600" },
+  corner: { justifyContent: "flex-end", paddingHorizontal: 12, paddingBottom: 8, gap: 3 },
+  cornerKicker: { fontSize: 10, fontWeight: "700", letterSpacing: 1 },
+  cornerCount: { fontSize: 15, fontWeight: "700", fontVariant: ["tabular-nums"] },
   row: { flexDirection: "row" },
   headerCell: {
     alignItems: "center",
@@ -3947,6 +3956,10 @@ const styles = StyleSheet.create({
   },
   leaderTag: { fontSize: 10 },
   subCount: { fontSize: 11, fontWeight: "600", marginTop: 1 },
+  cov: { flexDirection: "row", alignItems: "center", gap: 7, marginTop: 4 },
+  covBar: { width: 52, height: 5, borderRadius: 5, overflow: "hidden" },
+  covFill: { height: "100%", borderRadius: 5 },
+  covText: { fontSize: 10.5, fontWeight: "600", fontVariant: ["tabular-nums"] },
   cell: {
     alignItems: "center",
     justifyContent: "center",
@@ -3964,6 +3977,17 @@ const styles = StyleSheet.create({
   },
   overflowChip: { width: 26, height: 26 },
   overflowText: { fontSize: 10, fontWeight: "700" },
+  statusBadge: {
+    position: "absolute",
+    right: -3,
+    bottom: -3,
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    borderWidth: 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   openSlot: {
     width: 26,
     height: 26,

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -1027,20 +1027,29 @@ export function RosterGridScreen() {
         )}
       </View>
       {groupId && <GridPresenceBar groupId={groupId} />}
-      {/* On desktop the view toggle moves into the single toolbar row below
-          (renderDesktopToolbar); on mobile it stays here in the header. */}
-      {!isWide && (
-        <SegmentedTabs
-          options={[
-            { key: "roles", label: "Roles" },
-            { key: "people", label: "People" },
-          ]}
-          value={mode}
-          onChange={setMode}
-          accessibilityLabel="Roster view"
-        />
-      )}
-      {!isWide && renderOverflowButton()}
+      {/* View toggle + Publish + overflow sit on the title row (matching the
+          prototype); the row below is just filters. On mobile the toggle stays
+          here and Publish is the bottom bar. */}
+      {!isWide ? (
+        <>
+          <SegmentedTabs
+            options={[
+              { key: "roles", label: "Roles" },
+              { key: "people", label: "People" },
+            ]}
+            value={mode}
+            onChange={setMode}
+            accessibilityLabel="Roster view"
+          />
+          {renderOverflowButton()}
+        </>
+      ) : data ? (
+        <View style={styles.headerActions}>
+          {renderViewToggle()}
+          {renderPublishButton(false)}
+          {renderOverflowButton()}
+        </View>
+      ) : null}
     </View>
   );
 
@@ -1228,19 +1237,16 @@ export function RosterGridScreen() {
     </View>
   );
 
-  // Desktop: one horizontal toolbar row — view toggle, filters, then Publish
-  // pinned right. Replaces both the header toggle and the stacked filter bar.
+  // Desktop: the filters row. View toggle + Publish + overflow now live on the
+  // title row (renderHeaderBar), matching the prototype.
   const renderDesktopToolbar = () => (
     <View style={[styles.toolbar, { borderBottomColor: colors.border }]}>
-      {renderViewToggle()}
       {teamChip}
       {groupScopeChip}
       {openOnlyChip}
       {availableOnlyChip}
       {mode === "people" && <View style={styles.toolbarSearch}>{renderSearchBox()}</View>}
       <View style={styles.toolbarSpacer} />
-      {renderPublishButton(false)}
-      {renderOverflowButton()}
     </View>
   );
 
@@ -3787,6 +3793,7 @@ const styles = StyleSheet.create({
   back: { width: 36, padding: 4 },
   overflowBtn: { width: 36, height: 36, alignItems: "center", justifyContent: "center" },
   headerTitleWrap: { flex: 1 },
+  headerActions: { flexDirection: "row", alignItems: "center", gap: 8 },
   headerTitle: { fontSize: 17, fontWeight: "600" },
   headerSub: { fontSize: 12, marginTop: 1 },
   centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },

--- a/apps/mobile/features/scheduling/components/RunSheetItemEditors.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetItemEditors.tsx
@@ -147,6 +147,11 @@ export function AddButton({
   );
 }
 
+// Monospace + tabular figures give the numeric run-sheet cells a "broadcast
+// rundown" feel (aligned digits). The repo already uses this Menlo/monospace
+// Platform.select idiom elsewhere.
+const MONO_FONT = Platform.select({ ios: "Menlo", default: "monospace" });
+
 // RN-Web draws a browser focus ring on the underlying <input> that visually
 // bleeds past this tiny cell; suppress it so the input stays fully contained.
 const webNoOutline: TextStyle | undefined =
@@ -175,11 +180,8 @@ export function DurationCell({
       keyboardType="numbers-and-punctuation"
       maxLength={6}
       accessibilityLabel="Duration (minutes:seconds)"
-      style={[
-        styles.durationInput,
-        { color: colors.text, borderColor: colors.border },
-        webNoOutline,
-      ]}
+      borderless
+      style={[styles.durationInput, { color: colors.text }, webNoOutline]}
     />
   );
 }
@@ -530,15 +532,18 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   timingChipText: { fontSize: 12, fontWeight: "600" },
+  // Reads as plain text at rest (InlineText `borderless` supplies the border /
+  // fill on focus); monospace + tabular figures keep durations digit-aligned.
   durationInput: {
     width: 60,
     alignSelf: "center",
     fontSize: 13,
     textAlign: "center",
-    borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 6,
     paddingVertical: 3,
     paddingHorizontal: 4,
+    fontFamily: MONO_FONT,
+    fontVariant: ["tabular-nums"],
   },
   actionBtn: { padding: 4 },
   fieldLabel: {

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -551,14 +551,31 @@ export function RunSheetScreen() {
           { backgroundColor: colors.surface, borderBottomColor: colors.border },
         ]}
       >
-        <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBtn}>
-          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBackBtn}>
+          <Ionicons name="chevron-back" size={26} color={colors.text} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text }]}>Run sheet</Text>
+        <View style={styles.headerTitleBlock}>
+          <Text
+            style={[styles.headerEventTitle, { color: colors.text }]}
+            numberOfLines={1}
+          >
+            {event?.title ?? "Run sheet"}
+          </Text>
+          {event ? (
+            <Text
+              style={[styles.headerEventMeta, { color: colors.textSecondary }]}
+              numberOfLines={1}
+            >
+              {formatEventDateLong(event.eventDate)}
+              {times.length > 0
+                ? ` · ${formatServiceRanges(times, duringTotalSec)}`
+                : ""}
+            </Text>
+          ) : null}
+        </View>
         {/* Run sheet ⇄ Tasks switcher — the entry point to the leader Event Tasks
             "database view" for this plan. Shown only when the community has opted
-            into Event Tasks; the Tasks screen itself re-checks the flag + leader
-            role. When the flag is off, keep a spacer so the title stays centered. */}
+            into Event Tasks; the Tasks screen itself re-checks the flag + leader role. */}
         {eventTasksEnabled ? (
           <SegmentedTabs
             options={[
@@ -572,9 +589,7 @@ export function RunSheetScreen() {
             }}
             accessibilityLabel="View"
           />
-        ) : (
-          <View style={styles.headerBtn} />
-        )}
+        ) : null}
       </View>
 
       {loading ? (
@@ -591,18 +606,6 @@ export function RunSheetScreen() {
         (() => {
           const listHeader = (
             <View>
-              <Text style={[styles.planTitle, { color: colors.text }]}>
-                {event.title}
-              </Text>
-              <Text style={[styles.planDate, { color: colors.textSecondary }]}>
-                {formatEventDateLong(event.eventDate)}
-              </Text>
-              {/* The "during" phase is the event window; before/after bracket it. */}
-              {times.length > 0 ? (
-                <Text style={[styles.ranges, { color: colors.text }]}>
-                  {formatServiceRanges(times, duringTotalSec)}
-                </Text>
-              ) : null}
               {isLeader ? (
                 <PlanTemplateToolbar
                   label="Run-sheet template"
@@ -943,6 +946,15 @@ const styles = StyleSheet.create({
   },
   headerBtn: { width: 36, padding: 4, alignItems: "center" },
   headerTitle: { flex: 1, fontSize: 17, fontWeight: "600", textAlign: "center" },
+  headerBackBtn: { padding: 4 },
+  headerTitleBlock: { flex: 1, minWidth: 0, marginLeft: 4, marginRight: 8 },
+  headerEventTitle: { fontSize: 18, fontWeight: "700", letterSpacing: -0.3 },
+  headerEventMeta: {
+    fontSize: 12,
+    marginTop: 2,
+    fontFamily: Platform.select({ ios: "Menlo", default: "monospace" }),
+    fontVariant: ["tabular-nums"],
+  },
   centered: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
   errorText: { fontSize: 14 },
   gridContent: { paddingBottom: 8 },

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -959,8 +959,13 @@ const styles = StyleSheet.create({
   cellText: { fontSize: 13 },
   muted: { fontSize: 13, fontWeight: "500" },
   whoChips: { flexDirection: "row", alignItems: "center", gap: 4, flexWrap: "wrap" },
-  // "Time" — a quiet, contained read-only clock value ("9:00 AM").
-  timeText: { fontSize: 13, fontVariant: ["tabular-nums"] },
+  // "Time" — a quiet, contained read-only clock value ("9:00 AM"). Monospace +
+  // tabular figures give it the aligned "broadcast rundown" feel.
+  timeText: {
+    fontSize: 13,
+    fontFamily: Platform.select({ ios: "Menlo", default: "monospace" }),
+    fontVariant: ["tabular-nums"],
+  },
   // The per-row "⋯" actions trigger — centered in its compact cell.
   actionsTrigger: { flex: 1, alignItems: "center", justifyContent: "center" },
 });


### PR DESCRIPTION
## What
Brings the **roster grid**, **run sheet**, and **event tasks** screens to visual parity with the approved prototypes (spacing + components) and adds the roster date-header → Tasks link. Companion to #554 (which shipped the run-sheet/tasks structure). Only **color** differs from the prototype — prod uses each community's brand color + neutral surfaces (no cream/amber), as approved.

## Roster grid
- Coverage **mini-meter** (bar + `X/Y` + warning) replacing `covered X/Y` text
- Avatar **status badges** (✓ / ⏱ / ✕) on the status ring
- **Filled-disc legend** with glyphs
- Shared **SegmentedTabs** for Roles/People (replaces local SegBtn)
- **ROLES/PEOPLE** kicker + tabular count corner
- **Tasks** chip + "Open tasks" menu in the date header (gated on `eventTasksEnabled`), one shared row with the Run-sheet chip so header height is unchanged
- Team sections, People view, assign flow, synced scroll — untouched

## Run sheet
- **Monospace/tabular** time + duration
- Duration field reads as **text (borderless until focus)** via a scoped opt-in `InlineText` prop (default unchanged for other callers)

## Event tasks
- Readiness: four tiles → one compact **READY bar** + inline Pre/During/Post counts; per-team breakdown kept as small chips
- Monospace readiness counts

## Verification
`tsc` clean (no new errors). Verified all three screens in-browser (Playwright) against the prototypes: coverage meters, badges, legend, corner, SegmentedTabs, mono numerics, borderless duration, and the readiness bar all render as intended; team sections / People view / drag / filters intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)