### PR TITLE
Dev dashboard: per-person auto-merge cap + reliable manual-merge detection

### DIFF
--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -2388,6 +2388,49 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test("a raised per-originator cap lets a higher-risk item auto-merge", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    enableAutoMerge();
+    // This originator is trusted up to high risk.
+    await t.run(async (ctx) =>
+      ctx.db.patch(maintainerId, { autoMergeMaxSeverity: "high" }),
+    );
+    const id = await seedMergeBug(t, maintainerId, { riskLevel: "high" });
+    const fetchMock = stubMergeFetch(
+      () => new Response(JSON.stringify({ merged: true }), { status: 200 }),
+    );
+
+    await t.action(internal.functions.devAssistant.actions.attemptAutoMerge, {
+      bugId: id,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("MERGED");
+  });
+
+  test("a 'none' cap blocks auto-merge even for a low-risk item", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    enableAutoMerge();
+    await t.run(async (ctx) =>
+      ctx.db.patch(maintainerId, { autoMergeMaxSeverity: "none" }),
+    );
+    const id = await seedMergeBug(t, maintainerId, { riskLevel: "low" });
+    const fetchMock = stubMergeFetch(() => new Response(null, { status: 200 }));
+
+    await t.action(internal.functions.devAssistant.actions.attemptAutoMerge, {
+      bugId: id,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("READY_TO_MERGE");
+  });
+
   test("all gates passing merges via squash and applies MERGED directly", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
@@ -3638,5 +3681,103 @@ describe("archive pauses the pipeline", () => {
       id,
     });
     expect((await t.run((ctx) => ctx.db.get(id)))?.archivedAt).toBeUndefined();
+  });
+});
+
+describe("reconcileMergedPrs (manual-merge backstop)", () => {
+  const PR_URL = "https://github.com/togathernyc/togather/pull/77";
+  const PR_GET_URL =
+    "https://api.github.com/repos/togathernyc/togather/pulls/77";
+
+  async function seedOpenPrBug(
+    t: ReturnType<typeof convexTest>,
+    originatorId: Id<"users">,
+    status: "CODE_REVIEW" | "READY_TO_MERGE",
+  ): Promise<Id<"devBugs">> {
+    const now = Date.now();
+    return await t.run(async (ctx) =>
+      ctx.db.insert("devBugs", {
+        originatorUserId: originatorId,
+        status,
+        kind: "bug",
+        source: "dashboard",
+        title: "Fix typo",
+        body: "B",
+        riskLevel: "medium",
+        reviewVerdict: status === "READY_TO_MERGE" ? "approved" : undefined,
+        routineRunId: "run-merge",
+        prUrl: PR_URL,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
+  test("flips an open-PR bug to MERGED when GitHub reports it merged", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_MIRROR_TOKEN = "gh-merge-pat";
+    const id = await seedOpenPrBug(t, maintainerId, "READY_TO_MERGE");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ merged: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(
+      internal.functions.devAssistant.actions.reconcileMergedPrs,
+      {},
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Polled the PR's GitHub endpoint, then applied the merge.
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(PR_GET_URL);
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("MERGED");
+  });
+
+  test("leaves the bug untouched when the PR isn't merged yet", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_MIRROR_TOKEN = "gh-merge-pat";
+    const id = await seedOpenPrBug(t, maintainerId, "CODE_REVIEW");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ merged: false }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(
+      internal.functions.devAssistant.actions.reconcileMergedPrs,
+      {},
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("CODE_REVIEW");
+  });
+
+  test("no-ops when the GitHub integration is unconfigured", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    // GH_MIRROR_TOKEN intentionally unset.
+    const id = await seedOpenPrBug(t, maintainerId, "READY_TO_MERGE");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ merged: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(
+      internal.functions.devAssistant.actions.reconcileMergedPrs,
+      {},
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("READY_TO_MERGE");
   });
 });

--- a/apps/convex/__tests__/devAssistant-maintainers.test.ts
+++ b/apps/convex/__tests__/devAssistant-maintainers.test.ts
@@ -20,6 +20,8 @@ import {
   canUseDevAssistant,
   isDevAssistantSuperAdmin,
   DEV_MAINTAINER_ROLE,
+  AUTO_MERGE_SEVERITY_ORDER,
+  DEFAULT_AUTO_MERGE_MAX_SEVERITY,
 } from "../functions/devAssistant/maintainers";
 import type { Doc } from "../_generated/dataModel";
 
@@ -247,6 +249,103 @@ describe("maintainer management", () => {
       { token: superId },
     );
     expect(list.map((u) => u._id)).toEqual([maintainerId]);
+  });
+});
+
+// ============================================================================
+// Auto-merge severity cap (ADR-029 Phase 3)
+// ============================================================================
+
+describe("auto-merge severity cap", () => {
+  test("severity order ranks none < low < medium < high", () => {
+    expect(AUTO_MERGE_SEVERITY_ORDER.none).toBeLessThan(
+      AUTO_MERGE_SEVERITY_ORDER.low,
+    );
+    expect(AUTO_MERGE_SEVERITY_ORDER.low).toBeLessThan(
+      AUTO_MERGE_SEVERITY_ORDER.medium,
+    );
+    expect(AUTO_MERGE_SEVERITY_ORDER.medium).toBeLessThan(
+      AUTO_MERGE_SEVERITY_ORDER.high,
+    );
+  });
+
+  test("getAutoMergeCapForUser defaults to low, reflects an explicit value", async () => {
+    const t = convexTest(schema, modules);
+    const defId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: [DEV_MAINTAINER_ROLE] })),
+    );
+    const highId = await t.run((ctx) =>
+      ctx.db.insert(
+        "users",
+        user({
+          platformRoles: [DEV_MAINTAINER_ROLE],
+          autoMergeMaxSeverity: "high",
+        }),
+      ),
+    );
+
+    expect(
+      await t.query(
+        internal.functions.devAssistant.maintainers.getAutoMergeCapForUser,
+        { userId: defId },
+      ),
+    ).toBe(DEFAULT_AUTO_MERGE_MAX_SEVERITY);
+    expect(
+      await t.query(
+        internal.functions.devAssistant.maintainers.getAutoMergeCapForUser,
+        { userId: highId },
+      ),
+    ).toBe("high");
+  });
+
+  test("super admin sets a cap; it persists and surfaces in listMaintainers", async () => {
+    const t = convexTest(schema, modules);
+    const superId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ isSuperuser: true })),
+    );
+    const maintainerId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: [DEV_MAINTAINER_ROLE] })),
+    );
+
+    // Defaults to "low" in the list before any set.
+    let list = await t.query(
+      api.functions.devAssistant.maintainers.listMaintainers,
+      { token: superId },
+    );
+    expect(list.find((u) => u._id === maintainerId)?.autoMergeMaxSeverity).toBe(
+      "low",
+    );
+
+    await t.mutation(
+      api.functions.devAssistant.maintainers.setAutoMergeMaxSeverity,
+      { token: superId, userId: maintainerId, maxSeverity: "high" },
+    );
+
+    const target = await t.run((ctx) => ctx.db.get(maintainerId));
+    expect(target?.autoMergeMaxSeverity).toBe("high");
+    list = await t.query(
+      api.functions.devAssistant.maintainers.listMaintainers,
+      { token: superId },
+    );
+    expect(list.find((u) => u._id === maintainerId)?.autoMergeMaxSeverity).toBe(
+      "high",
+    );
+  });
+
+  test("non-superusers cannot set a cap", async () => {
+    const t = convexTest(schema, modules);
+    const maintainerId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: [DEV_MAINTAINER_ROLE] })),
+    );
+    const targetId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ platformRoles: [DEV_MAINTAINER_ROLE] })),
+    );
+    await expect(
+      t.mutation(
+        api.functions.devAssistant.maintainers.setAutoMergeMaxSeverity,
+        { token: maintainerId, userId: targetId, maxSeverity: "high" },
+      ),
+    ).rejects.toThrow();
   });
 });
 

--- a/apps/convex/__tests__/devAssistant-maintainers.test.ts
+++ b/apps/convex/__tests__/devAssistant-maintainers.test.ts
@@ -229,10 +229,13 @@ describe("maintainer management", () => {
     ).rejects.toThrow();
   });
 
-  test("listMaintainers returns only granted users", async () => {
+  test("listMaintainers returns explicit maintainers and implicit staff, not plain users", async () => {
     const t = convexTest(schema, modules);
     const superId = await t.run((ctx) =>
       ctx.db.insert("users", user({ isSuperuser: true })),
+    );
+    const staffId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Stan", isStaff: true })),
     );
     const maintainerId = await t.run((ctx) =>
       ctx.db.insert(
@@ -240,7 +243,7 @@ describe("maintainer management", () => {
         user({ firstName: "Maint", platformRoles: [DEV_MAINTAINER_ROLE] }),
       ),
     );
-    await t.run((ctx) =>
+    const otherId = await t.run((ctx) =>
       ctx.db.insert("users", user({ firstName: "Other" })),
     );
 
@@ -248,7 +251,14 @@ describe("maintainer management", () => {
       api.functions.devAssistant.maintainers.listMaintainers,
       { token: superId },
     );
-    expect(list.map((u) => u._id)).toEqual([maintainerId]);
+    const ids = list.map((u) => u._id);
+    // Explicit maintainers AND implicit staff/superusers are manageable here
+    // (the auto-merge cap gate applies to them as originators); plain users
+    // are excluded.
+    expect(ids).toContain(maintainerId);
+    expect(ids).toContain(staffId);
+    expect(ids).toContain(superId);
+    expect(ids).not.toContain(otherId);
   });
 });
 
@@ -330,6 +340,45 @@ describe("auto-merge severity cap", () => {
     expect(list.find((u) => u._id === maintainerId)?.autoMergeMaxSeverity).toBe(
       "high",
     );
+  });
+
+  test("a staff originator's cap surfaces and is settable (no dev_maintainer role needed)", async () => {
+    const t = convexTest(schema, modules);
+    const superId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ isSuperuser: true })),
+    );
+    const staffId = await t.run((ctx) =>
+      ctx.db.insert("users", user({ firstName: "Stan", isStaff: true })),
+    );
+
+    // Defaults to "low" and appears in the list despite holding no role.
+    let list = await t.query(
+      api.functions.devAssistant.maintainers.listMaintainers,
+      { token: superId },
+    );
+    expect(list.find((u) => u._id === staffId)?.autoMergeMaxSeverity).toBe(
+      "low",
+    );
+
+    await t.mutation(
+      api.functions.devAssistant.maintainers.setAutoMergeMaxSeverity,
+      { token: superId, userId: staffId, maxSeverity: "high" },
+    );
+
+    list = await t.query(
+      api.functions.devAssistant.maintainers.listMaintainers,
+      { token: superId },
+    );
+    expect(list.find((u) => u._id === staffId)?.autoMergeMaxSeverity).toBe(
+      "high",
+    );
+    // And the gate lookup reflects it.
+    expect(
+      await t.query(
+        internal.functions.devAssistant.maintainers.getAutoMergeCapForUser,
+        { userId: staffId },
+      ),
+    ).toBe("high");
   });
 
   test("non-superusers cannot set a cap", async () => {

--- a/apps/convex/crons.ts
+++ b/apps/convex/crons.ts
@@ -293,4 +293,19 @@ crons.monthly(
   {}
 );
 
+// =============================================================================
+// DEV-ASSISTANT PR MERGE RECONCILE
+// =============================================================================
+// Backstop for the /github/webhook: polls open dev-dashboard PRs and flips a
+// bug to MERGED when its PR has merged on GitHub, so manual merges reflect on
+// the Contribute dashboard even when the webhook isn't delivering. Idempotent;
+// no-ops when the GitHub integration is unconfigured. See ADR-029 Phase 3.
+
+crons.cron(
+  "dev-assistant-pr-merge-reconcile",
+  "*/15 * * * *",
+  internal.functions.devAssistant.actions.reconcileMergedPrs,
+  {}
+);
+
 export default crons;

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -21,6 +21,7 @@ import {
   scopeValidator,
   splitSlicesValidator,
 } from "./bugs";
+import { AUTO_MERGE_SEVERITY_ORDER } from "./maintainers";
 import type { ToolExecutionContext } from "./tools";
 
 const FLAG_KEY = "dev-assistant-bot";
@@ -721,8 +722,10 @@ export const dispatchFix = internalAction({
  * itself, so double-scheduling is harmless.
  *
  * Gates (all must hold): AUTO_MERGE_ENABLED === "true" (master safety switch —
- * anything else means the feature is off), status READY_TO_MERGE, riskLevel
- * "low", reviewVerdict "approved", staging verified when required, prUrl set.
+ * anything else means the feature is off), status READY_TO_MERGE, reviewVerdict
+ * "approved", prUrl set, and the bug's riskLevel at or below the auto-merge cap
+ * configured for its originator (default "low"; "none" opts out). Staging is
+ * NOT a gate — it happens post-merge.
  *
  * Merges via the GitHub REST API with GH_MIRROR_TOKEN (the PAT needs Contents
  * read/write in addition to Issues). On success it posts a system thread
@@ -754,7 +757,6 @@ export const attemptAutoMerge = internalAction({
     // production deploy instead. Merge gates on review + CI + low-risk only.
     if (
       bug.status !== "READY_TO_MERGE" ||
-      bug.riskLevel !== "low" ||
       bug.reviewVerdict !== "approved" ||
       !bug.prUrl
     ) {
@@ -762,6 +764,25 @@ export const attemptAutoMerge = internalAction({
         "[DevAssistant] Auto-merge gates not met for bug",
         args.bugId,
       );
+      return;
+    }
+
+    // Per-person severity cap (ADR-029 Phase 3): a contribution auto-merges only
+    // when its risk level is at or below the cap configured for its originator
+    // on the maintainers screen (default "low"; "none" opts them out entirely).
+    const cap = await ctx.runQuery(
+      internal.functions.devAssistant.maintainers.getAutoMergeCapForUser,
+      { userId: bug.originatorUserId },
+    );
+    const riskRank =
+      bug.riskLevel !== undefined
+        ? AUTO_MERGE_SEVERITY_ORDER[bug.riskLevel]
+        : undefined;
+    if (riskRank === undefined || riskRank > AUTO_MERGE_SEVERITY_ORDER[cap]) {
+      console.log("[DevAssistant] Auto-merge blocked by severity cap", args.bugId, {
+        riskLevel: bug.riskLevel,
+        cap,
+      });
       return;
     }
 
@@ -852,6 +873,62 @@ export const attemptAutoMerge = internalAction({
       await blocked(reason);
     } catch (error) {
       await blocked(String(error));
+    }
+  },
+});
+
+/**
+ * Reconcile open dev-dashboard PRs against GitHub (ADR-029 Phase 3 backstop).
+ *
+ * The /github/webhook flips a bug to MERGED when its PR merges, but webhook
+ * delivery isn't guaranteed (unconfigured repo, secret mismatch, transient
+ * failure), and items that don't auto-merge (higher risk than their cap) wait on
+ * a human merge the dashboard would otherwise never notice. This cron polls each
+ * open-PR bug's merge state directly and applies merges through the same
+ * webhook-correlation path, so a manual GitHub merge always reflects within a
+ * cron interval even with no webhook configured at all. Idempotent:
+ * already-MERGED rows no-op inside handleGithubPrClosed.
+ */
+export const reconcileMergedPrs = internalAction({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const token = githubMirrorToken();
+    if (!token) return; // GitHub integration not configured — nothing to poll.
+
+    const bugs = await ctx.runQuery(
+      internal.functions.devAssistant.bugs.listOpenPrBugs,
+      {},
+    );
+    for (const bug of bugs) {
+      if (!bug.prUrl) continue;
+      const prMatch = /\/pull\/(\d+)/.exec(bug.prUrl);
+      if (!prMatch) continue;
+      try {
+        const res = await fetch(`${GITHUB_PULLS_ENDPOINT}/${prMatch[1]}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        });
+        if (!res.ok) continue;
+        const pr = (await res.json()) as { merged?: boolean };
+        if (pr.merged === true) {
+          // Reuse the webhook path: an empty branchRef falls through to the
+          // prUrl-match fallback, which scans exactly these open-PR states and
+          // applies MERGED idempotently.
+          await ctx.runMutation(
+            internal.functions.devAssistant.bugs.handleGithubPrClosed,
+            { branchRef: "", prUrl: bug.prUrl, merged: true },
+          );
+        }
+      } catch (error) {
+        console.error(
+          "[DevAssistant] reconcileMergedPrs failed for",
+          bug.prUrl,
+          String(error),
+        );
+      }
     }
   },
 });

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -384,6 +384,26 @@ export const getBug = internalQuery({
   },
 });
 
+/**
+ * Bugs whose PR is open (CODE_REVIEW / READY_TO_MERGE) and has a prUrl. The
+ * reconciliation cron (actions.reconcileMergedPrs) polls these against GitHub to
+ * catch manual merges the webhook missed.
+ */
+export const listOpenPrBugs = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<Doc<"devBugs">[]> => {
+    const out: Doc<"devBugs">[] = [];
+    for (const status of ["CODE_REVIEW", "READY_TO_MERGE"] as const) {
+      const rows = await ctx.db
+        .query("devBugs")
+        .withIndex("by_status", (q) => q.eq("status", status))
+        .collect();
+      for (const b of rows) if (b.prUrl) out.push(b);
+    }
+    return out;
+  },
+});
+
 // ============================================================================
 // Mobile review screen (token-authed, staff only)
 // ============================================================================

--- a/apps/convex/functions/devAssistant/maintainers.ts
+++ b/apps/convex/functions/devAssistant/maintainers.ts
@@ -130,7 +130,16 @@ export const listMaintainers = query({
     // this list is small and the page is operator-only (mirrors listPosterAdmins).
     const users = await ctx.db.query("users").collect();
     return users
-      .filter((u) => u.platformRoles?.includes(DEV_MAINTAINER_ROLE))
+      .filter(
+        (u) =>
+          // Explicit maintainers, plus staff/superusers who have implicit
+          // access. Staff can originate dashboard items too, so the auto-merge
+          // cap gate applies to them — surface them here so their cap is
+          // manageable (they just can't be granted/revoked the role).
+          u.platformRoles?.includes(DEV_MAINTAINER_ROLE) ||
+          u.isSuperuser === true ||
+          u.isStaff === true,
+      )
       .map((u) => ({
         _id: u._id,
         firstName: u.firstName ?? null,

--- a/apps/convex/functions/devAssistant/maintainers.ts
+++ b/apps/convex/functions/devAssistant/maintainers.ts
@@ -17,12 +17,49 @@
  */
 
 import { v, ConvexError } from "convex/values";
-import { query, mutation } from "../../_generated/server";
+import { query, mutation, internalQuery } from "../../_generated/server";
 import type { QueryCtx, MutationCtx } from "../../_generated/server";
 import type { Doc } from "../../_generated/dataModel";
 import { requireAuth, requireAuthUser } from "../../lib/auth";
 
 export const DEV_MAINTAINER_ROLE = "dev_maintainer" as const;
+
+// ============================================================================
+// Auto-merge severity cap (ADR-029 Phase 3)
+// ============================================================================
+
+/**
+ * Per-user cap on the contribution risk level that may auto-merge. Keyed off a
+ * bug's originator: an item auto-merges only when its `riskLevel` is at or below
+ * this cap. Managed on the maintainers screen.
+ */
+export const autoMergeSeverityValidator = v.union(
+  v.literal("none"),
+  v.literal("low"),
+  v.literal("medium"),
+  v.literal("high"),
+);
+
+export type AutoMergeSeverity = "none" | "low" | "medium" | "high";
+
+/**
+ * Ordinal rank for the severity gate. A contribution auto-merges only when its
+ * riskLevel rank is <= the originator's cap rank. "none" (-1) sits below every
+ * real risk level, so those contributions never auto-merge.
+ */
+export const AUTO_MERGE_SEVERITY_ORDER: Record<AutoMergeSeverity, number> = {
+  none: -1,
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+/**
+ * Default cap for a user without an explicit setting. "low" preserves the
+ * original global policy (only low-risk contributions auto-merge); an operator
+ * raises it per person on the maintainers screen.
+ */
+export const DEFAULT_AUTO_MERGE_MAX_SEVERITY: AutoMergeSeverity = "low";
 
 // ============================================================================
 // Access helpers
@@ -102,6 +139,8 @@ export const listMaintainers = query({
         phone: u.phone ?? null,
         profilePhoto: u.profilePhoto ?? null,
         isSuperuser: u.isSuperuser === true || u.isStaff === true,
+        autoMergeMaxSeverity:
+          u.autoMergeMaxSeverity ?? DEFAULT_AUTO_MERGE_MAX_SEVERITY,
       }));
   },
 });
@@ -164,5 +203,42 @@ export const revokeMaintainer = mutation({
     const next = current.filter((r) => r !== DEV_MAINTAINER_ROLE);
     await ctx.db.patch(args.userId, { platformRoles: next });
     return { ok: true };
+  },
+});
+
+/**
+ * Set a user's auto-merge severity cap (superuser-only). Governs the max
+ * contribution risk level that may auto-merge for items this user originated —
+ * "none" opts them out, "high" auto-merges everything up to high risk.
+ */
+export const setAutoMergeMaxSeverity = mutation({
+  args: {
+    token: v.string(),
+    userId: v.id("users"),
+    maxSeverity: autoMergeSeverityValidator,
+  },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    await requireSuperAdmin(ctx, args.token);
+    const target = await ctx.db.get(args.userId);
+    if (!target) throw new ConvexError("User not found");
+    await ctx.db.patch(args.userId, { autoMergeMaxSeverity: args.maxSeverity });
+    return { ok: true };
+  },
+});
+
+// ============================================================================
+// Internal — auto-merge gate lookup
+// ============================================================================
+
+/**
+ * The effective auto-merge severity cap for a user (default when unset). Called
+ * by the auto-merge action, which runs outside a DB context.
+ */
+export const getAutoMergeCapForUser = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args): Promise<AutoMergeSeverity> => {
+    const user = await ctx.db.get(args.userId);
+    return (user?.autoMergeMaxSeverity ??
+      DEFAULT_AUTO_MERGE_MAX_SEVERITY) as AutoMergeSeverity;
   },
 });

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -176,6 +176,18 @@ export default defineSchema({
     // Granular platform-level roles for delegated operator access.
     // Values: "poster_admin" (may expand later). isSuperuser/isStaff bypass this check.
     platformRoles: v.optional(v.array(v.string())),
+    // Max contribution risk level whose PR may auto-merge, for dashboard
+    // contributions this user originated (ADR-029 Phase 3). Set per person on
+    // the maintainers screen; unset defaults to "low" (see
+    // maintainers.DEFAULT_AUTO_MERGE_MAX_SEVERITY). "none" opts out entirely.
+    autoMergeMaxSeverity: v.optional(
+      v.union(
+        v.literal("none"),
+        v.literal("low"),
+        v.literal("medium"),
+        v.literal("high"),
+      ),
+    ),
     username: v.optional(v.string()),
     firstName: v.optional(v.string()),
     lastName: v.optional(v.string()),

--- a/apps/mobile/features/admin/components/BugDetailScreen.tsx
+++ b/apps/mobile/features/admin/components/BugDetailScreen.tsx
@@ -237,7 +237,9 @@ export function BugDetailScreen() {
                 </Text>
               </TouchableOpacity>
             ) : null}
-            {bug.status === "READY_TO_MERGE" ? (
+            {(bug.status === "READY_TO_MERGE" ||
+              bug.status === "CODE_REVIEW") &&
+            bug.prUrl ? (
               <TouchableOpacity
                 style={[styles.actionBtn, { backgroundColor: "#34C75920" }]}
                 disabled={busy}

--- a/apps/mobile/features/admin/components/MaintainersContent.tsx
+++ b/apps/mobile/features/admin/components/MaintainersContent.tsx
@@ -213,13 +213,17 @@ export function MaintainersContent() {
                   user={u}
                   busy={busyUserId === u._id}
                   trailing={
-                    <TouchableOpacity
-                      onPress={() => handleRevoke(u._id)}
-                      disabled={busyUserId === u._id}
-                      style={styles.revokeBtn}
-                    >
-                      <Text style={styles.revokeBtnText}>Remove</Text>
-                    </TouchableOpacity>
+                    // Staff/superusers have implicit access (no revocable
+                    // role) — show the cap selector but not a Remove button.
+                    u.isSuperuser ? null : (
+                      <TouchableOpacity
+                        onPress={() => handleRevoke(u._id)}
+                        disabled={busyUserId === u._id}
+                        style={styles.revokeBtn}
+                      >
+                        <Text style={styles.revokeBtnText}>Remove</Text>
+                      </TouchableOpacity>
+                    )
                   }
                 />
                 <SeverityStrip

--- a/apps/mobile/features/admin/components/MaintainersContent.tsx
+++ b/apps/mobile/features/admin/components/MaintainersContent.tsx
@@ -36,6 +36,19 @@ import { useAuth } from "@providers/AuthProvider";
 import { useTheme } from "@hooks/useTheme";
 import { Avatar } from "@components/ui/Avatar";
 
+type Severity = "none" | "low" | "medium" | "high";
+
+/**
+ * Auto-merge cap options, low→high. A maintainer's contributions auto-merge only
+ * up to the selected risk level; "None" opts them out of auto-merge entirely.
+ */
+const SEVERITY_OPTIONS: { key: Severity; label: string }[] = [
+  { key: "none", label: "None" },
+  { key: "low", label: "Low" },
+  { key: "medium", label: "Med" },
+  { key: "high", label: "High" },
+];
+
 type UserResult = {
   _id: Id<"users">;
   firstName: string | null;
@@ -45,6 +58,7 @@ type UserResult = {
   profilePhoto: string | null;
   alreadyMaintainer?: boolean;
   isSuperuser?: boolean;
+  autoMergeMaxSeverity?: Severity;
 };
 
 export function MaintainersContent() {
@@ -79,6 +93,9 @@ export function MaintainersContent() {
   const revoke = useAuthenticatedMutation(
     api.functions.devAssistant.maintainers.revokeMaintainer,
   );
+  const setSeverity = useAuthenticatedMutation(
+    api.functions.devAssistant.maintainers.setAutoMergeMaxSeverity,
+  );
 
   const handleGrant = async (userId: Id<"users">) => {
     setBusyUserId(userId);
@@ -88,6 +105,23 @@ export function MaintainersContent() {
     } catch (err) {
       Alert.alert(
         "Add failed",
+        err instanceof Error ? err.message : "Unknown error",
+      );
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const handleSetSeverity = async (
+    userId: Id<"users">,
+    maxSeverity: Severity,
+  ) => {
+    setBusyUserId(userId);
+    try {
+      await setSeverity({ userId, maxSeverity });
+    } catch (err) {
+      Alert.alert(
+        "Update failed",
         err instanceof Error ? err.message : "Unknown error",
       );
     } finally {
@@ -166,24 +200,37 @@ export function MaintainersContent() {
           No maintainers yet. Staff and superusers always have access.
         </Text>
       ) : (
-        <View style={{ gap: 8 }}>
-          {maintainers.map((u) => (
-            <UserRow
-              key={u._id}
-              user={u}
-              busy={busyUserId === u._id}
-              trailing={
-                <TouchableOpacity
-                  onPress={() => handleRevoke(u._id)}
+        <>
+          <Text style={[styles.caption, { color: colors.textSecondary }]}>
+            “Auto-merge up to” sets the highest risk level whose approved PRs
+            merge automatically for this person’s contributions. “None” means
+            every one waits for a manual merge.
+          </Text>
+          <View style={{ gap: 12 }}>
+            {maintainers.map((u) => (
+              <View key={u._id} style={{ gap: 8 }}>
+                <UserRow
+                  user={u}
+                  busy={busyUserId === u._id}
+                  trailing={
+                    <TouchableOpacity
+                      onPress={() => handleRevoke(u._id)}
+                      disabled={busyUserId === u._id}
+                      style={styles.revokeBtn}
+                    >
+                      <Text style={styles.revokeBtnText}>Remove</Text>
+                    </TouchableOpacity>
+                  }
+                />
+                <SeverityStrip
+                  value={u.autoMergeMaxSeverity ?? "low"}
                   disabled={busyUserId === u._id}
-                  style={styles.revokeBtn}
-                >
-                  <Text style={styles.revokeBtnText}>Remove</Text>
-                </TouchableOpacity>
-              }
-            />
-          ))}
-        </View>
+                  onChange={(sev) => handleSetSeverity(u._id, sev)}
+                />
+              </View>
+            ))}
+          </View>
+        </>
       )}
 
       <Text
@@ -331,6 +378,62 @@ function UserRow({
   );
 }
 
+/**
+ * Per-maintainer auto-merge cap selector: a labeled row of severity pills. The
+ * active level is highlighted; tapping another sets it. Sits under the
+ * maintainer's row so the whole entry reads as one control group.
+ */
+function SeverityStrip({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: Severity;
+  onChange: (sev: Severity) => void;
+  disabled: boolean;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.sevStrip}>
+      <Text style={[styles.sevLabel, { color: colors.textSecondary }]}>
+        Auto-merge up to
+      </Text>
+      <View style={styles.sevPills}>
+        {SEVERITY_OPTIONS.map((o) => {
+          const active = value === o.key;
+          return (
+            <TouchableOpacity
+              key={o.key}
+              disabled={disabled || active}
+              onPress={() => onChange(o.key)}
+              style={[
+                styles.sevPill,
+                { borderColor: colors.border },
+                active && {
+                  backgroundColor: colors.text,
+                  borderColor: colors.text,
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={`Auto-merge up to ${o.label}`}
+            >
+              <Text
+                style={[
+                  styles.sevPillText,
+                  { color: active ? colors.background : colors.textSecondary },
+                ]}
+              >
+                {o.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
 async function confirmRevoke(): Promise<boolean> {
   const title = "Remove maintainer?";
   const message = "They'll lose dev-assistant access immediately.";
@@ -377,6 +480,36 @@ const styles = StyleSheet.create({
     textTransform: "uppercase",
     letterSpacing: 0.4,
     marginBottom: 8,
+  },
+  caption: {
+    fontSize: 12,
+    lineHeight: 17,
+    marginBottom: 12,
+  },
+  sevStrip: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+    paddingHorizontal: 4,
+  },
+  sevLabel: {
+    fontSize: 12,
+    flexShrink: 1,
+  },
+  sevPills: {
+    flexDirection: "row",
+    gap: 6,
+  },
+  sevPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  sevPillText: {
+    fontSize: 12,
+    fontWeight: "600",
   },
   searchBar: {
     flexDirection: "row",

--- a/docs/architecture/ADR-029-contributor-dev-dashboard.md
+++ b/docs/architecture/ADR-029-contributor-dev-dashboard.md
@@ -328,13 +328,19 @@ gate holds**:
 - `AUTO_MERGE_ENABLED === "true"` — master safety switch; anything else means
   the feature is off (double-scheduling is harmless because the action
   re-checks everything itself).
-- `status === "READY_TO_MERGE"`, `riskLevel === "low"`,
-  `reviewVerdict === "approved"`.
+- `status === "READY_TO_MERGE"`, `reviewVerdict === "approved"`.
 - A `prUrl` to merge.
+- The bug's `riskLevel` is **at or below the per-originator auto-merge cap**.
+  Each user has an `autoMergeMaxSeverity` (`none` < `low` < `medium` < `high`),
+  set on the `/admin/maintainers` screen and defaulting to `low` when unset —
+  so the original "low-risk only" behavior is the default, and an operator can
+  trust an individual up to `high` or opt them out with `none`. The gate keys
+  off the contribution's originator (`getAutoMergeCapForUser`).
 
 Staging verification is **not** a merge gate: nothing reaches staging until the
 merge, so the reporter's staging try-it happens *after* merge and gates the
-manual production deploy instead. Merge gates on review + CI + low-risk only.
+manual production deploy instead. Merge gates on review + CI + the originator's
+severity cap only.
 
 The merge uses `GH_MIRROR_TOKEN` (the Phase 2 mirroring PAT, which now needs
 **Contents read/write** in addition to Issues) and the merge method from
@@ -345,6 +351,23 @@ passed (…)"; the action never sets `MERGED` itself — the `/github/webhook`
 failure (branch protection, conflict, auth) the thread gets "Auto-merge
 blocked: <reason> — needs a maintainer" and nothing retries — branch
 protection remains the backstop.
+
+### Detecting a manual merge
+
+`MERGED` is applied by the `/github/webhook` handler (or auto-merge itself),
+never claimed by a Routine. But webhook delivery isn't guaranteed — an
+unconfigured repo hook or a secret mismatch would leave a manually-merged PR's
+dashboard item stuck at `CODE_REVIEW`/`READY_TO_MERGE` forever. Two backstops
+cover that gap:
+
+- **Reconciliation cron.** `reconcileMergedPrs` runs every 15 minutes, polls
+  each open-PR bug's merge state on GitHub (via `GH_MIRROR_TOKEN`), and applies
+  the merge through the same webhook-correlation path — so a manual merge always
+  reflects within a cron interval even with no webhook configured. Idempotent;
+  a no-op when the GitHub integration is unset.
+- **Manual "Mark merged".** The review screen's button is available from
+  `CODE_REVIEW` as well as `READY_TO_MERGE` (both are legal forward transitions
+  to `MERGED`), so a maintainer can always flip an open-PR item by hand.
 
 ## Phase 1.7 — low-friction filing, pictures, and copyable split prompts (Accepted)
 


### PR DESCRIPTION
## What this does

Two operator-facing gaps in the ADR-029 dev-dashboard auto-merge pipeline.

### 1. Per-person auto-merge severity cap (`/admin/maintainers`)
- Auto-merge was globally gated to `riskLevel === "low"`. Replace that with a **per-user cap** (`users.autoMergeMaxSeverity`: `none < low < medium < high`), keyed off a contribution's **originator**. `attemptAutoMerge` now merges only when the bug's `riskLevel` is at or below the originator's cap.
- Default is **`low`** when unset, so existing behavior is preserved; an operator can trust an individual up to `high` or opt them out with `none`.
- Managed on the maintainers screen: each maintainer row gets an **"Auto-merge up to"** selector wired to a new superuser-only `setAutoMergeMaxSeverity` mutation. `listMaintainers` returns the effective cap; `getAutoMergeCapForUser` resolves it for the merge gate.

### 2. Reliable manual-merge detection
- A PR merged by hand on GitHub only reflected on the dashboard via `/github/webhook` — with no backstop, an undelivered webhook left the item stuck at `CODE_REVIEW`/`READY_TO_MERGE`.
- Add **`reconcileMergedPrs`**, a 15-minute cron that polls open-PR bugs against GitHub and applies merges through the same webhook-correlation path (idempotent; no-op when the GitHub integration is unconfigured).
- Make the review screen's **"Mark merged"** button available from `CODE_REVIEW` as well as `READY_TO_MERGE` (both are legal forward transitions).

## Testing
- Full Convex suite green (**2180 passed**), including new tests for the cap gate (raise / `none`), the mutation's auth + persistence, severity ordering, and reconcile (merged / not-merged / unconfigured).
- Convex typechecks clean; the two changed mobile files are type-clean; pre-commit ESLint passed.
- The `/admin/maintainers` screen is behind superuser auth + a live Convex backend, so it wasn't drivable on the headless runner — the new selector is presentational and type-clean; a device/staging capture belongs in staging verification.

## Notes
- ADR-029 updated (per-originator cap + manual-merge detection section).
- Default cap `low` means **no behavior change** until an operator raises someone's cap or enables `AUTO_MERGE_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF2x1kzKFYkZB1uEG6Ui1C)_