### PR TITLE
Add "No preloaded task" empty state to serving Task View

### DIFF
--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -572,6 +572,12 @@ export function ServingTasksScreen() {
   const overallDone = allTasks.filter((t) => t.completed).length;
   const overallTotal = allTasks.length;
 
+  // "Preloaded" tasks are the template (assigned) tasks for the user's role;
+  // personal tasks are the ones the user adds themselves. When the role has no
+  // preloaded tasks, we guide the user to their team lead while still letting
+  // them add their own tasks per segment.
+  const hasPreloadedTasks = allTasks.some((t) => !t.isPersonal);
+
   // Small badges on the section pills (null hides the badge).
   const sectionCounts: Record<Section, string | null> = {
     mine: overallTotal > 0 ? `${overallDone}/${overallTotal}` : null,
@@ -626,7 +632,9 @@ export function ServingTasksScreen() {
               </View>
             )
           ) : (
-            SEGMENTS.map(({ key, label }) => {
+            <>
+            {!hasPreloadedTasks ? <NoPreloadedNotice colors={colors} /> : null}
+            {SEGMENTS.map(({ key, label }) => {
             const segmentTasks = mineWithOverlay[key] ?? [];
             const done = segmentTasks.filter((t) => t.completed).length;
             const total = segmentTasks.length;
@@ -650,6 +658,10 @@ export function ServingTasksScreen() {
                   height={4}
                 />
 
+                {/* When the role has no preloaded tasks, the notice above already
+                    explains the empty state, so we skip the per-segment empty
+                    card and leave just the "Add my own task" affordance. */}
+                {segmentTasks.length === 0 && !hasPreloadedTasks ? null : (
                 <View
                   style={[
                     styles.card,
@@ -709,6 +721,7 @@ export function ServingTasksScreen() {
                     ))
                   )}
                 </View>
+                )}
 
                 {addingSegment === key ? (
                   <AddTaskForm
@@ -750,7 +763,8 @@ export function ServingTasksScreen() {
                 )}
                 </View>
               );
-            })
+            })}
+            </>
           ))}
 
         {section === "shared" && (
@@ -1854,6 +1868,38 @@ function OfflineBanner({ colors }: { colors: ThemeColors }) {
   );
 }
 
+/**
+ * Shown at the top of the "Mine" section when the user's role has no preloaded
+ * (template) tasks. Explains the empty state and points the user to their team
+ * lead, while the per-segment "Add my own task" affordances remain available.
+ */
+function NoPreloadedNotice({ colors }: { colors: ThemeColors }) {
+  return (
+    <View style={styles.segment}>
+      <View
+        style={[
+          styles.noticeCard,
+          { backgroundColor: colors.surface, borderColor: colors.border },
+        ]}
+      >
+        <Ionicons
+          name="information-circle-outline"
+          size={20}
+          color={colors.textSecondary}
+        />
+        <View style={styles.noticeBody}>
+          <Text style={[styles.noticeMessage, { color: colors.text }]}>
+            No preloaded task. Please contact your team lead to add tasks.
+          </Text>
+          <Text style={[styles.noticeHint, { color: colors.textTertiary }]}>
+            You can still add your own tasks below.
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
 function SectionLoading({ colors }: { colors: ThemeColors }) {
   return (
     <View style={styles.inlineLoading}>
@@ -1942,6 +1988,19 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
   cardEmpty: { fontSize: 14, fontStyle: "italic", padding: 16 },
+
+  // "No preloaded task" notice (Mine section, role with no assigned tasks)
+  noticeCard: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 14,
+  },
+  noticeBody: { flex: 1 },
+  noticeMessage: { fontSize: 14, lineHeight: 20, fontWeight: "500" },
+  noticeHint: { fontSize: 13, lineHeight: 18, marginTop: 4 },
 
   // Task rows
   taskRow: { paddingHorizontal: 14, paddingVertical: 12 },

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { ServingTasksScreen } from "../ServingTasksScreen";
+import { useAuthenticatedQuery } from "@services/api/convex";
+
+// --- Convex API refs used by the screen -------------------------------------
+const REF = {
+  mine: "api.functions.scheduling.eventTasks.getMyServingTasks",
+  eligibility: "api.functions.scheduling.serving.getServingEligibility",
+  shared: "api.functions.scheduling.eventTasks.getSharedTeamTasks",
+  crew: "api.functions.scheduling.eventTasks.getCrewTasks",
+  allTeams: "api.functions.scheduling.eventTasks.getAllTeamsTasks",
+};
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      scheduling: {
+        eventTasks: {
+          getMyServingTasks: "api.functions.scheduling.eventTasks.getMyServingTasks",
+          getSharedTeamTasks: "api.functions.scheduling.eventTasks.getSharedTeamTasks",
+          getCrewTasks: "api.functions.scheduling.eventTasks.getCrewTasks",
+          getAllTeamsTasks: "api.functions.scheduling.eventTasks.getAllTeamsTasks",
+          toggleSharedTeamTask: "toggleSharedTeamTask",
+          toggleTaskCompletion: "toggleTaskCompletion",
+          togglePersonalTask: "togglePersonalTask",
+          addPersonalTask: "addPersonalTask",
+          updatePersonalTask: "updatePersonalTask",
+          deletePersonalTask: "deletePersonalTask",
+        },
+        serving: {
+          getServingEligibility: "api.functions.scheduling.serving.getServingEligibility",
+        },
+      },
+    },
+  },
+  useAuthenticatedQuery: jest.fn(),
+  useAuthenticatedMutation: () => jest.fn(),
+}));
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#fff",
+      surface: "#fafafa",
+      border: "#e5e5e5",
+      text: "#000",
+      textSecondary: "#666",
+      textTertiary: "#999",
+      error: "#c00",
+    },
+    isDark: false,
+  }),
+}));
+
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#D9A441" }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@/stores/eventModeStore", () => ({
+  useEventModeStore: (sel: (s: { activePlanId: string }) => unknown) =>
+    sel({ activePlanId: "plan-1" }),
+}));
+
+jest.mock("@providers/ConnectionProvider", () => ({
+  useConnectionStatus: () => ({
+    isNetworkAvailable: true,
+    isEffectivelyOffline: false,
+  }),
+}));
+
+const mockCacheState = { getSectionStale: () => null, setSection: jest.fn() };
+jest.mock("@/stores/servingTasksCache", () => {
+  const hook = () => mockCacheState;
+  (hook as unknown as { getState: () => typeof mockCacheState }).getState = () =>
+    mockCacheState;
+  return { useServingTasksCache: hook };
+});
+
+const mockQueueState = {
+  pending: {} as Record<string, unknown>,
+  enqueue: jest.fn(),
+  dequeue: jest.fn(),
+  all: () => [] as unknown[],
+};
+jest.mock("@/stores/servingTaskQueue", () => {
+  const hook = (sel: (s: typeof mockQueueState) => unknown) => sel(mockQueueState);
+  (hook as unknown as { getState: () => typeof mockQueueState }).getState = () =>
+    mockQueueState;
+  return {
+    useServingTaskQueue: hook,
+    completionId: (kind: string, taskId: string, timeLabel?: string | null) =>
+      `${kind}:${taskId}:${timeLabel ?? ""}`,
+  };
+});
+
+jest.mock("../ServingPlanSwitcher", () => ({ ServingPlanSwitcher: () => null }));
+jest.mock("../HowToViewer", () => ({ HowToViewer: () => null }));
+jest.mock("@components/ui/ProgressBar", () => ({ ProgressBar: () => null }));
+
+const mockQuery = useAuthenticatedQuery as jest.Mock;
+
+const EMPTY_MINE = { before: [], during: [], after: [] };
+
+function templateTask(overrides: Record<string, unknown> = {}) {
+  return {
+    key: "t1",
+    taskId: "task-1",
+    title: "Set up chairs",
+    segment: "before",
+    isPersonal: false,
+    completed: false,
+    ...overrides,
+  };
+}
+
+function personalTask(overrides: Record<string, unknown> = {}) {
+  return {
+    key: "p1",
+    taskId: "personal-1",
+    title: "Bring water bottle",
+    segment: "before",
+    isPersonal: true,
+    completed: false,
+    ...overrides,
+  };
+}
+
+function mockQueries(mine: unknown) {
+  mockQuery.mockImplementation((ref: string) => {
+    switch (ref) {
+      case REF.mine:
+        return mine;
+      case REF.eligibility:
+        return {
+          plans: [{ planId: "plan-1", title: "Sunday Gathering", startsAt: 0 }],
+        };
+      case REF.shared:
+      case REF.crew:
+      case REF.allTeams:
+        return [];
+      default:
+        return undefined;
+    }
+  });
+}
+
+const NO_PRELOAD_MESSAGE =
+  "No preloaded task. Please contact your team lead to add tasks.";
+
+describe("ServingTasksScreen — no preloaded tasks", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("shows the no-preloaded-task notice when the role has no template tasks", () => {
+    mockQueries(EMPTY_MINE);
+    const { getByText, queryByText, getAllByText } = render(<ServingTasksScreen />);
+
+    // The exact guidance message is shown.
+    expect(getByText(NO_PRELOAD_MESSAGE)).toBeTruthy();
+    // The generic per-segment empty text is suppressed in this state.
+    expect(queryByText("Nothing here yet.")).toBeNull();
+    // Users can still add their own tasks in every segment.
+    expect(getAllByText("Add my own task")).toHaveLength(3);
+  });
+
+  it("still shows the notice when only personal (user-added) tasks exist", () => {
+    mockQueries({ before: [personalTask()], during: [], after: [] });
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText(NO_PRELOAD_MESSAGE)).toBeTruthy();
+    // The personal task is still rendered.
+    expect(getByText("Bring water bottle")).toBeTruthy();
+  });
+
+  it("hides the notice when the role has preloaded (template) tasks", () => {
+    mockQueries({ before: [templateTask()], during: [], after: [] });
+    const { queryByText, getByText, getAllByText } = render(<ServingTasksScreen />);
+
+    expect(queryByText(NO_PRELOAD_MESSAGE)).toBeNull();
+    expect(getByText("Set up chairs")).toBeTruthy();
+    // The other (empty) segments fall back to the generic empty text.
+    expect(getAllByText("Nothing here yet.")).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a clear "No preloaded task" state to the **Mine** section of the serving Task View (`ServingTasksScreen`).

Previously, when a volunteer's role had no preloaded (template) tasks, all three segments (Before / During / After) just showed a generic *"Nothing here yet."* with no guidance on what to do.

Now, when the role has no preloaded tasks, a notice is shown at the top of the Mine section:

> **No preloaded task. Please contact your team lead to add tasks.**
> You can still add your own tasks below.

The per-segment **"Add my own task"** affordances remain, so users can still add their own tasks. The redundant per-segment empty cards are suppressed in this state (the notice already explains it).

## Behavior details

- **"Preloaded"** is defined as any assigned/template task (`isPersonal === false`).
- A role with **only personal (user-added) tasks** still shows the notice, and those personal tasks continue to render.
- When the role **does** have preloaded tasks, the notice is hidden and empty segments fall back to the existing *"Nothing here yet."* text.

## Testing

- New component test `ServingTasksScreen.test.tsx` covering three cases: no preloaded tasks, personal-only, and has-preloaded.
- Full mobile test suite passes (1186 tests), typecheck clean for the serving files, and eslint clean.

## Screens affected

Serving mode → **Tasks** tab → **Mine** section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZvCq1rT8FsMzhreyeTmPx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZvCq1rT8FsMzhreyeTmPx)_