### PR TITLE
Move the "check it on staging" step to after merge, before production

### DIFF
--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -418,7 +418,9 @@ describe("shipped", () => {
     expect(notifications).toHaveLength(0);
 
     // The webhook source (GitHub reported the merge) stamps shippedAt and
-    // records the shipped notification.
+    // records the merged/live-on-staging notification. This item isn't
+    // interactive (verifyOnStaging unset), so the push is the honest "live on
+    // staging" note, not a "shipped to production" claim.
     await t.action(
       internal.functions.devAssistant.actions.handleRoutineCallback,
       { bugId: id, routineRunId: "run-ship", status: "MERGED", source: "webhook" },
@@ -433,7 +435,7 @@ describe("shipped", () => {
     );
     expect(
       notifications.some(
-        (n) => n.userId === maintainerId && /shipped/i.test(n.title),
+        (n) => n.userId === maintainerId && /staging/i.test(n.title),
       ),
     ).toBe(true);
   });
@@ -784,11 +786,11 @@ describe("conversation thread (Phase 1.5)", () => {
     expect(thread.map((m) => m.body)).toEqual([
       "Pull request opened",
       "Ready to merge",
-      "Shipped 🎉",
+      "Merged — live on staging",
     ]);
   });
 
-  test("CODE_REVIEW push says 'test on staging' when verifyOnStaging is set", async () => {
+  test("the 'test on staging' push fires on MERGED (not CODE_REVIEW) when verifyOnStaging is set", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
     const { maintainerId } = await seedUsers(t);
@@ -809,6 +811,8 @@ describe("conversation thread (Phase 1.5)", () => {
       }),
     );
 
+    // CODE_REVIEW: the PR is still open, nothing is on staging — the push is
+    // the generic "in code review" note, NOT the staging ask.
     await t.action(
       internal.functions.devAssistant.actions.handleRoutineCallback,
       {
@@ -820,7 +824,37 @@ describe("conversation thread (Phase 1.5)", () => {
     );
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
-    const notifications = await t.run(async (ctx) =>
+    let notifications = await t.run(async (ctx) =>
+      ctx.db.query("notifications").collect(),
+    );
+    expect(
+      notifications.filter((n) => /staging/i.test(n.title)),
+    ).toHaveLength(0);
+    expect(
+      notifications.some((n) => n.title === "Your contribution is in code review"),
+    ).toBe(true);
+
+    // MERGED (auto-deployed to staging): now the "try it on staging" push fires.
+    await t.action(
+      internal.functions.devAssistant.actions.handleRoutineCallback,
+      {
+        bugId: id,
+        routineRunId: "run-staging-push",
+        status: "READY_TO_MERGE",
+      },
+    );
+    await t.action(
+      internal.functions.devAssistant.actions.handleRoutineCallback,
+      {
+        bugId: id,
+        routineRunId: "run-staging-push",
+        status: "MERGED",
+        source: "webhook",
+      },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    notifications = await t.run(async (ctx) =>
       ctx.db.query("notifications").collect(),
     );
     const stagingPush = notifications.filter(
@@ -1171,7 +1205,8 @@ describe("staging verification", () => {
     return await t.run(async (ctx) =>
       ctx.db.insert("devBugs", {
         originatorUserId: originatorId,
-        status: overrides.status ?? "CODE_REVIEW",
+        // Staging is checked after merge (ADR-029) — the window is MERGED.
+        status: overrides.status ?? "MERGED",
         kind: "bug",
         source: "dashboard",
         title: "Fix RSVP message",
@@ -1198,7 +1233,7 @@ describe("staging verification", () => {
 
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.stagingVerifiedAt).toBeTruthy();
-    expect(bug?.status).toBe("CODE_REVIEW"); // status untouched
+    expect(bug?.status).toBe("MERGED"); // status untouched — already merged
 
     const thread = await t.query(
       api.functions.devAssistant.contributions.getThread,
@@ -1207,7 +1242,7 @@ describe("staging verification", () => {
     expect(thread).toHaveLength(1);
     expect(thread[0]).toMatchObject({
       authorType: "system",
-      body: "Marge Maintainer confirmed it works on staging",
+      body: "Marge Maintainer confirmed it works on staging — ready for a maintainer to deploy to production",
     });
 
     // Confirmed by someone else -> the originator gets a push.
@@ -1249,14 +1284,26 @@ describe("staging verification", () => {
       }),
     ).rejects.toThrow(/already verified/);
 
-    // PR not up yet.
+    // Not merged yet — the PR is still open in code review, so nothing is on
+    // staging to check. The window only opens at MERGED (ADR-029).
     const earlyId = await seedStagingBug(t, maintainerId, {
-      status: "IN_PROGRESS",
+      status: "CODE_REVIEW",
     });
     await expect(
       t.mutation(api.functions.devAssistant.contributions.confirmStaging, {
         token: maintainerId,
         id: earlyId,
+      }),
+    ).rejects.toThrow(/current status/);
+
+    // Reviewed and approved but still not merged — also rejected.
+    const preMergeId = await seedStagingBug(t, maintainerId, {
+      status: "READY_TO_MERGE",
+    });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.confirmStaging, {
+        token: maintainerId,
+        id: preMergeId,
       }),
     ).rejects.toThrow(/current status/);
   });
@@ -1267,7 +1314,7 @@ describe("staging verification", () => {
     const { maintainerId } = await seedUsers(t);
 
     const id = await seedStagingBug(t, maintainerId, {
-      status: "READY_TO_MERGE",
+      status: "MERGED",
     });
     const fetchMock = stubRoutineEnv();
 
@@ -1289,7 +1336,7 @@ describe("staging verification", () => {
 
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.stagingVerifiedAt).toBeUndefined();
-    expect(bug?.status).toBe("READY_TO_MERGE");
+    expect(bug?.status).toBe("MERGED");
   });
 });
 
@@ -1787,13 +1834,15 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
       { token: maintainerId, id },
     );
     expect(thread.map((m) => [m.authorType, m.body])).toEqual([
-      ["system", "Shipped 🎉"],
+      ["system", "Merged — live on staging"],
     ]);
 
-    // The originator got the shipped push (dashboard item, no chat thread).
+    // The originator got the merged/live-on-staging push (dashboard item, no
+    // chat thread). Non-interactive item, so it's the "live on staging" note,
+    // not a "shipped to production" claim.
     const shippedPushes = async () =>
       (await t.run(async (ctx) => ctx.db.query("notifications").collect()))
-        .filter((n) => n.userId === maintainerId && /shipped/i.test(n.title));
+        .filter((n) => n.userId === maintainerId && /staging/i.test(n.title));
     expect(await shippedPushes()).toHaveLength(1);
 
     // Replayed delivery: no double system message, no double push.
@@ -1855,7 +1904,7 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
       { token: maintainerId, id },
     );
     expect(thread.map((m) => [m.authorType, m.body])).toEqual([
-      ["system", "Shipped 🎉"],
+      ["system", "Merged — live on staging"],
     ]);
   });
 
@@ -2231,7 +2280,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     t: ReturnType<typeof convexTest>,
     originatorId: Id<"users">,
     overrides: Partial<{
-      status: "CODE_REVIEW" | "READY_TO_MERGE";
+      status: "CODE_REVIEW" | "READY_TO_MERGE" | "MERGED";
       riskLevel: "low" | "medium" | "high";
       reviewVerdict: "approved" | "changes_requested";
       verifyOnStaging: boolean;
@@ -2326,7 +2375,6 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
       { status: "CODE_REVIEW" as const },
       { riskLevel: "medium" as const },
       { reviewVerdict: "changes_requested" as const },
-      { verifyOnStaging: true }, // required but not verified
       { noPrUrl: true },
     ];
     for (const overrides of gateFailures) {
@@ -2369,7 +2417,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
 
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Shipped 🎉",
+      "Merged — live on staging",
     ]);
     // GitHub confirmed the merge, so the action applies MERGED itself via
     // the trusted "automerge" source — the row must not strand at
@@ -2388,29 +2436,33 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     await t.finishAllScheduledFunctions(vi.runAllTimers);
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Shipped 🎉",
+      "Merged — live on staging",
     ]);
   });
 
-  test("the success line notes staging verification when applicable", async () => {
+  test("an interactive item auto-merges without staging verification (staging is not a merge gate)", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
     const { maintainerId } = await seedUsers(t);
     enableAutoMerge();
-    const id = await seedMergeBug(t, maintainerId, {
-      verifyOnStaging: true,
-      stagingVerifiedAt: Date.now(),
-    });
-    stubMergeFetch(() => new Response(null, { status: 200 }));
+    // Interactive (verifyOnStaging) but never verified on staging — nothing
+    // reaches staging until the merge, so this must NOT block the merge
+    // (ADR-029). The staging try-it happens post-merge and gates production.
+    const id = await seedMergeBug(t, maintainerId, { verifyOnStaging: true });
+    const fetchMock = stubMergeFetch(() => new Response(null, { status: 200 }));
 
     await t.action(internal.functions.devAssistant.actions.attemptAutoMerge, {
       bugId: id,
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(await threadBodies(t, maintainerId, id)).toEqual([
-      "Auto-merged ✓ — all gates passed (low risk, review approved, verified on staging)",
-      "Shipped 🎉",
+      "Auto-merged ✓ — all gates passed (low risk, review approved)",
+      "Merged — live on staging",
     ]);
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("MERGED");
+    expect(bug?.stagingVerifiedAt).toBeUndefined();
   });
 
   test("a 405 method-not-allowed retries once with plain merge", async () => {
@@ -2442,7 +2494,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     });
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Shipped 🎉",
+      "Merged — live on staging",
     ]);
   });
 
@@ -2524,18 +2576,23 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
       "Code review passed ✓",
       "Ready to merge",
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Shipped 🎉",
+      "Merged — live on staging",
     ]);
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.status).toBe("MERGED");
   });
 
-  test("confirmStaging triggers the merge attempt once staging was the last gate", async () => {
+  test("confirmStaging does NOT trigger a merge — the change is already merged", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
     const { maintainerId } = await seedUsers(t);
     enableAutoMerge();
-    const id = await seedMergeBug(t, maintainerId, { verifyOnStaging: true });
+    // Staging is checked post-merge now, so the item is already MERGED when the
+    // contributor signs off — there is nothing left to merge.
+    const id = await seedMergeBug(t, maintainerId, {
+      status: "MERGED",
+      verifyOnStaging: true,
+    });
     const fetchMock = stubMergeFetch(() => new Response(null, { status: 200 }));
 
     await t.mutation(api.functions.devAssistant.contributions.confirmStaging, {
@@ -2544,17 +2601,10 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
-    const mergeCalls = fetchMock.mock.calls.filter(
-      (c) => String(c[0]) === MERGE_URL,
-    );
-    expect(mergeCalls).toHaveLength(1);
-    expect(await threadBodies(t, maintainerId, id)).toEqual([
-      "Connie Tributor confirmed it works on staging",
-      "Auto-merged ✓ — all gates passed (low risk, review approved, verified on staging)",
-      "Shipped 🎉",
-    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.status).toBe("MERGED");
+    expect(bug?.stagingVerifiedAt).toBeTruthy();
   });
 });
 

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -749,11 +749,13 @@ export const attemptAutoMerge = internalAction({
     if (!bug) return;
 
     // Central policy gate — trigger points schedule freely and rely on this.
+    // Staging is NOT a merge gate (ADR-029): nothing reaches staging until the
+    // merge, so the staging try-it happens post-merge and gates the manual
+    // production deploy instead. Merge gates on review + CI + low-risk only.
     if (
       bug.status !== "READY_TO_MERGE" ||
       bug.riskLevel !== "low" ||
       bug.reviewVerdict !== "approved" ||
-      (bug.verifyOnStaging && !bug.stagingVerifiedAt) ||
       !bug.prUrl
     ) {
       console.log(
@@ -807,15 +809,11 @@ export const attemptAutoMerge = internalAction({
       }
 
       if (res.ok) {
-        const verified = bug.verifyOnStaging && bug.stagingVerifiedAt;
         await ctx.runMutation(
           internal.functions.devAssistant.bugs.addSystemThreadMessage,
           {
             bugId: args.bugId,
-            body:
-              "Auto-merged ✓ — all gates passed (low risk, review approved" +
-              (verified ? ", verified on staging" : "") +
-              ")",
+            body: "Auto-merged ✓ — all gates passed (low risk, review approved)",
           },
         );
         // GitHub just confirmed the merge, so apply MERGED directly through
@@ -909,23 +907,28 @@ function contributorPushForStatus(
     case "CODE_REVIEW":
       // The module treats CODE_REVIEW as "the PR exists" (READY_TO_MERGE is a
       // later, maintainer-facing step) — pushing here and not on READY_TO_MERGE
-      // means one "PR opened" push, not two.
-      // Staging gate (ADR-029 P1.5): interactive changes ask the originator to
-      // verify on staging rather than just announcing the PR.
-      if (bug.verifyOnStaging) {
-        return {
-          title: "Ready to test on staging",
-          body: `"${bug.title}" is built — try it on staging and confirm it works.`,
-        };
-      }
+      // means one "PR opened" push, not two. Nothing is on staging yet (the PR
+      // is still open), so this stays an honest "in code review" note — the
+      // "try it on staging" ask waits for MERGED (ADR-029).
       return {
         title: "Your contribution is in code review",
         body: `A pull request is open for "${bug.title}".`,
       };
     case "MERGED":
+      // The change is merged to `main` and auto-deployed to staging. For
+      // interactive items, this is the moment to ask the originator to try it
+      // on staging — their sign-off then gates the manual production deploy
+      // (ADR-029). Non-interactive items (copy/colour) just get an honest
+      // "it's live on staging" note, not a "shipped to production" claim.
+      if (bug.verifyOnStaging) {
+        return {
+          title: "Ready to test on staging",
+          body: `"${bug.title}" is merged and live on staging — try it and confirm it works.`,
+        };
+      }
       return {
-        title: "Your contribution shipped 🎉",
-        body: `"${bug.title}" was merged. Thanks for making Togather better!`,
+        title: "Your contribution is live on staging",
+        body: `"${bug.title}" was merged and is now live on the staging app.`,
       };
     default:
       return null;

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -201,7 +201,9 @@ const STATUS_SYSTEM_MESSAGES: Partial<Record<BugStatus, string>> = {
   IN_PROGRESS: "Build started",
   CODE_REVIEW: "Pull request opened",
   READY_TO_MERGE: "Ready to merge",
-  MERGED: "Shipped 🎉",
+  // Merge auto-deploys to staging; production is a separate manual step, so the
+  // honest line is "live on staging", not "shipped" (ADR-029).
+  MERGED: "Merged — live on staging",
 };
 
 export type ThreadHistoryEntry = {
@@ -560,8 +562,8 @@ export const PR_CLOSED_UNMERGED_MESSAGE =
  * merged === true replays the bug's own routineRunId through the existing
  * handleRoutineCallback machinery with source "webhook" (the trusted channel
  * allowed to apply MERGED), which validates the transition, stamps shippedAt,
- * logs the "Shipped 🎉" system turn, pushes the originator, and (for chat
- * items) posts the sourceKey-idempotent bot message. The early-return on an
+ * logs the "Merged — live on staging" system turn, pushes the originator, and
+ * (for chat items) posts the sourceKey-idempotent bot message. The early-return on an
  * already-MERGED bug makes replayed webhooks — and the race with the
  * auto-merge action's own MERGED apply — no-ops.
  *
@@ -637,7 +639,12 @@ export const handleGithubPrClosed = internalMutation({
             ...(target.shippedAt ? {} : { shippedAt: Date.now() }),
             updatedAt: Date.now(),
           });
-          await insertThreadMessage(ctx, target._id, "system", "Shipped 🎉");
+          await insertThreadMessage(
+            ctx,
+            target._id,
+            "system",
+            "Merged — live on staging",
+          );
         } else {
           console.error(
             "[DevAssistant] GitHub merge webhook ignored: bug in status",

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -495,7 +495,13 @@ export const postMessage = mutation({
   },
 });
 
-/** Guard shared by confirmStaging/reportStagingIssue: the staging-check window. */
+/**
+ * Guard shared by confirmStaging/reportStagingIssue: the staging-check window.
+ * Nothing reaches staging until the PR is merged to `main` (deploys auto-run on
+ * merge), so the window opens at MERGED — not while the PR is still open. The
+ * change is then live on staging and awaiting the contributor's try-it, which
+ * in turn gates the manual production deploy (ADR-029).
+ */
 function assertStagingWindow(bug: Doc<"devBugs">): void {
   if (!bug.verifyOnStaging) {
     throw new ConvexError("This item does not require staging verification");
@@ -503,18 +509,21 @@ function assertStagingWindow(bug: Doc<"devBugs">): void {
   if (bug.stagingVerifiedAt) {
     throw new ConvexError("This item was already verified on staging");
   }
-  if (bug.status !== "CODE_REVIEW" && bug.status !== "READY_TO_MERGE") {
+  if (bug.status !== "MERGED") {
     throw new ConvexError(
-      `Staging can only be checked once the PR is up (current status: ${bug.status})`,
+      `Staging can only be checked once the change is merged and live on staging (current status: ${bug.status})`,
     );
   }
 }
 
 /**
  * Contributor confirms the change works on staging. Valid only in the staging
- * window (verifyOnStaging set, not yet verified, PR up). Stamps
- * stagingVerifiedAt and logs a system message; if someone other than the
- * originator confirmed, the originator gets a push (matches approveSpec).
+ * window (verifyOnStaging set, not yet verified, already merged and live on
+ * staging). Stamps stagingVerifiedAt and logs a system message; if someone
+ * other than the originator confirmed, the originator gets a push (matches
+ * approveSpec). The change is already merged, so there is nothing to merge
+ * here — the sign-off marks the item ready for a maintainer's manual
+ * production deploy (ADR-029).
  */
 export const confirmStaging = mutation({
   args: { token: v.string(), id: v.id("devBugs") },
@@ -534,23 +543,14 @@ export const confirmStaging = mutation({
       ctx,
       args.id,
       "system",
-      `${name} confirmed it works on staging`,
+      `${name} confirmed it works on staging — ready for a maintainer to deploy to production`,
     );
 
     await notifyOriginatorUnlessSelf(ctx, bug, user._id, {
-      title: "Verified on staging",
-      body: `${name} confirmed "${bug.title}" works on staging.`,
+      title: "Verified on staging 🎉",
+      body: `${name} confirmed "${bug.title}" works on staging — a maintainer will ship it to production.`,
       status: bug.status,
     });
-
-    // Policy auto-merge (ADR-029 Phase 3): staging sign-off may have been the
-    // last unsatisfied merge gate. Schedule the attempt — the action re-reads
-    // the bug and re-checks every gate itself, so this is always safe.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.functions.devAssistant.actions.attemptAutoMerge,
-      { bugId: args.id },
-    );
 
     return { ok: true };
   },

--- a/apps/mobile/features/contribute/components/ContributeListScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributeListScreen.tsx
@@ -166,9 +166,15 @@ export function ContributeListScreen({
       if (segment === "archived") return isArchived(item);
       if (isArchived(item)) return false;
       if (segment === "yourTurn") return isYourTurn(item);
-      // "Done" = terminal conversations, shipped or set aside.
+      // "Done" = terminal conversations, shipped or set aside. A merged item
+      // still awaiting the contributor's staging try-it is "your turn", not
+      // done yet (ADR-029: staging check happens after merge), so keep it out
+      // of Done until it's verified.
       if (segment === "done")
-        return item.status === "MERGED" || item.status === "REJECTED";
+        return (
+          (item.status === "MERGED" || item.status === "REJECTED") &&
+          !isYourTurn(item)
+        );
       // "In progress" = fired off and actively being built/reviewed.
       return isInProgress(item);
     });

--- a/apps/mobile/features/contribute/components/ContributionBadges.tsx
+++ b/apps/mobile/features/contribute/components/ContributionBadges.tsx
@@ -16,7 +16,10 @@ import {
 export function StatusChip({
   contribution,
 }: {
-  contribution: Pick<Contribution, "status" | "spec" | "specApprovedAt">;
+  contribution: Pick<
+    Contribution,
+    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
+  >;
 }) {
   const { label, color, icon } = statusPresentation(contribution);
   return (

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -599,8 +599,9 @@ export function ContributionDetailScreen({
               </Text>
             </View>
             <Text style={[styles.hint, { color: colors.textSecondary }]}>
-              Your change is live on the staging app. Open it, try the thing you
-              reported, and tell us how it went.
+              Your change is now merged and live on the staging app. Open it,
+              try the thing you reported, and tell us how it went — your
+              sign-off is what clears it to ship to production.
             </Text>
             {issueMode ? (
               <>

--- a/apps/mobile/features/contribute/components/ThreadBubbles.tsx
+++ b/apps/mobile/features/contribute/components/ThreadBubbles.tsx
@@ -97,7 +97,7 @@ export function AssistantBubble({ body, createdAt }: { body: string; createdAt?:
   );
 }
 
-/** A system event ("Build started", "Shipped 🎉") — small centered caption. */
+/** A system event ("Build started", "Merged — live on staging") — small centered caption. */
 export function SystemCaption({ body, createdAt }: { body: string; createdAt?: number }) {
   const { colors } = useTheme();
   return (

--- a/apps/mobile/features/contribute/utils/status.test.ts
+++ b/apps/mobile/features/contribute/utils/status.test.ts
@@ -40,16 +40,33 @@ describe("isInProgress", () => {
     expect(isInProgress(item)).toBe(false);
   });
 
-  it("is false when the item awaits a staging check", () => {
+  it("is false when a merged item awaits its staging check (ADR-029: staging is post-merge)", () => {
+    // Nothing reaches staging until the merge, so the try-it window opens at
+    // MERGED — an interactive item there is the contributor's turn, not "in
+    // progress" and not yet "done".
     const item = make({
-      status: "CODE_REVIEW",
+      status: "MERGED",
       verifyOnStaging: true,
     });
     expect(isYourTurn(item)).toBe(true);
     expect(isInProgress(item)).toBe(false);
   });
 
+  it("does NOT treat an open PR as a staging check — nothing is on staging until merge", () => {
+    // Interactive item still in code review / awaiting merge: the PR is open,
+    // nothing is on staging, so it's still "in progress", not the user's turn.
+    for (const status of ["CODE_REVIEW", "READY_TO_MERGE"] as const) {
+      const item = make({ status, verifyOnStaging: true });
+      expect(isYourTurn(item)).toBe(false);
+      expect(isInProgress(item)).toBe(true);
+    }
+  });
+
   it("is false for shipped and closed items", () => {
+    // Merged with the staging check already done (or never required).
+    expect(
+      isInProgress(make({ status: "MERGED", verifyOnStaging: true, stagingVerifiedAt: 123 })),
+    ).toBe(false);
     expect(isInProgress(make({ status: "MERGED" }))).toBe(false);
     expect(isInProgress(make({ status: "REJECTED" }))).toBe(false);
   });

--- a/apps/mobile/features/contribute/utils/status.ts
+++ b/apps/mobile/features/contribute/utils/status.ts
@@ -57,7 +57,10 @@ export function needsSpecApproval(
 
 /**
  * The contributor should try the change on the staging app: it's flagged for
- * staging verification, not yet verified, and far enough along to test.
+ * staging verification, not yet verified, and merged. Nothing reaches staging
+ * until the PR merges to `main` (deploys auto-run on merge), so the try-it
+ * window opens at MERGED — never while the PR is still open. The sign-off then
+ * gates the manual production deploy (ADR-029).
  */
 export function needsStagingVerify(
   contribution: Pick<Contribution, "status" | "verifyOnStaging" | "stagingVerifiedAt">,
@@ -65,7 +68,7 @@ export function needsStagingVerify(
   return (
     !!contribution.verifyOnStaging &&
     !contribution.stagingVerifiedAt &&
-    (contribution.status === "CODE_REVIEW" || contribution.status === "READY_TO_MERGE")
+    contribution.status === "MERGED"
   );
 }
 
@@ -167,7 +170,10 @@ export function displayTitle(contribution: Pick<Contribution, "title" | "aiTitle
  * explicit build start).
  */
 export function statusPresentation(
-  contribution: Pick<Contribution, "status" | "spec" | "specApprovedAt" | "scope">,
+  contribution: Pick<
+    Contribution,
+    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
+  >,
 ): StatusPresentation {
   switch (contribution.status) {
     case "IN_REVIEW":
@@ -190,11 +196,30 @@ export function statusPresentation(
     case "IN_PROGRESS":
       return { label: "Building", color: "#FF9500", icon: "construct-outline" };
     case "CODE_REVIEW":
+      // The PR is still open — nothing is on staging yet.
       return { label: "In code review", color: "#007AFF", icon: "git-pull-request-outline" };
     case "READY_TO_MERGE":
-      return { label: "Awaiting merge", color: "#34C759", icon: "git-merge-outline" };
+      // Reviewed and approved, but not merged — still nothing on staging.
+      return { label: "Awaiting merge", color: "#FF9500", icon: "git-merge-outline" };
     case "MERGED":
-      return { label: "Shipped", color: "#34C759", icon: "checkmark-circle-outline" };
+      // A merge auto-deploys to staging; production is a separate manual step.
+      // For interactive items the contributor tries it on staging first (their
+      // turn), then a maintainer ships to production (ADR-029).
+      if (contribution.verifyOnStaging && !contribution.stagingVerifiedAt) {
+        return {
+          label: "On staging — ready for you to try",
+          color: "#5856D6",
+          icon: "flask-outline",
+        };
+      }
+      if (contribution.stagingVerifiedAt) {
+        return {
+          label: "Verified — ready to ship to production",
+          color: "#34C759",
+          icon: "checkmark-circle-outline",
+        };
+      }
+      return { label: "Merged — live on staging", color: "#34C759", icon: "checkmark-circle-outline" };
     case "REJECTED":
       return { label: "Not planned", color: "#999999", icon: "close-circle-outline" };
     case "DRAFT":

--- a/apps/web/src/pages/ContributeAI.tsx
+++ b/apps/web/src/pages/ContributeAI.tsx
@@ -173,26 +173,27 @@ export function ContributeAI() {
                   ),
                 },
                 {
-                  title: "You try it on the staging app",
+                  title: "It gets merged",
                   body: (
                     <>
-                      For anything interactive, you'll get a push notification
-                      when your change is live on the staging app. Try it
-                      against your acceptance criteria and tap "Works — ship
-                      it" — merging waits for your confirmation, even for
-                      low-risk changes. (Pure text or color tweaks skip this
-                      step.)
+                      A maintainer makes the final merge decision on GitHub
+                      (low-risk changes can merge automatically once review and
+                      CI pass). Merging to <code>main</code> auto-deploys the
+                      change to the staging app — every status change lands in
+                      your conversation as it happens.
                     </>
                   ),
                 },
                 {
-                  title: "A maintainer merges",
+                  title: "You try it on the staging app",
                   body: (
                     <>
-                      A maintainer makes the final merge decision on GitHub —
-                      every status change lands in your conversation as it
-                      happens, and you'll get a push notification when your
-                      change ships.
+                      For anything interactive, you'll get a push notification
+                      once your change is merged and live on staging. Try it
+                      against your acceptance criteria and tap "Works — ship
+                      it" — your confirmation is what clears it for the manual
+                      production deploy, even for low-risk changes. (Pure text
+                      or color tweaks skip this step.)
                     </>
                   ),
                 },
@@ -231,9 +232,10 @@ export function ContributeAI() {
           <p className="text-neutral-600 leading-relaxed mb-6">
             For changes that are clearly low risk, the pipeline runs from your
             approval onward without a maintainer in the middle: the change is
-            implemented, verified, and merged automatically. It pauses for a
-            human only twice — your approved spec, and (for anything
-            interactive) your confirmation on the staging app — which is
+            implemented, verified, and merged automatically once review and CI
+            pass. It pauses for a human only twice — your approved spec, and
+            (for anything interactive) your confirmation on staging after it's
+            merged, which is what clears it to ship to production — which is
             exactly why writing a good spec matters.
           </p>
 
@@ -248,9 +250,9 @@ export function ContributeAI() {
                   <strong className="text-neutral-700">Low risk:</strong> the
                   build starts the moment you approve the spec. AI implements,
                   verifies with automated tests and screenshots, and merges on
-                  its own — pausing first for your "Works — ship it" on the
-                  staging app if the change is interactive. It ships in the
-                  next release.
+                  its own once review and CI pass. The merge deploys it to
+                  staging; if the change is interactive, your "Works — ship it"
+                  there is what clears it for the next production release.
                 </>,
                 <>
                   <strong className="text-neutral-700">Medium or high risk:</strong>{" "}

--- a/docs/architecture/ADR-029-contributor-dev-dashboard.md
+++ b/docs/architecture/ADR-029-contributor-dev-dashboard.md
@@ -132,8 +132,9 @@ spec, kind) but keep their existing role gates.
   callback (`IN_PROGRESS → CODE_REVIEW → READY_TO_MERGE → MERGED`).
 
 > **Phase 1.5 adds two gates around this flow:** a scope verdict before any
-> spec can be approved, and reporter staging verification before merge for
-> interactive changes — see
+> spec can be approved, and reporter staging verification **after merge, before
+> the production deploy** for interactive changes (nothing reaches staging until
+> the merge auto-deploys it) — see
 > [Phase 1.5](#phase-15--conversation-first-dashboard-accepted).
 
 ### 5. Risk levels — blast radius, assigned by AI, human-overridable
@@ -197,8 +198,9 @@ machine, Routine dispatch, signed callbacks, role gate) is unchanged.
 Rationale: non-coders already know how to read a chat, so the pipeline
 becomes messages instead of a form-shaped detail screen; the scope gate turns
 "too big" into momentum by answering with buildable slices instead of a bad
-build; staging verification puts the reporter's hands on the change before
-merge, closing the loop the way decision 4's spec gate opened it.
+build; staging verification puts the reporter's hands on the change once it's
+merged and live on staging — gating the production deploy, not the merge —
+closing the loop the way decision 4's spec gate opened it.
 
 ### 1. Conversation-first — every contribution is a thread
 
@@ -238,8 +240,11 @@ The spec agent's **first** verdict is
 - `area: "events" | "chat" | "groups" | "prayer" | "settings" | "other"` —
   items file themselves; used as a filter/tag.
 - `verifyOnStaging: boolean` — anything **interactive** requires the reporter
-  to test the change on the staging app and tap **"Works — ship it"** before
-  merge, even at low risk. Pure copy/color changes skip it.
+  to test the change on the staging app and tap **"Works — ship it"** once it's
+  **merged and live on staging**, even at low risk. Nothing reaches staging
+  until the merge auto-deploys it, so this check happens *after* merge and
+  gates the manual production deploy — not the merge. Pure copy/color changes
+  skip it.
 
 New `devBugs` fields: `aiTitle`, `area`, `scope`, `verifyOnStaging`,
 `stagingVerifiedAt`. New functions: `getThread`, `postMessage`,
@@ -316,17 +321,20 @@ is pushed.
 ### Policy auto-merge
 
 A single self-gating action, `attemptAutoMerge`, is scheduled whenever a gate
-might have just been satisfied: on a genuine entry into `READY_TO_MERGE` and
-after `confirmStaging` stamps `stagingVerifiedAt`. It re-reads the bug and
-merges the PR via the GitHub REST API **only when every gate holds**:
+might have just been satisfied: on a genuine entry into `READY_TO_MERGE`. It
+re-reads the bug and merges the PR via the GitHub REST API **only when every
+gate holds**:
 
 - `AUTO_MERGE_ENABLED === "true"` — master safety switch; anything else means
   the feature is off (double-scheduling is harmless because the action
   re-checks everything itself).
 - `status === "READY_TO_MERGE"`, `riskLevel === "low"`,
   `reviewVerdict === "approved"`.
-- Staging verified (`stagingVerifiedAt`) whenever `verifyOnStaging` is set.
 - A `prUrl` to merge.
+
+Staging verification is **not** a merge gate: nothing reaches staging until the
+merge, so the reporter's staging try-it happens *after* merge and gates the
+manual production deploy instead. Merge gates on review + CI + low-risk only.
 
 The merge uses `GH_MIRROR_TOKEN` (the Phase 2 mirroring PAT, which now needs
 **Contents read/write** in addition to Issues) and the merge method from
@@ -397,10 +405,10 @@ Owner-requested follow-up to make filing feel like chatting and to turn a
 
 - We own state sync with GitHub (webhook + mirroring) — a second source of
   truth to keep consistent; the webhook must be idempotent.
-- Staging verification (Phase 1.5) adds a human wait state before merge:
-  interactive changes sit in `READY_TO_MERGE` until the reporter confirms on
-  staging, so stale items need nudges (push reminders) or a maintainer
-  override.
+- Staging verification (Phase 1.5) adds a human wait state after merge, before
+  the production deploy: interactive changes sit in `MERGED` (live on staging)
+  until the reporter confirms on staging, so stale items need nudges (push
+  reminders) or a maintainer to ship to production without the sign-off.
 - A PAT with write access to the repo lives in Convex env; needs rotation
   policy and least-privilege scoping (issues only — the Routine, not Convex,
   pushes code).

--- a/docs/dev-assistant/ROUTINE-PROMPT.md
+++ b/docs/dev-assistant/ROUTINE-PROMPT.md
@@ -118,7 +118,10 @@ can, and produce:
      offline).
    - area: one of "events", "chat", "groups", "prayer", "settings", "other".
    - verifyOnStaging: true for anything the user taps, types into, or
-     navigates through; false only for pure copy/color changes.
+     navigates through; false only for pure copy/color changes. Verification
+     happens on staging **after merge** (nothing reaches staging until the
+     merge auto-deploys it) and gates the manual **production** deploy, not the
+     merge.
    - aiTitle: a short imperative headline for the conversation list, e.g.
      "Fix RSVP message after tapping Going". Keep it under ~60 characters.
 


### PR DESCRIPTION
## What was wrong

When you opened one of your contribution conversations while its pull request was still **open** (not merged), the app showed a green **"Ready for you to try"** card claiming *"Your change is live on the staging app."* — and sent a **"Ready to test on staging"** push.

But nothing reaches staging until the PR is **merged to `main`**: our deploy workflows auto-deploy to staging on merge, and production is a separate manual step. So the card told contributors to go try something that wasn't there yet, while the status right above it still read "Awaiting merge."

## What changed

Reorder the flow to match how deploys actually work:

> PR → review + CI pass → **merge to `main`** → auto-deploys to **staging** → *you verify on staging* → a maintainer runs the **manual** production deploy.

- **The staging check moves to after merge.** The "Ready for you to try" card and the "Ready to test on staging" push now appear **only once the change is merged** (and therefore auto-deployed to staging) — never while the PR is open.
- **Merge no longer waits on staging.** Auto-merge (low-risk items) gates on **review + CI + low-risk only**; the pre-merge staging gate is removed.
- **"Works — ship it" now gates production, not merge.** Tapping it records the change as verified on staging and surfaces it as **ready for a maintainer's manual production deploy** — it does **not** merge or deploy anything.
- **Pre-merge copy is honest.** While the PR is open, nothing claims to be on staging.

No new statuses and no schema migration — the post-merge verification lives inside the existing terminal `MERGED` state using the fields that already exist (`verifyOnStaging`, `stagingVerifiedAt`), just stamped *after* merge instead of before.

## Before / after copy

| Pipeline state | Before | After |
| --- | --- | --- |
| **In code review** (PR open) | Green "live on staging" card + "Works — ship it". Push: *"Ready to test on staging."* | No card, no buttons. Chip *"In code review."* Push: *"Your contribution is in code review."* |
| **Awaiting merge** | Same green "live on staging" card. | No card. Chip *"Awaiting merge."* No push. |
| **Merged, not yet tried** | Chip *"Shipped."* Push: *"…shipped 🎉."* | Green **"Ready for you to try"** card: *"…now merged and live on the staging app…"* + try-it buttons. Chip *"On staging — ready for you to try."* Purple dot (your turn). Push: *"Ready to test on staging."* |
| **Verified on staging** | n/a (verification was pre-merge) | Chip *"Verified — ready to ship to production."* Green dot. Push (originator): *"Verified on staging 🎉 — a maintainer will ship it to production."* |
| **Merged, no staging check** (copy/colour) | Chip *"Shipped."* | Chip *"Merged — live on staging."* No card. |

## Where it lives

**Backend** (`apps/convex/functions/devAssistant/`): `assertStagingWindow` opens at `MERGED`; `confirmStaging` stops scheduling auto-merge and marks the item ready for production; `attemptAutoMerge` drops the staging gate; `contributorPushForStatus` moves the staging ask to `MERGED`; `STATUS_SYSTEM_MESSAGES` and the webhook fallback say "Merged — live on staging" instead of "Shipped 🎉".

**Frontend** (`apps/mobile/features/contribute/`): `needsStagingVerify` keys on `MERGED`; `statusPresentation` shows the three merged labels; a merged-but-unverified interactive item stays in "Your turn" (not "Done") until verified.

**Docs**: ADR-029, the routine prompt's `verifyOnStaging` note, and the `/contribute` explainer all describe staging-after-merge, before production.

## Testing

- `apps/convex`: full suite green (2127 tests) — updated staging window, push timing, dropped auto-merge staging gate, and merged system-message copy.
- `apps/mobile`: full suite green (1228 tests) — updated `status.test.ts` for the post-merge staging window.
- Typecheck clean on convex, web, and the touched mobile files.
- Verified the frontend status helpers end-to-end across all five pipeline states (chip label, "your turn" flag, dot colour) and rendered a before/after mock to confirm the copy reads honestly at each state.

Closes the dashboard contribution that reported this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PWyWso3SCfGmu7jqdoSWy

---
_Generated by [Claude Code](https://claude.ai/code/session_012PWyWso3SCfGmu7jqdoSWy)_