### PR TITLE
Remove manual billing override — active-member count is always automatic

### DIFF
--- a/apps/convex/__tests__/member-activity.test.ts
+++ b/apps/convex/__tests__/member-activity.test.ts
@@ -222,120 +222,28 @@ describe("getBillableSummary", () => {
     expect(summary.billableActiveUsers).toBe(2);
   });
 
-  test("manually marked inactive members are excluded until re-activated", async () => {
+  test("an active member always counts — the count is purely automatic", async () => {
     const t = convexTest(schema, modules);
     const { communityId, adminToken } = await seedCommunity(t);
-    const memberId = await addMember(t, communityId, "+15555560006", { age: 0 });
+    await addMember(t, communityId, "+15555560006", { age: 0 });
 
-    await t.mutation(api.functions.memberActivity.setMemberBillingActive, {
-      token: adminToken,
-      communityId,
-      targetUserId: memberId,
-      active: false,
-    });
-    let summary = await t.query(api.functions.memberActivity.getBillableSummary, {
-      token: adminToken,
-      communityId,
-    });
-    expect(summary.billableActiveUsers).toBe(1); // admin only
-
-    await t.mutation(api.functions.memberActivity.setMemberBillingActive, {
-      token: adminToken,
-      communityId,
-      targetUserId: memberId,
-      active: true,
-    });
-    summary = await t.query(api.functions.memberActivity.getBillableSummary, {
-      token: adminToken,
-      communityId,
-    });
-    expect(summary.billableActiveUsers).toBe(2);
-  });
-});
-
-describe("setMemberBillingActive permissions", () => {
-  test("a plain member cannot mark others inactive", async () => {
-    const t = convexTest(schema, modules);
-    const { communityId } = await seedCommunity(t);
-    const memberA = await addMember(t, communityId, "+15555560007", { age: 0 });
-    const memberB = await addMember(t, communityId, "+15555560008", { age: 0 });
-
-    const { accessToken } = await generateTokens(memberA);
-    await expect(
-      t.mutation(api.functions.memberActivity.setMemberBillingActive, {
-        token: accessToken,
-        communityId,
-        targetUserId: memberB,
-        active: false,
-      }),
-    ).rejects.toThrow("group leaders");
-  });
-
-  test("a group leader can mark their group's members inactive", async () => {
-    const t = convexTest(schema, modules);
-    const { communityId, adminToken } = await seedCommunity(t);
-    const leaderId = await addMember(t, communityId, "+15555560009", { age: 0 });
-    const memberId = await addMember(t, communityId, "+15555560010", { age: 0 });
-    const outsiderId = await addMember(t, communityId, "+15555560011", { age: 0 });
-
+    // There is no manual override mutation to exclude an active member; the
+    // count is purely the automatic 30-day rule. Even a stray billingInactive
+    // value left on a row (from before the override was removed) is ignored.
     await t.run(async (ctx) => {
-      const timestamp = Date.now();
-      const groupTypeId = await ctx.db.insert("groupTypes", {
-        communityId,
-        name: "Small Groups",
-        slug: "small-groups",
-        isActive: true,
-        displayOrder: 1,
-        createdAt: timestamp,
-      });
-      const groupId = await ctx.db.insert("groups", {
-        communityId,
-        groupTypeId,
-        name: "Alpha Group",
-        isArchived: false,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      });
-      await ctx.db.insert("groupMembers", {
-        groupId,
-        userId: leaderId,
-        role: "leader",
-        joinedAt: timestamp,
-        notificationsEnabled: true,
-      });
-      await ctx.db.insert("groupMembers", {
-        groupId,
-        userId: memberId,
-        role: "member",
-        joinedAt: timestamp,
-        notificationsEnabled: true,
-      });
+      const membership = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .collect();
+      const memberRow = membership.find((m) => m.roles === COMMUNITY_ROLES.MEMBER);
+      await ctx.db.patch(memberRow!._id, { billingInactive: true } as never);
     });
 
-    const { accessToken: leaderToken } = await generateTokens(leaderId);
-
-    // Leader can manage a member of their group…
-    await t.mutation(api.functions.memberActivity.setMemberBillingActive, {
-      token: leaderToken,
-      communityId,
-      targetUserId: memberId,
-      active: false,
-    });
     const summary = await t.query(api.functions.memberActivity.getBillableSummary, {
       token: adminToken,
       communityId,
     });
-    // admin + leader + outsider (member marked inactive)
-    expect(summary.billableActiveUsers).toBe(3);
-
-    // …but not someone outside their group.
-    await expect(
-      t.mutation(api.functions.memberActivity.setMemberBillingActive, {
-        token: leaderToken,
-        communityId,
-        targetUserId: outsiderId,
-        active: false,
-      }),
-    ).rejects.toThrow("group leaders");
+    // admin + the active member — the stale billingInactive flag does nothing.
+    expect(summary.billableActiveUsers).toBe(2);
   });
 });

--- a/apps/convex/__tests__/member-activity.test.ts
+++ b/apps/convex/__tests__/member-activity.test.ts
@@ -3,9 +3,8 @@
  *
  * Covers the billable-member definition (opened the app in THIS community
  * within the past month — per-community membership.lastLogin, not app-wide
- * activity — matching the admin Stats "Active Members" card), the manual
- * inactive flag, placeholder exclusion, and the permissions on manually
- * marking members inactive (community admins + the member's group leaders).
+ * activity — matching the admin Stats "Active Members" card), placeholder
+ * exclusion, and that the count is purely automatic with no manual override.
  *
  * Run with: cd apps/convex && pnpm test __tests__/member-activity.test.ts
  */

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -283,8 +283,8 @@ crons.daily(
 // Runs monthly, ahead of the billing anchor (subscriptions bill on the 1st),
 // and updates each per-active-user community's Stripe subscription quantity
 // to its current billable member count: real accounts who opened the app in
-// that community within the past month and aren't manually marked inactive
-// ($1/month each). See functions/memberActivity.ts for the definition.
+// that community within the past month ($1/month each). See
+// functions/memberActivity.ts for the definition.
 
 crons.monthly(
   "per-user-billing-sync",

--- a/apps/convex/functions/admin/members.ts
+++ b/apps/convex/functions/admin/members.ts
@@ -321,8 +321,6 @@ export const getCommunityMemberById = query({
         status: communityMembership.status || 0,
         joinedAt: communityMembership.createdAt || null,
         anniversary: communityMembership.communityAnniversary || null,
-        // Manual per-active-user billing override (see functions/memberActivity.ts)
-        billingInactive: communityMembership.billingInactive ?? false,
       },
       activeGroups: await Promise.all(
         activeGroups.map(async (m) => {

--- a/apps/convex/functions/ee/billing.ts
+++ b/apps/convex/functions/ee/billing.ts
@@ -1048,9 +1048,9 @@ export const savePerUserBillingCount = internalMutation({
 
 /**
  * Monthly cron (see crons.ts): re-count each per-active-user community's
- * billable members — opened the app in that community within the past month,
- * not manually marked inactive, real accounts only — and update the Stripe
- * subscription quantity so the next invoice bills $1 per active member.
+ * billable members — real accounts that opened the app in that community
+ * within the past month — and update the Stripe subscription quantity so the
+ * next invoice bills $1 per active member.
  */
 export const syncPerUserSubscriptionQuantities = internalAction({
   args: {},

--- a/apps/convex/functions/ee/billing.ts
+++ b/apps/convex/functions/ee/billing.ts
@@ -1117,7 +1117,7 @@ export const syncPerUserSubscriptionQuantities = internalAction({
         }
 
         // Pre-period disclosure: tell the community's admins what the 1st
-        // will bill, while there's still time to mark members inactive.
+        // will bill, before the invoice goes out — no surprise charge.
         await notifyCommunityAdmins(ctx, {
           type: "billing.monthly_preview",
           communityId: community.communityId,

--- a/apps/convex/functions/memberActivity.ts
+++ b/apps/convex/functions/memberActivity.ts
@@ -14,9 +14,12 @@
  *   - they are a real account (not an isPlaceholder provisional/demo user),
  *   - they opened the app in this community within the past month
  *     (membership.lastLogin — strictly; members who were added or imported
- *     but never opened the app here are NOT billable),
- *   - no admin/leader has manually marked them inactive
- *     (userCommunities.billingInactive).
+ *     but never opened the app here are NOT billable).
+ *
+ * This is entirely automatic and cannot be overridden — there is deliberately
+ * no way for an admin to mark an active member as non-billable (that would let
+ * a community zero out its bill while members keep using the app). The 30-day
+ * activity rule is the single source of truth.
  *
  * The count is used when a demo community converts to live (initial Stripe
  * subscription quantity, see functions/ee/billing.ts convertDemoToLive) and
@@ -24,13 +27,11 @@
  */
 
 import { v } from "convex/values";
-import { mutation, query } from "../_generated/server";
+import { query } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { requireAuth } from "../lib/auth";
 import { now } from "../lib/utils";
-import { isCommunityAdmin } from "../lib/permissions";
-import { isLeaderRole } from "../lib/helpers";
 
 /**
  * "Opened the app in this community within the past month" — the same
@@ -58,7 +59,6 @@ export async function countBillableActiveUsers(
   let count = 0;
   for (const membership of memberships) {
     if (membership.status !== 1) continue;
-    if (membership.billingInactive) continue;
 
     const user = await ctx.db.get(membership.userId);
     if (!user || user.isPlaceholder) continue;
@@ -72,87 +72,6 @@ export async function countBillableActiveUsers(
   }
   return count;
 }
-
-/**
- * Whether `actorId` may manage billing activity for `targetUserId` in this
- * community: community admins always can; group leaders can for members of
- * a group they lead.
- */
-async function canManageBillingActivity(
-  ctx: QueryCtx | MutationCtx,
-  communityId: Id<"communities">,
-  actorId: Id<"users">,
-  targetUserId: Id<"users">,
-): Promise<boolean> {
-  if (await isCommunityAdmin(ctx, communityId, actorId)) return true;
-
-  // Leader path: actor leads a (community-scoped) group the target belongs to.
-  const actorMemberships = await ctx.db
-    .query("groupMembers")
-    .withIndex("by_user", (q) => q.eq("userId", actorId))
-    .collect();
-
-  for (const gm of actorMemberships) {
-    if (gm.leftAt !== undefined || !isLeaderRole(gm.role)) continue;
-    const group = await ctx.db.get(gm.groupId);
-    if (!group || group.communityId !== communityId) continue;
-
-    const targetMembership = await ctx.db
-      .query("groupMembers")
-      .withIndex("by_group_user", (q) =>
-        q.eq("groupId", gm.groupId).eq("userId", targetUserId),
-      )
-      .first();
-    if (targetMembership && targetMembership.leftAt === undefined) return true;
-  }
-  return false;
-}
-
-/**
- * Manually mark a member as billing-inactive (or re-activate them).
- * Community admins can manage anyone; group leaders can manage members of
- * groups they lead.
- */
-export const setMemberBillingActive = mutation({
-  args: {
-    token: v.string(),
-    communityId: v.id("communities"),
-    targetUserId: v.id("users"),
-    active: v.boolean(),
-  },
-  handler: async (ctx, args) => {
-    const actorId = await requireAuth(ctx, args.token);
-
-    const allowed = await canManageBillingActivity(
-      ctx,
-      args.communityId,
-      actorId,
-      args.targetUserId,
-    );
-    if (!allowed) {
-      throw new Error(
-        "Only community admins or the member's group leaders can change billing activity",
-      );
-    }
-
-    const membership = await ctx.db
-      .query("userCommunities")
-      .withIndex("by_user_community", (q) =>
-        q.eq("userId", args.targetUserId).eq("communityId", args.communityId),
-      )
-      .first();
-    if (!membership) {
-      throw new Error("That person is not a member of this community");
-    }
-
-    await ctx.db.patch(membership._id, {
-      billingInactive: args.active ? undefined : true,
-      updatedAt: now(),
-    });
-
-    return { billingInactive: !args.active };
-  },
-});
 
 /**
  * Billing-activity summary for a community — powers the go-live screen and

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -1034,9 +1034,8 @@ interface BillingMonthlyPreviewData {
 /**
  * Pre-period bill disclosure for per-active-user billing: sent to community
  * admins right after the monthly quantity sync (the 28th), a few days before
- * the invoice on the 1st, so the amount is never a surprise and admins still
- * have time to mark members inactive. See functions/ee/billing.ts
- * syncPerUserSubscriptionQuantities and ADR-030.
+ * the invoice on the 1st, so the amount is never a surprise. See
+ * functions/ee/billing.ts syncPerUserSubscriptionQuantities and ADR-030.
  */
 export const billingMonthlyPreview: NotificationDefinition<BillingMonthlyPreviewData> = {
   type: 'billing.monthly_preview',
@@ -1061,8 +1060,8 @@ export const billingMonthlyPreview: NotificationDefinition<BillingMonthlyPreview
         </p>
         <p class="text">
           This is the same number as the Active Members card on your admin
-          Stats tab. If someone shouldn't count, an admin or their group
-          leader can mark them inactive from their person page before the 1st.
+          Stats tab. It updates automatically each month &mdash; anyone who
+          stops opening the app rolls off, and returns when they come back.
         </p>
       `),
       };

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -277,10 +277,12 @@ export default defineSchema({
     // Denormalized PCO person ID for efficient indexed lookups
     // This mirrors externalIds.planningCenterId but is top-level for indexing
     pcoPersonId: v.optional(v.string()),
-    // Manual billing override for the per-active-user pricing model: admins
-    // and leaders can mark a member inactive so they don't count toward the
-    // $1/month/active-user subscription even if they opened the app this
-    // month. See functions/memberActivity.ts.
+    // DEPRECATED — unused. Was a manual "mark this member non-billable"
+    // override, removed because it let a community zero out its bill while
+    // members kept using the app; billing is now purely the automatic 30-day
+    // activity rule (functions/memberActivity.ts). No code reads or writes
+    // this field. Kept in the schema only so any row that already has a value
+    // still validates; drop it in a follow-up after a clear migration.
     billingInactive: v.optional(v.boolean()),
   })
     .index("by_legacyId", ["legacyId"])

--- a/apps/mobile/features/admin/components/PersonDetailScreen.tsx
+++ b/apps/mobile/features/admin/components/PersonDetailScreen.tsx
@@ -61,7 +61,6 @@ export function PersonDetailScreen() {
     currentPresent: boolean;
   } | null>(null);
   const [isUpdatingAttendance, setIsUpdatingAttendance] = useState(false);
-  const [isUpdatingBilling, setIsUpdatingBilling] = useState(false);
 
   // Fetch member details using Convex
   const rawMember = useQuery(
@@ -91,7 +90,6 @@ export function PersonDetailScreen() {
         created_at: rawMember.communityMembership?.joinedAt,
         is_admin: rawMember.communityMembership?.isAdmin ?? false,
         is_primary_admin: rawMember.communityMembership?.isPrimaryAdmin ?? false,
-        billing_inactive: rawMember.communityMembership?.billingInactive ?? false,
         role: rawMember.communityMembership?.roles,
         groups: (rawMember.activeGroups || []).map((g: any) => ({
           group_id: g.groupId,
@@ -121,27 +119,10 @@ export function PersonDetailScreen() {
   const transferPrimaryAdminMutation = useAuthenticatedMutation(api.functions.admin.members.transferPrimaryAdmin);
   const removeMemberMutation = useAuthenticatedMutation(api.functions.communities.removeMember);
   const updateAttendanceMutation = useAuthenticatedMutation(api.functions.memberFollowups.updateAttendance);
-  const setBillingActiveMutation = useAuthenticatedMutation(api.functions.memberActivity.setMemberBillingActive);
 
   const canManageAdmins = currentUser?.is_primary_admin ?? false;
   const isCurrentUserAdmin = currentUser?.is_admin || currentUser?.is_primary_admin;
   const isSelf = currentUser?.id === userId;
-
-  const handleToggleBillingActive = useCallback(async () => {
-    if (!userId || !community?.id || !member) return;
-    setIsUpdatingBilling(true);
-    try {
-      await setBillingActiveMutation({
-        communityId: community.id as Id<"communities">,
-        targetUserId: userId as Id<"users">,
-        active: member.billing_inactive, // currently inactive -> re-activate
-      });
-    } catch (error: any) {
-      Alert.alert("Error", error?.message || "Failed to update billing activity");
-    } finally {
-      setIsUpdatingBilling(false);
-    }
-  }, [userId, community?.id, member, setBillingActiveMutation]);
 
   const handleAdminUpdateAttendance = useCallback(
     async (status: number) => {
@@ -454,37 +435,6 @@ export function PersonDetailScreen() {
               )}
             </View>
           </View>
-
-          {/* Billing activity: communities pay $1/month per active member;
-              admins can exclude someone from the count regardless of app use. */}
-          {isCurrentUserAdmin && !isSelf && (
-            <View style={[styles.billingRow, { borderTopColor: colors.borderLight }]}>
-              <View style={styles.billingRowText}>
-                <Text style={[styles.infoLabel, { color: colors.textSecondary }]}>Billing</Text>
-                <Text style={[styles.infoValue, { color: colors.text }]}>
-                  {member.billing_inactive ? "Marked inactive" : "Counts as active member"}
-                </Text>
-                <Text style={[styles.infoSubtext, { color: colors.textTertiary }]}>
-                  {member.billing_inactive
-                    ? "Excluded from the $1/month per-active-member bill."
-                    : "Billed at $1/month in any month they open the app here."}
-                </Text>
-              </View>
-              <TouchableOpacity
-                style={[styles.billingToggle, { borderColor: colors.border }]}
-                disabled={isUpdatingBilling}
-                onPress={handleToggleBillingActive}
-              >
-                {isUpdatingBilling ? (
-                  <ActivityIndicator size="small" color={colors.textSecondary} />
-                ) : (
-                  <Text style={[styles.billingToggleText, { color: colors.text }]}>
-                    {member.billing_inactive ? "Mark active" : "Mark inactive"}
-                  </Text>
-                )}
-              </TouchableOpacity>
-            </View>
-          )}
         </View>
 
         {/* Groups Section */}
@@ -935,30 +885,6 @@ const styles = StyleSheet.create({
   infoSubtext: {
     fontSize: 11,
     marginTop: 2,
-  },
-  billingRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 12,
-    marginTop: 12,
-    paddingTop: 12,
-    borderTopWidth: 1,
-  },
-  billingRowText: {
-    flex: 1,
-  },
-  billingToggle: {
-    borderWidth: 1,
-    borderRadius: 10,
-    paddingVertical: 8,
-    paddingHorizontal: 14,
-    minWidth: 110,
-    alignItems: "center",
-  },
-  billingToggleText: {
-    fontSize: 13,
-    fontWeight: "600",
   },
   groupCard: {
     flexDirection: "row",

--- a/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
+++ b/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
@@ -5,8 +5,8 @@
  *
  * Pricing is $1/month per active member: someone who opened the app in this
  * community within the past month (the same heuristic as the admin Stats
- * "Active Members" card) and hasn't been manually marked inactive by an
- * admin/leader.
+ * "Active Members" card). It is entirely automatic — there is no manual
+ * override.
  * The screen shows the current billable count and starts a Stripe checkout
  * (functions/ee/billing.convertDemoToLive). When the webhook confirms
  * payment, the community leaves demo mode and its 100 seeded demo members
@@ -175,10 +175,10 @@ export function GoLiveScreen() {
                 <Text style={[styles.cardBody, { color: colors.textSecondary }]}>
                   An active member is someone who opened the app in your
                   community within the past month — the same number as the
-                  Active Members card on your admin Stats tab. Admins and
-                  group leaders can also mark people as inactive so you're
-                  never billed for them. Your bill adjusts automatically every
-                  month.
+                  Active Members card on your admin Stats tab. It's fully
+                  automatic: anyone who stops opening the app rolls off next
+                  month, so your bill always tracks who's actually using
+                  Togather.
                 </Text>
                 {monthlyPrice !== null && (
                   <View style={[styles.estimate, { borderTopColor: colors.borderLight }]}>

--- a/apps/web/src/pages/guides/CreateCommunity.tsx
+++ b/apps/web/src/pages/guides/CreateCommunity.tsx
@@ -133,11 +133,11 @@ export function CreateCommunity() {
           always see exactly what you'll pay. Your bill adjusts automatically
           every month as people join, drift away, or come back.
         </P>
-        <Callout tone="tip" title="You control who counts">
-          Admins and group leaders can mark anyone as inactive from their
-          person page in the admin area (<Term>Billing → Mark inactive</Term>),
-          and they immediately stop counting toward the bill — even if they
-          still open the app. Mark them active again any time.
+        <Callout tone="tip" title="Nothing to manage">
+          There's no seat list to prune and no toggles to flip — the count is
+          fully automatic. Anyone who stops opening the app rolls off the next
+          month, and comes back the month they return. What you pay always
+          reflects who's actually using Togather.
         </Callout>
         <P>
           Payment is handled by Stripe. As soon as checkout completes, the

--- a/docs/architecture/decisions/ADR-030-per-active-member-billing.md
+++ b/docs/architecture/decisions/ADR-030-per-active-member-billing.md
@@ -40,11 +40,15 @@ rolling 30-day activity window, per community.**
   membership (`status === 1`) of a real account (not `isPlaceholder`), whose
   `userCommunities.lastLogin` — stamped on login, community switch, join, and
   app foreground while that community is active (`users.recordActivity`) — is
-  within the past 30 days, and who has not been manually marked inactive
-  (`userCommunities.billingInactive`, settable by community admins and the
-  member's group leaders). Strictly `lastLogin`: members who were added or
+  within the past 30 days. Strictly `lastLogin`: members who were added or
   imported (e.g. PCO sync) but never opened the app in the community are
   never billable.
+- **Fully automatic, no override**: there is deliberately no way to manually
+  mark an active member as non-billable. An earlier revision had an admin/
+  leader "mark inactive" toggle (`userCommunities.billingInactive`); it was
+  removed because it let a community zero out its bill while members kept
+  using the app. The 30-day activity rule is the single source of truth. (The
+  schema field is retained, unread, pending a clear-migration then drop.)
 - **Per community, not app-wide**: activity in one community never makes a
   person billable in another.
 - **Same number the admin already sees**: the definition intentionally
@@ -58,9 +62,8 @@ rolling 30-day activity window, per community.**
   count (the 28th→1st drift window is ~3 days and roughly symmetric).
 - **Pre-period disclosure**: after each sync, community admins get an email
   (`billing.monthly_preview`) with the count and the amount the 1st will
-  bill, while there's still time to mark members inactive. This is stronger
-  disclosure than any surveyed model (Slack's customers learn after the
-  fact).
+  bill, so the charge is never a surprise. This is stronger disclosure than
+  any surveyed model (Slack's customers learn after the fact).
 - **Ops alerting**: sync failures and >30% month-over-month count swings
   (on baselines ≥10) email `BILLING_ALERT_EMAIL` — silent billing drift is
   the pre-renewal-sync pattern's main operational risk.


### PR DESCRIPTION
## What & why

The per-active-member bill had an admin/leader **"mark inactive"** toggle (on a member's admin person page) that excluded someone from the count regardless of app use. That's an abuse vector: a community could mark members inactive to zero out its bill while those members keep using the app. Removed entirely — the automatic **30-day activity rule is now the single source of truth**.

## Changes
- **`memberActivity.ts`**: deleted `setMemberBillingActive` and `canManageBillingActivity`; dropped the `billingInactive` skip from `countBillableActiveUsers`.
- **`admin/members.ts`**: `getCommunityMemberById` no longer returns `billingInactive`.
- **`PersonDetailScreen.tsx`**: removed the entire Billing row ("Counts as active member" / Mark inactive toggle), its handler, mutation, state, and styles.
- **Copy**: Go Live screen, the web guide callout (now "Nothing to manage"), ADR-030, and the cron/sync comments all state the count is fully automatic with no override.
- **Schema**: `userCommunities.billingInactive` is kept but marked **DEPRECATED/unread**. Dropping a Convex field that may already hold values requires a clear-migration first, so it stays inert (nothing reads or writes it) pending a follow-up drop. A test patches a stray `billingInactive: true` and asserts it's ignored, proving the abuse vector is gone.

## Testing
- 2,162 backend tests pass. The `member-activity` suite drops the manual-inactive/permission tests and adds "an active member always counts — the count is purely automatic" (including the stale-flag-ignored assertion).
- Mobile + web typecheck clean; web guide builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQLRNeL7gUToheWEhBnrLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQLRNeL7gUToheWEhBnrLs)_