### PR TITLE
chore(secrets): sync GH_MIRROR_TOKEN + document secret flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,23 @@ They need:
 - Depending on what the user is asking, use the relevant keys from the relevant environment (dev, staging, prod)
 - Typically you will only make dev or staging related changes, double check if any action you take will affect production
 
+### Secret Update Flow
+Secrets flow **1Password → GitHub → Convex/Expo** — never shortcut either hop.
+See the full "Secret Update Flow" section in `docs/secrets.md` for the why and
+the step-by-step. In short:
+- **1Password is the source of truth.** Set/rotate the value there, never
+  directly in the GitHub UI (GitHub secrets are write-only; you can't read them
+  back, and the next sync overwrites manual edits).
+- **Don't push 1Password → Convex/Expo directly** — every deploy re-syncs all
+  secrets and would hit 1Password rate limits. GitHub is the buffer.
+- To add a new secret: (1) add the item to 1Password vault `Togather` with
+  `staging`/`production` fields; (2) add `<KEY>` to the allowlist array in
+  `ee/scripts/sync-1password-to-github.sh` (a key not listed is never synced);
+  (3) **only if a Convex function needs it**, also add it to `SECRET_KEYS` in
+  `ee/scripts/sync-secrets-to-convex.sh` — CI-only tokens stop at GitHub;
+  (4) run `gh workflow run sync-secrets.yml -f environment=both` to push it to
+  GitHub; deploys forward it onward.
+
 ### Agent Backend Selection (Maintainer CI Agents Only)
 
 This section applies **only** to Cursor Cloud Agents and similar CI agents run by project maintainers. Open-source contributors should ignore this section — you create your own personal Convex deployment via `npx convex dev` (see "Helping New Developers Onboard" above).

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -227,7 +227,9 @@ GitHub happens once per change; GitHub → Convex/Expo happens on every deploy.
 2. Add `<KEY>` to the allowlist array in
    `ee/scripts/sync-1password-to-github.sh` — `COMMON_SECRETS` (required; logs a
    loud skip if missing) or `OPTIONAL_SECRETS` (silently skipped if absent). **A
-   key that isn't listed here is never synced.**
+   key that isn't listed here is never synced.** Note: GitHub reserves the
+   `GITHUB_` prefix for secret names, so a `GITHUB_*` item can't sync under its
+   own name — add an alias block (see `MIRROR_TOKEN`) to rename it on the way in.
 3. **Only if a Convex function needs it at runtime**, also add `<KEY>` to
    `SECRET_KEYS` in `ee/scripts/sync-secrets-to-convex.sh`. CI-only tokens (repo
    automation, mirror pushes, etc.) stop at GitHub — leave them out.
@@ -246,7 +248,7 @@ Store service tokens as GitHub repository secrets for use in CI workflows. Examp
 | `EXPO_TOKEN` | Expo/EAS authentication | Build and deploy workflows |
 | `CLOUDFLARE_API_TOKEN` | Cloudflare Workers deployment | Landing page and worker deployments |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account identifier | Worker deployments |
-| `GITHUB_MIRROR_TOKEN` | PAT for mirroring the repo to another remote | Repo mirror workflow (CI-only; not forwarded to Convex) |
+| `MIRROR_TOKEN` | PAT for mirroring the repo to another remote (stored in 1Password as `GITHUB_MIRROR_TOKEN`; renamed on sync because GitHub reserves the `GITHUB_` prefix) | Repo mirror workflow (CI-only; not forwarded to Convex) |
 
 ---
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -195,6 +195,48 @@ When adding a new `EXPO_PUBLIC_*` environment variable:
 
 ## CI/CD Integration
 
+### Secret Update Flow (the one true path)
+
+Secrets always flow **1Password → GitHub → Convex/Expo**. Never shortcut either hop:
+
+```
+1Password (source of truth)
+   │  sync-secrets.yml  (manual: op read → gh secret set, per environment)
+   ▼
+GitHub environment secrets  (staging / production)
+   │  deploy-convex.yml / mobile deploys  (on every deploy)
+   ▼
+Convex env vars + Expo/EAS env
+```
+
+**Why 1Password → GitHub first (not straight into GitHub)?** GitHub secrets are
+write-only — you can't read a value back out. 1Password is the single source of
+truth, so you set the value there and sync it forward. Editing a value directly
+in the GitHub UI means the next sync silently overwrites it and nothing else
+knows the real value.
+
+**Why GitHub → Convex/Expo on deploy (not 1Password → Convex/Expo directly)?**
+Every deploy re-pushes the full secret set. Reading all of them from 1Password on
+each deploy hits 1Password rate limits, so GitHub acts as the buffer: 1Password →
+GitHub happens once per change; GitHub → Convex/Expo happens on every deploy.
+
+**To add or rotate a secret:**
+
+1. Add/update the item in **1Password** vault `Togather` — one item per `KEY`,
+   with `staging` and `production` fields (`op://Togather/<KEY>/<env>`).
+2. Add `<KEY>` to the allowlist array in
+   `ee/scripts/sync-1password-to-github.sh` — `COMMON_SECRETS` (required; logs a
+   loud skip if missing) or `OPTIONAL_SECRETS` (silently skipped if absent). **A
+   key that isn't listed here is never synced.**
+3. **Only if a Convex function needs it at runtime**, also add `<KEY>` to
+   `SECRET_KEYS` in `ee/scripts/sync-secrets-to-convex.sh`. CI-only tokens (repo
+   automation, mirror pushes, etc.) stop at GitHub — leave them out.
+4. Push the value into GitHub by running the **Sync Secrets from 1Password**
+   workflow (needs `op` in CI): `gh workflow run sync-secrets.yml -f environment=both`.
+5. On the next deploy, `deploy-convex.yml` forwards GitHub → Convex/Expo
+   automatically (`.github/actions/load-secrets` exports every GitHub secret).
+6. Add a row to the tables in this doc.
+
 ### GitHub Secrets
 
 Store service tokens as GitHub repository secrets for use in CI workflows. Example secrets:
@@ -204,6 +246,7 @@ Store service tokens as GitHub repository secrets for use in CI workflows. Examp
 | `EXPO_TOKEN` | Expo/EAS authentication | Build and deploy workflows |
 | `CLOUDFLARE_API_TOKEN` | Cloudflare Workers deployment | Landing page and worker deployments |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account identifier | Worker deployments |
+| `GITHUB_MIRROR_TOKEN` | PAT for mirroring the repo to another remote | Repo mirror workflow (CI-only; not forwarded to Convex) |
 
 ---
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -229,7 +229,7 @@ GitHub happens once per change; GitHub → Convex/Expo happens on every deploy.
    loud skip if missing) or `OPTIONAL_SECRETS` (silently skipped if absent). **A
    key that isn't listed here is never synced.** Note: GitHub reserves the
    `GITHUB_` prefix for secret names, so a `GITHUB_*` item can't sync under its
-   own name — add an alias block (see `MIRROR_TOKEN`) to rename it on the way in.
+   own name — add an alias block (see `GH_MIRROR_TOKEN`) to rename it on the way in.
 3. **Only if a Convex function needs it at runtime**, also add `<KEY>` to
    `SECRET_KEYS` in `ee/scripts/sync-secrets-to-convex.sh`. CI-only tokens (repo
    automation, mirror pushes, etc.) stop at GitHub — leave them out.
@@ -248,7 +248,7 @@ Store service tokens as GitHub repository secrets for use in CI workflows. Examp
 | `EXPO_TOKEN` | Expo/EAS authentication | Build and deploy workflows |
 | `CLOUDFLARE_API_TOKEN` | Cloudflare Workers deployment | Landing page and worker deployments |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account identifier | Worker deployments |
-| `MIRROR_TOKEN` | PAT for mirroring the repo to another remote (stored in 1Password as `GITHUB_MIRROR_TOKEN`; renamed on sync because GitHub reserves the `GITHUB_` prefix) | Repo mirror workflow (CI-only; not forwarded to Convex) |
+| `GH_MIRROR_TOKEN` | PAT for mirroring the repo to another remote (stored in 1Password as `GITHUB_MIRROR_TOKEN`; renamed on sync because GitHub reserves the `GITHUB_` prefix) | Repo mirror workflow (CI-only; not forwarded to Convex) |
 
 ---
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -229,7 +229,9 @@ GitHub happens once per change; GitHub → Convex/Expo happens on every deploy.
    loud skip if missing) or `OPTIONAL_SECRETS` (silently skipped if absent). **A
    key that isn't listed here is never synced.** Note: GitHub reserves the
    `GITHUB_` prefix for secret names, so a `GITHUB_*` item can't sync under its
-   own name — add an alias block (see `GH_MIRROR_TOKEN`) to rename it on the way in.
+   own name — name the item without that prefix (e.g. `GH_MIRROR_TOKEN`, not
+   `GITHUB_MIRROR_TOKEN`), or add an alias block (see `IMAGE_CDN_URL`) to rename
+   it on the way in.
 3. **Only if a Convex function needs it at runtime**, also add `<KEY>` to
    `SECRET_KEYS` in `ee/scripts/sync-secrets-to-convex.sh`. CI-only tokens (repo
    automation, mirror pushes, etc.) stop at GitHub — leave them out.
@@ -248,7 +250,7 @@ Store service tokens as GitHub repository secrets for use in CI workflows. Examp
 | `EXPO_TOKEN` | Expo/EAS authentication | Build and deploy workflows |
 | `CLOUDFLARE_API_TOKEN` | Cloudflare Workers deployment | Landing page and worker deployments |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account identifier | Worker deployments |
-| `GH_MIRROR_TOKEN` | PAT for mirroring the repo to another remote (stored in 1Password as `GITHUB_MIRROR_TOKEN`; renamed on sync because GitHub reserves the `GITHUB_` prefix) | Repo mirror workflow (CI-only; not forwarded to Convex) |
+| `GH_MIRROR_TOKEN` | PAT for mirroring the repo to another remote (named `GH_*` not `GITHUB_*` because GitHub reserves the `GITHUB_` secret-name prefix) | Repo mirror workflow (CI-only; not forwarded to Convex) |
 
 ---
 

--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -144,6 +144,9 @@ OPTIONAL_SECRETS=(
   "EXPO_PUBLIC_POSTHOG_API_KEY"
   "GOOGLE_MAPS_API_KEY"
   "EXPO_PUBLIC_KLIPY_API_KEY"
+  # Repo automation token used by GitHub Actions (mirror push). CI-only — it is
+  # NOT forwarded to Convex/Expo (absent from sync-secrets-to-convex.sh).
+  "GITHUB_MIRROR_TOKEN"
   # Dev-assistant bot (@Togather pipeline). Optional — only present once the
   # feature is being enabled; missing items are skipped without failing.
   "CLAUDE_ROUTINES_TRIGGER_URL"

--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -144,6 +144,11 @@ OPTIONAL_SECRETS=(
   "EXPO_PUBLIC_POSTHOG_API_KEY"
   "GOOGLE_MAPS_API_KEY"
   "EXPO_PUBLIC_KLIPY_API_KEY"
+  # Repo automation token used by GitHub Actions (mirror push). CI-only — it is
+  # NOT forwarded to Convex/Expo (absent from sync-secrets-to-convex.sh). Named
+  # GH_MIRROR_TOKEN, not GITHUB_MIRROR_TOKEN, because GitHub reserves the
+  # GITHUB_ prefix for secret names (`gh secret set GITHUB_*` → HTTP 422).
+  "GH_MIRROR_TOKEN"
   # Dev-assistant bot (@Togather pipeline). Optional — only present once the
   # feature is being enabled; missing items are skipped without failing.
   "CLAUDE_ROUTINES_TRIGGER_URL"
@@ -220,28 +225,6 @@ sync_environment() {
       skipped=$((skipped + 1))
     fi
   done
-
-  echo ""
-
-  # GITHUB_MIRROR_TOKEN alias. GitHub reserves the GITHUB_ prefix for secret
-  # names (`gh secret set GITHUB_*` → HTTP 422), so the 1Password item
-  # GITHUB_MIRROR_TOKEN is synced to the GitHub secret named GH_MIRROR_TOKEN.
-  # CI-only (repo mirror workflow) — intentionally not forwarded to Convex.
-  MIRROR_TOKEN=$(op read "op://Togather/GITHUB_MIRROR_TOKEN/$env" 2>/dev/null || true)
-  if [ -n "$MIRROR_TOKEN" ]; then
-    if [ "$DRY_RUN" = true ]; then
-      echo "  [dry-run] Would set GH_MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)"
-    else
-      echo -n "  Setting GH_MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)..."
-      if printf '%s' "$MIRROR_TOKEN" | gh secret set "GH_MIRROR_TOKEN" --env "$env" --repo "$REPO"; then
-        echo " done"
-      else
-        echo " FAILED"
-        failed=$((failed + 1))
-      fi
-    fi
-    synced=$((synced + 1))
-  fi
 
   echo ""
 

--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -144,9 +144,6 @@ OPTIONAL_SECRETS=(
   "EXPO_PUBLIC_POSTHOG_API_KEY"
   "GOOGLE_MAPS_API_KEY"
   "EXPO_PUBLIC_KLIPY_API_KEY"
-  # Repo automation token used by GitHub Actions (mirror push). CI-only — it is
-  # NOT forwarded to Convex/Expo (absent from sync-secrets-to-convex.sh).
-  "GITHUB_MIRROR_TOKEN"
   # Dev-assistant bot (@Togather pipeline). Optional — only present once the
   # feature is being enabled; missing items are skipped without failing.
   "CLAUDE_ROUTINES_TRIGGER_URL"
@@ -223,6 +220,28 @@ sync_environment() {
       skipped=$((skipped + 1))
     fi
   done
+
+  echo ""
+
+  # GITHUB_MIRROR_TOKEN alias. GitHub reserves the GITHUB_ prefix for secret
+  # names (`gh secret set GITHUB_*` → HTTP 422), so the 1Password item
+  # GITHUB_MIRROR_TOKEN is synced to the GitHub secret named MIRROR_TOKEN.
+  # CI-only (repo mirror workflow) — intentionally not forwarded to Convex.
+  MIRROR_TOKEN=$(op read "op://Togather/GITHUB_MIRROR_TOKEN/$env" 2>/dev/null || true)
+  if [ -n "$MIRROR_TOKEN" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "  [dry-run] Would set MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)"
+    else
+      echo -n "  Setting MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)..."
+      if printf '%s' "$MIRROR_TOKEN" | gh secret set "MIRROR_TOKEN" --env "$env" --repo "$REPO"; then
+        echo " done"
+      else
+        echo " FAILED"
+        failed=$((failed + 1))
+      fi
+    fi
+    synced=$((synced + 1))
+  fi
 
   echo ""
 

--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -225,15 +225,15 @@ sync_environment() {
 
   # GITHUB_MIRROR_TOKEN alias. GitHub reserves the GITHUB_ prefix for secret
   # names (`gh secret set GITHUB_*` → HTTP 422), so the 1Password item
-  # GITHUB_MIRROR_TOKEN is synced to the GitHub secret named MIRROR_TOKEN.
+  # GITHUB_MIRROR_TOKEN is synced to the GitHub secret named GH_MIRROR_TOKEN.
   # CI-only (repo mirror workflow) — intentionally not forwarded to Convex.
   MIRROR_TOKEN=$(op read "op://Togather/GITHUB_MIRROR_TOKEN/$env" 2>/dev/null || true)
   if [ -n "$MIRROR_TOKEN" ]; then
     if [ "$DRY_RUN" = true ]; then
-      echo "  [dry-run] Would set MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)"
+      echo "  [dry-run] Would set GH_MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)"
     else
-      echo -n "  Setting MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)..."
-      if printf '%s' "$MIRROR_TOKEN" | gh secret set "MIRROR_TOKEN" --env "$env" --repo "$REPO"; then
+      echo -n "  Setting GH_MIRROR_TOKEN (from GITHUB_MIRROR_TOKEN)..."
+      if printf '%s' "$MIRROR_TOKEN" | gh secret set "GH_MIRROR_TOKEN" --env "$env" --repo "$REPO"; then
         echo " done"
       else
         echo " FAILED"


### PR DESCRIPTION
## What

- Add **GH_MIRROR_TOKEN** to the 1Password→GitHub sync allowlist so it's pushed to GitHub environment secrets. Named `GH_*` (not `GITHUB_*`) because GitHub reserves the `GITHUB_` secret-name prefix (`gh secret set GITHUB_*` → HTTP 422).
- Document the **1Password → GitHub → Convex/Expo** secret flow — including *why* each hop exists — in `docs/secrets.md` and `CLAUDE.md`, so it doesn't need re-explaining per new variable.

## Why not the Convex/Expo whitelist

`GH_MIRROR_TOKEN` is a CI-only repo-automation token (mirror push). It intentionally stops at GitHub — not added to `SECRET_KEYS` in `sync-secrets-to-convex.sh`, and not an `EXPO_PUBLIC_*` var, so it never reaches Convex or the Expo bundle.

## Verification

Ran the **Sync Secrets from 1Password** workflow against this branch — `GH_MIRROR_TOKEN` now set in both `staging` and `production` environment secrets (confirmed in the run's Verify step). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)