### PR TITLE
Remove the "Notify" tab from the Admin screen

### DIFF
--- a/apps/mobile/features/admin/components/AdminScreen.tsx
+++ b/apps/mobile/features/admin/components/AdminScreen.tsx
@@ -22,9 +22,8 @@ import { StatsContent } from "./StatsContent";
 import { PeopleContent } from "./PeopleContent";
 import { SettingsContent } from "./SettingsContent";
 import { SuperAdminDashboardContent } from "./SuperAdminDashboardContent";
-import { NotificationsContent } from "./NotificationsContent";
 
-type TabKey = "dashboard" | "requests" | "people" | "stats" | "notifications" | "settings";
+type TabKey = "dashboard" | "requests" | "people" | "stats" | "settings";
 
 interface Tab {
   key: TabKey;
@@ -54,7 +53,6 @@ export function AdminScreen() {
           { key: "requests", label: "Requests" },
           { key: "people", label: "People" },
           { key: "stats", label: "Stats" },
-          { key: "notifications", label: "Notify" },
           { key: "settings", label: "Settings" },
           { key: "dashboard", label: "Dashboard" },
         ];
@@ -64,7 +62,6 @@ export function AdminScreen() {
         { key: "requests", label: "Requests" },
         { key: "people", label: "People" },
         { key: "stats", label: "Stats" },
-        { key: "notifications", label: "Notify" },
         { key: "settings", label: "Settings" },
       ];
     },
@@ -140,8 +137,6 @@ export function AdminScreen() {
           <PeopleContent />
         ) : activeTab === "stats" ? (
           <StatsContent />
-        ) : activeTab === "notifications" ? (
-          <NotificationsContent />
         ) : (
           <SettingsContent />
         )}

--- a/apps/mobile/features/admin/components/__tests__/AdminScreen.test.tsx
+++ b/apps/mobile/features/admin/components/__tests__/AdminScreen.test.tsx
@@ -41,10 +41,11 @@ describe("AdminScreen", () => {
       user: { is_staff: true, is_superuser: false, is_admin: true },
     });
 
-    const { getByText } = render(<AdminScreen />);
+    const { getByText, queryByText } = render(<AdminScreen />);
 
     expect(getByText("Dashboard")).toBeTruthy();
     expect(getByText("Requests")).toBeTruthy();
+    expect(queryByText("Notify")).toBeNull();
   });
 
   test("shows only Dashboard tab for internal users who are not community admins", () => {
@@ -69,6 +70,7 @@ describe("AdminScreen", () => {
 
     expect(queryByText("Dashboard")).toBeNull();
     expect(getByText("Requests")).toBeTruthy();
+    expect(queryByText("Notify")).toBeNull();
   });
 
   test("shows internal dashboard without requiring a selected community", () => {


### PR DESCRIPTION
## What this does

Removes the **Notify** tab from the Admin hub's segmented control so the broadcast/notifications panel can no longer be reached by tapping around the app.

This is **one slice of a larger split**. Only the tab and its reachability are removed here. The broadcast feature's code stays on disk untouched for a separate follow-up bug: `NotificationsContent.tsx`, `BroadcastComposer.tsx`, `BroadcastApprovalList.tsx`, `BroadcastDetailModal.tsx`, and all backend/schema code.

## Before / After

**Community admin**
```
Before:  [ Requests ][ People ][ Stats ][ Notify ][ Settings ]
After:   [ Requests ][ People ][ Stats ][ Settings ]
```

**Internal staff (community selected)**
```
Before:  [ Requests ][ People ][ Stats ][ Notify ][ Settings ][ Dashboard ]
After:   [ Requests ][ People ][ Stats ][ Settings ][ Dashboard ]
```

The remaining tabs widen to fill the freed space (equal-width segments); no other visual change. A rendered before/after mock of the segmented control was produced from the component's real styles and shared on the dashboard thread.

## Changes (single file: `apps/mobile/features/admin/components/AdminScreen.tsx`)

- Removed the `{ key: "notifications", label: "Notify" }` entry from **both** tab arrays (internal-staff and community-admin).
- Removed the `activeTab === "notifications" ? <NotificationsContent /> : …` render branch; Settings and the other tabs render as before.
- Removed the `import { NotificationsContent } from "./NotificationsContent";` line.
- Removed `"notifications"` from the `TabKey` union.

Plus a regression assertion in `__tests__/AdminScreen.test.tsx` that no **Notify** tab renders for either audience.

## Verification

- `AdminScreen` test suite passes (4/4), including new `queryByText("Notify")` is null assertions for community-admin and internal-staff layouts.
- Type-check clean for `AdminScreen.tsx` (no new TS errors introduced).
- No live iOS-simulator capture: this runs on a Linux CI runner with no iOS simulator available, so the visual is a faithful rendered mock of the segmented control (built from the component's actual `StyleSheet` and label sets) rather than a device screenshot.
- The existing `useEffect` that resets `activeTab` to the first available tab already handles any stale selection, and the screen opens on `Requests`, so removing `Notify` cannot strand the UI on a missing tab.

## Out of scope (intentionally untouched)

- `NotificationsContent.tsx`, `BroadcastComposer.tsx`, `BroadcastApprovalList.tsx`, `BroadcastDetailModal.tsx` — still present on disk.
- Any broadcast/notifications backend function or schema.

Dashboard item: `x97dhf5xgs91eqp53xqeh51ws18a36cf` · reported by Seyi Olujide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv5iCpEkHgEF4EXhb4Rpmy)_