### PR TITLE
feat(scheduling): re-base run sheet timing per service time (fix multi-service highlight)

### DIFF
--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -35,8 +35,10 @@ import {
   formatClockTime,
   formatDuration,
   formatServiceRanges,
+  pickActiveServiceIndex,
   totalDurationSec,
 } from "@features/scheduling/utils/runSheetTiming";
+import { ServiceTimeSelector } from "@features/scheduling/components/ServiceTimeSelector";
 import { renderTextWithLinks } from "../utils/runSheetLinks";
 
 /** Current-item highlight, mirroring the PCO run sheet (RunSheetScreen). */
@@ -290,10 +292,6 @@ function PlanRunSheet({
       : undefined);
 
   const times = effEvent?.times ?? [];
-  const earliestStart = useMemo(
-    () => (times.length > 0 ? Math.min(...times.map((t) => t.startsAt)) : Date.now()),
-    [times],
-  );
   // Group into before / during / after phases (listItems returns them sorted
   // by (segment, sequence)), then time each phase: during from the event start,
   // before backward to it, after from the event end. Keeps clocks consistent
@@ -310,20 +308,59 @@ function PlanRunSheet({
     }
     return groups;
   }, [effItems]);
+  // Phase totals feed both the header ranges and the active-service window.
+  const duringTotalSec = useMemo(
+    () => totalDurationSec(itemsBySegment.during),
+    [itemsBySegment.during],
+  );
+  const beforeTotalSec = useMemo(
+    () => totalDurationSec(itemsBySegment.before),
+    [itemsBySegment.before],
+  );
+  const afterTotalSec = useMemo(
+    () => totalDurationSec(itemsBySegment.after),
+    [itemsBySegment.after],
+  );
+
+  // Live clock: tick every 30s so the current-item highlight — and, on a
+  // multi-service plan, the auto-selected service — advance as the day moves.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Which service the sheet is anchored to. `null` = follow the live service
+  // (auto, day-of); a number = the user manually picked one (sticky override).
+  const [manualServiceIdx, setManualServiceIdx] = useState<number | null>(null);
+  const autoServiceIdx = useMemo(
+    () =>
+      pickActiveServiceIndex(
+        times,
+        now,
+        beforeTotalSec,
+        duringTotalSec,
+        afterTotalSec,
+      ),
+    [times, now, beforeTotalSec, duringTotalSec, afterTotalSec],
+  );
+  // A manual pick can go stale if `times` shrinks (rare) — clamp it.
+  const effectiveServiceIdx =
+    manualServiceIdx != null && manualServiceIdx < times.length
+      ? manualServiceIdx
+      : autoServiceIdx;
+  const serviceStartMs =
+    times.length > 0 ? times[effectiveServiceIdx].startsAt : now;
+
   const clockTimes = useMemo(
     () =>
       computeSegmentedClockTimes(
         itemsBySegment.before,
         itemsBySegment.during,
         itemsBySegment.after,
-        earliestStart,
+        serviceStartMs,
       ),
-    [itemsBySegment, earliestStart],
-  );
-  // The service window is the "during" phase — before/after bracket it.
-  const duringTotalSec = useMemo(
-    () => totalDurationSec(itemsBySegment.during),
-    [itemsBySegment.during],
+    [itemsBySegment, serviceStartMs],
   );
   const peopleByRole = useMemo(() => {
     const map: Record<string, string[]> = {};
@@ -398,21 +435,13 @@ function PlanRunSheet({
     ).catch((err) => console.error("Failed to save collapsed state:", err));
   }, [collapsedHeaders, collapsedHeadersLoaded, collapsedStorageKey]);
 
-  // Live "current item": tick a clock every 30s and match the item whose
-  // computed [start, start + durationSec) window contains now. Same logic as
-  // the PCO renderer, but sourced from client-computed clock times.
-  // TODO(followup): clock times are anchored to the earliest service time, so
-  // on a multi-service plan only the earliest service ever highlights. To
-  // support later services we'd need a service-time selector (like PCO's) and
-  // re-base clockTimes to the chosen window before matching.
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 30_000);
-    return () => clearInterval(interval);
-  }, []);
+  // Live "current item": match the item whose computed [start, start +
+  // durationSec) window contains `now` (ticked above). Because `clockTimes` is
+  // anchored to the active/selected service, this highlights the right rows on
+  // every service of a multi-service plan, not just the earliest.
   const currentItemId = useMemo(() => {
-    // Without real service times the clocks are anchored to `now` (see
-    // earliestStart fallback), which would spuriously highlight the first item.
+    // Without real service times the clocks are anchored to `now` (the
+    // serviceStartMs fallback), which would spuriously highlight the first item.
     if (times.length === 0) return null;
     const list = effItems ?? [];
     for (let i = list.length - 1; i >= 0; i--) {
@@ -488,6 +517,14 @@ function PlanRunSheet({
           ) : null}
         </View>
       </View>
+
+      <ServiceTimeSelector
+        times={times}
+        selectedIndex={effectiveServiceIdx}
+        following={manualServiceIdx == null}
+        onSelect={setManualServiceIdx}
+        onResetToLive={() => setManualServiceIdx(null)}
+      />
 
       {effItems.length === 0 ? (
         <Text style={[styles.emptyText, { color: colors.textSecondary }]}>

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -344,7 +344,9 @@ function PlanRunSheet({
       ),
     [times, now, beforeTotalSec, duringTotalSec, afterTotalSec],
   );
-  // A manual pick can go stale if `times` shrinks (rare) — clamp it.
+  // Guard the upper bound so a manual pick that outran a shrunk `times` falls
+  // back to auto. (A reorder that keeps the length isn't tracked — editing
+  // service times mid-serving is rare enough to accept.)
   const effectiveServiceIdx =
     manualServiceIdx != null && manualServiceIdx < times.length
       ? manualServiceIdx

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -419,6 +419,8 @@ export function RunSheetScreen() {
   const [selectedServiceIdx, setSelectedServiceIdx] = useState<number | null>(
     null,
   );
+  // Guard the upper bound so a pick that outran a shrunk `times` falls back to
+  // the earliest (a same-length reorder isn't tracked — an acceptable rarity).
   const effectiveServiceIdx =
     selectedServiceIdx != null && selectedServiceIdx < times.length
       ? selectedServiceIdx

--- a/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RunSheetScreen.tsx
@@ -60,6 +60,7 @@ import { AnchoredMenu, measureAnchor, type AnchorRect } from "./AnchoredMenu";
 import { SegmentedTabs } from "@components/ui/SegmentedTabs";
 import { CustomModal } from "@components/ui/Modal";
 import { PlanTemplateToolbar } from "./PlanTemplateToolbar";
+import { ServiceTimeSelector } from "./ServiceTimeSelector";
 import { listRunSheetTemplatesRef } from "../api/eventTemplates";
 import {
   getPlanTemplateStateRef,
@@ -402,15 +403,30 @@ export function RunSheetScreen() {
     if (router.canGoBack()) router.back();
   }, [router]);
 
-  // The shared run sheet is timed from the earliest service start.
+  // The shared run sheet is timed from the SELECTED service start. Rows default
+  // to the earliest service; on a multi-service plan the toolbar's service
+  // selector re-bases every row to another service with no writes.
   const times = event?.times ?? [];
-  const earliestStart = useMemo(
-    () =>
-      times.length > 0
-        ? Math.min(...times.map((t) => t.startsAt))
-        : (event?.eventDate ?? Date.now()),
-    [times, event?.eventDate],
+  const earliestIndex = useMemo(() => {
+    if (times.length === 0) return 0;
+    let idx = 0;
+    for (let i = 1; i < times.length; i++) {
+      if (times[i].startsAt < times[idx].startsAt) idx = i;
+    }
+    return idx;
+  }, [times]);
+  // `null` = show the default (earliest) service; a number = user's pick.
+  const [selectedServiceIdx, setSelectedServiceIdx] = useState<number | null>(
+    null,
   );
+  const effectiveServiceIdx =
+    selectedServiceIdx != null && selectedServiceIdx < times.length
+      ? selectedServiceIdx
+      : earliestIndex;
+  const serviceStartMs =
+    times.length > 0
+      ? times[effectiveServiceIdx].startsAt
+      : (event?.eventDate ?? Date.now());
 
   // Group items into before / during / after phases. `listItems` already
   // returns them sorted by (segment, sequence), so each group stays ordered.
@@ -433,9 +449,9 @@ export function RunSheetScreen() {
         itemsBySegment.before,
         itemsBySegment.during,
         itemsBySegment.after,
-        earliestStart,
+        serviceStartMs,
       ),
-    [itemsBySegment, earliestStart],
+    [itemsBySegment, serviceStartMs],
   );
 
   // The service window is the "during" phase — before/after bracket it.
@@ -669,6 +685,13 @@ export function RunSheetScreen() {
                   onRevert={handleRevertTemplate}
                 />
               ) : null}
+              {/* Multi-service plans: pick which service the row clocks anchor
+                  to (renders nothing for a single-service plan). */}
+              <ServiceTimeSelector
+                times={times}
+                selectedIndex={effectiveServiceIdx}
+                onSelect={setSelectedServiceIdx}
+              />
             </View>
           );
 

--- a/apps/mobile/features/scheduling/components/ServiceTimeSelector.tsx
+++ b/apps/mobile/features/scheduling/components/ServiceTimeSelector.tsx
@@ -1,0 +1,126 @@
+/**
+ * ServiceTimeSelector
+ *
+ * A pill row for choosing which of a plan's service times the run sheet is
+ * anchored to. Only meaningful for multi-service plans, so it renders nothing
+ * when there are fewer than two times.
+ *
+ * Selecting a pill re-bases the run sheet's derived clock times to that service
+ * (no writes — see `runSheetTiming.ts`). In serving mode the caller auto-picks
+ * the live service and passes `following` + `onResetToLive`, so a manual pick
+ * shows a "Live" chip to hand control back to the automatic day-of tracking.
+ */
+import React from "react";
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { formatClockTime } from "@features/scheduling/utils/runSheetTiming";
+
+export function ServiceTimeSelector({
+  times,
+  selectedIndex,
+  onSelect,
+  /** True while the selection is auto-following the live service (serving mode). */
+  following,
+  /** When provided (serving mode), a "Live" chip appears once the user overrides. */
+  onResetToLive,
+}: {
+  times: Array<{ label: string; startsAt: number }>;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  following?: boolean;
+  onResetToLive?: () => void;
+}) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  // A single service has nothing to switch between.
+  if (times.length < 2) return null;
+
+  const showLiveChip = onResetToLive != null && following === false;
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={[styles.label, { color: colors.textTertiary }]}>SERVICE</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.row}
+      >
+        {times.map((t, i) => {
+          const active = i === selectedIndex;
+          // Prefer the stored label ("9:00 AM"); fall back to the formatted start.
+          const text = t.label?.trim() || formatClockTime(t.startsAt);
+          return (
+            <TouchableOpacity
+              key={`${t.startsAt}:${i}`}
+              onPress={() => onSelect(i)}
+              activeOpacity={0.7}
+              style={[
+                styles.pill,
+                {
+                  backgroundColor: active
+                    ? primaryColor + "1F"
+                    : colors.surfaceSecondary,
+                  borderColor: active ? primaryColor : colors.border,
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={`Show ${text} service`}
+            >
+              {active && following ? (
+                <View style={[styles.liveDot, { backgroundColor: primaryColor }]} />
+              ) : null}
+              <Text
+                style={[
+                  styles.pillText,
+                  { color: active ? primaryColor : colors.textSecondary },
+                ]}
+                numberOfLines={1}
+              >
+                {text}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+
+        {showLiveChip ? (
+          <TouchableOpacity
+            onPress={onResetToLive}
+            activeOpacity={0.7}
+            style={[styles.pill, styles.livePill, { borderColor: primaryColor }]}
+            accessibilityRole="button"
+            accessibilityLabel="Follow the live service"
+          >
+            <Ionicons name="radio-outline" size={13} color={primaryColor} />
+            <Text style={[styles.pillText, { color: primaryColor }]}>Live</Text>
+          </TouchableOpacity>
+        ) : null}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: 6, paddingVertical: 8 },
+  label: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+  row: { flexDirection: "row", gap: 8, paddingRight: 8 },
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  livePill: { gap: 4 },
+  liveDot: { width: 7, height: 7, borderRadius: 4 },
+  pillText: { fontSize: 13, fontWeight: "600" },
+});

--- a/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
@@ -110,6 +110,22 @@ describe("pickActiveServiceIndex", () => {
     expect(pickActiveServiceIndex(unordered, at(9, 30), 0, DURING, 0)).toBe(1);
   });
 
+  it("when windows overlap, the later-starting service wins", () => {
+    // 90-min "during" makes 9:00's window run to 10:30, overlapping 10:00's
+    // window [10:00, 11:30). At 10:15 both contain now → pick the later one.
+    const overlapping = [{ startsAt: at(9) }, { startsAt: at(10) }];
+    expect(pickActiveServiceIndex(overlapping, at(10, 15), 0, 90 * 60, 0)).toBe(
+      1,
+    );
+  });
+
+  it("after all services with unordered times, picks the max-start index", () => {
+    // Windows end by 12:00; 13:00 is past all → the latest service (11:00),
+    // which is index 0 in this unordered array.
+    const unordered = [{ startsAt: at(11) }, { startsAt: at(9) }];
+    expect(pickActiveServiceIndex(unordered, at(13), 0, DURING, 0)).toBe(0);
+  });
+
   it("handles empty times", () => {
     expect(pickActiveServiceIndex([], at(9), 0, DURING, 0)).toBe(0);
   });

--- a/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
@@ -2,6 +2,7 @@ import {
   computeItemClockTimes,
   formatDuration,
   formatServiceRanges,
+  pickActiveServiceIndex,
   type TimingItem,
 } from "../runSheetTiming";
 
@@ -69,5 +70,47 @@ describe("formatDuration", () => {
     expect(formatDuration(45)).toBe("45 sec");
     expect(formatDuration(300)).toBe("5 min");
     expect(formatDuration(3900)).toBe("1 hr 5 min");
+  });
+});
+
+describe("pickActiveServiceIndex", () => {
+  const at = (h: number, m = 0) => new Date(2026, 5, 7, h, m).getTime();
+  // Two services: 9:00 AM and 11:00 AM; 60-min "during", no before/after.
+  const times = [{ startsAt: at(9) }, { startsAt: at(11) }];
+  const DURING = 60 * 60; // 1 hr in seconds
+
+  it("picks the service whose window contains now", () => {
+    expect(pickActiveServiceIndex(times, at(9, 30), 0, DURING, 0)).toBe(0);
+    expect(pickActiveServiceIndex(times, at(11, 30), 0, DURING, 0)).toBe(1);
+  });
+
+  it("before any service, picks the soonest upcoming", () => {
+    expect(pickActiveServiceIndex(times, at(8), 0, DURING, 0)).toBe(0);
+  });
+
+  it("between services, picks the next upcoming", () => {
+    // 10:30 is past the 9:00 window (ends 10:00) and before 11:00.
+    expect(pickActiveServiceIndex(times, at(10, 30), 0, DURING, 0)).toBe(1);
+  });
+
+  it("after all services, picks the last", () => {
+    expect(pickActiveServiceIndex(times, at(13), 0, DURING, 0)).toBe(1);
+  });
+
+  it("counts a before pre-roll as part of the service window", () => {
+    // 30-min pre-roll → the 9:00 window opens at 8:30.
+    expect(pickActiveServiceIndex(times, at(8, 45), 30 * 60, DURING, 0)).toBe(0);
+    // ...but 8:15 is still ahead of it → soonest upcoming (still index 0).
+    expect(pickActiveServiceIndex(times, at(8, 15), 30 * 60, DURING, 0)).toBe(0);
+  });
+
+  it("returns the array index even when times are unordered", () => {
+    const unordered = [{ startsAt: at(11) }, { startsAt: at(9) }];
+    // 9:30 is inside the second element's window.
+    expect(pickActiveServiceIndex(unordered, at(9, 30), 0, DURING, 0)).toBe(1);
+  });
+
+  it("handles empty times", () => {
+    expect(pickActiveServiceIndex([], at(9), 0, DURING, 0)).toBe(0);
   });
 });

--- a/apps/mobile/features/scheduling/utils/runSheetTiming.ts
+++ b/apps/mobile/features/scheduling/utils/runSheetTiming.ts
@@ -88,6 +88,56 @@ export function computeSegmentedClockTimes(
   };
 }
 
+/**
+ * Pick which service a multi-service plan's run sheet should anchor to for a
+ * given wall-clock `now`, so day-of the sheet re-bases to the service you're
+ * actually in (and its live highlight tracks the right rows). Each service `i`
+ * owns the window `[startsAt_i − before, startsAt_i + during + after]` — its
+ * pre-roll leading in through its post-roll.
+ *
+ * Selection order:
+ *   1. a service whose window contains `now` (the one happening now — if two
+ *      overlap, the later-starting wins, since that's the one you're rolling into);
+ *   2. else the soonest service still ahead of `now` (its window hasn't opened);
+ *   3. else the last service (everything's already over).
+ *
+ * Returns an index into `times` (0 when empty). Durations are in seconds.
+ */
+export function pickActiveServiceIndex(
+  times: Array<{ startsAt: number }>,
+  now: number,
+  beforeSec: number,
+  duringSec: number,
+  afterSec: number,
+): number {
+  if (times.length === 0) return 0;
+  const beforeMs = Math.max(0, beforeSec) * 1000;
+  const tailMs = (Math.max(0, duringSec) + Math.max(0, afterSec)) * 1000;
+
+  let containing = -1;
+  let nextUpcoming = -1;
+  let last = 0;
+  for (let i = 0; i < times.length; i++) {
+    const winStart = times[i].startsAt - beforeMs;
+    const winEnd = times[i].startsAt + tailMs;
+    if (now >= winStart && now < winEnd) {
+      if (containing === -1 || times[i].startsAt > times[containing].startsAt) {
+        containing = i;
+      }
+    }
+    if (winStart > now) {
+      if (nextUpcoming === -1 || times[i].startsAt < times[nextUpcoming].startsAt) {
+        nextUpcoming = i;
+      }
+    }
+    if (times[i].startsAt > times[last].startsAt) last = i;
+  }
+
+  if (containing !== -1) return containing;
+  if (nextUpcoming !== -1) return nextUpcoming;
+  return last;
+}
+
 /** "10:04 AM" — clock label for a run sheet row. */
 export function formatClockTime(ms: number): string {
   return new Date(ms).toLocaleTimeString("en-US", {


### PR DESCRIPTION
## Problem
Run sheet clock times derive from a single service-start anchor, but the editor and the day-of serving view both hard-anchored to the **earliest** service (`Math.min(...times)`). On a multi-service plan (e.g. 9 AM + 11 AM):
- later services showed the wrong row times, and
- the live "current item" highlight (which matches `now` against those clocks) **went dark during the second service** — `now` was past every earliest-anchored window.

This was the documented `TODO(followup)` in `NativeRunSheetView.tsx`.

## Fix
- **`pickActiveServiceIndex(times, now, before, during, after)`** — picks the service whose window `[start−before, start+during+after]` contains `now`; else the soonest upcoming; else the last.
- **`ServiceTimeSelector`** — a shared pill row (renders only when there are ≥2 services) to switch which service the rows anchor to. No writes — the clocks just re-base.
- **Serving view** (`NativeRunSheetView`): auto-follows the live service and advances automatically via the existing 30s tick; a manual pick sticks and surfaces a **Live** chip to hand control back. The current-item highlight now tracks the right rows on *every* service.
- **Editor** (`RunSheetScreen`): same selector, defaulting to the earliest service.

## Confirmed with maintainer
- Auto-pick the live service + manual override (serving mode).
- Add the selector to **both** the serving view and the editor.
- Highlight the current **item** only (now works across all services).

## Tests
- 7 new `pickActiveServiceIndex` cases (window / upcoming / last / pre-roll / unordered / empty). Full timing suite green; mobile `tsc` clean.

## Not yet done
- No live visual pass (dev server is down). Logic is unit-tested; happy to drive a simulator/Playwright pass on a multi-service plan on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)