### PR TITLE
feat: share announcement channels with other groups

### DIFF
--- a/apps/convex/__tests__/messaging/shared-announcements.test.ts
+++ b/apps/convex/__tests__/messaging/shared-announcements.test.ts
@@ -1037,3 +1037,354 @@ describe("decline and cancel have no announcements side effects", () => {
     await t.finishAllScheduledFunctions(vi.runAllTimers);
   });
 });
+
+// ============================================================================
+// Owner archive clears the share itself
+// ============================================================================
+
+describe("archiving the owner clears the share from the archived channel", () => {
+  test("sharedGroups is emptied and isShared cleared so unarchiving can't resurrect the share", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.groups.mutations.update, {
+      token: data.adminToken,
+      groupId: data.ownerGroupId,
+      isArchived: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(sharedChannel!.isArchived).toBe(true);
+    expect(sharedChannel!.sharedGroups).toHaveLength(0);
+    expect(sharedChannel!.isShared).toBe(false);
+  });
+});
+
+// ============================================================================
+// archiveChannel guard
+// ============================================================================
+
+describe("archiveChannel on a shared channel", () => {
+  test("cannot archive a channel with shared groups (pending entry is enough)", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+
+    await expect(
+      t.mutation(api.functions.messaging.channels.archiveChannel, {
+        token: data.ownerLeaderToken,
+        channelId: data.ownerAnnouncementsChannelId,
+      })
+    ).rejects.toThrow(/CHANNEL_SHARED/);
+  });
+});
+
+// ============================================================================
+// Disabled/archived channel guards on invite + accept
+// ============================================================================
+
+describe("disabled/archived shared channel guards", () => {
+  test("cannot accept an invite to a disabled channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(data.ownerAnnouncementsChannelId, { isEnabled: false });
+    });
+
+    await expect(acceptShare(t, data)).rejects.toThrow(/CHANNEL_DISABLED/);
+
+    // No side effects: the accepting group's own channel stays enabled.
+    const ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(true);
+  });
+
+  test("cannot accept an invite to an archived channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(data.ownerAnnouncementsChannelId, {
+        isArchived: true,
+        archivedAt: Date.now(),
+      });
+    });
+
+    await expect(acceptShare(t, data)).rejects.toThrow(/CHANNEL_DISABLED/);
+  });
+
+  test("cannot invite a group to a disabled announcements channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(data.ownerAnnouncementsChannelId, { isEnabled: false });
+    });
+
+    await expect(inviteSecondary(t, data)).rejects.toThrow(/CHANNEL_DISABLED/);
+  });
+
+  test("a group that receives announcements through a share cannot share its own channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Force the secondary's own channel back to enabled directly (bypassing
+    // the IN_SHARED_ANNOUNCEMENTS toggle guard) so the disabled-channel
+    // invite guard doesn't fire first.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(data.secondaryAnnouncementsChannelId, {
+        isEnabled: true,
+        disabledByUserId: undefined,
+      });
+    });
+
+    const fourthGroupId = await t.run(async (ctx) => {
+      return await ctx.db.insert("groups", {
+        name: "Fourth Group",
+        communityId: data.communityId,
+        groupTypeId: data.groupTypeId,
+        isPublic: true,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+        token: data.secondaryLeaderToken,
+        channelId: data.secondaryAnnouncementsChannelId,
+        groupId: fourthGroupId,
+      })
+    ).rejects.toThrow(/OWNER_IS_SECONDARY/);
+  });
+});
+
+// ============================================================================
+// Backfill race guard
+// ============================================================================
+
+describe("populateChannelMembersBatch race guard", () => {
+  test("in-flight backfill bails when the group is removed from the share before it runs", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+
+    // Remove the group from the share BEFORE the scheduled backfill runs.
+    await t.mutation(api.functions.messaging.sharedChannels.removeGroupFromChannel, {
+      token: data.secondaryLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The stale backfill must NOT have re-added the removed group's members.
+    for (const userId of [data.secondaryLeaderId, data.secondaryMemberId]) {
+      const row = await getChannelMember(t, data.ownerAnnouncementsChannelId, userId);
+      if (row) {
+        expect(row.leftAt).toBeDefined();
+      }
+    }
+
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(sharedChannel!.memberCount).toBe(2);
+  });
+});
+
+// ============================================================================
+// Accepting leader gets immediate membership
+// ============================================================================
+
+describe("accepting leader membership", () => {
+  test("the responding leader is an active channel admin before the batch runs", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+
+    // BEFORE running scheduled functions — the synchronous ensure must
+    // already have added the leader so an immediate post can't fail with
+    // "Not a member of this channel".
+    const leaderRow = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.secondaryLeaderId
+    );
+    expect(leaderRow).not.toBeNull();
+    expect(leaderRow!.leftAt).toBeUndefined();
+    expect(leaderRow!.role).toBe("admin");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+});
+
+// ============================================================================
+// Legacy entries without recorded prior state
+// ============================================================================
+
+describe("switching from a legacy entry without previousAnnouncementsChannelEnabled", () => {
+  test("falls back to the current own-channel state instead of storing undefined", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    // Third owner group with its own announcements channel.
+    const thirdGroupId = await t.run(async (ctx) => {
+      return await ctx.db.insert("groups", {
+        name: "Third Owner Group",
+        communityId: data.communityId,
+        groupTypeId: data.groupTypeId,
+        isPublic: true,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    const thirdLeader = await createUserInGroup(
+      t,
+      data.communityId,
+      thirdGroupId,
+      "leader",
+      "ThirdOwnerL"
+    );
+    const thirdChannelId = await createAnnouncementsChannel(
+      t,
+      thirdGroupId,
+      thirdLeader.userId
+    );
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Simulate a legacy entry created before prior-state tracking: strip the
+    // recorded previousAnnouncementsChannelEnabled off the accepted entry.
+    await t.run(async (ctx) => {
+      const channel = await ctx.db.get(data.ownerAnnouncementsChannelId);
+      const stripped = (channel!.sharedGroups ?? []).map((sg) => {
+        const { previousAnnouncementsChannelEnabled: _omit, ...rest } = sg;
+        return rest;
+      });
+      await ctx.db.patch(data.ownerAnnouncementsChannelId, {
+        sharedGroups: stripped,
+      });
+    });
+
+    // Switch to the third group's share.
+    await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+      token: thirdLeader.token,
+      channelId: thirdChannelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+      token: data.secondaryLeaderToken,
+      channelId: thirdChannelId,
+      groupId: data.secondaryGroupId,
+      response: "accepted",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The new entry stores the CURRENT own-channel state (disabled by the
+    // first accept → false), not undefined.
+    const newChannel = await t.run((ctx) => ctx.db.get(thirdChannelId));
+    const newEntry = newChannel!.sharedGroups!.find(
+      (sg) => sg.groupId === data.secondaryGroupId
+    );
+    expect(newEntry!.previousAnnouncementsChannelEnabled).toBe(false);
+  });
+});
+
+// ============================================================================
+// Community-scoped share metadata
+// ============================================================================
+
+describe("community scoping of shared channels", () => {
+  test("inviting stamps communityId on the shared channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    // Seeded without communityId (legacy shape).
+    let channel = await t.run((ctx) => ctx.db.get(data.ownerAnnouncementsChannelId));
+    expect(channel!.communityId).toBeUndefined();
+
+    await inviteSecondary(t, data);
+
+    channel = await t.run((ctx) => ctx.db.get(data.ownerAnnouncementsChannelId));
+    expect(channel!.communityId).toBe(data.communityId);
+  });
+});
+
+// ============================================================================
+// listGroupChannels — shared-in announcements shape
+// ============================================================================
+
+describe("listGroupChannels with a shared announcements channel", () => {
+  test("secondary side gets sharedFromGroupName (no sharedGroupCount); owner side gets sharedGroupCount", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Secondary group's view: the shared-in channel carries the owning
+    // group's name; its own (disabled) channel does not.
+    const secondaryChannels = await t.query(
+      api.functions.messaging.channels.listGroupChannels,
+      {
+        token: data.secondaryLeaderToken,
+        groupId: data.secondaryGroupId,
+        includeArchived: true,
+      }
+    );
+    const sharedIn = secondaryChannels.find(
+      (c) => c._id === data.ownerAnnouncementsChannelId
+    );
+    expect(sharedIn).toBeDefined();
+    expect(sharedIn!.sharedFromGroupId).toBe(data.ownerGroupId);
+    expect(sharedIn!.sharedFromGroupName).toBe("Owner Group");
+    expect(sharedIn!.sharedGroupCount).toBeUndefined();
+
+    const ownDisabled = secondaryChannels.find(
+      (c) => c._id === data.secondaryAnnouncementsChannelId
+    );
+    expect(ownDisabled).toBeDefined();
+    expect(ownDisabled!.sharedFromGroupName).toBeUndefined();
+
+    // Owner group's view: its channel is owner-side shared.
+    const ownerChannels = await t.query(
+      api.functions.messaging.channels.listGroupChannels,
+      {
+        token: data.ownerLeaderToken,
+        groupId: data.ownerGroupId,
+        includeArchived: true,
+      }
+    );
+    const owned = ownerChannels.find(
+      (c) => c._id === data.ownerAnnouncementsChannelId
+    );
+    expect(owned).toBeDefined();
+    expect(owned!.sharedGroupCount).toBe(1);
+    expect(owned!.sharedFromGroupName).toBeUndefined();
+  });
+});

--- a/apps/convex/__tests__/messaging/shared-announcements.test.ts
+++ b/apps/convex/__tests__/messaging/shared-announcements.test.ts
@@ -1,0 +1,1039 @@
+/**
+ * Shared Announcements Channel Tests
+ *
+ * Covers sharing a group's announcements channel with other groups:
+ * - Accepting an invite backfills the accepting group's members (leaders
+ *   mirror to channel role "admin") and keeps them in sync on join/leave/role
+ *   changes.
+ * - Accepting disables the accepting group's own announcements channel and
+ *   records its prior enabled state on the sharedGroups entry.
+ * - Posting is allowed for leaders of the owning group OR any accepted
+ *   secondary group; everyone else is read-only.
+ * - Leaving/removal restores the group's own announcements channel (when it
+ *   was enabled before the share) and removes exclusive members.
+ * - Accepting a new share while already in one switches shares, carrying the
+ *   original prior-enabled state forward.
+ * - Guards: cannot accept while your own announcements channel is shared;
+ *   cannot disable a shared announcements channel; cannot enable your own
+ *   while an accepted secondary elsewhere.
+ * - Archiving the owning group restores accepted secondaries' own channels.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import type { Id } from "../../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+vi.useFakeTimers();
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+const COMMUNITY_ROLES = {
+  MEMBER: 1,
+  ADMIN: 3,
+} as const;
+
+// ============================================================================
+// Seed Helpers
+// ============================================================================
+
+interface SeedData {
+  communityId: Id<"communities">;
+  groupTypeId: Id<"groupTypes">;
+  // Owner group (owns the shared announcements channel)
+  ownerGroupId: Id<"groups">;
+  ownerLeaderId: Id<"users">;
+  ownerLeaderToken: string;
+  ownerMemberId: Id<"users">;
+  ownerMemberToken: string;
+  ownerAnnouncementsChannelId: Id<"chatChannels">;
+  // Secondary group (accepts the share); has its own announcements channel
+  secondaryGroupId: Id<"groups">;
+  secondaryLeaderId: Id<"users">;
+  secondaryLeaderToken: string;
+  secondaryMemberId: Id<"users">;
+  secondaryMemberToken: string;
+  secondaryAnnouncementsChannelId: Id<"chatChannels">;
+  // Community admin (for archive tests)
+  adminUserId: Id<"users">;
+  adminToken: string;
+}
+
+let phoneCounter = 100;
+
+async function createUserInGroup(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  groupId: Id<"groups">,
+  role: "leader" | "member",
+  name: string
+): Promise<{ userId: Id<"users">; token: string }> {
+  phoneCounter += 1;
+  const userId = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("users", {
+      firstName: name,
+      lastName: role === "leader" ? "Leader" : "Member",
+      phone: `+1555666${String(phoneCounter).padStart(4, "0")}`,
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await ctx.db.insert("groupMembers", {
+      userId: id,
+      groupId,
+      role,
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+    return id;
+  });
+  const { accessToken } = await generateTokens(userId);
+  return { userId, token: accessToken };
+}
+
+/**
+ * Creates an enabled announcements channel for a group with all the group's
+ * current active members as channel members (leaders as channel "admin").
+ */
+async function createAnnouncementsChannel(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  createdById: Id<"users">
+): Promise<Id<"chatChannels">> {
+  return await t.run(async (ctx) => {
+    const channelId = await ctx.db.insert("chatChannels", {
+      groupId,
+      slug: "announcements",
+      channelType: "announcements",
+      name: "Announcements",
+      createdById,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isArchived: false,
+      isEnabled: true,
+      memberCount: 0,
+    });
+    const members = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", groupId))
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .collect();
+    for (const member of members) {
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: member.userId,
+        role: member.role === "leader" ? "admin" : "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    }
+    await ctx.db.patch(channelId, { memberCount: members.length });
+    return channelId;
+  });
+}
+
+async function seedData(t: ReturnType<typeof convexTest>): Promise<SeedData> {
+  const communityId = await t.run(async (ctx) => {
+    return await ctx.db.insert("communities", {
+      name: "Test Community",
+      subdomain: "test-shared-ann",
+      slug: "test-shared-ann",
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const groupTypeId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Groups",
+      slug: "small-groups",
+      isActive: true,
+      displayOrder: 1,
+      createdAt: Date.now(),
+    });
+  });
+
+  const ownerGroupId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groups", {
+      name: "Owner Group",
+      communityId,
+      groupTypeId,
+      isPublic: true,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const secondaryGroupId = await t.run(async (ctx) => {
+    return await ctx.db.insert("groups", {
+      name: "Secondary Group",
+      communityId,
+      groupTypeId,
+      isPublic: true,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const ownerLeader = await createUserInGroup(t, communityId, ownerGroupId, "leader", "OwnerL");
+  const ownerMember = await createUserInGroup(t, communityId, ownerGroupId, "member", "OwnerM");
+  const secondaryLeader = await createUserInGroup(t, communityId, secondaryGroupId, "leader", "SecL");
+  const secondaryMember = await createUserInGroup(t, communityId, secondaryGroupId, "member", "SecM");
+
+  const ownerAnnouncementsChannelId = await createAnnouncementsChannel(
+    t,
+    ownerGroupId,
+    ownerLeader.userId
+  );
+  const secondaryAnnouncementsChannelId = await createAnnouncementsChannel(
+    t,
+    secondaryGroupId,
+    secondaryLeader.userId
+  );
+
+  // Community admin (not in any group)
+  phoneCounter += 1;
+  const adminUserId = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("users", {
+      firstName: "Community",
+      lastName: "Admin",
+      phone: `+1555666${String(phoneCounter).padStart(4, "0")}`,
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await ctx.db.insert("userCommunities", {
+      userId: id,
+      communityId,
+      roles: COMMUNITY_ROLES.ADMIN,
+      status: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return id;
+  });
+  const { accessToken: adminToken } = await generateTokens(adminUserId);
+
+  return {
+    communityId,
+    groupTypeId,
+    ownerGroupId,
+    ownerLeaderId: ownerLeader.userId,
+    ownerLeaderToken: ownerLeader.token,
+    ownerMemberId: ownerMember.userId,
+    ownerMemberToken: ownerMember.token,
+    ownerAnnouncementsChannelId,
+    secondaryGroupId,
+    secondaryLeaderId: secondaryLeader.userId,
+    secondaryLeaderToken: secondaryLeader.token,
+    secondaryMemberId: secondaryMember.userId,
+    secondaryMemberToken: secondaryMember.token,
+    secondaryAnnouncementsChannelId,
+    adminUserId,
+    adminToken,
+  };
+}
+
+async function inviteSecondary(t: ReturnType<typeof convexTest>, data: SeedData) {
+  await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+    token: data.ownerLeaderToken,
+    channelId: data.ownerAnnouncementsChannelId,
+    groupId: data.secondaryGroupId,
+  });
+}
+
+async function acceptShare(t: ReturnType<typeof convexTest>, data: SeedData) {
+  await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+    token: data.secondaryLeaderToken,
+    channelId: data.ownerAnnouncementsChannelId,
+    groupId: data.secondaryGroupId,
+    response: "accepted",
+  });
+}
+
+async function getChannelMember(
+  t: ReturnType<typeof convexTest>,
+  channelId: Id<"chatChannels">,
+  userId: Id<"users">
+) {
+  return await t.run(async (ctx) => {
+    return await ctx.db
+      .query("chatChannelMembers")
+      .withIndex("by_channel_user", (q) =>
+        q.eq("channelId", channelId).eq("userId", userId)
+      )
+      .first();
+  });
+}
+
+// ============================================================================
+// Accept → membership backfill
+// ============================================================================
+
+describe("accepting an announcements share backfills membership", () => {
+  test("all active members of the accepting group are added; leaders mirror to admin", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const leaderRow = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.secondaryLeaderId
+    );
+    expect(leaderRow).not.toBeNull();
+    expect(leaderRow!.leftAt).toBeUndefined();
+    expect(leaderRow!.role).toBe("admin");
+
+    const memberRow = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.secondaryMemberId
+    );
+    expect(memberRow).not.toBeNull();
+    expect(memberRow!.leftAt).toBeUndefined();
+    expect(memberRow!.role).toBe("member");
+
+    // Member count covers owner (2) + secondary (2), not just the backfilled roster.
+    const channel = await t.run((ctx) => ctx.db.get(data.ownerAnnouncementsChannelId));
+    expect(channel!.memberCount).toBe(4);
+  });
+
+  test("user joining the accepting group later is synced into the shared channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // A brand-new user joins the secondary group after the share is accepted.
+    const newUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        firstName: "Late",
+        lastName: "Joiner",
+        phone: "+15556669999",
+        phoneVerified: true,
+        activeCommunityId: data.communityId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    const { accessToken: newUserToken } = await generateTokens(newUserId);
+
+    await t.mutation(api.functions.groups.index.join, {
+      token: newUserToken,
+      groupId: data.secondaryGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const row = await getChannelMember(t, data.ownerAnnouncementsChannelId, newUserId);
+    expect(row).not.toBeNull();
+    expect(row!.leftAt).toBeUndefined();
+    expect(row!.role).toBe("member");
+  });
+
+  test("user leaving the accepting group is removed from the shared channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.groups.index.leave, {
+      token: data.secondaryMemberToken,
+      groupId: data.secondaryGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const row = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.secondaryMemberId
+    );
+    expect(row).not.toBeNull();
+    expect(row!.leftAt).toBeDefined();
+  });
+
+  test("user leaving the owning group stays if active member of an accepted secondary", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    // A user who is a member of BOTH the owner group and the secondary group.
+    const dual = await createUserInGroup(
+      t,
+      data.communityId,
+      data.ownerGroupId,
+      "member",
+      "Dual"
+    );
+    await t.run(async (ctx) => {
+      await ctx.db.insert("groupMembers", {
+        userId: dual.userId,
+        groupId: data.secondaryGroupId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+      // Also give them a channel membership row like other owner-group members.
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: data.ownerAnnouncementsChannelId,
+        userId: dual.userId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    });
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Leaving the OWNER group must not remove them: they're still an active
+    // member of the accepted secondary group.
+    await t.mutation(api.functions.groups.index.leave, {
+      token: dual.token,
+      groupId: data.ownerGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const row = await getChannelMember(t, data.ownerAnnouncementsChannelId, dual.userId);
+    expect(row).not.toBeNull();
+    expect(row!.leftAt).toBeUndefined();
+  });
+
+  test("promoting a secondary-group member to leader mirrors channel role to admin", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.groups.index.updateMemberRole, {
+      token: data.secondaryLeaderToken,
+      groupId: data.secondaryGroupId,
+      targetUserId: data.secondaryMemberId,
+      role: "leader",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const row = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.secondaryMemberId
+    );
+    expect(row).not.toBeNull();
+    expect(row!.leftAt).toBeUndefined();
+    expect(row!.role).toBe("admin");
+  });
+});
+
+// ============================================================================
+// Accept → own channel disabled, prior state recorded
+// ============================================================================
+
+describe("accepting disables the accepting group's own announcements channel", () => {
+  test("own channel is disabled and prior enabled state recorded on the entry", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+
+    const ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(false);
+    expect(ownChannel!.disabledByUserId).toBe(data.secondaryLeaderId);
+
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    const entry = sharedChannel!.sharedGroups!.find(
+      (sg) => sg.groupId === data.secondaryGroupId
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.status).toBe("accepted");
+    expect(entry!.previousAnnouncementsChannelEnabled).toBe(true);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("group without its own announcements channel records a falsy prior state", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    // Third group with NO announcements channel of its own.
+    const thirdGroupId = await t.run(async (ctx) => {
+      return await ctx.db.insert("groups", {
+        name: "Third Group",
+        communityId: data.communityId,
+        groupTypeId: data.groupTypeId,
+        isPublic: true,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    const thirdLeader = await createUserInGroup(
+      t,
+      data.communityId,
+      thirdGroupId,
+      "leader",
+      "ThirdL"
+    );
+
+    await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+      token: data.ownerLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      groupId: thirdGroupId,
+    });
+    await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+      token: thirdLeader.token,
+      channelId: data.ownerAnnouncementsChannelId,
+      groupId: thirdGroupId,
+      response: "accepted",
+    });
+
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    const entry = sharedChannel!.sharedGroups!.find(
+      (sg) => sg.groupId === thirdGroupId
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.previousAnnouncementsChannelEnabled).not.toBe(true);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+});
+
+// ============================================================================
+// Posting rights
+// ============================================================================
+
+describe("posting rights on a shared announcements channel", () => {
+  test("leader of an accepted secondary group can post", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const messageId = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: data.secondaryLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      content: "Hello from the secondary group's leader",
+    });
+    const message = await t.run((ctx) => ctx.db.get(messageId));
+    expect(message?.channelId).toBe(data.ownerAnnouncementsChannelId);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("non-leader member of an accepted secondary group cannot post", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: data.secondaryMemberToken,
+        channelId: data.ownerAnnouncementsChannelId,
+        content: "I should not be able to post",
+      })
+    ).rejects.toThrow(/Only group leaders can post in Announcements/);
+  });
+
+  test("leader of a pending (not accepted) invited group cannot post", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    // No accept — invite stays pending; no membership row exists.
+
+    await expect(
+      t.mutation(api.functions.messaging.messages.sendMessage, {
+        token: data.secondaryLeaderToken,
+        channelId: data.ownerAnnouncementsChannelId,
+        content: "Pending invitees get nothing",
+      })
+    ).rejects.toThrow(/Not a member of this channel/);
+  });
+
+  test("owning group leader can still post", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const messageId = await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: data.ownerLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      content: "Owner leader announcement",
+    });
+    expect(messageId).toBeDefined();
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+});
+
+// ============================================================================
+// Leaving / removal restores the group's own channel
+// ============================================================================
+
+describe("removeGroupFromChannel on an announcements share", () => {
+  test("removes exclusive members and restores the group's own announcements channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // A user joins the secondary group DURING the share.
+    const midShareUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        firstName: "Mid",
+        lastName: "Share",
+        phone: "+15556668888",
+        phoneVerified: true,
+        activeCommunityId: data.communityId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    const { accessToken: midShareToken } = await generateTokens(midShareUserId);
+    await t.mutation(api.functions.groups.index.join, {
+      token: midShareToken,
+      groupId: data.secondaryGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Secondary leader opts the group out of the share.
+    await t.mutation(api.functions.messaging.sharedChannels.removeGroupFromChannel, {
+      token: data.secondaryLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Exclusive secondary-group members are gone from the shared channel.
+    for (const userId of [
+      data.secondaryLeaderId,
+      data.secondaryMemberId,
+      midShareUserId,
+    ]) {
+      const row = await getChannelMember(t, data.ownerAnnouncementsChannelId, userId);
+      expect(row).not.toBeNull();
+      expect(row!.leftAt).toBeDefined();
+    }
+
+    // Owner members stay.
+    const ownerRow = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.ownerMemberId
+    );
+    expect(ownerRow!.leftAt).toBeUndefined();
+
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(sharedChannel!.sharedGroups).toHaveLength(0);
+    expect(sharedChannel!.isShared).toBe(false);
+    expect(sharedChannel!.memberCount).toBe(2);
+
+    // Own announcements channel is restored...
+    const ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(true);
+    expect(ownChannel!.disabledByUserId).toBeUndefined();
+
+    // ...and repopulated, including the member who joined during the share.
+    const midShareOwnRow = await getChannelMember(
+      t,
+      data.secondaryAnnouncementsChannelId,
+      midShareUserId
+    );
+    expect(midShareOwnRow).not.toBeNull();
+    expect(midShareOwnRow!.leftAt).toBeUndefined();
+    expect(ownChannel!.memberCount).toBe(3);
+  });
+
+  test("removal does NOT re-enable an own channel that was disabled before the share", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    // Secondary group's own channel was already disabled before the share.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(data.secondaryAnnouncementsChannelId, {
+        isEnabled: false,
+        disabledByUserId: data.secondaryLeaderId,
+      });
+    });
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.messaging.sharedChannels.removeGroupFromChannel, {
+      token: data.secondaryLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(false);
+  });
+});
+
+// ============================================================================
+// Accept = switch
+// ============================================================================
+
+describe("accepting a new share while already in one (switch)", () => {
+  async function seedThirdOwnerGroup(
+    t: ReturnType<typeof convexTest>,
+    data: SeedData
+  ) {
+    const thirdGroupId = await t.run(async (ctx) => {
+      return await ctx.db.insert("groups", {
+        name: "Third Owner Group",
+        communityId: data.communityId,
+        groupTypeId: data.groupTypeId,
+        isPublic: true,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    const thirdLeader = await createUserInGroup(
+      t,
+      data.communityId,
+      thirdGroupId,
+      "leader",
+      "ThirdOwnerL"
+    );
+    const thirdChannelId = await createAnnouncementsChannel(
+      t,
+      thirdGroupId,
+      thirdLeader.userId
+    );
+    return { thirdGroupId, thirdLeader, thirdChannelId };
+  }
+
+  test("switch leaves the old share, carries prior state, and restores only on final leave", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+    const { thirdGroupId, thirdLeader, thirdChannelId } = await seedThirdOwnerGroup(
+      t,
+      data
+    );
+
+    // Secondary accepts owner's share first (own channel enabled → disabled, prev=true).
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Third group invites the secondary group; accepting switches shares.
+    await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+      token: thirdLeader.token,
+      channelId: thirdChannelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+      token: data.secondaryLeaderToken,
+      channelId: thirdChannelId,
+      groupId: data.secondaryGroupId,
+      response: "accepted",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Old share: entry removed, exclusive members soft-deleted.
+    const oldChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(
+      oldChannel!.sharedGroups!.some((sg) => sg.groupId === data.secondaryGroupId)
+    ).toBe(false);
+    const oldRow = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.secondaryMemberId
+    );
+    expect(oldRow!.leftAt).toBeDefined();
+
+    // New share: accepted entry carries over the ORIGINAL prior-enabled state.
+    const newChannel = await t.run((ctx) => ctx.db.get(thirdChannelId));
+    const newEntry = newChannel!.sharedGroups!.find(
+      (sg) => sg.groupId === data.secondaryGroupId
+    );
+    expect(newEntry).toBeDefined();
+    expect(newEntry!.status).toBe("accepted");
+    expect(newEntry!.previousAnnouncementsChannelEnabled).toBe(true);
+
+    // Members were backfilled into the new share.
+    const newRow = await getChannelMember(t, thirdChannelId, data.secondaryMemberId);
+    expect(newRow).not.toBeNull();
+    expect(newRow!.leftAt).toBeUndefined();
+
+    // Own channel stays disabled during the switch — no restore mid-switch.
+    let ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(false);
+
+    // Leaving the (new, last) share finally restores the own channel.
+    await t.mutation(api.functions.messaging.sharedChannels.removeGroupFromChannel, {
+      token: data.secondaryLeaderToken,
+      channelId: thirdChannelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(true);
+    expect(ownChannel!.disabledByUserId).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Guards
+// ============================================================================
+
+describe("guards", () => {
+  test("cannot accept while the group's OWN announcements channel is shared", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    // The secondary group's own announcements channel is itself shared
+    // (a pending invite to another group is enough).
+    const fourthGroupId = await t.run(async (ctx) => {
+      return await ctx.db.insert("groups", {
+        name: "Fourth Group",
+        communityId: data.communityId,
+        groupTypeId: data.groupTypeId,
+        isPublic: true,
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+      token: data.secondaryLeaderToken,
+      channelId: data.secondaryAnnouncementsChannelId,
+      groupId: fourthGroupId,
+    });
+
+    await inviteSecondary(t, data);
+
+    await expect(acceptShare(t, data)).rejects.toThrow(/OWN_CHANNEL_SHARED/);
+  });
+
+  test("cannot disable an announcements channel that is currently shared", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data); // pending entry is enough
+
+    await expect(
+      t.mutation(api.functions.messaging.channels.toggleAnnouncementsChannel, {
+        token: data.ownerLeaderToken,
+        groupId: data.ownerGroupId,
+        enabled: false,
+      })
+    ).rejects.toThrow(/CHANNEL_SHARED/);
+  });
+
+  test("cannot enable own announcements channel while an accepted secondary elsewhere", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await expect(
+      t.mutation(api.functions.messaging.channels.toggleAnnouncementsChannel, {
+        token: data.secondaryLeaderToken,
+        groupId: data.secondaryGroupId,
+        enabled: true,
+      })
+    ).rejects.toThrow(/IN_SHARED_ANNOUNCEMENTS/);
+  });
+});
+
+// ============================================================================
+// Owner group archive cascade
+// ============================================================================
+
+describe("archiving the owning group of a shared announcements channel", () => {
+  test("restores each accepted secondary's own announcements channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Sanity: own channel disabled while the share is active.
+    let ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(false);
+
+    // Community admin archives the OWNER group.
+    await t.mutation(api.functions.groups.mutations.update, {
+      token: data.adminToken,
+      groupId: data.ownerGroupId,
+      isArchived: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Owner's channels are archived (existing cascade).
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(sharedChannel!.isArchived).toBe(true);
+
+    // The secondary group's own channel is re-enabled and repopulated.
+    ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(true);
+    expect(ownChannel!.disabledByUserId).toBeUndefined();
+    expect(ownChannel!.memberCount).toBe(2);
+
+    const leaderRow = await getChannelMember(
+      t,
+      data.secondaryAnnouncementsChannelId,
+      data.secondaryLeaderId
+    );
+    expect(leaderRow!.leftAt).toBeUndefined();
+  });
+
+  test("archiving a secondary group does not restore its own channel (it's archived)", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.groups.mutations.update, {
+      token: data.adminToken,
+      groupId: data.secondaryGroupId,
+      isArchived: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Entry pulled from the shared channel (existing cascade)...
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(sharedChannel!.sharedGroups).toHaveLength(0);
+
+    // ...but the archived group's own channel is NOT re-enabled — the group
+    // archive cascade already archived it.
+    const ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isArchived).toBe(true);
+    expect(ownChannel!.isEnabled).not.toBe(true);
+  });
+});
+
+// ============================================================================
+// Decline / cancel — no side effects
+// ============================================================================
+
+describe("decline and cancel have no announcements side effects", () => {
+  test("declining an announcements share leaves the own channel untouched", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+      token: data.secondaryLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      groupId: data.secondaryGroupId,
+      response: "declined",
+    });
+
+    const ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(true);
+
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(sharedChannel!.sharedGroups).toHaveLength(0);
+    expect(sharedChannel!.isShared).toBe(false);
+
+    // No membership was created for the declining group.
+    const row = await getChannelMember(
+      t,
+      data.ownerAnnouncementsChannelId,
+      data.secondaryLeaderId
+    );
+    expect(row).toBeNull();
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("cancelling a pending announcements invite leaves everything untouched", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await t.mutation(api.functions.messaging.sharedChannels.cancelChannelInvite, {
+      token: data.ownerLeaderToken,
+      channelId: data.ownerAnnouncementsChannelId,
+      groupId: data.secondaryGroupId,
+    });
+
+    const ownChannel = await t.run((ctx) =>
+      ctx.db.get(data.secondaryAnnouncementsChannelId)
+    );
+    expect(ownChannel!.isEnabled).toBe(true);
+
+    const sharedChannel = await t.run((ctx) =>
+      ctx.db.get(data.ownerAnnouncementsChannelId)
+    );
+    expect(sharedChannel!.sharedGroups).toHaveLength(0);
+    expect(sharedChannel!.isShared).toBe(false);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+});

--- a/apps/convex/functions/groups/mutations.ts
+++ b/apps/convex/functions/groups/mutations.ts
@@ -393,10 +393,7 @@ export const update = mutation({
         // Archiving the OWNER of a shared announcements channel ends the
         // share: every accepted secondary whose own announcements channel was
         // disabled by accepting gets it re-enabled and repopulated.
-        if (
-          channel.channelType === "announcements" &&
-          (channel.sharedGroups?.length ?? 0) > 0
-        ) {
+        if (channel.channelType === "announcements") {
           for (const sg of channel.sharedGroups ?? []) {
             if (
               sg.status === "accepted" &&
@@ -404,6 +401,16 @@ export const update = mutation({
             ) {
               await restoreOwnAnnouncementsChannelLogic(ctx, sg.groupId, userId);
             }
+          }
+
+          // The share itself ends too — clear the entries so unarchiving the
+          // group and re-enabling the channel doesn't resurrect the share
+          // from stale accepted entries.
+          if ((channel.sharedGroups?.length ?? 0) > 0) {
+            await ctx.db.patch(channel._id, {
+              sharedGroups: [],
+              isShared: false,
+            });
           }
         }
       }

--- a/apps/convex/functions/groups/mutations.ts
+++ b/apps/convex/functions/groups/mutations.ts
@@ -22,7 +22,10 @@ import {
   DEFAULT_RSVP_OPTIONS,
 } from "../../lib/meetingConfig";
 import { syncUserChannelMembershipsLogic } from "../sync/memberships";
-import { ensureChannelsForGroupLogic } from "../messaging/channels";
+import {
+  ensureChannelsForGroupLogic,
+  restoreOwnAnnouncementsChannelLogic,
+} from "../messaging/channels";
 import { MutationCtx } from "../../_generated/server";
 import { buildMeetingSearchText } from "../../lib/meetingSearchText";
 
@@ -385,6 +388,23 @@ export const update = mutation({
 
         for (const member of activeMembers) {
           await ctx.db.patch(member._id, { leftAt: timestamp });
+        }
+
+        // Archiving the OWNER of a shared announcements channel ends the
+        // share: every accepted secondary whose own announcements channel was
+        // disabled by accepting gets it re-enabled and repopulated.
+        if (
+          channel.channelType === "announcements" &&
+          (channel.sharedGroups?.length ?? 0) > 0
+        ) {
+          for (const sg of channel.sharedGroups ?? []) {
+            if (
+              sg.status === "accepted" &&
+              sg.previousAnnouncementsChannelEnabled === true
+            ) {
+              await restoreOwnAnnouncementsChannelLogic(ctx, sg.groupId, userId);
+            }
+          }
         }
       }
 

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1237,10 +1237,16 @@ export const listGroupChannels = query({
     isPinned: v.boolean(),
     lastMessageAt: v.optional(v.number()),
     isShared: v.optional(v.boolean()),
-    /** Number of groups with an ACCEPTED share on this channel. Lets the
-     *  group page label an owned shared channel ("Shared with N groups")
-     *  without shipping the full sharedGroups array to the client. */
+    /** Number of groups with an ACCEPTED share on this channel. Only set
+     *  when the channel is OWNED by the queried group, so the group page can
+     *  label an owned shared channel ("Shared with N groups") without
+     *  shipping the full sharedGroups array to the client. */
     sharedGroupCount: v.optional(v.number()),
+    /** For announcements channels shared INTO this group (owned by another
+     *  group): the owning group, so the group page can label the row
+     *  ("announcements come from …") and disambiguate same-slug channels. */
+    sharedFromGroupId: v.optional(v.id("groups")),
+    sharedFromGroupName: v.optional(v.string()),
     isEnabled: v.boolean(),
     isServingTeam: v.optional(v.boolean()),
   })),
@@ -1423,6 +1429,23 @@ export const listGroupChannels = query({
         const channelSlug = getChannelSlug(channel);
         const isPinned = pinnedChannelSlugs.includes(channelSlug);
 
+        const ownedByThisGroup = channel.groupId === args.groupId;
+
+        // Announcements channel shared INTO this group — surface the owning
+        // group so the client can label the row and open the right channel
+        // (its slug collides with the group's own announcements channel).
+        let sharedFromGroupId: Id<"groups"> | undefined;
+        let sharedFromGroupName: string | undefined;
+        if (
+          !ownedByThisGroup &&
+          channel.groupId &&
+          channel.channelType === "announcements"
+        ) {
+          sharedFromGroupId = channel.groupId;
+          const owningGroup = await ctx.db.get(channel.groupId);
+          sharedFromGroupName = owningGroup?.name ?? "Unknown Group";
+        }
+
         return {
           _id: channel._id,
           slug: channelSlug,
@@ -1438,9 +1461,12 @@ export const listGroupChannels = query({
           isPinned,
           lastMessageAt: channel.lastMessageAt,
           isShared: channel.isShared || undefined,
-          sharedGroupCount:
-            channel.sharedGroups?.filter((sg) => sg.status === "accepted")
-              .length || undefined,
+          sharedGroupCount: ownedByThisGroup
+            ? channel.sharedGroups?.filter((sg) => sg.status === "accepted")
+                .length || undefined
+            : undefined,
+          sharedFromGroupId,
+          sharedFromGroupName,
           isEnabled: channelEffectiveEnabledForGroup(channel, args.groupId),
           isServingTeam: channel.isServingTeam ?? undefined,
         };
@@ -2262,6 +2288,17 @@ export const archiveChannel = mutation({
       (groupMembership.role !== "leader" && groupMembership.role !== "admin")
     ) {
       throw new Error("Only group leaders can archive channels");
+    }
+
+    // A shared channel (pending OR accepted entries) can't be archived out
+    // from under the groups it's shared with — unshare first. Mirrors the
+    // toggleAnnouncementsChannel disable guard.
+    if ((channel.sharedGroups?.length ?? 0) > 0) {
+      throw new ConvexError({
+        code: "CHANNEL_SHARED",
+        message:
+          "This channel is shared with other groups. Remove the shared groups before archiving it.",
+      });
     }
 
     const now = Date.now();
@@ -3888,9 +3925,12 @@ export async function ensureAnnouncementsChannelLogic(
     return existing._id;
   }
 
+  const group = await ctx.db.get(groupId);
   const now = Date.now();
   return ctx.db.insert("chatChannels", {
     groupId,
+    // Denormalized so share scans can use the by_community_isShared index.
+    communityId: group?.communityId,
     slug: "announcements",
     channelType: "announcements",
     name: "Announcements",
@@ -4379,7 +4419,7 @@ const CHANNEL_MEMBER_SYNC_BATCH = 500;
  * channel". Inserting the caller up front closes that race; the later batch
  * reactivates the same row idempotently and the final memberCount is unaffected.
  */
-async function ensureChannelMembership(
+export async function ensureChannelMembership(
   ctx: MutationCtx,
   channelId: Id<"chatChannels">,
   userId: Id<"users">,
@@ -4437,12 +4477,11 @@ async function ensureChannelMembership(
  * "admin"; otherwise everyone is "member". Posting permission is always
  * enforced server-side in `sendMessage`, independent of channel role.
  *
- * `recountMemberCount`: when true, the final page recounts active channel
- * members instead of assuming the processed roster IS the channel. Required
- * when fanning a group's roster into a channel that also holds other groups'
- * members (e.g. backfilling an accepted secondary group into a shared
- * announcements channel) — otherwise `memberCount` would collapse to just the
- * backfilled group's size.
+ * The final page recounts active channel members from actual membership rows
+ * rather than assuming the processed roster IS the channel — a channel may
+ * also hold other groups' members (e.g. backfilling an accepted secondary
+ * group into a shared announcements channel), and assuming would collapse
+ * `memberCount` to just the backfilled group's size.
  */
 export const populateChannelMembersBatch = internalMutation({
   args: {
@@ -4451,13 +4490,26 @@ export const populateChannelMembersBatch = internalMutation({
     mirrorGroupRole: v.boolean(),
     cursor: v.union(v.string(), v.null()),
     processed: v.number(),
-    recountMemberCount: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     // Bail if the channel was archived/disabled since this chain started
     // (e.g. a quick enable → disable), so we don't repopulate a closed channel.
     const channel = await ctx.db.get(args.channelId);
     if (!channel || channel.isArchived || channel.isEnabled === false) {
+      return;
+    }
+
+    // Also bail if the group is no longer a participant on the channel —
+    // neither the owning group nor an ACCEPTED sharedGroups entry. Stops
+    // in-flight backfill chains when the group is removed from a share
+    // mid-run (accept → immediate removal), which would otherwise re-add
+    // members the removal just cleaned up.
+    const isParticipant =
+      channel.groupId === args.groupId ||
+      (channel.sharedGroups ?? []).some(
+        (sg) => sg.groupId === args.groupId && sg.status === "accepted"
+      );
+    if (!isParticipant) {
       return;
     }
 
@@ -4512,15 +4564,10 @@ export const populateChannelMembersBatch = internalMutation({
     const processed = args.processed + page.page.length;
 
     if (page.isDone) {
-      if (args.recountMemberCount) {
-        // The channel holds members beyond this group's roster (shared
-        // channel) — recount from actual membership rows.
-        await updateChannelMemberCount(ctx, args.channelId);
-      } else {
-        // Every active group member is now an active channel member, so the
-        // running count equals the channel's member count.
-        await ctx.db.patch(args.channelId, { memberCount: processed });
-      }
+      // Recount from actual membership rows — the channel may hold members
+      // beyond this group's roster (shared channels), so the processed
+      // roster count can't be assumed to be the channel's member count.
+      await updateChannelMemberCount(ctx, args.channelId);
     } else {
       await ctx.scheduler.runAfter(
         0,
@@ -4685,8 +4732,11 @@ export const toggleAnnouncementsChannel = mutation({
               "This group already has a channel using the slug \"announcements\" (possibly archived). Rename it before enabling the Announcements broadcast channel.",
           });
         }
+        const group = await ctx.db.get(args.groupId);
         channelId = await ctx.db.insert("chatChannels", {
           groupId: args.groupId,
+          // Denormalized so share scans can use the by_community_isShared index.
+          communityId: group?.communityId,
           slug: "announcements",
           channelType: "announcements",
           name: "Announcements",

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -24,6 +24,7 @@ import { syncUserChannelMembershipsLogic } from "../sync/memberships";
 import {
   updateChannelMemberCount,
   isCommunityAdminForGroup,
+  findAcceptedSharedAnnouncementsChannelsForGroup,
 } from "./helpers";
 import { matchesSearchTerms, parseSearchTerms } from "../../lib/memberSearch";
 import { canAccessEventChannel } from "./eventChat";
@@ -3898,6 +3899,47 @@ export async function ensureAnnouncementsChannelLogic(
 }
 
 /**
+ * Restore a group's own announcements channel after it leaves (or is removed
+ * from) a shared announcements channel that had disabled it on accept.
+ *
+ * Re-enables the channel (creating it via `ensureAnnouncementsChannelLogic`
+ * if it somehow no longer exists), clears the disable audit trail, and
+ * repopulates members via `populateChannelMembersBatch` with
+ * `mirrorGroupRole: true` so members who joined the group during the share
+ * are included and leaders mirror to channel role "admin".
+ */
+export async function restoreOwnAnnouncementsChannelLogic(
+  ctx: MutationCtx,
+  groupId: Id<"groups">,
+  actingUserId: Id<"users">
+): Promise<void> {
+  const now = Date.now();
+  const channelId = await ensureAnnouncementsChannelLogic(ctx, groupId, actingUserId);
+  const channel = await ctx.db.get(channelId);
+  if (!channel) return;
+
+  if (channel.isEnabled === false || channel.disabledByUserId !== undefined) {
+    await ctx.db.patch(channelId, {
+      isEnabled: true,
+      disabledByUserId: undefined,
+      updatedAt: now,
+    });
+  }
+
+  await ctx.scheduler.runAfter(
+    0,
+    internal.functions.messaging.channels.populateChannelMembersBatch,
+    {
+      groupId,
+      channelId,
+      mirrorGroupRole: true,
+      cursor: null,
+      processed: 0,
+    }
+  );
+}
+
+/**
  * Internal mutation to ensure channels exist for a group.
  * Creates main and leaders channels if they don't exist.
  *
@@ -4387,6 +4429,13 @@ async function ensureChannelMembership(
  * `mirrorGroupRole`: when true (announcements), leaders map to channel role
  * "admin"; otherwise everyone is "member". Posting permission is always
  * enforced server-side in `sendMessage`, independent of channel role.
+ *
+ * `recountMemberCount`: when true, the final page recounts active channel
+ * members instead of assuming the processed roster IS the channel. Required
+ * when fanning a group's roster into a channel that also holds other groups'
+ * members (e.g. backfilling an accepted secondary group into a shared
+ * announcements channel) — otherwise `memberCount` would collapse to just the
+ * backfilled group's size.
  */
 export const populateChannelMembersBatch = internalMutation({
   args: {
@@ -4395,6 +4444,7 @@ export const populateChannelMembersBatch = internalMutation({
     mirrorGroupRole: v.boolean(),
     cursor: v.union(v.string(), v.null()),
     processed: v.number(),
+    recountMemberCount: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     // Bail if the channel was archived/disabled since this chain started
@@ -4455,9 +4505,15 @@ export const populateChannelMembersBatch = internalMutation({
     const processed = args.processed + page.page.length;
 
     if (page.isDone) {
-      // Every active group member is now an active channel member, so the
-      // running count equals the channel's member count.
-      await ctx.db.patch(args.channelId, { memberCount: processed });
+      if (args.recountMemberCount) {
+        // The channel holds members beyond this group's roster (shared
+        // channel) — recount from actual membership rows.
+        await updateChannelMemberCount(ctx, args.channelId);
+      } else {
+        // Every active group member is now an active channel member, so the
+        // running count equals the channel's member count.
+        await ctx.db.patch(args.channelId, { memberCount: processed });
+      }
     } else {
       await ctx.scheduler.runAfter(
         0,
@@ -4568,6 +4624,21 @@ export const toggleAnnouncementsChannel = mutation({
       .first();
 
     if (args.enabled) {
+      // While this group is an accepted secondary of another group's shared
+      // announcements channel, its own channel stays disabled — announcements
+      // flow through the share. Leave the share first.
+      const acceptedShares = await findAcceptedSharedAnnouncementsChannelsForGroup(
+        ctx,
+        args.groupId
+      );
+      if (acceptedShares.length > 0) {
+        throw new ConvexError({
+          code: "IN_SHARED_ANNOUNCEMENTS",
+          message:
+            "This group receives announcements through another group's shared Announcements channel. Leave that share before enabling its own Announcements channel.",
+        });
+      }
+
       let channelId: Id<"chatChannels">;
 
       if (existingChannel) {
@@ -4655,6 +4726,16 @@ export const toggleAnnouncementsChannel = mutation({
     }
     if (existingChannel.isEnabled === false || existingChannel.isArchived) {
       return { channelId: existingChannel._id, status: "already_disabled" as const };
+    }
+
+    // A shared announcements channel (pending OR accepted entries) can't be
+    // disabled out from under the groups it's shared with — unshare first.
+    if ((existingChannel.sharedGroups?.length ?? 0) > 0) {
+      throw new ConvexError({
+        code: "CHANNEL_SHARED",
+        message:
+          "This Announcements channel is shared with other groups. Remove the shared groups before disabling it.",
+      });
     }
 
     await ctx.db.patch(existingChannel._id, {

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1237,6 +1237,10 @@ export const listGroupChannels = query({
     isPinned: v.boolean(),
     lastMessageAt: v.optional(v.number()),
     isShared: v.optional(v.boolean()),
+    /** Number of groups with an ACCEPTED share on this channel. Lets the
+     *  group page label an owned shared channel ("Shared with N groups")
+     *  without shipping the full sharedGroups array to the client. */
+    sharedGroupCount: v.optional(v.number()),
     isEnabled: v.boolean(),
     isServingTeam: v.optional(v.boolean()),
   })),
@@ -1434,6 +1438,9 @@ export const listGroupChannels = query({
           isPinned,
           lastMessageAt: channel.lastMessageAt,
           isShared: channel.isShared || undefined,
+          sharedGroupCount:
+            channel.sharedGroups?.filter((sg) => sg.status === "accepted")
+              .length || undefined,
           isEnabled: channelEffectiveEnabledForGroup(channel, args.groupId),
           isServingTeam: channel.isServingTeam ?? undefined,
         };

--- a/apps/convex/functions/messaging/helpers.ts
+++ b/apps/convex/functions/messaging/helpers.ts
@@ -67,3 +67,40 @@ export async function updateChannelMemberCount(
 
   await ctx.db.patch(channelId, { memberCount: activeMembers.length });
 }
+
+/** One entry of `chatChannels.sharedGroups`. */
+export type SharedGroupEntry = NonNullable<
+  Doc<"chatChannels">["sharedGroups"]
+>[number];
+
+/**
+ * Finds non-archived shared ANNOUNCEMENTS channels where `groupId` is an
+ * ACCEPTED secondary group (i.e. the group receives announcements through
+ * another group's channel).
+ *
+ * Same `by_isShared` scan pattern as `listActiveSharedChannelsForGroup`:
+ * shared channels are rare, so the indexed scan stays cheap.
+ */
+export async function findAcceptedSharedAnnouncementsChannelsForGroup(
+  ctx: QueryCtx,
+  groupId: Id<"groups">
+): Promise<Array<{ channel: Doc<"chatChannels">; entry: SharedGroupEntry }>> {
+  const sharedChannels = await ctx.db
+    .query("chatChannels")
+    .withIndex("by_isShared", (q) => q.eq("isShared", true))
+    .filter((q) => q.eq(q.field("archivedAt"), undefined))
+    .collect();
+
+  const results: Array<{ channel: Doc<"chatChannels">; entry: SharedGroupEntry }> = [];
+  for (const channel of sharedChannels) {
+    if (channel.channelType !== "announcements") continue;
+    if (!channel.groupId || channel.groupId === groupId) continue;
+    const entry = (channel.sharedGroups ?? []).find(
+      (sg) => sg.groupId === groupId && sg.status === "accepted"
+    );
+    if (entry) {
+      results.push({ channel, entry });
+    }
+  }
+  return results;
+}

--- a/apps/convex/functions/messaging/helpers.ts
+++ b/apps/convex/functions/messaging/helpers.ts
@@ -78,16 +78,23 @@ export type SharedGroupEntry = NonNullable<
  * ACCEPTED secondary group (i.e. the group receives announcements through
  * another group's channel).
  *
- * Same `by_isShared` scan pattern as `listActiveSharedChannelsForGroup`:
- * shared channels are rare, so the indexed scan stays cheap.
+ * Shared channels are community-scoped (`inviteGroupToChannel` enforces it
+ * and stamps `communityId`), so the scan uses `by_community_isShared` to
+ * stay cheap even on deployments with many communities. This runs on hot
+ * paths (membership sync), so it must never scan shares deployment-wide.
  */
 export async function findAcceptedSharedAnnouncementsChannelsForGroup(
   ctx: QueryCtx,
   groupId: Id<"groups">
 ): Promise<Array<{ channel: Doc<"chatChannels">; entry: SharedGroupEntry }>> {
+  const group = await ctx.db.get(groupId);
+  if (!group) return [];
+
   const sharedChannels = await ctx.db
     .query("chatChannels")
-    .withIndex("by_isShared", (q) => q.eq("isShared", true))
+    .withIndex("by_community_isShared", (q) =>
+      q.eq("communityId", group.communityId).eq("isShared", true)
+    )
     .filter((q) => q.eq(q.field("archivedAt"), undefined))
     .collect();
 

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -738,7 +738,9 @@ export const sendMessage = mutation({
       // member is a channel member (so unread counts work) but only group
       // leaders can post. Block sends from non-leaders here regardless of
       // channel-member role, since channel role is denormalized at sync time
-      // and may lag the source-of-truth on `groupMembers`.
+      // and may lag the source-of-truth on `groupMembers`. For shared
+      // announcements channels, leaders of any ACCEPTED secondary group can
+      // post too; pending invitees get nothing.
       if (channel.channelType === "announcements") {
         if (!channelIsLeaderEnabled(channel) || channel.isArchived) {
           throw new Error("This channel is disabled");
@@ -753,7 +755,24 @@ export const sendMessage = mutation({
           )
           .filter((q) => q.eq(q.field("leftAt"), undefined))
           .first();
-        if (!isLeaderRole(groupMembership?.role)) {
+        let canPost = isLeaderRole(groupMembership?.role);
+        if (!canPost) {
+          for (const sg of channel.sharedGroups ?? []) {
+            if (sg.status !== "accepted") continue;
+            const secondaryMembership = await ctx.db
+              .query("groupMembers")
+              .withIndex("by_group_user", (q) =>
+                q.eq("groupId", sg.groupId).eq("userId", userId)
+              )
+              .filter((q) => q.eq(q.field("leftAt"), undefined))
+              .first();
+            if (isLeaderRole(secondaryMembership?.role)) {
+              canPost = true;
+              break;
+            }
+          }
+        }
+        if (!canPost) {
           throw new ConvexError({
             code: "FORBIDDEN",
             message: "Only group leaders can post in Announcements",

--- a/apps/convex/functions/messaging/sharedChannels.ts
+++ b/apps/convex/functions/messaging/sharedChannels.ts
@@ -13,12 +13,110 @@
 
 import { v, ConvexError } from "convex/values";
 import { mutation, query } from "../../_generated/server";
+import type { MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
-import type { Id } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
 import { getChannelSlug } from "../../lib/slugs";
-import { updateChannelMemberCount } from "./helpers";
+import {
+  updateChannelMemberCount,
+  findAcceptedSharedAnnouncementsChannelsForGroup,
+  type SharedGroupEntry,
+} from "./helpers";
+import { restoreOwnAnnouncementsChannelLogic } from "./channels";
+
+// ============================================================================
+// Shared Helpers
+// ============================================================================
+
+/**
+ * Removes a group's entry from a shared channel's `sharedGroups` and
+ * soft-deletes channel members who belong ONLY to the removed group (members
+ * also in the primary group or another accepted group stay). Recomputes
+ * `memberCount` and unsets `isShared` when no entries remain.
+ *
+ * Returns the removed entry, or null if the group wasn't on the channel.
+ * Used by `removeGroupFromChannel` and by the announcements accept-switch
+ * path in `respondToChannelInvite`.
+ */
+async function removeGroupEntryAndCleanupMembers(
+  ctx: MutationCtx,
+  channel: Doc<"chatChannels">,
+  groupId: Id<"groups">,
+  now: number
+): Promise<SharedGroupEntry | null> {
+  const existingSharedGroups = channel.sharedGroups ?? [];
+  const groupIndex = existingSharedGroups.findIndex(
+    (sg) => sg.groupId === groupId
+  );
+  if (groupIndex === -1) {
+    return null;
+  }
+
+  const removedEntry = existingSharedGroups[groupIndex];
+
+  // Remove the entry
+  const updatedSharedGroups = existingSharedGroups.filter(
+    (_, i) => i !== groupIndex
+  );
+  const isStillShared = updatedSharedGroups.length > 0;
+
+  // Determine the set of remaining group IDs (primary + other accepted secondary groups)
+  const remainingGroupIds = new Set<string>();
+  if (channel.groupId) {
+    remainingGroupIds.add(channel.groupId); // primary group always remains
+  }
+  for (const sg of updatedSharedGroups) {
+    if (sg.status === "accepted") {
+      remainingGroupIds.add(sg.groupId);
+    }
+  }
+
+  // Get all active channel members
+  const activeMembers = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .collect();
+
+  // For each active channel member, check if they belong to any remaining group
+  for (const member of activeMembers) {
+    let belongsToRemainingGroup = false;
+
+    for (const gId of remainingGroupIds) {
+      const gMembership = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", gId as Id<"groups">).eq("userId", member.userId)
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
+
+      if (gMembership) {
+        belongsToRemainingGroup = true;
+        break;
+      }
+    }
+
+    if (!belongsToRemainingGroup) {
+      // Soft-delete the channel membership
+      await ctx.db.patch(member._id, { leftAt: now });
+    }
+  }
+
+  // Update the channel
+  await ctx.db.patch(channel._id, {
+    sharedGroups: updatedSharedGroups,
+    isShared: isStillShared,
+    updatedAt: now,
+  });
+
+  // Recompute member count
+  await updateChannelMemberCount(ctx, channel._id);
+
+  return removedEntry;
+}
 
 // ============================================================================
 // Invitation Flow Mutations
@@ -176,6 +274,73 @@ export const respondToChannelInvite = mutation({
     const now = Date.now();
 
     if (args.response === "accepted") {
+      // Announcements shares have accept-time side effects: the accepting
+      // group's members are backfilled into the shared channel and its own
+      // announcements channel is disabled (prior state recorded so it can be
+      // restored when the group later leaves the share).
+      let previousAnnouncementsChannelEnabled: boolean | undefined;
+
+      if (channel.channelType === "announcements") {
+        // Guard: a group whose OWN announcements channel is itself shared
+        // (pending or accepted entries) can't also receive announcements
+        // through another group's channel — unshare first.
+        const ownChannel = await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group_type", (q) =>
+            q.eq("groupId", args.groupId).eq("channelType", "announcements")
+          )
+          .first();
+        if (ownChannel && (ownChannel.sharedGroups?.length ?? 0) > 0) {
+          throw new ConvexError({
+            code: "OWN_CHANNEL_SHARED",
+            message:
+              "This group's own Announcements channel is shared with other groups. Unshare it before accepting another group's Announcements channel.",
+          });
+        }
+
+        // Accept = switch: if already an accepted secondary of a DIFFERENT
+        // shared announcements channel, leave it (same cleanup as
+        // removeGroupFromChannel) — but do NOT restore the own channel
+        // mid-switch. Carry the OLD entry's recorded prior state onto the new
+        // entry so the true original state is restored on the final leave.
+        const acceptedShares = await findAcceptedSharedAnnouncementsChannelsForGroup(
+          ctx,
+          args.groupId
+        );
+        let switched = false;
+        for (const { channel: otherChannel, entry: oldEntry } of acceptedShares) {
+          if (otherChannel._id === args.channelId) continue;
+          switched = true;
+          previousAnnouncementsChannelEnabled =
+            oldEntry.previousAnnouncementsChannelEnabled;
+          await removeGroupEntryAndCleanupMembers(
+            ctx,
+            otherChannel,
+            args.groupId,
+            now
+          );
+        }
+
+        const ownChannelEnabled =
+          !!ownChannel &&
+          ownChannel.isArchived !== true &&
+          ownChannel.isEnabled !== false;
+
+        if (!switched) {
+          previousAnnouncementsChannelEnabled = ownChannelEnabled;
+        }
+
+        // Accepting disables the group's own announcements channel —
+        // announcements now flow through the share.
+        if (ownChannel && ownChannelEnabled) {
+          await ctx.db.patch(ownChannel._id, {
+            isEnabled: false,
+            disabledByUserId: userId,
+            updatedAt: now,
+          });
+        }
+      }
+
       // Update the entry in place
       const updatedSharedGroups = [...existingSharedGroups];
       updatedSharedGroups[inviteIndex] = {
@@ -183,12 +348,34 @@ export const respondToChannelInvite = mutation({
         status: "accepted",
         respondedById: userId,
         respondedAt: now,
+        ...(channel.channelType === "announcements"
+          ? { previousAnnouncementsChannelEnabled }
+          : {}),
       };
 
       await ctx.db.patch(args.channelId, {
         sharedGroups: updatedSharedGroups,
         updatedAt: now,
       });
+
+      // Backfill: every active member of the accepting group becomes a
+      // channel member (leaders mirror to channel role "admin"), in scheduled
+      // batches. `recountMemberCount` because the channel already holds the
+      // owning group's members.
+      if (channel.channelType === "announcements") {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.messaging.channels.populateChannelMembersBatch,
+          {
+            groupId: args.groupId,
+            channelId: args.channelId,
+            mirrorGroupRole: true,
+            cursor: null,
+            processed: 0,
+            recountMemberCount: true,
+          }
+        );
+      }
     } else {
       // Decline: remove the entry from sharedGroups
       const updatedSharedGroups = existingSharedGroups.filter(
@@ -264,74 +451,29 @@ export const removeGroupFromChannel = mutation({
       );
     }
 
-    // Find the group in sharedGroups
-    const existingSharedGroups = channel.sharedGroups ?? [];
-    const groupIndex = existingSharedGroups.findIndex(
-      (sg) => sg.groupId === args.groupId
+    const now = Date.now();
+
+    // Remove the entry and soft-delete members exclusive to the removed group
+    const removedEntry = await removeGroupEntryAndCleanupMembers(
+      ctx,
+      channel,
+      args.groupId,
+      now
     );
 
-    if (groupIndex === -1) {
+    if (!removedEntry) {
       throw new ConvexError("Group is not shared on this channel");
     }
 
-    // Remove the entry
-    const updatedSharedGroups = existingSharedGroups.filter(
-      (_, i) => i !== groupIndex
-    );
-
-    const now = Date.now();
-    const isStillShared = updatedSharedGroups.length > 0;
-
-    // Determine the set of remaining group IDs (primary + other accepted secondary groups)
-    const remainingGroupIds = new Set<string>();
-    remainingGroupIds.add(channelGroupId); // primary group always remains
-    for (const sg of updatedSharedGroups) {
-      if (sg.status === "accepted") {
-        remainingGroupIds.add(sg.groupId);
-      }
+    // Leaving an announcements share restores the group's own announcements
+    // channel if accepting the share is what disabled it.
+    if (
+      channel.channelType === "announcements" &&
+      removedEntry.status === "accepted" &&
+      removedEntry.previousAnnouncementsChannelEnabled === true
+    ) {
+      await restoreOwnAnnouncementsChannelLogic(ctx, args.groupId, userId);
     }
-
-    // Get all active channel members
-    const activeMembers = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .collect();
-
-    // For each active channel member, check if they belong to any remaining group
-    for (const member of activeMembers) {
-      let belongsToRemainingGroup = false;
-
-      for (const gId of remainingGroupIds) {
-        const gMembership = await ctx.db
-          .query("groupMembers")
-          .withIndex("by_group_user", (q) =>
-            q.eq("groupId", gId as Id<"groups">).eq("userId", member.userId)
-          )
-          .filter((q) => q.eq(q.field("leftAt"), undefined))
-          .first();
-
-        if (gMembership) {
-          belongsToRemainingGroup = true;
-          break;
-        }
-      }
-
-      if (!belongsToRemainingGroup) {
-        // Soft-delete the channel membership
-        await ctx.db.patch(member._id, { leftAt: now });
-      }
-    }
-
-    // Update the channel
-    await ctx.db.patch(args.channelId, {
-      sharedGroups: updatedSharedGroups,
-      isShared: isStillShared,
-      updatedAt: now,
-    });
-
-    // Recompute member count
-    await updateChannelMemberCount(ctx, args.channelId);
   },
 });
 

--- a/apps/convex/functions/messaging/sharedChannels.ts
+++ b/apps/convex/functions/messaging/sharedChannels.ts
@@ -17,14 +17,17 @@ import type { MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
-import { isLeaderRole } from "../../lib/helpers";
+import { channelIsLeaderEnabled, isLeaderRole } from "../../lib/helpers";
 import { getChannelSlug } from "../../lib/slugs";
 import {
   updateChannelMemberCount,
   findAcceptedSharedAnnouncementsChannelsForGroup,
   type SharedGroupEntry,
 } from "./helpers";
-import { restoreOwnAnnouncementsChannelLogic } from "./channels";
+import {
+  ensureChannelMembership,
+  restoreOwnAnnouncementsChannelLogic,
+} from "./channels";
 
 // ============================================================================
 // Shared Helpers
@@ -181,6 +184,32 @@ export const inviteGroupToChannel = mutation({
       throw new ConvexError("Can only invite groups from the same community");
     }
 
+    if (channel.channelType === "announcements") {
+      // Can't share a disabled/archived channel — the invited group would
+      // accept into a channel nobody can use.
+      if (channel.isArchived || !channelIsLeaderEnabled(channel)) {
+        throw new ConvexError({
+          code: "CHANNEL_DISABLED",
+          message:
+            "This Announcements channel is disabled or archived. Re-enable it before sharing it with other groups.",
+        });
+      }
+
+      // A group that receives announcements through another group's shared
+      // channel can't share its own — it would relay a share of a share.
+      const owningGroupShares = await findAcceptedSharedAnnouncementsChannelsForGroup(
+        ctx,
+        channelGroupId
+      );
+      if (owningGroupShares.length > 0) {
+        throw new ConvexError({
+          code: "OWNER_IS_SECONDARY",
+          message:
+            "This group receives announcements through another group's shared Announcements channel. Leave that share before sharing its own Announcements channel.",
+        });
+      }
+    }
+
     // Duplicate check: cannot invite a group that's already in sharedGroups
     const existingSharedGroups = channel.sharedGroups ?? [];
     const alreadyInvited = existingSharedGroups.some(
@@ -207,6 +236,10 @@ export const inviteGroupToChannel = mutation({
       isShared: true,
       sharedGroups: updatedSharedGroups,
       updatedAt: now,
+      // Stamp communityId (from the owning group) so community-scoped share
+      // scans (by_community_isShared) see this channel — defensive for
+      // channels created before communityId was denormalized.
+      ...(channel.communityId ? {} : { communityId: primaryGroup.communityId }),
     });
 
     // Notify leaders of the invited group
@@ -274,6 +307,17 @@ export const respondToChannelInvite = mutation({
     const now = Date.now();
 
     if (args.response === "accepted") {
+      // Can't accept into a disabled/archived channel — the accepting group
+      // would be joined to a channel nobody can use, and the backfill batch
+      // would bail anyway.
+      if (channel.isArchived || !channelIsLeaderEnabled(channel)) {
+        throw new ConvexError({
+          code: "CHANNEL_DISABLED",
+          message:
+            "This channel is disabled or archived and can't be joined. Ask the owning group to re-enable it first.",
+        });
+      }
+
       // Announcements shares have accept-time side effects: the accepting
       // group's members are backfilled into the shared channel and its own
       // announcements channel is disabled (prior state recorded so it can be
@@ -299,23 +343,22 @@ export const respondToChannelInvite = mutation({
         }
 
         // Accept = switch: if already an accepted secondary of a DIFFERENT
-        // shared announcements channel, leave it (same cleanup as
-        // removeGroupFromChannel) — but do NOT restore the own channel
-        // mid-switch. Carry the OLD entry's recorded prior state onto the new
-        // entry so the true original state is restored on the final leave.
+        // shared announcements channel (at most one can exist per group),
+        // leave it (same cleanup as removeGroupFromChannel) — but do NOT
+        // restore the own channel mid-switch. Carry the OLD entry's recorded
+        // prior state onto the new entry so the true original state is
+        // restored on the final leave.
         const acceptedShares = await findAcceptedSharedAnnouncementsChannelsForGroup(
           ctx,
           args.groupId
         );
-        let switched = false;
-        for (const { channel: otherChannel, entry: oldEntry } of acceptedShares) {
-          if (otherChannel._id === args.channelId) continue;
-          switched = true;
-          previousAnnouncementsChannelEnabled =
-            oldEntry.previousAnnouncementsChannelEnabled;
+        const oldShare = acceptedShares.find(
+          ({ channel: otherChannel }) => otherChannel._id !== args.channelId
+        );
+        if (oldShare) {
           await removeGroupEntryAndCleanupMembers(
             ctx,
-            otherChannel,
+            oldShare.channel,
             args.groupId,
             now
           );
@@ -324,11 +367,14 @@ export const respondToChannelInvite = mutation({
         const ownChannelEnabled =
           !!ownChannel &&
           ownChannel.isArchived !== true &&
-          ownChannel.isEnabled !== false;
+          channelIsLeaderEnabled(ownChannel);
 
-        if (!switched) {
-          previousAnnouncementsChannelEnabled = ownChannelEnabled;
-        }
+        // Legacy entries created before prior-state tracking have no recorded
+        // value — fall back to the CURRENT own-channel state.
+        previousAnnouncementsChannelEnabled =
+          (oldShare
+            ? oldShare.entry.previousAnnouncementsChannelEnabled
+            : undefined) ?? ownChannelEnabled;
 
         // Accepting disables the group's own announcements channel —
         // announcements now flow through the share.
@@ -360,9 +406,13 @@ export const respondToChannelInvite = mutation({
 
       // Backfill: every active member of the accepting group becomes a
       // channel member (leaders mirror to channel role "admin"), in scheduled
-      // batches. `recountMemberCount` because the channel already holds the
-      // owning group's members.
+      // batches.
       if (channel.channelType === "announcements") {
+        // Add the accepting leader synchronously so they can post immediately,
+        // before the async batch backfills everyone else (see
+        // ensureChannelMembership). Leaders mirror to channel role "admin".
+        await ensureChannelMembership(ctx, args.channelId, userId, "admin", now);
+
         await ctx.scheduler.runAfter(
           0,
           internal.functions.messaging.channels.populateChannelMembersBatch,
@@ -372,7 +422,6 @@ export const respondToChannelInvite = mutation({
             mirrorGroupRole: true,
             cursor: null,
             processed: 0,
-            recountMemberCount: true,
           }
         );
       }

--- a/apps/convex/functions/sync/memberships.ts
+++ b/apps/convex/functions/sync/memberships.ts
@@ -13,7 +13,7 @@ import { v } from "convex/values";
 import { internalMutation, action } from "../../_generated/server";
 import type { MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
-import type { Id } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { COMMUNITY_ADMIN_THRESHOLD } from "../../lib/permissions";
 
@@ -169,6 +169,137 @@ export async function syncAnnouncementGroupMembership(
 // Channel Membership Sync
 // ============================================================================
 
+/** Whether a channel is a shared announcements channel with accepted secondaries. */
+function channelIsSharedAnnouncements(channel: Doc<"chatChannels">): boolean {
+  return (
+    channel.channelType === "announcements" &&
+    channel.isShared === true &&
+    (channel.sharedGroups ?? []).some((sg) => sg.status === "accepted")
+  );
+}
+
+/**
+ * Where a user stands across ALL groups participating in a shared
+ * announcements channel: the owning group plus every accepted secondary.
+ *
+ * - `isMemberOfAny`: active member of at least one participating group
+ *   (→ should be a channel member)
+ * - `isLeaderOfAny`: leader/admin of at least one participating group
+ *   (→ channel role mirrors to "admin")
+ */
+async function resolveSharedAnnouncementsStanding(
+  ctx: MutationCtx,
+  channel: Doc<"chatChannels">,
+  userId: Id<"users">
+): Promise<{ isMemberOfAny: boolean; isLeaderOfAny: boolean }> {
+  const participatingGroupIds: Id<"groups">[] = [];
+  if (channel.groupId) {
+    participatingGroupIds.push(channel.groupId);
+  }
+  for (const sg of channel.sharedGroups ?? []) {
+    if (sg.status === "accepted") {
+      participatingGroupIds.push(sg.groupId);
+    }
+  }
+
+  let isMemberOfAny = false;
+  let isLeaderOfAny = false;
+  for (const gId of participatingGroupIds) {
+    const membership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q: any) =>
+        q.eq("groupId", gId).eq("userId", userId)
+      )
+      .first();
+    if (membership && !membership.leftAt) {
+      isMemberOfAny = true;
+      if (membership.role === "leader" || membership.role === "admin") {
+        isLeaderOfAny = true;
+      }
+    }
+  }
+  return { isMemberOfAny, isLeaderOfAny };
+}
+
+/**
+ * Reconciles a single user's membership row on a channel to the desired
+ * state: adds/reactivates, soft-removes, or updates the role — and keeps the
+ * channel's `memberCount` in step. Shared body of the per-group channel loop
+ * and the shared-announcements reconcile in `syncUserChannelMembershipsLogic`.
+ */
+async function reconcileChannelMembershipRow(
+  ctx: MutationCtx,
+  channel: Doc<"chatChannels">,
+  userId: Id<"users">,
+  shouldBeInChannel: boolean,
+  expectedChannelRole: string,
+  displayName: string | undefined,
+  profilePhoto: string | undefined,
+  now: number
+): Promise<void> {
+  // Get current channel membership
+  const currentMembership = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_channel_user", (q: any) =>
+      q.eq("channelId", channel._id).eq("userId", userId)
+    )
+    .first();
+
+  const isCurrentlyInChannel = currentMembership && !currentMembership.leftAt;
+
+  // Sync membership to desired state
+  let memberCountDelta = 0;
+  if (shouldBeInChannel && !isCurrentlyInChannel) {
+    // ADD to channel
+    if (currentMembership) {
+      // Reactivate existing membership
+      await ctx.db.patch(currentMembership._id, {
+        leftAt: undefined,
+        joinedAt: now,
+        role: expectedChannelRole,
+        displayName,
+        profilePhoto,
+      });
+      console.log(`[syncUserChannelMembershipsLogic] Reactivated user ${userId} in ${channel.channelType} channel ${channel._id}`);
+    } else {
+      // Create new membership
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: channel._id,
+        userId,
+        role: expectedChannelRole,
+        joinedAt: now,
+        isMuted: false,
+        displayName,
+        profilePhoto,
+      });
+      console.log(`[syncUserChannelMembershipsLogic] Added user ${userId} to ${channel.channelType} channel ${channel._id}`);
+    }
+    memberCountDelta = 1;
+  } else if (!shouldBeInChannel && isCurrentlyInChannel) {
+    // REMOVE from channel (soft delete)
+    await ctx.db.patch(currentMembership!._id, {
+      leftAt: now,
+    });
+    console.log(`[syncUserChannelMembershipsLogic] Removed user ${userId} from ${channel.channelType} channel ${channel._id}`);
+    memberCountDelta = -1;
+  } else if (shouldBeInChannel && isCurrentlyInChannel && currentMembership.role !== expectedChannelRole) {
+    // UPDATE role if it changed (e.g., promoted to leader or demoted from leader)
+    await ctx.db.patch(currentMembership._id, {
+      role: expectedChannelRole,
+      displayName,
+      profilePhoto,
+    });
+  }
+
+  // Increment/decrement channel member count
+  if (memberCountDelta !== 0) {
+    const currentCount = channel.memberCount ?? 0;
+    await ctx.db.patch(channel._id, {
+      memberCount: Math.max(0, currentCount + memberCountDelta),
+    });
+  }
+}
+
 /**
  * Sync a user's channel memberships for a specific group.
  *
@@ -237,6 +368,8 @@ export async function syncUserChannelMembershipsLogic(
 
     // Determine if user SHOULD be in this channel
     let shouldBeInChannel = false;
+    // Determine expected channel role
+    let expectedChannelRole = isLeaderOrAdmin ? "admin" : "member";
     if (channel.channelType === "main") {
       shouldBeInChannel = isActiveGroupMember;
     } else if (channel.channelType === "leaders") {
@@ -246,73 +379,64 @@ export async function syncUserChannelMembershipsLogic(
     } else if (channel.channelType === "announcements") {
       // Announcements: every active group member is a channel member so they
       // can read; posting is gated to leaders in sendMessage.
-      shouldBeInChannel = isActiveGroupMember;
-    }
-
-    // Get current channel membership
-    const currentMembership = await ctx.db
-      .query("chatChannelMembers")
-      .withIndex("by_channel_user", (q: any) =>
-        q.eq("channelId", channel._id).eq("userId", userId)
-      )
-      .first();
-
-    const isCurrentlyInChannel = currentMembership && !currentMembership.leftAt;
-
-    // Determine expected channel role
-    const expectedChannelRole = isLeaderOrAdmin ? "admin" : "member";
-
-    // Sync membership to desired state
-    let memberCountDelta = 0;
-    if (shouldBeInChannel && !isCurrentlyInChannel) {
-      // ADD to channel
-      if (currentMembership) {
-        // Reactivate existing membership
-        await ctx.db.patch(currentMembership._id, {
-          leftAt: undefined,
-          joinedAt: now,
-          role: expectedChannelRole,
-          displayName,
-          profilePhoto,
-        });
-        console.log(`[syncUserChannelMembershipsLogic] Reactivated user ${userId} in ${channel.channelType} channel ${channel._id}`);
+      if (channelIsSharedAnnouncements(channel)) {
+        // Shared announcements: membership spans the owning group AND every
+        // accepted secondary group, so leaving one of them must not remove a
+        // user who is still active in another. Channel role is admin if they
+        // lead ANY of those groups.
+        const standing = await resolveSharedAnnouncementsStanding(
+          ctx,
+          channel,
+          userId
+        );
+        shouldBeInChannel = standing.isMemberOfAny;
+        expectedChannelRole = standing.isLeaderOfAny ? "admin" : "member";
       } else {
-        // Create new membership
-        await ctx.db.insert("chatChannelMembers", {
-          channelId: channel._id,
-          userId,
-          role: expectedChannelRole,
-          joinedAt: now,
-          isMuted: false,
-          displayName,
-          profilePhoto,
-        });
-        console.log(`[syncUserChannelMembershipsLogic] Added user ${userId} to ${channel.channelType} channel ${channel._id}`);
+        shouldBeInChannel = isActiveGroupMember;
       }
-      memberCountDelta = 1;
-    } else if (!shouldBeInChannel && isCurrentlyInChannel) {
-      // REMOVE from channel (soft delete)
-      await ctx.db.patch(currentMembership!._id, {
-        leftAt: now,
-      });
-      console.log(`[syncUserChannelMembershipsLogic] Removed user ${userId} from ${channel.channelType} channel ${channel._id}`);
-      memberCountDelta = -1;
-    } else if (shouldBeInChannel && isCurrentlyInChannel && currentMembership.role !== expectedChannelRole) {
-      // UPDATE role if it changed (e.g., promoted to leader or demoted from leader)
-      await ctx.db.patch(currentMembership._id, {
-        role: expectedChannelRole,
-        displayName,
-        profilePhoto,
-      });
     }
 
-    // Increment/decrement channel member count
-    if (memberCountDelta !== 0) {
-      const currentCount = channel.memberCount ?? 0;
-      await ctx.db.patch(channel._id, {
-        memberCount: Math.max(0, currentCount + memberCountDelta),
-      });
-    }
+    await reconcileChannelMembershipRow(
+      ctx,
+      channel,
+      userId,
+      shouldBeInChannel,
+      expectedChannelRole,
+      displayName,
+      profilePhoto,
+      now
+    );
+  }
+
+  // Reconcile shared announcements channels owned by OTHER groups where this
+  // group is an accepted secondary — a join/leave/role change here must flow
+  // into those channels too. The `by_isShared` index keeps this scan limited
+  // to shared channels (rare), so the common path is unaffected.
+  const sharedChannels = await ctx.db
+    .query("chatChannels")
+    .withIndex("by_isShared", (q: any) => q.eq("isShared", true))
+    .filter((q: any) => q.eq(q.field("isArchived"), false))
+    .collect();
+
+  for (const channel of sharedChannels) {
+    if (channel.channelType !== "announcements") continue;
+    if (!channel.groupId || channel.groupId === groupId) continue; // own channels handled above
+    const isAcceptedSecondary = (channel.sharedGroups ?? []).some(
+      (sg) => sg.groupId === groupId && sg.status === "accepted"
+    );
+    if (!isAcceptedSecondary) continue;
+
+    const standing = await resolveSharedAnnouncementsStanding(ctx, channel, userId);
+    await reconcileChannelMembershipRow(
+      ctx,
+      channel,
+      userId,
+      standing.isMemberOfAny,
+      standing.isLeaderOfAny ? "admin" : "member",
+      displayName,
+      profilePhoto,
+      now
+    );
   }
 
   // Handle custom channels when user leaves group

--- a/apps/convex/functions/sync/memberships.ts
+++ b/apps/convex/functions/sync/memberships.ts
@@ -16,6 +16,7 @@ import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { COMMUNITY_ADMIN_THRESHOLD } from "../../lib/permissions";
+import { findAcceptedSharedAnnouncementsChannelsForGroup } from "../messaging/helpers";
 
 // ============================================================================
 // Main Entry Point
@@ -410,22 +411,14 @@ export async function syncUserChannelMembershipsLogic(
 
   // Reconcile shared announcements channels owned by OTHER groups where this
   // group is an accepted secondary — a join/leave/role change here must flow
-  // into those channels too. The `by_isShared` index keeps this scan limited
-  // to shared channels (rare), so the common path is unaffected.
-  const sharedChannels = await ctx.db
-    .query("chatChannels")
-    .withIndex("by_isShared", (q: any) => q.eq("isShared", true))
-    .filter((q: any) => q.eq(q.field("isArchived"), false))
-    .collect();
+  // into those channels too. The helper's community-scoped index keeps this
+  // scan limited to the group's community, so the common path is unaffected.
+  const acceptedShares = await findAcceptedSharedAnnouncementsChannelsForGroup(
+    ctx,
+    groupId
+  );
 
-  for (const channel of sharedChannels) {
-    if (channel.channelType !== "announcements") continue;
-    if (!channel.groupId || channel.groupId === groupId) continue; // own channels handled above
-    const isAcceptedSecondary = (channel.sharedGroups ?? []).some(
-      (sg) => sg.groupId === groupId && sg.status === "accepted"
-    );
-    if (!isAcceptedSecondary) continue;
-
+  for (const { channel } of acceptedShares) {
     const standing = await resolveSharedAnnouncementsStanding(ctx, channel, userId);
     await reconcileChannelMembershipRow(
       ctx,

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1628,6 +1628,14 @@ export default defineSchema({
           sortOrder: v.optional(v.number()), // How this group orders the channel
           /** Linked group's leaders hid the channel from tab bar / chat; owning group unchanged. */
           hiddenFromNavigation: v.optional(v.boolean()),
+          /**
+           * Announcements-type shares only: whether this group's OWN
+           * announcements channel was enabled when it accepted the share
+           * (accepting disables it). Used to restore the prior state when the
+           * group later leaves the share. Carried over when switching shares
+           * so the true original state survives back-to-back shares.
+           */
+          previousAnnouncementsChannelEnabled: v.optional(v.boolean()),
         }),
       ),
     ),

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1581,7 +1581,11 @@ export default defineSchema({
    */
   chatChannels: defineTable({
     groupId: v.optional(v.id("groups")),
-    /** Set for ad-hoc channels (dm, group_dm) that are not bound to a group. */
+    /**
+     * Set for ad-hoc channels (dm, group_dm) that are not bound to a group,
+     * and for announcements/shared channels so `by_community_isShared` can
+     * scope share scans to one community.
+     */
     communityId: v.optional(v.id("communities")),
     /** Convenience flag: true for ad-hoc dm/group_dm channels. */
     isAdHoc: v.optional(v.boolean()),
@@ -1677,6 +1681,7 @@ export default defineSchema({
     .index("by_lastMessageAt", ["lastMessageAt"])
     .index("by_archived", ["isArchived"])
     .index("by_isShared", ["isShared"])
+    .index("by_community_isShared", ["communityId", "isShared"])
     .index("by_inviteShortId", ["inviteShortId"])
     .index("by_meetingId", ["meetingId"])
     .index("by_dmPairKey", ["dmPairKey"])

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
@@ -43,6 +43,7 @@ import {
   useAuthenticatedMutation,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { errorMessage } from "@/utils/error-handling";
 
 export default function ChannelActiveStateRoute() {
   const { groupId, channelSlug } = useLocalSearchParams<{
@@ -170,10 +171,7 @@ export default function ChannelActiveStateRoute() {
         // ConvexError guards (e.g. CHANNEL_SHARED / IN_SHARED_ANNOUNCEMENTS on
         // announcements toggles) carry the readable message on `.data.message`;
         // `.message` is a generic "Server Error" string in production.
-        Alert.alert(
-          "Error",
-          e?.data?.message ?? e?.message ?? "Failed to update channel",
-        );
+        Alert.alert("Error", errorMessage(e, "Failed to update channel"));
       } finally {
         setSubmitting(false);
       }

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/info/active-state.tsx
@@ -167,7 +167,13 @@ export default function ChannelActiveStateRoute() {
           router.back();
         }
       } catch (e: any) {
-        Alert.alert("Error", e?.message || "Failed to update channel");
+        // ConvexError guards (e.g. CHANNEL_SHARED / IN_SHARED_ANNOUNCEMENTS on
+        // announcements toggles) carry the readable message on `.data.message`;
+        // `.message` is a generic "Server Error" string in production.
+        Alert.alert(
+          "Error",
+          e?.data?.message ?? e?.message ?? "Failed to update channel",
+        );
       } finally {
         setSubmitting(false);
       }

--- a/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
+++ b/apps/mobile/app/inbox/[groupId]/[channelSlug]/members.tsx
@@ -199,8 +199,13 @@ export default function ChannelMembersScreen() {
     return isOwner || isGroupLeader;
   }, [channelData, user]);
 
-  // Can the user share this channel (primary leader only, custom/pco channels)
-  const canShare = canManage && isPrimaryGroup && (channelData?.channelType === "custom" || channelData?.channelType === "pco_services");
+  // Can the user share this channel (primary leader only, custom/pco/announcements channels)
+  const canShare =
+    canManage &&
+    isPrimaryGroup &&
+    (channelData?.channelType === "custom" ||
+      channelData?.channelType === "pco_services" ||
+      channelData?.channelType === "announcements");
 
   // Check if this is a custom channel
   const isCustomChannel = useMemo(() => {

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -70,6 +70,8 @@ import {
   getDebugReasonText,
   type UnsyncedPerson,
 } from "@/utils/channel-members";
+import { errorMessage } from "@/utils/error-handling";
+import { confirmAnnouncementsShareAccept } from "@features/groups/hooks/useRespondToChannelInvite";
 
 type Props = {
   groupId: string;
@@ -508,10 +510,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
     } catch (e: any) {
       // ConvexError payloads (e.g. OWN_CHANNEL_SHARED) carry the readable
       // message on `.data.message`; `.message` is generic in production.
-      Alert.alert(
-        "Couldn't accept",
-        e?.data?.message ?? e?.message ?? "Please try again.",
-      );
+      Alert.alert("Couldn't accept", errorMessage(e, "Please try again."));
     } finally {
       setPendingResponding(null);
     }
@@ -522,22 +521,15 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
     // backfill + this group's own Announcements channel turned off), so it
     // gets an explicit confirmation. Other channel types accept immediately.
     if (channel?.channelType === "announcements") {
-      const ownerName = primaryGroupName ?? "the owning group";
       const currentShare = (activeSharedChannels ?? []).find(
         (c: any) =>
           c.channelType === "announcements" && c.channelId !== channel._id,
       );
-      Alert.alert(
-        "Accept Announcements share?",
-        `Accepting will add all members of this group to ${ownerName}'s Announcements and turn off this group's own Announcements channel. Leaders of both groups can post.` +
-          (currentShare
-            ? ` This group will stop receiving announcements from ${currentShare.primaryGroupName}.`
-            : ""),
-        [
-          { text: "Cancel", style: "cancel" },
-          { text: "Accept", onPress: () => void performAcceptInvite() },
-        ],
-      );
+      confirmAnnouncementsShareAccept({
+        ownerName: primaryGroupName ?? "the owning group",
+        switchFromGroupName: currentShare?.primaryGroupName,
+        onConfirm: () => void performAcceptInvite(),
+      });
       return;
     }
     void performAcceptInvite();

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -86,6 +86,7 @@ type ChannelType =
   | "main"
   | "leaders"
   | "reach_out"
+  | "announcements"
   | "pco_services"
   | "custom"
   | "cross_team";
@@ -121,6 +122,8 @@ function getChannelIconConfig(
       return { icon: "star", color: "#FFA500", bg: "#FFA50015", defaultName: "Leaders" };
     case "reach_out":
       return { icon: "hand-left", color: "#8E44AD", bg: "#8E44AD15", defaultName: "Reach Out" };
+    case "announcements":
+      return { icon: "megaphone", color: "#E11D48", bg: "#E11D4815", defaultName: "Announcements" };
     case "pco_services":
       return { icon: "sync", color: "#2196F3", bg: "#2196F315", defaultName: "PCO Channel" };
     case "cross_team":
@@ -334,6 +337,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
   const isReachOut = channelType === "reach_out";
   const isPco = channelType === "pco_services";
   const isCrossTeam = channelType === "cross_team";
+  const isAnnouncements = channelType === "announcements";
   // Renameable types: plain custom, serving-team (which is a `custom` channel
   // flagged isServingTeam — renaming it also renames the team, backend-side),
   // and cross-team. NOT pco_services or system channels (main/leaders/
@@ -404,6 +408,17 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
       (sg: any) => sg.groupId === groupId && sg.status === "accepted",
     );
   }, [channel?.groupId, channel?.sharedGroups, groupId]);
+
+  // Only fetched while reviewing a pending ANNOUNCEMENTS invite (leader-gated
+  // on the backend): tells us whether this group already receives
+  // announcements through another share, so the accept confirmation can warn
+  // about the automatic switch.
+  const activeSharedChannels = useQuery(
+    api.functions.messaging.sharedChannels.listActiveSharedChannelsForGroup,
+    token && isPendingShareInvite && channel?.channelType === "announcements"
+      ? { token, groupId: groupId as Id<"groups"> }
+      : "skip",
+  );
 
   const handleBack = useCallback(() => {
     if (router.canGoBack()) {
@@ -479,7 +494,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
     }
   }, [channel?._id, leaveChannelMutation, groupId, router]);
 
-  const handleAcceptInvite = useCallback(async () => {
+  const performAcceptInvite = useCallback(async () => {
     if (!channel?._id) return;
     setPendingResponding("accept");
     try {
@@ -491,11 +506,48 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
       // Stay on the screen — getChannelBySlug now re-resolves the channel as an
       // accepted shared channel and the normal management UI takes over.
     } catch (e: any) {
-      Alert.alert("Couldn't accept", e?.message || "Please try again.");
+      // ConvexError payloads (e.g. OWN_CHANNEL_SHARED) carry the readable
+      // message on `.data.message`; `.message` is generic in production.
+      Alert.alert(
+        "Couldn't accept",
+        e?.data?.message ?? e?.message ?? "Please try again.",
+      );
     } finally {
       setPendingResponding(null);
     }
   }, [channel?._id, respondToInviteMutation, groupId]);
+
+  const handleAcceptInvite = useCallback(() => {
+    // Accepting an announcements share has group-wide side effects (member
+    // backfill + this group's own Announcements channel turned off), so it
+    // gets an explicit confirmation. Other channel types accept immediately.
+    if (channel?.channelType === "announcements") {
+      const ownerName = primaryGroupName ?? "the owning group";
+      const currentShare = (activeSharedChannels ?? []).find(
+        (c: any) =>
+          c.channelType === "announcements" && c.channelId !== channel._id,
+      );
+      Alert.alert(
+        "Accept Announcements share?",
+        `Accepting will add all members of this group to ${ownerName}'s Announcements and turn off this group's own Announcements channel. Leaders of both groups can post.` +
+          (currentShare
+            ? ` This group will stop receiving announcements from ${currentShare.primaryGroupName}.`
+            : ""),
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Accept", onPress: () => void performAcceptInvite() },
+        ],
+      );
+      return;
+    }
+    void performAcceptInvite();
+  }, [
+    channel?.channelType,
+    channel?._id,
+    primaryGroupName,
+    activeSharedChannels,
+    performAcceptInvite,
+  ]);
 
   const handleDeclineInvite = useCallback(() => {
     Alert.alert(
@@ -1560,8 +1612,11 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                 </Pressable>
               )}
 
-              {/* Share with groups — custom + pco_services */}
-              {(isCustom || isPco) && (
+              {/* Share with groups — custom + pco_services + announcements.
+                  Announcements can only be shared by the OWNING group's
+                  leaders (a secondary group receives the share; it has
+                  nothing to share out). */}
+              {(isCustom || isPco || (isAnnouncements && !isSecondaryShare)) && (
                 <Pressable
                   onPress={handleManageMembers}
                   style={({ pressed }) => [

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -40,6 +40,7 @@ import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
+import { errorMessage } from "@/utils/error-handling";
 import { useGroupChannels } from "../hooks/useGroupChannels";
 import { ChannelJoinRequestsBanner } from "./ChannelJoinRequestsBanner";
 
@@ -70,8 +71,11 @@ interface Channel {
   isPinned: boolean;
   lastMessageAt?: number;
   isShared?: boolean;
-  /** Number of groups with an accepted share on this channel (owner side). */
+  /** Number of groups with an accepted share on this channel (owner side only). */
   sharedGroupCount?: number;
+  /** For announcements channels shared INTO this group: the owning group. */
+  sharedFromGroupId?: string;
+  sharedFromGroupName?: string;
   /** false when leader hid channel; memberships stay (see Convex isEnabled). */
   isEnabled: boolean;
   /** true for custom channels auto-created from an event plan's serving team. */
@@ -101,17 +105,6 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
     token && isLeader ? { token, groupId: groupId as Id<"groups"> } : "skip"
   );
 
-  // Shared channels this group participates in as an accepted SECONDARY.
-  // Used to detect when announcements flow in through another group's shared
-  // Announcements channel (which keeps this group's own channel disabled).
-  const activeSharedChannels = useQuery(
-    api.functions.messaging.sharedChannels.listActiveSharedChannelsForGroup,
-    token && isLeader ? { token, groupId: groupId as Id<"groups"> } : "skip"
-  );
-  const announcementsShare = activeSharedChannels?.find(
-    (c) => c.channelType === "announcements"
-  );
-
   const { channels: rawChannels } = useGroupChannels(groupId, {
     includeArchived: isLeader,
   });
@@ -125,8 +118,16 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
   const mainChannel = channels?.find((c: Channel) => c.channelType === "main");
   const leadersChannel = channels?.find((c: Channel) => c.channelType === "leaders");
   const reachOutChannel = channels?.find((c: Channel) => c.channelType === "reach_out");
+  // An announcements channel shared INTO this group (owned by another group,
+  // sharedFromGroupName set) IS the group's announcements surface while the
+  // share is active — the group's own channel stays intentionally disabled.
+  // Both come out of the same cached listGroupChannels payload, so this works
+  // offline too.
+  const sharedInAnnouncements = channels?.find(
+    (c: Channel) => c.channelType === "announcements" && !!c.sharedFromGroupName
+  );
   const announcementsChannel = channels?.find(
-    (c: Channel) => c.channelType === "announcements"
+    (c: Channel) => c.channelType === "announcements" && !c.sharedFromGroupName
   );
   const pcoSyncedChannels = channels?.filter((c: Channel) => c.channelType === "pco_services") ?? [];
   const crossTeamChannels = channels?.filter((c: Channel) => c.channelType === "cross_team") ?? [];
@@ -163,10 +164,7 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
     } catch (e: any) {
       // ConvexError payloads (e.g. IN_SHARED_ANNOUNCEMENTS) carry the readable
       // message on `.data.message`; `.message` is generic in production.
-      Alert.alert(
-        "Error",
-        e?.data?.message ?? e?.message ?? "Failed to enable Announcements"
-      );
+      Alert.alert("Error", errorMessage(e, "Failed to enable Announcements"));
     } finally {
       setEnablingAnnouncements(false);
     }
@@ -286,47 +284,68 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
   // Announcements: opt-in leader-broadcast channel. Leaders see the row
   // even before the channel exists so they can enable it; members only see
   // it once a leader has turned it on.
-  if (announcementsChannel || isLeader) {
-    const hasAnnouncementsRecord = !!announcementsChannel;
-    // Accepted shares on this group's OWN announcements channel (owner side).
-    const sharedWithCount = announcementsChannel?.sharedGroupCount ?? 0;
+  if (sharedInAnnouncements) {
+    // Announcements come from another group's shared channel — THE one
+    // announcements row opens that channel. The group's own (intentionally
+    // disabled) channel doesn't render at all: re-enabling it is guarded
+    // backend-side by IN_SHARED_ANNOUNCEMENTS, and leaving the share happens
+    // from the shared channel's info screen. The channel id disambiguates the
+    // shared channel from the own channel that shares the same slug.
+    rows.push({
+      key: sharedInAnnouncements._id,
+      icon: "megaphone",
+      iconColor: "#E11D48",
+      iconBg: "#E11D4815",
+      name: "Announcements",
+      subtitle: `Shared — announcements come from ${sharedInAnnouncements.sharedFromGroupName}`,
+      enabled: sharedInAnnouncements.isEnabled !== false,
+      onPress: () =>
+        navigateToChannelInfo(sharedInAnnouncements.slug, sharedInAnnouncements._id),
+      unreadCount: sharedInAnnouncements.unreadCount,
+      pinned: sharedInAnnouncements.isPinned,
+      archived: false,
+    });
+  } else if (announcementsChannel || isLeader) {
+    let subtitle: string;
+    if (!announcementsChannel) {
+      subtitle = enablingAnnouncements
+        ? "Enabling…"
+        : "Tap to enable — leaders post, members read";
+    } else if (!announcementsEnabled) {
+      subtitle = "Disabled";
+    } else {
+      const memberCountLabel = `${announcementsChannel.memberCount} member${announcementsChannel.memberCount !== 1 ? "s" : ""}`;
+      // Accepted shares on this group's OWN announcements channel (owner side).
+      const sharedWithCount = announcementsChannel.sharedGroupCount ?? 0;
+      subtitle =
+        sharedWithCount > 0
+          ? `${memberCountLabel} · Shared with ${sharedWithCount} group${sharedWithCount !== 1 ? "s" : ""}`
+          : `${memberCountLabel} · Leaders post`;
+    }
     rows.push({
       key: announcementsChannel?._id ?? "announcements-placeholder",
       icon: "megaphone",
       iconColor: "#E11D48",
       iconBg: "#E11D4815",
       name: "Announcements",
-      // When this group receives announcements through another group's shared
-      // channel, its own channel is intentionally disabled — say so instead of
-      // showing a "Disabled"/"Tap to enable" state that would just error
-      // (enable is guarded backend-side by IN_SHARED_ANNOUNCEMENTS).
-      subtitle: announcementsShare
-        ? `Shared — announcements come from ${announcementsShare.primaryGroupName}`
-        : hasAnnouncementsRecord
-          ? announcementsEnabled
-            ? sharedWithCount > 0
-              ? `${announcementsChannel!.memberCount} member${announcementsChannel!.memberCount !== 1 ? "s" : ""} · Shared with ${sharedWithCount} group${sharedWithCount !== 1 ? "s" : ""}`
-              : `${announcementsChannel!.memberCount} member${announcementsChannel!.memberCount !== 1 ? "s" : ""} · Leaders post`
-            : "Disabled"
-          : enablingAnnouncements
-            ? "Enabling…"
-            : "Tap to enable — leaders post, members read",
+      subtitle,
       enabled: announcementsEnabled,
       // Placeholder (no record yet) tap → lazy-create via mutation (surfaces
       // the backend guard message if announcements come through a share).
-      // Existing record tap → channel info screen for further toggling.
-      onPress: hasAnnouncementsRecord
-        ? () => navigateToChannelInfo(announcementsChannel!.slug)
+      // Existing record tap → channel info screen for further toggling. The
+      // channel id is passed so routing can't resolve a same-slug shared
+      // channel instead of this group's own channel.
+      onPress: announcementsChannel
+        ? () =>
+            navigateToChannelInfo(announcementsChannel.slug, announcementsChannel._id)
         : isLeader
           ? handleEnableAnnouncements
           : undefined,
       unreadCount: announcementsChannel?.unreadCount,
       pinned: announcementsChannel?.isPinned,
       // Keep the "Tap to enable" CTA (no record) in the main list; fold only
-      // an existing-but-disabled Announcements channel. While receiving a
-      // share, keep the row visible — the disabled state is explained by the
-      // "Shared — announcements come from …" subtitle.
-      archived: !!announcementsChannel && !announcementsEnabled && !announcementsShare,
+      // an existing-but-disabled Announcements channel.
+      archived: !!announcementsChannel && !announcementsEnabled,
     });
   }
 

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -70,6 +70,8 @@ interface Channel {
   isPinned: boolean;
   lastMessageAt?: number;
   isShared?: boolean;
+  /** Number of groups with an accepted share on this channel (owner side). */
+  sharedGroupCount?: number;
   /** false when leader hid channel; memberships stay (see Convex isEnabled). */
   isEnabled: boolean;
   /** true for custom channels auto-created from an event plan's serving team. */
@@ -97,6 +99,17 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
   const pendingInvites = useQuery(
     api.functions.messaging.sharedChannels.listPendingInvitesForGroup,
     token && isLeader ? { token, groupId: groupId as Id<"groups"> } : "skip"
+  );
+
+  // Shared channels this group participates in as an accepted SECONDARY.
+  // Used to detect when announcements flow in through another group's shared
+  // Announcements channel (which keeps this group's own channel disabled).
+  const activeSharedChannels = useQuery(
+    api.functions.messaging.sharedChannels.listActiveSharedChannelsForGroup,
+    token && isLeader ? { token, groupId: groupId as Id<"groups"> } : "skip"
+  );
+  const announcementsShare = activeSharedChannels?.find(
+    (c) => c.channelType === "announcements"
   );
 
   const { channels: rawChannels } = useGroupChannels(groupId, {
@@ -148,7 +161,12 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
         enabled: true,
       });
     } catch (e: any) {
-      Alert.alert("Error", e?.message || "Failed to enable Announcements");
+      // ConvexError payloads (e.g. IN_SHARED_ANNOUNCEMENTS) carry the readable
+      // message on `.data.message`; `.message` is generic in production.
+      Alert.alert(
+        "Error",
+        e?.data?.message ?? e?.message ?? "Failed to enable Announcements"
+      );
     } finally {
       setEnablingAnnouncements(false);
     }
@@ -270,21 +288,32 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
   // it once a leader has turned it on.
   if (announcementsChannel || isLeader) {
     const hasAnnouncementsRecord = !!announcementsChannel;
+    // Accepted shares on this group's OWN announcements channel (owner side).
+    const sharedWithCount = announcementsChannel?.sharedGroupCount ?? 0;
     rows.push({
       key: announcementsChannel?._id ?? "announcements-placeholder",
       icon: "megaphone",
       iconColor: "#E11D48",
       iconBg: "#E11D4815",
       name: "Announcements",
-      subtitle: hasAnnouncementsRecord
-        ? announcementsEnabled
-          ? `${announcementsChannel!.memberCount} member${announcementsChannel!.memberCount !== 1 ? "s" : ""} · Leaders post`
-          : "Disabled"
-        : enablingAnnouncements
-          ? "Enabling…"
-          : "Tap to enable — leaders post, members read",
+      // When this group receives announcements through another group's shared
+      // channel, its own channel is intentionally disabled — say so instead of
+      // showing a "Disabled"/"Tap to enable" state that would just error
+      // (enable is guarded backend-side by IN_SHARED_ANNOUNCEMENTS).
+      subtitle: announcementsShare
+        ? `Shared — announcements come from ${announcementsShare.primaryGroupName}`
+        : hasAnnouncementsRecord
+          ? announcementsEnabled
+            ? sharedWithCount > 0
+              ? `${announcementsChannel!.memberCount} member${announcementsChannel!.memberCount !== 1 ? "s" : ""} · Shared with ${sharedWithCount} group${sharedWithCount !== 1 ? "s" : ""}`
+              : `${announcementsChannel!.memberCount} member${announcementsChannel!.memberCount !== 1 ? "s" : ""} · Leaders post`
+            : "Disabled"
+          : enablingAnnouncements
+            ? "Enabling…"
+            : "Tap to enable — leaders post, members read",
       enabled: announcementsEnabled,
-      // Placeholder (no record yet) tap → lazy-create via mutation.
+      // Placeholder (no record yet) tap → lazy-create via mutation (surfaces
+      // the backend guard message if announcements come through a share).
       // Existing record tap → channel info screen for further toggling.
       onPress: hasAnnouncementsRecord
         ? () => navigateToChannelInfo(announcementsChannel!.slug)
@@ -294,8 +323,10 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
       unreadCount: announcementsChannel?.unreadCount,
       pinned: announcementsChannel?.isPinned,
       // Keep the "Tap to enable" CTA (no record) in the main list; fold only
-      // an existing-but-disabled Announcements channel.
-      archived: !!announcementsChannel && !announcementsEnabled,
+      // an existing-but-disabled Announcements channel. While receiving a
+      // share, keep the row visible — the disabled state is explained by the
+      // "Shared — announcements come from …" subtitle.
+      archived: !!announcementsChannel && !announcementsEnabled && !announcementsShare,
     });
   }
 

--- a/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/ChannelsSection.test.tsx
@@ -472,4 +472,138 @@ describe("ChannelsSection (redesigned)", () => {
       expect(queryByText("Archived")).toBeNull();
     });
   });
+
+  describe("Announcements", () => {
+    const ownAnnouncementsChannel = {
+      _id: "channel-announcements-own",
+      slug: "announcements",
+      channelType: "announcements",
+      name: "Announcements",
+      memberCount: 12,
+      isArchived: false,
+      isMember: true,
+      unreadCount: 0,
+      isPinned: false,
+      isEnabled: true,
+    };
+
+    // Another group's announcements channel shared INTO this group — same
+    // slug as the own channel, disambiguated by sharedFromGroupName/_id.
+    const sharedInAnnouncementsChannel = {
+      _id: "channel-announcements-shared",
+      slug: "announcements",
+      channelType: "announcements",
+      name: "Announcements",
+      memberCount: 40,
+      isArchived: false,
+      isMember: true,
+      unreadCount: 3,
+      isPinned: false,
+      isEnabled: true,
+      sharedFromGroupId: "owner-group",
+      sharedFromGroupName: "Owner Group",
+    };
+
+    it("renders the own channel with member count and passes the channel id on tap", () => {
+      mockChannelsData = [mockMainChannel, ownAnnouncementsChannel];
+
+      const { getByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(getByText("Announcements")).toBeTruthy();
+      expect(getByText("12 members · Leaders post")).toBeTruthy();
+
+      act(() => {
+        fireEvent.press(getByText("Announcements").parent!.parent!.parent!);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: "/inbox/test-group/announcements/info",
+        params: { channelId: "channel-announcements-own" },
+      });
+    });
+
+    it("shows the owner-side shared count on the own channel", () => {
+      mockChannelsData = [
+        mockMainChannel,
+        { ...ownAnnouncementsChannel, sharedGroupCount: 2 },
+      ];
+
+      const { getByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(getByText("12 members · Shared with 2 groups")).toBeTruthy();
+    });
+
+    it("renders ONE row from the shared-in channel and hides the own disabled channel", () => {
+      mockChannelsData = [
+        mockMainChannel,
+        // Own channel is disabled while receiving the share.
+        { ...ownAnnouncementsChannel, isEnabled: false },
+        sharedInAnnouncementsChannel,
+      ];
+
+      const { getByText, getAllByText, queryByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(getAllByText("Announcements")).toHaveLength(1);
+      expect(
+        getByText("Shared — announcements come from Owner Group")
+      ).toBeTruthy();
+      // The disabled own channel neither renders as a second row nor folds
+      // under Archived.
+      expect(queryByText("Archived")).toBeNull();
+      // Unread badge comes from the shared-in channel.
+      expect(getByText("3")).toBeTruthy();
+    });
+
+    it("navigates to the SHARED channel (by id) when the shared-in row is tapped", () => {
+      mockChannelsData = [
+        mockMainChannel,
+        { ...ownAnnouncementsChannel, isEnabled: false },
+        sharedInAnnouncementsChannel,
+      ];
+
+      const { getByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      act(() => {
+        fireEvent.press(getByText("Announcements").parent!.parent!.parent!);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: "/inbox/test-group/announcements/info",
+        params: { channelId: "channel-announcements-shared" },
+      });
+    });
+
+    it("members with a shared-in channel see the shared subtitle too", () => {
+      // Members never receive the own disabled channel from the query.
+      mockChannelsData = [mockMainChannel, sharedInAnnouncementsChannel];
+
+      const { getByText } = render(
+        <ChannelsSection groupId="test-group" userRole="member" />
+      );
+
+      expect(
+        getByText("Shared — announcements come from Owner Group")
+      ).toBeTruthy();
+    });
+
+    it("shows the enable CTA for leaders when no announcements channel exists", () => {
+      mockChannelsData = [mockMainChannel];
+
+      const { getByText } = render(
+        <ChannelsSection groupId="test-group" userRole="leader" />
+      );
+
+      expect(
+        getByText("Tap to enable — leaders post, members read")
+      ).toBeTruthy();
+    });
+  });
 });

--- a/apps/mobile/features/groups/hooks/useRespondToChannelInvite.ts
+++ b/apps/mobile/features/groups/hooks/useRespondToChannelInvite.ts
@@ -9,6 +9,30 @@ interface UseRespondToChannelInviteOptions {
 }
 
 /**
+ * Optional invite metadata, used to show the announcements-specific accept
+ * confirmation. Fields come straight off `listPendingInvitesForGroup` rows.
+ */
+export interface RespondInviteContext {
+  channelType?: string;
+  primaryGroupName?: string;
+  /**
+   * Name of the group whose shared Announcements channel this group is
+   * currently an accepted secondary of, if any — accepting a new
+   * announcements share automatically switches away from it.
+   */
+  switchFromGroupName?: string | null;
+}
+
+/** ConvexError carries its payload on `.data`; production `.message` is a
+ *  generic "Server Error" string, so prefer `.data.message` when present. */
+function errorMessage(error: unknown, fallback: string): string {
+  const data = (error as { data?: { message?: string } } | null)?.data;
+  if (typeof data?.message === "string") return data.message;
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+/**
  * Hook to handle responding to shared channel invitations.
  * Encapsulates the mutation, loading state, and confirmation flow.
  */
@@ -25,7 +49,8 @@ export function useRespondToChannelInvite({
   const handleRespond = useCallback(
     async (
       channelId: Id<"chatChannels">,
-      response: "accepted" | "declined"
+      response: "accepted" | "declined",
+      invite?: RespondInviteContext
     ) => {
       if (!token || !groupId) return;
 
@@ -48,11 +73,7 @@ export function useRespondToChannelInvite({
                     response: "declined",
                   });
                 } catch (error) {
-                  const message =
-                    error instanceof Error
-                      ? error.message
-                      : "Failed to decline.";
-                  Alert.alert("Error", message);
+                  Alert.alert("Error", errorMessage(error, "Failed to decline."));
                 } finally {
                   setRespondingTo(null);
                 }
@@ -63,21 +84,41 @@ export function useRespondToChannelInvite({
         return;
       }
 
-      setRespondingTo(`${channelId}-accept`);
-      try {
-        await respondMutation({
-          token,
-          channelId,
-          groupId: groupId as Id<"groups">,
-          response: "accepted",
-        });
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Failed to accept.";
-        Alert.alert("Error", message);
-      } finally {
-        setRespondingTo(null);
+      const performAccept = async () => {
+        setRespondingTo(`${channelId}-accept`);
+        try {
+          await respondMutation({
+            token,
+            channelId,
+            groupId: groupId as Id<"groups">,
+            response: "accepted",
+          });
+        } catch (error) {
+          Alert.alert("Error", errorMessage(error, "Failed to accept."));
+        } finally {
+          setRespondingTo(null);
+        }
+      };
+
+      // Accepting an announcements share has group-wide side effects (member
+      // backfill + own Announcements channel turned off), so confirm first.
+      if (invite?.channelType === "announcements") {
+        const ownerName = invite.primaryGroupName ?? "the owning group";
+        Alert.alert(
+          "Accept Announcements share?",
+          `Accepting will add all members of this group to ${ownerName}'s Announcements and turn off this group's own Announcements channel. Leaders of both groups can post.` +
+            (invite.switchFromGroupName
+              ? ` This group will stop receiving announcements from ${invite.switchFromGroupName}.`
+              : ""),
+          [
+            { text: "Cancel", style: "cancel" },
+            { text: "Accept", onPress: () => void performAccept() },
+          ]
+        );
+        return;
       }
+
+      await performAccept();
     },
     [token, groupId, respondMutation]
   );

--- a/apps/mobile/features/groups/hooks/useRespondToChannelInvite.ts
+++ b/apps/mobile/features/groups/hooks/useRespondToChannelInvite.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { Alert } from "react-native";
 import { useMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
+import { errorMessage } from "@/utils/error-handling";
 
 interface UseRespondToChannelInviteOptions {
   token: string | null;
@@ -23,13 +24,34 @@ export interface RespondInviteContext {
   switchFromGroupName?: string | null;
 }
 
-/** ConvexError carries its payload on `.data`; production `.message` is a
- *  generic "Server Error" string, so prefer `.data.message` when present. */
-function errorMessage(error: unknown, fallback: string): string {
-  const data = (error as { data?: { message?: string } } | null)?.data;
-  if (typeof data?.message === "string") return data.message;
-  if (error instanceof Error && error.message) return error.message;
-  return fallback;
+/**
+ * Confirmation dialog for accepting an announcements share. Accepting has
+ * group-wide side effects (member backfill + the group's own Announcements
+ * channel turned off), so it always gets an explicit confirmation. When
+ * `switchFromGroupName` is set the copy also warns about the automatic
+ * switch away from the current share. Shared by this hook and
+ * ChannelInfoScreen so the copy can't drift between the two entry points.
+ */
+export function confirmAnnouncementsShareAccept({
+  ownerName,
+  switchFromGroupName,
+  onConfirm,
+}: {
+  ownerName: string;
+  switchFromGroupName?: string | null;
+  onConfirm: () => void;
+}): void {
+  Alert.alert(
+    "Accept Announcements share?",
+    `Accepting will add all members of this group to ${ownerName}'s Announcements and turn off this group's own Announcements channel. Leaders of both groups can post.` +
+      (switchFromGroupName
+        ? ` This group will stop receiving announcements from ${switchFromGroupName}.`
+        : ""),
+    [
+      { text: "Cancel", style: "cancel" },
+      { text: "Accept", onPress: onConfirm },
+    ]
+  );
 }
 
 /**
@@ -103,18 +125,11 @@ export function useRespondToChannelInvite({
       // Accepting an announcements share has group-wide side effects (member
       // backfill + own Announcements channel turned off), so confirm first.
       if (invite?.channelType === "announcements") {
-        const ownerName = invite.primaryGroupName ?? "the owning group";
-        Alert.alert(
-          "Accept Announcements share?",
-          `Accepting will add all members of this group to ${ownerName}'s Announcements and turn off this group's own Announcements channel. Leaders of both groups can post.` +
-            (invite.switchFromGroupName
-              ? ` This group will stop receiving announcements from ${invite.switchFromGroupName}.`
-              : ""),
-          [
-            { text: "Cancel", style: "cancel" },
-            { text: "Accept", onPress: () => void performAccept() },
-          ]
-        );
+        confirmAnnouncementsShareAccept({
+          ownerName: invite.primaryGroupName ?? "the owning group",
+          switchFromGroupName: invite.switchFromGroupName,
+          onConfirm: () => void performAccept(),
+        });
         return;
       }
 

--- a/apps/mobile/features/leader-tools/components/SharedChannelInvitesScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/SharedChannelInvitesScreen.tsx
@@ -110,7 +110,18 @@ export function SharedChannelInvitesScreen() {
                         { backgroundColor: primaryColor },
                       ]}
                       onPress={() =>
-                        handleRespond(invite.channelId, "accepted")
+                        handleRespond(invite.channelId, "accepted", {
+                          channelType: invite.channelType,
+                          primaryGroupName: invite.primaryGroupName,
+                          // Accepting a new announcements share auto-switches
+                          // away from the one this group already receives.
+                          switchFromGroupName:
+                            activeChannels?.find(
+                              (c) =>
+                                c.channelType === "announcements" &&
+                                c.channelId !== invite.channelId
+                            )?.primaryGroupName ?? null,
+                        })
                       }
                       disabled={respondingTo !== null}
                     >

--- a/apps/mobile/utils/error-handling.ts
+++ b/apps/mobile/utils/error-handling.ts
@@ -24,6 +24,19 @@ export function showAlert(title: string, message: string): void {
 }
 
 /**
+ * Extract a readable message from a ConvexError (or plain Error).
+ *
+ * ConvexError carries its payload on `.data`; production `.message` is a
+ * generic "Server Error" string, so prefer `.data.message` when present.
+ */
+export function errorMessage(error: unknown, fallback: string): string {
+  const data = (error as { data?: { message?: string } } | null)?.data;
+  if (typeof data?.message === 'string') return data.message;
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+/**
  * Map of known error messages to user-friendly versions
  * Add entries here to customize error messages shown to users
  */

--- a/apps/web/src/pages/guides/GroupsAndChannels.tsx
+++ b/apps/web/src/pages/guides/GroupsAndChannels.tsx
@@ -17,6 +17,7 @@ import { appLinks } from "../../guides/appLinks";
 const toc: TocItem[] = [
   { id: "create", label: "Create groups for teams & campuses" },
   { id: "channels", label: "The channels inside a group" },
+  { id: "share-announcements", label: "Sharing an Announcements channel" },
   { id: "custom-channels", label: "Custom channels & invite links" },
   { id: "leaders", label: "Members & leaders" },
   { id: "make-leader", label: "Making someone a leader" },
@@ -476,6 +477,53 @@ export function GroupsAndChannels() {
         </P>
       </Section>
 
+      <Section
+        id="share-announcements"
+        title="Sharing an Announcements channel"
+      >
+        <P>
+          Related groups often need the same announcements — think of a{" "}
+          <strong>Worship Team</strong> and the <strong>Tech Team</strong> that
+          serves alongside it. Instead of posting the same message in each
+          group, a leader can <strong>share their group&rsquo;s Announcements
+          channel with other groups</strong> so everyone reads one feed.
+        </P>
+
+        <Steps>
+          <Step n={1}>
+            Open your Announcements channel and go to its info/members screen.
+          </Step>
+          <Step n={2}>
+            Tap <Term>Share with Groups</Term> and pick the group you want to
+            invite.
+          </Step>
+          <Step n={3}>
+            That group&rsquo;s leaders get the invite and choose to accept or
+            decline.
+          </Step>
+        </Steps>
+
+        <P>
+          When a group accepts, all of its members are added to the shared
+          channel automatically — and anyone who joins the group later is added
+          too, so the roster never drifts. The accepting group&rsquo;s own
+          Announcements channel is turned off automatically (its history is
+          kept), so members see one announcements feed instead of two. Leaders
+          of the owning group <strong>and</strong> of every group that accepted
+          can post.
+        </P>
+
+        <Callout tone="note" title="One Announcements channel per group">
+          A group can only be part of one Announcements channel at a time.
+          Accepting a different share moves the group over automatically, and
+          leaving a share (or being removed from one) restores the group&rsquo;s
+          own Announcements channel to how it was before. One more rule: a group
+          that&rsquo;s sharing its own Announcements channel with others
+          can&rsquo;t also accept another group&rsquo;s share — it needs to
+          unshare first.
+        </Callout>
+      </Section>
+
       <Section id="custom-channels" title="Custom channels & invite links">
         <P>
           Beyond the built-in channels, leaders can create their own{" "}
@@ -538,7 +586,8 @@ export function GroupsAndChannels() {
         </P>
         <Steps>
           <Step n={1}>
-            Create custom channels and enable the Announcements channel.
+            Create custom channels, enable the Announcements channel, and share
+            it with other groups.
           </Step>
           <Step n={2}>
             Post in the Announcements channel (members can only read it).

--- a/apps/web/src/pages/guides/GroupsAndChannels.tsx
+++ b/apps/web/src/pages/guides/GroupsAndChannels.tsx
@@ -520,7 +520,9 @@ export function GroupsAndChannels() {
           own Announcements channel to how it was before. One more rule: a group
           that&rsquo;s sharing its own Announcements channel with others
           can&rsquo;t also accept another group&rsquo;s share — it needs to
-          unshare first.
+          unshare first. And a shared Announcements channel can&rsquo;t be
+          turned off while other groups are still connected — remove the shared
+          groups first.
         </Callout>
       </Section>
 


### PR DESCRIPTION
## Summary

Groups can now share their Announcements channel with other groups in the community. Unlike custom shared channels (manual membership), shared announcement channels keep membership fully automatic while preserving the one-announcement-channel-per-group rule.

### Behavior

- **Share**: leaders of the owning group can invite other groups via the existing shared-channel invite flow ("Share with Groups"), now unlocked for `announcements` channels.
- **Accept**: all active members of the accepting group are backfilled into the shared channel (leaders mirror to channel admin), and the accepting group's own Announcements channel is automatically disabled — history kept, prior state recorded on the share entry.
- **Ongoing sync**: joins, leaves, and role changes in the owning group or any accepted group flow into the shared channel automatically; leaving one participating group doesn't remove users still active in another.
- **Posting**: leaders of the owning group and of every accepted group can post; members are read-only.
- **Leave/removal** (incl. owner group archived): members exclusive to the leaving group are removed, and that group's own Announcements channel is restored to its pre-share state and repopulated (mid-share joiners included).
- **Switch**: accepting a new share while already in one automatically leaves the old one, carrying the original pre-share state forward.
- **Guards** (`ConvexError` codes): `OWN_CHANNEL_SHARED` (can't accept while your own channel is shared out), `CHANNEL_SHARED` (can't disable a shared channel), `IN_SHARED_ANNOUNCEMENTS` (can't re-enable your own channel while receiving a share).

### Changes

- **Convex**: schema field `sharedGroups[].previousAnnouncementsChannelEnabled`; accept/backfill + switch logic in `respondToChannelInvite`; restore logic in `removeGroupFromChannel` and the group-archive cascade; shared-announcements-aware `syncUserChannelMembershipsLogic`; multi-group leader posting gate in `sendMessage`; guards in `toggleAnnouncementsChannel`; `sharedGroupCount` on `listGroupChannels`.
- **Mobile**: "Share with Groups" unlocked for announcements (owning-group leaders); accept confirmation dialog explaining member backfill / own-channel disable / auto-switch; group-settings row shows "Shared — announcements come from [group]" (receiving side) and "Shared with N groups" (owning side); guard errors surfaced via `ConvexError.data.message`.
- **Docs**: new "Sharing an Announcements channel" section in the GroupsAndChannels onboarding guide.

### Testing

- New `apps/convex/__tests__/messaging/shared-announcements.test.ts` (21 tests) covering backfill, sync, posting rights, restore, switch, guards, and archive cascades.
- Full Convex suite: 131 files / 2031 tests passing. Mobile jest: 129 suites / 1206 tests passing (pre-push hook). Typechecks clean (convex, mobile baseline, web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxN4KJN67mHb6JPVKtnHdv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxN4KJN67mHb6JPVKtnHdv)_