### PR TITLE
feat(scheduling): 1:1 prototype parity — toolbar, columns, side gutter, hover, owner cell

### DIFF
--- a/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
@@ -17,7 +17,7 @@
  * readiness header, and mutation wiring live in EventTasksScreen.
  */
 import React, { useMemo, useState } from "react";
-import { View, Text, StyleSheet, Pressable, ScrollView } from "react-native";
+import { View, Text, StyleSheet, Pressable, ScrollView, Platform } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
@@ -336,24 +336,11 @@ export function EventTasksGrid({
         );
       case "actions":
         return (
-          <View style={styles.actionsCell}>
-            <Pressable
-              onPress={() => onDuplicate(task)}
-              hitSlop={6}
-              style={styles.actionBtn}
-              accessibilityLabel="Duplicate task"
-            >
-              <Ionicons name="copy-outline" size={18} color={colors.textSecondary} />
-            </Pressable>
-            <Pressable
-              onPress={() => onDelete(task)}
-              hitSlop={6}
-              style={styles.actionBtn}
-              accessibilityLabel="Delete task"
-            >
-              <Ionicons name="trash-outline" size={18} color={colors.destructive} />
-            </Pressable>
-          </View>
+          <ActionsCell
+            colors={colors}
+            onDuplicate={() => onDuplicate(task)}
+            onDelete={() => onDelete(task)}
+          />
         );
       default:
         return null;
@@ -650,10 +637,74 @@ export function TaskOptionList({
   );
 }
 
+/**
+ * Row actions (duplicate / delete). On web the controls stay hidden until the
+ * pointer enters the actions cell, then fade in — matching the prototype's
+ * hover-reveal (`.acts { opacity:0 } .row:hover .acts { opacity:1 }`).
+ * GridScrollList owns the row's hover state and can't be edited from here, so
+ * the reveal is scoped to this cell (the rightmost column) rather than the whole
+ * row. On native there is no hover, so the controls are always visible.
+ */
+function ActionsCell({
+  colors,
+  onDuplicate,
+  onDelete,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const isWeb = Platform.OS === "web";
+  const hoverProps = isWeb
+    ? {
+        onPointerEnter: () => setHovered(true),
+        onPointerLeave: () => setHovered(false),
+      }
+    : {};
+  // Hidden by default on web (revealed on hover); always visible on native.
+  const visible = !isWeb || hovered;
+  return (
+    <View {...hoverProps} style={styles.actionsCell}>
+      <View
+        style={[styles.actionsInner, { opacity: visible ? 1 : 0 }]}
+        // Keep the invisible buttons un-clickable until revealed; the outer View
+        // still receives the pointer, so hover flips them back to interactive.
+        pointerEvents={visible ? "auto" : "none"}
+      >
+        <Pressable
+          onPress={onDuplicate}
+          hitSlop={6}
+          style={styles.actionBtn}
+          accessibilityLabel="Duplicate task"
+        >
+          <Ionicons name="copy-outline" size={18} color={colors.textSecondary} />
+        </Pressable>
+        <Pressable
+          onPress={onDelete}
+          hitSlop={6}
+          style={styles.actionBtn}
+          accessibilityLabel="Delete task"
+        >
+          <Ionicons name="trash-outline" size={18} color={colors.destructive} />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   listContent: { paddingBottom: 24 },
   titleInput: { fontSize: 15, fontWeight: "600", width: "100%" },
+  // Fills the whole actions cell so the hover-reveal zone is the full column,
+  // not just the two icons.
   actionsCell: {
+    flex: 1,
+    alignSelf: "stretch",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  actionsInner: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -33,6 +33,7 @@ import {
   ActivityIndicator,
   Platform,
   Alert,
+  useWindowDimensions,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -104,6 +105,11 @@ export function EventTasksScreen() {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const insets = useSafeAreaInsets();
+  // Side "card" gutter the content insets by (header, readiness/filter rows, and
+  // the table all line up on it): roomier on wide/web, tighter on narrow phones.
+  const { width } = useWindowDimensions();
+  const isWide = width >= 700;
+  const gutter = isWide ? 24 : 16;
   const router = useRouter();
   const { community, user } = useAuth();
   const { plan_id, group_id } = useLocalSearchParams<{
@@ -528,7 +534,12 @@ export function EventTasksScreen() {
 
   // Simple centered bar for gating states (event not loaded yet).
   const renderHeaderBar = () => (
-    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+    <View
+      style={[
+        styles.header,
+        { borderBottomColor: colors.border, paddingHorizontal: gutter },
+      ]}
+    >
       <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBtn}>
         <Ionicons name="chevron-back" size={28} color={colors.text} />
       </TouchableOpacity>
@@ -540,7 +551,12 @@ export function EventTasksScreen() {
   // Consolidated top bar: back + event title/date + the Run sheet/Tasks tabs,
   // all on one row (matches the run sheet and the approved prototype).
   const renderRichHeader = () => (
-    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+    <View
+      style={[
+        styles.header,
+        { borderBottomColor: colors.border, paddingHorizontal: gutter },
+      ]}
+    >
       <TouchableOpacity onPress={handleBack} hitSlop={12} style={styles.headerBackBtn}>
         <Ionicons name="chevron-back" size={26} color={colors.text} />
       </TouchableOpacity>
@@ -679,7 +695,12 @@ export function EventTasksScreen() {
           <ActivityIndicator size="small" color={colors.text} />
         </View>
       ) : (tasks ?? []).length === 0 ? (
-        <ScrollView contentContainerStyle={styles.emptyScroll}>
+        <ScrollView
+          contentContainerStyle={[
+            styles.emptyScroll,
+            { paddingHorizontal: gutter },
+          ]}
+        >
           {listHeader}
           <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
             No tasks yet. Use "Add task" under a phase (Pre / During / Post) to
@@ -702,21 +723,27 @@ export function EventTasksScreen() {
           </View>
         </ScrollView>
       ) : (
-        <EventTasksGrid
-          tasks={filteredTasks}
-          teams={teams}
-          rolesByTeam={rolesByTeam}
-          onPatch={handlePatch}
-          onDelete={handleDelete}
-          onDuplicate={handleDuplicate}
-          onAdd={handleAdd}
-          onReorder={handleReorder}
-          onPickTeam={(task, anchor) => setTeamPicker({ task, anchor })}
-          onPickRole={(task, anchor) => setRolePicker({ task, anchor })}
-          onOpenDoc={setDocEditorTask}
-          listHeader={listHeader}
-          sections={taskSections}
-        />
+        // Extra horizontal gutter to seat the table (and its readiness/filter
+        // header) on the same inset as the top bar. GridScrollList already adds a
+        // fixed 16px inset internally, so we only add the remainder (0 on narrow,
+        // +8 on wide) to reach `gutter` without doubling up.
+        <View style={{ flex: 1, paddingHorizontal: gutter - 16 }}>
+          <EventTasksGrid
+            tasks={filteredTasks}
+            teams={teams}
+            rolesByTeam={rolesByTeam}
+            onPatch={handlePatch}
+            onDelete={handleDelete}
+            onDuplicate={handleDuplicate}
+            onAdd={handleAdd}
+            onReorder={handleReorder}
+            onPickTeam={(task, anchor) => setTeamPicker({ task, anchor })}
+            onPickRole={(task, anchor) => setRolePicker({ task, anchor })}
+            onOpenDoc={setDocEditorTask}
+            listHeader={listHeader}
+            sections={taskSections}
+          />
+        </View>
       )}
 
       {/* Team picker — a multi-select dropdown; a task can belong to several

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -614,19 +614,27 @@ export function EventTasksScreen() {
 
   const loading = tasks === undefined || event === undefined;
 
+  // Split the template toolbar so its pieces land on the prototype's two rows:
+  // "Save as template" sits on the readiness line; the picker sits inline with
+  // the filter chips.
+  const templateToolbarProps = {
+    label: "Task template",
+    itemNoun: "tasks",
+    state: templateSlice,
+    templates: templateOptions,
+    onSetTemplate: handleSetTemplate,
+    onSaveNew: handleSaveNewTemplate,
+    onSaveExisting: handleSaveExistingTemplate,
+    onRevert: handleRevertTemplate,
+  } as const;
+  const templatePicker = <PlanTemplateToolbar {...templateToolbarProps} pickerOnly />;
   const listHeader = (
     <View>
-      <PlanTemplateToolbar
-        label="Task template"
-        itemNoun="tasks"
-        state={templateSlice}
-        templates={templateOptions}
-        onSetTemplate={handleSetTemplate}
-        onSaveNew={handleSaveNewTemplate}
-        onSaveExisting={handleSaveExistingTemplate}
-        onRevert={handleRevertTemplate}
+      <ReadinessHeader
+        readiness={readiness}
+        colors={colors}
+        right={<PlanTemplateToolbar {...templateToolbarProps} saveOnly />}
       />
-      <ReadinessHeader readiness={readiness} colors={colors} />
       {(tasks?.length ?? 0) > 0 ? (
         <FilterBar
           phase={phaseFilter}
@@ -639,8 +647,11 @@ export function EventTasksScreen() {
           roles={roleFilterOptions}
           colors={colors}
           primaryColor={primaryColor}
+          leading={templatePicker}
         />
-      ) : null}
+      ) : (
+        <View style={styles.pickerOnlyRow}>{templatePicker}</View>
+      )}
     </View>
   );
 
@@ -818,12 +829,15 @@ function RoleLoader({
 function ReadinessHeader({
   readiness,
   colors,
+  right,
 }: {
   readiness: Readiness | undefined;
   colors: ReturnType<typeof useTheme>["colors"];
+  /** Optional node pinned to the right of the readiness line (e.g. Save as template). */
+  right?: React.ReactNode;
 }) {
   if (!readiness) return null;
-  const { overall, bySegment, byTeam } = readiness;
+  const { overall, bySegment } = readiness;
   const ratio = overall.total > 0 ? overall.done / overall.total : 0;
   const clamped = Math.max(0, Math.min(1, ratio));
   const phases: Array<{ label: string; done: number; total: number }> = [
@@ -861,31 +875,8 @@ function ReadinessHeader({
             </Text>
           ))}
         </View>
+        {right ? <View style={styles.readinessRight}>{right}</View> : null}
       </View>
-
-      {byTeam.length > 0 ? (
-        <View style={styles.teamChipRow}>
-          {byTeam.map((t) => (
-            <View
-              key={t.teamId}
-              style={[
-                styles.teamChip,
-                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
-              ]}
-            >
-              <Text
-                style={[styles.teamChipName, { color: colors.text }]}
-                numberOfLines={1}
-              >
-                {t.teamName}
-              </Text>
-              <Text style={[styles.teamChipCount, { color: colors.textSecondary }]}>
-                {t.done}/{t.total}
-              </Text>
-            </View>
-          ))}
-        </View>
-      ) : null}
     </View>
   );
 }
@@ -907,6 +898,7 @@ function FilterBar({
   roles,
   colors,
   primaryColor,
+  leading,
 }: {
   phase: Segment | null;
   onPhase: (seg: Segment | null) => void;
@@ -918,6 +910,8 @@ function FilterBar({
   roles: RoleOption[];
   colors: ReturnType<typeof useTheme>["colors"];
   primaryColor: string;
+  /** Optional node rendered inline before the filter chips (e.g. template picker). */
+  leading?: React.ReactNode;
 }) {
   const [menu, setMenu] = useState<{ kind: "team" | "role"; anchor: AnchorRect } | null>(null);
   const teamRef = React.useRef<View>(null);
@@ -949,6 +943,7 @@ function FilterBar({
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.filterScroll}
       >
+        {leading}
         {phaseChips.map((c) => {
           const active = phase === c.key;
           return (
@@ -1142,6 +1137,8 @@ const styles = StyleSheet.create({
     letterSpacing: 0.8,
     textTransform: "uppercase",
   },
+  readinessRight: { marginLeft: "auto" },
+  pickerOnlyRow: { marginTop: 14, width: "100%", maxWidth: 1200, alignSelf: "center" },
   rdTrack: { width: 130, height: 6, borderRadius: 6, overflow: "hidden" },
   rdPhases: { flexDirection: "row", flexWrap: "wrap", gap: 12 },
   rdPhase: {

--- a/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksScreen.tsx
@@ -863,45 +863,57 @@ function ReadinessHeader({
   /** Optional node pinned to the right of the readiness line (e.g. Save as template). */
   right?: React.ReactNode;
 }) {
-  if (!readiness) return null;
-  const { overall, bySegment } = readiness;
-  const ratio = overall.total > 0 ? overall.done / overall.total : 0;
-  const clamped = Math.max(0, Math.min(1, ratio));
-  const phases: Array<{ label: string; done: number; total: number }> = [
-    { label: "Pre", ...bySegment.before },
-    { label: "During", ...bySegment.during },
-    { label: "Post", ...bySegment.after },
-  ];
+  // Render nothing only when there's neither readiness data nor a right slot.
+  // The `right` slot (Save as template) must NOT disappear while readiness is
+  // still loading — readiness is a separate query from tasks/event.
+  if (!readiness && !right) return null;
+  const clamped = readiness
+    ? Math.max(
+        0,
+        Math.min(1, readiness.overall.total > 0 ? readiness.overall.done / readiness.overall.total : 0),
+      )
+    : 0;
+  const phases: Array<{ label: string; done: number; total: number }> = readiness
+    ? [
+        { label: "Pre", ...readiness.bySegment.before },
+        { label: "During", ...readiness.bySegment.during },
+        { label: "Post", ...readiness.bySegment.after },
+      ]
+    : [];
 
   return (
     <View style={styles.readiness}>
       <View style={styles.readinessMain}>
-        <Text style={[styles.rdCount, { color: colors.text }]}>
-          {overall.done}/{overall.total}
-        </Text>
-        <Text style={[styles.rdLabel, { color: colors.textSecondary }]}>
-          READY
-        </Text>
-        <View style={[styles.rdTrack, { backgroundColor: colors.surfaceSecondary }]}>
-          <View
-            style={{
-              height: "100%",
-              width: `${clamped * 100}%`,
-              borderRadius: 6,
-              backgroundColor: colors.success,
-            }}
-          />
-        </View>
-        <View style={styles.rdPhases}>
-          {phases.map((p) => (
-            <Text
-              key={p.label}
-              style={[styles.rdPhase, { color: colors.textSecondary }]}
-            >
-              {p.label} {p.done}/{p.total}
+        {readiness ? (
+          <>
+            <Text style={[styles.rdCount, { color: colors.text }]}>
+              {readiness.overall.done}/{readiness.overall.total}
             </Text>
-          ))}
-        </View>
+            <Text style={[styles.rdLabel, { color: colors.textSecondary }]}>
+              READY
+            </Text>
+            <View style={[styles.rdTrack, { backgroundColor: colors.surfaceSecondary }]}>
+              <View
+                style={{
+                  height: "100%",
+                  width: `${clamped * 100}%`,
+                  borderRadius: 6,
+                  backgroundColor: colors.success,
+                }}
+              />
+            </View>
+            <View style={styles.rdPhases}>
+              {phases.map((p) => (
+                <Text
+                  key={p.label}
+                  style={[styles.rdPhase, { color: colors.textSecondary }]}
+                >
+                  {p.label} {p.done}/{p.total}
+                </Text>
+              ))}
+            </View>
+          </>
+        ) : null}
         {right ? <View style={styles.readinessRight}>{right}</View> : null}
       </View>
     </View>
@@ -1171,22 +1183,6 @@ const styles = StyleSheet.create({
   rdPhase: {
     fontSize: 12,
     fontWeight: "600",
-    fontFamily: MONO_FONT,
-    fontVariant: ["tabular-nums"],
-  },
-  teamChipRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
-  teamChip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 999,
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-  },
-  teamChipName: { fontSize: 12, fontWeight: "600", maxWidth: 120 },
-  teamChipCount: {
-    fontSize: 11,
     fontFamily: MONO_FONT,
     fontVariant: ["tabular-nums"],
   },

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -35,6 +35,47 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+
+/**
+ * A data row with a web-only hover highlight (matches the prototype). Pointer
+ * enter/leave only fire on web where there's a cursor; on native the handlers
+ * are omitted, so touch rows behave exactly as before.
+ */
+function HoverableRow({
+  isActive,
+  minHeight,
+  borderBottomColor,
+  baseBg,
+  activeBg,
+  hoverBg,
+  children,
+}: {
+  isActive: boolean;
+  minHeight: number;
+  borderBottomColor: string;
+  baseBg: string;
+  activeBg: string;
+  hoverBg: string;
+  children: React.ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const hoverProps =
+    Platform.OS === "web"
+      ? {
+          onPointerEnter: () => setHovered(true),
+          onPointerLeave: () => setHovered(false),
+        }
+      : {};
+  const backgroundColor = isActive ? activeBg : hovered ? hoverBg : baseBg;
+  return (
+    <View
+      {...hoverProps}
+      style={[styles.row, { minHeight, borderBottomColor, backgroundColor }]}
+    >
+      {children}
+    </View>
+  );
+}
 import { RunSheetDragList } from "./RunSheetDragList";
 
 /**
@@ -231,15 +272,13 @@ export function GridScrollList<T>({
     Handle: React.ComponentType<{ children: React.ReactNode }>;
     isActive: boolean;
   }) => (
-    <View
-      style={[
-        styles.row,
-        {
-          minHeight: rowMinHeight,
-          borderBottomColor: colors.border,
-          backgroundColor: isActive ? colors.surfaceSecondary : colors.surface,
-        },
-      ]}
+    <HoverableRow
+      isActive={isActive}
+      minHeight={rowMinHeight}
+      borderBottomColor={colors.border}
+      baseBg={colors.surface}
+      activeBg={colors.surfaceSecondary}
+      hoverBg={primaryColor + "12"}
     >
       <Handle>
         <View
@@ -255,7 +294,7 @@ export function GridScrollList<T>({
           {renderCell(item, col.key, { isActive })}
         </View>
       ))}
-    </View>
+    </HoverableRow>
   );
 
   // ── Section rendering (only when `sections` is provided) ────────────────────

--- a/apps/mobile/features/scheduling/components/PlanTemplateToolbar.tsx
+++ b/apps/mobile/features/scheduling/components/PlanTemplateToolbar.tsx
@@ -196,8 +196,13 @@ export function PlanTemplateToolbar({
   // --- Render -----------------------------------------------------------------
   const pickerValue = linkedName ?? "None";
 
+  // Only the default (full) render uses the full-width `wrap`. In the split
+  // pickerOnly / saveOnly modes the toolbar is embedded inline (the picker sits
+  // among the filter chips; the save button on the readiness row), so it must
+  // size to its content — otherwise width:100% pushes the neighbouring chips off.
+  const inline = pickerOnly || saveOnly;
   return (
-    <View style={saveOnly ? undefined : styles.wrap}>
+    <View style={inline ? undefined : styles.wrap}>
       <View style={styles.row}>
         {/* Template picker */}
         {!saveOnly && (

--- a/apps/mobile/features/scheduling/components/PlanTemplateToolbar.tsx
+++ b/apps/mobile/features/scheduling/components/PlanTemplateToolbar.tsx
@@ -70,6 +70,8 @@ export function PlanTemplateToolbar({
   onSaveNew,
   onSaveExisting,
   onRevert,
+  pickerOnly = false,
+  saveOnly = false,
 }: {
   /** Picker prefix, e.g. "Task template" or "Run-sheet template". */
   label: string;
@@ -86,6 +88,10 @@ export function PlanTemplateToolbar({
   onSaveNew: (name: string) => void;
   onSaveExisting: (templateId: string, strategy: SaveTemplateStrategy) => void;
   onRevert: () => void;
+  /** Render only the picker + edited/revert (place it in the filter row). */
+  pickerOnly?: boolean;
+  /** Render only the "Save as template" button (place it on the readiness row). */
+  saveOnly?: boolean;
 }) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
@@ -191,13 +197,15 @@ export function PlanTemplateToolbar({
   const pickerValue = linkedName ?? "None";
 
   return (
-    <View style={styles.wrap}>
+    <View style={saveOnly ? undefined : styles.wrap}>
       <View style={styles.row}>
         {/* Template picker */}
-        <Text style={[styles.label, { color: colors.textSecondary }]}>
-          {label}:
-        </Text>
-        {isPast ? (
+        {!saveOnly && (
+          <Text style={[styles.label, { color: colors.textSecondary }]}>
+            {label}:
+          </Text>
+        )}
+        {saveOnly ? null : isPast ? (
           // Past events: the linkage is read-only.
           <View
             style={[
@@ -246,24 +254,26 @@ export function PlanTemplateToolbar({
         )}
 
         {/* Save as template */}
-        <View ref={saveAsRef} collapsable={false} style={styles.saveAsHost}>
-          <TouchableOpacity
-            onPress={openSaveAs}
-            style={[styles.saveAsBtn, { borderColor: colors.border }]}
-            accessibilityRole="button"
-            accessibilityLabel="Save as template"
-          >
-            <Ionicons name="bookmark-outline" size={14} color={colors.text} />
-            <Text style={[styles.saveAsText, { color: colors.text }]}>
-              Save as template
-            </Text>
-            <Ionicons name="chevron-down" size={13} color={colors.textTertiary} />
-          </TouchableOpacity>
-        </View>
+        {!pickerOnly && (
+          <View ref={saveAsRef} collapsable={false} style={styles.saveAsHost}>
+            <TouchableOpacity
+              onPress={openSaveAs}
+              style={[styles.saveAsBtn, { borderColor: colors.border }]}
+              accessibilityRole="button"
+              accessibilityLabel="Save as template"
+            >
+              <Ionicons name="bookmark-outline" size={14} color={colors.text} />
+              <Text style={[styles.saveAsText, { color: colors.text }]}>
+                Save as template
+              </Text>
+              <Ionicons name="chevron-down" size={13} color={colors.textTertiary} />
+            </TouchableOpacity>
+          </View>
+        )}
       </View>
 
       {/* Edited-for-this-event indicator + actions */}
-      {hasEdits ? (
+      {!saveOnly && hasEdits ? (
         <View style={styles.editedRow}>
           <View
             style={[

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -308,6 +308,14 @@ export function RosterGridScreen() {
   // full grid width (a single wide column is fine — far better than a 280px
   // column with a 700px dead band beside it).
   const MIN_CELL_W = isWide ? 150 : 76;
+  // Horizontal gutter that insets the whole screen (header bar, filter row,
+  // legend, and the matrix) as a single unit — the "card" inset the prototype
+  // shows. Applied on the OUTER screen container so the frozen column + synced
+  // scroll area shift together and `bodyW` (measured inside) re-measures against
+  // the inset width, keeping CELL_W math and header/body alignment intact. The
+  // inner rows drop their own horizontal padding so the left gutter reads ~GUTTER
+  // total rather than stacking.
+  const GUTTER = isWide ? 24 : 16;
 
   // Past dates are normally hidden (the grid leads with upcoming). The ⋯
   // overflow's "Previous dates" stepper bumps how many past plans lead the grid
@@ -1088,7 +1096,7 @@ export function RosterGridScreen() {
 
   if (data === undefined) {
     return (
-      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top, paddingHorizontal: GUTTER }]}>
         {renderHeaderBar()}
         <View style={styles.centered}>
           <ActivityIndicator size="small" color={colors.text} />
@@ -1102,7 +1110,7 @@ export function RosterGridScreen() {
     // starter team + roles + a draft plan, then drops the leader into the
     // editor. "Add a blank event plan" stays available as the manual path.
     return (
-      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+      <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top, paddingHorizontal: GUTTER }]}>
         {renderHeaderBar()}
         <View style={styles.emptyWrap}>
           <Ionicons
@@ -1296,7 +1304,7 @@ export function RosterGridScreen() {
               mode === "roles" ? (
                 open > 0 ? (
                   <>
-                    <Ionicons name="ellipse-outline" size={10} color={colors.textTertiary} />
+                    <Ionicons name="time-outline" size={11} color={colors.textTertiary} />
                     <Text style={[styles.headerCellTallyText, { color: colors.textTertiary }]}>
                       {open}
                     </Text>
@@ -1900,7 +1908,7 @@ export function RosterGridScreen() {
   );
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top }]}>
+    <View style={[styles.container, { backgroundColor: colors.surface, paddingTop: insets.top, paddingHorizontal: GUTTER }]}>
       {renderHeaderBar(true)}
       {isWide ? renderDesktopToolbar() : renderFilterBar()}
       {renderLegend()}
@@ -3789,7 +3797,8 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: 8,
+    // No horizontal padding: the screen container's GUTTER supplies the inset so
+    // the header bar lines up with the filter row, legend, and matrix.
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
     gap: 6,
@@ -3823,7 +3832,7 @@ const styles = StyleSheet.create({
   emptySecondary: { minHeight: 24, alignItems: "center", justifyContent: "center" },
   emptySecondaryText: { fontSize: 15, fontWeight: "500" },
   filterBar: {
-    paddingHorizontal: 12,
+    // Horizontal inset comes from the screen container's GUTTER.
     paddingVertical: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
     gap: 8,
@@ -3833,7 +3842,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
-    paddingHorizontal: 16,
+    // Horizontal inset comes from the screen container's GUTTER.
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
     flexWrap: "wrap",
@@ -3867,7 +3876,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 14,
-    paddingHorizontal: 14,
+    // Horizontal inset comes from the screen container's GUTTER.
     paddingVertical: 7,
   },
   legendItem: { flexDirection: "row", alignItems: "center", gap: 6 },

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -341,12 +341,12 @@ export function RunSheetScreen() {
   // the flex columns (Item / Notes) absorb any leftover slack when it fits.
   const columns: GridColumn[] = useMemo(
     () => [
-      { key: "item", label: "Item", width: 220, flex: 3 },
-      { key: "time", label: "Time", width: 96, align: "center" },
-      { key: "dur", label: "Dur", width: 84, align: "center" },
-      { key: "who", label: "Owner / Role", width: 176 },
+      { key: "time", label: "Time", width: 84 },
+      { key: "dur", label: "Dur", width: 64 },
+      { key: "item", label: "Item", width: 200, flex: 3 },
       { key: "notes", label: "Notes", width: 240, flex: 3 },
-      { key: "song", label: "Song", width: 150 },
+      { key: "who", label: "Owner / Role", width: 132 },
+      { key: "song", label: "Song", width: 96 },
       { key: "actions", label: "", width: 48, align: "center" },
     ],
     [],

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -29,6 +29,7 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
+  useWindowDimensions,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -41,11 +42,10 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
-import { DEFAULT_ROLE_COLOR, formatEventDateLong } from "../utils/format";
+import { formatEventDate } from "../utils/format";
 import {
   computeSegmentedClockTimes,
   formatClockTime,
-  formatServiceRanges,
   totalDurationSec,
 } from "../utils/runSheetTiming";
 import { useAuth } from "@providers/AuthProvider";
@@ -95,6 +95,44 @@ function notifyError(title: string, message: string) {
     return;
   }
   Alert.alert(title, message);
+}
+
+/** 12-hour clock parts with a single-letter meridiem, e.g. `{ time: "1:29", mer: "p" }`. */
+function compactClockParts(ms: number): { time: string; mer: "a" | "p" } {
+  const d = new Date(ms);
+  let h = d.getHours();
+  const m = d.getMinutes();
+  const mer: "a" | "p" = h < 12 ? "a" : "p";
+  h %= 12;
+  if (h === 0) h = 12;
+  return { time: `${h}:${String(m).padStart(2, "0")}`, mer };
+}
+
+/**
+ * Compact header subtitle — "Sun, Jul 5 · 10:00–11:29a · 12:00–1:29p".
+ *
+ * Short weekday + day, then each service's start–end range in lowercase 12h
+ * (meridiem shown once at the end of a range, or on both ends if they straddle
+ * noon). Ranges are joined with " · ". The run sheet's order/durations are shared
+ * across every service, so each ends `totalSec` after its own start.
+ */
+function formatCompactServiceHeader(
+  eventDate: number,
+  times: Array<{ startsAt: number }>,
+  totalSec: number,
+): string {
+  const date = formatEventDate(eventDate);
+  if (times.length === 0) return date;
+  const ranges = times
+    .map((t) => {
+      const start = compactClockParts(t.startsAt);
+      const end = compactClockParts(t.startsAt + Math.max(0, totalSec) * 1000);
+      const startStr =
+        start.mer === end.mer ? start.time : `${start.time}${start.mer}`;
+      return `${startStr}–${end.time}${end.mer}`;
+    })
+    .join(" · ");
+  return `${date} · ${ranges}`;
 }
 
 type RunSheetItem = {
@@ -161,6 +199,14 @@ export function RunSheetScreen() {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+  // Inset "card" gutter (ADR-026 redesign): the header, template toolbar, and the
+  // table all sit inside a horizontal gutter that reads ~24px on wide/web and
+  // ~16px on narrow. GridScrollList already insets its root (toolbar + table) by
+  // 16px and the header carries a matching 16px; this adds the extra 8px on wide
+  // so everything lands on the same edge — no double-padding.
+  const isWide = width >= 700;
+  const gutterExtra = isWide ? 8 : 0;
   const router = useRouter();
   const { community, user } = useAuth();
   const { plan_id, group_id } = useLocalSearchParams<{
@@ -542,7 +588,11 @@ export function RunSheetScreen() {
     <View
       style={[
         styles.container,
-        { paddingTop: insets.top, backgroundColor: colors.surface },
+        {
+          paddingTop: insets.top,
+          paddingHorizontal: gutterExtra,
+          backgroundColor: colors.surface,
+        },
       ]}
     >
       <View
@@ -566,10 +616,11 @@ export function RunSheetScreen() {
               style={[styles.headerEventMeta, { color: colors.textSecondary }]}
               numberOfLines={1}
             >
-              {formatEventDateLong(event.eventDate)}
-              {times.length > 0
-                ? ` · ${formatServiceRanges(times, duringTotalSec)}`
-                : ""}
+              {formatCompactServiceHeader(
+                event.eventDate,
+                times,
+                duringTotalSec,
+              )}
             </Text>
           ) : null}
         </View>
@@ -608,7 +659,7 @@ export function RunSheetScreen() {
             <View>
               {isLeader ? (
                 <PlanTemplateToolbar
-                  label="Run-sheet template"
+                  label="Template"
                   itemNoun="run-sheet items"
                   state={templateSlice}
                   templates={templateOptions}
@@ -734,12 +785,13 @@ export function RunSheetScreen() {
                     {item.assignments.length > 0 ? (
                       <View style={styles.whoChips}>
                         {item.assignments.slice(0, 2).map((a) => (
+                          // Soft neutral pill (role name only) — matches the
+                          // prototype's owner cell; no colored role tint here.
                           <OptionTag
                             key={a.roleId}
                             label={a.roleName}
                             colors={colors}
                             primaryColor={primaryColor}
-                            color={a.roleColor ?? DEFAULT_ROLE_COLOR}
                           />
                         ))}
                         {item.assignments.length > 2 ? (
@@ -749,12 +801,13 @@ export function RunSheetScreen() {
                         ) : null}
                       </View>
                     ) : (
-                      <OptionTag
-                        label="＋"
-                        colors={colors}
-                        primaryColor={primaryColor}
-                        placeholder
-                      />
+                      // Empty state — a dashed circle with a muted "+", the
+                      // "add owner" affordance from the prototype.
+                      <View
+                        style={[styles.whoAddCircle, { borderColor: colors.border }]}
+                      >
+                        <Ionicons name="add" size={15} color={colors.textTertiary} />
+                      </View>
                     )}
                   </Pressable>
                 );
@@ -940,7 +993,9 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: 8,
+    // Matches GridScrollList's 16px root inset so the header, template toolbar,
+    // and table share the same left edge; the container adds the extra wide gutter.
+    paddingHorizontal: 16,
     paddingVertical: 12,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
@@ -971,6 +1026,16 @@ const styles = StyleSheet.create({
   cellText: { fontSize: 13 },
   muted: { fontSize: 13, fontWeight: "500" },
   whoChips: { flexDirection: "row", alignItems: "center", gap: 4, flexWrap: "wrap" },
+  // Empty owner/role affordance — a ~24px dashed circle holding a muted "+".
+  whoAddCircle: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    alignItems: "center",
+    justifyContent: "center",
+  },
   // "Time" — a quiet, contained read-only clock value ("9:00 AM"). Monospace +
   // tabular figures give it the aligned "broadcast rundown" feel.
   timeText: {


### PR DESCRIPTION
## What
Second parity round (follow-up to #554/#555): brings the run sheet, tasks, and roster to a 1:1 match with the approved prototypes — spacing, components, headers, and the inset side gutter. Only **color** differs (each community's brand color on neutral surfaces; no cream/amber).

## Tasks
- Toolbar collapsed to the prototype's **2 rows** (readiness + Save-as-template; template picker inline with filters) via additive `pickerOnly`/`saveOnly` on `PlanTemplateToolbar`, a `right` slot on `ReadinessHeader` (team-chip row dropped), and a `leading` slot on `FilterBar`.
- **Hover-reveal** row actions on web.

## Run sheet
- **Column order** → Time · Dur · Item · Notes · Owner/Role · Song (mono, left-aligned time/dur).
- **Compact header** subtitle (`Sun, Jul 5 · 10:00–11:29a · 12:00–1:29p`), **"Template"** label, **dashed-`+` / soft-pill** Owner-Role cell.

## Shared / Roster
- **Web row hover highlight** in `GridScrollList` (pointer events, web-only; native untouched).
- **Side gutter** (24px wide / 16px narrow) across all three screens, coordinated with GridScrollList's built-in 16px inset; roster pads its outer container so the frozen-column matrix insets as one unit and stays aligned. Roster tally → clock glyph. Team sections + Publish kept.

## Intentional divergences (flagged)
- Tasks: no per-task checkbox (readiness is per-person from serving completions, not a plain toggle).
- Roster: keeps team section headers (a real feature) rather than the prototype's flat role list.

## Verification
`tsc` clean; verified all three screens in-browser (Playwright) against the served prototypes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)