### PR TITLE
feat(scheduling): drag-to-resize grid columns + serving-mode Team roster grid

### DIFF
--- a/apps/convex/__tests__/scheduling/serving.test.ts
+++ b/apps/convex/__tests__/scheduling/serving.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for serving-mode queries (serving.ts) — focused on the "Team" roster
+ * grid (`getServingTeamRoster`): the who's-serving payload behind the pinned
+ * Team card in the serving inbox. Verifies plan/team grouping, confirmed-only
+ * filtering, the same-day eligibility window, per-person fields (name, role,
+ * phone, isSelf), and de-duplication.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+async function setup() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/** Insert a plan directly (avoids reminder scheduling); `startsAt` = eventDate. */
+async function insertPlan(
+  t: ReturnType<typeof convexTest>,
+  world: Awaited<ReturnType<typeof setup>>["world"],
+  title: string,
+  eventDate: number,
+) {
+  return (await t.run(async (ctx: any) =>
+    ctx.db.insert("eventPlans", {
+      groupId: world.groupId,
+      communityId: world.communityId,
+      title,
+      eventDate,
+      times: [{ label: "9 AM", startsAt: eventDate }],
+      status: "published",
+      createdAt: Date.now(),
+      createdById: world.groupLeaderId,
+      updatedAt: Date.now(),
+    }),
+  )) as Id<"eventPlans">;
+}
+
+async function insertTeam(
+  t: ReturnType<typeof convexTest>,
+  world: Awaited<ReturnType<typeof setup>>["world"],
+  name: string,
+) {
+  return (await t.run(async (ctx: any) =>
+    ctx.db.insert("teams", {
+      groupId: world.groupId,
+      communityId: world.communityId,
+      name,
+      createdAt: Date.now(),
+      createdById: world.groupLeaderId,
+      updatedAt: Date.now(),
+    }),
+  )) as Id<"teams">;
+}
+
+async function insertRole(
+  t: ReturnType<typeof convexTest>,
+  world: Awaited<ReturnType<typeof setup>>["world"],
+  teamId: Id<"teams">,
+  name: string,
+  color?: string,
+) {
+  return (await t.run(async (ctx: any) =>
+    ctx.db.insert("teamRoles", {
+      teamId,
+      communityId: world.communityId,
+      name,
+      color,
+      sortOrder: 0,
+      createdAt: Date.now(),
+      createdById: world.groupLeaderId,
+    }),
+  )) as Id<"teamRoles">;
+}
+
+async function insertAssignment(
+  t: ReturnType<typeof convexTest>,
+  world: Awaited<ReturnType<typeof setup>>["world"],
+  args: {
+    planId: Id<"eventPlans">;
+    teamId: Id<"teams">;
+    roleId: Id<"teamRoles">;
+    userId: Id<"users">;
+    eventDate: number;
+    status: "confirmed" | "unconfirmed" | "declined";
+  },
+) {
+  await t.run(async (ctx: any) =>
+    ctx.db.insert("roleAssignments", {
+      ...args,
+      assignedById: world.groupLeaderId,
+      assignedAt: Date.now(),
+    }),
+  );
+}
+
+describe("getServingTeamRoster", () => {
+  it("groups confirmed volunteers by plan then team, with name/role/phone/isSelf", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Sunday Service", today);
+
+    // The fixture team is "Worship Team" with the "Drums" role. Add a second
+    // team "Production" so the grid has two columns (sorts before "Worship Team").
+    const worshipTeam = world.teamId; // "Worship Team"
+    const drums = world.roleId; // "Drums"
+    const production = await insertTeam(t, world, "Production");
+    const camera = await insertRole(t, world, production, "Camera", "#7C3AED");
+
+    // Me (the caller) on Worship Team; a teammate on Production; both confirmed.
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: worshipTeam,
+      roleId: drums,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "confirmed",
+    });
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: production,
+      roleId: camera,
+      userId: world.channelAdminId,
+      eventDate: today,
+      status: "confirmed",
+    });
+    // An UNCONFIRMED assignment must be excluded from the grid.
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: production,
+      roleId: camera,
+      userId: world.groupLeaderId,
+      eventDate: today,
+      status: "unconfirmed",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: meTok },
+    );
+
+    expect(res.plans).toHaveLength(1);
+    const p = res.plans[0];
+    expect(p.title).toBe("Sunday Service");
+    // Teams sorted by name: Production, Worship Team.
+    expect(p.teams.map((tm) => tm.name)).toEqual(["Production", "Worship Team"]);
+
+    const prod = p.teams.find((tm) => tm.name === "Production")!;
+    // Only the confirmed camera op — the unconfirmed leader is excluded.
+    expect(prod.people).toHaveLength(1);
+    expect(prod.people[0].displayName).toBe("Adminda Test");
+    expect(prod.people[0].roleName).toBe("Camera");
+    expect(prod.people[0].roleColor).toBe("#7C3AED");
+    expect(prod.people[0].isSelf).toBe(false);
+
+    const wor = p.teams.find((tm) => tm.name === "Worship Team")!;
+    expect(wor.people).toHaveLength(1);
+    expect(wor.people[0].displayName).toBe("Memberly Test");
+    expect(wor.people[0].roleName).toBe("Drums");
+    expect(wor.people[0].phone).toBe("+12025550003");
+    expect(wor.people[0].isSelf).toBe(true);
+  });
+
+  it("returns every eligible plan the user serves and excludes out-of-window plans", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+
+    const today = Date.now();
+    const nextMonth = today + 30 * DAY;
+
+    const planToday = await insertPlan(t, world, "Today Service", today);
+    const planFar = await insertPlan(t, world, "Next Month", nextMonth);
+
+    for (const [plan, when] of [
+      [planToday, today],
+      [planFar, nextMonth],
+    ] as const) {
+      await insertAssignment(t, world, {
+        planId: plan,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+        eventDate: when,
+        status: "confirmed",
+      });
+    }
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: meTok },
+    );
+
+    // Only the same-day plan is eligible; the next-month one is out of window.
+    expect(res.plans.map((p) => p.title)).toEqual(["Today Service"]);
+  });
+
+  it("de-dupes identical (user, role, team) rows into a single card", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Service", today);
+
+    for (let i = 0; i < 2; i++) {
+      await insertAssignment(t, world, {
+        planId: plan,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+        eventDate: today,
+        status: "confirmed",
+      });
+    }
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: meTok },
+    );
+    const team = res.plans[0].teams[0];
+    expect(team.people).toHaveLength(1);
+  });
+
+  it("returns no plans when the user has no confirmed assignments", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Service", today);
+    // Only an unconfirmed assignment — not eligible.
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "unconfirmed",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: meTok },
+    );
+    expect(res.plans).toEqual([]);
+  });
+});

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -415,7 +415,6 @@ type ServingTeamPerson = {
 type ServingTeamColumn = {
   teamId: string;
   name: string;
-  color: string | null;
   people: ServingTeamPerson[];
 };
 
@@ -540,7 +539,6 @@ export const getServingTeamRoster = query({
         teams.push({
           teamId,
           name: team.name,
-          color: null,
           people,
         });
       }

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -17,6 +17,7 @@ import { query } from "../../_generated/server";
 import type { QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
+import { getDisplayName } from "../../lib/utils";
 import { requireGroupMember } from "./permissions";
 import { ADD_DAYS_BEFORE } from "./teamChannelSync";
 
@@ -392,5 +393,167 @@ export const getServingUpcomingChannels = query({
     }
 
     return result;
+  },
+});
+
+/** One serving teammate card in the Team roster grid. */
+type ServingTeamPerson = {
+  userId: string;
+  displayName: string;
+  firstName: string | null;
+  /** The role they fill on this team for this plan, e.g. "Vocals". */
+  roleName: string;
+  roleColor: string | null;
+  profilePhoto: string | null;
+  /** Their phone number, if on file — powers the "Text" action. Null otherwise. */
+  phone: string | null;
+  /** True for the current user's own card (no message/text actions on self). */
+  isSelf: boolean;
+};
+
+/** One team column in a plan's Team roster grid. */
+type ServingTeamColumn = {
+  teamId: string;
+  name: string;
+  color: string | null;
+  people: ServingTeamPerson[];
+};
+
+/** One plan section in the Team roster grid. */
+type ServingTeamPlan = {
+  planId: string;
+  title: string;
+  eventDate: number;
+  teams: ServingTeamColumn[];
+};
+
+/**
+ * Serving-mode "Team" grid: who is serving alongside the current user, grouped
+ * by plan then by team. For EVERY plan the user can currently serve (same
+ * eligibility window as `getServingEligibility` — a `confirmed` assignment plus
+ * "now" inside the plan's same-day window), returns each team that has at least
+ * one confirmed volunteer as a column, and each volunteer as a card (name, the
+ * role they fill, avatar, and phone for the day-of "Text" action).
+ *
+ * One card per (user, role) confirmed assignment — a person filling two roles on
+ * the same team shows two cards. `isSelf` flags the current user's own cards so
+ * the client can suppress the message/text actions on them.
+ *
+ * Membership is already implied by the confirmed assignment, so there is no
+ * extra group-member gate here. Phone numbers are surfaced only among people
+ * confirmed to serve the same event — the day-of coordination context the grid
+ * exists for.
+ *
+ * Auth: any authenticated user.
+ */
+export const getServingTeamRoster = query({
+  args: { token: v.string() },
+  handler: async (ctx, args): Promise<{ plans: ServingTeamPlan[] }> => {
+    const userId = await requireAuth(ctx, args.token);
+    const now = Date.now();
+
+    // Plans the user is confirmed for (mirrors getServingEligibility's window).
+    const confirmed = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_user_status", (q) =>
+        q.eq("userId", userId).eq("status", "confirmed"),
+      )
+      .collect();
+    const planIds = [...new Set(confirmed.map((a) => a.planId as string))];
+
+    const eligiblePlans: Doc<"eventPlans">[] = [];
+    for (const planIdStr of planIds) {
+      const plan = await ctx.db.get(planIdStr as Id<"eventPlans">);
+      if (!plan) continue;
+      const startsAt = planStartsAt(plan);
+      const endsAt = planEndsAt(plan);
+      if (now < startsAt - SAME_DAY_LEAD_MS || now > endsAt) continue;
+      eligiblePlans.push(plan);
+    }
+    // Soonest-first so the grid's plan sections read in event order.
+    eligiblePlans.sort((a, b) => planStartsAt(a) - planStartsAt(b));
+
+    // Resolve every team/role/user referenced across the eligible plans once.
+    const teamCache = new Map<string, Doc<"teams"> | null>();
+    const roleCache = new Map<string, Doc<"teamRoles"> | null>();
+    const userCache = new Map<string, Doc<"users"> | null>();
+    const getTeam = async (id: string) => {
+      if (!teamCache.has(id))
+        teamCache.set(id, await ctx.db.get(id as Id<"teams">));
+      return teamCache.get(id) ?? null;
+    };
+    const getRole = async (id: string) => {
+      if (!roleCache.has(id))
+        roleCache.set(id, await ctx.db.get(id as Id<"teamRoles">));
+      return roleCache.get(id) ?? null;
+    };
+    const getUser = async (id: string) => {
+      if (!userCache.has(id))
+        userCache.set(id, await ctx.db.get(id as Id<"users">));
+      return userCache.get(id) ?? null;
+    };
+
+    const plans: ServingTeamPlan[] = [];
+    for (const plan of eligiblePlans) {
+      const assignments = (
+        await ctx.db
+          .query("roleAssignments")
+          .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+          .collect()
+      ).filter((a) => a.status === "confirmed");
+
+      // Group confirmed assignments by team, de-duping identical (user, role)
+      // rows so a double-written assignment can't produce a duplicate card.
+      const byTeam = new Map<string, typeof assignments>();
+      const seen = new Set<string>();
+      for (const a of assignments) {
+        const dedupeKey = `${a.userId}:${a.roleId}:${a.teamId}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        const teamId = a.teamId as string;
+        (byTeam.get(teamId) ?? byTeam.set(teamId, []).get(teamId)!).push(a);
+      }
+
+      const teams: ServingTeamColumn[] = [];
+      for (const [teamId, teamAssignments] of byTeam) {
+        const team = await getTeam(teamId);
+        if (!team || team.isArchived === true) continue;
+
+        const people: ServingTeamPerson[] = [];
+        for (const a of teamAssignments) {
+          const [role, user] = await Promise.all([
+            getRole(a.roleId as string),
+            getUser(a.userId as string),
+          ]);
+          people.push({
+            userId: a.userId as string,
+            displayName: getDisplayName(user?.firstName, user?.lastName),
+            firstName: user?.firstName ?? null,
+            roleName: role?.name ?? "Role",
+            roleColor: role?.color ?? null,
+            profilePhoto: user?.profilePhoto ?? null,
+            phone: user?.phone ?? null,
+            isSelf: (a.userId as string) === (userId as string),
+          });
+        }
+        people.sort((x, y) => x.displayName.localeCompare(y.displayName));
+        teams.push({
+          teamId,
+          name: team.name,
+          color: null,
+          people,
+        });
+      }
+      teams.sort((x, y) => x.name.localeCompare(y.name));
+
+      plans.push({
+        planId: plan._id as string,
+        title: plan.title,
+        eventDate: plan.eventDate,
+        teams,
+      });
+    }
+
+    return { plans };
   },
 });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -166,6 +166,15 @@ function ThemedStack() {
           gestureEnabled: true,
         }}
       />
+      {/* Serving-mode pushed screens (e.g. the Team who's-serving grid),
+          slide from right like inbox/rostering. */}
+      <Stack.Screen
+        name="serving"
+        options={{
+          animation: "slide_from_right",
+          gestureEnabled: true,
+        }}
+      />
       {/* Scheduling deep links — assignment request accept/decline screen */}
       <Stack.Screen
         name="scheduling"

--- a/apps/mobile/app/serving/team.tsx
+++ b/apps/mobile/app/serving/team.tsx
@@ -1,0 +1,7 @@
+import { ServingTeamScreen } from "@features/serving";
+
+/**
+ * Serving-mode "Team" screen — the who's-serving grid, pushed from the pinned
+ * Team card at the top of the serving inbox.
+ */
+export default ServingTeamScreen;

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -998,25 +998,12 @@ export function ChatInboxScreen({
               color={colors.iconSecondary}
               style={{ marginBottom: 16 }}
             />
-            {inServingMode ? (
-              <>
-                <Text style={[styles.emptyTitle, { color: colors.text }]}>
-                  Your event inbox
-                </Text>
-                <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
-                  This is your inbox for the event. Your team channels and shared
-                  team channels show up here, along with direct messages from the
-                  event day. Nothing yet — check back closer to the event.
-                </Text>
-              </>
-            ) : (
-              <>
-                <Text style={[styles.emptyTitle, { color: colors.text }]}>No Groups Yet</Text>
-                <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
-                  Join a group to start chatting
-                </Text>
-              </>
-            )}
+            {/* Serving mode always pins the Team card, so the inbox is never
+                empty there — this branch only renders outside serving mode. */}
+            <Text style={[styles.emptyTitle, { color: colors.text }]}>No Groups Yet</Text>
+            <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+              Join a group to start chatting
+            </Text>
           </ScrollView>
         </View>
       </Wrapper>

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -373,6 +373,8 @@ export function ChatInboxScreen({
     | { kind: "dm"; item: DirectInboxRow }
     | { kind: "notifications"; item: NotificationsRow }
     | { kind: "ghost"; item: UpcomingChannel }
+    // Serving-mode only: a pinned link to the "who's serving" Team grid.
+    | { kind: "team-link" }
     | { kind: "requests-link"; count: number };
 
   // Render a single inbox row (group, event, dm, section header, or
@@ -382,6 +384,40 @@ export function ChatInboxScreen({
   // Request flow, so we deliberately do NOT interleave them.
   const renderItem = useCallback(
     ({ item }: { item: InboxListItem }) => {
+      if (item.kind === "team-link") {
+        return (
+          <Pressable
+            onPress={() => router.push("/serving/team" as any)}
+            style={styles.requestsLinkRow}
+            accessibilityRole="button"
+            accessibilityLabel="Team — who's serving"
+          >
+            <View
+              style={[styles.requestsLinkIcon, { backgroundColor: primaryColor }]}
+            >
+              <Ionicons name="people" size={20} color="#ffffff" />
+            </View>
+            <View style={styles.requestsLinkContent}>
+              <Text style={[styles.requestsLinkTitle, { color: colors.text }]}>
+                Team
+              </Text>
+              <Text
+                style={[
+                  styles.requestsLinkSubtitle,
+                  { color: colors.textSecondary },
+                ]}
+              >
+                See who&apos;s serving
+              </Text>
+            </View>
+            <Ionicons
+              name="chevron-forward"
+              size={18}
+              color={colors.textSecondary}
+            />
+          </Pressable>
+        );
+      }
       if (item.kind === "requests-link") {
         return (
           <Pressable
@@ -470,6 +506,7 @@ export function ChatInboxScreen({
 
   // Key extractor for FlatList
   const keyExtractor = useCallback((item: InboxListItem) => {
+    if (item.kind === "team-link") return "team-link";
     if (item.kind === "requests-link") return "requests-link";
     if (item.kind === "notifications") return "notifications";
     if (item.kind === "ghost") return `ghost:${item.item.channelId}`;
@@ -814,7 +851,13 @@ export function ChatInboxScreen({
         .filter((c) => c.availableAt > now)
         .sort((a, b) => a.availableAt - b.availableAt)
         .map((c) => ({ kind: "ghost" as const, item: c }));
-      return [...listItems, ...dayDmItems, ...ghostItems];
+      // A pinned "Team" card leads the serving inbox — the who's-serving grid.
+      return [
+        { kind: "team-link" as const },
+        ...listItems,
+        ...dayDmItems,
+        ...ghostItems,
+      ];
     }
 
     const dmItems: InboxListItem[] = dmRows.map((row) => ({

--- a/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
+++ b/apps/mobile/features/scheduling/components/EventTasksGrid.tsx
@@ -138,6 +138,7 @@ export function EventTasksGrid({
   listHeader,
   listFooter,
   sections,
+  storageKey = "eventTasks",
 }: {
   tasks: PlanTask[];
   teams: TeamOption[];
@@ -163,6 +164,13 @@ export function EventTasksGrid({
    * its own team→role sort per segment, instead of one flat table.
    */
   sections?: TaskSection[];
+  /**
+   * Persistence key for drag-to-resize column widths (see `GridScrollList`).
+   * Defaults to "eventTasks" (the plan grid); the task-template editor passes a
+   * DISTINCT key so a template's column layout is remembered separately from a
+   * live plan's.
+   */
+  storageKey?: string;
 }) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
@@ -399,6 +407,7 @@ export function EventTasksGrid({
         onReorder={handleReorder}
         columns={columns}
         renderCell={(item, columnKey) => renderCell(item, columnKey)}
+        storageKey={storageKey}
         ListHeaderComponent={listHeader ?? undefined}
         ListFooterComponent={footer}
         contentContainerStyle={styles.listContent}

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -20,7 +20,7 @@
  * this component only lays the cells out and draws the divided, padded, sized
  * cell frame (the table chrome).
  */
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   View,
   Text,
@@ -28,6 +28,7 @@ import {
   StyleSheet,
   Pressable,
   Platform,
+  PanResponder,
   type LayoutChangeEvent,
   type StyleProp,
   type ViewStyle,
@@ -35,6 +36,7 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useGridColumnWidths } from "@/stores/gridColumnWidths";
 
 /**
  * A data row with a web-only hover highlight (matches the prototype). Pointer
@@ -134,6 +136,14 @@ const SECTION_MIN_HEIGHT = 32;
 const SECTION_KEY_PREFIX = "__gridSectionHeader__:";
 const FOOTER_KEY_PREFIX = "__gridSectionFooter__:";
 
+/** Drag-to-resize bounds — narrow enough to stay usable, wide enough for notes. */
+const MIN_COL_W = 56;
+const MAX_COL_W = 640;
+/** Clamp a candidate column width to the allowed resize range. */
+function clampColWidth(w: number): number {
+  return Math.max(MIN_COL_W, Math.min(MAX_COL_W, w));
+}
+
 interface Props<T> {
   data: T[];
   keyExtractor: (item: T) => string;
@@ -169,6 +179,14 @@ interface Props<T> {
    * drag is not specially handled.
    */
   sections?: GridSection<T>[];
+  /**
+   * OPTIONAL. When set, columns become drag-to-resize: a grab handle appears on
+   * the right edge of every header cell except the last, and the dragged widths
+   * persist (per grid, per column) under this key in `useGridColumnWidths`.
+   * When OMITTED, behavior is identical to before — no handles, no store reads —
+   * so callers that don't opt in are unaffected.
+   */
+  storageKey?: string;
 }
 
 export function GridScrollList<T>({
@@ -182,10 +200,41 @@ export function GridScrollList<T>({
   contentContainerStyle,
   dense = false,
   sections,
+  storageKey,
 }: Props<T>) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const rowMinHeight = dense ? DENSE_ROW_MIN_HEIGHT : ROW_MIN_HEIGHT;
+
+  // ── Column resize (only when `storageKey` is set) ───────────────────────────
+  // Persisted per-column overrides for THIS grid. Selecting the nested slice by
+  // key keeps the reference stable across unrelated store writes, so a resize on
+  // another grid never re-renders this one. `undefined` when not opted in.
+  const storedWidths = useGridColumnWidths((s) =>
+    storageKey ? s.widths[storageKey] : undefined,
+  );
+  const setStoredWidth = useGridColumnWidths((s) => s.setWidth);
+  const resetStoredColumn = useGridColumnWidths((s) => s.resetColumn);
+  // Live width WHILE a handle is being dragged. Held in local state (not the
+  // store) so each pointer/pan move re-renders smoothly without thrashing
+  // AsyncStorage — we only commit the final width to the store on release.
+  const [liveDrag, setLiveDrag] = useState<{ key: string; width: number } | null>(
+    null,
+  );
+  const resizable = !!storageKey;
+
+  // The columns the table actually lays out. An explicit override (or the live
+  // drag) both PINS the width AND cancels `flex`: once a leader has sized a
+  // column, its width is a promise — letting slack redistribution keep nudging
+  // it would make the drag feel indirect and springy. Non-overridden columns
+  // keep their `flex` so the table still fills the card. Label/align/key ride
+  // along unchanged (we spread the original column).
+  const resolvedColumns: GridColumn[] = columns.map((c) => {
+    const live = liveDrag && liveDrag.key === c.key ? liveDrag.width : undefined;
+    const override = storedWidths ? storedWidths[c.key] : undefined;
+    const pinned = live ?? override;
+    return pinned != null ? { ...c, width: pinned, flex: 0 } : c;
+  });
 
   // The card's measured inner size. Width drives the slack distribution; height
   // bounds the inner content so the drag list's vertical scroll works while it
@@ -205,10 +254,10 @@ export function GridScrollList<T>({
   //          and the table keeps its natural width (→ the ScrollView scrolls).
   // innerWidth = max(baseW, containerWidth) so the inner content fills the card
   //          when it fits, and keeps its natural width when it overflows.
-  const baseW = GRIP_W + columns.reduce((sum, c) => sum + c.width, 0);
-  const totalFlex = columns.reduce((sum, c) => sum + (c.flex ?? 0), 0);
+  const baseW = GRIP_W + resolvedColumns.reduce((sum, c) => sum + c.width, 0);
+  const totalFlex = resolvedColumns.reduce((sum, c) => sum + (c.flex ?? 0), 0);
   const slack = Math.max(0, size.w - baseW);
-  const effWidths = columns.map((c) =>
+  const effWidths = resolvedColumns.map((c) =>
     c.flex && totalFlex > 0 ? c.width + (slack * c.flex) / totalFlex : c.width,
   );
   const innerWidth = Math.max(baseW, size.w);
@@ -221,10 +270,21 @@ export function GridScrollList<T>({
     // its 1-line neighbours off-centre. The row stretches every cell to the same
     // height, so the vertical dividers still run the full row.
     justifyContent: "flex-start",
-    alignItems: columns[i].align === "center" ? "center" : "flex-start",
-    borderRightWidth: i < columns.length - 1 ? StyleSheet.hairlineWidth : 0,
+    alignItems: resolvedColumns[i].align === "center" ? "center" : "flex-start",
+    borderRightWidth: i < resolvedColumns.length - 1 ? StyleSheet.hairlineWidth : 0,
     borderRightColor: colors.border,
   });
+
+  // Commit a dragged width to the store on release, and clear the live-drag
+  // state so `resolvedColumns` reads the persisted value from here on.
+  const commitWidth = (columnKey: string, width: number) => {
+    if (storageKey) setStoredWidth(storageKey, columnKey, clampColWidth(width));
+    setLiveDrag(null);
+  };
+  const resetWidth = (columnKey: string) => {
+    if (storageKey) resetStoredColumn(storageKey, columnKey);
+    setLiveDrag(null);
+  };
 
   const headerRow = (
     <View
@@ -237,7 +297,7 @@ export function GridScrollList<T>({
       ]}
     >
       <View style={styles.gripCell} />
-      {columns.map((col, i) => (
+      {resolvedColumns.map((col, i) => (
         <View key={col.key} style={cellFrame(i)}>
           <Text
             style={[
@@ -249,6 +309,18 @@ export function GridScrollList<T>({
           >
             {col.label}
           </Text>
+          {/* Resize handle on the RIGHT edge — you size a column by dragging its
+              own right edge, so the LAST column (nothing to its right) has none. */}
+          {resizable && i < resolvedColumns.length - 1 ? (
+            <ColumnResizeHandle
+              width={effWidths[i]}
+              primaryColor={primaryColor}
+              borderColor={colors.border}
+              onDrag={(w) => setLiveDrag({ key: col.key, width: w })}
+              onCommit={(w) => commitWidth(col.key, w)}
+              onReset={() => resetWidth(col.key)}
+            />
+          ) : null}
         </View>
       ))}
     </View>
@@ -289,7 +361,7 @@ export function GridScrollList<T>({
           <Ionicons name="reorder-three" size={18} color={colors.textTertiary} />
         </View>
       </Handle>
-      {columns.map((col, i) => (
+      {resolvedColumns.map((col, i) => (
         <View key={col.key} style={cellFrame(i)}>
           {renderCell(item, col.key, { isActive })}
         </View>
@@ -484,6 +556,140 @@ export function GridScrollList<T>({
   );
 }
 
+/**
+ * The drag-to-resize grab strip on a header cell's right edge. Cross-platform:
+ *
+ *  - Web: `onPointerDown` snapshots the start clientX + width, then attaches
+ *    window `pointermove`/`pointerup` listeners so the drag keeps tracking even
+ *    when the pointer outruns the 8px strip. Each move reports a LIVE width to
+ *    the parent for smooth feedback; only `pointerup` COMMITS to the store —
+ *    writing on every move would thrash AsyncStorage. Double-click resets the
+ *    column to its default. The `col-resize` cursor is honored by RN-Web.
+ *  - Native: a `PanResponder` does the same live-move / commit-on-release, and
+ *    refuses termination so the horizontal ScrollView can't steal the gesture.
+ *
+ * `width` is the column's CURRENT effective width; it's snapshotted at gesture
+ * start (via a ref) so mid-drag re-renders don't compound the delta.
+ */
+function ColumnResizeHandle({
+  width,
+  primaryColor,
+  borderColor,
+  onDrag,
+  onCommit,
+  onReset,
+}: {
+  width: number;
+  primaryColor: string;
+  borderColor: string;
+  onDrag: (width: number) => void;
+  onCommit: (width: number) => void;
+  onReset: () => void;
+}) {
+  const [active, setActive] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  // Latest values mirrored into refs so the once-created PanResponder (native)
+  // and the window listeners (web) always read fresh callbacks / start width
+  // without re-subscribing every render.
+  const widthRef = useRef(width);
+  widthRef.current = width;
+  const onDragRef = useRef(onDrag);
+  onDragRef.current = onDrag;
+  const onCommitRef = useRef(onCommit);
+  onCommitRef.current = onCommit;
+  // The width captured when THIS drag began (stable for the whole gesture).
+  const startWidthRef = useRef(width);
+
+  // Native gesture handler, created once (its closures read the refs above so
+  // they never go stale). Declared UNCONDITIONALLY — before the web branch —
+  // to keep hook order stable; on web it's simply never attached.
+  const responder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      // Don't yield the gesture to the enclosing horizontal ScrollView.
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: () => {
+        startWidthRef.current = widthRef.current;
+        setActive(true);
+      },
+      onPanResponderMove: (_evt, gesture) => {
+        onDragRef.current(clampColWidth(startWidthRef.current + gesture.dx));
+      },
+      onPanResponderRelease: (_evt, gesture) => {
+        setActive(false);
+        onCommitRef.current(clampColWidth(startWidthRef.current + gesture.dx));
+      },
+      onPanResponderTerminate: (_evt, gesture) => {
+        setActive(false);
+        onCommitRef.current(clampColWidth(startWidthRef.current + gesture.dx));
+      },
+    }),
+  ).current;
+
+  const highlighted = active || hovered;
+  const lineColor = highlighted
+    ? primaryColor
+    : // On web the strip is invisible until hover (discoverable via the cursor);
+      // on native there's no hover, so a faint always-on line hints it's grabbable.
+      Platform.OS === "web"
+      ? "transparent"
+      : borderColor;
+
+  if (Platform.OS === "web") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handlePointerDown = (e: any) => {
+      e.preventDefault?.();
+      e.stopPropagation?.();
+      const startX: number = e.nativeEvent?.clientX ?? e.clientX ?? 0;
+      startWidthRef.current = widthRef.current;
+      setActive(true);
+      const move = (ev: PointerEvent) => {
+        onDragRef.current(clampColWidth(startWidthRef.current + (ev.clientX - startX)));
+      };
+      const up = (ev: PointerEvent) => {
+        window.removeEventListener("pointermove", move);
+        window.removeEventListener("pointerup", up);
+        setActive(false);
+        onCommitRef.current(
+          clampColWidth(startWidthRef.current + (ev.clientX - startX)),
+        );
+      };
+      window.addEventListener("pointermove", move);
+      window.addEventListener("pointerup", up);
+    };
+    return (
+      <View
+        // Web-only DOM props — RN-Web forwards these; `cursor` is honored too.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {...({
+          onPointerDown: handlePointerDown,
+          onPointerEnter: () => setHovered(true),
+          onPointerLeave: () => setHovered(false),
+          onDoubleClick: onReset,
+        } as any)}
+        style={[styles.resizeHandle, { cursor: "col-resize" } as any]}
+        accessibilityLabel="Drag to resize column"
+      >
+        <View style={[styles.resizeLine, { backgroundColor: lineColor }]} />
+      </View>
+    );
+  }
+
+  // Native: attach the PanResponder created above.
+  return (
+    <View
+      {...responder.panHandlers}
+      style={styles.resizeHandle}
+      hitSlop={{ left: 6, right: 6, top: 0, bottom: 0 }}
+      accessibilityLabel="Drag to resize column"
+    >
+      <View style={[styles.resizeLine, { backgroundColor: lineColor }]} />
+    </View>
+  );
+}
+
 /** #RRGGBB (with or without the leading #). Team / role colors are stored as hex. */
 const HEX6 = /^#?[0-9a-fA-F]{6}$/;
 
@@ -614,6 +820,21 @@ const styles = StyleSheet.create({
     textTransform: "uppercase",
   },
   headerLabelCenter: { textAlign: "center" },
+  // Grab strip on a header cell's right edge. ~8px wide hit area straddling the
+  // divider (right:-4), spanning the full header height. Above neighbouring
+  // cells so its live line/cursor win near the boundary.
+  resizeHandle: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    right: -4,
+    width: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 5,
+  },
+  // The 2px divider line inside the strip — emphasized on hover/active.
+  resizeLine: { width: 2, height: "100%", borderRadius: 1 },
   row: {
     flexDirection: "row",
     alignItems: "stretch",

--- a/apps/mobile/features/scheduling/components/GridScrollList.tsx
+++ b/apps/mobile/features/scheduling/components/GridScrollList.tsx
@@ -20,7 +20,7 @@
  * this component only lays the cells out and draws the divided, padded, sized
  * cell frame (the table chrome).
  */
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -207,9 +207,11 @@ export function GridScrollList<T>({
   const rowMinHeight = dense ? DENSE_ROW_MIN_HEIGHT : ROW_MIN_HEIGHT;
 
   // ── Column resize (only when `storageKey` is set) ───────────────────────────
-  // Persisted per-column overrides for THIS grid. Selecting the nested slice by
-  // key keeps the reference stable across unrelated store writes, so a resize on
-  // another grid never re-renders this one. `undefined` when not opted in.
+  // Persisted per-column overrides for THIS grid. On native (zustand), selecting
+  // the nested slice by key keeps the reference stable across unrelated store
+  // writes, so a resize on another grid doesn't re-render this one. (The web
+  // store re-renders all subscribers on any write, but grids are rarely
+  // co-mounted, so the extra render is immaterial.) `undefined` when not opted in.
   const storedWidths = useGridColumnWidths((s) =>
     storageKey ? s.widths[storageKey] : undefined,
   );
@@ -598,14 +600,32 @@ function ColumnResizeHandle({
   onDragRef.current = onDrag;
   const onCommitRef = useRef(onCommit);
   onCommitRef.current = onCommit;
+  const onResetRef = useRef(onReset);
+  onResetRef.current = onReset;
   // The width captured when THIS drag began (stable for the whole gesture).
   const startWidthRef = useRef(width);
+  // Timestamp of the last tap/click, for double-tap-to-reset detection. A
+  // double-click restores the column's default width on both platforms — see
+  // the web `onClick` handler and the native `onPanResponderRelease` below.
+  // (RN-Web drops `onDoubleClick` — it's not in its forwarded-prop whitelist —
+  // so we must detect the double manually via `onClick`, which IS whitelisted.)
+  const lastTapRef = useRef(0);
+  const DOUBLE_TAP_MS = 300;
+  // Guards setState/commit after unmount (e.g. columns re-render away mid-drag)
+  // so window pointer listeners resolving late don't touch a dead tree.
+  const mountedRef = useRef(true);
+  useEffect(() => () => {
+    mountedRef.current = false;
+  }, []);
 
-  // Native gesture handler, created once (its closures read the refs above so
-  // they never go stale). Declared UNCONDITIONALLY — before the web branch —
-  // to keep hook order stable; on web it's simply never attached.
-  const responder = useRef(
-    PanResponder.create({
+  // Native gesture handler, lazily created ONCE (its closures read the refs
+  // above so they never go stale). Declared UNCONDITIONALLY — before the web
+  // branch — to keep hook order stable; on web it's simply never attached.
+  const responderRef = useRef<ReturnType<typeof PanResponder.create> | null>(
+    null,
+  );
+  if (responderRef.current === null) {
+    responderRef.current = PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: () => true,
       // Don't yield the gesture to the enclosing horizontal ScrollView.
@@ -619,14 +639,27 @@ function ColumnResizeHandle({
       },
       onPanResponderRelease: (_evt, gesture) => {
         setActive(false);
+        // A near-stationary release is a TAP, not a drag: use it for
+        // double-tap-to-reset instead of committing an unchanged width.
+        if (Math.abs(gesture.dx) < 3) {
+          const now = Date.now();
+          if (now - lastTapRef.current < DOUBLE_TAP_MS) {
+            lastTapRef.current = 0;
+            onResetRef.current();
+          } else {
+            lastTapRef.current = now;
+          }
+          return;
+        }
         onCommitRef.current(clampColWidth(startWidthRef.current + gesture.dx));
       },
       onPanResponderTerminate: (_evt, gesture) => {
         setActive(false);
         onCommitRef.current(clampColWidth(startWidthRef.current + gesture.dx));
       },
-    }),
-  ).current;
+    });
+  }
+  const responder = responderRef.current;
 
   const highlighted = active || hovered;
   const lineColor = highlighted
@@ -644,20 +677,54 @@ function ColumnResizeHandle({
       e.stopPropagation?.();
       const startX: number = e.nativeEvent?.clientX ?? e.clientX ?? 0;
       startWidthRef.current = widthRef.current;
-      setActive(true);
-      const move = (ev: PointerEvent) => {
-        onDragRef.current(clampColWidth(startWidthRef.current + (ev.clientX - startX)));
-      };
-      const up = (ev: PointerEvent) => {
+      if (mountedRef.current) setActive(true);
+      let moved = false;
+      const cleanup = () => {
         window.removeEventListener("pointermove", move);
         window.removeEventListener("pointerup", up);
-        setActive(false);
-        onCommitRef.current(
+        window.removeEventListener("pointercancel", cancel);
+      };
+      const move = (ev: PointerEvent) => {
+        moved = true;
+        if (!mountedRef.current) return;
+        onDragRef.current(
           clampColWidth(startWidthRef.current + (ev.clientX - startX)),
         );
       };
+      const up = (ev: PointerEvent) => {
+        cleanup();
+        if (!mountedRef.current) return;
+        setActive(false);
+        // Only commit an actual drag; a click without movement is left for the
+        // `onClick` double-click-reset handler (a no-op commit would be fine but
+        // clutters the store with default-width entries).
+        if (moved) {
+          onCommitRef.current(
+            clampColWidth(startWidthRef.current + (ev.clientX - startX)),
+          );
+        }
+      };
+      // Pointer cancellation (browser takes over scrolling, OS interrupt) never
+      // fires `pointerup`, so without this the listeners would leak and the
+      // handle would stay stuck active. Revert to the last-committed width.
+      const cancel = () => {
+        cleanup();
+        if (mountedRef.current) setActive(false);
+      };
       window.addEventListener("pointermove", move);
       window.addEventListener("pointerup", up);
+      window.addEventListener("pointercancel", cancel);
+    };
+    // RN-Web drops `onDoubleClick` (not in its forwarded-prop whitelist), so
+    // detect the double manually off `onClick` (which IS whitelisted).
+    const handleClick = () => {
+      const now = Date.now();
+      if (now - lastTapRef.current < DOUBLE_TAP_MS) {
+        lastTapRef.current = 0;
+        onResetRef.current();
+      } else {
+        lastTapRef.current = now;
+      }
     };
     return (
       <View
@@ -667,10 +734,10 @@ function ColumnResizeHandle({
           onPointerDown: handlePointerDown,
           onPointerEnter: () => setHovered(true),
           onPointerLeave: () => setHovered(false),
-          onDoubleClick: onReset,
+          onClick: handleClick,
         } as any)}
         style={[styles.resizeHandle, { cursor: "col-resize" } as any]}
-        accessibilityLabel="Drag to resize column"
+        accessibilityLabel="Drag to resize column (double-click to reset)"
       >
         <View style={[styles.resizeLine, { backgroundColor: lineColor }]} />
       </View>

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -888,6 +888,7 @@ export function RunSheetScreen() {
               columns={columns}
               renderCell={renderCell}
               sections={sections}
+              storageKey="runSheet"
               dense
               ListHeaderComponent={listHeader}
               // Add controls now live in each section's footer, so the list footer

--- a/apps/mobile/features/scheduling/components/RunSheetTemplateEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetTemplateEditorScreen.tsx
@@ -670,6 +670,7 @@ export function RunSheetTemplateEditorScreen() {
           onReorder={handleReorder}
           columns={columns}
           renderCell={renderCell}
+          storageKey="runSheetTemplate"
           ListHeaderComponent={listHeader}
           ListFooterComponent={
             <View style={{ paddingBottom: insets.bottom + 8 }}>{listFooter}</View>

--- a/apps/mobile/features/scheduling/components/TaskTemplateEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TaskTemplateEditorScreen.tsx
@@ -454,6 +454,7 @@ export function TaskTemplateEditorScreen() {
           onPickRole={(task, anchor) => setRolePicker({ task, anchor })}
           onOpenDoc={setDocEditorTask}
           listHeader={listHeader}
+          storageKey="taskTemplate"
         />
       )}
 

--- a/apps/mobile/features/serving/components/ServingTeamScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTeamScreen.tsx
@@ -1,0 +1,361 @@
+/**
+ * ServingTeamScreen
+ *
+ * Serving-mode "Team" view: a grid of everyone serving alongside the current
+ * user. Opened from the pinned "Team" card at the top of the serving inbox.
+ *
+ * Layout mirrors the ask: one section per plan the user is serving (a volunteer
+ * can be on two campuses the same morning), and inside each plan a horizontally
+ * scrolling row of TEAM columns. Each column header is the team name; under it a
+ * card per confirmed volunteer showing their name + the role they fill. Tapping
+ * a card opens an action sheet to message them in Togather (a same-day DM, which
+ * the serving inbox surfaces) or text their number.
+ *
+ * Data comes from `scheduling.serving.getServingTeamRoster`, which already scopes
+ * to the user's eligible serving plans and confirmed assignments — so this screen
+ * is purely presentational over that shape.
+ */
+import React, { useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Linking,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { Avatar } from "@components/ui/Avatar";
+import {
+  ActionMenuSheet,
+  type MenuAction,
+} from "@components/ui/ActionMenuSheet";
+import { useStartDirectMessage } from "@features/chat/hooks/useStartDirectMessage";
+import { useEventModeStore } from "@/stores/eventModeStore";
+
+/** The person shape returned per team by `getServingTeamRoster`. */
+type RosterPerson = {
+  userId: string;
+  displayName: string;
+  firstName: string | null;
+  roleName: string;
+  roleColor: string | null;
+  profilePhoto: string | null;
+  phone: string | null;
+  isSelf: boolean;
+};
+
+/** Column width for each team — wide enough for a name + role, snug on mobile. */
+const TEAM_COL_WIDTH = 168;
+
+/** Format a stored phone (usually E.164) for display; falls back to raw. */
+function formatPhoneForDisplay(phone: string | null | undefined): string | null {
+  if (!phone) return null;
+  const trimmed = phone.trim();
+  if (!trimmed) return null;
+  const usMatch = trimmed.match(/^\+1(\d{3})(\d{3})(\d{4})$/);
+  if (usMatch) return `(${usMatch[1]}) ${usMatch[2]}-${usMatch[3]}`;
+  return trimmed;
+}
+
+function formatPlanDate(ms: number): string {
+  try {
+    return new Date(ms).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return "";
+  }
+}
+
+export function ServingTeamScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const isServingMode = useEventModeStore((s) => s.isServingMode);
+
+  const roster = useAuthenticatedQuery(
+    api.functions.scheduling.serving.getServingTeamRoster,
+    isServingMode ? {} : "skip",
+  );
+
+  const { messageUser, canMessage } = useStartDirectMessage();
+
+  // The person whose action sheet is open (null = closed).
+  const [selected, setSelected] = useState<RosterPerson | null>(null);
+
+  const actions = useMemo<MenuAction[]>(() => {
+    if (!selected) return [];
+    const list: MenuAction[] = [];
+    if (canMessage) {
+      list.push({
+        label: "Message in Togather",
+        onPress: () =>
+          messageUser({
+            otherUserId: selected.userId as Id<"users">,
+            firstName: selected.firstName,
+            displayName: selected.displayName,
+            profilePhoto: selected.profilePhoto,
+          }),
+      });
+    }
+    const pretty = formatPhoneForDisplay(selected.phone);
+    if (pretty) {
+      list.push({
+        label: `Text ${pretty}`,
+        onPress: () => {
+          // Strip formatting to a dialable string for the sms: scheme.
+          const dialable = (selected.phone ?? "").replace(/[^\d+]/g, "");
+          Linking.openURL(`sms:${dialable}`).catch(() => {});
+        },
+      });
+    }
+    return list;
+  }, [selected, canMessage, messageUser]);
+
+  const handleBack = () => {
+    if (router.canGoBack()) router.back();
+    else router.replace("/(tabs)/chat");
+  };
+
+  const plans = roster?.plans ?? [];
+  const hasAnyTeams = plans.some((p) => p.teams.length > 0);
+
+  const header = (
+    <View
+      style={[
+        styles.header,
+        { paddingTop: insets.top + 16, borderBottomColor: colors.border },
+      ]}
+    >
+      <TouchableOpacity
+        onPress={handleBack}
+        style={styles.headerSide}
+        accessibilityLabel="Back"
+      >
+        <Ionicons name="chevron-back" size={26} color={colors.text} />
+      </TouchableOpacity>
+      <Text style={[styles.headerTitle, { color: colors.text }]}>Team</Text>
+      <View style={styles.headerSide} />
+    </View>
+  );
+
+  return (
+    <View style={[styles.flex, { backgroundColor: colors.background }]}>
+      {header}
+
+      {roster === undefined ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="small" color={colors.text} />
+        </View>
+      ) : !hasAnyTeams ? (
+        <View style={styles.centered}>
+          <Ionicons
+            name="people-outline"
+            size={30}
+            color={colors.textTertiary}
+          />
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            No one else is confirmed to serve yet.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+        >
+          {plans.map((plan) => (
+            <View key={plan.planId} style={styles.planSection}>
+              <View style={styles.planHeader}>
+                <Text
+                  style={[styles.planTitle, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  {plan.title}
+                </Text>
+                <Text
+                  style={[styles.planDate, { color: colors.textTertiary }]}
+                >
+                  {formatPlanDate(plan.eventDate)}
+                </Text>
+              </View>
+
+              {plan.teams.length === 0 ? (
+                <Text
+                  style={[styles.planEmpty, { color: colors.textTertiary }]}
+                >
+                  No confirmed volunteers yet.
+                </Text>
+              ) : (
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.teamsRow}
+                >
+                  {plan.teams.map((team) => (
+                    <View key={team.teamId} style={styles.teamColumn}>
+                      <Text
+                        style={[
+                          styles.teamName,
+                          { color: colors.textSecondary },
+                        ]}
+                        numberOfLines={1}
+                      >
+                        {team.name}
+                      </Text>
+                      {team.people.map((person, i) => (
+                        <PersonCard
+                          key={`${person.userId}:${person.roleName}:${i}`}
+                          person={person}
+                          colors={colors}
+                          primaryColor={primaryColor}
+                          onPress={() =>
+                            person.isSelf ? undefined : setSelected(person)
+                          }
+                        />
+                      ))}
+                    </View>
+                  ))}
+                </ScrollView>
+              )}
+            </View>
+          ))}
+        </ScrollView>
+      )}
+
+      <ActionMenuSheet
+        visible={selected != null}
+        title={
+          selected
+            ? `${selected.displayName} · ${selected.roleName}`
+            : undefined
+        }
+        actions={actions}
+        onClose={() => setSelected(null)}
+      />
+    </View>
+  );
+}
+
+/** A single volunteer card in a team column: avatar, name, and their role. */
+function PersonCard({
+  person,
+  colors,
+  primaryColor,
+  onPress,
+}: {
+  person: RosterPerson;
+  colors: ReturnType<typeof useTheme>["colors"];
+  primaryColor: string;
+  onPress: () => void;
+}) {
+  const roleColor =
+    person.roleColor && /^#?[0-9a-fA-F]{6}$/.test(person.roleColor)
+      ? person.roleColor.startsWith("#")
+        ? person.roleColor
+        : `#${person.roleColor}`
+      : primaryColor;
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={person.isSelf ? 1 : 0.7}
+      disabled={person.isSelf}
+      style={[
+        styles.personCard,
+        { backgroundColor: colors.surface, borderColor: colors.border },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={
+        person.isSelf
+          ? `${person.displayName} (you), ${person.roleName}`
+          : `Message ${person.displayName}, ${person.roleName}`
+      }
+    >
+      <View style={styles.personTop}>
+        <Avatar
+          name={person.displayName}
+          imageUrl={person.profilePhoto}
+          size={28}
+        />
+        <Text
+          style={[styles.personName, { color: colors.text }]}
+          numberOfLines={1}
+        >
+          {person.displayName}
+          {person.isSelf ? " (you)" : ""}
+        </Text>
+      </View>
+      <View style={styles.roleRow}>
+        <View style={[styles.roleDot, { backgroundColor: roleColor }]} />
+        <Text
+          style={[styles.roleText, { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
+          {person.roleName}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerSide: { width: 40, height: 32, justifyContent: "center" },
+  headerTitle: { fontSize: 17, fontWeight: "700" },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    gap: 10,
+  },
+  emptyText: { fontSize: 15, textAlign: "center" },
+  planSection: { paddingTop: 20 },
+  planHeader: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 8,
+    paddingHorizontal: 16,
+    marginBottom: 10,
+  },
+  planTitle: { fontSize: 16, fontWeight: "700", flexShrink: 1 },
+  planDate: { fontSize: 13, fontWeight: "500" },
+  planEmpty: { fontSize: 13, paddingHorizontal: 16, paddingBottom: 8 },
+  teamsRow: { paddingHorizontal: 16, gap: 12 },
+  teamColumn: { width: TEAM_COL_WIDTH, gap: 8 },
+  teamName: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    paddingBottom: 2,
+  },
+  personCard: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    padding: 10,
+    gap: 8,
+  },
+  personTop: { flexDirection: "row", alignItems: "center", gap: 8 },
+  personName: { fontSize: 14, fontWeight: "600", flexShrink: 1 },
+  roleRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+  roleDot: { width: 8, height: 8, borderRadius: 4 },
+  roleText: { fontSize: 12, fontWeight: "500", flexShrink: 1 },
+});

--- a/apps/mobile/features/serving/components/ServingTeamScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTeamScreen.tsx
@@ -154,7 +154,20 @@ export function ServingTeamScreen() {
     <View style={[styles.flex, { backgroundColor: colors.background }]}>
       {header}
 
-      {roster === undefined ? (
+      {!isServingMode ? (
+        // The query is skipped outside serving mode, so `roster` would stay
+        // undefined and spin forever. Show a plain empty state instead.
+        <View style={styles.centered}>
+          <Ionicons
+            name="people-outline"
+            size={30}
+            color={colors.textTertiary}
+          />
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            Not currently serving on an event.
+          </Text>
+        </View>
+      ) : roster === undefined ? (
         <View style={styles.centered}>
           <ActivityIndicator size="small" color={colors.text} />
         </View>
@@ -212,17 +225,26 @@ export function ServingTeamScreen() {
                       >
                         {team.name}
                       </Text>
-                      {team.people.map((person, i) => (
-                        <PersonCard
-                          key={`${person.userId}:${person.roleName}:${i}`}
-                          person={person}
-                          colors={colors}
-                          primaryColor={primaryColor}
-                          onPress={() =>
-                            person.isSelf ? undefined : setSelected(person)
-                          }
-                        />
-                      ))}
+                      {team.people.map((person, i) => {
+                        // No actionable card for yourself, or for someone with
+                        // neither a DM path (no community context) nor a phone —
+                        // opening an empty action sheet would be a dead end.
+                        const actionable =
+                          !person.isSelf &&
+                          (canMessage || !!person.phone);
+                        return (
+                          <PersonCard
+                            key={`${person.userId}:${person.roleName}:${i}`}
+                            person={person}
+                            colors={colors}
+                            primaryColor={primaryColor}
+                            actionable={actionable}
+                            onPress={() =>
+                              actionable ? setSelected(person) : undefined
+                            }
+                          />
+                        );
+                      })}
                     </View>
                   ))}
                 </ScrollView>
@@ -251,11 +273,14 @@ function PersonCard({
   person,
   colors,
   primaryColor,
+  actionable,
   onPress,
 }: {
   person: RosterPerson;
   colors: ReturnType<typeof useTheme>["colors"];
   primaryColor: string;
+  /** Whether tapping does anything (has a message/text action available). */
+  actionable: boolean;
   onPress: () => void;
 }) {
   const roleColor =
@@ -267,17 +292,19 @@ function PersonCard({
   return (
     <TouchableOpacity
       onPress={onPress}
-      activeOpacity={person.isSelf ? 1 : 0.7}
-      disabled={person.isSelf}
+      activeOpacity={actionable ? 0.7 : 1}
+      disabled={!actionable}
       style={[
         styles.personCard,
         { backgroundColor: colors.surface, borderColor: colors.border },
       ]}
-      accessibilityRole="button"
+      accessibilityRole={actionable ? "button" : "text"}
       accessibilityLabel={
         person.isSelf
           ? `${person.displayName} (you), ${person.roleName}`
-          : `Message ${person.displayName}, ${person.roleName}`
+          : actionable
+            ? `Message ${person.displayName}, ${person.roleName}`
+            : `${person.displayName}, ${person.roleName}`
       }
     >
       <View style={styles.personTop}>

--- a/apps/mobile/features/serving/index.ts
+++ b/apps/mobile/features/serving/index.ts
@@ -5,3 +5,4 @@
 export { ServingTasksScreen } from "./components/ServingTasksScreen";
 export { ServingRunsheetScreen } from "./components/ServingRunsheetScreen";
 export { ServingExitScreen } from "./components/ServingExitScreen";
+export { ServingTeamScreen } from "./components/ServingTeamScreen";

--- a/apps/mobile/providers/AuthProvider.tsx
+++ b/apps/mobile/providers/AuthProvider.tsx
@@ -23,6 +23,7 @@ import { useRunSheetCache } from "../stores/runSheetCache";
 import { useServingRunSheetCache } from "../stores/servingRunSheetCache";
 import { useServingTasksCache } from "../stores/servingTasksCache";
 import { useServingTaskQueue } from "../stores/servingTaskQueue";
+import { useGridColumnWidths } from "../stores/gridColumnWidths";
 import type { User, Community } from "@/types/shared";
 import type { Id } from "@services/api/convex";
 
@@ -652,6 +653,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       "serving-runsheet-cache",
       "serving-tasks-cache",
       "serving-task-queue",
+      "grid-column-widths",
     ];
 
     await Promise.all(
@@ -671,6 +673,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     useServingRunSheetCache.getState().clearAll();
     useServingTasksCache.getState().clearAll();
     useServingTaskQueue.getState().clear();
+    useGridColumnWidths.getState().clearAll();
 
     // On web, clear localStorage
     if (Platform.OS === "web" && typeof window !== "undefined" && window.localStorage) {

--- a/apps/mobile/stores/__tests__/gridColumnWidths.test.ts
+++ b/apps/mobile/stores/__tests__/gridColumnWidths.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for gridColumnWidths Zustand store
+ */
+import { useGridColumnWidths } from "../gridColumnWidths";
+
+describe("gridColumnWidths", () => {
+  beforeEach(() => {
+    useGridColumnWidths.getState().clearAll();
+  });
+
+  it("stores and retrieves a column width by grid", () => {
+    useGridColumnWidths.getState().setWidth("runSheet", "item", 320);
+    expect(useGridColumnWidths.getState().getGridWidths("runSheet")).toEqual({
+      item: 320,
+    });
+  });
+
+  it("keeps grids and columns separate", () => {
+    useGridColumnWidths.getState().setWidth("runSheet", "item", 320);
+    useGridColumnWidths.getState().setWidth("runSheet", "notes", 400);
+    useGridColumnWidths.getState().setWidth("eventTasks", "task", 260);
+
+    expect(useGridColumnWidths.getState().getGridWidths("runSheet")).toEqual({
+      item: 320,
+      notes: 400,
+    });
+    expect(useGridColumnWidths.getState().getGridWidths("eventTasks")).toEqual({
+      task: 260,
+    });
+  });
+
+  it("overwrites a column's previous width", () => {
+    useGridColumnWidths.getState().setWidth("runSheet", "item", 320);
+    useGridColumnWidths.getState().setWidth("runSheet", "item", 200);
+    expect(
+      useGridColumnWidths.getState().getGridWidths("runSheet").item,
+    ).toBe(200);
+  });
+
+  it("returns an empty object for a grid with no overrides", () => {
+    expect(useGridColumnWidths.getState().getGridWidths("missing")).toEqual({});
+  });
+
+  it("resets a single column without touching its siblings", () => {
+    useGridColumnWidths.getState().setWidth("runSheet", "item", 320);
+    useGridColumnWidths.getState().setWidth("runSheet", "notes", 400);
+    useGridColumnWidths.getState().resetColumn("runSheet", "item");
+    expect(useGridColumnWidths.getState().getGridWidths("runSheet")).toEqual({
+      notes: 400,
+    });
+  });
+
+  it("reset is a no-op for an unknown column", () => {
+    useGridColumnWidths.getState().setWidth("runSheet", "item", 320);
+    useGridColumnWidths.getState().resetColumn("runSheet", "notes");
+    useGridColumnWidths.getState().resetColumn("other", "item");
+    expect(useGridColumnWidths.getState().getGridWidths("runSheet")).toEqual({
+      item: 320,
+    });
+  });
+
+  it("clears everything", () => {
+    useGridColumnWidths.getState().setWidth("runSheet", "item", 320);
+    useGridColumnWidths.getState().setWidth("eventTasks", "task", 260);
+    useGridColumnWidths.getState().clearAll();
+    expect(useGridColumnWidths.getState().getGridWidths("runSheet")).toEqual({});
+    expect(useGridColumnWidths.getState().getGridWidths("eventTasks")).toEqual(
+      {},
+    );
+  });
+});

--- a/apps/mobile/stores/gridColumnWidths.ts
+++ b/apps/mobile/stores/gridColumnWidths.ts
@@ -1,0 +1,75 @@
+/**
+ * Grid Column Widths Store
+ *
+ * Zustand + AsyncStorage store for per-grid, per-column width overrides set by
+ * dragging a column's right-edge handle in `GridScrollList`. Keyed by a stable
+ * `storageKey` (e.g. "runSheet", "eventTasks") so each grid remembers its own
+ * layout, then by the column's `key`.
+ *
+ * Unlike the offline data caches (`stores/*Cache.ts`, which ship a `.web.ts`
+ * no-op stub), these are a UI PREFERENCE we WANT to persist on web too — desktop
+ * is the primary surface for these tables. AsyncStorage maps to localStorage on
+ * web, so this single cross-platform file is correct; there is deliberately no
+ * `.web.ts` stub.
+ *
+ * Overrides are committed on drag RELEASE (not on every move) so we don't thrash
+ * AsyncStorage during a drag — the live width feeds off local component state
+ * while the pointer is down. See `GridScrollList`.
+ */
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+interface GridColumnWidthsState {
+  /** Overrides keyed `[storageKey][columnKey] = widthPx`. */
+  widths: Record<string, Record<string, number>>;
+  /** Persist a dragged width for one column of one grid. */
+  setWidth: (storageKey: string, columnKey: string, width: number) => void;
+  /** Forget a single column's override (double-click a handle → default width). */
+  resetColumn: (storageKey: string, columnKey: string) => void;
+  /** Read one grid's overrides (`{}` when none) for the width math. */
+  getGridWidths: (storageKey: string) => Record<string, number>;
+  /** Wipe everything (logout cleanup). */
+  clearAll: () => void;
+}
+
+export const useGridColumnWidths = create<GridColumnWidthsState>()(
+  persist(
+    (set, get) => ({
+      widths: {},
+
+      setWidth: (storageKey, columnKey, width) => {
+        set((state) => ({
+          widths: {
+            ...state.widths,
+            [storageKey]: {
+              ...(state.widths[storageKey] ?? {}),
+              [columnKey]: width,
+            },
+          },
+        }));
+      },
+
+      resetColumn: (storageKey, columnKey) => {
+        set((state) => {
+          const grid = state.widths[storageKey];
+          if (!grid || !(columnKey in grid)) return state;
+          // Drop just this column; keep the rest of the grid's overrides.
+          const { [columnKey]: _removed, ...rest } = grid;
+          return {
+            widths: { ...state.widths, [storageKey]: rest },
+          };
+        });
+      },
+
+      getGridWidths: (storageKey) => get().widths[storageKey] ?? {},
+
+      clearAll: () => set({ widths: {} }),
+    }),
+    {
+      name: "grid-column-widths",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ widths: state.widths }),
+    },
+  ),
+);

--- a/apps/mobile/stores/gridColumnWidths.web.ts
+++ b/apps/mobile/stores/gridColumnWidths.web.ts
@@ -1,0 +1,129 @@
+/**
+ * Grid Column Widths Store (Web)
+ *
+ * Web counterpart of `gridColumnWidths.ts`. The native store persists via
+ * zustand's `persist` middleware, which reads a bundler-only build-mode global
+ * that breaks the web bundle (see `__tests__/web-bundle-safety.test.ts`). This file provides
+ * a bundle-safe reactive store with the SAME public API, backed by React's
+ * `useSyncExternalStore` + a module-level state and a Set of listeners.
+ *
+ * Unlike the offline data caches (whose web stubs are no-ops — that data is
+ * irrelevant on web), column resizing is a WEB-PRIMARY feature: desktop is the
+ * main surface for these wide tables. So this web store is fully functional and
+ * persists to `localStorage` (guarded, SSR-safe) so dragged widths survive a
+ * refresh, exactly like the native AsyncStorage-persisted store.
+ */
+import { useSyncExternalStore } from 'react';
+
+interface GridColumnWidthsState {
+  /** Overrides keyed `[storageKey][columnKey] = widthPx`. */
+  widths: Record<string, Record<string, number>>;
+  setWidth: (storageKey: string, columnKey: string, width: number) => void;
+  resetColumn: (storageKey: string, columnKey: string) => void;
+  getGridWidths: (storageKey: string) => Record<string, number>;
+  clearAll: () => void;
+}
+
+const STORAGE_KEY = 'grid-column-widths';
+
+function hasStorage(): boolean {
+  return typeof window !== 'undefined' && !!window.localStorage;
+}
+
+function loadPersisted(): Record<string, Record<string, number>> {
+  if (!hasStorage()) return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as {
+      widths?: Record<string, Record<string, number>>;
+    };
+    return parsed.widths ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function persist(): void {
+  if (!hasStorage()) return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ widths: state.widths })
+    );
+  } catch {
+    // Ignore quota / privacy-mode failures — persistence is best-effort.
+  }
+}
+
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+const state: GridColumnWidthsState = {
+  widths: loadPersisted(),
+  setWidth: (storageKey, columnKey, width) => {
+    state.widths = {
+      ...state.widths,
+      [storageKey]: { ...(state.widths[storageKey] ?? {}), [columnKey]: width },
+    };
+    snapshot = makeSnapshot();
+    persist();
+    emit();
+  },
+  resetColumn: (storageKey, columnKey) => {
+    const grid = state.widths[storageKey];
+    if (!grid || !(columnKey in grid)) return;
+    const { [columnKey]: _removed, ...rest } = grid;
+    state.widths = { ...state.widths, [storageKey]: rest };
+    snapshot = makeSnapshot();
+    persist();
+    emit();
+  },
+  getGridWidths: (storageKey) => state.widths[storageKey] ?? {},
+  clearAll: () => {
+    state.widths = {};
+    snapshot = makeSnapshot();
+    persist();
+    emit();
+  },
+};
+
+function makeSnapshot(): GridColumnWidthsState {
+  return {
+    widths: state.widths,
+    setWidth: state.setWidth,
+    resetColumn: state.resetColumn,
+    getGridWidths: state.getGridWidths,
+    clearAll: state.clearAll,
+  };
+}
+
+/** Immutable snapshot for `useSyncExternalStore`; rebuilt on every mutation. */
+let snapshot: GridColumnWidthsState = makeSnapshot();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): GridColumnWidthsState {
+  return snapshot;
+}
+
+function useGridColumnWidthsHook(): GridColumnWidthsState;
+function useGridColumnWidthsHook<T>(selector: (s: GridColumnWidthsState) => T): T;
+function useGridColumnWidthsHook<T>(
+  selector?: (s: GridColumnWidthsState) => T
+): T | GridColumnWidthsState {
+  const snap = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return selector ? selector(snap) : snap;
+}
+
+export const useGridColumnWidths = Object.assign(useGridColumnWidthsHook, {
+  getState: (): GridColumnWidthsState => state,
+});


### PR DESCRIPTION
## What & why

Two day-of scheduling features requested by the maintainer.

### 1. Drag-to-resize grid columns
Run sheet, Tasks, and both template editors now have resizable columns — grab a header cell's right edge and drag; double-click resets.

- Resize logic centralized in the shared `GridScrollList` via an **opt-in `storageKey` prop** (callers that don't pass it are unchanged).
- Cross-platform: web pointer events (window `pointermove`/`pointerup`, `col-resize` cursor) + a native `PanResponder` that refuses to yield the gesture to the horizontal scroll. Live width tracks locally during drag; the final width **commits on release** to avoid storage thrash.
- Persists per-grid/per-column. Native: zustand + AsyncStorage (`stores/gridColumnWidths.ts`). Web: a `useSyncExternalStore` + `localStorage` counterpart (`gridColumnWidths.web.ts`) — web is the **primary** surface for these wide tables, and zustand's `persist` middleware breaks the web bundle (enforced by `web-bundle-safety.test.ts`), so the web store is fully functional, not a no-op. Wired into logout cleanup.
- `storageKey`s: `runSheet`, `runSheetTemplate`, `eventTasks`, `taskTemplate`.

### 2. Serving-mode "Team" roster grid
A pinned **Team** card at the top of the serving inbox → dedicated `/serving/team` screen showing who's serving alongside you.

- One section per plan you're serving (all eligible plans), team columns, a card per confirmed volunteer (avatar · name · role).
- Tapping a card → action sheet: **Message in Togather** (reuses `useStartDirectMessage` — a same-day DM the serving inbox already surfaces) or **Text &lt;number&gt;** via `sms:`.
- New Convex query `getServingTeamRoster`: confirmed-only assignments within the same-day serving window, grouped plan → team, phone surfaced when on file, `isSelf` flagged, `(user, role, team)` de-duped.

## Design decisions (confirmed with maintainer)
- Team grid shows **all** eligible serving plans (not just the active one).
- **Text** action surfaces a teammate's phone when present (day-of coordination among a confirmed serving team).
- Team grid is a **dedicated screen** (wide, horizontally-scrolling).
- Resized widths **persist** across sessions.

## Tests
- `getServingTeamRoster` — 4 cases (grouping, confirmed-only + window filter, de-dupe, empty). Convex `tsc` clean.
- `gridColumnWidths` store — 7 cases.
- Full mobile suite: **129 suites / 1197 passing**, incl. `web-bundle-safety`. Mobile `tsc` clean (no new errors).

## Not yet done
- Live visual pass was blocked (dev server went down mid-session); logic is covered by unit tests + typecheck. Happy to drive a Playwright/simulator smoke test on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)