### PR TITLE
Demo mode v2: photos, real campuses, guided tour, realistic roles (feedback round)

### DIFF
--- a/apps/convex/__tests__/demo-community.test.ts
+++ b/apps/convex/__tests__/demo-community.test.ts
@@ -60,7 +60,6 @@ describe("createDemoCommunity", () => {
       smallGroupCount: 3,
       zipCode: "11201",
       primaryColor: "#AA3366",
-      secondaryColor: "#112233",
     });
 
     expect(result.name).toBe("Grace Fellowship");
@@ -240,10 +239,10 @@ describe("createDemoCommunity", () => {
     const typeById = new Map(groupTypes.map((gt) => [gt._id, gt.slug]));
     expect(
       groups.filter((g) => typeById.get(g.groupTypeId!) === "small-groups"),
-    ).toHaveLength(6);
+    ).toHaveLength(12);
     expect(
       groups.filter((g) => typeById.get(g.groupTypeId!) === "campuses"),
-    ).toHaveLength(4);
+    ).toHaveLength(12);
   });
 
   test("generates unique demo codes for same-named churches", async () => {
@@ -280,6 +279,240 @@ describe("createDemoCommunity", () => {
         primaryColor: "blue",
       }),
     ).rejects.toThrow("hex color");
+  });
+});
+
+describe("demo v3: feedback fixes", () => {
+  test("creates one group per campus and honors custom names", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Campy", "+15555550170");
+
+    const result = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Eight Campus Church",
+      campusCount: 8,
+      smallGroupCount: 2,
+      campusNames: ["Harlem", "Bed-Stuy"],
+      groupNames: ["Tuesday Crew"],
+    });
+
+    const { groups, groupTypes } = await t.run(async (ctx) => ({
+      groups: await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", result.communityId))
+        .collect(),
+      groupTypes: await ctx.db
+        .query("groupTypes")
+        .withIndex("by_community", (q) => q.eq("communityId", result.communityId))
+        .collect(),
+    }));
+    const typeById = new Map(groupTypes.map((gt) => [gt._id, gt.slug]));
+    const campuses = groups.filter((g) => typeById.get(g.groupTypeId!) === "campuses");
+    expect(campuses).toHaveLength(8);
+    // Custom names first, placeholders fill the rest.
+    const campusNames = campuses.map((g) => g.name);
+    expect(campusNames).toContain("Harlem");
+    expect(campusNames).toContain("Bed-Stuy");
+    const smallGroupsNames = groups
+      .filter((g) => typeById.get(g.groupTypeId!) === "small-groups")
+      .map((g) => g.name);
+    expect(smallGroupsNames).toContain("Tuesday Crew");
+
+    // Group type names are singular.
+    const typeNames = new Map(groupTypes.map((gt) => [gt.slug, gt.name]));
+    expect(typeNames.get("small-groups")).toBe("Small Group");
+    expect(typeNames.get("campuses")).toBe("Campus");
+    expect(typeNames.get("teams")).toBe("Team");
+  });
+
+  test("seeded members, groups, and events all have imagery; locations spread from base coords", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Pic", "+15555550171");
+
+    const result = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Photo Church",
+      smallGroupCount: 2,
+      zipCode: "11201",
+      logo: "r2:uploads/logo.png",
+      baseCoordinates: { latitude: 40.69, longitude: -73.99 },
+    });
+
+    const { seededUsers, groups, meetings } = await t.run(async (ctx) => {
+      const memberships = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_community", (q) => q.eq("communityId", result.communityId))
+        .collect();
+      const seededUsers = [];
+      for (const m of memberships) {
+        const user = await ctx.db.get(m.userId);
+        if (user?.isDemoSeed) seededUsers.push(user);
+      }
+      return {
+        seededUsers,
+        groups: await ctx.db
+          .query("groups")
+          .withIndex("by_community", (q) => q.eq("communityId", result.communityId))
+          .collect(),
+        meetings: await ctx.db
+          .query("meetings")
+          .withIndex("by_community", (q) => q.eq("communityId", result.communityId))
+          .collect(),
+      };
+    });
+
+    // Every seeded member has a portrait.
+    expect(seededUsers.every((u) => !!u.profilePhoto)).toBe(true);
+    // Every group has an avatar; the announcement group wears the logo.
+    expect(groups.every((g) => !!g.preview)).toBe(true);
+    const announcementGroup = groups.find((g) => g.isAnnouncementGroup);
+    expect(announcementGroup?.preview).toBe("r2:uploads/logo.png");
+    // Groups carry coordinates near the base, and not all identical.
+    expect(groups.every((g) => g.coordinates !== undefined)).toBe(true);
+    const distinctLats = new Set(groups.map((g) => g.coordinates!.latitude));
+    expect(distinctLats.size).toBeGreaterThan(1);
+    // Every event has a cover image and a zip-bearing location.
+    expect(meetings.every((m) => !!m.coverImage)).toBe(true);
+    expect(meetings.every((m) => m.locationOverride?.includes("11201"))).toBe(true);
+  });
+
+  test("the creator leads the announcement group plus two groups, member elsewhere", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, token } = await createUser(t, "Lead", "+15555550172");
+
+    const result = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Role Church",
+      smallGroupCount: 4,
+    });
+
+    const roles = await t.run(async (ctx) => {
+      const rows = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect();
+      const out = [];
+      for (const row of rows) {
+        const group = await ctx.db.get(row.groupId);
+        if (group?.communityId !== result.communityId) continue;
+        out.push({ role: row.role, isAnnouncement: !!group.isAnnouncementGroup });
+      }
+      return out;
+    });
+
+    const leaderRoles = roles.filter((r) => r.role === "leader");
+    expect(leaderRoles.filter((r) => r.isAnnouncement)).toHaveLength(1);
+    expect(leaderRoles.filter((r) => !r.isAnnouncement)).toHaveLength(2);
+    expect(roles.filter((r) => r.role === "member").length).toBeGreaterThan(0);
+  });
+
+  test("seeds DMs, a group DM, and the Getting Started channel", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Inbox", "+15555550173");
+
+    const result = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Inbox Church",
+    });
+
+    const { adHoc, gettingStarted, botMessages } = await t.run(async (ctx) => {
+      const adHoc = await ctx.db
+        .query("chatChannels")
+        .withIndex("by_community_isAdHoc", (q) =>
+          q.eq("communityId", result.communityId).eq("isAdHoc", true),
+        )
+        .collect();
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", result.communityId))
+        .collect();
+      let gettingStarted = null;
+      for (const group of groups) {
+        const channel = await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group_slug", (q) =>
+            q.eq("groupId", group._id).eq("slug", "getting-started"),
+          )
+          .first();
+        if (channel) gettingStarted = channel;
+      }
+      const botMessages = gettingStarted
+        ? await ctx.db
+            .query("chatMessages")
+            .withIndex("by_channel", (q) => q.eq("channelId", gettingStarted!._id))
+            .collect()
+        : [];
+      return { adHoc, gettingStarted, botMessages };
+    });
+
+    expect(adHoc.filter((c) => c.channelType === "dm")).toHaveLength(2);
+    expect(adHoc.filter((c) => c.channelType === "group_dm")).toHaveLength(1);
+    // Seeded chats are accepted conversations, and DMs have a dedup key.
+    expect(adHoc.find((c) => c.channelType === "dm")?.dmPairKey).toContain(
+      String(result.communityId),
+    );
+
+    expect(gettingStarted).not.toBeNull();
+    expect(botMessages.length).toBeGreaterThanOrEqual(5);
+    // Bot-authored: no senderId, bot content type, named sender.
+    expect(botMessages.every((m) => m.senderId === undefined)).toBe(true);
+    expect(botMessages.every((m) => m.contentType === "bot")).toBe(true);
+  });
+
+  test("getDemoProgress tracks guided missions from real activity", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Prog", "+15555550174");
+
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Progress Church",
+    });
+
+    let progress = await t.query(api.functions.demo.getDemoProgress, {
+      token,
+      communityId: demo.communityId,
+    });
+    expect(progress?.total).toBe(4);
+    expect(progress?.completed).toBe(0);
+
+    // A teammate joins -> invite mission completes.
+    const { token: mateToken } = await createUser(t, "Mate", "+15555550175");
+    await t.mutation(api.functions.demo.joinDemoCommunity, {
+      token: mateToken,
+      code: demo.demoCode,
+    });
+    progress = await t.query(api.functions.demo.getDemoProgress, {
+      token,
+      communityId: demo.communityId,
+    });
+    expect(
+      progress?.missions.find((m) => m.key === "invite_teammate")?.done,
+    ).toBe(true);
+    expect(progress?.completed).toBe(1);
+  });
+
+  test("go-live purge removes seeded DMs but keeps everything real", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "DmPurge", "+15555550176");
+
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "DM Purge Church",
+    });
+
+    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+      communityId: demo.communityId,
+    });
+
+    const adHoc = await t.run(async (ctx) =>
+      ctx.db
+        .query("chatChannels")
+        .withIndex("by_community_isAdHoc", (q) =>
+          q.eq("communityId", demo.communityId).eq("isAdHoc", true),
+        )
+        .collect(),
+    );
+    expect(adHoc).toHaveLength(0);
   });
 });
 
@@ -551,9 +784,14 @@ describe("demo conversion (go live)", () => {
     );
     expect(landingPage?.isEnabled).toBe(true);
     expect(landingPage?.title).toBe("Welcome to Convert Chapel");
-    // Channel denormalization was recomputed (creator remains in channels).
+    // Channel denormalization was recomputed. The creator remains in main
+    // channels; leaders channels of groups they don't lead legitimately
+    // drop to zero members after the seeded leaders are purged.
     for (const channel of after.channels) {
-      expect(channel.memberCount).toBe(1);
+      expect(channel.memberCount).toBeLessThanOrEqual(1);
+      if (channel.channelType === "main") {
+        expect(channel.memberCount).toBe(1);
+      }
       expect(channel.lastMessagePreview).toBeUndefined();
     }
   });

--- a/apps/convex/__tests__/demo-community.test.ts
+++ b/apps/convex/__tests__/demo-community.test.ts
@@ -459,6 +459,105 @@ describe("demo v3: feedback fixes", () => {
     expect(botMessages.every((m) => m.contentType === "bot")).toBe(true);
   });
 
+  test("seeded events use the canonical RSVP labels", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Rsvp", "+15555550177");
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Rsvp Church",
+      smallGroupCount: 1,
+    });
+    const meeting = await t.run(async (ctx) =>
+      ctx.db
+        .query("meetings")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .first(),
+    );
+    // Matches lib/meetingConfig.ts DEFAULT_RSVP_OPTIONS, not "Attending".
+    expect(meeting?.rsvpOptions?.map((o) => o.label)).toEqual([
+      "Going",
+      "Maybe",
+      "Can't Go",
+    ]);
+  });
+
+  test("a message sent immediately counts, and seeded messages don't", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, token } = await createUser(t, "Fast", "+15555550178");
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Fast Church",
+    });
+
+    // Seeded DM lines "from the creator" exist but are isDemoSeed -> no credit.
+    let progress = await t.query(api.functions.demo.getDemoProgress, {
+      token,
+      communityId: demo.communityId,
+    });
+    expect(progress?.missions.find((m) => m.key === "send_message")?.done).toBe(
+      false,
+    );
+
+    // A real message right now (same wall-clock as seed) still counts — no
+    // 5-minute dead zone.
+    await t.run(async (ctx) => {
+      const channel = await ctx.db
+        .query("chatChannels")
+        .withIndex("by_community_isAdHoc", (q) =>
+          q.eq("communityId", demo.communityId).eq("isAdHoc", true),
+        )
+        .first();
+      await ctx.db.insert("chatMessages", {
+        channelId: channel!._id,
+        communityId: demo.communityId,
+        senderId: userId,
+        content: "hello from the admin",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+      });
+    });
+    progress = await t.query(api.functions.demo.getDemoProgress, {
+      token,
+      communityId: demo.communityId,
+    });
+    expect(progress?.missions.find((m) => m.key === "send_message")?.done).toBe(
+      true,
+    );
+  });
+
+  test("go-live strips placeholder stock covers from surviving groups and events", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Strip", "+15555550179");
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Strip Church",
+      smallGroupCount: 2,
+      logo: "r2:uploads/logo.png",
+    });
+
+    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+      communityId: demo.communityId,
+    });
+
+    const { groups, meetings } = await t.run(async (ctx) => ({
+      groups: await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect(),
+      meetings: await ctx.db
+        .query("meetings")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect(),
+    }));
+    // No surviving row points at picsum.
+    expect(groups.every((g) => !g.preview?.includes("picsum.photos"))).toBe(true);
+    expect(meetings.every((m) => !m.coverImage?.includes("picsum.photos"))).toBe(true);
+    // The church's real logo (r2:) is kept on the announcement group.
+    const announcement = groups.find((g) => g.isAnnouncementGroup);
+    expect(announcement?.preview).toBe("r2:uploads/logo.png");
+  });
+
   test("getDemoProgress tracks guided missions from real activity", async () => {
     const t = convexTest(schema, modules);
     const { token } = await createUser(t, "Prog", "+15555550174");

--- a/apps/convex/functions/demo.ts
+++ b/apps/convex/functions/demo.ts
@@ -41,10 +41,9 @@ import { COMMUNITY_ROLES } from "../lib/permissions";
 // ============================================================================
 
 // Caps keep a single mutation comfortably inside Convex write limits while
-// still looking like a real church. Larger answers scale the *labels* (e.g.
-// "12 of your 40 groups") rather than the row counts.
-const MAX_SMALL_GROUPS = 6;
-const MAX_CAMPUSES = 4;
+// still looking like a real church.
+const MAX_SMALL_GROUPS = 12;
+const MAX_CAMPUSES = 12;
 
 /** Every demo is populated by exactly this many placeholder members. */
 export const DEMO_SEED_USER_COUNT = 100;
@@ -76,23 +75,54 @@ function demoMemberName(i: number): { firstName: string; lastName: string } {
   };
 }
 
+// Demo-only external imagery so the app doesn't feel like an empty shell of
+// initials (getMediaUrl passes absolute https URLs through untouched). These
+// only ever live on seeded rows, which are purged on go-live. FIRST_NAMES
+// alternates female/male, so portrait gender tracks the name.
+function demoMemberPhoto(i: number): string {
+  const gender = i % 2 === 0 ? "women" : "men";
+  return `https://randomuser.me/api/portraits/${gender}/${Math.floor(i / 2) % 100}.jpg`;
+}
+
+/** Stable per-seed stock photo (Lorem Picsum serves a fixed image per seed). */
+function demoStockPhoto(seed: string, width = 800, height = 450): string {
+  return `https://picsum.photos/seed/${encodeURIComponent(seed)}/${width}/${height}`;
+}
+
+/**
+ * Deterministic jitter around the church's home coordinates so seeded groups
+ * and campuses spread out on the explore map instead of stacking on one pin
+ * (~±0.04° ≈ a few miles).
+ */
+function jitterCoordinates(
+  base: { latitude: number; longitude: number },
+  index: number,
+): { latitude: number; longitude: number } {
+  return {
+    latitude: base.latitude + (((index * 37) % 21) - 10) * 0.004,
+    longitude: base.longitude + (((index * 53) % 21) - 10) * 0.005,
+  };
+}
+
+// Type names are singular — they label individual groups ("Young Adults ·
+// Small Group"), not the category listing.
 const GROUP_TYPES = [
   {
-    name: "Small Groups",
+    name: "Small Group",
     slug: "small-groups",
     description: "Weekly small group gatherings for community and study",
     icon: "users",
     displayOrder: 1,
   },
   {
-    name: "Teams",
+    name: "Team",
     slug: "teams",
     description: "Ministry and service teams",
     icon: "briefcase",
     displayOrder: 2,
   },
   {
-    name: "Classes",
+    name: "Class",
     slug: "classes",
     description: "Educational classes and workshops",
     icon: "book-open",
@@ -108,13 +138,15 @@ const GROUP_TYPES = [
 ];
 
 const CAMPUS_GROUP_TYPE = {
-  name: "Campuses",
+  name: "Campus",
   slug: "campuses",
   description: "Campus communities",
   icon: "map-pin",
   displayOrder: 4,
 };
 
+// Placeholder names used when the questionnaire doesn't provide real ones —
+// the church can rename everything later.
 const SMALL_GROUP_NAMES = [
   "Northside Small Group",
   "Downtown Small Group",
@@ -122,9 +154,48 @@ const SMALL_GROUP_NAMES = [
   "Young Adults",
   "Families Small Group",
   "Men's Bible Study",
+  "Women's Bible Study",
+  "College & Career",
+  "Newlyweds Group",
+  "Parents of Littles",
+  "Neighborhood Group",
+  "Seniors Fellowship",
 ];
 
-const CAMPUS_NAMES = ["Main Campus", "North Campus", "East Campus", "South Campus"];
+const CAMPUS_NAMES = [
+  "Main Campus",
+  "North Campus",
+  "South Campus",
+  "East Campus",
+  "West Campus",
+  "Downtown Campus",
+  "Riverside Campus",
+  "Lakeside Campus",
+  "Hillside Campus",
+  "Midtown Campus",
+  "Uptown Campus",
+  "Parkside Campus",
+];
+
+/**
+ * Resolve the names for N seeded groups/campuses: questionnaire-provided
+ * names first (trimmed, blanks dropped), placeholder names for the rest.
+ */
+function resolveNames(
+  requested: number,
+  provided: string[] | undefined,
+  placeholders: string[],
+): string[] {
+  const custom = (provided ?? [])
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0)
+    .slice(0, requested);
+  const names = [...custom];
+  for (let i = names.length; i < requested; i++) {
+    names.push(placeholders[i % placeholders.length]);
+  }
+  return names;
+}
 
 // Conversation scripts, sender index rotates through group members.
 const SMALL_GROUP_CHAT: string[] = [
@@ -153,6 +224,35 @@ const CAMPUS_CHAT: string[] = [
   "Great turnout this Sunday — welcome to all our new faces!",
   "Parking reminder: overflow lot opens at 8:30am.",
   "Volunteers needed for next weekend, reply here if you can help.",
+];
+
+const DM_CHAT: string[] = [
+  "Hey! So glad you're checking out the app 😊",
+  "Same! The groups map is really nice.",
+  "Let's grab coffee after service Sunday?",
+  "Deal. See you then!",
+];
+
+const GROUP_DM_CHAT: string[] = [
+  "Starting a thread for Serve Day planning 🙌",
+  "I can own sign-ups if someone takes supplies.",
+  "Supplies are mine. What's our headcount target?",
+  "Let's aim for 40 and see who RSVPs this week.",
+];
+
+/**
+ * "Getting Started" guided missions, posted by the Togather bot into a
+ * dedicated channel and tracked live by getDemoProgress. Keep the mission
+ * list in sync with the progress query.
+ */
+const GETTING_STARTED_MESSAGES: string[] = [
+  "Welcome to your demo community! 👋 I'm the Togather bot. Here are a few things worth trying while you explore — I'll keep track of your progress on the Go Live screen (tap the demo banner).",
+  "1️⃣ Send a message — open any group's chat and say hi. Everything here is editable and safe to play with.",
+  "2️⃣ Create an event — open a group → Events → New Event. Try RSVP options and a cover photo.",
+  "3️⃣ Set up the Birthday Bot — open a group → settings → Bots. New members feel welcome when their birthday gets celebrated automatically.",
+  "4️⃣ Invite a teammate — share your demo code (on the Go Live screen) so a co-worker can explore with you. Up to 10 people can join.",
+  "5️⃣ Make it yours — Admin → Settings to change your name, logo, and brand color. The whole app re-themes instantly.",
+  "When you're ready for the real thing, tap Go live on the banner — your groups, branding, and teammates stay; these demo members and I clean ourselves up. 🎉",
 ];
 
 const PRAYER_REQUESTS = [
@@ -213,6 +313,10 @@ async function createDemoGroup(
     defaultDay?: number;
     defaultStartTime?: string;
     defaultEndTime?: string;
+    /** Group avatar (storage path or absolute URL) so the inbox has faces. */
+    preview?: string;
+    zipCode?: string;
+    coordinates?: { latitude: number; longitude: number };
   },
 ): Promise<{ groupId: Id<"groups">; channels: SeededChannels }> {
   const timestamp = now();
@@ -230,6 +334,9 @@ async function createDemoGroup(
     defaultStartTime: args.defaultStartTime,
     defaultEndTime: args.defaultEndTime,
     defaultMeetingType: 1, // In-Person
+    preview: args.preview,
+    zipCode: args.zipCode,
+    coordinates: args.coordinates,
     createdAt: timestamp,
     updatedAt: timestamp,
   });
@@ -300,6 +407,7 @@ async function addChannelMember(
   userId: Id<"users">,
   role: "admin" | "member",
   displayName: string,
+  profilePhoto?: string,
 ): Promise<void> {
   await ctx.db.insert("chatChannelMembers", {
     channelId,
@@ -308,6 +416,7 @@ async function addChannelMember(
     joinedAt: now(),
     isMuted: false,
     displayName,
+    profilePhoto,
   });
   const channel = await ctx.db.get(channelId);
   if (channel) {
@@ -328,6 +437,7 @@ async function addChannelMemberCounted(
   userId: Id<"users">,
   role: "admin" | "member",
   displayName: string,
+  profilePhoto?: string,
 ): Promise<void> {
   await ctx.db.insert("chatChannelMembers", {
     channelId,
@@ -336,6 +446,7 @@ async function addChannelMemberCounted(
     joinedAt: now(),
     isMuted: false,
     displayName,
+    profilePhoto,
   });
   counts.set(channelId, (counts.get(channelId) ?? 0) + 1);
 }
@@ -378,13 +489,17 @@ async function countRealUsers(
  * over the past few days, and denormalize the last message onto the channel so
  * inbox previews render.
  */
+type DemoSender = { userId?: Id<"users">; name: string; photo?: string };
+
 async function seedConversation(
   ctx: MutationCtx,
   args: {
     channelId: Id<"chatChannels">;
     communityId: Id<"communities">;
     script: string[];
-    senders: Array<{ userId: Id<"users">; name: string }>;
+    /** Rotating senders; a sender without userId posts as a bot message. */
+    senders: DemoSender[];
+    contentType?: string;
   },
 ): Promise<void> {
   if (args.senders.length === 0 || args.script.length === 0) return;
@@ -406,10 +521,11 @@ async function seedConversation(
       communityId: args.communityId,
       senderId: sender.userId,
       content: args.script[i],
-      contentType: "text",
+      contentType: args.contentType ?? "text",
       createdAt,
       isDeleted: false,
       senderName: sender.name,
+      senderProfilePhoto: sender.photo,
       lastActivityAt: createdAt,
     });
     lastContent = args.script[i];
@@ -436,6 +552,9 @@ async function createDemoMeeting(
     scheduledAt: number;
     note?: string;
     communityWideEventId?: Id<"communityWideEvents">;
+    coverImage?: string;
+    /** e.g. "Main Campus · 11201" — the events map geocodes the zip inside. */
+    locationOverride?: string;
   },
 ): Promise<Id<"meetings">> {
   return await ctx.db.insert("meetings", {
@@ -451,7 +570,9 @@ async function createDemoMeeting(
     rsvpEnabled: true,
     rsvpOptions: DEFAULT_RSVP_OPTIONS,
     visibility: "group",
-    locationMode: "tbd",
+    locationMode: args.locationOverride ? "address" : "tbd",
+    locationOverride: args.locationOverride,
+    coverImage: args.coverImage,
     communityWideEventId: args.communityWideEventId,
     communityId: args.communityId,
     searchText: args.title.toLowerCase(),
@@ -486,28 +607,46 @@ async function uniqueDemoSlug(ctx: MutationCtx, name: string): Promise<string> {
 }
 
 /**
- * Add a real user to every group and channel of a demo community so their
- * inbox, groups, and leader surfaces are fully populated the moment they land.
- * Used for both the creator and teammates joining via demo code.
+ * Add a real user to a demo community's groups with a REALISTIC role mix:
+ * leader of the announcement group and the first couple of regular groups,
+ * plain member everywhere else — like an actual staff member, not an
+ * everything-leader. Channel access follows the role: main (and announcement
+ * group extras like the Getting Started channel) everywhere, the
+ * leaders-only channel just where they lead. Used for both the creator and
+ * teammates joining via demo code; idempotent for re-joins.
  */
+const REAL_USER_LEADER_GROUP_COUNT = 2;
+
 async function enrollUserEverywhere(
   ctx: MutationCtx,
   communityId: Id<"communities">,
   userId: Id<"users">,
   displayName: string,
+  profilePhoto?: string,
 ): Promise<void> {
   const groups = await ctx.db
     .query("groups")
     .withIndex("by_community", (q) => q.eq("communityId", communityId))
     .collect();
 
-  for (const group of groups) {
+  // Stable ordering so "the first N groups" is deterministic across joins.
+  const orderedGroups = [...groups].sort((a, b) =>
+    a._creationTime - b._creationTime,
+  );
+
+  let regularGroupsLed = 0;
+  for (const group of orderedGroups) {
+    const leadsThisGroup =
+      group.isAnnouncementGroup === true ||
+      (!group.isAnnouncementGroup && regularGroupsLed < REAL_USER_LEADER_GROUP_COUNT);
+    if (leadsThisGroup && !group.isAnnouncementGroup) regularGroupsLed++;
+
     const existingMembership = await ctx.db
       .query("groupMembers")
       .withIndex("by_group_user", (q) => q.eq("groupId", group._id).eq("userId", userId))
       .first();
     if (!existingMembership) {
-      await addGroupMember(ctx, group._id, userId, "leader");
+      await addGroupMember(ctx, group._id, userId, leadsThisGroup ? "leader" : "member");
     }
 
     const channels = await ctx.db
@@ -515,6 +654,9 @@ async function enrollUserEverywhere(
       .withIndex("by_group", (q) => q.eq("groupId", group._id))
       .collect();
     for (const channel of channels) {
+      // Leaders-only channels stay leaders-only.
+      if (channel.channelType === "leaders" && !leadsThisGroup) continue;
+
       const existingChannelMembership = await ctx.db
         .query("chatChannelMembers")
         .withIndex("by_channel_user", (q) =>
@@ -522,7 +664,14 @@ async function enrollUserEverywhere(
         )
         .first();
       if (!existingChannelMembership) {
-        await addChannelMember(ctx, channel._id, userId, "admin", displayName);
+        await addChannelMember(
+          ctx,
+          channel._id,
+          userId,
+          leadsThisGroup ? "admin" : "member",
+          displayName,
+          profilePhoto,
+        );
       }
     }
   }
@@ -544,7 +693,14 @@ export const createDemoCommunity = mutation({
     zipCode: v.optional(v.string()),
     logo: v.optional(v.string()), // "r2:..." storage path from getR2UploadUrl
     primaryColor: v.optional(v.string()),
-    secondaryColor: v.optional(v.string()),
+    // Optional real names for campuses/groups; placeholders fill the rest.
+    campusNames: v.optional(v.array(v.string())),
+    groupNames: v.optional(v.array(v.string())),
+    // Home coordinates (client geocodes the zip) — seeded groups and events
+    // spread around this point on the map.
+    baseCoordinates: v.optional(
+      v.object({ latitude: v.number(), longitude: v.number() }),
+    ),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -553,9 +709,6 @@ export const createDemoCommunity = mutation({
     if (!name) throw new Error("Church name is required");
     if (args.primaryColor && !isValidHex(args.primaryColor)) {
       throw new Error("Primary color must be a hex color like #3B82F6");
-    }
-    if (args.secondaryColor && !isValidHex(args.secondaryColor)) {
-      throw new Error("Secondary color must be a hex color like #1E293B");
     }
 
     const caller = await ctx.db.get(userId);
@@ -588,7 +741,6 @@ export const createDemoCommunity = mutation({
       timezone: "America/New_York",
       country: "USA",
       primaryColor: args.primaryColor ?? "#1E8449",
-      secondaryColor: args.secondaryColor ?? "#2E86C1",
       // Every feature on, so the whole product is explorable in the demo.
       churchFeatures: { prayerEnabled: true, eventTasksEnabled: true },
       searchText: `${name} ${slug}`.toLowerCase(),
@@ -609,15 +761,17 @@ export const createDemoCommunity = mutation({
     await ctx.db.patch(userId, { activeCommunityId: communityId, updatedAt: timestamp });
 
     // ---- Placeholder members ----
-    const members: Array<{ userId: Id<"users">; name: string }> = [];
+    const members: Array<{ userId: Id<"users">; name: string; photo: string }> = [];
     for (let i = 0; i < DEMO_SEED_USER_COUNT; i++) {
       const person = demoMemberName(i);
+      const photo = demoMemberPhoto(i);
       const memberId = await ctx.db.insert("users", {
         firstName: person.firstName,
         lastName: person.lastName,
         isPlaceholder: true, // never a real login; see users.isPlaceholder
         isDemoSeed: true, // purged on go-live; see purgeDemoSeedUsers
         isActive: true,
+        profilePhoto: photo,
         searchText: buildSearchText(person),
         timezone: "America/New_York",
         createdAt: timestamp,
@@ -631,7 +785,11 @@ export const createDemoCommunity = mutation({
         createdAt: timestamp,
         updatedAt: timestamp,
       });
-      members.push({ userId: memberId, name: `${person.firstName} ${person.lastName}` });
+      members.push({
+        userId: memberId,
+        name: `${person.firstName} ${person.lastName}`,
+        photo,
+      });
     }
 
     // ---- Group types ----
@@ -657,11 +815,14 @@ export const createDemoCommunity = mutation({
       groupId: Id<"groups">;
       name: string;
       channels: SeededChannels;
-      groupMembers: Array<{ userId: Id<"users">; name: string }>;
+      groupMembers: Array<{ userId: Id<"users">; name: string; photo: string }>;
       isSmallGroup: boolean;
     }> = [];
 
-    // Announcement group (named after the church, everyone belongs).
+    const zipCode = args.zipCode?.trim() || undefined;
+
+    // Announcement group (named after the church, everyone belongs). Its
+    // avatar is the uploaded church logo so the inbox leads with their brand.
     const announcement = await createDemoGroup(ctx, {
       communityId,
       groupTypeId: groupTypeIds["announcements"],
@@ -671,13 +832,16 @@ export const createDemoCommunity = mutation({
       isPublic: true,
       isAnnouncementGroup: true,
       includeAnnouncementsChannel: true,
+      preview: args.logo ?? demoStockPhoto(`${slug}-announcements`, 400, 400),
+      zipCode,
+      coordinates: args.baseCoordinates,
     });
     const channelCounts = new Map<Id<"chatChannels">, number>();
     for (const member of members) {
       await addGroupMember(ctx, announcement.groupId, member.userId, "member");
-      await addChannelMemberCounted(ctx, channelCounts, announcement.channels.mainChannelId, member.userId, "member", member.name);
+      await addChannelMemberCounted(ctx, channelCounts, announcement.channels.mainChannelId, member.userId, "member", member.name, member.photo);
       if (announcement.channels.announcementsChannelId) {
-        await addChannelMemberCounted(ctx, channelCounts, announcement.channels.announcementsChannelId, member.userId, "member", member.name);
+        await addChannelMemberCounted(ctx, channelCounts, announcement.channels.announcementsChannelId, member.userId, "member", member.name, member.photo);
       }
     }
 
@@ -690,9 +854,14 @@ export const createDemoCommunity = mutation({
       defaultDay?: number;
     }> = [];
 
+    const smallGroupNames = resolveNames(
+      smallGroups,
+      args.groupNames,
+      SMALL_GROUP_NAMES,
+    );
     for (let i = 0; i < smallGroups; i++) {
       groupDefs.push({
-        name: SMALL_GROUP_NAMES[i],
+        name: smallGroupNames[i],
         typeSlug: "small-groups",
         description: "Weekly gathering for community, study, and prayer",
         script: SMALL_GROUP_CHAT,
@@ -721,9 +890,10 @@ export const createDemoCommunity = mutation({
       },
     );
     if (campuses > 1) {
+      const campusNames = resolveNames(campuses, args.campusNames, CAMPUS_NAMES);
       for (let i = 0; i < campuses; i++) {
         groupDefs.push({
-          name: CAMPUS_NAMES[i],
+          name: campusNames[i],
           typeSlug: "campuses",
           description: "Campus community and updates",
           script: CAMPUS_CHAT,
@@ -743,18 +913,25 @@ export const createDemoCommunity = mutation({
         defaultDay: def.defaultDay,
         defaultStartTime: def.defaultDay !== undefined ? "19:00" : undefined,
         defaultEndTime: def.defaultDay !== undefined ? "21:00" : undefined,
+        preview: demoStockPhoto(`${slug}-group-${g}`, 400, 400),
+        zipCode,
+        // Scatter groups/campuses around the church's home coordinates so the
+        // explore map looks like a real multi-site church, not a single pin.
+        coordinates: args.baseCoordinates
+          ? jitterCoordinates(args.baseCoordinates, g + 1)
+          : undefined,
       });
 
       // Rotate 6-8 placeholder members into each group; first one leads.
-      const groupMembers: Array<{ userId: Id<"users">; name: string }> = [];
+      const groupMembers: Array<{ userId: Id<"users">; name: string; photo: string }> = [];
       const size = 6 + (g % 3);
       for (let m = 0; m < Math.min(size, members.length); m++) {
         const member = members[(g * 7 + m * 3) % members.length];
         const isLeader = m === 0;
         await addGroupMember(ctx, created.groupId, member.userId, isLeader ? "leader" : "member");
-        await addChannelMemberCounted(ctx, channelCounts, created.channels.mainChannelId, member.userId, isLeader ? "admin" : "member", member.name);
+        await addChannelMemberCounted(ctx, channelCounts, created.channels.mainChannelId, member.userId, isLeader ? "admin" : "member", member.name, member.photo);
         if (isLeader) {
-          await addChannelMemberCounted(ctx, channelCounts, created.channels.leadersChannelId, member.userId, "admin", member.name);
+          await addChannelMemberCounted(ctx, channelCounts, created.channels.leadersChannelId, member.userId, "admin", member.name, member.photo);
         }
         groupMembers.push(member);
       }
@@ -785,6 +962,7 @@ export const createDemoCommunity = mutation({
       scheduledAt: serveDayAt,
       meetingType: 1,
       note: "All small groups serving our city together.",
+      coverImage: demoStockPhoto(`${slug}-serve-day`),
       status: "scheduled",
       createdAt: timestamp,
     });
@@ -802,6 +980,9 @@ export const createDemoCommunity = mutation({
           title: `${group.name} Weekly Meeting`,
           scheduledAt: timestamp + (3 + g) * DAY,
           note: "Regular weekly gathering",
+          coverImage: demoStockPhoto(`${slug}-event-${g}`),
+          // Zip inside the location string puts the event on the events map.
+          locationOverride: zipCode ? `${group.name} · ${zipCode}` : undefined,
         }),
       );
       if (group.isSmallGroup) {
@@ -814,6 +995,8 @@ export const createDemoCommunity = mutation({
             scheduledAt: serveDayAt,
             note: "All small groups serving our city together.",
             communityWideEventId: cweId,
+            coverImage: demoStockPhoto(`${slug}-serve-day`),
+            locationOverride: zipCode ? `City-wide · ${zipCode}` : undefined,
           }),
         );
       }
@@ -863,16 +1046,99 @@ export const createDemoCommunity = mutation({
       });
     }
 
-    // ---- Enroll the creator in every group/channel as leader ----
+    // ---- Getting Started channel (guided missions from the Togather bot) ----
+    const gettingStartedChannelId = await ctx.db.insert("chatChannels", {
+      groupId: announcement.groupId,
+      slug: "getting-started",
+      channelType: "custom",
+      name: "🎓 Getting Started",
+      description: "Guided tour: the best things to try in your demo.",
+      createdById: userId,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      isArchived: false,
+      isEnabled: true,
+      memberCount: 0,
+    });
+    await seedConversation(ctx, {
+      channelId: gettingStartedChannelId,
+      communityId,
+      script: GETTING_STARTED_MESSAGES,
+      // No userId -> stored like production bot messages (no senderId).
+      senders: [{ name: "Togather Bot" }],
+      contentType: "bot",
+    });
+
+    // ---- Enroll the creator with a realistic role mix ----
     await flushChannelCounts(ctx, channelCounts);
-    await enrollUserEverywhere(ctx, communityId, userId, callerName);
+    const callerPhoto = caller.profilePhoto ?? undefined;
+    await enrollUserEverywhere(ctx, communityId, userId, callerName, callerPhoto);
+
+    // ---- DMs + a group DM so the inbox reads like a lived-in church ----
+    const seedDmConversation = async (
+      partners: Array<{ userId: Id<"users">; name: string; photo: string }>,
+      groupName: string | undefined,
+      script: string[],
+    ) => {
+      const isGroupDm = partners.length > 1;
+      const participantIds = [String(userId), ...partners.map((p) => String(p.userId))];
+      const dmChannelId = await ctx.db.insert("chatChannels", {
+        communityId,
+        isAdHoc: true,
+        channelType: isGroupDm ? "group_dm" : "dm",
+        name: groupName ?? "",
+        dmPairKey: isGroupDm
+          ? undefined
+          : `${communityId}::${participantIds.sort().join("::")}`,
+        createdById: userId,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        isArchived: false,
+        memberCount: partners.length + 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: dmChannelId,
+        userId,
+        role: "admin",
+        joinedAt: timestamp,
+        isMuted: false,
+        requestState: "accepted",
+        displayName: callerName,
+        profilePhoto: callerPhoto,
+      });
+      for (const partner of partners) {
+        await ctx.db.insert("chatChannelMembers", {
+          channelId: dmChannelId,
+          userId: partner.userId,
+          role: "member",
+          joinedAt: timestamp,
+          isMuted: false,
+          requestState: "accepted", // seeded chats are already in-progress
+          invitedById: userId,
+          displayName: partner.name,
+          profilePhoto: partner.photo,
+        });
+      }
+      await seedConversation(ctx, {
+        channelId: dmChannelId,
+        communityId,
+        script,
+        senders: [partners[0], { userId, name: callerName, photo: callerPhoto }],
+      });
+    };
+    await seedDmConversation([members[0]], undefined, DM_CHAT);
+    await seedDmConversation([members[2]], undefined, DM_CHAT.slice(0, 2));
+    await seedDmConversation(
+      [members[1], members[3], members[5]],
+      "Serve Day planning",
+      GROUP_DM_CHAT,
+    );
 
     return {
       communityId,
       name,
       logo: getMediaUrl(args.logo) ?? null,
       primaryColor: args.primaryColor ?? "#1E8449",
-      secondaryColor: args.secondaryColor ?? "#2E86C1",
       // Shareable code teammates enter to join this demo as co-admins.
       demoCode: slug,
     };
@@ -950,15 +1216,123 @@ export const joinDemoCommunity = mutation({
     }
     await ctx.db.patch(userId, { activeCommunityId: community._id, updatedAt: timestamp });
 
-    await enrollUserEverywhere(ctx, community._id, userId, callerName);
+    await enrollUserEverywhere(
+      ctx,
+      community._id,
+      userId,
+      callerName,
+      caller.profilePhoto ?? undefined,
+    );
 
     return {
       communityId: community._id,
       name: community.name ?? "",
       logo: getMediaUrl(community.logo) ?? null,
       primaryColor: community.primaryColor ?? null,
-      secondaryColor: community.secondaryColor ?? null,
       demoCode: community.slug ?? code,
+    };
+  },
+});
+
+/**
+ * Live progress through the Getting Started missions (see
+ * GETTING_STARTED_MESSAGES) — computed from what real users actually did, so
+ * the go-live screen can show "3 of 4 explored". Only meaningful for demos.
+ */
+export const getDemoProgress = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const membership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", userId).eq("communityId", args.communityId),
+      )
+      .first();
+    if (!membership || membership.status !== 1) return null;
+
+    const community = await ctx.db.get(args.communityId);
+    if (!community?.isDemo) return null;
+
+    // Real (non-seeded) accounts in the demo.
+    const memberships = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    const realUserIds: Id<"users">[] = [];
+    for (const m of memberships) {
+      if (m.status !== 1) continue;
+      const user = await ctx.db.get(m.userId);
+      if (user && !user.isPlaceholder) realUserIds.push(m.userId);
+    }
+
+    // Anything created noticeably after the seed transaction was done by a
+    // human clicking around, not by the seeder.
+    const seededBefore = (community.createdAt ?? 0) + 5 * 60 * 1000;
+
+    let sentMessage = false;
+    for (const realUserId of realUserIds) {
+      // Seeded DM scripts include lines "from" the creator, so only messages
+      // written after the seed transaction count as the user's own activity.
+      const message = await ctx.db
+        .query("chatMessages")
+        .withIndex("by_sender", (q) => q.eq("senderId", realUserId))
+        .filter((q) =>
+          q.and(
+            q.eq(q.field("communityId"), args.communityId),
+            q.gt(q.field("createdAt"), seededBefore),
+          ),
+        )
+        .first();
+      if (message) {
+        sentMessage = true;
+        break;
+      }
+    }
+
+    const meetings = await ctx.db
+      .query("meetings")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    const createdEvent = meetings.some(
+      (m) =>
+        m.createdAt > seededBefore &&
+        m.createdById !== undefined &&
+        realUserIds.some((id) => id === m.createdById),
+    );
+
+    const groups = await ctx.db
+      .query("groups")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    let birthdayBot = false;
+    for (const group of groups) {
+      const config = await ctx.db
+        .query("groupBotConfigs")
+        .withIndex("by_group_botType", (q) =>
+          q.eq("groupId", group._id).eq("botType", "birthday"),
+        )
+        .first();
+      if (config?.enabled) {
+        birthdayBot = true;
+        break;
+      }
+    }
+
+    const missions = [
+      { key: "send_message", title: "Send a message in a group", done: sentMessage },
+      { key: "create_event", title: "Create an event", done: createdEvent },
+      { key: "birthday_bot", title: "Set up the Birthday Bot", done: birthdayBot },
+      { key: "invite_teammate", title: "Invite a teammate with your demo code", done: realUserIds.length >= 2 },
+    ];
+
+    return {
+      missions,
+      completed: missions.filter((m) => m.done).length,
+      total: missions.length,
     };
   },
 });
@@ -1022,6 +1396,38 @@ export const purgeDemoSeedUsers = internalMutation({
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
 
+    // Seeded DMs/group DMs involve demo members — delete the whole ad-hoc
+    // channel (members + messages) rather than leaving one-sided orphans.
+    const adHocChannels = await ctx.db
+      .query("chatChannels")
+      .withIndex("by_community_isAdHoc", (q) =>
+        q.eq("communityId", args.communityId).eq("isAdHoc", true),
+      )
+      .collect();
+    for (const channel of adHocChannels) {
+      const channelMembers = await ctx.db
+        .query("chatChannelMembers")
+        .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+        .collect();
+      let involvesSeedMember = false;
+      for (const member of channelMembers) {
+        const user = await ctx.db.get(member.userId);
+        if (user?.isDemoSeed) {
+          involvesSeedMember = true;
+          break;
+        }
+      }
+      if (!involvesSeedMember) continue; // real-user DMs survive go-live
+
+      for (const member of channelMembers) await ctx.db.delete(member._id);
+      const channelMessages = await ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+        .collect();
+      for (const message of channelMessages) await ctx.db.delete(message._id);
+      await ctx.db.delete(channel._id);
+    }
+
     let purged = 0;
     for (const membership of memberships) {
       const user = await ctx.db.get(membership.userId);
@@ -1079,6 +1485,23 @@ export const purgeDemoSeedUsers = internalMutation({
         .withIndex("by_group", (q) => q.eq("groupId", group._id))
         .collect();
       for (const channel of channels) {
+        // The Getting Started tour is demo-only — it removes itself on
+        // go-live, exactly as its bot messages promise.
+        if (channel.slug === "getting-started") {
+          const tourMembers = await ctx.db
+            .query("chatChannelMembers")
+            .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+            .collect();
+          for (const member of tourMembers) await ctx.db.delete(member._id);
+          const tourMessages = await ctx.db
+            .query("chatMessages")
+            .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+            .collect();
+          for (const message of tourMessages) await ctx.db.delete(message._id);
+          await ctx.db.delete(channel._id);
+          continue;
+        }
+
         const remaining = await ctx.db
           .query("chatChannelMembers")
           .withIndex("by_channel", (q) => q.eq("channelId", channel._id))

--- a/apps/convex/functions/demo.ts
+++ b/apps/convex/functions/demo.ts
@@ -35,6 +35,7 @@ import { MutationCtx, QueryCtx } from "../_generated/server";
 import { requireAuth } from "../lib/auth";
 import { now, generateShortId, buildSearchText, getMediaUrl } from "../lib/utils";
 import { COMMUNITY_ROLES } from "../lib/permissions";
+import { DEFAULT_RSVP_OPTIONS } from "../lib/meetingConfig";
 
 // ============================================================================
 // Template data
@@ -76,17 +77,28 @@ function demoMemberName(i: number): { firstName: string; lastName: string } {
 }
 
 // Demo-only external imagery so the app doesn't feel like an empty shell of
-// initials (getMediaUrl passes absolute https URLs through untouched). These
-// only ever live on seeded rows, which are purged on go-live. FIRST_NAMES
-// alternates female/male, so portrait gender tracks the name.
+// initials (getMediaUrl passes absolute https URLs through untouched).
+// Portraits live on seeded member rows (deleted on go-live); stock covers/
+// avatars live on groups/events that SURVIVE go-live, so purgeDemoSeedUsers
+// strips them (via isDemoStockUrl) rather than leaving a live community
+// depending on these third-party hosts in production.
+const DEMO_PORTRAIT_HOST = "https://randomuser.me/api/portraits/";
+const DEMO_STOCK_HOST = "https://picsum.photos/";
+
+// FIRST_NAMES alternates female/male, so portrait gender tracks the name.
 function demoMemberPhoto(i: number): string {
   const gender = i % 2 === 0 ? "women" : "men";
-  return `https://randomuser.me/api/portraits/${gender}/${Math.floor(i / 2) % 100}.jpg`;
+  return `${DEMO_PORTRAIT_HOST}${gender}/${Math.floor(i / 2) % 100}.jpg`;
 }
 
 /** Stable per-seed stock photo (Lorem Picsum serves a fixed image per seed). */
 function demoStockPhoto(seed: string, width = 800, height = 450): string {
-  return `https://picsum.photos/seed/${encodeURIComponent(seed)}/${width}/${height}`;
+  return `${DEMO_STOCK_HOST}seed/${encodeURIComponent(seed)}/${width}/${height}`;
+}
+
+/** True for a placeholder stock image this seeder put on a row. */
+function isDemoStockUrl(url: string | undefined | null): boolean {
+  return !!url && url.startsWith(DEMO_STOCK_HOST);
 }
 
 /**
@@ -241,17 +253,46 @@ const GROUP_DM_CHAT: string[] = [
 ];
 
 /**
- * "Getting Started" guided missions, posted by the Togather bot into a
- * dedicated channel and tracked live by getDemoProgress. Keep the mission
- * list in sync with the progress query.
+ * "Getting Started" guided missions — the SINGLE source of truth for both the
+ * bot's numbered tour messages and getDemoProgress's checklist, so the two
+ * can't drift. `title` shows on the Go Live screen; `instruction` is the bot
+ * line. Every mission here is tracked by getDemoProgress.
  */
+const GETTING_STARTED_MISSIONS = [
+  {
+    key: "send_message",
+    title: "Send a message in a group",
+    instruction:
+      "Send a message — open any group's chat and say hi. Everything here is editable and safe to play with.",
+  },
+  {
+    key: "create_event",
+    title: "Create an event",
+    instruction:
+      "Create an event — open a group → Events → New Event. Try RSVP options and a cover photo.",
+  },
+  {
+    key: "birthday_bot",
+    title: "Set up the Birthday Bot",
+    instruction:
+      "Set up the Birthday Bot — open a group → settings → Bots. New members feel welcome when their birthday gets celebrated automatically.",
+  },
+  {
+    key: "invite_teammate",
+    title: "Invite a teammate with your demo code",
+    instruction:
+      "Invite a teammate — share your demo code (on the Go Live screen) so a co-worker can explore with you. Up to 10 people can join.",
+  },
+] as const;
+
+const MISSION_NUMBER_EMOJI = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣"];
+
 const GETTING_STARTED_MESSAGES: string[] = [
-  "Welcome to your demo community! 👋 I'm the Togather bot. Here are a few things worth trying while you explore — I'll keep track of your progress on the Go Live screen (tap the demo banner).",
-  "1️⃣ Send a message — open any group's chat and say hi. Everything here is editable and safe to play with.",
-  "2️⃣ Create an event — open a group → Events → New Event. Try RSVP options and a cover photo.",
-  "3️⃣ Set up the Birthday Bot — open a group → settings → Bots. New members feel welcome when their birthday gets celebrated automatically.",
-  "4️⃣ Invite a teammate — share your demo code (on the Go Live screen) so a co-worker can explore with you. Up to 10 people can join.",
-  "5️⃣ Make it yours — Admin → Settings to change your name, logo, and brand color. The whole app re-themes instantly.",
+  "Welcome to your demo community! 👋 I'm the Togather bot. Here are the things worth trying while you explore — I'll check them off on the Go Live screen (tap the demo banner) as you go.",
+  ...GETTING_STARTED_MISSIONS.map(
+    (m, i) => `${MISSION_NUMBER_EMOJI[i]} ${m.instruction}`,
+  ),
+  "Any time, head to Admin → Settings to change your name, logo, and brand color — the whole app re-themes instantly. ✨",
   "When you're ready for the real thing, tap Go live on the banner — your groups, branding, and teammates stay; these demo members and I clean ourselves up. 🎉",
 ];
 
@@ -263,12 +304,6 @@ const PRAYER_REQUESTS = [
 
 const DAY = 24 * 60 * 60 * 1000;
 const HOUR = 60 * 60 * 1000;
-
-const DEFAULT_RSVP_OPTIONS = [
-  { id: 1, label: "Attending", enabled: true },
-  { id: 2, label: "Maybe", enabled: true },
-  { id: 3, label: "Not Attending", enabled: true },
-];
 
 function isValidHex(hex: string): boolean {
   return /^#[0-9A-Fa-f]{6}$/.test(hex);
@@ -466,7 +501,13 @@ async function flushChannelCounts(
   counts.clear();
 }
 
-/** Count the real (non-placeholder) accounts that belong to a demo. */
+/**
+ * Count the real (non-placeholder) accounts that belong to a demo. Seeded
+ * members are always inserted as COMMUNITY_ROLES.MEMBER and real accounts are
+ * always ADMIN+ (creator = primary admin, code-joiners = admin), so role
+ * alone separates them — no per-user document read needed. This runs on the
+ * hot path (getDemoStatus, subscribed by the app-wide banner on every screen).
+ */
 async function countRealUsers(
   ctx: QueryCtx | MutationCtx,
   communityId: Id<"communities">,
@@ -475,13 +516,9 @@ async function countRealUsers(
     .query("userCommunities")
     .withIndex("by_community", (q) => q.eq("communityId", communityId))
     .collect();
-  let count = 0;
-  for (const membership of memberships) {
-    if (membership.status !== 1) continue;
-    const user = await ctx.db.get(membership.userId);
-    if (user && !user.isPlaceholder) count++;
-  }
-  return count;
+  return memberships.filter(
+    (m) => m.status === 1 && (m.roles ?? 0) >= COMMUNITY_ROLES.ADMIN,
+  ).length;
 }
 
 /**
@@ -524,6 +561,7 @@ async function seedConversation(
       contentType: args.contentType ?? "text",
       createdAt,
       isDeleted: false,
+      isDemoSeed: true, // distinguishes seed chatter from real user activity
       senderName: sender.name,
       senderProfilePhoto: sender.photo,
       lastActivityAt: createdAt,
@@ -576,6 +614,7 @@ async function createDemoMeeting(
     communityWideEventId: args.communityWideEventId,
     communityId: args.communityId,
     searchText: args.title.toLowerCase(),
+    isDemoSeed: true, // distinguishes seed events from ones the church creates
     createdAt: now(),
     reminderSent: false,
     attendanceConfirmationSent: false,
@@ -1257,35 +1296,29 @@ export const getDemoProgress = query({
     const community = await ctx.db.get(args.communityId);
     if (!community?.isDemo) return null;
 
-    // Real (non-seeded) accounts in the demo.
+    // Real accounts = ADMIN+ memberships (seeds are always MEMBER); no
+    // per-user reads. See countRealUsers.
     const memberships = await ctx.db
       .query("userCommunities")
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
-    const realUserIds: Id<"users">[] = [];
-    for (const m of memberships) {
-      if (m.status !== 1) continue;
-      const user = await ctx.db.get(m.userId);
-      if (user && !user.isPlaceholder) realUserIds.push(m.userId);
-    }
+    const realUserIds = memberships
+      .filter((m) => m.status === 1 && (m.roles ?? 0) >= COMMUNITY_ROLES.ADMIN)
+      .map((m) => m.userId);
 
-    // Anything created noticeably after the seed transaction was done by a
-    // human clicking around, not by the seeder.
-    const seededBefore = (community.createdAt ?? 0) + 5 * 60 * 1000;
-
+    // "Sent a message" = a real user authored a NON-seeded message in this
+    // community. The by_sender_community index bounds the scan to this
+    // community (a real user could have thousands of messages elsewhere), and
+    // isDemoSeed excludes the scripted DM lines attributed to the creator —
+    // no wall-clock heuristic, so a message sent seconds after entering counts.
     let sentMessage = false;
     for (const realUserId of realUserIds) {
-      // Seeded DM scripts include lines "from" the creator, so only messages
-      // written after the seed transaction count as the user's own activity.
       const message = await ctx.db
         .query("chatMessages")
-        .withIndex("by_sender", (q) => q.eq("senderId", realUserId))
-        .filter((q) =>
-          q.and(
-            q.eq(q.field("communityId"), args.communityId),
-            q.gt(q.field("createdAt"), seededBefore),
-          ),
+        .withIndex("by_sender_community", (q) =>
+          q.eq("senderId", realUserId).eq("communityId", args.communityId),
         )
+        .filter((q) => q.neq(q.field("isDemoSeed"), true))
         .first();
       if (message) {
         sentMessage = true;
@@ -1297,11 +1330,12 @@ export const getDemoProgress = query({
       .query("meetings")
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
+    const realUserIdSet = new Set(realUserIds.map((id) => String(id)));
     const createdEvent = meetings.some(
       (m) =>
-        m.createdAt > seededBefore &&
+        !m.isDemoSeed &&
         m.createdById !== undefined &&
-        realUserIds.some((id) => id === m.createdById),
+        realUserIdSet.has(String(m.createdById)),
     );
 
     const groups = await ctx.db
@@ -1322,12 +1356,19 @@ export const getDemoProgress = query({
       }
     }
 
-    const missions = [
-      { key: "send_message", title: "Send a message in a group", done: sentMessage },
-      { key: "create_event", title: "Create an event", done: createdEvent },
-      { key: "birthday_bot", title: "Set up the Birthday Bot", done: birthdayBot },
-      { key: "invite_teammate", title: "Invite a teammate with your demo code", done: realUserIds.length >= 2 },
-    ];
+    // Derived from the same GETTING_STARTED_MISSIONS the bot posts, so the
+    // checklist and the tour can never disagree.
+    const doneByKey: Record<string, boolean> = {
+      send_message: sentMessage,
+      create_event: createdEvent,
+      birthday_bot: birthdayBot,
+      invite_teammate: realUserIds.length >= 2,
+    };
+    const missions = GETTING_STARTED_MISSIONS.map((m) => ({
+      key: m.key,
+      title: m.title,
+      done: doneByKey[m.key] ?? false,
+    }));
 
     return {
       missions,
@@ -1480,26 +1521,42 @@ export const purgeDemoSeedUsers = internalMutation({
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
     for (const group of groups) {
+      // Seeded group avatars are placeholder stock photos on a third-party
+      // host — drop them so the now-live community isn't left depending on
+      // picsum.photos in production. The church's own uploaded logo (an r2:
+      // path on the announcement group) is kept.
+      if (isDemoStockUrl(group.preview)) {
+        await ctx.db.patch(group._id, { preview: undefined });
+      }
+
       const channels = await ctx.db
         .query("chatChannels")
         .withIndex("by_group", (q) => q.eq("groupId", group._id))
         .collect();
       for (const channel of channels) {
-        // The Getting Started tour is demo-only — it removes itself on
-        // go-live, exactly as its bot messages promise.
-        if (channel.slug === "getting-started") {
-          const tourMembers = await ctx.db
-            .query("chatChannelMembers")
-            .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
-            .collect();
-          for (const member of tourMembers) await ctx.db.delete(member._id);
+        // The Getting Started tour is demo-only and removes itself on go-live,
+        // as its bot messages promise. Match it narrowly — the announcement
+        // group's tour channel whose messages are ALL bot-authored — so a
+        // real "Getting Started" channel a church happened to create (the slug
+        // isn't reserved) is never mistaken for it and deleted.
+        if (channel.slug === "getting-started" && group.isAnnouncementGroup) {
           const tourMessages = await ctx.db
             .query("chatMessages")
             .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
             .collect();
-          for (const message of tourMessages) await ctx.db.delete(message._id);
-          await ctx.db.delete(channel._id);
-          continue;
+          const allBotAuthored = tourMessages.every(
+            (m) => m.senderId === undefined,
+          );
+          if (allBotAuthored) {
+            const tourMembers = await ctx.db
+              .query("chatChannelMembers")
+              .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
+              .collect();
+            for (const member of tourMembers) await ctx.db.delete(member._id);
+            for (const message of tourMessages) await ctx.db.delete(message._id);
+            await ctx.db.delete(channel._id);
+            continue;
+          }
         }
 
         const remaining = await ctx.db
@@ -1518,6 +1575,30 @@ export const purgeDemoSeedUsers = internalMutation({
           lastMessageSenderId: lastMessage?.senderId,
           lastMessageSenderName: lastMessage?.senderName,
         });
+      }
+    }
+
+    // Strip placeholder stock covers from the events that survive go-live
+    // (meetings + the community-wide event are authored by the real creator,
+    // so they aren't deleted with the seed members).
+    const survivingMeetings = await ctx.db
+      .query("meetings")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    for (const meeting of survivingMeetings) {
+      if (isDemoStockUrl(meeting.coverImage)) {
+        await ctx.db.patch(meeting._id, { coverImage: undefined });
+      }
+    }
+    const cwes = await ctx.db
+      .query("communityWideEvents")
+      .withIndex("by_community_status", (q) =>
+        q.eq("communityId", args.communityId).eq("status", "scheduled"),
+      )
+      .collect();
+    for (const cwe of cwes) {
+      if (isDemoStockUrl(cwe.coverImage)) {
+        await ctx.db.patch(cwe._id, { coverImage: undefined });
       }
     }
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -758,6 +758,10 @@ export default defineSchema({
     // Search support (denormalized)
     communityId: v.optional(v.id("communities")), // Denormalized from group for search filtering
     searchText: v.optional(v.string()), // Denormalized: title + location + group name
+    // True only for events seeded into a demo community (functions/demo.ts).
+    // Lets getDemoProgress tell a seeded event from one the church created,
+    // without a wall-clock heuristic.
+    isDemoSeed: v.optional(v.boolean()),
   })
     .index("by_legacyId", ["legacyId"])
     .index("by_group", ["groupId"])
@@ -1860,11 +1864,18 @@ export default defineSchema({
     // For mirrored text blasts — backlink to the eventBlasts row so the UI
     // can render an "Also sent via SMS" badge and deep-link to delivery stats.
     blastId: v.optional(v.id("eventBlasts")),
+    // True only for messages seeded into a demo community (functions/demo.ts):
+    // the scripted group/DM conversations and the Getting Started tour. Lets
+    // getDemoProgress tell a seeded message from one a real user sent.
+    isDemoSeed: v.optional(v.boolean()),
   })
     .index("by_channel", ["channelId"])
     .index("by_channel_createdAt", ["channelId", "createdAt"])
     .index("by_channel_lastActivityAt", ["channelId", "lastActivityAt"])
     .index("by_sender", ["senderId"])
+    // Bounds getDemoProgress's "did this real user send a message here" check
+    // to one community instead of scanning the sender's cross-community history.
+    .index("by_sender_community", ["senderId", "communityId"])
     .index("by_parentMessage", ["parentMessageId"])
     .index("by_createdAt", ["createdAt"])
     .index("by_sourceKey", ["sourceKey"])

--- a/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
+++ b/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
@@ -36,7 +36,9 @@ import { useAuth } from "@providers/AuthProvider";
 import { useSelectCommunity } from "@features/auth/hooks/useAuth";
 import { useTheme } from "@hooks/useTheme";
 import { ImagePicker } from "@components/ui";
-import { ColorInput, isValidHex } from "./ColorInput";
+import { ColorPicker } from "@features/admin/components/ColorPicker";
+import { isValidHex } from "./ColorInput";
+import { geocodeZipCode } from "@features/groups/utils/geocodeLocation";
 
 type DemoResult = {
   communityId: string;
@@ -64,7 +66,8 @@ export function DemoCommunityScreen() {
   const [zipCode, setZipCode] = useState("");
   const [logoUri, setLogoUri] = useState<string | null>(null);
   const [primaryColor, setPrimaryColor] = useState("#1E8449");
-  const [secondaryColor, setSecondaryColor] = useState("#2E86C1");
+  const [campusNames, setCampusNames] = useState<string[]>([]);
+  const [groupNamesList, setGroupNamesList] = useState<string[]>([]);
 
   // ---- Join-by-code state ----
   const [joinCode, setJoinCode] = useState("");
@@ -76,10 +79,7 @@ export function DemoCommunityScreen() {
   const [error, setError] = useState<string | null>(null);
   const [demo, setDemo] = useState<DemoResult | null>(null);
 
-  const formValid =
-    name.trim().length > 0 &&
-    isValidHex(primaryColor) &&
-    isValidHex(secondaryColor);
+  const formValid = name.trim().length > 0 && isValidHex(primaryColor);
 
   /** Upload the picked logo to R2 and return its storage path. */
   async function uploadLogo(imageUri: string): Promise<string> {
@@ -117,6 +117,19 @@ export function DemoCommunityScreen() {
     return storagePath;
   }
 
+  function setNameAt(
+    setList: React.Dispatch<React.SetStateAction<string[]>>,
+    index: number,
+    value: string,
+  ) {
+    setList((prev) => {
+      const next = [...prev];
+      while (next.length <= index) next.push("");
+      next[index] = value;
+      return next;
+    });
+  }
+
   function parseCount(value: string): number | undefined {
     const parsed = parseInt(value, 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
@@ -128,6 +141,11 @@ export function DemoCommunityScreen() {
     setSubmitting(true);
     try {
       const logo = logoUri ? await uploadLogo(logoUri) : undefined;
+      // Best-effort: resolve the zip to coordinates (bundled US zip database)
+      // so seeded groups and events land on the map around their area.
+      const coords = geocodeZipCode(zipCode.trim() || null);
+      const cleanNames = (names: string[]) =>
+        names.map((n) => n.trim()).filter((n) => n.length > 0);
       const result = await createDemo({
         name: name.trim(),
         totalSize: parseCount(totalSize),
@@ -136,7 +154,9 @@ export function DemoCommunityScreen() {
         zipCode: zipCode.trim() || undefined,
         logo,
         primaryColor,
-        secondaryColor,
+        campusNames: cleanNames(campusNames).length > 0 ? cleanNames(campusNames) : undefined,
+        groupNames: cleanNames(groupNamesList).length > 0 ? cleanNames(groupNamesList) : undefined,
+        baseCoordinates: coords ?? undefined,
       });
       setDemo(result);
     } catch (err) {
@@ -375,6 +395,58 @@ export function DemoCommunityScreen() {
                 />
               </View>
             </View>
+
+            {/* Optional real names — skipping is explicitly fine. */}
+            {(parseCount(campusCount) ?? 0) >= 2 && (
+              <View style={styles.fieldGroup}>
+                <Text style={[styles.label, { color: colors.textSecondary }]}>
+                  Campus names <Text style={{ color: colors.textTertiary }}>(optional)</Text>
+                </Text>
+                <Text style={[styles.fieldHint, { color: colors.textTertiary }]}>
+                  Totally fine to skip — we'll use placeholder names and spots
+                  near your zip, and you can rename anything later.
+                </Text>
+                {Array.from({ length: Math.min(parseCount(campusCount) ?? 0, 12) }).map((_, i) => (
+                  <TextInput
+                    key={`campus-${i}`}
+                    style={[
+                      styles.input,
+                      styles.nameInput,
+                      { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text },
+                    ]}
+                    value={campusNames[i] ?? ""}
+                    onChangeText={(v) => setNameAt(setCampusNames, i, v)}
+                    placeholder={`Campus ${i + 1}`}
+                    placeholderTextColor={colors.inputPlaceholder}
+                  />
+                ))}
+              </View>
+            )}
+            {(parseCount(smallGroupCount) ?? 0) >= 1 && (
+              <View style={styles.fieldGroup}>
+                <Text style={[styles.label, { color: colors.textSecondary }]}>
+                  Small group names <Text style={{ color: colors.textTertiary }}>(optional)</Text>
+                </Text>
+                <Text style={[styles.fieldHint, { color: colors.textTertiary }]}>
+                  Same here — skip it and we'll seed friendly placeholder
+                  groups you can rename anytime.
+                </Text>
+                {Array.from({ length: Math.min(parseCount(smallGroupCount) ?? 0, 12) }).map((_, i) => (
+                  <TextInput
+                    key={`group-${i}`}
+                    style={[
+                      styles.input,
+                      styles.nameInput,
+                      { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text },
+                    ]}
+                    value={groupNamesList[i] ?? ""}
+                    onChangeText={(v) => setNameAt(setGroupNamesList, i, v)}
+                    placeholder={`Small group ${i + 1}`}
+                    placeholderTextColor={colors.inputPlaceholder}
+                  />
+                ))}
+              </View>
+            )}
           </View>
 
           {/* Branding */}
@@ -396,18 +468,17 @@ export function DemoCommunityScreen() {
               />
             </View>
 
-            <ColorInput
-              label="Primary color"
+            <ColorPicker
+              label="Brand color"
               value={primaryColor}
               onChange={setPrimaryColor}
-              colors={colors}
+              defaultColor="#1E8449"
             />
-            <ColorInput
-              label="Secondary color"
-              value={secondaryColor}
-              onChange={setSecondaryColor}
-              colors={colors}
-            />
+            <Text style={[styles.fieldHint, { color: colors.textTertiary }]}>
+              This colors buttons, tabs, and highlights — with white text on
+              top — so richer, darker shades work best. Every preset in the
+              picker looks great; very light or neon colors won't.
+            </Text>
           </View>
 
           {error && (
@@ -628,6 +699,14 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "500",
     marginBottom: 6,
+  },
+  fieldHint: {
+    fontSize: 13,
+    lineHeight: 18,
+    marginBottom: 8,
+  },
+  nameInput: {
+    marginBottom: 8,
   },
   input: {
     borderWidth: 1,

--- a/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
+++ b/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
@@ -37,8 +37,11 @@ import { useSelectCommunity } from "@features/auth/hooks/useAuth";
 import { useTheme } from "@hooks/useTheme";
 import { ImagePicker } from "@components/ui";
 import { ColorPicker } from "@features/admin/components/ColorPicker";
-import { isValidHex } from "./ColorInput";
 import { geocodeZipCode } from "@features/groups/utils/geocodeLocation";
+
+// Server caps in functions/demo.ts (MAX_CAMPUSES / MAX_SMALL_GROUPS): we only
+// show name inputs up to this many. Keep in sync with the backend.
+const MAX_NAMED_ITEMS = 12;
 
 type DemoResult = {
   communityId: string;
@@ -79,7 +82,14 @@ export function DemoCommunityScreen() {
   const [error, setError] = useState<string | null>(null);
   const [demo, setDemo] = useState<DemoResult | null>(null);
 
-  const formValid = name.trim().length > 0 && isValidHex(primaryColor);
+  // ColorPicker only ever emits valid hex (presets + validated input), so the
+  // brand color can't be invalid — name is the only required field. The
+  // server re-validates everything regardless.
+  const formValid = name.trim().length > 0;
+
+  // Derived once (used in the render below and to size the name-input lists).
+  const campusFields = Math.min(parseCount(campusCount) ?? 0, MAX_NAMED_ITEMS);
+  const groupFields = Math.min(parseCount(smallGroupCount) ?? 0, MAX_NAMED_ITEMS);
 
   /** Upload the picked logo to R2 and return its storage path. */
   async function uploadLogo(imageUri: string): Promise<string> {
@@ -146,6 +156,8 @@ export function DemoCommunityScreen() {
       const coords = geocodeZipCode(zipCode.trim() || null);
       const cleanNames = (names: string[]) =>
         names.map((n) => n.trim()).filter((n) => n.length > 0);
+      const cleanedCampusNames = cleanNames(campusNames);
+      const cleanedGroupNames = cleanNames(groupNamesList);
       const result = await createDemo({
         name: name.trim(),
         totalSize: parseCount(totalSize),
@@ -154,8 +166,8 @@ export function DemoCommunityScreen() {
         zipCode: zipCode.trim() || undefined,
         logo,
         primaryColor,
-        campusNames: cleanNames(campusNames).length > 0 ? cleanNames(campusNames) : undefined,
-        groupNames: cleanNames(groupNamesList).length > 0 ? cleanNames(groupNamesList) : undefined,
+        campusNames: cleanedCampusNames.length > 0 ? cleanedCampusNames : undefined,
+        groupNames: cleanedGroupNames.length > 0 ? cleanedGroupNames : undefined,
         baseCoordinates: coords ?? undefined,
       });
       setDemo(result);
@@ -397,7 +409,7 @@ export function DemoCommunityScreen() {
             </View>
 
             {/* Optional real names — skipping is explicitly fine. */}
-            {(parseCount(campusCount) ?? 0) >= 2 && (
+            {campusFields >= 2 && (
               <View style={styles.fieldGroup}>
                 <Text style={[styles.label, { color: colors.textSecondary }]}>
                   Campus names <Text style={{ color: colors.textTertiary }}>(optional)</Text>
@@ -406,7 +418,7 @@ export function DemoCommunityScreen() {
                   Totally fine to skip — we'll use placeholder names and spots
                   near your zip, and you can rename anything later.
                 </Text>
-                {Array.from({ length: Math.min(parseCount(campusCount) ?? 0, 12) }).map((_, i) => (
+                {Array.from({ length: campusFields }).map((_, i) => (
                   <TextInput
                     key={`campus-${i}`}
                     style={[
@@ -422,7 +434,7 @@ export function DemoCommunityScreen() {
                 ))}
               </View>
             )}
-            {(parseCount(smallGroupCount) ?? 0) >= 1 && (
+            {groupFields >= 1 && (
               <View style={styles.fieldGroup}>
                 <Text style={[styles.label, { color: colors.textSecondary }]}>
                   Small group names <Text style={{ color: colors.textTertiary }}>(optional)</Text>
@@ -431,7 +443,7 @@ export function DemoCommunityScreen() {
                   Same here — skip it and we'll seed friendly placeholder
                   groups you can rename anytime.
                 </Text>
-                {Array.from({ length: Math.min(parseCount(smallGroupCount) ?? 0, 12) }).map((_, i) => (
+                {Array.from({ length: groupFields }).map((_, i) => (
                   <TextInput
                     key={`group-${i}`}
                     style={[

--- a/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
+++ b/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
@@ -51,6 +51,10 @@ export function GoLiveScreen() {
     api.functions.memberActivity.getBillableSummary,
     isAuthenticated && communityId ? { communityId } : "skip",
   );
+  const progress = useAuthenticatedQuery(
+    api.functions.demo.getDemoProgress,
+    isAuthenticated && communityId ? { communityId } : "skip",
+  );
 
   const convertDemoToLive = useAuthenticatedAction(
     api.functions.ee.billing.convertDemoToLive,
@@ -188,6 +192,40 @@ export function GoLiveScreen() {
                   </View>
                 )}
               </View>
+
+              {progress && (
+                <View
+                  style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}
+                >
+                  <Text style={[styles.cardTitle, { color: colors.text }]}>
+                    While you explore · {progress.completed}/{progress.total}
+                  </Text>
+                  {progress.missions.map((mission) => (
+                    <View key={mission.key} style={styles.missionRow}>
+                      <Ionicons
+                        name={mission.done ? "checkmark-circle" : "ellipse-outline"}
+                        size={20}
+                        color={mission.done ? colors.success : colors.textTertiary}
+                      />
+                      <Text
+                        style={[
+                          styles.missionText,
+                          {
+                            color: mission.done ? colors.textSecondary : colors.text,
+                            textDecorationLine: mission.done ? "line-through" : "none",
+                          },
+                        ]}
+                      >
+                        {mission.title}
+                      </Text>
+                    </View>
+                  ))}
+                  <Text style={[styles.missionHint, { color: colors.textTertiary }]}>
+                    The 🎓 Getting Started conversation in your inbox walks
+                    through each one.
+                  </Text>
+                </View>
+              )}
 
               {error && (
                 <View
@@ -331,6 +369,21 @@ const styles = StyleSheet.create({
   estimateValue: {
     fontSize: 16,
     fontWeight: "700",
+  },
+  missionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 6,
+  },
+  missionText: {
+    fontSize: 14,
+    flex: 1,
+  },
+  missionHint: {
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 10,
   },
   notice: {
     flexDirection: "row",

--- a/apps/web/src/pages/guides/CreateCommunity.tsx
+++ b/apps/web/src/pages/guides/CreateCommunity.tsx
@@ -65,25 +65,31 @@ export function CreateCommunity() {
           </Step>
           <Step n={2}>
             <Term>Church size</Term>, <Term>Campuses</Term>, and{" "}
-            <Term>Small groups</Term> — we shape the demo's groups to roughly
-            match your congregation.
+            <Term>Small groups</Term> — we create a group for every campus and
+            small group you enter. Naming them is optional: skip it and we'll
+            use friendly placeholders you can rename anytime.
           </Step>
           <Step n={3}>
-            <Term>Main zip code</Term> — so the community's home base matches
-            yours.
+            <Term>Main zip code</Term> — your groups and events are placed on
+            the map around your area.
           </Step>
           <Step n={4}>
-            <Term>Logo</Term> and <Term>brand colors</Term> — the whole app is
-            themed with your look before you ever open it.
+            <Term>Logo</Term> and <Term>brand color</Term> — pick from preset
+            swatches that all work well (richer, darker shades carry the white
+            text used on buttons and tabs). The whole app is themed with your
+            look before you ever open it.
           </Step>
         </Steps>
         <P>
           Choose <Term>Create my community</Term> and in a few seconds you're
           the admin of a working community in demo mode: 100 seeded demo
-          members, groups with real channel conversations, upcoming events with
-          RSVPs, prayer requests, and the full admin settings screen.
-          Everything works — rename it, re-brand it, create events, post
-          messages.
+          members with real profile photos, groups with avatars and real
+          channel conversations, direct messages, upcoming events with cover
+          photos and RSVPs, prayer requests, and the full admin settings
+          screen. A <Term>🎓 Getting Started</Term> conversation in your inbox
+          walks you through the best things to try, and the Go Live screen
+          tracks your progress. Everything works — rename it, re-brand it,
+          create events, post messages.
         </P>
         <Callout tone="note" title="You'll always know it's a demo">
           While your community is in demo mode, a banner appears across the


### PR DESCRIPTION
## What this does

Addresses the first real-usage feedback round on demo mode (#568 follow-up).

### Fixes
- **"It didn't create a group for the 8 campuses"** — the seeder silently capped campuses at 4. Caps for campuses and small groups are now 12, one group per campus.
- **"The logo isn't even updated"** — the inbox shows group avatars and none was set. The announcement group now wears the uploaded church logo; every other group gets a stable avatar.
- **"No pictures / inbox overwhelming"** — all 100 seeded members get portrait photos (denormalized onto channel members and messages), every event gets a cover image, and the inbox gains two seeded DMs + a "Serve Day planning" group DM so it reads like a lived-in church. Demo-only external imagery, purged with the rest of the seed on go-live (including the ad-hoc chats, so no orphaned DMs).
- **"Small groups" → "Small Group"** — group type names are singular everywhere in the demo seed (slugs unchanged).
- **"Why am I a leader in every group?"** — the creator (and demo-code joiners) now lead the announcement group plus two groups and are plain members elsewhere; leaders-only channels stay leaders-only.

### New
- **Optional names & locations**: the questionnaire takes optional campus/group names with explicit "fine to skip — we'll use placeholders and spots near your zip, rename anytime" copy. The zip is geocoded client-side (bundled `us-zips`) and passed as `baseCoordinates`; groups/campuses scatter around it on the explore map, and seeded events carry a zip-bearing `locationOverride` so they land on the events map.
- **🎓 Getting Started**: a bot-authored guided-missions channel in the inbox, plus a `getDemoProgress` query that tracks real activity (send a message, create an event, enable the Birthday Bot, invite a teammate) and renders as a checklist on the Go Live screen. The tour removes itself on go-live.
- **Color UX**: the questionnaire now uses the admin `ColorPicker` (preset swatches that all work as the app tint) with guidance that richer/darker shades carry white text. The **secondary color field is removed** — verified it renders nowhere in the app beyond form previews (`useCommunityTheme` consumers only use primary).

### Docs
- Create Your Community guide updated for the new questionnaire (optional names, single brand color, Getting Started tour).

## Testing
- 2,161 backend tests pass, including new coverage: 8 campuses → 8 groups, custom names honored, singular type names, imagery on members/groups/events, jittered coordinates, creator role mix (announcement + exactly 2 leader roles), seeded DMs/group DM/Getting Started channel shapes, mission progress transitions, and purge behavior for DMs + the tour channel.
- Mobile and web typecheck clean; web guide builds.
- Not CI-covered: visual pass of the questionnaire and inbox on a live deployment.

## Notes
- Demo imagery uses stable external URLs (randomuser.me portraits, picsum covers) on seeded rows only; everything is deleted at go-live. If we'd rather self-host, swapping to R2-uploaded assets is a contained follow-up.
- Deferred pending product direction: merging announcement-group check-in with Admin → People (keeping make-admin / transfer-primary-admin) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQLRNeL7gUToheWEhBnrLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQLRNeL7gUToheWEhBnrLs)_