### PR TITLE
Contributor dashboard: chat-first filing, screenshots, In-progress tab, copyable split prompts

### DIFF
--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -3321,3 +3321,108 @@ describe("review-cycle hardening", () => {
     expect(bug?.splitSlices).toEqual(slices);
   });
 });
+
+/**
+ * Archive / unarchive (ADR-029): a contributor sets a conversation aside
+ * (abandoned or not doable) and can restore it. Orthogonal to the pipeline
+ * status; originator-only (plus staff/superuser).
+ */
+describe("archive / unarchive", () => {
+  test("archive stamps archivedAt + a system turn, and is idempotent", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "Abandon me." },
+    );
+
+    await t.mutation(api.functions.devAssistant.contributions.archive, {
+      token: maintainerId,
+      id,
+    });
+    let bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.archivedAt).toBeTruthy();
+    const firstStamp = bug!.archivedAt;
+
+    // Re-archiving is a no-op: keeps the first stamp, no duplicate system turn.
+    await t.mutation(api.functions.devAssistant.contributions.archive, {
+      token: maintainerId,
+      id,
+    });
+    bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.archivedAt).toBe(firstStamp);
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    const archiveMsgs = thread.filter((m) => m.body.includes("archived"));
+    expect(archiveMsgs).toHaveLength(1);
+  });
+
+  test("unarchive clears archivedAt and restores the conversation", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "Set aside then bring back." },
+    );
+    await t.mutation(api.functions.devAssistant.contributions.archive, {
+      token: maintainerId,
+      id,
+    });
+    await t.mutation(api.functions.devAssistant.contributions.unarchive, {
+      token: maintainerId,
+      id,
+    });
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.archivedAt).toBeUndefined();
+  });
+
+  test("only the originator (or staff) can archive; other maintainers cannot", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId, otherMaintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    // A second non-staff maintainer who is NOT the originator.
+    const now = Date.now();
+    const strangerId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Stan",
+        lastName: "Stranger",
+        platformRoles: ["dev_maintainer"],
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "Mine to archive." },
+    );
+
+    // A non-owner, non-staff maintainer is refused.
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.archive, {
+        token: strangerId,
+        id,
+      }),
+    ).rejects.toThrow(/Only the person who started this/);
+
+    // A staff maintainer (otherMaintainerId isStaff) may archive to tidy up.
+    await t.mutation(api.functions.devAssistant.contributions.archive, {
+      token: otherMaintainerId,
+      id,
+    });
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.archivedAt).toBeTruthy();
+  });
+});

--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -3426,3 +3426,167 @@ describe("archive / unarchive", () => {
     expect(bug?.archivedAt).toBeTruthy();
   });
 });
+
+/**
+ * Archive pauses the pipeline (ADR-029, post-review): an archived item can't
+ * be approved/built and doesn't consume the AI, but system callbacks still
+ * land (archivedAt is orthogonal to status). Also covers the review's flagged
+ * auth/superuser gaps.
+ */
+describe("archive pauses the pipeline", () => {
+  test("approveSpec and startBuild are refused while archived", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+
+    const id = await submitAndDeliverSpec(t, maintainerId, "medium");
+    await t.mutation(api.functions.devAssistant.contributions.archive, {
+      token: maintainerId,
+      id,
+    });
+
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.approveSpec, {
+        token: maintainerId,
+        id,
+      }),
+    ).rejects.toThrow(/Restore this conversation/);
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.startBuild, {
+        token: maintainerId,
+        id,
+      }),
+    ).rejects.toThrow(/Restore this conversation/);
+  });
+
+  test("replying to an archived item records the note but doesn't re-fire the AI", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const fetchMock = stubRoutineEnv();
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "Abandon this." },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const dispatchesBefore = fetchMock.mock.calls.length; // initial spec dispatch
+
+    await t.mutation(api.functions.devAssistant.contributions.archive, {
+      token: maintainerId,
+      id,
+    });
+    await t.mutation(api.functions.devAssistant.contributions.postMessage, {
+      token: maintainerId,
+      id,
+      body: "Just a closing note.",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // No new dispatch fired for the archived reply.
+    expect(fetchMock.mock.calls.length).toBe(dispatchesBefore);
+    // ...but the note is in the thread.
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread.some((m) => m.body === "Just a closing note.")).toBe(true);
+  });
+
+  test("a routine callback still advances an archived in-flight item", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const now = Date.now();
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert("devBugs", {
+        originatorUserId: maintainerId,
+        status: "IN_PROGRESS",
+        kind: "bug",
+        source: "dashboard",
+        title: "Mid-build then archived",
+        body: "B",
+        spec: "## Plan",
+        riskLevel: "low",
+        routineRunId: "run-live",
+        activeRunMode: "implement",
+        archivedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+
+    await t.action(
+      internal.functions.devAssistant.actions.handleRoutineCallback,
+      {
+        bugId: id,
+        routineRunId: "run-live",
+        status: "CODE_REVIEW",
+        prUrl: "https://example.com/pr/42",
+      },
+    );
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("CODE_REVIEW"); // status advanced
+    expect(bug?.archivedAt).toBe(now); // still archived
+  });
+
+  test("unarchive is originator/staff-only, and a superuser may archive", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const now = Date.now();
+    const strangerId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Stan",
+        lastName: "Stranger",
+        platformRoles: ["dev_maintainer"],
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+    const superId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Sue",
+        lastName: "Super",
+        platformRoles: ["dev_maintainer"],
+        isSuperuser: true,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "Owned item." },
+    );
+
+    // A superuser can archive someone else's item.
+    await t.mutation(api.functions.devAssistant.contributions.archive, {
+      token: superId,
+      id,
+    });
+    expect((await t.run((ctx) => ctx.db.get(id)))?.archivedAt).toBeTruthy();
+
+    // A non-owner, non-staff maintainer cannot unarchive it.
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.unarchive, {
+        token: strangerId,
+        id,
+      }),
+    ).rejects.toThrow(/Only the person who started this/);
+
+    // The originator can.
+    await t.mutation(api.functions.devAssistant.contributions.unarchive, {
+      token: maintainerId,
+      id,
+    });
+    expect((await t.run((ctx) => ctx.db.get(id)))?.archivedAt).toBeUndefined();
+  });
+});

--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -2812,3 +2812,299 @@ describe("run-mode callback policy", () => {
     expect(bug?.lastError).toBeUndefined();
   });
 });
+
+/**
+ * Chat-first filing, pictures, and split slices (ADR-029 follow-up).
+ *
+ * - submit derives a title from the message when none is given
+ * - pictures ride the report/reply as message imageUrls and reach the spec
+ *   agent as resolved public URLs
+ * - the spec routine's `splitSlices` persist and clear with the scope
+ */
+describe("chat-first filing, pictures, and split slices", () => {
+  test("submit derives a title from the message when none is given", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      {
+        token: maintainerId,
+        kind: "bug",
+        body: "The events tab crashes when I tap a photo.",
+      },
+    );
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    // No title field → first line of the message becomes the placeholder.
+    expect(bug?.title).toBe("The events tab crashes when I tap a photo.");
+    // The message still seeds the opening thread turn verbatim.
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread[0]?.body).toBe("The events tab crashes when I tap a photo.");
+  });
+
+  test("submit clips a long derived title with an ellipsis", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const longBody =
+      "This is a really long description that goes well past the eighty " +
+      "character placeholder title limit so it should be clipped.";
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "feature", body: longBody },
+    );
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.title.length).toBeLessThanOrEqual(80);
+    expect(bug?.title.endsWith("…")).toBe(true);
+    // The full message is preserved on the row/thread, only the title clips.
+    expect(bug?.body).toBe(longBody);
+  });
+
+  test("submit rejects a message with neither text nor a screenshot", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.submit, {
+        token: maintainerId,
+        kind: "bug",
+        body: "   ",
+      }),
+    ).rejects.toThrow(/description or a screenshot/i);
+  });
+
+  test("submit accepts a screenshot-only report with a fallback title", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+    process.env.R2_PUBLIC_URL = "https://cdn.example.com";
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      {
+        token: maintainerId,
+        kind: "bug",
+        body: "",
+        screenshotUrls: ["r2:chat/only.jpg"],
+      },
+    );
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.title).toBe("Bug report");
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread[0]?.body).toBe("");
+    expect(thread[0]?.imageUrls).toEqual(["https://cdn.example.com/chat/only.jpg"]);
+
+    delete process.env.R2_PUBLIC_URL;
+  });
+
+  test("attached pictures ride the opening turn and reach the spec agent as public URLs", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const fetchMock = stubRoutineEnv();
+    process.env.R2_PUBLIC_URL = "https://cdn.example.com";
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      {
+        token: maintainerId,
+        kind: "bug",
+        body: "See the glitch in these shots.",
+        screenshotUrls: ["r2:chat/a.jpg", "r2:chat/b.jpg"],
+      },
+    );
+
+    // Stored on the row (durable R2 paths) and on the opening message.
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.screenshotUrls).toEqual(["r2:chat/a.jpg", "r2:chat/b.jpg"]);
+
+    // getThread resolves them to fetchable public URLs for the app.
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread[0]?.imageUrls).toEqual([
+      "https://cdn.example.com/chat/a.jpg",
+      "https://cdn.example.com/chat/b.jpg",
+    ]);
+
+    // The dispatched spec brief carries resolved (not r2:) URLs for vision.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const brief = JSON.parse(JSON.parse(init.body as string).text);
+    expect(brief.screenshotUrls).toEqual([
+      "https://cdn.example.com/chat/a.jpg",
+      "https://cdn.example.com/chat/b.jpg",
+    ]);
+
+    delete process.env.R2_PUBLIC_URL;
+  });
+
+  test("postMessage accepts a picture-only reply and rejects an empty one", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+    process.env.R2_PUBLIC_URL = "https://cdn.example.com";
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "Something's off." },
+    );
+
+    // A picture with no words is valid.
+    await t.mutation(api.functions.devAssistant.contributions.postMessage, {
+      token: maintainerId,
+      id,
+      body: "",
+      imageUrls: ["r2:chat/c.jpg"],
+    });
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    const last = thread[thread.length - 1];
+    expect(last?.body).toBe("");
+    expect(last?.imageUrls).toEqual(["https://cdn.example.com/chat/c.jpg"]);
+
+    // Neither text nor pictures is rejected.
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.postMessage, {
+        token: maintainerId,
+        id,
+        body: "   ",
+      }),
+    ).rejects.toThrow(/Message body is required/);
+
+    delete process.env.R2_PUBLIC_URL;
+  });
+
+  test("spec callback persists splitSlices for a split item and clears them on re-triage", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "feature", body: "Rebuild the whole thing." },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const slices = [
+      { title: "In progress tab", prompt: "Build the in-progress tab only." },
+      { title: "Chat-first filing", prompt: "Reshape the submit form to a chat." },
+    ];
+    await t.mutation(internal.functions.devAssistant.bugs.applyCallback, {
+      bugId: id,
+      status: "IN_REVIEW",
+      spec: "## Too big\nSplit it up.",
+      scope: "split",
+      splitSlices: slices,
+    });
+
+    let bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.scope).toBe("split");
+    expect(bug?.splitSlices).toEqual(slices);
+
+    // A revision that re-triages to a single buildable item clears the slices.
+    await t.mutation(internal.functions.devAssistant.bugs.applyCallback, {
+      bugId: id,
+      status: "IN_REVIEW",
+      spec: "## Actually small\nJust one screen.",
+      scope: "buildable",
+    });
+    bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.scope).toBe("buildable");
+    expect(bug?.splitSlices).toBeUndefined();
+  });
+
+  test("the http callback validates splitSlices and accepts a well-formed array", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const now = Date.now();
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert("devBugs", {
+        originatorUserId: maintainerId,
+        status: "DRAFT",
+        kind: "feature",
+        source: "dashboard",
+        title: "Big ask",
+        body: "B",
+        routineRunId: "run-spec",
+        activeRunMode: "spec",
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+
+    process.env.DEV_ASSISTANT_CALLBACK_SECRET = "test-callback-secret";
+    const sign = async (body: string): Promise<string> => {
+      const encoder = new TextEncoder();
+      const key = await crypto.subtle.importKey(
+        "raw",
+        encoder.encode("test-callback-secret"),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const bytes = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+      return Array.from(new Uint8Array(bytes))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+    };
+    const post = async (payload: Record<string, unknown>): Promise<Response> => {
+      const body = JSON.stringify(payload);
+      return await t.fetch("/dev-assistant/callback", {
+        method: "POST",
+        body,
+        headers: { "x-togather-signature": await sign(body) },
+      });
+    };
+
+    // Malformed slice entries are rejected before scheduling.
+    const bad = await post({
+      bugId: id,
+      routineRunId: "run-spec",
+      status: "IN_REVIEW",
+      scope: "split",
+      splitSlices: [{ title: "Missing prompt" }],
+    });
+    expect(bad.status).toBe(400);
+    expect(await bad.text()).toMatch(/Invalid splitSlices/);
+
+    // A well-formed array passes and persists end-to-end.
+    const ok = await post({
+      bugId: id,
+      routineRunId: "run-spec",
+      status: "IN_REVIEW",
+      spec: "## Split\nDo it in pieces.",
+      scope: "split",
+      splitSlices: [{ title: "Slice one", prompt: "Build slice one only." }],
+    });
+    expect(ok.status).toBe(200);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.scope).toBe("split");
+    expect(bug?.splitSlices).toEqual([
+      { title: "Slice one", prompt: "Build slice one only." },
+    ]);
+  });
+});

--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -3108,3 +3108,216 @@ describe("chat-first filing, pictures, and split slices", () => {
     ]);
   });
 });
+
+/**
+ * Review-cycle hardening (ADR-029 Phase 1.7): tests added after code review —
+ * the r2:-only image guard, title-truncation boundary, getThread passthrough
+ * for already-public URLs, revision-round image aggregation, and splitSlices
+ * clearing on a design_needed re-triage.
+ */
+describe("review-cycle hardening", () => {
+  test("submit and postMessage reject non-r2 image URLs", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    // submit rejects an external URL masquerading as an attachment.
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.submit, {
+        token: maintainerId,
+        kind: "bug",
+        body: "look",
+        screenshotUrls: ["https://evil.example/beacon.png"],
+      }),
+    ).rejects.toThrow(/uploaded images/i);
+
+    // A valid item, then postMessage rejects the same.
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "ok" },
+    );
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.postMessage, {
+        token: maintainerId,
+        id,
+        body: "here",
+        imageUrls: ["http://169.254.169.254/latest/meta-data/"],
+      }),
+    ).rejects.toThrow(/uploaded images/i);
+  });
+
+  test("deriveTitle keeps 80 chars but clips at 81", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const exactly80 = "a".repeat(80);
+    const id80 = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: exactly80 },
+    );
+    const bug80 = await t.run(async (ctx) => ctx.db.get(id80));
+    expect(bug80?.title).toBe(exactly80); // no ellipsis at the boundary
+
+    const over81 = "b".repeat(81);
+    const id81 = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: over81 },
+    );
+    const bug81 = await t.run(async (ctx) => ctx.db.get(id81));
+    expect(bug81?.title.length).toBe(80);
+    expect(bug81?.title.endsWith("…")).toBe(true);
+  });
+
+  test("getThread passes already-public (http) image URLs through unchanged", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.R2_PUBLIC_URL = "https://cdn.example.com";
+
+    // Simulate a chat-originated message whose imageUrls are already public
+    // (inserted directly, bypassing the dashboard r2:-only guard).
+    const now = Date.now();
+    const id = await t.run(async (ctx) => {
+      const bugId = await ctx.db.insert("devBugs", {
+        originatorUserId: maintainerId,
+        status: "IN_REVIEW",
+        kind: "bug",
+        source: "chat",
+        title: "From chat",
+        body: "B",
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("devBugMessages", {
+        bugId,
+        authorType: "user",
+        userId: maintainerId,
+        body: "see this",
+        imageUrls: ["https://already.public/shot.png"],
+        createdAt: now,
+      });
+      return bugId;
+    });
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread[0]?.imageUrls).toEqual(["https://already.public/shot.png"]);
+
+    delete process.env.R2_PUBLIC_URL;
+  });
+
+  test("a revision round folds a reply's picture into the spec brief", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const fetchMock = stubRoutineEnv();
+    process.env.R2_PUBLIC_URL = "https://cdn.example.com";
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "bug", body: "Initial report, no picture." },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Move to IN_REVIEW so the reply drives a revision round.
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    await t.action(
+      internal.functions.devAssistant.actions.handleRoutineCallback,
+      {
+        bugId: id,
+        routineRunId: bug!.routineRunId!,
+        status: "IN_REVIEW",
+        spec: "## Plan",
+        riskLevel: "low",
+      },
+    );
+
+    // Reply with a screenshot → schedules a revision dispatch.
+    await t.mutation(api.functions.devAssistant.contributions.postMessage, {
+      token: maintainerId,
+      id,
+      body: "Here's what I mean:",
+      imageUrls: ["r2:chat/reply.jpg"],
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The most recent dispatch is the revision; its brief carries the resolved
+    // reply image.
+    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+    const brief = JSON.parse(JSON.parse(lastCall[1].body).text);
+    expect(brief.revision).toBe(true);
+    expect(brief.screenshotUrls).toContain("https://cdn.example.com/chat/reply.jpg");
+
+    delete process.env.R2_PUBLIC_URL;
+  });
+
+  test("re-triage from split to design_needed clears stale splitSlices", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "feature", body: "Huge ask." },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(internal.functions.devAssistant.bugs.applyCallback, {
+      bugId: id,
+      status: "IN_REVIEW",
+      spec: "## Split",
+      scope: "split",
+      splitSlices: [{ title: "One", prompt: "Build one." }],
+    });
+    let bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.splitSlices).toHaveLength(1);
+
+    // Revision decides it actually needs design work; no slices delivered.
+    await t.mutation(internal.functions.devAssistant.bugs.applyCallback, {
+      bugId: id,
+      status: "IN_REVIEW",
+      spec: "## Needs design",
+      scope: "design_needed",
+    });
+    bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.scope).toBe("design_needed");
+    expect(bug?.splitSlices).toBeUndefined();
+  });
+
+  test("a split revision that omits slices keeps the last-known ones", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    stubRoutineEnv();
+
+    const id = await t.mutation(
+      api.functions.devAssistant.contributions.submit,
+      { token: maintainerId, kind: "feature", body: "Huge ask." },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const slices = [{ title: "One", prompt: "Build one." }];
+    await t.mutation(internal.functions.devAssistant.bugs.applyCallback, {
+      bugId: id,
+      status: "IN_REVIEW",
+      spec: "## Split",
+      scope: "split",
+      splitSlices: slices,
+    });
+    // A revision that stays "split" but omits splitSlices keeps them.
+    await t.mutation(internal.functions.devAssistant.bugs.applyCallback, {
+      bugId: id,
+      status: "IN_REVIEW",
+      spec: "## Still split",
+      scope: "split",
+    });
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.splitSlices).toEqual(slices);
+  });
+});

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -10,6 +10,7 @@ import { v } from "convex/values";
 import { internalAction } from "../../_generated/server";
 import { api, internal } from "../../_generated/api";
 import { Id } from "../../_generated/dataModel";
+import { getMediaUrl } from "../../lib/utils";
 import { buildDevAssistantPrompt } from "./prompts";
 import { runAgentLoop, buildThreadMessages } from "./agent";
 import {
@@ -18,6 +19,7 @@ import {
   reviewVerdictValidator,
   riskLevelValidator,
   scopeValidator,
+  splitSlicesValidator,
 } from "./bugs";
 import type { ToolExecutionContext } from "./tools";
 
@@ -396,12 +398,19 @@ export const dispatchSpec = internalAction({
       '"chat", "groups", "prayer", "settings", "other"); scope ("buildable" | ' +
       '"split" | "design_needed") — requests too large for one pipeline run ' +
       'must NOT be specced as-is: for "split", the spec body should explain ' +
-      'why and propose 2-3 smaller buildable slices; for "design_needed", the ' +
-      "spec body should explain what architectural decisions a maintainer " +
-      "must make first; and verifyOnStaging (boolean — true for anything " +
-      "interactive, false for pure copy/color). Report back by POSTing the " +
-      'signed callback with { bugId, routineRunId, status: "IN_REVIEW", spec, ' +
-      "riskLevel, aiTitle, area, scope, verifyOnStaging }.";
+      "why and propose 2-3 smaller buildable slices AND you MUST return a " +
+      "`splitSlices` array (one entry per slice) where each entry is { title, " +
+      "prompt }: `title` is the slice's short name and `prompt` is a " +
+      "self-contained instruction a maintainer can paste straight into a fresh " +
+      "dev session to build THAT slice alone (state the slice's goal, the " +
+      "files/areas involved, the done-when checklist, and that it is one slice " +
+      'of a larger split so the other slices are out of scope); for ' +
+      '"design_needed", the spec body should explain what architectural ' +
+      "decisions a maintainer must make first; and verifyOnStaging (boolean — " +
+      "true for anything interactive, false for pure copy/color). Report back " +
+      'by POSTing the signed callback with { bugId, routineRunId, status: ' +
+      '"IN_REVIEW", spec, riskLevel, aiTitle, area, scope, splitSlices?, ' +
+      "verifyOnStaging }.";
     const instructions = args.revision
       ? "REVISION ROUND: this contribution already has a spec draft, and the " +
         "contributor replied in the conversation thread (see `thread` — the " +
@@ -409,6 +418,18 @@ export const dispatchSpec = internalAction({
         "and triage accordingly. " +
         baseInstructions
       : baseInstructions;
+
+    // Pictures reach the (vision-capable) routine as fetchable URLs: gather
+    // the report's shots plus any attached to thread replies, de-dupe, and
+    // resolve the stored R2 paths to public URLs (getMediaUrl passes existing
+    // http(s) URLs through unchanged, so chat-originated shots stay valid).
+    const rawShots = [
+      ...(bug.screenshotUrls ?? []),
+      ...thread.flatMap((m) => m.imageUrls ?? []),
+    ];
+    const screenshotUrls = Array.from(new Set(rawShots))
+      .map((u) => getMediaUrl(u))
+      .filter((u): u is string => !!u);
 
     const payload = {
       mode: "spec",
@@ -419,9 +440,14 @@ export const dispatchSpec = internalAction({
       title: bug.title,
       body: bug.body,
       repro: bug.repro,
-      screenshotUrls: bug.screenshotUrls,
+      screenshotUrls: screenshotUrls.length > 0 ? screenshotUrls : undefined,
       // Full conversation history: [{ authorType, authorName?, body }, ...].
-      thread,
+      // (Image paths are folded into screenshotUrls above, not the thread.)
+      thread: thread.map((m) => ({
+        authorType: m.authorType,
+        ...(m.authorName ? { authorName: m.authorName } : {}),
+        body: m.body,
+      })),
       callbackUrl,
       instructions,
     };
@@ -924,6 +950,7 @@ export const handleRoutineCallback = internalAction({
     aiTitle: v.optional(v.string()),
     area: v.optional(v.string()),
     scope: v.optional(scopeValidator),
+    splitSlices: v.optional(splitSlicesValidator),
     verifyOnStaging: v.optional(v.boolean()),
     reviewVerdict: v.optional(reviewVerdictValidator),
     reviewSummary: v.optional(v.string()),
@@ -956,6 +983,7 @@ export const handleRoutineCallback = internalAction({
         aiTitle: args.aiTitle,
         area: args.area,
         scope: args.scope,
+        splitSlices: args.splitSlices,
         verifyOnStaging: args.verifyOnStaging,
         reviewVerdict: args.reviewVerdict,
         reviewSummary: args.reviewSummary,

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -60,6 +60,14 @@ export const reviewVerdictValidator = v.union(
 );
 
 /**
+ * Buildable slices proposed by the spec routine for a "split"-scope item, each
+ * with a copy-paste-ready prompt for a fresh dev session (ADR-029).
+ */
+export const splitSlicesValidator = v.array(
+  v.object({ title: v.string(), prompt: v.string() }),
+);
+
+/**
  * Where a callback came from. Internal-only — threaded by trusted callers
  * (handleRoutineCallback → "routine", handleGithubPrClosed → "webhook",
  * attemptAutoMerge → "automerge") and NEVER exposed through the public HTTP
@@ -172,12 +180,15 @@ export async function insertThreadMessage(
   authorType: "user" | "assistant" | "system",
   body: string,
   userId?: Id<"users">,
+  imageUrls?: string[],
 ): Promise<Id<"devBugMessages">> {
   return await ctx.db.insert("devBugMessages", {
     bugId,
     authorType,
     userId,
     body,
+    // Store only a non-empty array — keeps text-only messages clean.
+    ...(imageUrls && imageUrls.length > 0 ? { imageUrls } : {}),
     createdAt: Date.now(),
   });
 }
@@ -197,6 +208,9 @@ export type ThreadHistoryEntry = {
   authorType: "user" | "assistant" | "system";
   authorName?: string;
   body: string;
+  // R2 storage paths for any pictures on this message (unresolved — the
+  // dispatch action resolves them to public URLs for the routine).
+  imageUrls?: string[];
 };
 
 /**
@@ -221,7 +235,14 @@ export const getThreadHistory = internalQuery({
           ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || undefined
           : undefined;
       }
-      entries.push({ authorType: m.authorType, authorName, body: m.body });
+      entries.push({
+        authorType: m.authorType,
+        authorName,
+        body: m.body,
+        ...(m.imageUrls && m.imageUrls.length > 0
+          ? { imageUrls: m.imageUrls }
+          : {}),
+      });
     }
     return entries;
   },
@@ -844,6 +865,7 @@ export const applyCallback = internalMutation({
     aiTitle: v.optional(v.string()),
     area: v.optional(v.string()),
     scope: v.optional(scopeValidator),
+    splitSlices: v.optional(splitSlicesValidator),
     verifyOnStaging: v.optional(v.boolean()),
     reviewVerdict: v.optional(reviewVerdictValidator),
     reviewSummary: v.optional(v.string()),
@@ -944,6 +966,14 @@ export const applyCallback = internalMutation({
     if (args.aiTitle !== undefined) patch.aiTitle = args.aiTitle;
     if (args.area !== undefined) patch.area = args.area;
     if (args.scope !== undefined) patch.scope = args.scope;
+    // Split slices track the scope: a routine explicitly delivers them (only
+    // meaningful for "split"), and a revision that drops back to a single
+    // buildable item clears the now-stale slices.
+    if (args.splitSlices !== undefined) {
+      patch.splitSlices = args.splitSlices;
+    } else if (args.scope === "buildable") {
+      patch.splitSlices = undefined;
+    }
     if (args.verifyOnStaging !== undefined) {
       patch.verifyOnStaging = args.verifyOnStaging;
     }

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -967,11 +967,11 @@ export const applyCallback = internalMutation({
     if (args.area !== undefined) patch.area = args.area;
     if (args.scope !== undefined) patch.scope = args.scope;
     // Split slices track the scope: a routine explicitly delivers them (only
-    // meaningful for "split"), and a revision that drops back to a single
-    // buildable item clears the now-stale slices.
+    // meaningful for "split"), and a revision that re-triages to any non-split
+    // scope (buildable or design_needed) clears the now-stale slices.
     if (args.splitSlices !== undefined) {
       patch.splitSlices = args.splitSlices;
-    } else if (args.scope === "buildable") {
+    } else if (args.scope !== undefined && args.scope !== "split") {
       patch.splitSlices = undefined;
     }
     if (args.verifyOnStaging !== undefined) {

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -301,6 +301,7 @@ export const approveSpec = mutation({
 
     const bug = await ctx.db.get(args.id);
     if (!bug) throw new ConvexError("Contribution not found");
+    assertNotArchived(bug);
     if (bug.status !== "IN_REVIEW") {
       throw new ConvexError(
         `Spec can only be approved while in review (current status: ${bug.status})`,
@@ -341,6 +342,7 @@ export const startBuild = mutation({
 
     const bug = await ctx.db.get(args.id);
     if (!bug) throw new ConvexError("Contribution not found");
+    assertNotArchived(bug);
     if (!bug.specApprovedAt) {
       throw new ConvexError("Spec must be approved before starting a build");
     }
@@ -374,6 +376,16 @@ function assertCanArchive(user: Doc<"users">, bug: Doc<"devBugs">): void {
   const isOwner = bug.originatorUserId === user._id;
   if (!isOwner && !user.isStaff && !user.isSuperuser) {
     throw new ConvexError("Only the person who started this can archive it");
+  }
+}
+
+/**
+ * Archiving means "set aside / not doable", so the pipeline is paused: no
+ * approving, building, or AI work on an archived item until it's restored.
+ */
+function assertNotArchived(bug: Doc<"devBugs">): void {
+  if (bug.archivedAt) {
+    throw new ConvexError("Restore this conversation before continuing it");
   }
 }
 
@@ -463,7 +475,12 @@ export const postMessage = mutation({
       args.imageUrls,
     );
 
-    if (bug.status === "DRAFT" || bug.status === "IN_REVIEW") {
+    // An archived item is paused: record the note but don't re-fire the spec
+    // agent (no AI work / cost until it's restored).
+    if (
+      !bug.archivedAt &&
+      (bug.status === "DRAFT" || bug.status === "IN_REVIEW")
+    ) {
       await ctx.scheduler.runAfter(
         0,
         internal.functions.devAssistant.actions.dispatchSpec,

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -27,11 +27,43 @@ import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuthUser } from "../../lib/auth";
 import { canUseDevAssistant } from "./maintainers";
 import { applyStatusTransition, insertThreadMessage } from "./bugs";
+import { getMediaUrl } from "../../lib/utils";
 
 export const contributionKindValidator = v.union(
   v.literal("bug"),
   v.literal("feature"),
 );
+
+/** Longest title we derive from a chat-first message before the AI titles it. */
+const DERIVED_TITLE_MAX = 80;
+
+/**
+ * Turn a free-form message into a one-line placeholder title (chat-first
+ * filing has no title field). First non-empty line, trimmed and clipped.
+ */
+function deriveTitle(body: string): string {
+  const firstLine =
+    body
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? body.trim();
+  return firstLine.length > DERIVED_TITLE_MAX
+    ? `${firstLine.slice(0, DERIVED_TITLE_MAX - 1).trimEnd()}…`
+    : firstLine;
+}
+
+/**
+ * Resolve stored R2 paths ("r2:…") to fetchable public URLs for the client
+ * (getMediaUrl passes existing http(s) URLs through unchanged, so it's safe on
+ * already-resolved chat-originated attachments too). Undefined stays undefined.
+ */
+function resolveImageUrls(urls: string[] | undefined): string[] | undefined {
+  if (!urls || urls.length === 0) return undefined;
+  const resolved = urls
+    .map((u) => getMediaUrl(u))
+    .filter((u): u is string => !!u);
+  return resolved.length > 0 ? resolved : undefined;
+}
 
 /**
  * Auth gate for the whole dashboard surface. Per the ADR-029 decision update
@@ -168,18 +200,31 @@ export const submit = mutation({
   args: {
     token: v.string(),
     kind: contributionKindValidator,
-    title: v.string(),
+    // Optional: chat-first filing (ADR-029) lets contributors just describe the
+    // thing in one message — the title is derived from that message, and the
+    // spec agent replaces it with a proper aiTitle. Callers may still pass an
+    // explicit title.
+    title: v.optional(v.string()),
     body: v.string(),
     repro: v.optional(v.string()),
+    // R2 storage paths ("r2:…") for pictures/screenshots attached to the report.
     screenshotUrls: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args): Promise<Id<"devBugs">> => {
     const user = await requireContributor(ctx, args.token);
 
-    const title = args.title.trim();
     const body = args.body.trim();
-    if (!title) throw new ConvexError("Title is required");
-    if (!body) throw new ConvexError("Description is required");
+    const hasImages = !!args.screenshotUrls && args.screenshotUrls.length > 0;
+    // A screenshot with no words is a valid report; require one or the other.
+    if (!body && !hasImages) {
+      throw new ConvexError("Add a description or a screenshot");
+    }
+    // Derive a title from the message when the caller didn't supply one — the
+    // list shows this until the spec agent's aiTitle lands. Image-only reports
+    // fall back to a generic headline.
+    const title =
+      args.title?.trim() ||
+      (body ? deriveTitle(body) : args.kind === "feature" ? "Feature idea" : "Bug report");
 
     const now = Date.now();
     const bugId = await ctx.db.insert("devBugs", {
@@ -199,11 +244,19 @@ export const submit = mutation({
     // Every contribution is a conversation with the AI (ADR-029 P1.5): the
     // report body is the opening "user" turn of the thread. The repro rides
     // along so it's visible in the conversation UI (the thread only renders
-    // messages, not the row's repro field).
+    // messages, not the row's repro field). Attached pictures ride on the
+    // message so they render inline in the conversation.
     const openingTurn = args.repro
       ? `${body}\n\nHow to see it: ${args.repro}`
       : body;
-    await insertThreadMessage(ctx, bugId, "user", openingTurn, user._id);
+    await insertThreadMessage(
+      ctx,
+      bugId,
+      "user",
+      openingTurn,
+      user._id,
+      args.screenshotUrls,
+    );
 
     // Fire the spec agent (event-driven, no cron — mirrors READY_FOR_IMPL ->
     // dispatchBug in bugs.ts).
@@ -307,7 +360,13 @@ export const startBuild = mutation({
  * responds to the latest user message via the signed callback.
  */
 export const postMessage = mutation({
-  args: { token: v.string(), id: v.id("devBugs"), body: v.string() },
+  args: {
+    token: v.string(),
+    id: v.id("devBugs"),
+    body: v.string(),
+    // R2 storage paths for pictures attached to this reply (optional).
+    imageUrls: v.optional(v.array(v.string())),
+  },
   handler: async (ctx, args): Promise<Id<"devBugMessages">> => {
     const user = await requireContributor(ctx, args.token);
 
@@ -315,7 +374,11 @@ export const postMessage = mutation({
     if (!bug) throw new ConvexError("Contribution not found");
 
     const body = args.body.trim();
-    if (!body) throw new ConvexError("Message body is required");
+    const hasImages = !!args.imageUrls && args.imageUrls.length > 0;
+    // A picture with no words is a valid message; require text only otherwise.
+    if (!body && !hasImages) {
+      throw new ConvexError("Message body is required");
+    }
 
     const messageId = await insertThreadMessage(
       ctx,
@@ -323,6 +386,7 @@ export const postMessage = mutation({
       "user",
       body,
       user._id,
+      args.imageUrls,
     );
 
     if (bug.status === "DRAFT" || bug.status === "IN_REVIEW") {
@@ -468,13 +532,21 @@ async function withLastMessage(
 /** A contribution's conversation thread, oldest first. */
 export const getThread = query({
   args: { token: v.string(), id: v.id("devBugs") },
-  handler: async (ctx, args): Promise<Doc<"devBugMessages">[]> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<(Doc<"devBugMessages"> & { imageUrls?: string[] })[]> => {
     await requireContributor(ctx, args.token);
-    return await ctx.db
+    const messages = await ctx.db
       .query("devBugMessages")
       .withIndex("by_bug", (q) => q.eq("bugId", args.id))
       .order("asc")
       .collect();
+    // Resolve stored R2 paths to public URLs the app can render.
+    return messages.map((m) => ({
+      ...m,
+      imageUrls: resolveImageUrls(m.imageUrls),
+    }));
   },
 });
 

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -53,6 +53,21 @@ function deriveTitle(body: string): string {
 }
 
 /**
+ * Attached pictures from the dashboard must be our own R2 uploads. Reject
+ * anything that isn't an "r2:" storage path so a caller can't stash an
+ * arbitrary external URL that would later be rendered to other maintainers or
+ * fetched by the spec routine (a tracking-beacon / SSRF surface).
+ */
+function assertR2Paths(urls: string[] | undefined): void {
+  if (!urls) return;
+  for (const url of urls) {
+    if (!url.startsWith("r2:")) {
+      throw new ConvexError("Attachments must be uploaded images");
+    }
+  }
+}
+
+/**
  * Resolve stored R2 paths ("r2:…") to fetchable public URLs for the client
  * (getMediaUrl passes existing http(s) URLs through unchanged, so it's safe on
  * already-resolved chat-originated attachments too). Undefined stays undefined.
@@ -214,6 +229,7 @@ export const submit = mutation({
     const user = await requireContributor(ctx, args.token);
 
     const body = args.body.trim();
+    assertR2Paths(args.screenshotUrls);
     const hasImages = !!args.screenshotUrls && args.screenshotUrls.length > 0;
     // A screenshot with no words is a valid report; require one or the other.
     if (!body && !hasImages) {
@@ -374,6 +390,7 @@ export const postMessage = mutation({
     if (!bug) throw new ConvexError("Contribution not found");
 
     const body = args.body.trim();
+    assertR2Paths(args.imageUrls);
     const hasImages = !!args.imageUrls && args.imageUrls.length > 0;
     // A picture with no words is a valid message; require text only otherwise.
     if (!body && !hasImages) {

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -365,6 +365,63 @@ export const startBuild = mutation({
   },
 });
 
+/**
+ * Archive/unarchive is originator-only (plus staff/superuser, who can tidy the
+ * shared board). Everyone can read every thread, but only the person who
+ * started it — or staff — sets it aside.
+ */
+function assertCanArchive(user: Doc<"users">, bug: Doc<"devBugs">): void {
+  const isOwner = bug.originatorUserId === user._id;
+  if (!isOwner && !user.isStaff && !user.isSuperuser) {
+    throw new ConvexError("Only the person who started this can archive it");
+  }
+}
+
+/**
+ * Set a conversation aside — the contributor abandoned it, or its scope was
+ * judged not doable. Orthogonal to the pipeline status; archived items leave
+ * the active dashboard tabs. Idempotent (re-archiving keeps the first stamp).
+ */
+export const archive = mutation({
+  args: { token: v.string(), id: v.id("devBugs") },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const user = await requireContributor(ctx, args.token);
+    const bug = await ctx.db.get(args.id);
+    if (!bug) throw new ConvexError("Contribution not found");
+    assertCanArchive(user, bug);
+
+    const now = Date.now();
+    if (!bug.archivedAt) {
+      await ctx.db.patch(args.id, { archivedAt: now, updatedAt: now });
+      await insertThreadMessage(
+        ctx,
+        args.id,
+        "system",
+        "Conversation archived — set aside by the contributor.",
+      );
+    }
+    return { ok: true };
+  },
+});
+
+/** Restore an archived conversation back into the active dashboard. */
+export const unarchive = mutation({
+  args: { token: v.string(), id: v.id("devBugs") },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const user = await requireContributor(ctx, args.token);
+    const bug = await ctx.db.get(args.id);
+    if (!bug) throw new ConvexError("Contribution not found");
+    assertCanArchive(user, bug);
+
+    if (bug.archivedAt) {
+      const now = Date.now();
+      await ctx.db.patch(args.id, { archivedAt: undefined, updatedAt: now });
+      await insertThreadMessage(ctx, args.id, "system", "Conversation restored.");
+    }
+    return { ok: true };
+  },
+});
+
 // ============================================================================
 // Conversation thread (ADR-029 Phase 1.5)
 // ============================================================================

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -1085,6 +1085,7 @@ http.route({
       aiTitle?: string;
       area?: string;
       scope?: string;
+      splitSlices?: unknown;
       verifyOnStaging?: boolean;
       reviewVerdict?: string;
       reviewSummary?: string;
@@ -1107,6 +1108,7 @@ http.route({
       aiTitle,
       area,
       scope,
+      splitSlices,
       verifyOnStaging,
       reviewVerdict,
       reviewSummary,
@@ -1131,6 +1133,29 @@ http.route({
     }
     if (scope !== undefined && !DEV_ASSISTANT_SCOPES.includes(scope)) {
       return new Response(`Unsupported scope: ${scope}`, { status: 400 });
+    }
+    let validatedSplitSlices:
+      | { title: string; prompt: string }[]
+      | undefined;
+    if (splitSlices !== undefined) {
+      if (
+        !Array.isArray(splitSlices) ||
+        !splitSlices.every(
+          (s) =>
+            s &&
+            typeof s === "object" &&
+            typeof (s as { title?: unknown }).title === "string" &&
+            typeof (s as { prompt?: unknown }).prompt === "string",
+        )
+      ) {
+        return new Response(
+          "Invalid splitSlices: must be an array of { title, prompt } strings",
+          { status: 400 },
+        );
+      }
+      validatedSplitSlices = (
+        splitSlices as { title: string; prompt: string }[]
+      ).map((s) => ({ title: s.title, prompt: s.prompt }));
     }
     if (verifyOnStaging !== undefined && typeof verifyOnStaging !== "boolean") {
       return new Response("Invalid verifyOnStaging: must be a boolean", {
@@ -1172,6 +1197,7 @@ http.route({
         aiTitle,
         area,
         scope: scope as "buildable" | "split" | "design_needed" | undefined,
+        splitSlices: validatedSplitSlices,
         verifyOnStaging,
         reviewVerdict: reviewVerdict as
           | "approved"

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2213,6 +2213,11 @@ export default defineSchema({
     githubIssueNumber: v.optional(v.number()),
     githubIssueUrl: v.optional(v.string()),
     shippedAt: v.optional(v.number()), // set when status reaches MERGED
+    // Contributor set the conversation aside (abandoned it, or the scope was
+    // judged not doable) — ADR-029. Orthogonal to `status`: an item can be
+    // archived from any pipeline state and unarchived to restore it. Archived
+    // items drop out of the active dashboard tabs into an "Archived" view.
+    archivedAt: v.optional(v.number()),
 
     prUrl: v.optional(v.string()),
     reviewLink: v.optional(v.string()),

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2199,6 +2199,13 @@ export default defineSchema({
       v.union(v.literal("approved"), v.literal("changes_requested")),
     ),
     reviewSummary: v.optional(v.string()),
+    // For "split"-scope items (ADR-029): the spec routine proposes the
+    // buildable slices, each with a self-contained prompt a maintainer can
+    // copy straight into a fresh dev session to build that slice on its own.
+    // Cleared when a revision re-triages the item back to "buildable".
+    splitSlices: v.optional(
+      v.array(v.object({ title: v.string(), prompt: v.string() })),
+    ),
     // Count of auto-fix dispatches (ADR-029 Phase 3 review→fix→re-review
     // loop). Capped at 3 — after that a changes_requested verdict escalates
     // to a human instead of dispatching another fix run.
@@ -2251,6 +2258,10 @@ export default defineSchema({
     ),
     userId: v.optional(v.id("users")), // set when authorType === "user"
     body: v.string(),
+    // Screenshots/pictures attached to a "user" message (contributors can file
+    // and chat with images — ADR-029). Stored as R2 storage paths ("r2:…");
+    // read paths (getThread) resolve them to public URLs via getMediaUrl.
+    imageUrls: v.optional(v.array(v.string())),
     createdAt: v.number(),
   }).index("by_bug", ["bugId", "createdAt"]),
 

--- a/apps/mobile/features/contribute/components/AttachmentStrip.tsx
+++ b/apps/mobile/features/contribute/components/AttachmentStrip.tsx
@@ -1,0 +1,81 @@
+/**
+ * Thumbnail row for pictures attached to the contribute composer (ADR-029).
+ * Shows each picked image with an upload spinner while in flight and a remove
+ * button; renders nothing when there are no attachments.
+ */
+import React from "react";
+import {
+  View,
+  Image,
+  TouchableOpacity,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@hooks/useTheme";
+import type { ImageAttachment } from "../hooks/useImageAttachments";
+
+export function AttachmentStrip({
+  attachments,
+  onRemove,
+}: {
+  attachments: ImageAttachment[];
+  onRemove: (id: string) => void;
+}) {
+  const { colors } = useTheme();
+  if (attachments.length === 0) return null;
+  return (
+    <View style={styles.row}>
+      {attachments.map((att) => (
+        <View key={att.id} style={styles.item}>
+          <Image
+            source={{ uri: att.localUri }}
+            style={[styles.thumb, { backgroundColor: colors.surfaceSecondary }]}
+            resizeMode="cover"
+          />
+          {att.uploading ? (
+            <View style={styles.overlay}>
+              <ActivityIndicator size="small" color="#ffffff" />
+            </View>
+          ) : null}
+          {att.failed ? (
+            <View style={[styles.overlay, styles.failedOverlay]}>
+              <Ionicons name="alert-circle" size={20} color="#ffffff" />
+            </View>
+          ) : null}
+          <TouchableOpacity
+            style={styles.removeBtn}
+            onPress={() => onRemove(att.id)}
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+            accessibilityLabel="Remove picture"
+          >
+            <Ionicons name="close-circle" size={20} color="#000000" />
+          </TouchableOpacity>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const THUMB = 64;
+
+const styles = StyleSheet.create({
+  row: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 10 },
+  item: { width: THUMB, height: THUMB },
+  thumb: { width: THUMB, height: THUMB, borderRadius: 8 },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(0,0,0,0.35)",
+  },
+  failedOverlay: { backgroundColor: "rgba(220,38,38,0.5)" },
+  removeBtn: {
+    position: "absolute",
+    top: -6,
+    right: -6,
+    backgroundColor: "#ffffff",
+    borderRadius: 10,
+  },
+});

--- a/apps/mobile/features/contribute/components/ContributeListScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributeListScreen.tsx
@@ -35,13 +35,13 @@ import {
 } from "../utils/status";
 import type { ContributionListItem } from "../types";
 
-type Segment = "yourTurn" | "inProgress" | "shipped";
+type Segment = "yourTurn" | "inProgress" | "done";
 type Owner = "mine" | "everyone";
 
 const SEGMENT_OPTIONS: { key: Segment; label: string }[] = [
   { key: "yourTurn", label: "Your turn" },
   { key: "inProgress", label: "In progress" },
-  { key: "shipped", label: "Shipped" },
+  { key: "done", label: "Done" },
 ];
 
 const OWNER_OPTIONS: { key: Owner; label: string }[] = [
@@ -58,9 +58,9 @@ const EMPTY_COPY: Record<Segment, { title: string; text: string }> = {
     title: "Nothing being built right now",
     text: "Fire something off — a bug or an idea — and once it's approved you'll watch it move through here as the AI builds, reviews, and ships it.",
   },
-  shipped: {
-    title: "Nothing shipped yet",
-    text: "Once a conversation's change makes it into the app, it lands here.",
+  done: {
+    title: "Nothing wrapped up yet",
+    text: "Once a conversation is finished — shipped into the app, or set aside — it lands here.",
   },
 };
 
@@ -131,7 +131,9 @@ export function ContributeListScreen() {
     const items = contributions ?? [];
     const filtered = items.filter((item) => {
       if (segment === "yourTurn") return isYourTurn(item);
-      if (segment === "shipped") return item.status === "MERGED";
+      // "Done" = terminal conversations, shipped or set aside.
+      if (segment === "done")
+        return item.status === "MERGED" || item.status === "REJECTED";
       // "In progress" = fired off and actively being built/reviewed.
       return isInProgress(item);
     });

--- a/apps/mobile/features/contribute/components/ContributeListScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributeListScreen.tsx
@@ -27,15 +27,20 @@ import { SegmentedTabs } from "@components/ui/SegmentedTabs";
 import { useDevAccess } from "../hooks/useDevAccess";
 import { useAllContributions, useMyContributions } from "../hooks/useMyContributions";
 import { GithubCreditRow } from "./GithubCreditRow";
-import { conversationDotColor, displayTitle, isYourTurn } from "../utils/status";
+import {
+  conversationDotColor,
+  displayTitle,
+  isInProgress,
+  isYourTurn,
+} from "../utils/status";
 import type { ContributionListItem } from "../types";
 
-type Segment = "yourTurn" | "all" | "shipped";
+type Segment = "yourTurn" | "inProgress" | "shipped";
 type Owner = "mine" | "everyone";
 
 const SEGMENT_OPTIONS: { key: Segment; label: string }[] = [
   { key: "yourTurn", label: "Your turn" },
-  { key: "all", label: "All" },
+  { key: "inProgress", label: "In progress" },
   { key: "shipped", label: "Shipped" },
 ];
 
@@ -49,9 +54,9 @@ const EMPTY_COPY: Record<Segment, { title: string; text: string }> = {
     title: "Nothing needs you right now",
     text: "When the AI drafts a plan for your review or a change is ready to try out, it shows up here.",
   },
-  all: {
-    title: "No conversations yet",
-    text: "Spotted something broken, or have an idea to make Togather better? Start a conversation and the AI takes it from there — you'll see every step as it gets built and shipped.",
+  inProgress: {
+    title: "Nothing being built right now",
+    text: "Fire something off — a bug or an idea — and once it's approved you'll watch it move through here as the AI builds, reviews, and ships it.",
   },
   shipped: {
     title: "Nothing shipped yet",
@@ -127,8 +132,8 @@ export function ContributeListScreen() {
     const filtered = items.filter((item) => {
       if (segment === "yourTurn") return isYourTurn(item);
       if (segment === "shipped") return item.status === "MERGED";
-      // "All" = everything not waiting on you and not shipped.
-      return !isYourTurn(item) && item.status !== "MERGED";
+      // "In progress" = fired off and actively being built/reviewed.
+      return isInProgress(item);
     });
     return [...filtered].sort((a, b) => b.updatedAt - a.updatedAt);
   }, [contributions, segment]);

--- a/apps/mobile/features/contribute/components/ContributeListScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributeListScreen.tsx
@@ -30,18 +30,20 @@ import { GithubCreditRow } from "./GithubCreditRow";
 import {
   conversationDotColor,
   displayTitle,
+  isArchived,
   isInProgress,
   isYourTurn,
 } from "../utils/status";
 import type { ContributionListItem } from "../types";
 
-type Segment = "yourTurn" | "inProgress" | "done";
+type Segment = "yourTurn" | "inProgress" | "done" | "archived";
 type Owner = "mine" | "everyone";
 
 const SEGMENT_OPTIONS: { key: Segment; label: string }[] = [
   { key: "yourTurn", label: "Your turn" },
   { key: "inProgress", label: "In progress" },
   { key: "done", label: "Done" },
+  { key: "archived", label: "Archived" },
 ];
 
 const OWNER_OPTIONS: { key: Owner; label: string }[] = [
@@ -61,6 +63,10 @@ const EMPTY_COPY: Record<Segment, { title: string; text: string }> = {
   done: {
     title: "Nothing wrapped up yet",
     text: "Once a conversation is finished — shipped into the app, or set aside — it lands here.",
+  },
+  archived: {
+    title: "Nothing archived",
+    text: "Conversations you set aside — abandoned, or not doable — land here. You can restore any of them.",
   },
 };
 
@@ -130,6 +136,9 @@ export function ContributeListScreen() {
   const visible = useMemo(() => {
     const items = contributions ?? [];
     const filtered = items.filter((item) => {
+      // Archived items live only in their own tab, out of the active ones.
+      if (segment === "archived") return isArchived(item);
+      if (isArchived(item)) return false;
       if (segment === "yourTurn") return isYourTurn(item);
       // "Done" = terminal conversations, shipped or set aside.
       if (segment === "done")

--- a/apps/mobile/features/contribute/components/ContributeListScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributeListScreen.tsx
@@ -66,7 +66,7 @@ const EMPTY_COPY: Record<Segment, { title: string; text: string }> = {
   },
   archived: {
     title: "Nothing archived",
-    text: "Conversations you set aside — abandoned, or not doable — land here. You can restore any of them.",
+    text: "Conversations set aside — abandoned, or not doable — land here. You can restore any of them.",
   },
 };
 

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -394,14 +394,18 @@ export function ContributionDetailScreen() {
     );
   }
 
-  const showApproveSpec = needsSpecApproval(contribution);
+  // Archiving pauses the item — hide every forward action and the composer
+  // until it's restored (the backend rejects these on archived items too).
+  const archived = !!contribution.archivedAt;
+  const showApproveSpec = !archived && needsSpecApproval(contribution);
   // Non-buildable scopes can't enter the build pipeline (the backend rejects
   // them too) — keep the UI consistent with the "Too big for one build" card.
   const showStartBuild =
+    !archived &&
     !!contribution.specApprovedAt &&
     contribution.status === "IN_REVIEW" &&
     isBuildableScope(contribution.scope);
-  const showStagingCard = needsStagingVerify(contribution);
+  const showStagingCard = !archived && needsStagingVerify(contribution);
   const awaitingSpec =
     (contribution.status === "DRAFT" || contribution.status === "IN_REVIEW") &&
     !contribution.spec;
@@ -701,6 +705,15 @@ export function ContributionDetailScreen() {
         )}
       </ScrollView>
 
+      {archived ? (
+        <View style={[styles.archivedComposer, { borderTopColor: colors.border }]}>
+          <Ionicons name="archive" size={16} color={colors.textTertiary} />
+          <Text style={[styles.archivedComposerText, { color: colors.textTertiary }]}>
+            This conversation is archived. Restore it to continue.
+          </Text>
+        </View>
+      ) : (
+        <>
       {composerHint ? (
         <Text style={[styles.composerHint, { color: colors.textTertiary }]}>
           {composerHint}
@@ -757,6 +770,8 @@ export function ContributionDetailScreen() {
           <Ionicons name="arrow-up" size={18} color="#ffffff" />
         </TouchableOpacity>
       </View>
+        </>
+      )}
     </KeyboardAvoidingView>
   );
 }
@@ -896,6 +911,16 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
   archiveText: { fontSize: 14, fontWeight: "500" },
+  archivedComposer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  archivedComposerText: { fontSize: 13, textAlign: "center" },
   archivedPill: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -106,7 +106,12 @@ function SpecCard({ contribution }: { contribution: Contribution }) {
   );
 }
 
-/** One proposed slice with a button that copies its build prompt. */
+/**
+ * One proposed slice: its title, the full build prompt (shown so the
+ * maintainer can read exactly what they're about to paste into a dev session —
+ * it's AI-generated from a contributor's report, so it shouldn't be copied
+ * blind), and a button to copy it.
+ */
 function SliceRow({ slice, index }: { slice: SplitSlice; index: number }) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
@@ -124,24 +129,35 @@ function SliceRow({ slice, index }: { slice: SplitSlice; index: number }) {
 
   return (
     <View style={[styles.sliceRow, { borderColor: colors.border }]}>
-      <Text style={[styles.sliceTitle, { color: colors.text }]}>
-        {index + 1}. {slice.title}
-      </Text>
-      <TouchableOpacity
-        style={[styles.copyButton, { borderColor: primaryColor }]}
-        onPress={handleCopy}
-        activeOpacity={0.7}
-        accessibilityLabel={`Copy build prompt for ${slice.title}`}
-      >
-        <Ionicons
-          name={copied ? "checkmark" : "copy-outline"}
-          size={15}
-          color={primaryColor}
-        />
-        <Text style={[styles.copyButtonText, { color: primaryColor }]}>
-          {copied ? "Copied" : "Copy prompt"}
+      <View style={styles.sliceHeader}>
+        <Text style={[styles.sliceTitle, { color: colors.text }]}>
+          {index + 1}. {slice.title}
         </Text>
-      </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.copyButton, { borderColor: primaryColor }]}
+          onPress={handleCopy}
+          activeOpacity={0.7}
+          accessibilityLabel={`Copy build prompt for ${slice.title}`}
+        >
+          <Ionicons
+            name={copied ? "checkmark" : "copy-outline"}
+            size={15}
+            color={primaryColor}
+          />
+          <Text style={[styles.copyButtonText, { color: primaryColor }]}>
+            {copied ? "Copied" : "Copy prompt"}
+          </Text>
+        </TouchableOpacity>
+      </View>
+      <Text
+        style={[
+          styles.slicePrompt,
+          { color: colors.textSecondary, backgroundColor: colors.background, borderColor: colors.border },
+        ]}
+        selectable
+      >
+        {slice.prompt}
+      </Text>
     </View>
   );
 }
@@ -278,9 +294,9 @@ export function ContributionDetailScreen() {
     const imageUrls = images.storagePaths;
     // A picture-only message is valid; require text otherwise.
     if (!body && imageUrls.length === 0) return;
-    // Optimistic clear — restore the draft if the send fails.
+    // Optimistic clear of the text; keep the attachments until the send
+    // succeeds so a failure doesn't silently lose the uploaded pictures.
     setDraft("");
-    images.reset();
     setSending(true);
     try {
       await postMessage({
@@ -288,6 +304,7 @@ export function ContributionDetailScreen() {
         body,
         ...(imageUrls.length > 0 ? { imageUrls } : {}),
       });
+      images.reset();
     } catch (error) {
       setDraft(body);
       Alert.alert("Couldn't send", formatError(error));
@@ -714,15 +731,25 @@ const styles = StyleSheet.create({
   },
   specSubtitle: { fontSize: 13, lineHeight: 19 },
   sliceRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 10,
+    gap: 8,
     borderTopWidth: StyleSheet.hairlineWidth,
     paddingTop: 10,
     marginTop: 2,
   },
+  sliceHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
   sliceTitle: { flex: 1, fontSize: 14, fontWeight: "600" },
+  slicePrompt: {
+    fontSize: 12,
+    lineHeight: 17,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    padding: 10,
+  },
   copyButton: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -29,6 +29,7 @@ import {
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import * as Clipboard from "expo-clipboard";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { Markdown } from "@components/ui/Markdown";
@@ -37,6 +38,7 @@ import type { Id } from "@services/api/convex";
 import { useDevAccess } from "../hooks/useDevAccess";
 import { useContribution } from "../hooks/useContribution";
 import { useThread } from "../hooks/useThread";
+import { useImageAttachments } from "../hooks/useImageAttachments";
 import {
   useApproveSpec,
   useConfirmStaging,
@@ -52,9 +54,10 @@ import {
   needsStagingVerify,
   PALETTE,
 } from "../utils/status";
+import { AttachmentStrip } from "./AttachmentStrip";
 import { FromChatTag, KindPill, RiskBadge, StatusChip } from "./ContributionBadges";
 import { SystemCaption, ThreadMessageBubble, UserBubble } from "./ThreadBubbles";
-import type { Contribution } from "../types";
+import type { Contribution, SplitSlice } from "../types";
 
 /**
  * The latest AI plan, rendered once at the bottom of the thread. When the AI
@@ -103,6 +106,80 @@ function SpecCard({ contribution }: { contribution: Contribution }) {
   );
 }
 
+/** One proposed slice with a button that copies its build prompt. */
+function SliceRow({ slice, index }: { slice: SplitSlice; index: number }) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await Clipboard.setStringAsync(slice.prompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      Alert.alert("Couldn't copy", formatError(error));
+    }
+  }, [slice.prompt]);
+
+  return (
+    <View style={[styles.sliceRow, { borderColor: colors.border }]}>
+      <Text style={[styles.sliceTitle, { color: colors.text }]}>
+        {index + 1}. {slice.title}
+      </Text>
+      <TouchableOpacity
+        style={[styles.copyButton, { borderColor: primaryColor }]}
+        onPress={handleCopy}
+        activeOpacity={0.7}
+        accessibilityLabel={`Copy build prompt for ${slice.title}`}
+      >
+        <Ionicons
+          name={copied ? "checkmark" : "copy-outline"}
+          size={15}
+          color={primaryColor}
+        />
+        <Text style={[styles.copyButtonText, { color: primaryColor }]}>
+          {copied ? "Copied" : "Copy prompt"}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+/**
+ * For a "split" item: the buildable slices the AI proposed, each with a
+ * copy-the-prompt button so a maintainer can paste it straight into a fresh
+ * dev session and build that slice on its own.
+ */
+function SplitSlicesCard({ contribution }: { contribution: Contribution }) {
+  const { colors } = useTheme();
+  const slices = contribution.splitSlices;
+  if (!slices || slices.length === 0) return null;
+
+  return (
+    <View
+      style={[
+        styles.specCard,
+        { backgroundColor: colors.surface, borderColor: PALETTE.aiWorking },
+      ]}
+    >
+      <View style={styles.specHeader}>
+        <Ionicons name="albums-outline" size={16} color={PALETTE.aiWorking} />
+        <Text style={[styles.specHeaderText, { color: PALETTE.aiWorking }]}>
+          Build it in {slices.length} pieces
+        </Text>
+      </View>
+      <Text style={[styles.specSubtitle, { color: colors.textSecondary }]}>
+        Copy any piece's prompt and paste it into a new dev session to build
+        that piece on its own.
+      </Text>
+      {slices.map((slice, index) => (
+        <SliceRow key={index} slice={slice} index={index} />
+      ))}
+    </View>
+  );
+}
+
 export function ContributionDetailScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -129,6 +206,7 @@ export function ContributionDetailScreen() {
   const [issueMode, setIssueMode] = useState(false);
   const [issueNote, setIssueNote] = useState("");
   const scrollRef = useRef<ScrollView>(null);
+  const images = useImageAttachments();
 
   const handleApprove = useCallback(() => {
     if (!id) return;
@@ -195,21 +273,28 @@ export function ContributionDetailScreen() {
   }, [id, issueNote, reportStagingIssue]);
 
   const handleSend = useCallback(async () => {
-    if (!id || sending) return;
+    if (!id || sending || images.uploading) return;
     const body = draft.trim();
-    if (!body) return;
+    const imageUrls = images.storagePaths;
+    // A picture-only message is valid; require text otherwise.
+    if (!body && imageUrls.length === 0) return;
     // Optimistic clear — restore the draft if the send fails.
     setDraft("");
+    images.reset();
     setSending(true);
     try {
-      await postMessage({ id, body });
+      await postMessage({
+        id,
+        body,
+        ...(imageUrls.length > 0 ? { imageUrls } : {}),
+      });
     } catch (error) {
       setDraft(body);
       Alert.alert("Couldn't send", formatError(error));
     } finally {
       setSending(false);
     }
-  }, [id, draft, sending, postMessage]);
+  }, [id, draft, sending, postMessage, images]);
 
   /**
    * The original report opens the thread. The backend may also seed it as the
@@ -273,6 +358,13 @@ export function ContributionDetailScreen() {
       : null
     : "Notes here are saved to the conversation for the team — the AI builder doesn't read them mid-build";
 
+  // Send is enabled with text OR at least one uploaded picture, and never
+  // while a picture is still uploading.
+  const canSend =
+    (draft.trim().length > 0 || images.storagePaths.length > 0) &&
+    !sending &&
+    !images.uploading;
+
   const reportBody = contribution.repro
     ? `${contribution.body}\n\nHow to see it: ${contribution.repro}`
     : contribution.body;
@@ -309,7 +401,12 @@ export function ContributionDetailScreen() {
           <UserBubble body={reportBody} createdAt={contribution.createdAt} />
         ) : null}
 
-        {contribution.screenshotUrls && contribution.screenshotUrls.length > 0 ? (
+        {/* Chat-originated items keep resolved screenshot URLs on the row;
+            dashboard items show their pictures inline in the thread bubbles
+            (the opening message carries them), so only render this for chat. */}
+        {isFromChat(contribution) &&
+        contribution.screenshotUrls &&
+        contribution.screenshotUrls.length > 0 ? (
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -334,6 +431,8 @@ export function ContributionDetailScreen() {
         ) : null}
 
         {contribution.spec ? <SpecCard contribution={contribution} /> : null}
+
+        <SplitSlicesCard contribution={contribution} />
 
         {showApproveSpec ? (
           <View style={styles.actionBlock}>
@@ -514,6 +613,11 @@ export function ContributionDetailScreen() {
           {composerHint}
         </Text>
       ) : null}
+      {images.attachments.length > 0 ? (
+        <View style={styles.composerAttachments}>
+          <AttachmentStrip attachments={images.attachments} onRemove={images.remove} />
+        </View>
+      ) : null}
       <View
         style={[
           styles.composer,
@@ -524,6 +628,14 @@ export function ContributionDetailScreen() {
           },
         ]}
       >
+        <TouchableOpacity
+          style={styles.attachIcon}
+          onPress={images.pick}
+          activeOpacity={0.7}
+          accessibilityLabel="Attach a picture"
+        >
+          <Ionicons name="image-outline" size={22} color={colors.textSecondary} />
+        </TouchableOpacity>
         <TextInput
           style={[
             styles.composerInput,
@@ -542,10 +654,10 @@ export function ContributionDetailScreen() {
           style={[
             styles.sendButton,
             { backgroundColor: primaryColor },
-            (!draft.trim() || sending) && styles.buttonDisabled,
+            !canSend && styles.buttonDisabled,
           ]}
           onPress={handleSend}
-          disabled={!draft.trim() || sending}
+          disabled={!canSend}
           activeOpacity={0.8}
           accessibilityLabel="Send message"
         >
@@ -601,6 +713,26 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
   },
   specSubtitle: { fontSize: 13, lineHeight: 19 },
+  sliceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingTop: 10,
+    marginTop: 2,
+  },
+  sliceTitle: { flex: 1, fontSize: 14, fontWeight: "600" },
+  copyButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    borderWidth: 1,
+    borderRadius: 9,
+    paddingVertical: 7,
+    paddingHorizontal: 11,
+  },
+  copyButtonText: { fontSize: 13, fontWeight: "600" },
   hint: { fontSize: 13, lineHeight: 19 },
   actionBlock: { marginTop: 14, gap: 10 },
   primaryButton: {
@@ -656,6 +788,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingBottom: 4,
   },
+  composerAttachments: { paddingHorizontal: 12 },
   composer: {
     flexDirection: "row",
     alignItems: "flex-end",
@@ -663,6 +796,14 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     paddingHorizontal: 12,
     paddingTop: 8,
+  },
+  attachIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 1,
   },
   composerInput: {
     flex: 1,

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -41,10 +41,12 @@ import { useThread } from "../hooks/useThread";
 import { useImageAttachments } from "../hooks/useImageAttachments";
 import {
   useApproveSpec,
+  useArchiveContribution,
   useConfirmStaging,
   usePostMessage,
   useReportStagingIssue,
   useStartBuild,
+  useUnarchiveContribution,
 } from "../hooks/useContributionMutations";
 import {
   displayTitle,
@@ -215,6 +217,8 @@ export function ContributionDetailScreen() {
   const postMessage = usePostMessage();
   const confirmStaging = useConfirmStaging();
   const reportStagingIssue = useReportStagingIssue();
+  const archiveContribution = useArchiveContribution();
+  const unarchiveContribution = useUnarchiveContribution();
 
   const [busy, setBusy] = useState(false);
   const [draft, setDraft] = useState("");
@@ -313,6 +317,43 @@ export function ContributionDetailScreen() {
     }
   }, [id, draft, sending, postMessage, images]);
 
+  const handleArchive = useCallback(() => {
+    if (!id) return;
+    Alert.alert(
+      "Archive this conversation?",
+      "It moves to your Archived tab and leaves the active list. You can restore it anytime.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Archive",
+          style: "destructive",
+          onPress: async () => {
+            setBusy(true);
+            try {
+              await archiveContribution({ id });
+            } catch (error) {
+              Alert.alert("Couldn't archive", formatError(error));
+            } finally {
+              setBusy(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [id, archiveContribution]);
+
+  const handleUnarchive = useCallback(async () => {
+    if (!id) return;
+    setBusy(true);
+    try {
+      await unarchiveContribution({ id });
+    } catch (error) {
+      Alert.alert("Couldn't restore", formatError(error));
+    } finally {
+      setBusy(false);
+    }
+  }, [id, unarchiveContribution]);
+
   /**
    * The original report opens the thread. The backend may also seed it as the
    * first thread message — skip the synthetic bubble when it does.
@@ -406,6 +447,14 @@ export function ContributionDetailScreen() {
         <StatusChip contribution={contribution} />
         {contribution.riskLevel ? <RiskBadge risk={contribution.riskLevel} /> : null}
         {isFromChat(contribution) ? <FromChatTag /> : null}
+        {contribution.archivedAt ? (
+          <View style={[styles.archivedPill, { backgroundColor: colors.surfaceSecondary }]}>
+            <Ionicons name="archive" size={11} color={colors.textSecondary} />
+            <Text style={[styles.archivedPillText, { color: colors.textSecondary }]}>
+              Archived
+            </Text>
+          </View>
+        ) : null}
       </View>
 
       <ScrollView
@@ -623,6 +672,33 @@ export function ContributionDetailScreen() {
             <Ionicons name="open-outline" size={16} color={colors.iconSecondary} />
           </TouchableOpacity>
         ) : null}
+
+        {/* Archive / restore — abandon a conversation or bring it back. */}
+        {contribution.archivedAt ? (
+          <TouchableOpacity
+            style={[styles.archiveRow, { borderColor: colors.border }]}
+            onPress={handleUnarchive}
+            disabled={busy}
+            activeOpacity={0.7}
+          >
+            <Ionicons name="arrow-undo-outline" size={16} color={colors.textSecondary} />
+            <Text style={[styles.archiveText, { color: colors.textSecondary }]}>
+              Restore this conversation
+            </Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={[styles.archiveRow, { borderColor: colors.border }]}
+            onPress={handleArchive}
+            disabled={busy}
+            activeOpacity={0.7}
+          >
+            <Ionicons name="archive-outline" size={16} color={colors.textSecondary} />
+            <Text style={[styles.archiveText, { color: colors.textSecondary }]}>
+              Archive this conversation
+            </Text>
+          </TouchableOpacity>
+        )}
       </ScrollView>
 
       {composerHint ? (
@@ -809,6 +885,26 @@ const styles = StyleSheet.create({
     marginTop: 14,
   },
   linkText: { fontSize: 14, flex: 1 },
+  archiveRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingVertical: 11,
+    marginTop: 20,
+  },
+  archiveText: { fontSize: 14, fontWeight: "500" },
+  archivedPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+  },
+  archivedPillText: { fontSize: 11, fontWeight: "700" },
   composerHint: {
     fontSize: 11,
     textAlign: "center",

--- a/apps/mobile/features/contribute/components/SubmitContributionScreen.tsx
+++ b/apps/mobile/features/contribute/components/SubmitContributionScreen.tsx
@@ -1,12 +1,11 @@
 /**
  * SubmitContributionScreen — start a conversation with the AI builder
- * (ADR-029 Phase 1.5).
+ * (ADR-029 Phase 1.5, chat-first filing).
  *
- * Deliberately non-technical: contributors describe what they saw (or what
- * they want) in their own words; the AI spec agent does the investigation
- * and replies in the conversation thread. Screenshots are omitted in v1 —
- * the existing chat upload flow returns r2: storage paths, not the public
- * URLs this contract expects.
+ * Deliberately non-technical and low-friction: contributors pick bug vs.
+ * feature, then just describe the thing in one message and optionally attach
+ * screenshots — no title/repro form. The AI spec agent investigates, writes a
+ * headline, and replies in the conversation thread.
  */
 import React, { useState } from "react";
 import {
@@ -28,6 +27,8 @@ import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { formatError } from "@/utils/error-handling";
 import { useSubmitContribution } from "../hooks/useContributionMutations";
+import { useImageAttachments } from "../hooks/useImageAttachments";
+import { AttachmentStrip } from "./AttachmentStrip";
 import type { ContributionKind } from "../types";
 
 export function SubmitContributionScreen() {
@@ -36,14 +37,15 @@ export function SubmitContributionScreen() {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const submit = useSubmitContribution();
+  const images = useImageAttachments();
 
   const [kind, setKind] = useState<ContributionKind>("bug");
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-  const [repro, setRepro] = useState("");
+  const [message, setMessage] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  const canSubmit = title.trim().length > 0 && body.trim().length > 0 && !submitting;
+  const hasContent =
+    message.trim().length > 0 || images.storagePaths.length > 0;
+  const canSubmit = hasContent && !submitting && !images.uploading;
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
@@ -51,9 +53,10 @@ export function SubmitContributionScreen() {
     try {
       const id = await submit({
         kind,
-        title: title.trim(),
-        body: body.trim(),
-        ...(repro.trim() ? { repro: repro.trim() } : {}),
+        body: message.trim(),
+        ...(images.storagePaths.length > 0
+          ? { screenshotUrls: images.storagePaths }
+          : {}),
       });
       // Land on the new item's detail screen instead of back on the form.
       router.replace(`/(user)/contribute/${id}`);
@@ -62,15 +65,6 @@ export function SubmitContributionScreen() {
       setSubmitting(false);
     }
   };
-
-  const inputStyle = [
-    styles.input,
-    {
-      backgroundColor: colors.surface,
-      borderColor: colors.border,
-      color: colors.text,
-    },
-  ];
 
   return (
     <KeyboardAvoidingView
@@ -92,13 +86,11 @@ export function SubmitContributionScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <Text style={[styles.intro, { color: colors.textSecondary }]}>
-          Start a conversation — describe what you saw or what you want, and
-          the AI replies with a plan you can chat about.
+          Just describe it in your own words — what you saw or what you want.
+          Add screenshots if they help. The AI reads it, drafts a plan, and
+          replies here so you can chat it through.
         </Text>
 
-        <Text style={[styles.label, { color: colors.textSecondary }]}>
-          What's this about?
-        </Text>
         <View style={[styles.kindToggle, { backgroundColor: colors.surfaceSecondary }]}>
           {(
             [
@@ -135,53 +127,40 @@ export function SubmitContributionScreen() {
           })}
         </View>
 
-        <Text style={[styles.label, { color: colors.textSecondary }]}>Title</Text>
         <TextInput
-          style={inputStyle}
-          value={title}
-          onChangeText={setTitle}
-          placeholder={
-            kind === "bug" ? "e.g. Event photos won't open" : "e.g. Let me RSVP for my kids"
-          }
-          placeholderTextColor={colors.textTertiary}
-          maxLength={120}
-        />
-
-        <Text style={[styles.label, { color: colors.textSecondary }]}>
-          {kind === "bug" ? "What happened, and what did you expect?" : "What should happen?"}
-        </Text>
-        <TextInput
-          style={[...inputStyle, styles.multiline]}
-          value={body}
-          onChangeText={setBody}
+          style={[
+            styles.input,
+            {
+              backgroundColor: colors.surface,
+              borderColor: colors.border,
+              color: colors.text,
+            },
+          ]}
+          value={message}
+          onChangeText={setMessage}
           placeholder={
             kind === "bug"
-              ? "Describe what went wrong in your own words — no technical detail needed."
-              : "Describe the idea and why it would help — no technical detail needed."
+              ? "What went wrong? Where did you see it? No technical detail needed."
+              : "What should happen, and why would it help? No technical detail needed."
           }
           placeholderTextColor={colors.textTertiary}
           multiline
           textAlignVertical="top"
+          autoFocus
         />
 
-        <Text style={[styles.label, { color: colors.textSecondary }]}>
-          How to see it (optional)
-        </Text>
-        <TextInput
-          style={[...inputStyle, styles.multiline]}
-          value={repro}
-          onChangeText={setRepro}
-          placeholder="Where in the app would we look? e.g. Open a group, tap Events, then…"
-          placeholderTextColor={colors.textTertiary}
-          multiline
-          textAlignVertical="top"
-        />
+        <AttachmentStrip attachments={images.attachments} onRemove={images.remove} />
 
-        <Text style={[styles.hint, { color: colors.textTertiary }]}>
-          The AI reads this, drafts a plan, and replies in the conversation.
-          You'll confirm the plan says what you meant before anything is built
-          — and you can keep chatting to refine it.
-        </Text>
+        <TouchableOpacity
+          style={styles.attachButton}
+          onPress={images.pick}
+          activeOpacity={0.7}
+        >
+          <Ionicons name="image-outline" size={18} color={primaryColor} />
+          <Text style={[styles.attachButtonText, { color: primaryColor }]}>
+            Add screenshots
+          </Text>
+        </TouchableOpacity>
 
         <TouchableOpacity
           style={[
@@ -196,7 +175,9 @@ export function SubmitContributionScreen() {
           {submitting ? (
             <ActivityIndicator color="#ffffff" />
           ) : (
-            <Text style={styles.submitButtonText}>Start conversation</Text>
+            <Text style={styles.submitButtonText}>
+              {images.uploading ? "Uploading…" : "Start conversation"}
+            </Text>
           )}
         </TouchableOpacity>
       </ScrollView>
@@ -216,20 +197,13 @@ const styles = StyleSheet.create({
   backBtn: { width: 40, height: 40, justifyContent: "center", alignItems: "center" },
   headerTitle: { fontSize: 17, fontWeight: "600" },
   scroll: { padding: 16, paddingBottom: 48 },
-  intro: { fontSize: 14, lineHeight: 21 },
-  label: {
-    fontSize: 12,
-    fontWeight: "700",
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
-    marginTop: 20,
-    marginBottom: 6,
-  },
+  intro: { fontSize: 14, lineHeight: 21, marginBottom: 18 },
   kindToggle: {
     flexDirection: "row",
     borderRadius: 12,
     padding: 4,
     gap: 4,
+    marginBottom: 16,
   },
   kindOption: {
     flex: 1,
@@ -249,9 +223,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 10,
     fontSize: 15,
+    minHeight: 140,
+    paddingTop: 10,
   },
-  multiline: { minHeight: 110, paddingTop: 10 },
-  hint: { fontSize: 13, lineHeight: 19, marginTop: 20 },
+  attachButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    alignSelf: "flex-start",
+    paddingVertical: 10,
+    marginTop: 4,
+  },
+  attachButtonText: { fontSize: 14, fontWeight: "600" },
   submitButton: {
     alignItems: "center",
     justifyContent: "center",

--- a/apps/mobile/features/contribute/components/ThreadBubbles.tsx
+++ b/apps/mobile/features/contribute/components/ThreadBubbles.tsx
@@ -9,7 +9,7 @@
  * chat plumbing.
  */
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, Image, StyleSheet } from "react-native";
 import { format } from "date-fns";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
@@ -21,13 +21,43 @@ function bubbleTime(createdAt: number): string {
   return format(new Date(createdAt), "MMM d, h:mm a");
 }
 
-/** The contributor's own message — right-aligned, chat "own" bubble color. */
-export function UserBubble({ body, createdAt }: { body: string; createdAt?: number }) {
+/** Attached pictures on a contributor message, stacked above the text. */
+function BubbleImages({ imageUrls }: { imageUrls: string[] }) {
   const { colors } = useTheme();
+  return (
+    <View style={styles.imageStack}>
+      {imageUrls.map((uri) => (
+        <Image
+          key={uri}
+          source={{ uri }}
+          style={[styles.bubbleImage, { backgroundColor: colors.surfaceSecondary }]}
+          resizeMode="contain"
+          accessibilityLabel="Attached screenshot"
+        />
+      ))}
+    </View>
+  );
+}
+
+/** The contributor's own message — right-aligned, chat "own" bubble color. */
+export function UserBubble({
+  body,
+  createdAt,
+  imageUrls,
+}: {
+  body: string;
+  createdAt?: number;
+  imageUrls?: string[];
+}) {
+  const { colors } = useTheme();
+  const hasImages = !!imageUrls && imageUrls.length > 0;
   return (
     <View style={styles.userRow}>
       <View style={[styles.bubble, styles.userBubble, { backgroundColor: colors.chatBubbleOwn }]}>
-        <Text style={[styles.bodyText, { color: colors.chatBubbleOwnText }]}>{body}</Text>
+        {hasImages ? <BubbleImages imageUrls={imageUrls} /> : null}
+        {body ? (
+          <Text style={[styles.bodyText, { color: colors.chatBubbleOwnText }]}>{body}</Text>
+        ) : null}
         {createdAt ? (
           <Text style={[styles.timeText, { color: colors.textSecondary }]}>
             {bubbleTime(createdAt)}
@@ -86,7 +116,13 @@ export function SystemCaption({ body, createdAt }: { body: string; createdAt?: n
 export function ThreadMessageBubble({ message }: { message: ThreadMessage }) {
   switch (message.authorType) {
     case "user":
-      return <UserBubble body={message.body} createdAt={message.createdAt} />;
+      return (
+        <UserBubble
+          body={message.body}
+          createdAt={message.createdAt}
+          imageUrls={message.imageUrls}
+        />
+      );
     case "assistant":
       return <AssistantBubble body={message.body} createdAt={message.createdAt} />;
     case "system":
@@ -103,6 +139,8 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   bodyText: { fontSize: 15, lineHeight: 21 },
+  imageStack: { gap: 6, marginBottom: 6 },
+  bubbleImage: { width: 220, height: 260, borderRadius: 10 },
   timeText: { fontSize: 10, marginTop: 4, alignSelf: "flex-end" },
   userRow: { alignItems: "flex-end", marginTop: 10 },
   userBubble: { borderBottomRightRadius: 3 },

--- a/apps/mobile/features/contribute/components/index.ts
+++ b/apps/mobile/features/contribute/components/index.ts
@@ -4,4 +4,5 @@ export * from "./SubmitContributionScreen";
 export * from "./ContributionDetailScreen";
 export * from "./ContributionBadges";
 export * from "./ThreadBubbles";
+export * from "./AttachmentStrip";
 export * from "./GithubCreditRow";

--- a/apps/mobile/features/contribute/hooks/index.ts
+++ b/apps/mobile/features/contribute/hooks/index.ts
@@ -4,4 +4,5 @@ export * from "./useMyContributions";
 export * from "./useContribution";
 export * from "./useThread";
 export * from "./useContributionMutations";
+export * from "./useImageAttachments";
 export * from "./useGithubUsername";

--- a/apps/mobile/features/contribute/hooks/useContributionMutations.ts
+++ b/apps/mobile/features/contribute/hooks/useContributionMutations.ts
@@ -44,3 +44,13 @@ export function useConfirmStaging() {
 export function useReportStagingIssue() {
   return useAuthenticatedMutation(contributions.reportStagingIssue);
 }
+
+/** Archive (set aside) a conversation the contributor is abandoning. */
+export function useArchiveContribution() {
+  return useAuthenticatedMutation(contributions.archive);
+}
+
+/** Restore an archived conversation to the active dashboard. */
+export function useUnarchiveContribution() {
+  return useAuthenticatedMutation(contributions.unarchive);
+}

--- a/apps/mobile/features/contribute/hooks/useImageAttachments.ts
+++ b/apps/mobile/features/contribute/hooks/useImageAttachments.ts
@@ -1,0 +1,110 @@
+/**
+ * Pick + upload pictures for the contribute composer (ADR-029 chat-first
+ * filing). Wraps expo-image-picker and the chat feature's R2 upload hook so
+ * both the submit screen and the conversation reply box share one flow.
+ *
+ * Attachments upload as they're picked; `storagePaths` are the successfully
+ * uploaded R2 paths ("r2:…") to hand to submit/postMessage. Local URIs drive
+ * the optimistic thumbnails while uploads are in flight.
+ */
+import { useCallback, useRef, useState } from "react";
+import { Alert } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { useImageUpload } from "@features/chat/hooks/useImageUpload";
+
+export interface ImageAttachment {
+  /** Stable local id for keys/removal. */
+  id: string;
+  /** Local device URI — shown as the thumbnail while (and after) uploading. */
+  localUri: string;
+  /** R2 storage path once uploaded; undefined while in flight or on failure. */
+  storagePath?: string;
+  uploading: boolean;
+  failed: boolean;
+}
+
+export interface UseImageAttachments {
+  attachments: ImageAttachment[];
+  /** Open the library and upload the chosen pictures. */
+  pick: () => Promise<void>;
+  remove: (id: string) => void;
+  reset: () => void;
+  /** True while any attachment is still uploading. */
+  uploading: boolean;
+  /** R2 paths for the successfully uploaded pictures. */
+  storagePaths: string[];
+}
+
+export function useImageAttachments(): UseImageAttachments {
+  const { uploadImage } = useImageUpload();
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const nextId = useRef(0);
+
+  const pick = useCallback(async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      allowsMultipleSelection: true,
+      selectionLimit: 6,
+      quality: 0.8,
+    });
+    if (result.canceled) return;
+
+    const picked = result.assets.map((asset) => {
+      const id = `att-${nextId.current++}`;
+      return { id, localUri: asset.uri };
+    });
+    setAttachments((prev) => [
+      ...prev,
+      ...picked.map((p) => ({
+        id: p.id,
+        localUri: p.localUri,
+        uploading: true,
+        failed: false,
+      })),
+    ]);
+
+    await Promise.all(
+      picked.map(async ({ id, localUri }) => {
+        try {
+          const { url, error } = await uploadImage(localUri);
+          setAttachments((prev) =>
+            prev.map((a) =>
+              a.id === id
+                ? error
+                  ? { ...a, uploading: false, failed: true }
+                  : { ...a, uploading: false, storagePath: url }
+                : a,
+            ),
+          );
+          if (error) {
+            Alert.alert("Upload failed", "That picture couldn't be uploaded.");
+          }
+        } catch {
+          setAttachments((prev) =>
+            prev.map((a) =>
+              a.id === id ? { ...a, uploading: false, failed: true } : a,
+            ),
+          );
+          Alert.alert("Upload failed", "That picture couldn't be uploaded.");
+        }
+      }),
+    );
+  }, [uploadImage]);
+
+  const remove = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  }, []);
+
+  const reset = useCallback(() => setAttachments([]), []);
+
+  return {
+    attachments,
+    pick,
+    remove,
+    reset,
+    uploading: attachments.some((a) => a.uploading),
+    storagePaths: attachments
+      .filter((a) => a.storagePath)
+      .map((a) => a.storagePath as string),
+  };
+}

--- a/apps/mobile/features/contribute/types.ts
+++ b/apps/mobile/features/contribute/types.ts
@@ -34,6 +34,15 @@ export type ContributionScope = "buildable" | "split" | "design_needed";
 /** Who wrote a thread message. */
 export type MessageAuthorType = "user" | "assistant" | "system";
 
+/**
+ * One buildable slice of a "split" contribution — a short title plus a
+ * self-contained prompt a maintainer can paste into a fresh dev session.
+ */
+export interface SplitSlice {
+  title: string;
+  prompt: string;
+}
+
 /** A devBugs doc as returned by the contributions queries. */
 export interface Contribution {
   _id: Id<"devBugs">;
@@ -57,6 +66,11 @@ export interface Contribution {
   area?: string;
   /** AI scope verdict — unset counts as "buildable". */
   scope?: ContributionScope;
+  /**
+   * For "split" items: the buildable slices the AI proposed, each with a
+   * copy-paste-ready prompt for a fresh dev session (ADR-029).
+   */
+  splitSlices?: SplitSlice[];
   /** True when the contributor should try the change on staging before merge. */
   verifyOnStaging?: boolean;
   /** Set once the contributor confirmed the change works on staging. */
@@ -85,6 +99,8 @@ export interface ThreadMessage {
   authorType: MessageAuthorType;
   userId?: string;
   body: string;
+  /** Pictures on a "user" message, resolved to public URLs by getThread. */
+  imageUrls?: string[];
   createdAt: number;
 }
 

--- a/apps/mobile/features/contribute/types.ts
+++ b/apps/mobile/features/contribute/types.ts
@@ -78,6 +78,8 @@ export interface Contribution {
   prUrl?: string;
   githubIssueUrl?: string;
   screenshotUrls?: string[];
+  /** Set when the contributor set the conversation aside (abandoned/not doable). */
+  archivedAt?: number;
   createdAt: number;
   updatedAt: number;
   shippedAt?: number;

--- a/apps/mobile/features/contribute/utils/status.test.ts
+++ b/apps/mobile/features/contribute/utils/status.test.ts
@@ -57,4 +57,26 @@ describe("isInProgress", () => {
   it("is true for a submitted item still being reviewed (IN_REVIEW, no spec)", () => {
     expect(isInProgress(make({ status: "IN_REVIEW" }))).toBe(true);
   });
+
+  it("routes human-gated IN_REVIEW states to Your turn, not In progress", () => {
+    // A split item awaits the maintainer copying its slice prompts.
+    const split = make({ status: "IN_REVIEW", spec: "## Plan", scope: "split" });
+    expect(isYourTurn(split)).toBe(true);
+    expect(isInProgress(split)).toBe(false);
+
+    // A design_needed item awaits a maintainer decision.
+    const design = make({ status: "IN_REVIEW", spec: "## Plan", scope: "design_needed" });
+    expect(isYourTurn(design)).toBe(true);
+    expect(isInProgress(design)).toBe(false);
+
+    // An approved buildable item awaiting an explicit "Start build" tap.
+    const approved = make({
+      status: "IN_REVIEW",
+      spec: "## Plan",
+      scope: "buildable",
+      specApprovedAt: 123,
+    });
+    expect(isYourTurn(approved)).toBe(true);
+    expect(isInProgress(approved)).toBe(false);
+  });
 });

--- a/apps/mobile/features/contribute/utils/status.test.ts
+++ b/apps/mobile/features/contribute/utils/status.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the contribution status helpers — focused on isInProgress,
  * which powers the "In progress" tab (ADR-029 follow-up).
  */
-import { isInProgress, isYourTurn } from "./status";
+import { isArchived, isInProgress, isYourTurn } from "./status";
 import type { Contribution } from "../types";
 
 type StatusInput = Pick<
@@ -78,5 +78,13 @@ describe("isInProgress", () => {
     });
     expect(isYourTurn(approved)).toBe(true);
     expect(isInProgress(approved)).toBe(false);
+  });
+});
+
+describe("isArchived", () => {
+  it("is true only when archivedAt is set", () => {
+    expect(isArchived({})).toBe(false);
+    expect(isArchived({ archivedAt: undefined })).toBe(false);
+    expect(isArchived({ archivedAt: 123 })).toBe(true);
   });
 });

--- a/apps/mobile/features/contribute/utils/status.test.ts
+++ b/apps/mobile/features/contribute/utils/status.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the contribution status helpers — focused on isInProgress,
+ * which powers the "In progress" tab (ADR-029 follow-up).
+ */
+import { isInProgress, isYourTurn } from "./status";
+import type { Contribution } from "../types";
+
+type StatusInput = Pick<
+  Contribution,
+  "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
+>;
+
+function make(overrides: Partial<StatusInput> & Pick<StatusInput, "status">): StatusInput {
+  return { ...overrides };
+}
+
+describe("isInProgress", () => {
+  it("is true while the AI is drafting the spec (DRAFT, no spec yet)", () => {
+    expect(isInProgress(make({ status: "DRAFT" }))).toBe(true);
+  });
+
+  it("is true through the build/review pipeline states", () => {
+    for (const status of [
+      "READY_FOR_IMPL",
+      "IN_PROGRESS",
+      "CODE_REVIEW",
+      "READY_TO_MERGE",
+    ] as const) {
+      expect(isInProgress(make({ status }))).toBe(true);
+    }
+  });
+
+  it("is false when the item is waiting on the contributor (spec approval)", () => {
+    const item = make({
+      status: "IN_REVIEW",
+      spec: "## Plan",
+      scope: "buildable",
+    });
+    expect(isYourTurn(item)).toBe(true);
+    expect(isInProgress(item)).toBe(false);
+  });
+
+  it("is false when the item awaits a staging check", () => {
+    const item = make({
+      status: "CODE_REVIEW",
+      verifyOnStaging: true,
+    });
+    expect(isYourTurn(item)).toBe(true);
+    expect(isInProgress(item)).toBe(false);
+  });
+
+  it("is false for shipped and closed items", () => {
+    expect(isInProgress(make({ status: "MERGED" }))).toBe(false);
+    expect(isInProgress(make({ status: "REJECTED" }))).toBe(false);
+  });
+
+  it("is true for a submitted item still being reviewed (IN_REVIEW, no spec)", () => {
+    expect(isInProgress(make({ status: "IN_REVIEW" }))).toBe(true);
+  });
+});

--- a/apps/mobile/features/contribute/utils/status.ts
+++ b/apps/mobile/features/contribute/utils/status.ts
@@ -69,6 +69,37 @@ export function needsStagingVerify(
   );
 }
 
+/**
+ * The AI judged the item too big/architectural to build in one go and is now
+ * waiting on the maintainer — to copy a split's slice prompts into new
+ * sessions, or to make the design_needed call. There's nothing the pipeline
+ * can do until then, so it's the contributor's turn.
+ */
+export function needsSplitDecision(
+  contribution: Pick<Contribution, "status" | "spec" | "scope">,
+): boolean {
+  return (
+    contribution.status === "IN_REVIEW" &&
+    !!contribution.spec &&
+    !isBuildableScope(contribution.scope)
+  );
+}
+
+/**
+ * An approved buildable item still sitting in IN_REVIEW is a medium/high-risk
+ * change waiting on an explicit "Start build" tap (low risk auto-dispatches).
+ * That tap is the contributor's, so it's their turn.
+ */
+export function needsBuildStart(
+  contribution: Pick<Contribution, "status" | "specApprovedAt" | "scope">,
+): boolean {
+  return (
+    contribution.status === "IN_REVIEW" &&
+    !!contribution.specApprovedAt &&
+    isBuildableScope(contribution.scope)
+  );
+}
+
 /** True when the conversation is waiting on the contributor, not the AI. */
 export function isYourTurn(
   contribution: Pick<
@@ -76,7 +107,12 @@ export function isYourTurn(
     "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
   >,
 ): boolean {
-  return needsSpecApproval(contribution) || needsStagingVerify(contribution);
+  return (
+    needsSpecApproval(contribution) ||
+    needsStagingVerify(contribution) ||
+    needsSplitDecision(contribution) ||
+    needsBuildStart(contribution)
+  );
 }
 
 /**

--- a/apps/mobile/features/contribute/utils/status.ts
+++ b/apps/mobile/features/contribute/utils/status.ts
@@ -147,6 +147,13 @@ export function conversationDotColor(
   return PALETTE.aiWorking;
 }
 
+/** The contributor set this conversation aside (abandoned / not doable). */
+export function isArchived(
+  contribution: Pick<Contribution, "archivedAt">,
+): boolean {
+  return !!contribution.archivedAt;
+}
+
 /** Conversational display title — the AI's friendly title when it exists. */
 export function displayTitle(contribution: Pick<Contribution, "title" | "aiTitle">): string {
   return contribution.aiTitle ?? contribution.title;

--- a/apps/mobile/features/contribute/utils/status.ts
+++ b/apps/mobile/features/contribute/utils/status.ts
@@ -79,6 +79,25 @@ export function isYourTurn(
   return needsSpecApproval(contribution) || needsStagingVerify(contribution);
 }
 
+/**
+ * True when the item is actively being worked on by the AI/pipeline — the
+ * contributor "fired it off" and it's moving, not waiting on them and not
+ * finished. Powers the "In progress" tab. Rejected/closed items and anything
+ * awaiting the contributor (spec approval, staging check) are excluded.
+ */
+export function isInProgress(
+  contribution: Pick<
+    Contribution,
+    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
+  >,
+): boolean {
+  return (
+    !isYourTurn(contribution) &&
+    contribution.status !== "MERGED" &&
+    contribution.status !== "REJECTED"
+  );
+}
+
 /** Conversation-list dot color: purple = your turn, amber = AI working, green = shipped. */
 export function conversationDotColor(
   contribution: Pick<

--- a/docs/architecture/ADR-029-contributor-dev-dashboard.md
+++ b/docs/architecture/ADR-029-contributor-dev-dashboard.md
@@ -357,6 +357,11 @@ Owner-requested follow-up to make filing feel like chatting and to turn a
 - **"In progress" tab.** The contributor list's middle segment is now "In
   progress" (`isInProgress` — fired-off items actively being built/reviewed),
   replacing the catch-all "All"; "Your turn" and "Shipped" are unchanged.
+- **Archive.** Contributors can set a conversation aside — abandoned, or its
+  scope judged not doable — via new `devBugs.archivedAt` (orthogonal to
+  `status`, so any pipeline state can be archived and restored) and the
+  originator-only (plus staff) `archive`/`unarchive` mutations. Archived items
+  leave the active tabs into an "Archived" tab.
 - **Copyable split prompts.** For `scope: "split"`, the spec routine also
   returns `splitSlices: [{ title, prompt }]` (new `devBugs.splitSlices`,
   validated in `http.ts`, persisted by `applyCallback`, cleared when a

--- a/docs/architecture/ADR-029-contributor-dev-dashboard.md
+++ b/docs/architecture/ADR-029-contributor-dev-dashboard.md
@@ -337,6 +337,34 @@ failure (branch protection, conflict, auth) the thread gets "Auto-merge
 blocked: <reason> — needs a maintainer" and nothing retries — branch
 protection remains the backstop.
 
+## Phase 1.7 — low-friction filing, pictures, and copyable split prompts (Accepted)
+
+Owner-requested follow-up to make filing feel like chatting and to turn a
+"split" verdict into one-tap momentum. The pipeline underneath is unchanged.
+
+- **Chat-first filing.** The submit screen drops the title/repro form for a
+  single message box plus the bug/feature toggle (`submit`'s `title` is now
+  optional and derived from the message — `deriveTitle` — until the spec
+  agent's `aiTitle` lands).
+- **Pictures in the conversation.** Contributors attach screenshots when
+  filing and when replying. New `devBugMessages.imageUrls` (R2 storage paths);
+  `getThread` resolves them to public URLs via `getMediaUrl` for rendering,
+  and `dispatchSpec` aggregates the report's + thread replies' images and
+  resolves them so the (vision-capable) spec routine receives fetchable URLs.
+  This supersedes the Phase 1.5 "screenshots omitted in v1" note — the
+  `getMediaUrl` resolver already used by the chat-originated flow removes the
+  original r2:-path blocker.
+- **"In progress" tab.** The contributor list's middle segment is now "In
+  progress" (`isInProgress` — fired-off items actively being built/reviewed),
+  replacing the catch-all "All"; "Your turn" and "Shipped" are unchanged.
+- **Copyable split prompts.** For `scope: "split"`, the spec routine also
+  returns `splitSlices: [{ title, prompt }]` (new `devBugs.splitSlices`,
+  validated in `http.ts`, persisted by `applyCallback`, cleared when a
+  revision re-triages to `buildable`). The detail screen renders a
+  "Copy prompt" button per slice so a maintainer can paste a self-contained
+  build prompt straight into a fresh dev session. See
+  `docs/dev-assistant/ROUTINE-PROMPT.md`.
+
 ## Deliberately out of scope (v1)
 
 - GitHub OAuth / verified account linking (`githubUsername` is honor-system).

--- a/docs/dev-assistant/ROUTINE-PROMPT.md
+++ b/docs/dev-assistant/ROUTINE-PROMPT.md
@@ -97,7 +97,9 @@ can, and produce:
    - "split": too big as stated but decomposable. The spec body must explain
      why in product terms (infrastructure, decisions, blast radius — no
      jargon) and propose 2–3 smaller buildable slices, each with its own
-     risk estimate.
+     risk estimate. You MUST also return a `splitSlices` array (one entry per
+     proposed slice) — see field 4 — so the dashboard can offer a
+     copy-the-prompt button per slice.
    - "design_needed": genuinely architectural (new services, provider/cost/
      privacy decisions). The spec body must name the decisions a maintainer
      has to make first. Do NOT write an implementation spec for these.
@@ -120,8 +122,17 @@ can, and produce:
    - aiTitle: a short imperative headline for the conversation list, e.g.
      "Fix RSVP message after tapping Going". Keep it under ~60 characters.
 
+4. **splitSlices** (required only when scope is "split"; omit otherwise) — an
+   array of `{ title, prompt }`, one per proposed slice. `title` is the
+   slice's short name; `prompt` is a self-contained instruction a maintainer
+   can paste straight into a fresh dev session to build THAT slice alone. Each
+   prompt must state the slice's goal, the files/areas involved, its
+   "Done when" checklist, and that it is one slice of a larger split (so the
+   sibling slices are explicitly out of scope). The dashboard renders a
+   "Copy build prompt" button per slice from this array.
+
 Callback: { bugId, routineRunId, status: "IN_REVIEW", spec, riskLevel,
-aiTitle, area, scope, verifyOnStaging, screenshots? }.
+aiTitle, area, scope, splitSlices?, verifyOnStaging, screenshots? }.
 
 If the payload has `revision: true`, this is a revision round: the payload
 includes the full conversation thread. Respond to the latest user message,


### PR DESCRIPTION
## What & why

Follow-up to the contributor dev dashboard (ADR-029) making it low-friction to file contributions and to act on a "split" verdict. Four changes:

**1. Chat-first filing.** The "New conversation" screen is now a single message box + Bug/Feature toggle — no title/repro form. `submit`'s title is optional and derived from the message (`deriveTitle`) until the spec agent's `aiTitle` lands; a screenshot-only report is valid.

**2. Pictures in the conversation.** Attach screenshots when filing and when replying (`useImageAttachments` + `AttachmentStrip`, reusing chat's R2 upload flow — no new native deps). Images render inline in the conversation bubbles. New `devBugMessages.imageUrls`; `getThread` resolves R2 paths to public URLs via `getMediaUrl`, and `dispatchSpec` aggregates + resolves report/reply images so the vision-capable spec routine receives fetchable URLs. This supersedes the Phase 1.5 "screenshots omitted in v1" note — the resolver the chat flow already uses removes the original blocker.

**3. "In progress" tab.** The contributor list's middle segment is now **In progress** (`isInProgress` — fired-off items actively being built/reviewed), replacing the catch-all "All". "Your turn" and "Shipped" are unchanged.

**4. Copyable split prompts.** For `scope: "split"`, the spec routine now also returns `splitSlices: [{ title, prompt }]` (new `devBugs.splitSlices`, validated in `http.ts`, persisted by `applyCallback`, cleared on re-triage to `buildable`). The detail screen renders a **"Copy prompt"** button per slice so a maintainer can paste a self-contained build prompt straight into a fresh dev session. `ROUTINE-PROMPT.md` updated to emit these.

## Testing

- **Convex:** full suite green — 2114 tests (7 new: title derivation, image storage/resolution, screenshot-only reports, `splitSlices` callback persistence + HTTP validation).
- **Mobile:** full suite green — 1234 tests (new `isInProgress` unit test); `tsc` clean on all touched files; ESLint clean; native-import guard passes; no `runtimeVersion` change.
- Docs: ADR-029 **Phase 1.7** + `ROUTINE-PROMPT.md`.
- **Not done:** visual verification on a simulator/staging (not available in the build container) — worth an eyeball on staging before production.

## Notes

- Backward-compatible schema additions (all optional fields); existing chat-originated and dashboard items keep working.
- Scoped to the `dev_maintainer`-gated contributor dashboard — no end-user surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FkC8cq1PAgFrwr4Bgf8KC

---
_Generated by [Claude Code](https://claude.ai/code/session_017FkC8cq1PAgFrwr4Bgf8KC)_