### PR TITLE
Fix plus-ones disappearing on events with custom RSVP labels

### DIFF
--- a/apps/convex/__tests__/api-keys.test.ts
+++ b/apps/convex/__tests__/api-keys.test.ts
@@ -211,9 +211,11 @@ async function seedMeeting(
         });
       }
     };
+    // Option ids follow the standard slots: 1 = Going, 2 = Maybe, 3 = Can't Go
+    // (see DEFAULT_RSVP_OPTIONS in lib/meetingConfig.ts).
     await insertRsvps(rsvps.going ?? 0, 1, rsvps.goingGuests);
-    await insertRsvps(rsvps.notGoing ?? 0, 2);
-    await insertRsvps(rsvps.maybe ?? 0, 3);
+    await insertRsvps(rsvps.maybe ?? 0, 2);
+    await insertRsvps(rsvps.notGoing ?? 0, 3);
 
     return meetingId;
   });

--- a/apps/convex/__tests__/rsvpGuests.test.ts
+++ b/apps/convex/__tests__/rsvpGuests.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for shared RSVP plus-one helpers.
  *
- * Covers the label-based heuristic that decides which RSVP option
- * counts as "Going" — regressions here silently mis-categorize RSVPs
- * and inflate or deflate headcounts.
+ * Covers the id-slot rule that decides which RSVP option counts as
+ * "Going" — regressions here silently mis-categorize RSVPs and inflate
+ * or deflate headcounts.
  */
 
 import { describe, expect, test } from "vitest";
@@ -15,29 +15,25 @@ import {
 } from "../lib/rsvpGuests";
 
 describe("isGoingOption", () => {
-  test("accepts canonical affirmative labels", () => {
+  test("accepts the Going slot (id 1) regardless of label", () => {
     expect(isGoingOption({ id: 1, label: "Going" })).toBe(true);
-    expect(isGoingOption({ id: 1, label: "going" })).toBe(true);
     expect(isGoingOption({ id: 1, label: "Going 👍" })).toBe(true);
-    expect(isGoingOption({ id: 1, label: "  Going  " })).toBe(true);
-    expect(isGoingOption({ id: 1, label: "I'm going" })).toBe(true);
+    // Custom labels must still work — hosts rename options freely.
+    expect(isGoingOption({ id: 1, label: "I'm there 😳" })).toBe(true);
+    expect(isGoingOption({ id: 1, label: "Count me in" })).toBe(true);
   });
 
-  test("rejects decline variants that also contain 'going'", () => {
-    expect(isGoingOption({ id: 1, label: "Not Going" })).toBe(false);
-    expect(isGoingOption({ id: 1, label: "not going" })).toBe(false);
-    expect(isGoingOption({ id: 1, label: "Can't Go" })).toBe(false);
-    expect(isGoingOption({ id: 1, label: "Cannot Go" })).toBe(false);
-    expect(isGoingOption({ id: 1, label: "Not Attending" })).toBe(false);
+  test("rejects other slots regardless of label", () => {
+    expect(isGoingOption({ id: 2, label: "Maybe" })).toBe(false);
+    expect(isGoingOption({ id: 3, label: "Can't Go" })).toBe(false);
+    // Even a label containing "going" is not the Going slot.
+    expect(isGoingOption({ id: 3, label: "Not Going" })).toBe(false);
+    expect(isGoingOption({ id: 2, label: "Going later" })).toBe(false);
   });
 
-  test("rejects unrelated or empty labels", () => {
+  test("rejects missing options", () => {
     expect(isGoingOption(null)).toBe(false);
     expect(isGoingOption(undefined)).toBe(false);
-    expect(isGoingOption({ id: 1, label: "Maybe" })).toBe(false);
-    expect(isGoingOption({ id: 1, label: "Yes" })).toBe(false);
-    expect(isGoingOption({ id: 1, label: "No" })).toBe(false);
-    expect(isGoingOption({ id: 1, label: "Attending" })).toBe(false);
   });
 });
 
@@ -52,9 +48,10 @@ describe("getMaxGuestsForMeeting", () => {
 });
 
 describe("normalizeGuestCount", () => {
-  const going = { id: 1, label: "Going" };
-  const notGoing = { id: 2, label: "Not Going" };
-  const maybe = { id: 3, label: "Maybe" };
+  // Custom label on the Going slot — guest counts must still be allowed.
+  const going = { id: 1, label: "I'm there 😳" };
+  const maybe = { id: 2, label: "Still deciding 🫣" };
+  const notGoing = { id: 3, label: "No can do ☹️" };
 
   test("returns 0 for missing or zero counts", () => {
     expect(normalizeGuestCount(undefined, going, 3)).toBe(0);

--- a/apps/convex/functions/meetings/queries.ts
+++ b/apps/convex/functions/meetings/queries.ts
@@ -13,6 +13,11 @@ import { getOptionalAuth } from "../../lib/auth";
 import { getSeriesNumber } from "../eventSeries";
 import { isLeaderRole } from "../../lib/helpers";
 import { getHostUserIds, isMeetingHost } from "../../lib/meetingPermissions";
+import {
+  GOING_RSVP_OPTION_ID,
+  MAYBE_RSVP_OPTION_ID,
+  CANT_GO_RSVP_OPTION_ID,
+} from "../../lib/meetingConfig";
 
 /**
  * Get meeting by short ID (for public sharing URLs)
@@ -41,11 +46,11 @@ export const getByShortId = query({
       .withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id))
       .take(1000);
 
-    // Count by rsvpOptionId (1=yes, 2=no, 3=maybe based on rsvpOptions)
+    // Count by the standard option id slots (1=Going, 2=Maybe, 3=Can't Go)
     const rsvpCounts = {
-      yes: rsvps.filter((r) => r.rsvpOptionId === 1).length,
-      no: rsvps.filter((r) => r.rsvpOptionId === 2).length,
-      maybe: rsvps.filter((r) => r.rsvpOptionId === 3).length,
+      yes: rsvps.filter((r) => r.rsvpOptionId === GOING_RSVP_OPTION_ID).length,
+      no: rsvps.filter((r) => r.rsvpOptionId === CANT_GO_RSVP_OPTION_ID).length,
+      maybe: rsvps.filter((r) => r.rsvpOptionId === MAYBE_RSVP_OPTION_ID).length,
       total: rsvps.length,
     };
 
@@ -257,11 +262,11 @@ export const getWithDetails = query({
       .withIndex("by_meeting", (q) => q.eq("meetingId", args.meetingId))
       .collect();
 
-    // Count by rsvpOptionId (1=yes, 2=no, 3=maybe based on rsvpOptions)
+    // Count by the standard option id slots (1=Going, 2=Maybe, 3=Can't Go)
     const rsvpCounts = {
-      yes: rsvps.filter((r) => r.rsvpOptionId === 1).length,
-      no: rsvps.filter((r) => r.rsvpOptionId === 2).length,
-      maybe: rsvps.filter((r) => r.rsvpOptionId === 3).length,
+      yes: rsvps.filter((r) => r.rsvpOptionId === GOING_RSVP_OPTION_ID).length,
+      no: rsvps.filter((r) => r.rsvpOptionId === CANT_GO_RSVP_OPTION_ID).length,
+      maybe: rsvps.filter((r) => r.rsvpOptionId === MAYBE_RSVP_OPTION_ID).length,
       total: rsvps.length,
     };
 

--- a/apps/convex/functions/publicApi.ts
+++ b/apps/convex/functions/publicApi.ts
@@ -10,14 +10,14 @@ import { v } from "convex/values";
 import { internalQuery, internalMutation, QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { now } from "../lib/utils";
+import {
+  GOING_RSVP_OPTION_ID,
+  MAYBE_RSVP_OPTION_ID,
+  CANT_GO_RSVP_OPTION_ID,
+} from "../lib/meetingConfig";
 
 // Attendance status code that means "attended" (see meetings/attendance.ts).
 const ATTENDED_STATUS = 1;
-
-// Standard RSVP option ids (see meetings.rsvpOptions defaults).
-const RSVP_GOING = 1;
-const RSVP_NOT_GOING = 2;
-const RSVP_MAYBE = 3;
 
 // Default and maximum number of events returned in a single call. Callers
 // should page through history with the `since`/`until` filters.
@@ -94,12 +94,12 @@ async function countMeeting(
   let maybe = 0;
   let guestsExpected = 0;
   for (const rsvp of rsvps) {
-    if (rsvp.rsvpOptionId === RSVP_GOING) {
+    if (rsvp.rsvpOptionId === GOING_RSVP_OPTION_ID) {
       going++;
       guestsExpected += rsvp.guestCount ?? 0;
-    } else if (rsvp.rsvpOptionId === RSVP_NOT_GOING) {
+    } else if (rsvp.rsvpOptionId === CANT_GO_RSVP_OPTION_ID) {
       notGoing++;
-    } else if (rsvp.rsvpOptionId === RSVP_MAYBE) {
+    } else if (rsvp.rsvpOptionId === MAYBE_RSVP_OPTION_ID) {
       maybe++;
     }
   }

--- a/apps/convex/lib/meetingConfig.ts
+++ b/apps/convex/lib/meetingConfig.ts
@@ -62,6 +62,17 @@ export const DEFAULT_RSVP_OPTIONS: RsvpOption[] = [
 ];
 
 /**
+ * RSVP option ids are stable semantic slots — hosts can rename the labels
+ * (e.g. "I'm there 😳") but the editor (RsvpOptionsEditor.tsx) never changes
+ * the ids, so id is the label-agnostic way to identify an option's meaning.
+ * Keep in sync with GOING_RSVP_OPTION_ID in
+ * apps/mobile/features/events/components/EventRsvpSection.tsx.
+ */
+export const GOING_RSVP_OPTION_ID = 1;
+export const MAYBE_RSVP_OPTION_ID = 2;
+export const CANT_GO_RSVP_OPTION_ID = 3;
+
+/**
  * RSVP option IDs whose responders are considered "attending enough" to:
  *   - be seated in the event chat channel (and thus get update notifications)
  *   - receive host text blasts
@@ -70,7 +81,10 @@ export const DEFAULT_RSVP_OPTIONS: RsvpOption[] = [
  * excluded. These are matched by id, so events using custom option labels are
  * still keyed off the conventional Going/Maybe slots.
  */
-export const NOTIFIED_RSVP_OPTION_IDS: number[] = [1, 2];
+export const NOTIFIED_RSVP_OPTION_IDS: number[] = [
+  GOING_RSVP_OPTION_ID,
+  MAYBE_RSVP_OPTION_ID,
+];
 
 /** Whether an RSVP option id grants chat membership + blast/update delivery. */
 export function isNotifiedRsvpOptionId(optionId: number): boolean {

--- a/apps/convex/lib/rsvpGuests.ts
+++ b/apps/convex/lib/rsvpGuests.ts
@@ -6,6 +6,8 @@
  * via meetings.maxGuestsPerRsvp (future admin setting).
  */
 
+import { GOING_RSVP_OPTION_ID } from "./meetingConfig";
+
 export const MAX_GUESTS_PER_RSVP = 3;
 
 interface RsvpOptionLike {
@@ -15,28 +17,16 @@ interface RsvpOptionLike {
 }
 
 /**
- * Heuristic: is this RSVP option the "Going" option?
+ * Is this RSVP option the "Going" option?
  *
- * Matches on the label since the RSVP options schema doesn't include an
- * explicit flag. Must reject common decline variants before falling back
- * to a "going" substring check — otherwise labels like "Not Going" and
- * "Can't Go" would match as affirmative. Keep this in sync with
- * isGoingOptionLabel in EventRsvpSection.tsx.
+ * Matched by id, not label: option ids are stable semantic slots
+ * (1 = Going, 2 = Maybe, 3 = Can't Go — see DEFAULT_RSVP_OPTIONS and
+ * NOTIFIED_RSVP_OPTION_IDS in meetingConfig.ts). Hosts can freely rename
+ * labels ("I'm there 😳"), so any label heuristic breaks on custom labels.
+ * Keep in sync with isGoingRsvpOption in EventRsvpSection.tsx.
  */
 export function isGoingOption(option: RsvpOptionLike | null | undefined): boolean {
-  if (!option) return false;
-  const label = option.label.toLowerCase().trim();
-  // Explicit decline variants: reject first
-  if (
-    label.includes("can't") ||
-    label.includes("cannot") ||
-    label.includes("not going") ||
-    label.includes("not attending") ||
-    label === "no"
-  ) {
-    return false;
-  }
-  return label.includes("going");
+  return option?.id === GOING_RSVP_OPTION_ID;
 }
 
 export function getMaxGuestsForMeeting(meeting: {

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/guests.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/guests.tsx
@@ -17,6 +17,11 @@ import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { Avatar } from "@components/ui/Avatar";
 import { CustomModal } from "@components/ui/Modal";
 import { useTheme } from "@hooks/useTheme";
+import {
+  GOING_RSVP_OPTION_ID,
+  MAYBE_RSVP_OPTION_ID,
+  CANT_GO_RSVP_OPTION_ID,
+} from "@/features/events/components/EventRsvpSection";
 
 function GuestListPage() {
   const { colors } = useTheme();
@@ -103,13 +108,15 @@ function GuestListPage() {
   const isLoading = isLoadingMeeting || isLoadingRsvp;
 
   // Get all users grouped by RSVP status. Options are matched by their
-  // stable id slots (1 = Going, 2 = Maybe, 3 = Can't Go) so custom labels
-  // ("I'm there 😳") don't break the grouping.
-  const goingUsers = rsvpData?.rsvps?.find((r) => r.option.id === 1)?.users || [];
+  // stable id slots so custom labels ("I'm there 😳") don't break the grouping.
+  const goingUsers =
+    rsvpData?.rsvps?.find((r) => r.option.id === GOING_RSVP_OPTION_ID)?.users || [];
 
-  const maybeUsers = rsvpData?.rsvps?.find((r) => r.option.id === 2)?.users || [];
+  const maybeUsers =
+    rsvpData?.rsvps?.find((r) => r.option.id === MAYBE_RSVP_OPTION_ID)?.users || [];
 
-  const cantGoUsers = rsvpData?.rsvps?.find((r) => r.option.id === 3)?.users || [];
+  const cantGoUsers =
+    rsvpData?.rsvps?.find((r) => r.option.id === CANT_GO_RSVP_OPTION_ID)?.users || [];
 
   return (
     <UserRoute>

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/guests.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/guests.tsx
@@ -102,18 +102,14 @@ function GuestListPage() {
 
   const isLoading = isLoadingMeeting || isLoadingRsvp;
 
-  // Get all users grouped by RSVP status
-  const goingUsers = rsvpData?.rsvps?.find((r) =>
-    r.option.label.toLowerCase().includes("going") && !r.option.label.toLowerCase().includes("can't")
-  )?.users || [];
+  // Get all users grouped by RSVP status. Options are matched by their
+  // stable id slots (1 = Going, 2 = Maybe, 3 = Can't Go) so custom labels
+  // ("I'm there 😳") don't break the grouping.
+  const goingUsers = rsvpData?.rsvps?.find((r) => r.option.id === 1)?.users || [];
 
-  const maybeUsers = rsvpData?.rsvps?.find((r) =>
-    r.option.label.toLowerCase().includes("maybe")
-  )?.users || [];
+  const maybeUsers = rsvpData?.rsvps?.find((r) => r.option.id === 2)?.users || [];
 
-  const cantGoUsers = rsvpData?.rsvps?.find((r) =>
-    r.option.label.toLowerCase().includes("can't")
-  )?.users || [];
+  const cantGoUsers = rsvpData?.rsvps?.find((r) => r.option.id === 3)?.users || [];
 
   return (
     <UserRoute>

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -449,10 +449,9 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
         guestCount: 0,
       });
       // Navigate to success screen with animation (use replace to avoid duplicate event screens in stack)
-      const selectedOption = rsvpOptions.find((o) => o.id === optionId);
       router.replace({
         pathname: `/e/${shortId}/rsvp/success`,
-        params: { optionLabel: selectedOption?.label || "Going" },
+        params: { optionId: String(optionId) },
       });
     } finally {
       setLoadingOptionId(null);
@@ -473,10 +472,9 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
       // Only navigate to success screen if the option actually changed.
       // Guest-count-only edits should stay on the event page.
       if (optionId !== myRsvp?.optionId) {
-        const selectedOption = rsvpOptions.find((o) => o.id === optionId);
         router.replace({
           pathname: `/e/${shortId}/rsvp/success`,
-          params: { optionLabel: selectedOption?.label || "Going" },
+          params: { optionId: String(optionId) },
         });
       }
     } finally {
@@ -997,7 +995,6 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
           {showGuestListPreview && !isLoadingRsvp && rsvpData && (
             <GuestListPreview
               rsvpData={rsvpData as RsvpData}
-              rsvpOptions={rsvpOptions}
               onViewAll={handleViewGuestList}
               hideRsvpCount={(eventData as any)?.hideRsvpCount === true}
               canSeeCount={canEdit}

--- a/apps/mobile/app/e/[shortId]/guests.tsx
+++ b/apps/mobile/app/e/[shortId]/guests.tsx
@@ -16,7 +16,7 @@ import { Avatar } from "@components/ui/Avatar";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { BlurView } from "expo-blur";
 import {
-  getEmojiForLabel,
+  getEmojiForOption,
   getCleanLabel,
 } from "@/features/events/components/EventRsvpSection";
 
@@ -106,7 +106,7 @@ export default function GuestListScreen() {
         const option = rsvpOptions.find(
           (opt) => opt.id === rsvpGroup.option.id
         );
-        const emoji = option ? getEmojiForLabel(option.label) : "";
+        const emoji = option ? getEmojiForOption(option) : "";
         const label = option ? getCleanLabel(option.label) : rsvpGroup.option.label;
 
         return (

--- a/apps/mobile/app/e/[shortId]/rsvp/confirm.tsx
+++ b/apps/mobile/app/e/[shortId]/rsvp/confirm.tsx
@@ -52,19 +52,11 @@ export default function RsvpConfirmScreen() {
     name: string;
   }>;
 
-  // Get event details to find the option label using Convex
+  // Get event details (for the meeting id) using Convex
   const event = useQuery(
     api.functions.meetings.index.getByShortId,
     shortId ? { shortId } : "skip"
   );
-
-  const getOptionLabel = useCallback(() => {
-    if (!event?.rsvpOptions || !optionId) return "Going";
-    const option = (event.rsvpOptions as any[]).find(
-      (o) => o.id === parseInt(optionId, 10)
-    );
-    return option?.label || "Going";
-  }, [event, optionId]);
 
   const submitRsvp = useCallback(async () => {
     if (!event?.id || !optionId) return;
@@ -142,7 +134,7 @@ export default function RsvpConfirmScreen() {
       // Navigate to success
       router.replace({
         pathname: `/e/${shortId}/rsvp/success`,
-        params: { optionLabel: getOptionLabel() },
+        params: { optionId },
       });
     } catch (err: any) {
       setVerifyPending(false);

--- a/apps/mobile/app/e/[shortId]/rsvp/profile.tsx
+++ b/apps/mobile/app/e/[shortId]/rsvp/profile.tsx
@@ -38,19 +38,11 @@ export default function RsvpProfileScreen() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [registerPending, setRegisterPending] = useState(false);
 
-  // Get event details to find the option label using Convex
+  // Get event details (for the meeting id) using Convex
   const event = useQuery(
     api.functions.meetings.index.getByShortId,
     shortId ? { shortId } : "skip"
   );
-
-  const getOptionLabel = useCallback(() => {
-    if (!event?.rsvpOptions || !optionId) return "Going";
-    const option = (event.rsvpOptions as any[]).find(
-      (o) => o.id === parseInt(optionId, 10)
-    );
-    return option?.label || "Going";
-  }, [event, optionId]);
 
   const submitRsvp = useCallback(async () => {
     if (!event?.id || !optionId) return;
@@ -118,7 +110,7 @@ export default function RsvpProfileScreen() {
       // Navigate to success
       router.replace({
         pathname: `/e/${shortId}/rsvp/success`,
-        params: { optionLabel: getOptionLabel() },
+        params: { optionId },
       });
     } catch (err: any) {
       setRegisterPending(false);

--- a/apps/mobile/app/e/[shortId]/rsvp/success.tsx
+++ b/apps/mobile/app/e/[shortId]/rsvp/success.tsx
@@ -2,6 +2,11 @@ import React, { useEffect } from "react";
 import { View, Text, StyleSheet, Image, ImageSourcePropType } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  GOING_RSVP_OPTION_ID,
+  MAYBE_RSVP_OPTION_ID,
+  CANT_GO_RSVP_OPTION_ID,
+} from "@/features/events/components/EventRsvpSection";
 
 // Import GIF animations
 const starStrikeGif = require("../../../../assets/star-strike.gif");
@@ -13,41 +18,44 @@ interface AnimationConfig {
   message: string;
 }
 
-function getRsvpAnimationConfig(optionLabel: string): AnimationConfig {
-  const label = optionLabel.toLowerCase();
+/**
+ * Pick the animation by the RSVP option's id slot (1=Going, 2=Maybe,
+ * 3=Can't Go) — labels are host-customizable, so they can't be used to
+ * infer the option's meaning. Missing/unparseable ids default to Going,
+ * matching the pre-existing fallback.
+ */
+function getRsvpAnimationConfig(optionId: string | undefined): AnimationConfig {
+  const id = optionId ? parseInt(optionId, 10) : GOING_RSVP_OPTION_ID;
 
-  // Check for "going" but not "can't go"
-  if (label.includes("going") && !label.includes("can't") && !label.includes("cannot")) {
-    return {
-      gif: starStrikeGif,
-      message: "You're Going!",
-    };
-  }
-
-  // Check for "maybe" or similar
-  if (label.includes("maybe") || label.includes("interested") || label.includes("tentative")) {
+  if (id === MAYBE_RSVP_OPTION_ID) {
     return {
       gif: raisedEyebrowGif,
       message: "Let us know soon",
     };
   }
 
-  // Default for "can't go", "no", "not going", etc.
+  if (id === CANT_GO_RSVP_OPTION_ID) {
+    return {
+      gif: sadGif,
+      message: "Sad you can't make it",
+    };
+  }
+
   return {
-    gif: sadGif,
-    message: "Sad you can't make it",
+    gif: starStrikeGif,
+    message: "You're Going!",
   };
 }
 
 export default function RsvpSuccessScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { shortId, optionLabel } = useLocalSearchParams<{
+  const { shortId, optionId } = useLocalSearchParams<{
     shortId: string;
-    optionLabel: string;
+    optionId: string;
   }>();
 
-  const config = getRsvpAnimationConfig(optionLabel || "going");
+  const config = getRsvpAnimationConfig(optionId);
 
   // Auto-redirect back to event page after 3 seconds
   useEffect(() => {

--- a/apps/mobile/app/e/[shortId]/rsvp/verify.tsx
+++ b/apps/mobile/app/e/[shortId]/rsvp/verify.tsx
@@ -51,21 +51,13 @@ export default function RsvpVerifyScreen() {
   const [verifyPending, setVerifyPending] = useState(false);
   const [resendPending, setResendPending] = useState(false);
 
-  // Get event details to find the option label using Convex
+  // Get event details (for the meeting id) using Convex
   const event = useQuery(
     api.functions.meetings.index.getByShortId,
     shortId ? { shortId } : "skip"
   );
 
   const isLoading = verifyPending || isSubmitting;
-
-  const getOptionLabel = useCallback(() => {
-    if (!event?.rsvpOptions || !optionId) return "Going";
-    const option = (event.rsvpOptions as any[]).find(
-      (o) => o.id === parseInt(optionId, 10)
-    );
-    return option?.label || "Going";
-  }, [event, optionId]);
 
   const submitRsvp = useCallback(async () => {
     if (!event?.id || !optionId) return;
@@ -151,7 +143,7 @@ export default function RsvpVerifyScreen() {
         // Navigate to success
         router.replace({
           pathname: `/e/${shortId}/rsvp/success`,
-          params: { optionLabel: getOptionLabel() },
+          params: { optionId },
         });
       } else if (userExists && !userHasVerifiedPhone) {
         // Case 2: User exists but phone not verified - go to confirm identity

--- a/apps/mobile/features/chat/components/EventLinkCard.tsx
+++ b/apps/mobile/features/chat/components/EventLinkCard.tsx
@@ -24,7 +24,7 @@ import type { PrefetchedEventData } from '../context/ChatPrefetchContext';
 import {
   DEFAULT_MAX_GUESTS_PER_RSVP,
   GuestStepper,
-  isGoingOptionLabel,
+  isGoingRsvpOption,
 } from '@/features/events/components/EventRsvpSection';
 
 interface EventLinkCardProps {
@@ -511,9 +511,7 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
   // Identify the currently-selected option (if any) to conditionally show
   // the plus-ones stepper underneath the RSVP list.
   const selectedOption = rsvpOptions.find((o) => o.id === myRsvp?.optionId) ?? null;
-  const selectedIsGoing = selectedOption
-    ? isGoingOptionLabel(selectedOption.label)
-    : false;
+  const selectedIsGoing = isGoingRsvpOption(selectedOption);
   const maxGuests =
     ((eventData as any)?.maxGuestsPerRsvp as number | undefined) ??
     DEFAULT_MAX_GUESTS_PER_RSVP;

--- a/apps/mobile/features/events/components/EventGuestList.tsx
+++ b/apps/mobile/features/events/components/EventGuestList.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { Avatar } from "@components/ui/Avatar";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useTheme } from "@hooks/useTheme";
-import { isGoingOptionLabel } from "./EventRsvpSection";
+import { isGoingRsvpOption, MAYBE_RSVP_OPTION_ID } from "./EventRsvpSection";
 
 // ============================================================================
 // Types
@@ -72,19 +72,15 @@ export function GuestListPreview({
   // there are enough attendees to fill the row (otherwise the sparse stack
   // would leak roughly how many RSVP'd).
   const countIsHidden = hideRsvpCount && !canSeeCount;
-  // Find the "Going" option to show those guests. Uses the same heuristic
-  // as isGoingOption in apps/convex/lib/rsvpGuests.ts so decline variants
-  // ("Not Going") aren't mistakenly treated as Going.
-  const goingOption = rsvpOptions.find((opt) => isGoingOptionLabel(opt.label));
+  // Options are matched by their stable id slots (1 = Going, 2 = Maybe) so
+  // custom labels ("I'm there 😳") don't break the guest preview.
+  const goingOption = rsvpOptions.find((opt) => isGoingRsvpOption(opt));
   const goingRsvp = rsvpData.rsvps.find((r) => r.option.id === goingOption?.id);
   const goingCount = goingRsvp?.count || 0;
   const goingGuestCount = goingRsvp?.guestCount || 0;
   const goingUsers = goingRsvp?.users || [];
 
-  // Find the "Maybe" option to also show those guests
-  const maybeOption = rsvpOptions.find((opt) =>
-    opt.label.toLowerCase().includes("maybe")
-  );
+  const maybeOption = rsvpOptions.find((opt) => opt.id === MAYBE_RSVP_OPTION_ID);
   const maybeRsvp = rsvpData.rsvps.find((r) => r.option.id === maybeOption?.id);
   const maybeCount = maybeRsvp?.count || 0;
   const maybeUsers = maybeRsvp?.users || [];

--- a/apps/mobile/features/events/components/EventGuestList.tsx
+++ b/apps/mobile/features/events/components/EventGuestList.tsx
@@ -30,15 +30,8 @@ export interface RsvpData {
   totalWithGuests?: number;
 }
 
-export interface RsvpOption {
-  id: number;
-  label: string;
-  enabled: boolean;
-}
-
 interface GuestListPreviewProps {
   rsvpData: RsvpData;
-  rsvpOptions: RsvpOption[];
   onViewAll: () => void;
   /** When true, the RSVP count is considered private. */
   hideRsvpCount?: boolean;
@@ -61,7 +54,6 @@ const AVATAR_ROW_MIN_FOR_HIDDEN_COUNT = 5;
  */
 export function GuestListPreview({
   rsvpData,
-  rsvpOptions,
   onViewAll,
   hideRsvpCount = false,
   canSeeCount = false,
@@ -72,16 +64,14 @@ export function GuestListPreview({
   // there are enough attendees to fill the row (otherwise the sparse stack
   // would leak roughly how many RSVP'd).
   const countIsHidden = hideRsvpCount && !canSeeCount;
-  // Options are matched by their stable id slots (1 = Going, 2 = Maybe) so
-  // custom labels ("I'm there 😳") don't break the guest preview.
-  const goingOption = rsvpOptions.find((opt) => isGoingRsvpOption(opt));
-  const goingRsvp = rsvpData.rsvps.find((r) => r.option.id === goingOption?.id);
+  // RSVP groups are matched by their stable id slots (1 = Going, 2 = Maybe)
+  // so custom labels ("I'm there 😳") don't break the guest preview.
+  const goingRsvp = rsvpData.rsvps.find((r) => isGoingRsvpOption(r.option));
   const goingCount = goingRsvp?.count || 0;
   const goingGuestCount = goingRsvp?.guestCount || 0;
   const goingUsers = goingRsvp?.users || [];
 
-  const maybeOption = rsvpOptions.find((opt) => opt.id === MAYBE_RSVP_OPTION_ID);
-  const maybeRsvp = rsvpData.rsvps.find((r) => r.option.id === maybeOption?.id);
+  const maybeRsvp = rsvpData.rsvps.find((r) => r.option.id === MAYBE_RSVP_OPTION_ID);
   const maybeCount = maybeRsvp?.count || 0;
   const maybeUsers = maybeRsvp?.users || [];
 

--- a/apps/mobile/features/events/components/EventRsvpSection.tsx
+++ b/apps/mobile/features/events/components/EventRsvpSection.tsx
@@ -18,25 +18,22 @@ import { useTheme } from "@hooks/useTheme";
 export const DEFAULT_MAX_GUESTS_PER_RSVP = 3;
 
 /**
- * Heuristic — is this RSVP option the "Going" option?
- *
- * Must reject decline variants ("Not Going", "Can't Go") before falling
- * back to a "going" substring check. Keep in sync with isGoingOption in
- * apps/convex/lib/rsvpGuests.ts.
+ * RSVP option ids are stable semantic slots — hosts can rename the labels
+ * (e.g. "I'm there 😳") but the options editor never changes the ids, so id
+ * is the label-agnostic way to identify an option's meaning. Mirrors
+ * GOING_RSVP_OPTION_ID etc. in apps/convex/lib/meetingConfig.ts.
  */
-export function isGoingOptionLabel(label: string | undefined | null): boolean {
-  if (!label) return false;
-  const lower = label.toLowerCase().trim();
-  if (
-    lower.includes("can't") ||
-    lower.includes("cannot") ||
-    lower.includes("not going") ||
-    lower.includes("not attending") ||
-    lower === "no"
-  ) {
-    return false;
-  }
-  return lower.includes("going");
+export const GOING_RSVP_OPTION_ID = 1;
+export const MAYBE_RSVP_OPTION_ID = 2;
+
+/**
+ * Is this RSVP option the "Going" option (the slot that allows plus-ones)?
+ * Keep in sync with isGoingOption in apps/convex/lib/rsvpGuests.ts.
+ */
+export function isGoingRsvpOption(
+  option: { id: number } | null | undefined,
+): boolean {
+  return option?.id === GOING_RSVP_OPTION_ID;
 }
 
 // ============================================================================
@@ -339,7 +336,7 @@ export function FloatingRsvpCard({
   const selectedOption = options.find((opt) => opt.id === response.optionId);
   const emoji = selectedOption ? getEmojiForLabel(selectedOption.label) : "👍";
   const label = selectedOption ? getCleanLabel(selectedOption.label) : "Going";
-  const isGoing = selectedOption ? isGoingOptionLabel(selectedOption.label) : false;
+  const isGoing = isGoingRsvpOption(selectedOption);
   const displayedGuestCount = response.guestCount ?? 0;
 
   return (
@@ -408,14 +405,14 @@ export function RsvpEditModal({
   }, [visible, currentOptionId, currentGuestCount]);
 
   const stagedOption = options.find((o) => o.id === stagedOptionId) ?? null;
-  const stagedIsGoing = stagedOption ? isGoingOptionLabel(stagedOption.label) : false;
+  const stagedIsGoing = isGoingRsvpOption(stagedOption);
 
   const handleStageOption = (optionId: number) => {
     if (loadingOptionId !== null || submitting) return;
     setStagedOptionId(optionId);
     // Reset guest count when switching away from Going
     const next = options.find((o) => o.id === optionId);
-    if (!next || !isGoingOptionLabel(next.label)) {
+    if (!isGoingRsvpOption(next)) {
       setStagedGuestCount(0);
     }
   };

--- a/apps/mobile/features/events/components/EventRsvpSection.tsx
+++ b/apps/mobile/features/events/components/EventRsvpSection.tsx
@@ -25,6 +25,7 @@ export const DEFAULT_MAX_GUESTS_PER_RSVP = 3;
  */
 export const GOING_RSVP_OPTION_ID = 1;
 export const MAYBE_RSVP_OPTION_ID = 2;
+export const CANT_GO_RSVP_OPTION_ID = 3;
 
 /**
  * Is this RSVP option the "Going" option (the slot that allows plus-ones)?
@@ -96,26 +97,27 @@ interface RsvpEditModalProps {
 // ============================================================================
 
 /**
- * Get emoji for an RSVP option label.
+ * Get emoji for an RSVP option.
  * Labels may include emojis (e.g., "Going 👍") or be plain (e.g., "Going").
- * This function first tries to extract an emoji from the label,
- * then falls back to keyword-based matching.
+ * Tries to extract an emoji from the label first, then falls back to the
+ * option's id slot so custom emoji-less labels still get a matching emoji.
  */
-export function getEmojiForLabel(label: string): string {
+export function getEmojiForOption(option: { id: number; label: string }): string {
   // Try to extract emoji from the end of the label
   const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)$/u;
-  const match = label.match(emojiRegex);
+  const match = option.label.match(emojiRegex);
   if (match) {
     return match[0];
   }
 
-  // Fallback to keyword-based matching for labels without emojis
-  const lowerLabel = label.toLowerCase();
-  if (lowerLabel.includes("going") && !lowerLabel.includes("can't")) return "👍";
-  if (lowerLabel.includes("maybe")) return "🤔";
-  if (lowerLabel.includes("can't") || lowerLabel.includes("no")) return "😢";
-  if (lowerLabel.includes("yes")) return "👍";
-  return "👍"; // default
+  switch (option.id) {
+    case MAYBE_RSVP_OPTION_ID:
+      return "🤔";
+    case CANT_GO_RSVP_OPTION_ID:
+      return "😢";
+    default:
+      return "👍";
+  }
 }
 
 /**
@@ -290,7 +292,7 @@ export function FloatingRsvpButtons({
     >
       <View style={styles.buttonRow}>
         {enabledOptions.map((option) => {
-          const emoji = getEmojiForLabel(option.label);
+          const emoji = getEmojiForOption(option);
           const gradient = getGradientForLabel(option.label);
           const displayLabel = getCleanLabel(option.label);
           const isLoading = loadingOptionId === option.id;
@@ -334,7 +336,7 @@ export function FloatingRsvpCard({
 }: FloatingRsvpCardProps) {
   const { colors } = useTheme();
   const selectedOption = options.find((opt) => opt.id === response.optionId);
-  const emoji = selectedOption ? getEmojiForLabel(selectedOption.label) : "👍";
+  const emoji = selectedOption ? getEmojiForOption(selectedOption) : "👍";
   const label = selectedOption ? getCleanLabel(selectedOption.label) : "Going";
   const isGoing = isGoingRsvpOption(selectedOption);
   const displayedGuestCount = response.guestCount ?? 0;

--- a/apps/mobile/features/events/components/__tests__/EventRsvpSection.test.tsx
+++ b/apps/mobile/features/events/components/__tests__/EventRsvpSection.test.tsx
@@ -3,6 +3,7 @@ import { render } from "@testing-library/react-native";
 import {
   RsvpEditModal,
   isGoingRsvpOption,
+  getEmojiForOption,
   GOING_RSVP_OPTION_ID,
 } from "../EventRsvpSection";
 
@@ -43,6 +44,18 @@ describe("isGoingRsvpOption", () => {
     expect(isGoingRsvpOption(CUSTOM_LABEL_OPTIONS[2])).toBe(false);
     expect(isGoingRsvpOption(null)).toBe(false);
     expect(isGoingRsvpOption(undefined)).toBe(false);
+  });
+});
+
+describe("getEmojiForOption", () => {
+  test("extracts the label's own emoji when present", () => {
+    expect(getEmojiForOption({ id: 3, label: "No can do ☹️" })).toBe("☹️");
+  });
+
+  test("falls back to the id slot for emoji-less custom labels", () => {
+    expect(getEmojiForOption({ id: 1, label: "Count me in" })).toBe("👍");
+    expect(getEmojiForOption({ id: 2, label: "Still deciding" })).toBe("🤔");
+    expect(getEmojiForOption({ id: 3, label: "Count me out" })).toBe("😢");
   });
 });
 

--- a/apps/mobile/features/events/components/__tests__/EventRsvpSection.test.tsx
+++ b/apps/mobile/features/events/components/__tests__/EventRsvpSection.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import {
+  RsvpEditModal,
+  isGoingRsvpOption,
+  GOING_RSVP_OPTION_ID,
+} from "../EventRsvpSection";
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      text: "#000",
+      textSecondary: "#666",
+      textTertiary: "#999",
+      surface: "#fff",
+      border: "#eee",
+      iconSecondary: "#999",
+    },
+  }),
+}));
+
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({
+    primaryColor: "#007AFF",
+    secondaryColor: "#F5F5F5",
+  }),
+}));
+
+// Regression: plus-ones must key off the stable option id slot (1 = Going),
+// not the label text — hosts rename labels freely ("I'm there 😳") and the
+// old label heuristic hid the guest stepper on custom-labeled events.
+const CUSTOM_LABEL_OPTIONS = [
+  { id: 1, label: "I'm there 😳", enabled: true },
+  { id: 2, label: "Still deciding 🫣", enabled: true },
+  { id: 3, label: "No can do ☹️", enabled: true },
+];
+
+describe("isGoingRsvpOption", () => {
+  test("matches the Going slot regardless of label", () => {
+    expect(isGoingRsvpOption({ id: GOING_RSVP_OPTION_ID })).toBe(true);
+    expect(isGoingRsvpOption(CUSTOM_LABEL_OPTIONS[0])).toBe(true);
+    expect(isGoingRsvpOption(CUSTOM_LABEL_OPTIONS[1])).toBe(false);
+    expect(isGoingRsvpOption(CUSTOM_LABEL_OPTIONS[2])).toBe(false);
+    expect(isGoingRsvpOption(null)).toBe(false);
+    expect(isGoingRsvpOption(undefined)).toBe(false);
+  });
+});
+
+describe("RsvpEditModal guest stepper", () => {
+  const baseProps = {
+    visible: true,
+    onClose: jest.fn(),
+    options: CUSTOM_LABEL_OPTIONS,
+    loadingOptionId: null,
+    onSelect: jest.fn(),
+  };
+
+  test("shows the stepper when the Going slot is selected, even with a custom label", () => {
+    const { getByTestId } = render(
+      <RsvpEditModal {...baseProps} currentOptionId={1} />
+    );
+    expect(getByTestId("guest-stepper-increment")).toBeTruthy();
+  });
+
+  test("hides the stepper for non-Going slots", () => {
+    const { queryByTestId } = render(
+      <RsvpEditModal {...baseProps} currentOptionId={3} />
+    );
+    expect(queryByTestId("guest-stepper-increment")).toBeNull();
+  });
+});

--- a/apps/mobile/features/leader-tools/components/FloatingRsvpButtons.tsx
+++ b/apps/mobile/features/leader-tools/components/FloatingRsvpButtons.tsx
@@ -9,6 +9,11 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useTheme } from "@hooks/useTheme";
+import {
+  getEmojiForOption,
+  MAYBE_RSVP_OPTION_ID,
+  CANT_GO_RSVP_OPTION_ID,
+} from "@/features/events/components/EventRsvpSection";
 
 interface RsvpOption {
   id: number;
@@ -22,31 +27,14 @@ interface FloatingRsvpButtonsProps {
   onSelect: (optionId: number) => void;
 }
 
-// Canonical labels are stored as "<text> <emoji>" (e.g. "Going 👍"), set by
-// RsvpOptionsEditor. Parse the emoji off the end of the label so the circle
-// matches what the user actually picked. Keep a default in case a legacy
-// option slipped through without an emoji suffix.
-const DEFAULT_EMOJI = "👍";
-const EMOJI_REGEX = /\s*(\p{Emoji_Presentation}|\p{Emoji}️)$/u;
-
-function parseLabel(label: string): { text: string; emoji: string } {
-  const match = label.match(EMOJI_REGEX);
-  if (match) {
-    return { text: label.slice(0, match.index).trim(), emoji: match[1] };
-  }
-  return { text: label, emoji: "" };
-}
-
-// Map RSVP option text (without emoji) to button color. We only branch on
-// a few known text tokens; everything else falls back to primary.
+// Map an option's id slot (1=Going, 2=Maybe, 3=Can't Go) to button color —
+// labels are host-customizable, so semantics must come from the id.
 function getButtonColor(
-  text: string,
+  optionId: number,
   colors: { warning: string; textSecondary: string; buttonPrimary: string },
 ): string {
-  const key = text.trim().toLowerCase();
-  if (key === "going" || key === "yes") return DEFAULT_PRIMARY_COLOR;
-  if (key === "maybe") return colors.warning;
-  if (key === "can't go" || key === "cant go" || key === "no") return colors.textSecondary;
+  if (optionId === MAYBE_RSVP_OPTION_ID) return colors.warning;
+  if (optionId === CANT_GO_RSVP_OPTION_ID) return colors.textSecondary;
   return DEFAULT_PRIMARY_COLOR;
 }
 
@@ -64,8 +52,8 @@ export function FloatingRsvpButtons({
     <View style={[styles.container, { paddingBottom: insets.bottom + 20, backgroundColor: colors.surface, borderTopColor: colors.border }]}>
       <View style={styles.buttonsRow}>
         {enabledOptions.map((option) => {
-          const { text, emoji } = parseLabel(option.label);
-          const circleColor = getButtonColor(text, colors);
+          const emoji = getEmojiForOption(option);
+          const circleColor = getButtonColor(option.id, colors);
           const isLoading = loadingOptionId === option.id;
 
           return (
@@ -80,7 +68,7 @@ export function FloatingRsvpButtons({
                 {isLoading ? (
                   <ActivityIndicator size="small" color={colors.textInverse} />
                 ) : (
-                  <Text style={styles.emoji}>{emoji || DEFAULT_EMOJI}</Text>
+                  <Text style={styles.emoji}>{emoji}</Text>
                 )}
               </View>
               <Text style={[styles.label, { color: colors.text }]}>{option.label}</Text>


### PR DESCRIPTION
## Summary

Plus-ones ("Bringing guests") vanished on any event whose host renamed the RSVP labels (e.g. "I'm there 😳" instead of "Going 👍"). The stepper visibility and the backend guest-count validation both identified the "Going" option by matching the word "going" in the label text.

RSVP option ids are stable semantic slots (1 = Going, 2 = Maybe, 3 = Can't Go) — the options editor only edits label text, never ids, and chat seating / text blasts already key off ids for exactly this reason (`NOTIFIED_RSVP_OPTION_IDS`). This PR switches every "is this the Going option?" check to the id slot, making all RSVP behavior label-agnostic.

## Changes

- **Convex**: `isGoingOption` (`lib/rsvpGuests.ts`) now matches on id slot; shared slot constants (`GOING/MAYBE/CANT_GO_RSVP_OPTION_ID`) added to `lib/meetingConfig.ts`
- **Mobile**: `isGoingRsvpOption` (id-based) replaces `isGoingOptionLabel` in `EventRsvpSection`, `EventLinkCard`, and `EventGuestList`
- **Guest lists**: the event-page avatar preview and the leader Guest List screen grouped attendees by label keywords too — custom-labeled events showed empty sections; both now group by id slot
- **Public API**: `publicApi.ts` had the Maybe/Can't Go slots swapped (2 → `notGoing`, 3 → `maybe`), so the attendance API reported Maybe responders as not-going and vice versa; aligned with the real slot convention (the test fixture mirrored the same swap)

No data migration needed — `meetingRsvps.rsvpOptionId` was always stored correctly; the bug was read-time interpretation only, so past and future events are both fixed. Mobile changes are pure JS/TS (no native deps), OTA-safe.

## Testing

- New regression test renders `RsvpEditModal` with custom labels and asserts the guest stepper appears (`EventRsvpSection.test.tsx`)
- `rsvpGuests.test.ts` rewritten for the id-slot rule, including custom-label cases
- All RSVP-related Convex suites (78 tests) and mobile `features/events|chat|leader-tools` suites (444 tests) pass; both apps typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3jE8Fc4WbWosbKV3Rq1Yu

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3jE8Fc4WbWosbKV3Rq1Yu)_