### PR TITLE
Fix keyboard covering the reply box on contributor conversations

### DIFF
--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -435,6 +435,11 @@ export function ContributionDetailScreen() {
     <KeyboardAvoidingView
       style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
+      // This screen opens as an iOS sheet (the `(user)` route group is a modal),
+      // where "padding" alone doesn't lift the composer above the keyboard — it
+      // stays hidden behind it. The sibling `dev/notifications.tsx`, in the same
+      // modal group, corrects the sheet inset with a 64pt offset; mirror it here.
+      keyboardVerticalOffset={Platform.OS === "ios" ? 64 : 0}
     >
       <View style={styles.headerRow}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>


### PR DESCRIPTION
## What this fixes

On the contributor dashboard (**Profile → Contribute**), opening a conversation and tapping the **"Message @Togather…"** reply box slid the on-screen keyboard up **over the composer**, so you couldn't see what you were typing — the input sat hidden behind the keyboard. This is what the reporter hit while "doing maintenance" in the dashboard.

## Why it happened

The contributor dashboard opens as an iOS **sheet** (the `(user)` route group is presented as a modal). On `ContributionDetailScreen.tsx` the composer's `KeyboardAvoidingView` used `behavior="padding"` with **no `keyboardVerticalOffset`**. Inside a sheet presentation the view's measured frame is offset from the window, so with no offset the composer isn't lifted enough and ends up behind the keyboard.

A sibling screen in the **same** modal group — `app/(user)/dev/notifications.tsx` — already handles this with `keyboardVerticalOffset={Platform.OS === 'ios' ? 64 : 0}`. This screen was simply missing that offset.

## The change

Add `keyboardVerticalOffset={Platform.OS === "ios" ? 64 : 0}` to the one `KeyboardAvoidingView` in `ContributionDetailScreen.tsx`, mirroring the working sibling in the same sheet group.

- **iOS:** composer, attachment strip, and the composer hint line now ride up together above the keyboard.
- **Android:** left on its default resize behavior (unchanged), per the spec.
- Scope: a single line (plus an explanatory comment) in one file.

## A note on the spec's fallback

The spec offered a fallback of switching to `react-native-keyboard-controller`'s `KeyboardAvoidingView`, stating "`KeyboardProvider` is already mounted at the app root." **That is not the case** — `KeyboardProvider` was deliberately *removed* from `app/_layout.tsx` because it "was causing conflicts with Stream Chat's overlay system during interactive keyboard dismiss" (a comment marks where it used to be). Re-mounting it to enable that component would risk regressing chat and is out of scope, so the recommended fixed-offset approach is the right in-scope path here. The `64` is the empirically-working value from the sibling screen in the identical modal group, not a guess.

## Verification

- ✅ Native import gating, native fingerprint (no native change; `runtimeVersion` untouched), navigator-screen registration checks
- ✅ ESLint clean on the changed file
- ✅ Full mobile Jest suite (131 suites / 1227 tests) passes
- ⚠️ **Visual confirmation on a device/simulator is still pending** — this build environment is Linux, so no iOS simulator was available to screenshot the before/after. The offset value is carried over from a sibling screen that already renders correctly in the same sheet presentation, so behavior should match. Recommend a quick visual check on iOS staging before merge.

## Dashboard item

Contributor dashboard bug `x973r00983txvy4bssjtf51nq58a2qzf` — reported by **Seyi Olujide**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQhTVQ92p3pLf2qS8iQ5Sg

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQhTVQ92p3pLf2qS8iQ5Sg)_