### PR TITLE
Port PCO-dependent serving features to native rostering (native-first, PCO fallback)

### DIFF
--- a/apps/convex/__tests__/native-serving.test.ts
+++ b/apps/convex/__tests__/native-serving.test.ts
@@ -1,10 +1,11 @@
 /**
- * Native-first serving tests.
+ * Combined (PCO + native) serving tests.
  *
  * The profile "Serving" system score (sys_service / pco_services_past_2mo) and
- * the serving-history card are native-first: when a community uses native
- * rostering (has ≥1 eventPlans row) serving comes from `roleAssignments`; when
- * it has no native rostering it falls back to cached PCO `pcoServingCounts`.
+ * the serving-history card combine BOTH sources: the cached PCO
+ * `pcoServingCounts` snapshot AND native rostering (`roleAssignments`). Native
+ * counts/rows exclude PCO-imported plans (`eventPlans.pcoPlanId`) so a migrated
+ * plan isn't double-counted.
  *
  * Run with: cd apps/convex && pnpm test __tests__/native-serving.test.ts
  */
@@ -17,8 +18,8 @@ import { modules } from "../test.setup";
 import type { Id } from "../_generated/dataModel";
 import {
   countNativeServing,
-  communityUsesNativeRostering,
   nativeServingHistory,
+  mergeServingHistory,
 } from "../lib/nativeServing";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -78,6 +79,7 @@ describe("countNativeServing", () => {
         title: string,
         eventDate: number,
         status = "confirmed",
+        pcoPlanId?: string,
       ) => {
         const planId = await ctx.db.insert("eventPlans", {
           groupId: gtr.groupId,
@@ -86,6 +88,7 @@ describe("countNativeServing", () => {
           eventDate,
           times: [{ label: "9:00 AM", startsAt: eventDate }],
           status: "published",
+          ...(pcoPlanId ? { pcoPlanId } : {}),
           createdAt: nowTs,
           createdById: userId,
           updatedAt: nowTs,
@@ -122,6 +125,9 @@ describe("countNativeServing", () => {
       await addPlan(c1.communityId, a, "Old", nowTs - 90 * DAY_MS);
       // Future plan — rostered ahead but not yet served → must NOT count.
       await addPlan(c1.communityId, a, "Future", nowTs + 5 * DAY_MS);
+      // PCO-imported plan (pcoPlanId set) — already in the PCO snapshot the
+      // caller adds, so the native count must NOT include it.
+      await addPlan(c1.communityId, a, "Imported", nowTs - 8 * DAY_MS, "confirmed", "pco-plan-123");
       // Community 2: an in-window plan that must NOT count toward community 1.
       await addPlan(c2.communityId, b, "OtherComm", nowTs - 3 * DAY_MS);
 
@@ -136,8 +142,9 @@ describe("countNativeServing", () => {
     const count = await t.run((ctx) =>
       countNativeServing(ctx, assignments, nowTs, communityId),
     );
-    // 3 distinct plans in this community's window; duplicate slot, declined,
-    // out-of-window, FUTURE, and the other community's plan are all excluded.
+    // 3 native-origin distinct plans in this community's window; duplicate
+    // slot, declined, out-of-window, FUTURE, PCO-imported, and the other
+    // community's plan are all excluded.
     expect(count).toBe(3);
 
     const zero = await t.run((ctx) =>
@@ -280,11 +287,11 @@ async function callScoreBatch(
 }
 
 // ============================================================================
-// (a) Native rostering present → serving from roleAssignments
+// (a) Native rostering present → serving = PCO count + native plans
 // ============================================================================
 
-describe("native rostering present", () => {
-  test("serving score uses distinct native plans, ignoring stale PCO counts", async () => {
+describe("PCO + native combined", () => {
+  test("serving score sums cached PCO count and distinct native plans", async () => {
     const t = convexTest(schema, modules);
     const nowTs = Date.now();
 
@@ -398,12 +405,21 @@ describe("native rostering present", () => {
         eventDate: nowTs + 7 * DAY_MS,
       });
 
-      // Stale PCO cache that would (wrongly) win if we weren't native-first.
+      // Cached PCO snapshot: 1 past service, plus one servingDetails row for a
+      // PCO-only service the native side never sees.
       await ctx.db.patch(announcementGroupId, {
         pcoServingCounts: {
           updatedAt: nowTs,
-          counts: [{ userId, count: 99 }],
-          servingDetails: [],
+          counts: [{ userId, count: 1 }],
+          servingDetails: [
+            {
+              userId,
+              date: new Date(nowTs - 40 * DAY_MS).toISOString().split("T")[0],
+              serviceTypeName: "PCO Service",
+              teamName: "PCO Team",
+              position: "Usher",
+            },
+          ],
         },
       });
 
@@ -411,10 +427,10 @@ describe("native rostering present", () => {
     });
 
     const scored = await callScoreBatch(t, world);
-    // Native count = 3 distinct plans (PCO's 99 is ignored).
-    expect(scored.rawValues.pco_services_past_2mo).toBe(3);
-    // sys_service = min(100, 3 * 20) = 60.
-    expect(scored.score1).toBe(60);
+    // Combined = PCO count (1) + native distinct plans (3) = 4.
+    expect(scored.rawValues.pco_services_past_2mo).toBe(4);
+    // sys_service = min(100, 4 * 20) = 80.
+    expect(scored.score1).toBe(80);
 
     // Serving-history card lists native rows, newest event first.
     const history = await t.run((ctx) =>
@@ -432,20 +448,15 @@ describe("native rostering present", () => {
     expect(titles).not.toContain("Declined Day");
     // Future assignment never appears on the past-only serving-history card.
     expect(titles).not.toContain("Future Day");
-
-    const usesNative = await t.run((ctx) =>
-      communityUsesNativeRostering(ctx, world.communityId),
-    );
-    expect(usesNative).toBe(true);
   });
 });
 
 // ============================================================================
-// (b) No native rostering → fall back to PCO pcoServingCounts
+// (b) No native plans → serving = cached PCO count only
 // ============================================================================
 
-describe("no native rostering", () => {
-  test("serving score falls back to cached PCO counts", async () => {
+describe("PCO only (no native plans)", () => {
+  test("serving score uses the cached PCO count when there is no native rostering", async () => {
     const t = convexTest(schema, modules);
     const nowTs = Date.now();
 
@@ -461,7 +472,7 @@ describe("no native rostering", () => {
         userId,
       );
 
-      // No eventPlans at all → PCO fallback. Cached count = 4.
+      // No eventPlans at all → native contributes 0. Cached PCO count = 4.
       await ctx.db.patch(announcementGroupId, {
         pcoServingCounts: {
           updatedAt: nowTs,
@@ -474,13 +485,46 @@ describe("no native rostering", () => {
     });
 
     const scored = await callScoreBatch(t, world);
+    // native (0) + PCO (4) = 4.
     expect(scored.rawValues.pco_services_past_2mo).toBe(4);
     // sys_service = min(100, 4 * 20) = 80.
     expect(scored.score1).toBe(80);
+  });
+});
 
-    const usesNative = await t.run((ctx) =>
-      communityUsesNativeRostering(ctx, world.communityId),
-    );
-    expect(usesNative).toBe(false);
+// ============================================================================
+// (c) mergeServingHistory — union of native + PCO rows, deduped, newest-first
+// ============================================================================
+
+describe("mergeServingHistory", () => {
+  test("merges native + PCO rows newest-first and dedupes overlap", () => {
+    const native = [
+      { date: "2026-06-01", serviceTypeName: "Sunday", teamName: "Worship", position: "Drums" },
+      { date: "2026-05-15", serviceTypeName: "Sunday", teamName: "Worship", position: "Drums" },
+    ];
+    const pco = [
+      // Same service as the first native row → deduped.
+      { date: "2026-06-01", serviceTypeName: "Sunday", teamName: "Worship", position: "Drums" },
+      { date: "2026-06-10", serviceTypeName: "PCO Service", teamName: "Hospitality", position: "Usher" },
+    ];
+    const merged = mergeServingHistory(native, pco, 15);
+    // Newest first: 06-10 (PCO), 06-01 (deduped), 05-15 (native).
+    expect(merged.map((r) => r.date)).toEqual([
+      "2026-06-10",
+      "2026-06-01",
+      "2026-05-15",
+    ]);
+    // The overlapping 06-01 row appears exactly once.
+    expect(merged.filter((r) => r.date === "2026-06-01")).toHaveLength(1);
+  });
+
+  test("respects the cap", () => {
+    const rows = Array.from({ length: 20 }, (_, i) => ({
+      date: `2026-06-${String(i + 1).padStart(2, "0")}`,
+      serviceTypeName: "S",
+      teamName: "T",
+      position: null,
+    }));
+    expect(mergeServingHistory(rows, [], 15)).toHaveLength(15);
   });
 });

--- a/apps/convex/__tests__/native-serving.test.ts
+++ b/apps/convex/__tests__/native-serving.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Native-first serving tests.
+ *
+ * The profile "Serving" system score (sys_service / pco_services_past_2mo) and
+ * the serving-history card are native-first: when a community uses native
+ * rostering (has ≥1 eventPlans row) serving comes from `roleAssignments`; when
+ * it has no native rostering it falls back to cached PCO `pcoServingCounts`.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/native-serving.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import {
+  countNativeServing,
+  communityUsesNativeRostering,
+  nativeServingHistory,
+} from "../lib/nativeServing";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ============================================================================
+// countNativeServing (community-scoped: distinct plans, window, declined,
+// and cross-community exclusion)
+// ============================================================================
+
+describe("countNativeServing", () => {
+  test("counts distinct in-window non-declined plans, scoped to the community", async () => {
+    const t = convexTest(schema, modules);
+    const nowTs = Date.now();
+
+    const { communityId, assignments } = await t.run(async (ctx) => {
+      const c1 = await seedCommunity(ctx, "Count C1");
+      const c2 = await seedCommunity(ctx, "Count C2");
+      const userId = await seedUser(ctx, "Nate");
+
+      // Campus group + team + role per community to roster onto.
+      const mkTeamRole = async (
+        communityId: Id<"communities">,
+        groupTypeId: Id<"groupTypes">,
+      ) => {
+        const groupId = await ctx.db.insert("groups", {
+          communityId,
+          groupTypeId,
+          name: "Campus",
+          isArchived: false,
+          createdAt: nowTs,
+          updatedAt: nowTs,
+        });
+        const teamId = await ctx.db.insert("teams", {
+          groupId,
+          communityId,
+          name: "Worship",
+          createdAt: nowTs,
+          createdById: userId,
+          updatedAt: nowTs,
+        });
+        const roleId = await ctx.db.insert("teamRoles", {
+          teamId,
+          communityId,
+          name: "Drums",
+          sortOrder: 0,
+          createdAt: nowTs,
+          createdById: userId,
+        });
+        return { groupId, teamId, roleId };
+      };
+      const a = await mkTeamRole(c1.communityId, c1.groupTypeId);
+      const b = await mkTeamRole(c2.communityId, c2.groupTypeId);
+
+      const addPlan = async (
+        communityId: Id<"communities">,
+        gtr: { groupId: Id<"groups">; teamId: Id<"teams">; roleId: Id<"teamRoles"> },
+        title: string,
+        eventDate: number,
+        status = "confirmed",
+      ) => {
+        const planId = await ctx.db.insert("eventPlans", {
+          groupId: gtr.groupId,
+          communityId,
+          title,
+          eventDate,
+          times: [{ label: "9:00 AM", startsAt: eventDate }],
+          status: "published",
+          createdAt: nowTs,
+          createdById: userId,
+          updatedAt: nowTs,
+        });
+        await ctx.db.insert("roleAssignments", {
+          planId,
+          teamId: gtr.teamId,
+          roleId: gtr.roleId,
+          userId,
+          eventDate,
+          status,
+          assignedById: userId,
+          assignedAt: nowTs,
+        });
+        return planId;
+      };
+
+      // Community 1: 3 distinct in-window plans (one with a duplicate slot),
+      // 1 declined, 1 out-of-window → distinct in-window non-declined = 3.
+      const p1 = await addPlan(c1.communityId, a, "P1", nowTs - 10 * DAY_MS);
+      await ctx.db.insert("roleAssignments", {
+        planId: p1,
+        teamId: a.teamId,
+        roleId: a.roleId,
+        userId,
+        eventDate: nowTs - 10 * DAY_MS,
+        status: "unconfirmed",
+        assignedById: userId,
+        assignedAt: nowTs,
+      });
+      await addPlan(c1.communityId, a, "P2", nowTs - 20 * DAY_MS);
+      await addPlan(c1.communityId, a, "P3", nowTs - 30 * DAY_MS);
+      await addPlan(c1.communityId, a, "Declined", nowTs - 5 * DAY_MS, "declined");
+      await addPlan(c1.communityId, a, "Old", nowTs - 90 * DAY_MS);
+      // Community 2: an in-window plan that must NOT count toward community 1.
+      await addPlan(c2.communityId, b, "OtherComm", nowTs - 3 * DAY_MS);
+
+      const assignments = await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_user_eventDate", (q: any) => q.eq("userId", userId))
+        .order("desc")
+        .take(200);
+      return { communityId: c1.communityId, assignments };
+    });
+
+    const count = await t.run((ctx) =>
+      countNativeServing(ctx, assignments, nowTs, communityId),
+    );
+    // 3 distinct plans in this community's window; duplicate slot, declined,
+    // out-of-window, and the other community's plan are all excluded.
+    expect(count).toBe(3);
+
+    const zero = await t.run((ctx) =>
+      countNativeServing(ctx, [], nowTs, communityId),
+    );
+    expect(zero).toBe(0);
+  });
+});
+
+// ============================================================================
+// Integration world builder
+// ============================================================================
+
+interface ServingWorld {
+  communityId: Id<"communities">;
+  announcementGroupId: Id<"groups">;
+  groupMemberId: Id<"groupMembers">;
+  userId: Id<"users">;
+}
+
+async function seedUser(ctx: any, first: string): Promise<Id<"users">> {
+  const t = Date.now();
+  return ctx.db.insert("users", {
+    firstName: first,
+    lastName: "Server",
+    isActive: true,
+    createdAt: t,
+    updatedAt: t,
+  });
+}
+
+async function seedCommunity(
+  ctx: any,
+  name: string,
+): Promise<{
+  communityId: Id<"communities">;
+  groupTypeId: Id<"groupTypes">;
+  announcementGroupId: Id<"groups">;
+}> {
+  const t = Date.now();
+  const communityId = await ctx.db.insert("communities", {
+    name,
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    isPublic: true,
+  });
+  const groupTypeId = await ctx.db.insert("groupTypes", {
+    communityId,
+    name: "Campus",
+    slug: "campus",
+    isActive: true,
+    createdAt: t,
+    displayOrder: 1,
+  });
+  const announcementGroupId = await ctx.db.insert("groups", {
+    communityId,
+    groupTypeId,
+    name: "Announcements",
+    isAnnouncementGroup: true,
+    isArchived: false,
+    createdAt: t,
+    updatedAt: t,
+  });
+  return { communityId, groupTypeId, announcementGroupId };
+}
+
+async function joinAnnouncementGroup(
+  ctx: any,
+  announcementGroupId: Id<"groups">,
+  userId: Id<"users">,
+): Promise<Id<"groupMembers">> {
+  return ctx.db.insert("groupMembers", {
+    groupId: announcementGroupId,
+    userId,
+    role: "member",
+    joinedAt: Date.now() - 90 * DAY_MS,
+    notificationsEnabled: true,
+  });
+}
+
+/** Insert a plan + one non-declined assignment for `userId` on it. */
+async function seedPlanWithAssignment(
+  ctx: any,
+  args: {
+    communityId: Id<"communities">;
+    groupId: Id<"groups">;
+    teamId: Id<"teams">;
+    roleId: Id<"teamRoles">;
+    userId: Id<"users">;
+    title: string;
+    eventDate: number;
+    status?: string;
+  },
+): Promise<Id<"eventPlans">> {
+  const t = Date.now();
+  const planId = await ctx.db.insert("eventPlans", {
+    groupId: args.groupId,
+    communityId: args.communityId,
+    title: args.title,
+    eventDate: args.eventDate,
+    times: [{ label: "9:00 AM", startsAt: args.eventDate }],
+    status: "published",
+    createdAt: t,
+    createdById: args.userId,
+    updatedAt: t,
+  });
+  await ctx.db.insert("roleAssignments", {
+    planId,
+    teamId: args.teamId,
+    roleId: args.roleId,
+    userId: args.userId,
+    eventDate: args.eventDate,
+    status: args.status ?? "confirmed",
+    assignedById: args.userId,
+    assignedAt: t,
+  });
+  return planId;
+}
+
+async function callScoreBatch(
+  t: ReturnType<typeof convexTest>,
+  world: ServingWorld,
+) {
+  const results = await t.query(
+    internal.functions.communityScoreComputation.computeCommunityScoresBatch,
+    {
+      communityId: world.communityId,
+      announcementGroupId: world.announcementGroupId,
+      members: [
+        {
+          groupMemberId: world.groupMemberId,
+          userId: world.userId,
+          joinedAt: Date.now() - 90 * DAY_MS,
+          firstName: "Test",
+          lastName: "Server",
+        },
+      ],
+    },
+  );
+  return results[0];
+}
+
+// ============================================================================
+// (a) Native rostering present → serving from roleAssignments
+// ============================================================================
+
+describe("native rostering present", () => {
+  test("serving score uses distinct native plans, ignoring stale PCO counts", async () => {
+    const t = convexTest(schema, modules);
+    const nowTs = Date.now();
+
+    const world = await t.run(async (ctx): Promise<ServingWorld> => {
+      const { communityId, groupTypeId, announcementGroupId } =
+        await seedCommunity(ctx, "Native Community");
+      const userId = await seedUser(ctx, "Nate");
+      const groupMemberId = await joinAnnouncementGroup(
+        ctx,
+        announcementGroupId,
+        userId,
+      );
+
+      // A campus group + team + role to roster onto.
+      const groupId = await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name: "Campus",
+        isArchived: false,
+        createdAt: nowTs,
+        updatedAt: nowTs,
+      });
+      const teamId = await ctx.db.insert("teams", {
+        groupId,
+        communityId,
+        name: "Worship",
+        createdAt: nowTs,
+        createdById: userId,
+        updatedAt: nowTs,
+      });
+      const roleId = await ctx.db.insert("teamRoles", {
+        teamId,
+        communityId,
+        name: "Drums",
+        sortOrder: 0,
+        createdAt: nowTs,
+        createdById: userId,
+      });
+
+      // 3 distinct plans in-window (one with a duplicate slot), 1 declined,
+      // 1 outside the window → distinct in-window non-declined = 3.
+      const p1 = await seedPlanWithAssignment(ctx, {
+        communityId,
+        groupId,
+        teamId,
+        roleId,
+        userId,
+        title: "Sunday AM",
+        eventDate: nowTs - 10 * DAY_MS,
+      });
+      // Duplicate slot on the same plan p1 — must not double-count.
+      await ctx.db.insert("roleAssignments", {
+        planId: p1,
+        teamId,
+        roleId,
+        userId,
+        eventDate: nowTs - 10 * DAY_MS,
+        status: "unconfirmed",
+        assignedById: userId,
+        assignedAt: nowTs,
+      });
+      await seedPlanWithAssignment(ctx, {
+        communityId,
+        groupId,
+        teamId,
+        roleId,
+        userId,
+        title: "Wednesday",
+        eventDate: nowTs - 20 * DAY_MS,
+      });
+      await seedPlanWithAssignment(ctx, {
+        communityId,
+        groupId,
+        teamId,
+        roleId,
+        userId,
+        title: "Sunday PM",
+        eventDate: nowTs - 30 * DAY_MS,
+      });
+      // Declined — excluded.
+      await seedPlanWithAssignment(ctx, {
+        communityId,
+        groupId,
+        teamId,
+        roleId,
+        userId,
+        title: "Declined Day",
+        eventDate: nowTs - 5 * DAY_MS,
+        status: "declined",
+      });
+      // Outside the 60-day window — excluded.
+      await seedPlanWithAssignment(ctx, {
+        communityId,
+        groupId,
+        teamId,
+        roleId,
+        userId,
+        title: "Old Day",
+        eventDate: nowTs - 90 * DAY_MS,
+      });
+
+      // Stale PCO cache that would (wrongly) win if we weren't native-first.
+      await ctx.db.patch(announcementGroupId, {
+        pcoServingCounts: {
+          updatedAt: nowTs,
+          counts: [{ userId, count: 99 }],
+          servingDetails: [],
+        },
+      });
+
+      return { communityId, announcementGroupId, groupMemberId, userId };
+    });
+
+    const scored = await callScoreBatch(t, world);
+    // Native count = 3 distinct plans (PCO's 99 is ignored).
+    expect(scored.rawValues.pco_services_past_2mo).toBe(3);
+    // sys_service = min(100, 3 * 20) = 60.
+    expect(scored.score1).toBe(60);
+
+    // Serving-history card lists native rows, newest event first.
+    const history = await t.run((ctx) =>
+      nativeServingHistory(ctx, world.userId, world.communityId),
+    );
+    // 4 non-declined assignments across the window+old plan, but distinct
+    // rows returned newest-first (one row per assignment).
+    expect(history[0].serviceTypeName).toBe("Sunday AM");
+    expect(history[0].teamName).toBe("Worship");
+    expect(history[0].position).toBe("Drums");
+    const titles = history.map((h) => h.serviceTypeName);
+    expect(titles).toContain("Wednesday");
+    expect(titles).toContain("Sunday PM");
+    // Declined assignment never appears.
+    expect(titles).not.toContain("Declined Day");
+
+    const usesNative = await t.run((ctx) =>
+      communityUsesNativeRostering(ctx, world.communityId),
+    );
+    expect(usesNative).toBe(true);
+  });
+});
+
+// ============================================================================
+// (b) No native rostering → fall back to PCO pcoServingCounts
+// ============================================================================
+
+describe("no native rostering", () => {
+  test("serving score falls back to cached PCO counts", async () => {
+    const t = convexTest(schema, modules);
+    const nowTs = Date.now();
+
+    const world = await t.run(async (ctx): Promise<ServingWorld> => {
+      const { communityId, announcementGroupId } = await seedCommunity(
+        ctx,
+        "PCO Community",
+      );
+      const userId = await seedUser(ctx, "Paul");
+      const groupMemberId = await joinAnnouncementGroup(
+        ctx,
+        announcementGroupId,
+        userId,
+      );
+
+      // No eventPlans at all → PCO fallback. Cached count = 4.
+      await ctx.db.patch(announcementGroupId, {
+        pcoServingCounts: {
+          updatedAt: nowTs,
+          counts: [{ userId, count: 4 }],
+          servingDetails: [],
+        },
+      });
+
+      return { communityId, announcementGroupId, groupMemberId, userId };
+    });
+
+    const scored = await callScoreBatch(t, world);
+    expect(scored.rawValues.pco_services_past_2mo).toBe(4);
+    // sys_service = min(100, 4 * 20) = 80.
+    expect(scored.score1).toBe(80);
+
+    const usesNative = await t.run((ctx) =>
+      communityUsesNativeRostering(ctx, world.communityId),
+    );
+    expect(usesNative).toBe(false);
+  });
+});

--- a/apps/convex/__tests__/native-serving.test.ts
+++ b/apps/convex/__tests__/native-serving.test.ts
@@ -120,6 +120,8 @@ describe("countNativeServing", () => {
       await addPlan(c1.communityId, a, "P3", nowTs - 30 * DAY_MS);
       await addPlan(c1.communityId, a, "Declined", nowTs - 5 * DAY_MS, "declined");
       await addPlan(c1.communityId, a, "Old", nowTs - 90 * DAY_MS);
+      // Future plan — rostered ahead but not yet served → must NOT count.
+      await addPlan(c1.communityId, a, "Future", nowTs + 5 * DAY_MS);
       // Community 2: an in-window plan that must NOT count toward community 1.
       await addPlan(c2.communityId, b, "OtherComm", nowTs - 3 * DAY_MS);
 
@@ -135,7 +137,7 @@ describe("countNativeServing", () => {
       countNativeServing(ctx, assignments, nowTs, communityId),
     );
     // 3 distinct plans in this community's window; duplicate slot, declined,
-    // out-of-window, and the other community's plan are all excluded.
+    // out-of-window, FUTURE, and the other community's plan are all excluded.
     expect(count).toBe(3);
 
     const zero = await t.run((ctx) =>
@@ -373,7 +375,8 @@ describe("native rostering present", () => {
         eventDate: nowTs - 5 * DAY_MS,
         status: "declined",
       });
-      // Outside the 60-day window — excluded.
+      // Outside the 60-day window — excluded from the count, still shown on
+      // the (unbounded) history card.
       await seedPlanWithAssignment(ctx, {
         communityId,
         groupId,
@@ -382,6 +385,17 @@ describe("native rostering present", () => {
         userId,
         title: "Old Day",
         eventDate: nowTs - 90 * DAY_MS,
+      });
+      // Future assignment (rostered ahead) — must NOT appear on the past-only
+      // serving-history card.
+      await seedPlanWithAssignment(ctx, {
+        communityId,
+        groupId,
+        teamId,
+        roleId,
+        userId,
+        title: "Future Day",
+        eventDate: nowTs + 7 * DAY_MS,
       });
 
       // Stale PCO cache that would (wrongly) win if we weren't native-first.
@@ -416,6 +430,8 @@ describe("native rostering present", () => {
     expect(titles).toContain("Sunday PM");
     // Declined assignment never appears.
     expect(titles).not.toContain("Declined Day");
+    // Future assignment never appears on the past-only serving-history card.
+    expect(titles).not.toContain("Future Day");
 
     const usesNative = await t.run((ctx) =>
       communityUsesNativeRostering(ctx, world.communityId),

--- a/apps/convex/__tests__/scheduling/nativePlaceholders.test.ts
+++ b/apps/convex/__tests__/scheduling/nativePlaceholders.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests for native-first communication-bot placeholder resolution.
+ *
+ * Communication bots expand `{{Team > Role}}` placeholders into the first names
+ * of whoever is scheduled. Resolution is native-first: it reads the app's own
+ * rostering (`teams` → `teamRoles` → upcoming `eventPlans` → `roleAssignments`)
+ * and only falls back to Planning Center (PCO) when there's no native match.
+ *
+ * PCO API calls are mocked (as in `pco/filterActions.test.ts`) so the fallback
+ * path can be exercised without real credentials.
+ */
+
+import { convexTest } from "convex-test";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api, internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { generateTokens } from "../../lib/auth";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// Mock the PCO API so the fallback path is deterministic.
+vi.mock("../../lib/pcoServicesApi", () => ({
+  getValidAccessToken: vi.fn().mockResolvedValue("mock-access-token"),
+  fetchServiceTypes: vi
+    .fn()
+    .mockResolvedValue([{ id: "st-1", attributes: { name: "Sunday Service" } }]),
+  fetchTeamsForServiceType: vi.fn(),
+  fetchUpcomingPlans: vi.fn().mockResolvedValue([]),
+  fetchPlanTeamMembers: vi.fn().mockResolvedValue([]),
+  getPersonContactInfo: vi.fn(),
+}));
+
+import {
+  fetchServiceTypes,
+  fetchUpcomingPlans,
+  fetchPlanTeamMembers,
+} from "../../lib/pcoServicesApi";
+
+function ts(offsetDays = 0): number {
+  return Date.now() + offsetDays * 24 * 60 * 60 * 1000;
+}
+
+interface World {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  teamId: Id<"teams">;
+  vocalsRoleId: Id<"teamRoles">;
+  planId: Id<"eventPlans">;
+  aliceId: Id<"users">;
+  bobId: Id<"users">;
+  charlieId: Id<"users">;
+  adminId: Id<"users">;
+}
+
+describe("native-first placeholder resolution", () => {
+  let t: ReturnType<typeof convexTest>;
+  let world: World;
+  let adminToken: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    (fetchServiceTypes as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "st-1", attributes: { name: "Sunday Service" } },
+    ]);
+    (fetchUpcomingPlans as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (fetchPlanTeamMembers as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    t = convexTest(schema, modules);
+
+    world = await t.run(async (ctx): Promise<World> => {
+      const communityId = await ctx.db.insert("communities", {
+        name: "Test Community",
+        slug: "test",
+        isPublic: true,
+      });
+      const groupTypeId = await ctx.db.insert("groupTypes", {
+        communityId,
+        name: "Campus",
+        slug: "campus",
+        isActive: true,
+        createdAt: ts(),
+        displayOrder: 1,
+      });
+      const groupId = await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name: "Brooklyn Campus",
+        isArchived: false,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+
+      const mkUser = async (firstName: string) =>
+        ctx.db.insert("users", {
+          firstName,
+          lastName: "Test",
+          email: `${firstName.toLowerCase()}@example.com`,
+          isActive: true,
+          roles: 1,
+          createdAt: ts(),
+          updatedAt: ts(),
+        });
+      const aliceId = await mkUser("Alice");
+      const bobId = await mkUser("Bob");
+      const charlieId = await mkUser("Charlie");
+      const adminId = await mkUser("Adminda");
+
+      await ctx.db.insert("userCommunities", {
+        communityId,
+        userId: adminId,
+        roles: 3,
+        status: 1,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+
+      const teamId = await ctx.db.insert("teams", {
+        groupId,
+        communityId,
+        name: "Worship",
+        isArchived: false,
+        createdAt: ts(),
+        createdById: adminId,
+        updatedAt: ts(),
+      });
+      const vocalsRoleId = await ctx.db.insert("teamRoles", {
+        teamId,
+        communityId,
+        name: "Vocals",
+        sortOrder: 0,
+        isArchived: false,
+        createdAt: ts(),
+        createdById: adminId,
+      });
+
+      // A past plan (should be ignored) and an upcoming published plan.
+      await ctx.db.insert("eventPlans", {
+        groupId,
+        communityId,
+        title: "Last Sunday",
+        eventDate: ts(-7),
+        times: [],
+        status: "published",
+        createdAt: ts(),
+        createdById: adminId,
+        updatedAt: ts(),
+      });
+      const planId = await ctx.db.insert("eventPlans", {
+        groupId,
+        communityId,
+        title: "This Sunday",
+        eventDate: ts(3),
+        times: [],
+        status: "published",
+        createdAt: ts(),
+        createdById: adminId,
+        updatedAt: ts(),
+      });
+
+      // Assign: Alice confirmed, Bob unconfirmed, Charlie declined.
+      for (const [userId, status] of [
+        [aliceId, "confirmed"],
+        [bobId, "unconfirmed"],
+        [charlieId, "declined"],
+      ] as const) {
+        await ctx.db.insert("roleAssignments", {
+          planId,
+          teamId,
+          roleId: vocalsRoleId,
+          userId,
+          eventDate: ts(3),
+          status,
+          assignedById: adminId,
+          assignedAt: ts(),
+        });
+      }
+
+      return {
+        communityId,
+        groupId,
+        teamId,
+        vocalsRoleId,
+        planId,
+        aliceId,
+        bobId,
+        charlieId,
+        adminId,
+      };
+    });
+
+    const tokens = await generateTokens(world.adminId as string);
+    adminToken = tokens.accessToken;
+  });
+
+  it("resolves a native placeholder to scheduled users' first names (confirmed + unconfirmed, declined excluded)", async () => {
+    const result = await t.action(
+      internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        message: "Hey {{Worship > Vocals}}, you're on this Sunday!",
+      },
+    );
+    // Alice (confirmed) + Bob (unconfirmed); Charlie (declined) excluded.
+    expect(result).toBe("Hey Alice and Bob, you're on this Sunday!");
+    // Native match — PCO must NOT be consulted.
+    expect(fetchServiceTypes).not.toHaveBeenCalled();
+  });
+
+  it("is case-insensitive on team and role names", async () => {
+    const result = await t.action(
+      internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        message: "{{worship > VOCALS}}",
+      },
+    );
+    expect(result).toBe("Alice and Bob");
+  });
+
+  it("renders [TBD] when the team/role match but nobody is scheduled", async () => {
+    // A native role with no assignments still counts as a native match, so it
+    // renders like the PCO 'no data' case and never falls back to PCO.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("teamRoles", {
+        teamId: world.teamId,
+        communityId: world.communityId,
+        name: "Drums",
+        sortOrder: 1,
+        isArchived: false,
+        createdAt: ts(),
+        createdById: world.adminId,
+      });
+    });
+    const result = await t.action(
+      internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        message: "Drummer: {{Worship > Drums}}",
+      },
+    );
+    expect(result).toBe("Drummer: [TBD]");
+    expect(fetchServiceTypes).not.toHaveBeenCalled();
+  });
+
+  it("also accepts the legacy 3-part placeholder using its last two segments", async () => {
+    const result = await t.action(
+      internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        message: "{{Sunday Service > Worship > Vocals}}",
+      },
+    );
+    expect(result).toBe("Alice and Bob");
+    expect(fetchServiceTypes).not.toHaveBeenCalled();
+  });
+
+  it("native resolver returns matched:false when no team/role matches (so PCO fallback triggers)", async () => {
+    const results = await t.query(
+      internal.functions.scheduling.nativePlaceholders.resolveNativePlaceholders,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        placeholders: [
+          { fullMatch: "{{Band > Drums}}", teamName: "Band", roleName: "Drums" },
+          {
+            fullMatch: "{{Worship > Vocals}}",
+            teamName: "Worship",
+            roleName: "Vocals",
+          },
+        ],
+      },
+    );
+    const byMatch = new Map(results.map((r) => [r.fullMatch, r]));
+    expect(byMatch.get("{{Band > Drums}}")?.matched).toBe(false);
+    expect(byMatch.get("{{Worship > Vocals}}")?.matched).toBe(true);
+    expect(byMatch.get("{{Worship > Vocals}}")?.names).toEqual([
+      "Alice",
+      "Bob",
+    ]);
+  });
+
+  it("falls back to PCO for a 3-part placeholder with no native match", async () => {
+    (fetchUpcomingPlans as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "plan-1", attributes: { sort_date: "2026-02-01" } },
+    ]);
+    (fetchPlanTeamMembers as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: "m1",
+        name: "Dave Grohl",
+        status: "C",
+        position: "Drums",
+        pcoPersonId: "p1",
+        teamId: "t1",
+        teamName: "Band",
+      },
+    ]);
+
+    const result = await t.action(
+      internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        // "Band" is not a native team → native misses → PCO resolves it.
+        message: "{{Sunday Service > Band > Drums}}",
+      },
+    );
+    expect(result).toBe("Dave");
+    expect(fetchServiceTypes).toHaveBeenCalled();
+  });
+
+  it("resolves native and PCO placeholders together in one message", async () => {
+    (fetchUpcomingPlans as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "plan-1", attributes: { sort_date: "2026-02-01" } },
+    ]);
+    (fetchPlanTeamMembers as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: "m1",
+        name: "Dave Grohl",
+        status: "C",
+        position: "Drums",
+        pcoPersonId: "p1",
+        teamId: "t1",
+        teamName: "Band",
+      },
+    ]);
+
+    const result = await t.action(
+      internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        message:
+          "Vocals: {{Worship > Vocals}} / Drums: {{Sunday Service > Band > Drums}}",
+      },
+    );
+    expect(result).toBe("Vocals: Alice and Bob / Drums: Dave");
+  });
+
+  it("leaves a 2-part placeholder untouched when it matches neither native nor PCO", async () => {
+    const result = await t.action(
+      internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
+      {
+        communityId: world.communityId,
+        groupId: world.groupId,
+        // 2-part, no native match, and no serviceType so PCO can't help.
+        message: "{{Nonexistent > Role}}",
+      },
+    );
+    expect(result).toBe("{{Nonexistent > Role}}");
+    expect(fetchServiceTypes).not.toHaveBeenCalled();
+  });
+
+  it("getNativePositions lists community teams x roles as Team > Role suggestions", async () => {
+    const positions = await t.query(
+      api.functions.scheduling.nativePlaceholders.getNativePositions,
+      { token: adminToken, communityId: world.communityId },
+    );
+    expect(positions).toEqual([
+      { teamName: "Worship", roleName: "Vocals", displayName: "Worship > Vocals" },
+    ]);
+  });
+});

--- a/apps/convex/__tests__/slackServiceBot.native.test.ts
+++ b/apps/convex/__tests__/slackServiceBot.native.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Slack Service Planning Bot — Native-first rostering tests.
+ *
+ * Proves the native-first path added in the PCO → native migration:
+ *   • the native context reader returns roster + run-sheet items sourced from
+ *     the native tables (`roleAssignments`, `teams`, `teamRoles`, `eventItems`),
+ *     shaped like the PCO context the prompt logic consumes;
+ *   • native writes land real rows — an assignment writes `roleAssignments`, a
+ *     setlist sync writes `eventItems` song rows, an item update patches an
+ *     `eventItem`;
+ *   • when there is NO upcoming native plan the reader returns null and the
+ *     write mutations return `handled: false` — the signal for the bot to fall
+ *     back to the PCO path;
+ *   • the `assignPersonToRoleCore` router takes the native branch (no PCO HTTP)
+ *     when an upcoming native plan exists.
+ *
+ * These exercise the internal Convex functions directly (no external HTTP), so
+ * the PCO fallback is never actually hit — we only assert the "no native plan"
+ * signal that triggers it.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/slackServiceBot.native.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { describe, it, expect, afterEach } from "vitest";
+import schema from "../schema";
+import { modules } from "../test.setup";
+import { internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { assignPersonToRoleCore } from "../functions/slackServiceBot/pcoSync";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+interface NativeWorld {
+  communityId: Id<"communities">;
+  mhGroupId: Id<"groups">;
+  bkGroupId: Id<"groups">;
+  leaderId: Id<"users">;
+  preacherUserId: Id<"users">;
+  mlUserId: Id<"users">;
+  teamId: Id<"teams">;
+  preacherRoleId: Id<"teamRoles">;
+  mlRoleId: Id<"teamRoles">;
+  planId: Id<"eventPlans">;
+  messageItemId: Id<"eventItems">;
+}
+
+/**
+ * Seed a native world: a community with a Manhattan campus group that has an
+ * upcoming plan, a channel-less "Platform" team with "Preacher" / "Meeting
+ * Leader" roles, a couple of members, one existing assignment, and two run-sheet
+ * items. Also a Brooklyn campus group with NO plan (the fallback case).
+ */
+async function buildNativeWorld(
+  t: ReturnType<typeof convexTest>,
+): Promise<NativeWorld> {
+  return t.run(async (ctx): Promise<NativeWorld> => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "FOUNT Test",
+      slug: "fount-test",
+      isPublic: true,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Campus",
+      slug: "campus",
+      isActive: true,
+      createdAt: Date.now(),
+      displayOrder: 1,
+    });
+    const mhGroupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Manhattan Campus",
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const bkGroupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Brooklyn Campus",
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const mkUser = async (firstName: string, lastName: string) =>
+      ctx.db.insert("users", {
+        firstName,
+        lastName,
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    const leaderId = await mkUser("Leona", "Lead");
+    const preacherUserId = await mkUser("Kevin", "Myers");
+    const mlUserId = await mkUser("Tameeka", "Walker");
+
+    // Active group memberships — assignees must be active campus-group members.
+    for (const userId of [leaderId, preacherUserId, mlUserId]) {
+      await ctx.db.insert("groupMembers", {
+        groupId: mhGroupId,
+        userId,
+        role: userId === leaderId ? "leader" : "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    }
+
+    // Channel-less "Platform" serving team (reconcile is a safe no-op).
+    const teamId = await ctx.db.insert("teams", {
+      groupId: mhGroupId,
+      communityId,
+      name: "Platform",
+      isArchived: false,
+      createdAt: Date.now(),
+      createdById: leaderId,
+      updatedAt: Date.now(),
+    });
+    const preacherRoleId = await ctx.db.insert("teamRoles", {
+      teamId,
+      communityId,
+      name: "Preacher",
+      sortOrder: 0,
+      createdAt: Date.now(),
+      createdById: leaderId,
+    });
+    const mlRoleId = await ctx.db.insert("teamRoles", {
+      teamId,
+      communityId,
+      name: "Meeting Leader",
+      sortOrder: 1,
+      createdAt: Date.now(),
+      createdById: leaderId,
+    });
+
+    // Upcoming plan (tomorrow), draft.
+    const eventDate = Date.now() + DAY;
+    const planId = await ctx.db.insert("eventPlans", {
+      groupId: mhGroupId,
+      communityId,
+      title: "Sunday Service",
+      eventDate,
+      times: [{ label: "10 AM", startsAt: eventDate }],
+      status: "draft",
+      createdAt: Date.now(),
+      createdById: leaderId,
+      updatedAt: Date.now(),
+    });
+
+    // Existing confirmed assignment: Kevin as Preacher.
+    await ctx.db.insert("roleAssignments", {
+      planId,
+      teamId,
+      roleId: preacherRoleId,
+      userId: preacherUserId,
+      eventDate,
+      status: "confirmed",
+      assignedById: leaderId,
+      assignedAt: Date.now(),
+    });
+
+    // Run-sheet items: a Message item and an Announcements item.
+    const messageItemId = await ctx.db.insert("eventItems", {
+      planId,
+      communityId,
+      segment: "during",
+      sequence: 0,
+      type: "item",
+      title: "Message",
+      durationSec: 1800,
+      createdAt: Date.now(),
+      createdById: leaderId,
+      updatedAt: Date.now(),
+    });
+    await ctx.db.insert("eventItems", {
+      planId,
+      communityId,
+      segment: "during",
+      sequence: 1,
+      type: "item",
+      title: "Announcements",
+      description: "GIVING\nText to give to 555-1234",
+      durationSec: 120,
+      createdAt: Date.now(),
+      createdById: leaderId,
+      updatedAt: Date.now(),
+    });
+
+    return {
+      communityId,
+      mhGroupId,
+      bkGroupId,
+      leaderId,
+      preacherUserId,
+      mlUserId,
+      teamId,
+      preacherRoleId,
+      mlRoleId,
+      planId,
+      messageItemId,
+    };
+  });
+}
+
+function setup() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  return t;
+}
+
+describe("native context reader (getNativeContext)", () => {
+  it("returns roster + items from the native tables", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    const ctx = await t.query(
+      internal.functions.slackServiceBot.nativeSync.getNativeContext,
+      { communityId: world.communityId, campusGroupName: "Manhattan" },
+    );
+
+    expect(ctx).not.toBeNull();
+    // Confirmed preacher surfaces in platformRolesAll keyed by role name.
+    expect(ctx!.platformRolesAll["Preacher"]).toEqual({
+      name: "Kevin Myers",
+      status: "C",
+    });
+    expect(ctx!.platformRoles["Preacher"]).toBe("Kevin Myers");
+    // teamMembers carries the native assignment.
+    const kevin = ctx!.teamMembers.find((m) => m.name === "Kevin Myers");
+    expect(kevin?.position).toBe("Preacher");
+    expect(kevin?.teamName).toBe("Platform");
+    expect(kevin?.status).toBe("C");
+    // Run-sheet items are present.
+    expect(ctx!.items.map((i) => i.title)).toContain("Message");
+    expect(ctx!.items.map((i) => i.title)).toContain("Announcements");
+  });
+
+  it("returns null when the campus group has no upcoming plan (PCO fallback)", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    // Brooklyn campus exists but has no plan → no native plan → fall back.
+    const ctx = await t.query(
+      internal.functions.slackServiceBot.nativeSync.getNativeContext,
+      { communityId: world.communityId, campusGroupName: "Brooklyn" },
+    );
+    expect(ctx).toBeNull();
+  });
+});
+
+describe("native assign (nativeAssignRole)", () => {
+  it("writes a roleAssignment row", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    const result = await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeAssignRole,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Manhattan",
+        teamName: "Platform",
+        roleName: "Meeting Leader",
+        personName: "Tameeka Walker",
+      },
+    );
+    expect(result).toMatchObject({ handled: true, success: true });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan_role", (q) =>
+          q.eq("planId", world.planId).eq("roleId", world.mlRoleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(world.mlUserId);
+    expect(rows[0].status).toBe("unconfirmed");
+  });
+
+  it("is idempotent for an already-assigned person", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+    // Kevin is already the Preacher (seeded).
+    const result = await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeAssignRole,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Manhattan",
+        teamName: "Platform",
+        roleName: "Preacher",
+        personName: "Kevin Myers",
+      },
+    );
+    expect(result).toMatchObject({ handled: true, success: true });
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan_role", (q) =>
+          q.eq("planId", world.planId).eq("roleId", world.preacherRoleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(1); // no duplicate
+  });
+
+  it("returns handled:false when there is no upcoming native plan", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+    // Brooklyn campus has no plan → not handled → PCO fallback.
+    const result = await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeAssignRole,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Brooklyn",
+        teamName: "Platform",
+        roleName: "Preacher",
+        personName: "Kevin Myers",
+      },
+    );
+    expect(result.handled).toBe(false);
+  });
+});
+
+describe("native setlist + item writes", () => {
+  it("nativeSyncSetlist writes song eventItems (dedup on re-sync)", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    const first = await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeSyncSetlist,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Manhattan",
+        songs: ["Great Are You Lord", "Build My Life"],
+      },
+    );
+    expect(first).toMatchObject({ handled: true, success: true, songsAdded: 2 });
+
+    const songs = await t.run((ctx) =>
+      ctx.db
+        .query("eventItems")
+        .withIndex("by_plan", (q) => q.eq("planId", world.planId))
+        .collect(),
+    ).then((items) => items.filter((i) => i.type === "song"));
+    expect(songs.map((s) => s.title).sort()).toEqual([
+      "Build My Life",
+      "Great Are You Lord",
+    ]);
+
+    // Re-sync with an overlapping title → only the new one is added.
+    const second = await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeSyncSetlist,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Manhattan",
+        songs: ["Build My Life", "Goodness of God"],
+      },
+    );
+    expect(second).toMatchObject({ handled: true, songsAdded: 1 });
+  });
+
+  it("nativeUpdateItem patches an item description", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    const result = await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeUpdateItem,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Manhattan",
+        titlePattern: "message|preach|sermon",
+        field: "description",
+        content: "Hope For The Battle — Matthew 1:18-25",
+      },
+    );
+    expect(result).toMatchObject({ handled: true, success: true });
+
+    const item = await t.run((ctx) => ctx.db.get(world.messageItemId));
+    expect(item?.description).toBe("Hope For The Battle — Matthew 1:18-25");
+  });
+
+  it("nativeUpdateItem preserves a named section (GIVING) on announcements", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeUpdateItem,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Manhattan",
+        titlePattern: "announcement",
+        field: "description",
+        content: "Baptism class Sunday",
+        preserveSections: ["GIVING"],
+      },
+    );
+
+    const items = await t.run((ctx) =>
+      ctx.db
+        .query("eventItems")
+        .withIndex("by_plan", (q) => q.eq("planId", world.planId))
+        .collect(),
+    );
+    const announcements = items.find((i) => i.title === "Announcements");
+    expect(announcements?.description).toContain("Baptism class Sunday");
+    expect(announcements?.description).toContain("GIVING");
+  });
+});
+
+describe("assignPersonToRoleCore router (native-first)", () => {
+  it("takes the native branch when an upcoming native plan exists", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    // A fake ActionCtx that forwards to the convex-test handle. The native
+    // branch never touches PCO HTTP, so no stubbing is required.
+    const fakeCtx = {
+      runQuery: (ref: any, args: any) => t.query(ref, args),
+      runMutation: (ref: any, args: any) => t.mutation(ref, args),
+    } as unknown as ActionCtx;
+
+    const result = await assignPersonToRoleCore(
+      fakeCtx,
+      "Manhattan",
+      "meetingLead",
+      "Tameeka Walker",
+      // pcoConfig is unused on the native branch.
+      {} as any,
+      world.communityId,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.detail.toLowerCase()).toContain("native");
+
+    // The assignment landed natively.
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan_role", (q) =>
+          q.eq("planId", world.planId).eq("roleId", world.mlRoleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/apps/convex/__tests__/slackServiceBot.native.test.ts
+++ b/apps/convex/__tests__/slackServiceBot.native.test.ts
@@ -317,6 +317,54 @@ describe("native assign (nativeAssignRole)", () => {
     expect(rows).toHaveLength(1); // no duplicate
   });
 
+  it("reopens a previously declined assignment instead of a no-op success", async () => {
+    const t = setup();
+    const world = await buildNativeWorld(t);
+
+    // Tameeka previously declined Meeting Leader.
+    const declinedId = await t.run((ctx) =>
+      ctx.db.insert("roleAssignments", {
+        planId: world.planId,
+        teamId: world.teamId,
+        roleId: world.mlRoleId,
+        userId: world.mlUserId,
+        eventDate: Date.now() + DAY,
+        status: "declined",
+        declineNote: "can't make it",
+        respondedAt: Date.now(),
+        assignedById: world.leaderId,
+        assignedAt: Date.now(),
+      }),
+    );
+
+    const result = await t.mutation(
+      internal.functions.slackServiceBot.nativeSync.nativeAssignRole,
+      {
+        communityId: world.communityId,
+        campusGroupName: "Manhattan",
+        teamName: "Platform",
+        roleName: "Meeting Leader",
+        personName: "Tameeka Walker",
+      },
+    );
+    expect(result).toMatchObject({ handled: true, success: true });
+    expect(result.detail.toLowerCase()).toContain("declined");
+
+    // Same row reopened (no duplicate), decline metadata cleared.
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan_role", (q) =>
+          q.eq("planId", world.planId).eq("roleId", world.mlRoleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]._id).toBe(declinedId);
+    expect(rows[0].status).toBe("unconfirmed");
+    expect(rows[0].declineNote).toBeUndefined();
+  });
+
   it("returns handled:false when there is no upcoming native plan", async () => {
     const t = setup();
     const world = await buildNativeWorld(t);

--- a/apps/convex/__tests__/slackServiceBot.nativeConfig.test.ts
+++ b/apps/convex/__tests__/slackServiceBot.nativeConfig.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Slack Service Planning Bot — Native config promotion tests.
+ *
+ * Proves the native campus-group-name and role→{teamName,roleName} mappings are
+ * driven by the `slackBotConfig.nativeConfig` DB section, with the hardcoded
+ * `config.ts` constants kept only as the seed defaults + fallback:
+ *
+ *   • unit: the `configDb` accessors return the DB-configured value when
+ *     `nativeConfig` has the mapping, and fall back to the `config.ts`
+ *     constants when it is absent / empty / missing the key;
+ *   • integration (convex-test): with a `slackBotConfig` row whose
+ *     `nativeConfig` maps a location/role to a NON-default campus group / team /
+ *     role, the native-first router (`assignPersonToRoleCore`) resolves via the
+ *     DB config and lands a native assignment; with NO config row it falls back
+ *     to the constants and still lands.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/slackServiceBot.nativeConfig.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { describe, it, test, expect, afterEach } from "vitest";
+import schema from "../schema";
+import { modules } from "../test.setup";
+import { internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { assignPersonToRoleCore } from "../functions/slackServiceBot/pcoSync";
+import {
+  getNativeCampusGroupNameFromConfig,
+  getNativeRoleMappingFromConfig,
+} from "../functions/slackServiceBot/configDb";
+import {
+  NATIVE_CAMPUS_GROUP_NAMES,
+  NATIVE_ROLE_MAPPINGS,
+} from "../functions/slackServiceBot/config";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+// ============================================================================
+// Unit: configDb native accessors (DB-first, constants as fallback)
+// ============================================================================
+
+describe("native config accessors", () => {
+  const dbNativeConfig = {
+    campusGroupNames: { Manhattan: "Downtown Hub", Brooklyn: "Kings Hub" },
+    roleMappings: {
+      preacher: { teamName: "MainStage", roleName: "Speaker" },
+      meetingLead: { teamName: "MainStage", roleName: "Host" },
+    },
+  };
+
+  test("campus group name: DB config wins when present", () => {
+    expect(getNativeCampusGroupNameFromConfig(dbNativeConfig, "Manhattan")).toBe(
+      "Downtown Hub",
+    );
+  });
+
+  test("campus group name: falls back to constant when nativeConfig absent", () => {
+    expect(getNativeCampusGroupNameFromConfig(undefined, "Manhattan")).toBe(
+      NATIVE_CAMPUS_GROUP_NAMES.Manhattan,
+    );
+  });
+
+  test("campus group name: falls back to constant when maps empty", () => {
+    const empty = { campusGroupNames: {}, roleMappings: {} };
+    expect(getNativeCampusGroupNameFromConfig(empty, "Brooklyn")).toBe(
+      NATIVE_CAMPUS_GROUP_NAMES.Brooklyn,
+    );
+  });
+
+  test("campus group name: unknown location returns null", () => {
+    expect(getNativeCampusGroupNameFromConfig(dbNativeConfig, "Nowhere")).toBeNull();
+  });
+
+  test("role mapping: DB config wins when present", () => {
+    expect(getNativeRoleMappingFromConfig(dbNativeConfig, "preacher")).toEqual({
+      teamName: "MainStage",
+      roleName: "Speaker",
+    });
+  });
+
+  test("role mapping: falls back to constant when nativeConfig absent", () => {
+    expect(getNativeRoleMappingFromConfig(undefined, "preacher")).toEqual(
+      NATIVE_ROLE_MAPPINGS.preacher,
+    );
+  });
+
+  test("role mapping: falls back to constant when key missing from DB config", () => {
+    const partial = {
+      campusGroupNames: { Manhattan: "Downtown Hub" },
+      roleMappings: { preacher: { teamName: "MainStage", roleName: "Speaker" } },
+    };
+    // "meetingLead" isn't in the DB config → constant.
+    expect(getNativeRoleMappingFromConfig(partial, "meetingLead")).toEqual(
+      NATIVE_ROLE_MAPPINGS.meetingLead,
+    );
+  });
+
+  test("role mapping: unknown role returns null", () => {
+    expect(getNativeRoleMappingFromConfig(dbNativeConfig, "bogus")).toBeNull();
+  });
+});
+
+// ============================================================================
+// Integration: the native-first router resolves via DB config (convex-test)
+// ============================================================================
+
+interface RouterWorld {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  planId: Id<"eventPlans">;
+  teamId: Id<"teams">;
+  roleId: Id<"teamRoles">;
+  tameekaId: Id<"users">;
+}
+
+/**
+ * Seed a native world with configurable group/team/role names so a test can
+ * make the DB `nativeConfig` point at names that DON'T match the hardcoded
+ * constants — proving resolution came from the DB config.
+ */
+async function buildRouterWorld(
+  t: ReturnType<typeof convexTest>,
+  opts: { groupName: string; teamName: string; roleName: string },
+): Promise<RouterWorld> {
+  return t.run(async (ctx): Promise<RouterWorld> => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "FOUNT Test",
+      slug: "fount-native-config-test",
+      isPublic: true,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Campus",
+      slug: "campus",
+      isActive: true,
+      createdAt: Date.now(),
+      displayOrder: 1,
+    });
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: opts.groupName,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Leona",
+      lastName: "Lead",
+      isActive: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const tameekaId = await ctx.db.insert("users", {
+      firstName: "Tameeka",
+      lastName: "Walker",
+      isActive: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    for (const userId of [leaderId, tameekaId]) {
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId,
+        role: userId === leaderId ? "leader" : "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    }
+
+    const teamId = await ctx.db.insert("teams", {
+      groupId,
+      communityId,
+      name: opts.teamName,
+      isArchived: false,
+      createdAt: Date.now(),
+      createdById: leaderId,
+      updatedAt: Date.now(),
+    });
+    const roleId = await ctx.db.insert("teamRoles", {
+      teamId,
+      communityId,
+      name: opts.roleName,
+      sortOrder: 0,
+      createdAt: Date.now(),
+      createdById: leaderId,
+    });
+
+    const eventDate = Date.now() + DAY;
+    const planId = await ctx.db.insert("eventPlans", {
+      groupId,
+      communityId,
+      title: "Sunday Service",
+      eventDate,
+      times: [{ label: "10 AM", startsAt: eventDate }],
+      status: "draft",
+      createdAt: Date.now(),
+      createdById: leaderId,
+      updatedAt: Date.now(),
+    });
+
+    return { communityId, groupId, planId, teamId, roleId, tameekaId };
+  });
+}
+
+/** Insert a slackBotConfig row for a community with the given nativeConfig. */
+async function seedBotConfig(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  nativeConfig: {
+    campusGroupNames: Record<string, string>;
+    roleMappings: Record<string, { teamName: string; roleName: string }>;
+  },
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("slackBotConfig", {
+      communityId,
+      enabled: true,
+      slackChannelId: "C_TEST",
+      botSlackUserId: "U_BOT",
+      devMode: true,
+      teamMembers: [],
+      threadMentions: {},
+      nagSchedule: [],
+      threadCreation: { dayOfWeek: 2, hourET: 10 },
+      servicePlanItems: [],
+      servicePlanLabels: {},
+      itemResponsibleRoles: {},
+      pcoConfig: {
+        communityId: communityId as string,
+        serviceTypeIds: {},
+        roleMappings: {},
+      },
+      nativeConfig,
+      aiConfig: {
+        model: "gpt-4o-mini",
+        botPersonality: "test",
+        responseRules: "test",
+        nagToneByLevel: {},
+        teamContext: "test",
+      },
+      processedMessageTs: [],
+      nagsSent: {},
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+/** An ActionCtx that forwards runQuery/runMutation to the convex-test handle. */
+function fakeActionCtx(t: ReturnType<typeof convexTest>): ActionCtx {
+  return {
+    runQuery: (ref: any, args: any) => t.query(ref, args),
+    runMutation: (ref: any, args: any) => t.mutation(ref, args),
+  } as unknown as ActionCtx;
+}
+
+function setup() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  return t;
+}
+
+describe("assignPersonToRoleCore resolves native mappings via DB config", () => {
+  it("uses the DB nativeConfig campus group + role mapping (non-default names)", async () => {
+    const t = setup();
+    // Names deliberately do NOT match the config.ts constants; only the DB
+    // config knows how to reach them.
+    const world = await buildRouterWorld(t, {
+      groupName: "Downtown Hub",
+      teamName: "MainStage",
+      roleName: "Host",
+    });
+    await seedBotConfig(t, world.communityId, {
+      campusGroupNames: { Manhattan: "Downtown Hub" },
+      roleMappings: { meetingLead: { teamName: "MainStage", roleName: "Host" } },
+    });
+
+    const result = await assignPersonToRoleCore(
+      fakeActionCtx(t),
+      "Manhattan",
+      "meetingLead",
+      "Tameeka Walker",
+      {} as any, // pcoConfig unused on the native branch
+      world.communityId,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.detail.toLowerCase()).toContain("native");
+
+    // The assignment landed on the DB-configured team/role.
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan_role", (q) =>
+          q.eq("planId", world.planId).eq("roleId", world.roleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(world.tameekaId);
+  });
+
+  it("falls back to config.ts constants when no slackBotConfig row exists", async () => {
+    const t = setup();
+    // Names match the hardcoded constants (Manhattan → group containing
+    // "Manhattan", meetingLead → Platform / Meeting Leader). No config row.
+    const world = await buildRouterWorld(t, {
+      groupName: "Manhattan Campus",
+      teamName: "Platform",
+      roleName: "Meeting Leader",
+    });
+
+    const result = await assignPersonToRoleCore(
+      fakeActionCtx(t),
+      "Manhattan",
+      "meetingLead",
+      "Tameeka Walker",
+      {} as any,
+      world.communityId,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.detail.toLowerCase()).toContain("native");
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan_role", (q) =>
+          q.eq("planId", world.planId).eq("roleId", world.roleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(world.tameekaId);
+  });
+});

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -152,6 +152,7 @@ import type * as functions_scheduling_eventTasks from "../functions/scheduling/e
 import type * as functions_scheduling_events from "../functions/scheduling/events.js";
 import type * as functions_scheduling_index from "../functions/scheduling/index.js";
 import type * as functions_scheduling_mySchedule from "../functions/scheduling/mySchedule.js";
+import type * as functions_scheduling_nativePlaceholders from "../functions/scheduling/nativePlaceholders.js";
 import type * as functions_scheduling_people from "../functions/scheduling/people.js";
 import type * as functions_scheduling_permissions from "../functions/scheduling/permissions.js";
 import type * as functions_scheduling_planTemplates from "../functions/scheduling/planTemplates.js";
@@ -177,6 +178,7 @@ import type * as functions_slackServiceBot_config from "../functions/slackServic
 import type * as functions_slackServiceBot_configDb from "../functions/slackServiceBot/configDb.js";
 import type * as functions_slackServiceBot_configHelpers from "../functions/slackServiceBot/configHelpers.js";
 import type * as functions_slackServiceBot_index from "../functions/slackServiceBot/index.js";
+import type * as functions_slackServiceBot_nativeSync from "../functions/slackServiceBot/nativeSync.js";
 import type * as functions_slackServiceBot_pcoSync from "../functions/slackServiceBot/pcoSync.js";
 import type * as functions_slackServiceBot_prompts from "../functions/slackServiceBot/prompts.js";
 import type * as functions_slackServiceBot_seedConfig from "../functions/slackServiceBot/seedConfig.js";
@@ -383,6 +385,7 @@ declare const fullApi: ApiFromModules<{
   "functions/scheduling/events": typeof functions_scheduling_events;
   "functions/scheduling/index": typeof functions_scheduling_index;
   "functions/scheduling/mySchedule": typeof functions_scheduling_mySchedule;
+  "functions/scheduling/nativePlaceholders": typeof functions_scheduling_nativePlaceholders;
   "functions/scheduling/people": typeof functions_scheduling_people;
   "functions/scheduling/permissions": typeof functions_scheduling_permissions;
   "functions/scheduling/planTemplates": typeof functions_scheduling_planTemplates;
@@ -408,6 +411,7 @@ declare const fullApi: ApiFromModules<{
   "functions/slackServiceBot/configDb": typeof functions_slackServiceBot_configDb;
   "functions/slackServiceBot/configHelpers": typeof functions_slackServiceBot_configHelpers;
   "functions/slackServiceBot/index": typeof functions_slackServiceBot_index;
+  "functions/slackServiceBot/nativeSync": typeof functions_slackServiceBot_nativeSync;
   "functions/slackServiceBot/pcoSync": typeof functions_slackServiceBot_pcoSync;
   "functions/slackServiceBot/prompts": typeof functions_slackServiceBot_prompts;
   "functions/slackServiceBot/seedConfig": typeof functions_slackServiceBot_seedConfig;

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -22,6 +22,10 @@ import { isActiveMembership, isLeaderRole } from "../lib/helpers";
 import { VALID_CUSTOM_SLOTS } from "../lib/followupConstants";
 import { SYSTEM_SCORES, SYSTEM_VARIABLE_IDS } from "./systemScoring";
 import { getMediaUrl, safeSliceForJson } from "../lib/utils";
+import {
+  communityUsesNativeRostering,
+  nativeServingHistory,
+} from "../lib/nativeServing";
 
 // ============================================================================
 // Auth Helpers
@@ -2052,15 +2056,29 @@ export const history = query({
         }) ?? [],
     }));
 
-    // Serving history from announcement group's PCO data
-    const servingHistory: Array<{
+    // Serving history — native-first. If the community uses native rostering,
+    // build the card from roleAssignments; otherwise fall back to the cached
+    // PCO servingDetails on the announcement group doc.
+    let servingHistory: Array<{
       date: string;
       serviceTypeName: string;
       teamName: string;
       position: string | null;
     }> = [];
 
-    if (announcementGroup) {
+    const usesNativeRostering = await communityUsesNativeRostering(
+      ctx,
+      cpRecord.communityId,
+    );
+
+    if (usesNativeRostering) {
+      servingHistory = await nativeServingHistory(
+        ctx,
+        cpRecord.userId,
+        cpRecord.communityId,
+        15,
+      );
+    } else if (announcementGroup) {
       const allDetails =
         (announcementGroup as any)?.pcoServingCounts?.servingDetails ?? [];
       const userDetails = allDetails

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -23,8 +23,8 @@ import { VALID_CUSTOM_SLOTS } from "../lib/followupConstants";
 import { SYSTEM_SCORES, SYSTEM_VARIABLE_IDS } from "./systemScoring";
 import { getMediaUrl, safeSliceForJson } from "../lib/utils";
 import {
-  communityUsesNativeRostering,
   nativeServingHistory,
+  mergeServingHistory,
 } from "../lib/nativeServing";
 
 // ============================================================================
@@ -2056,45 +2056,35 @@ export const history = query({
         }) ?? [],
     }));
 
-    // Serving history — native-first. If the community uses native rostering,
-    // build the card from roleAssignments; otherwise fall back to the cached
-    // PCO servingDetails on the announcement group doc.
-    let servingHistory: Array<{
+    // Serving history combines BOTH sources: native-origin rows from
+    // roleAssignments AND the cached PCO servingDetails on the announcement
+    // group doc, merged newest-first and deduped.
+    const nativeRows = await nativeServingHistory(
+      ctx,
+      cpRecord.userId,
+      cpRecord.communityId,
+      15,
+    );
+    const pcoRows: Array<{
       date: string;
       serviceTypeName: string;
       teamName: string;
       position: string | null;
     }> = [];
-
-    const usesNativeRostering = await communityUsesNativeRostering(
-      ctx,
-      cpRecord.communityId,
-    );
-
-    if (usesNativeRostering) {
-      servingHistory = await nativeServingHistory(
-        ctx,
-        cpRecord.userId,
-        cpRecord.communityId,
-        15,
-      );
-    } else if (announcementGroup) {
+    if (announcementGroup) {
       const allDetails =
         (announcementGroup as any)?.pcoServingCounts?.servingDetails ?? [];
-      const userDetails = allDetails
-        .filter((d: any) => d.userId.toString() === cpRecord.userId.toString())
-        .sort((a: any, b: any) => b.date.localeCompare(a.date));
-
-      for (const d of userDetails) {
-        servingHistory.push({
+      for (const d of allDetails) {
+        if (d.userId.toString() !== cpRecord.userId.toString()) continue;
+        pcoRows.push({
           date: d.date,
           serviceTypeName: d.serviceTypeName,
           teamName: d.teamName,
           position: d.position ?? null,
         });
-        if (servingHistory.length >= 15) break;
       }
     }
+    const servingHistory = mergeServingHistory(nativeRows, pcoRows, 15);
 
     // Get profile image URL
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -31,10 +31,7 @@ import {
   calculateAllSystemScores,
   evaluateSystemAlerts,
 } from "./systemScoring";
-import {
-  communityUsesNativeRostering,
-  countNativeServing,
-} from "../lib/nativeServing";
+import { countNativeServing } from "../lib/nativeServing";
 
 // ============================================================================
 // Constants
@@ -274,14 +271,9 @@ export const computeCommunityScoresBatch = internalQuery({
     const currentTime = now();
     const announcementGroup = await ctx.db.get(args.announcementGroupId);
 
-    // Serving is native-first: if the community has any native rostering
-    // (an eventPlans row), the Serving score comes from roleAssignments;
-    // otherwise it falls back to the cached PCO pcoServingCounts below.
-    // Decided once per batch (not per member).
-    const communityUsesNative = await communityUsesNativeRostering(
-      ctx,
-      args.communityId,
-    );
+    // Serving combines BOTH sources: the cached PCO pcoServingCounts snapshot
+    // (built below) AND native rostering (roleAssignments, added per member).
+    // Native-origin plans exclude PCO-imported ones, so the two are disjoint.
 
     // Build PCO serving map from announcement group doc
     const pcoServingMap = new Map<string, number>();
@@ -534,18 +526,18 @@ export const computeCommunityScoresBatch = internalQuery({
           lastRosteredAt,
         );
 
-        // Native-first Serving count: distinct plans in the past ~60 days with
-        // a non-declined roleAssignment. Reuses recentAssignments (no extra
-        // read). Falls back to the cached PCO count when the community has no
-        // native rostering.
-        const servingCount = communityUsesNative
-          ? await countNativeServing(
-              ctx,
-              recentAssignments,
-              currentTime,
-              args.communityId,
-            )
-          : pcoCount;
+        // Combined Serving count = cached PCO count + native-origin distinct
+        // plans in the past ~60 days with a non-declined roleAssignment
+        // (reuses recentAssignments, no extra read). The native helper excludes
+        // PCO-imported plans, so the two sources don't double-count.
+        const servingCount =
+          pcoCount +
+          (await countNativeServing(
+            ctx,
+            recentAssignments,
+            currentTime,
+            args.communityId,
+          ));
 
         // Extract system raw values
         const rawValues = extractSystemRawValues({

--- a/apps/convex/functions/communityScoreComputation.ts
+++ b/apps/convex/functions/communityScoreComputation.ts
@@ -31,6 +31,10 @@ import {
   calculateAllSystemScores,
   evaluateSystemAlerts,
 } from "./systemScoring";
+import {
+  communityUsesNativeRostering,
+  countNativeServing,
+} from "../lib/nativeServing";
 
 // ============================================================================
 // Constants
@@ -270,6 +274,15 @@ export const computeCommunityScoresBatch = internalQuery({
     const currentTime = now();
     const announcementGroup = await ctx.db.get(args.announcementGroupId);
 
+    // Serving is native-first: if the community has any native rostering
+    // (an eventPlans row), the Serving score comes from roleAssignments;
+    // otherwise it falls back to the cached PCO pcoServingCounts below.
+    // Decided once per batch (not per member).
+    const communityUsesNative = await communityUsesNativeRostering(
+      ctx,
+      args.communityId,
+    );
+
     // Build PCO serving map from announcement group doc
     const pcoServingMap = new Map<string, number>();
     if (announcementGroup?.pcoServingCounts?.counts) {
@@ -498,7 +511,7 @@ export const computeCommunityScoresBatch = internalQuery({
           }
         }
 
-        // PCO serving count
+        // PCO serving count (fallback source)
         const pcoCount = pcoServingMap.get(member.userId.toString()) ?? 0;
 
         // Serving activity = most recent of PCO serving and native rostering
@@ -521,6 +534,19 @@ export const computeCommunityScoresBatch = internalQuery({
           lastRosteredAt,
         );
 
+        // Native-first Serving count: distinct plans in the past ~60 days with
+        // a non-declined roleAssignment. Reuses recentAssignments (no extra
+        // read). Falls back to the cached PCO count when the community has no
+        // native rostering.
+        const servingCount = communityUsesNative
+          ? await countNativeServing(
+              ctx,
+              recentAssignments,
+              currentTime,
+              args.communityId,
+            )
+          : pcoCount;
+
         // Extract system raw values
         const rawValues = extractSystemRawValues({
           crossGroupAttendancePct: crossGroupPct,
@@ -532,7 +558,7 @@ export const computeCommunityScoresBatch = internalQuery({
           daysSinceLastInPerson: daysSince(lastInPerson),
           daysSinceLastCall: daysSince(lastCall),
           daysSinceLastText: daysSince(lastText),
-          pcoServicesCount: pcoCount,
+          pcoServicesCount: servingCount,
         });
 
         // Calculate scores and alerts

--- a/apps/convex/functions/groupBots.ts
+++ b/apps/convex/functions/groupBots.ts
@@ -861,7 +861,11 @@ export const sendCommunicationNow = action({
     try {
       resolvedMessage = await ctx.runAction(
         internal.functions.pcoServices.actions.resolvePositionPlaceholdersInternal,
-        { communityId: group.communityId, message: args.message }
+        {
+          communityId: group.communityId,
+          message: args.message,
+          groupId: args.groupId,
+        }
       );
     } catch (error) {
       console.warn(

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -44,6 +44,11 @@ import {
   type PcoServingData,
 } from "./followupScoring";
 import { VALID_CUSTOM_SLOTS } from "../lib/followupConstants";
+import {
+  communityUsesNativeRostering,
+  countNativeServing,
+  nativeServingHistory,
+} from "../lib/nativeServing";
 
 // ============================================================================
 // Types and Constants
@@ -417,13 +422,20 @@ export const internalScoreBatch = internalQuery({
     const scoreConfig: ScoreConfig = group?.followupScoreConfig ?? DEFAULT_SCORE_CONFIG;
     const useCustomScoring = !!group?.followupScoreConfig;
 
-    // Build PCO serving map from group doc
+    // Build PCO serving map from group doc (fallback source)
     const pcoServingMap = new Map<string, PcoServingData>();
     if (group?.pcoServingCounts?.counts) {
       for (const { userId, count } of group.pcoServingCounts.counts) {
         pcoServingMap.set(userId.toString(), { servicesPast2Months: count });
       }
     }
+
+    // Serving is native-first: when the community has native rostering, the
+    // per-member serving value comes from roleAssignments (below); otherwise
+    // the cached PCO map is used. Decided once per batch.
+    const communityUsesNative = group?.communityId
+      ? await communityUsesNativeRostering(ctx, group.communityId)
+      : false;
 
     const results = await Promise.all(
       args.members.map(async (member) => {
@@ -538,7 +550,24 @@ export const internalScoreBatch = internalQuery({
           const connectionParts = computeConnectionParts(
             meetingData, followupData, isSnoozed, currentTime
           );
-          const pcoServing = pcoServingMap.get(member.userId.toString());
+          let pcoServing = pcoServingMap.get(member.userId.toString());
+          if (communityUsesNative) {
+            const recentAssignments = await ctx.db
+              .query("roleAssignments")
+              .withIndex("by_user_eventDate", (q) =>
+                q.eq("userId", member.userId),
+              )
+              .order("desc")
+              .take(100);
+            pcoServing = {
+              servicesPast2Months: await countNativeServing(
+                ctx,
+                recentAssignments,
+                currentTime,
+                group!.communityId,
+              ),
+            };
+          }
           const rawValues = extractRawValues(
             meetingData, followupData, isSnoozed, currentTime, connectionParts, pcoServing,
             crossGroupAttendancePct
@@ -1407,9 +1436,29 @@ export const history = query({
       meetingData, followupData, isSnoozed, currentTime
     );
 
-    // Build PCO serving data
+    // Build serving data — native-first. When the community uses native
+    // rostering, count distinct plans served in the past ~60 days from
+    // roleAssignments; otherwise fall back to the cached PCO counts.
+    const usesNativeRostering = group?.communityId
+      ? await communityUsesNativeRostering(ctx, group.communityId)
+      : false;
+
     let pcoServing: PcoServingData | undefined;
-    if (group?.pcoServingCounts?.counts) {
+    if (usesNativeRostering) {
+      const recentAssignments = await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_user_eventDate", (q) => q.eq("userId", member.userId))
+        .order("desc")
+        .take(100);
+      pcoServing = {
+        servicesPast2Months: await countNativeServing(
+          ctx,
+          recentAssignments,
+          currentTime,
+          group!.communityId,
+        ),
+      };
+    } else if (group?.pcoServingCounts?.counts) {
       const entry = group.pcoServingCounts.counts.find(
         (c: { userId: Id<"users">; count: number }) => c.userId.toString() === member.userId.toString()
       );
@@ -1508,27 +1557,38 @@ export const history = query({
     const crossGroupAttendancePct =
       allGroupsTotal > 0 ? Math.round((allGroupsAttended / allGroupsTotal) * 100) : 0;
 
-    // ---- Serving history (from PCO serving counts cache on group doc) ----
-    const servingHistory: Array<{
+    // ---- Serving history — native-first ----
+    // Native rostering builds the card from roleAssignments; otherwise fall
+    // back to the cached PCO serving details on the group doc.
+    let servingHistory: Array<{
       date: string;
       serviceTypeName: string;
       teamName: string;
       position: string | null;
     }> = [];
 
-    const allDetails = group?.pcoServingCounts?.servingDetails ?? [];
-    const userDetails = allDetails
-      .filter((d: { userId: Id<"users"> }) => d.userId.toString() === member.userId.toString())
-      .sort((a: { date: string }, b: { date: string }) => b.date.localeCompare(a.date));
+    if (usesNativeRostering) {
+      servingHistory = await nativeServingHistory(
+        ctx,
+        member.userId,
+        group!.communityId,
+        15,
+      );
+    } else {
+      const allDetails = group?.pcoServingCounts?.servingDetails ?? [];
+      const userDetails = allDetails
+        .filter((d: { userId: Id<"users"> }) => d.userId.toString() === member.userId.toString())
+        .sort((a: { date: string }, b: { date: string }) => b.date.localeCompare(a.date));
 
-    for (const d of userDetails) {
-      servingHistory.push({
-        date: d.date,
-        serviceTypeName: d.serviceTypeName,
-        teamName: d.teamName,
-        position: d.position ?? null,
-      });
-      if (servingHistory.length >= 15) break;
+      for (const d of userDetails) {
+        servingHistory.push({
+          date: d.date,
+          serviceTypeName: d.serviceTypeName,
+          teamName: d.teamName,
+          position: d.position ?? null,
+        });
+        if (servingHistory.length >= 15) break;
+      }
     }
 
     const rawValues = extractRawValues(

--- a/apps/convex/functions/memberFollowups.ts
+++ b/apps/convex/functions/memberFollowups.ts
@@ -45,9 +45,9 @@ import {
 } from "./followupScoring";
 import { VALID_CUSTOM_SLOTS } from "../lib/followupConstants";
 import {
-  communityUsesNativeRostering,
   countNativeServing,
   nativeServingHistory,
+  mergeServingHistory,
 } from "../lib/nativeServing";
 
 // ============================================================================
@@ -430,12 +430,9 @@ export const internalScoreBatch = internalQuery({
       }
     }
 
-    // Serving is native-first: when the community has native rostering, the
-    // per-member serving value comes from roleAssignments (below); otherwise
-    // the cached PCO map is used. Decided once per batch.
-    const communityUsesNative = group?.communityId
-      ? await communityUsesNativeRostering(ctx, group.communityId)
-      : false;
+    // Serving combines BOTH sources: the cached PCO map above AND native
+    // rostering (added per member below). Native-origin plans exclude
+    // PCO-imported ones, so the two are disjoint.
 
     const results = await Promise.all(
       args.members.map(async (member) => {
@@ -551,7 +548,7 @@ export const internalScoreBatch = internalQuery({
             meetingData, followupData, isSnoozed, currentTime
           );
           let pcoServing = pcoServingMap.get(member.userId.toString());
-          if (communityUsesNative) {
+          if (group?.communityId) {
             const recentAssignments = await ctx.db
               .query("roleAssignments")
               .withIndex("by_user_eventDate", (q) =>
@@ -559,13 +556,15 @@ export const internalScoreBatch = internalQuery({
               )
               .order("desc")
               .take(100);
+            const nativeCount = await countNativeServing(
+              ctx,
+              recentAssignments,
+              currentTime,
+              group.communityId,
+            );
             pcoServing = {
-              servicesPast2Months: await countNativeServing(
-                ctx,
-                recentAssignments,
-                currentTime,
-                group!.communityId,
-              ),
+              servicesPast2Months:
+                (pcoServing?.servicesPast2Months ?? 0) + nativeCount,
             };
           }
           const rawValues = extractRawValues(
@@ -1436,36 +1435,34 @@ export const history = query({
       meetingData, followupData, isSnoozed, currentTime
     );
 
-    // Build serving data — native-first. When the community uses native
-    // rostering, count distinct plans served in the past ~60 days from
-    // roleAssignments; otherwise fall back to the cached PCO counts.
-    const usesNativeRostering = group?.communityId
-      ? await communityUsesNativeRostering(ctx, group.communityId)
-      : false;
+    // Build serving data — combines BOTH sources: the cached PCO count AND
+    // native-origin distinct plans served in the past ~60 days from
+    // roleAssignments (native excludes PCO-imported plans, so no double-count).
+    const pcoCount =
+      group?.pcoServingCounts?.counts?.find(
+        (c: { userId: Id<"users">; count: number }) =>
+          c.userId.toString() === member.userId.toString(),
+      )?.count ?? 0;
 
-    let pcoServing: PcoServingData | undefined;
-    if (usesNativeRostering) {
+    let nativeCount = 0;
+    if (group?.communityId) {
       const recentAssignments = await ctx.db
         .query("roleAssignments")
         .withIndex("by_user_eventDate", (q) => q.eq("userId", member.userId))
         .order("desc")
         .take(100);
-      pcoServing = {
-        servicesPast2Months: await countNativeServing(
-          ctx,
-          recentAssignments,
-          currentTime,
-          group!.communityId,
-        ),
-      };
-    } else if (group?.pcoServingCounts?.counts) {
-      const entry = group.pcoServingCounts.counts.find(
-        (c: { userId: Id<"users">; count: number }) => c.userId.toString() === member.userId.toString()
+      nativeCount = await countNativeServing(
+        ctx,
+        recentAssignments,
+        currentTime,
+        group.communityId,
       );
-      if (entry) {
-        pcoServing = { servicesPast2Months: entry.count };
-      }
     }
+
+    const pcoServing: PcoServingData | undefined =
+      pcoCount + nativeCount > 0
+        ? { servicesPast2Months: pcoCount + nativeCount }
+        : undefined;
 
     // ---- Cross-group attendance ----
     // Find all other groups the user belongs to
@@ -1557,39 +1554,29 @@ export const history = query({
     const crossGroupAttendancePct =
       allGroupsTotal > 0 ? Math.round((allGroupsAttended / allGroupsTotal) * 100) : 0;
 
-    // ---- Serving history — native-first ----
-    // Native rostering builds the card from roleAssignments; otherwise fall
-    // back to the cached PCO serving details on the group doc.
-    let servingHistory: Array<{
+    // ---- Serving history — combines BOTH sources ----
+    // Native-origin rows from roleAssignments AND the cached PCO serving
+    // details on the group doc, merged newest-first and deduped.
+    const nativeRows = group?.communityId
+      ? await nativeServingHistory(ctx, member.userId, group.communityId, 15)
+      : [];
+    const pcoRows: Array<{
       date: string;
       serviceTypeName: string;
       teamName: string;
       position: string | null;
     }> = [];
-
-    if (usesNativeRostering) {
-      servingHistory = await nativeServingHistory(
-        ctx,
-        member.userId,
-        group!.communityId,
-        15,
-      );
-    } else {
-      const allDetails = group?.pcoServingCounts?.servingDetails ?? [];
-      const userDetails = allDetails
-        .filter((d: { userId: Id<"users"> }) => d.userId.toString() === member.userId.toString())
-        .sort((a: { date: string }, b: { date: string }) => b.date.localeCompare(a.date));
-
-      for (const d of userDetails) {
-        servingHistory.push({
-          date: d.date,
-          serviceTypeName: d.serviceTypeName,
-          teamName: d.teamName,
-          position: d.position ?? null,
-        });
-        if (servingHistory.length >= 15) break;
-      }
+    const allDetails = group?.pcoServingCounts?.servingDetails ?? [];
+    for (const d of allDetails) {
+      if (d.userId.toString() !== member.userId.toString()) continue;
+      pcoRows.push({
+        date: d.date,
+        serviceTypeName: d.serviceTypeName,
+        teamName: d.teamName,
+        position: d.position ?? null,
+      });
     }
+    const servingHistory = mergeServingHistory(nativeRows, pcoRows, 15);
 
     const rawValues = extractRawValues(
       meetingData, followupData, isSnoozed, currentTime, connectionParts, pcoServing, crossGroupAttendancePct

--- a/apps/convex/functions/pcoServices/actions.ts
+++ b/apps/convex/functions/pcoServices/actions.ts
@@ -6,8 +6,18 @@
  */
 
 import { v } from "convex/values";
-import { action, internalAction, internalMutation, internalQuery } from "../../_generated/server";
+import {
+  action,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  type ActionCtx,
+} from "../../_generated/server";
 import { internal } from "../../_generated/api";
+import {
+  parseNativePlaceholders,
+  type NativePlaceholder,
+} from "../scheduling/nativePlaceholders";
 import {
   fetchServiceTypes,
   fetchTeamsForServiceType,
@@ -1243,22 +1253,112 @@ async function resolvePlaceholdersCore(
 }
 
 /**
- * Resolve PCO position placeholders in a message (public action).
- * Used for testing/preview in the UI.
+ * Native-first placeholder resolution shared by the public + internal actions.
  *
- * Placeholders format: {{ServiceType > Team > Position}}
- * Example: "Hey {{Sunday Service > Worship > Vocals}}, you're on this week!"
+ * Each placeholder is resolved against native rostering FIRST (see
+ * `scheduling/nativePlaceholders.ts`). A native match — the referenced team +
+ * role exist in the community's scheduling data — wins, and the placeholder is
+ * replaced with the first names of everyone non-declined on the next upcoming
+ * plan. Only placeholders WITHOUT a native match, and that carry the legacy
+ * 3-part `ServiceType > Team > Position` shape, fall back to the PCO resolver
+ * (and only when PCO is connected). Anything left unresolved is rendered
+ * exactly as the PCO path renders "no data" ("[TBD]" for a native match with
+ * nobody scheduled; the raw placeholder when neither source has it).
  *
- * Matches team members from the upcoming plan who:
- * - Are on the specified team
- * - Have the specified position
- * - Have "C" (confirmed) status
+ * @param throwOnError - true for the public preview action (surface PCO errors),
+ *   false for scheduled jobs (best-effort).
+ */
+async function resolvePlaceholdersNativeFirst(
+  ctx: ActionCtx,
+  communityId: Id<"communities">,
+  groupId: Id<"groups"> | undefined,
+  message: string,
+  throwOnError: boolean
+): Promise<string> {
+  const placeholders = parseNativePlaceholders(message);
+  if (placeholders.length === 0) {
+    return message;
+  }
+
+  // --- Native-first pass. ---
+  const nativeResults = await ctx.runQuery(
+    internal.functions.scheduling.nativePlaceholders.resolveNativePlaceholders,
+    {
+      communityId,
+      groupId,
+      placeholders: placeholders.map((p) => ({
+        fullMatch: p.fullMatch,
+        teamName: p.teamName,
+        roleName: p.roleName,
+      })),
+    }
+  );
+  const nativeByMatch = new Map(nativeResults.map((r) => [r.fullMatch, r]));
+
+  let resolvedMessage = message;
+  const unmatched: NativePlaceholder[] = [];
+  for (const ph of placeholders) {
+    const native = nativeByMatch.get(ph.fullMatch);
+    if (native?.matched) {
+      resolvedMessage = resolvedMessage.replace(
+        ph.fullMatch,
+        formatNamesList(native.names) || "[TBD]"
+      );
+    } else {
+      unmatched.push(ph);
+    }
+  }
+
+  // --- PCO fallback pass (only legacy 3-part placeholders can resolve here). ---
+  const pcoPlaceholders: Placeholder[] = unmatched
+    .filter((p) => p.serviceTypeName)
+    .map((p) => ({
+      fullMatch: p.fullMatch,
+      serviceTypeName: p.serviceTypeName as string,
+      teamName: p.teamName,
+      positionName: p.roleName,
+    }));
+
+  if (pcoPlaceholders.length > 0) {
+    let accessToken: string | null = null;
+    try {
+      accessToken = await getValidAccessToken(ctx, communityId);
+    } catch (error) {
+      if (throwOnError) throw error;
+      console.warn("No valid PCO integration found for community:", error);
+      accessToken = null;
+    }
+    if (accessToken) {
+      resolvedMessage = await resolvePlaceholdersCore(
+        accessToken,
+        resolvedMessage,
+        pcoPlaceholders,
+        throwOnError
+      );
+    }
+  }
+
+  return resolvedMessage;
+}
+
+/**
+ * Resolve position placeholders in a message (public action).
+ * Used for testing/preview in the UI. Native-first, PCO fallback.
+ *
+ * Placeholder formats:
+ *   - Native:  {{Team > Role}}
+ *   - Legacy:  {{ServiceType > Team > Position}}
+ * Example: "Hey {{Worship > Vocals}}, you're on this week!"
+ *
+ * Native match → first names of everyone non-declined on the upcoming plan.
+ * No native match + PCO connected → the existing PCO resolution.
  */
 export const resolvePositionPlaceholders = action({
   args: {
     token: v.string(),
     communityId: v.id("communities"),
     message: v.string(),
+    groupId: v.optional(v.id("groups")),
   },
   handler: async (ctx, args): Promise<string> => {
     // Verify access
@@ -1267,50 +1367,40 @@ export const resolvePositionPlaceholders = action({
       { token: args.token, communityId: args.communityId }
     );
 
-    // Get valid access token
-    const accessToken = await getValidAccessToken(ctx, args.communityId);
-    if (!accessToken) {
-      throw new Error("No valid PCO integration found");
-    }
-
-    // Parse placeholders
-    const placeholders = parsePlaceholders(args.message);
-    if (placeholders.length === 0) {
-      return args.message;
-    }
-
     // Resolve placeholders (throw on errors for public action)
-    return await resolvePlaceholdersCore(accessToken, args.message, placeholders, true);
+    return await resolvePlaceholdersNativeFirst(
+      ctx,
+      args.communityId,
+      args.groupId,
+      args.message,
+      true
+    );
   },
 });
 
 /**
- * Internal action to resolve PCO position placeholders.
- * Used by scheduled jobs (communication bot) to resolve placeholders without auth token.
+ * Internal action to resolve position placeholders.
+ * Used by scheduled jobs (communication bot) to resolve placeholders without
+ * an auth token. Native-first, PCO fallback.
  *
- * Placeholders format: {{ServiceType > Team > Position}}
+ * Placeholder formats: {{Team > Role}} or {{ServiceType > Team > Position}}
  */
 export const resolvePositionPlaceholdersInternal = internalAction({
   args: {
     communityId: v.id("communities"),
     message: v.string(),
+    /** Bot group — scopes native team/plan matching to this group when set. */
+    groupId: v.optional(v.id("groups")),
   },
   handler: async (ctx, args): Promise<string> => {
-    // Get valid access token (no auth verification needed for internal action)
-    const accessToken = await getValidAccessToken(ctx, args.communityId);
-    if (!accessToken) {
-      console.warn("No valid PCO integration found for community");
-      return args.message;
-    }
-
-    // Parse placeholders
-    const placeholders = parsePlaceholders(args.message);
-    if (placeholders.length === 0) {
-      return args.message;
-    }
-
     // Resolve placeholders (don't throw on errors for internal action)
-    return await resolvePlaceholdersCore(accessToken, args.message, placeholders, false);
+    return await resolvePlaceholdersNativeFirst(
+      ctx,
+      args.communityId,
+      args.groupId,
+      args.message,
+      false
+    );
   },
 });
 

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -2486,7 +2486,11 @@ export const processCommunicationBotBucket = internalAction({
                   resolvedMessage = await ctx.runAction(
                     internal.functions.pcoServices.actions
                       .resolvePositionPlaceholdersInternal,
-                    { communityId: config.communityId, message: msg.message },
+                    {
+                      communityId: config.communityId,
+                      message: msg.message,
+                      groupId: config.groupId,
+                    },
                   );
                 } catch (error) {
                   console.warn(
@@ -2566,7 +2570,11 @@ export const processCommunicationBotBucket = internalAction({
               resolvedMessage = await ctx.runAction(
                 internal.functions.pcoServices.actions
                   .resolvePositionPlaceholdersInternal,
-                { communityId: config.communityId, message },
+                {
+                  communityId: config.communityId,
+                  message,
+                  groupId: config.groupId,
+                },
               );
             } catch (error) {
               console.warn(

--- a/apps/convex/functions/scheduling/nativePlaceholders.ts
+++ b/apps/convex/functions/scheduling/nativePlaceholders.ts
@@ -1,0 +1,313 @@
+/**
+ * Native rostering resolution for communication-bot message placeholders.
+ *
+ * Communication bots let leaders write messages with position placeholders that
+ * get expanded into the first names of whoever is scheduled, e.g.
+ *   "Hey {{Worship > Vocals}}, you're on this Sunday!"
+ *
+ * Historically these resolved against Planning Center (PCO) `team_members`.
+ * This module is the NATIVE-FIRST path: it resolves against the app's own
+ * scheduling data (`teams` → `teamRoles` → upcoming `eventPlans` →
+ * `roleAssignments`). The PCO resolver in `pcoServices/actions.ts` remains as
+ * the fallback for communities with no native match.
+ *
+ * Placeholder formats accepted:
+ *   - Native 2-part:  {{Team > Role}}
+ *   - Legacy 3-part:  {{ServiceType > Team > Position}}  (last two segments
+ *     are treated as Team/Role, so the same string resolves either way)
+ */
+
+import { v } from "convex/values";
+import { internalQuery, query } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+
+/** Assignment statuses that count as "scheduled" (mirrors the PCO non-declined rule). */
+const SCHEDULED_STATUSES = new Set(["confirmed", "unconfirmed"]);
+
+function startOfTodayMs(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Format a list of names with proper grammar. Parallels
+ * `formatNamesList` in `pcoServices/actions.ts` so native and PCO output match.
+ */
+export function formatNamesList(names: string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+export interface NativePlaceholder {
+  fullMatch: string;
+  teamName: string;
+  roleName: string;
+  /** Present only for legacy 3-part placeholders; enables PCO fallback. */
+  serviceTypeName?: string;
+}
+
+/**
+ * Parse `{{...}}` placeholders from a message, accepting BOTH the native
+ * 2-part (`Team > Role`) and legacy 3-part (`ServiceType > Team > Position`)
+ * shapes. For 3-part, the last two segments are used as Team/Role.
+ */
+export function parseNativePlaceholders(message: string): NativePlaceholder[] {
+  const placeholderRegex = /\{\{([^}]+)\}\}/g;
+  const placeholders: NativePlaceholder[] = [];
+
+  let match;
+  while ((match = placeholderRegex.exec(message)) !== null) {
+    const segments = match[1].split(">").map((s) => s.trim());
+    if (segments.length === 2) {
+      placeholders.push({
+        fullMatch: match[0],
+        teamName: segments[0],
+        roleName: segments[1],
+      });
+    } else if (segments.length >= 3) {
+      // Legacy 3-part: last two segments are Team/Role; keep the leading
+      // ServiceType so the caller can fall back to PCO if native misses.
+      placeholders.push({
+        fullMatch: match[0],
+        serviceTypeName: segments.slice(0, -2).join(" > "),
+        teamName: segments[segments.length - 2],
+        roleName: segments[segments.length - 1],
+      });
+    }
+    // 1-segment placeholders (`{{Foo}}`) are not position placeholders; skip.
+  }
+
+  return placeholders;
+}
+
+/**
+ * Pick the plan to resolve against for a group: the next upcoming plan
+ * (eventDate >= today), preferring a published one over a draft.
+ */
+function pickUpcomingPlan(plans: Doc<"eventPlans">[]): Doc<"eventPlans"> | null {
+  const cutoff = startOfTodayMs();
+  const upcoming = plans
+    .filter((p) => p.eventDate >= cutoff)
+    .sort((a, b) => a.eventDate - b.eventDate);
+  if (upcoming.length === 0) return null;
+  const published = upcoming.find((p) => p.status === "published");
+  return published ?? upcoming[0];
+}
+
+/**
+ * Resolve a batch of placeholders against native rostering data.
+ *
+ * For each placeholder we match `teams.name` (case-insensitive), then
+ * `teamRoles.name` within that team, then read the non-declined
+ * `roleAssignments` on that team's next upcoming plan. `matched` is true when a
+ * team+role was found in native data — the caller uses it to decide whether to
+ * fall back to PCO (fallback only when `matched` is false).
+ */
+export const resolveNativePlaceholders = internalQuery({
+  args: {
+    communityId: v.id("communities"),
+    /** Optional bot group — when set, teams/plans are scoped to this group. */
+    groupId: v.optional(v.id("groups")),
+    placeholders: v.array(
+      v.object({
+        fullMatch: v.string(),
+        teamName: v.string(),
+        roleName: v.string(),
+      }),
+    ),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    Array<{ fullMatch: string; matched: boolean; names: string[] }>
+  > => {
+    // Candidate teams: scoped to the bot's group when provided, else the whole
+    // community. Archived teams never resolve.
+    const teams = (
+      args.groupId
+        ? await ctx.db
+            .query("teams")
+            .withIndex("by_group", (q) => q.eq("groupId", args.groupId!))
+            .collect()
+        : await ctx.db
+            .query("teams")
+            .withIndex("by_community", (q) =>
+              q.eq("communityId", args.communityId),
+            )
+            .collect()
+    ).filter((t) => !t.isArchived);
+
+    // Cache upcoming-plan and role lookups per group/team to avoid rework when
+    // several placeholders target the same team.
+    const plansByGroup = new Map<string, Doc<"eventPlans"> | null>();
+    const rolesByTeam = new Map<string, Doc<"teamRoles">[]>();
+
+    const getUpcomingPlan = async (
+      groupId: Id<"groups">,
+    ): Promise<Doc<"eventPlans"> | null> => {
+      const key = groupId as string;
+      if (plansByGroup.has(key)) return plansByGroup.get(key) ?? null;
+      const plans = await ctx.db
+        .query("eventPlans")
+        .withIndex("by_group", (q) => q.eq("groupId", groupId))
+        .collect();
+      const plan = pickUpcomingPlan(plans);
+      plansByGroup.set(key, plan);
+      return plan;
+    };
+
+    const getRoles = async (
+      teamId: Id<"teams">,
+    ): Promise<Doc<"teamRoles">[]> => {
+      const key = teamId as string;
+      const cached = rolesByTeam.get(key);
+      if (cached) return cached;
+      const roles = (
+        await ctx.db
+          .query("teamRoles")
+          .withIndex("by_team", (q) => q.eq("teamId", teamId))
+          .collect()
+      ).filter((r) => !r.isArchived);
+      rolesByTeam.set(key, roles);
+      return roles;
+    };
+
+    // Resolve each unique placeholder once.
+    const resultByMatch = new Map<
+      string,
+      { matched: boolean; names: string[] }
+    >();
+
+    for (const ph of args.placeholders) {
+      if (resultByMatch.has(ph.fullMatch)) continue;
+
+      const teamName = ph.teamName.toLowerCase();
+      const roleName = ph.roleName.toLowerCase();
+
+      let resolved: { matched: boolean; names: string[] } = {
+        matched: false,
+        names: [],
+      };
+
+      for (const team of teams) {
+        if (team.name.trim().toLowerCase() !== teamName) continue;
+        const roles = await getRoles(team._id);
+        const role = roles.find(
+          (r) => r.name.trim().toLowerCase() === roleName,
+        );
+        if (!role) continue;
+
+        // Team + role found natively — this is a match regardless of whether
+        // anyone is currently scheduled.
+        const plan = await getUpcomingPlan(team.groupId);
+        let names: string[] = [];
+        if (plan) {
+          const assignments = await ctx.db
+            .query("roleAssignments")
+            .withIndex("by_plan_role", (q) =>
+              q.eq("planId", plan._id).eq("roleId", role._id),
+            )
+            .collect();
+          const users = await Promise.all(
+            assignments
+              .filter((a) => SCHEDULED_STATUSES.has(a.status))
+              .map((a) => ctx.db.get(a.userId)),
+          );
+          names = users
+            .filter((u): u is Doc<"users"> => u !== null)
+            .map((u) => (u.firstName ?? "").trim())
+            .filter((n) => n.length > 0);
+        }
+        resolved = { matched: true, names };
+        break;
+      }
+
+      resultByMatch.set(ph.fullMatch, resolved);
+    }
+
+    return args.placeholders.map((ph) => ({
+      fullMatch: ph.fullMatch,
+      ...(resultByMatch.get(ph.fullMatch) ?? { matched: false, names: [] }),
+    }));
+  },
+});
+
+/**
+ * Native position suggestions for the communication-bot autocomplete:
+ * every non-archived team × role in the community (or a single group), shaped
+ * as `Team > Role` placeholder suggestions. Parallels the PCO
+ * `getAvailablePositions` action but reads native rostering data.
+ *
+ * Community-member gated (the bot config UI is leader-facing).
+ */
+export const getNativePositions = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    /** Optional — scope suggestions to a single group's teams. */
+    groupId: v.optional(v.id("groups")),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    Array<{ teamName: string; roleName: string; displayName: string }>
+  > => {
+    const userId = await requireAuth(ctx, args.token);
+
+    // Require active community membership.
+    const membership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", userId).eq("communityId", args.communityId),
+      )
+      .first();
+    if (!membership || membership.status !== 1) {
+      throw new Error("Not a member of this community");
+    }
+
+    const teams = (
+      args.groupId
+        ? await ctx.db
+            .query("teams")
+            .withIndex("by_group", (q) => q.eq("groupId", args.groupId!))
+            .collect()
+        : await ctx.db
+            .query("teams")
+            .withIndex("by_community", (q) =>
+              q.eq("communityId", args.communityId),
+            )
+            .collect()
+    ).filter((t) => !t.isArchived);
+
+    const suggestions: Array<{
+      teamName: string;
+      roleName: string;
+      displayName: string;
+    }> = [];
+
+    for (const team of teams) {
+      const roles = (
+        await ctx.db
+          .query("teamRoles")
+          .withIndex("by_team", (q) => q.eq("teamId", team._id))
+          .collect()
+      ).filter((r) => !r.isArchived);
+      for (const role of roles) {
+        suggestions.push({
+          teamName: team.name,
+          roleName: role.name,
+          displayName: `${team.name} > ${role.name}`,
+        });
+      }
+    }
+
+    suggestions.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    return suggestions;
+  },
+});

--- a/apps/convex/functions/slackServiceBot/config.ts
+++ b/apps/convex/functions/slackServiceBot/config.ts
@@ -250,14 +250,15 @@ export const PCO_ROLE_MAPPINGS: Record<
 // `teams`, `teamRoles`, `eventItems`) instead of Planning Center. The PCO
 // config above stays as the fallback for communities without a native plan.
 //
-// NOTE: These mappings live here in code (not in the `slackBotConfig` DB row)
-// on purpose — adding them to the DB config would require a schema change to
-// the shared `apps/convex/schema.ts`, which is intentionally out of scope for
-// this migration (three migrations run in parallel; touching the shared schema
-// risks conflicts). This is consistent with the hardcoded PCO config above.
-// A future enhancement can promote these to `slackBotConfig` once the schema
-// can be changed safely. The bot is currently single-tenant (FOUNT), so global
-// constants are sufficient.
+// NOTE: These mappings have been promoted into the `slackBotConfig.nativeConfig`
+// DB section (seeded from the constants below by `seedConfig.ts`). At runtime
+// the DB config is the source of truth; the constants below remain as the seed
+// defaults and as the fallback when a community's config row is missing the
+// mapping. Native resolution goes through the DB-config accessors in
+// `configDb.ts` (`getNativeCampusGroupNameFromConfig` /
+// `getNativeRoleMappingFromConfig`), which read `nativeConfig` and fall back
+// here — mirroring the PCO `*FromConfig` accessors. Keep these constants in
+// sync with the seed defaults so a fresh seed reproduces current behavior.
 
 export interface NativeRoleMapping {
   /** Native serving-team name — case-insensitive substring match within the campus group. */

--- a/apps/convex/functions/slackServiceBot/config.ts
+++ b/apps/convex/functions/slackServiceBot/config.ts
@@ -239,3 +239,64 @@ export const PCO_ROLE_MAPPINGS: Record<
   preacher: { teamNamePattern: "platform", positionName: "Preacher" },
   meetingLead: { teamNamePattern: "platform", positionName: "Meeting Leader" },
 };
+
+// ============================================================================
+// Native Rostering Configuration (native-first, PCO fallback)
+// ============================================================================
+//
+// When a community uses Togather's own native rostering (an upcoming
+// `eventPlans` row exists for the location's campus group), the bot reads plan
+// context from and writes changes to the native tables (`roleAssignments`,
+// `teams`, `teamRoles`, `eventItems`) instead of Planning Center. The PCO
+// config above stays as the fallback for communities without a native plan.
+//
+// NOTE: These mappings live here in code (not in the `slackBotConfig` DB row)
+// on purpose — adding them to the DB config would require a schema change to
+// the shared `apps/convex/schema.ts`, which is intentionally out of scope for
+// this migration (three migrations run in parallel; touching the shared schema
+// risks conflicts). This is consistent with the hardcoded PCO config above.
+// A future enhancement can promote these to `slackBotConfig` once the schema
+// can be changed safely. The bot is currently single-tenant (FOUNT), so global
+// constants are sufficient.
+
+export interface NativeRoleMapping {
+  /** Native serving-team name — case-insensitive substring match within the campus group. */
+  teamName: string;
+  /**
+   * Native `teamRoles.name` — case-insensitive exact match within that team.
+   * Kept equal to the corresponding PCO `positionName` so the existing prompt
+   * status logic (which keys off `pcoPositionName`) works unchanged on native
+   * context.
+   */
+  roleName: string;
+}
+
+/**
+ * Maps a bot location to the native campus group's name (case-insensitive
+ * substring match against `groups.name` within the community). Parallels
+ * `PCO_SERVICE_TYPE_IDS`.
+ */
+export const NATIVE_CAMPUS_GROUP_NAMES: Record<string, string> = {
+  Manhattan: "Manhattan",
+  Brooklyn: "Brooklyn",
+};
+
+/**
+ * Maps a semantic service-plan role id to a native team + role. Parallels
+ * `PCO_ROLE_MAPPINGS`. Role ids match the `assign_role` item ids in the V2
+ * service-plan config (e.g. "preacher", "meetingLead").
+ */
+export const NATIVE_ROLE_MAPPINGS: Record<string, NativeRoleMapping> = {
+  preacher: { teamName: "Platform", roleName: "Preacher" },
+  meetingLead: { teamName: "Platform", roleName: "Meeting Leader" },
+};
+
+/** Native campus group name for a location, or null if none configured. */
+export function getNativeCampusGroupName(location: string): string | null {
+  return NATIVE_CAMPUS_GROUP_NAMES[location] ?? null;
+}
+
+/** Native team+role for a semantic role id, or null if none configured. */
+export function getNativeRoleMapping(role: string): NativeRoleMapping | null {
+  return NATIVE_ROLE_MAPPINGS[role] ?? null;
+}

--- a/apps/convex/functions/slackServiceBot/configDb.ts
+++ b/apps/convex/functions/slackServiceBot/configDb.ts
@@ -7,9 +7,57 @@
 
 import { v } from "convex/values";
 import { internalQuery, internalMutation } from "../../_generated/server";
+import { Doc } from "../../_generated/dataModel";
+import {
+  getNativeCampusGroupName,
+  getNativeRoleMapping,
+  type NativeRoleMapping,
+} from "./config";
 
 /** Max processed message timestamps to keep (circular buffer) */
 const MAX_PROCESSED_MESSAGES = 100;
+
+// ============================================================================
+// Native Config Accessors (DB-first, config.ts constants as fallback)
+// ============================================================================
+//
+// The native campus-group-name and role→{teamName,roleName} mappings live in
+// the `slackBotConfig.nativeConfig` DB section (seeded from the hardcoded
+// `config.ts` constants). These accessors read that section and fall back to
+// the constants when the DB config is absent/empty — exactly how the PCO path's
+// `*FromConfig` helpers degrade. They are plain functions (not Convex queries)
+// so callers that already hold the config can resolve without another read.
+
+/** The optional native config section of a slackBotConfig row. */
+export type NativeDbConfig = Doc<"slackBotConfig">["nativeConfig"];
+
+/**
+ * Native campus group name for a location, preferring the DB config and
+ * falling back to the `NATIVE_CAMPUS_GROUP_NAMES` constant. Returns null when
+ * neither has a mapping.
+ */
+export function getNativeCampusGroupNameFromConfig(
+  nativeConfig: NativeDbConfig,
+  location: string,
+): string | null {
+  const fromDb = nativeConfig?.campusGroupNames?.[location];
+  if (fromDb) return fromDb;
+  return getNativeCampusGroupName(location);
+}
+
+/**
+ * Native team+role for a semantic role id, preferring the DB config and
+ * falling back to the `NATIVE_ROLE_MAPPINGS` constant. Returns null when
+ * neither has a mapping.
+ */
+export function getNativeRoleMappingFromConfig(
+  nativeConfig: NativeDbConfig,
+  role: string,
+): NativeRoleMapping | null {
+  const fromDb = nativeConfig?.roleMappings?.[role];
+  if (fromDb) return { teamName: fromDb.teamName, roleName: fromDb.roleName };
+  return getNativeRoleMapping(role);
+}
 
 // ============================================================================
 // Config Read/Write

--- a/apps/convex/functions/slackServiceBot/nativeSync.ts
+++ b/apps/convex/functions/slackServiceBot/nativeSync.ts
@@ -247,7 +247,12 @@ export const getNativeContext = internalQuery({
         pcoPersonId: a.userId as string,
       });
 
-      if (position) {
+      // Only the Platform team's positions are "platform roles" (preacher,
+      // meeting leader, …) — the same gate the PCO path applies
+      // (pcoSync teamName.includes("platform")). Without it, every rostered
+      // position on every team (Worship, Production, …) would be surfaced as a
+      // platform role and a same-named role on another team could collide.
+      if (position && teamName?.toLowerCase().includes("platform")) {
         if (status === "C") platformRoles[position] = name;
         if (status === "C" || status === "U") {
           platformRolesAll[position] = { name, status };
@@ -437,7 +442,27 @@ export const nativeAssignRole = internalMutation({
         q.eq("planId", plan._id).eq("roleId", role._id),
       )
       .collect();
-    if (existing.some((a) => a.userId === user._id)) {
+    const existingForUser = existing.find((a) => a.userId === user._id);
+    if (existingForUser) {
+      if (existingForUser.status === "declined") {
+        // Reopen a previously declined assignment. Returning a no-op success
+        // here would tell Slack the person is assigned while the status
+        // builders + placeholder resolver (which exclude declined rows) still
+        // treat the role as unfilled and the team channel is never restored.
+        await ctx.db.patch(existingForUser._id, {
+          status: "unconfirmed",
+          declineNote: undefined,
+          respondedAt: undefined,
+          assignedById: plan.createdById,
+          assignedAt: Date.now(),
+        });
+        await scheduleTeamChannelReconcile(ctx, team._id);
+        return {
+          handled: true,
+          success: true,
+          detail: `Re-assigned ${displayName(user)} as ${args.roleName} (was declined)`,
+        };
+      }
       return {
         handled: true,
         success: true,
@@ -509,15 +534,32 @@ export const nativeUnassignRole = internalMutation({
       .collect();
 
     const needle = args.personName.trim().toLowerCase();
+    const withNames = await Promise.all(
+      rows.map(async (a) => ({
+        a,
+        name: displayName(await ctx.db.get(a.userId)).toLowerCase(),
+      })),
+    );
+    // Prefer an exact full-name match; fall back to an unambiguous partial.
+    // Never delete on a loose match when several people match the needle —
+    // this is a hard-delete, so "remove Jon" must not delete Jonathan.
+    let matches = withNames.filter((m) => m.name === needle);
+    if (matches.length === 0) {
+      matches = withNames.filter(
+        (m) => m.name.includes(needle) || needle.includes(m.name),
+      );
+    }
+    if (matches.length > 1) {
+      return {
+        handled: true,
+        success: false,
+        detail: `"${args.personName}" matches ${matches.length} people on ${args.roleName} — be more specific`,
+      };
+    }
     let removed: Id<"roleAssignments"> | null = null;
-    for (const a of rows) {
-      const user = await ctx.db.get(a.userId);
-      const name = displayName(user).toLowerCase();
-      if (name.includes(needle) || needle.includes(name)) {
-        await ctx.db.delete(a._id);
-        removed = a._id;
-        break;
-      }
+    if (matches.length === 1) {
+      await ctx.db.delete(matches[0].a._id);
+      removed = matches[0].a._id;
     }
 
     if (!removed) {

--- a/apps/convex/functions/slackServiceBot/nativeSync.ts
+++ b/apps/convex/functions/slackServiceBot/nativeSync.ts
@@ -1,0 +1,708 @@
+/**
+ * FOUNT Service Planning Bot - Native Sync
+ *
+ * Native-rostering read/write layer for the service planning bot. Mirrors the
+ * PCO read/write helpers in `pcoSync.ts`, but sources plan context from — and
+ * writes assignments + run-sheet items to — Togather's own native scheduling
+ * tables (`eventPlans`, `teams`, `teamRoles`, `roleAssignments`, `eventItems`).
+ *
+ * Routing lives in `pcoSync.ts`: each public entry point tries native first
+ * (when the location's campus group has an upcoming `eventPlans`) and falls
+ * back to PCO otherwise. Every write mutation here returns a `handled` flag —
+ * `false` means "no upcoming native plan, fall back to PCO"; `true` means the
+ * native path owns the outcome (`success`/`detail` describe it).
+ *
+ * Auth: the bot runs system-level (no user token), exactly like the PCO path
+ * which authenticates via the community's OAuth credentials. These internal
+ * functions therefore skip the per-user `requireAuth`/`requirePlanScheduler`
+ * gates used by the interactive scheduling mutations, and attribute writes to
+ * the plan's `createdById`. They still schedule the same team-channel
+ * reconciliation jobs the native assign/unassign paths schedule, so bot-made
+ * assignments mirror into serving-team channels just like human-made ones.
+ */
+
+import { v } from "convex/values";
+import { internalQuery, internalMutation } from "../../_generated/server";
+import type { QueryCtx, MutationCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
+import type { PcoContext } from "./pcoSync";
+
+// ============================================================================
+// Shared helpers (read side — QueryCtx | MutationCtx)
+// ============================================================================
+
+/** Start of the current UTC day, in Unix ms. Events on/after this are "upcoming". */
+function startOfTodayMs(): number {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/** Display name for a user, matching the rest of the app ("first last"). */
+function displayName(user: Doc<"users"> | null): string {
+  if (!user) return "Someone";
+  return `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || "Someone";
+}
+
+/**
+ * Resolve the campus group for a community by name (case-insensitive substring
+ * match against `groups.name`). Returns the first non-archived match.
+ */
+async function resolveCampusGroup(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+  campusGroupName: string,
+): Promise<Doc<"groups"> | null> {
+  const needle = campusGroupName.toLowerCase();
+  const groups = await ctx.db
+    .query("groups")
+    .withIndex("by_community", (q) => q.eq("communityId", communityId))
+    .collect();
+  return (
+    groups.find(
+      (g) => !g.isArchived && g.name.toLowerCase().includes(needle),
+    ) ?? null
+  );
+}
+
+/**
+ * Find the next upcoming native plan for a campus group — the earliest
+ * `eventPlans` row whose `eventDate` is today or later. Draft and published
+ * plans both count (a draft plan still means the community rosters natively).
+ * Returns null when the group has no upcoming plan → callers fall back to PCO.
+ */
+async function findUpcomingPlan(
+  ctx: QueryCtx | MutationCtx,
+  groupId: Id<"groups">,
+): Promise<Doc<"eventPlans"> | null> {
+  const cutoff = startOfTodayMs();
+  const plans = await ctx.db
+    .query("eventPlans")
+    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+    .collect();
+  const upcoming = plans
+    .filter((p) => p.eventDate >= cutoff)
+    .sort((a, b) => a.eventDate - b.eventDate);
+  return upcoming[0] ?? null;
+}
+
+/** Find a serving team in a group by name (case-insensitive substring). */
+async function findTeamByName(
+  ctx: QueryCtx | MutationCtx,
+  groupId: Id<"groups">,
+  teamName: string,
+): Promise<Doc<"teams"> | null> {
+  const needle = teamName.toLowerCase();
+  const teams = await ctx.db
+    .query("teams")
+    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+    .collect();
+  return (
+    teams.find(
+      (tm) => tm.isArchived !== true && tm.name.toLowerCase().includes(needle),
+    ) ?? null
+  );
+}
+
+/** Find a role on a team by name (case-insensitive exact match). */
+async function findRoleByName(
+  ctx: QueryCtx | MutationCtx,
+  teamId: Id<"teams">,
+  roleName: string,
+): Promise<Doc<"teamRoles"> | null> {
+  const needle = roleName.toLowerCase();
+  const roles = await ctx.db
+    .query("teamRoles")
+    .withIndex("by_team", (q) => q.eq("teamId", teamId))
+    .collect();
+  return (
+    roles.find(
+      (r) => r.isArchived !== true && r.name.toLowerCase() === needle,
+    ) ?? null
+  );
+}
+
+/** Whether a group membership is active (present, not left, request accepted). */
+function isActiveMembership(m: Doc<"groupMembers">): boolean {
+  return (
+    !m.leftAt && (!m.requestStatus || m.requestStatus === "accepted")
+  );
+}
+
+/**
+ * Resolve a person by name to an active member of the campus group. Match is
+ * case-insensitive: exact full-name first, then a partial match (full name
+ * includes the query, or the query is just the first name). Returns null when
+ * no unambiguous active group member matches.
+ *
+ * Unlike the PCO path (`findOrCreatePcoPerson`, which creates a PCO person on
+ * miss), native assignment requires the person to already be an active member
+ * of the campus group — `roleAssignments` reference a real `users` row and the
+ * team-channel sync derives membership from them. A miss returns a clear
+ * message so the bot can ask for a full name / add-to-group first.
+ */
+async function resolvePersonInGroup(
+  ctx: QueryCtx | MutationCtx,
+  groupId: Id<"groups">,
+  name: string,
+): Promise<Doc<"users"> | null> {
+  const query = name.trim().toLowerCase();
+  if (!query) return null;
+
+  const memberships = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group", (q) => q.eq("groupId", groupId))
+    .collect();
+  const active = memberships.filter(isActiveMembership);
+
+  const candidates: Array<{ user: Doc<"users">; full: string; first: string }> =
+    [];
+  for (const m of active) {
+    const user = await ctx.db.get(m.userId);
+    if (!user) continue;
+    candidates.push({
+      user,
+      full: displayName(user).toLowerCase(),
+      first: (user.firstName ?? "").trim().toLowerCase(),
+    });
+  }
+
+  // 1. Exact full-name match.
+  const exact = candidates.find((c) => c.full === query);
+  if (exact) return exact.user;
+
+  // 2. Partial: the stored name contains the query, or the query starts with
+  //    the person's first name (handles "Kevin" → "Kevin Myers").
+  const partial = candidates.filter(
+    (c) =>
+      c.full.includes(query) ||
+      query.includes(c.full) ||
+      (c.first && (query === c.first || query.startsWith(`${c.first} `))),
+  );
+  // Only return a partial match when it's unambiguous.
+  return partial.length === 1 ? partial[0].user : null;
+}
+
+// ============================================================================
+// Native Context Reader (parallels fetchPcoContextCore)
+// ============================================================================
+
+/** Run-sheet item segment ordering, mirroring `eventItems.listItems`. */
+const SEGMENT_RANK: Record<string, number> = { before: 0, during: 1, after: 2 };
+
+/**
+ * Read the upcoming native plan's context for a community + campus group and
+ * shape it exactly like `PcoContext` so the bot's prompt/status logic works
+ * unchanged. Returns null when there's no native campus group or no upcoming
+ * native plan — the signal to the caller to fall back to PCO.
+ */
+export const getNativeContext = internalQuery({
+  args: {
+    communityId: v.id("communities"),
+    campusGroupName: v.string(),
+  },
+  handler: async (ctx, args): Promise<PcoContext | null> => {
+    const group = await resolveCampusGroup(
+      ctx,
+      args.communityId,
+      args.campusGroupName,
+    );
+    if (!group) return null;
+
+    const plan = await findUpcomingPlan(ctx, group._id);
+    if (!plan) return null;
+
+    const assignments = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+      .collect();
+
+    const teamMembers: PcoContext["teamMembers"] = [];
+    const platformRoles: Record<string, string> = {};
+    const platformRolesAll: Record<string, { name: string; status: string }> =
+      {};
+
+    for (const a of assignments) {
+      const [role, team, user] = await Promise.all([
+        ctx.db.get(a.roleId),
+        ctx.db.get(a.teamId),
+        ctx.db.get(a.userId),
+      ]);
+      const name = displayName(user);
+      const position = role?.name ?? null;
+      const teamName = team?.name ?? null;
+      // Map native status to the PCO letter codes the prompt logic expects:
+      // confirmed → "C", unconfirmed → "U", declined → "D".
+      const status =
+        a.status === "confirmed" ? "C" : a.status === "declined" ? "D" : "U";
+
+      teamMembers.push({
+        name,
+        status,
+        position,
+        teamName,
+        // `pcoPersonId` doubles as "an actual person is assigned" (vs a PCO
+        // 'Needed' placeholder). Native rows always have a real user.
+        pcoPersonId: a.userId as string,
+      });
+
+      if (position) {
+        if (status === "C") platformRoles[position] = name;
+        if (status === "C" || status === "U") {
+          platformRolesAll[position] = { name, status };
+        }
+      }
+    }
+
+    const rawItems = await ctx.db
+      .query("eventItems")
+      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+      .collect();
+    const segRank = (s: string | undefined) => SEGMENT_RANK[s ?? "during"] ?? 1;
+    rawItems.sort(
+      (a, b) => segRank(a.segment) - segRank(b.segment) || a.sequence - b.sequence,
+    );
+
+    const items: PcoContext["items"] = rawItems.map((i) => ({
+      title: i.title,
+      itemType: i.type,
+      description: i.description ?? null,
+      notes:
+        i.notes && i.notes.length > 0
+          ? i.notes.map((n) => n.content).filter(Boolean).join("\n") || null
+          : null,
+      length: i.durationSec ?? null,
+    }));
+
+    return {
+      planId: plan._id as string,
+      // No PCO service type for a native plan — carry the campus group id so the
+      // shape is populated and debuggable.
+      serviceTypeId: group._id as string,
+      planDate: new Date(plan.eventDate).toISOString().split("T")[0],
+      teamMembers,
+      platformRoles,
+      platformRolesAll,
+      items,
+    };
+  },
+});
+
+/** People-search result shape shared with the PCO path. */
+export interface NativePeopleResult {
+  results: Array<{ name: string; position: string | null }>;
+}
+
+/**
+ * Search active members of the campus group by name, annotating anyone already
+ * rostered on the upcoming plan with their role/position. Native analog of
+ * `searchPcoPeopleCore`. Returns null when there's no upcoming native plan
+ * (caller falls back to PCO search).
+ */
+export const searchNativePeople = internalQuery({
+  args: {
+    communityId: v.id("communities"),
+    campusGroupName: v.string(),
+    query: v.string(),
+  },
+  handler: async (ctx, args): Promise<NativePeopleResult | null> => {
+    const group = await resolveCampusGroup(
+      ctx,
+      args.communityId,
+      args.campusGroupName,
+    );
+    if (!group) return null;
+    const plan = await findUpcomingPlan(ctx, group._id);
+    if (!plan) return null;
+
+    const needle = args.query.trim().toLowerCase();
+
+    // Positions on the upcoming plan, by user id.
+    const assignments = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+      .collect();
+    const positionByUser = new Map<string, string>();
+    for (const a of assignments) {
+      const role = await ctx.db.get(a.roleId);
+      if (role) positionByUser.set(a.userId as string, role.name);
+    }
+
+    const memberships = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group", (q) => q.eq("groupId", group._id))
+      .collect();
+
+    const results: NativePeopleResult["results"] = [];
+    for (const m of memberships.filter(isActiveMembership)) {
+      const user = await ctx.db.get(m.userId);
+      if (!user) continue;
+      const name = displayName(user);
+      if (needle && !name.toLowerCase().includes(needle)) continue;
+      results.push({
+        name,
+        position: positionByUser.get(user._id as string) ?? null,
+      });
+    }
+
+    return { results };
+  },
+});
+
+// ============================================================================
+// Native Write Mutations (parallel the sync*ToPCO / *Core writers)
+// ============================================================================
+
+/** Common return shape for native writers: `handled: false` ⇒ fall back to PCO. */
+interface NativeWriteResult {
+  handled: boolean;
+  success: boolean;
+  detail: string;
+}
+
+/** Schedule the same team-channel reconciliation the native assign path uses. */
+async function scheduleTeamChannelReconcile(
+  ctx: MutationCtx,
+  teamId: Id<"teams">,
+): Promise<void> {
+  await ctx.scheduler.runAfter(
+    0,
+    internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
+    { teamId },
+  );
+  await ctx.scheduler.runAfter(
+    0,
+    internal.functions.scheduling.teamChannelSync
+      .reconcileCrossTeamChannelsForSource,
+    { sourceTeamId: teamId },
+  );
+}
+
+/**
+ * Assign a person (by name) to a semantic role on the upcoming native plan.
+ * Resolves semantic role → native team + role, resolves the person to an active
+ * campus-group member, inserts an `unconfirmed` `roleAssignments` row, and
+ * schedules the team-channel reconcile. Idempotent: a re-assign of the same
+ * person to the same role is reported as already-assigned, not an error.
+ */
+export const nativeAssignRole = internalMutation({
+  args: {
+    communityId: v.id("communities"),
+    campusGroupName: v.string(),
+    teamName: v.string(),
+    roleName: v.string(),
+    personName: v.string(),
+  },
+  handler: async (ctx, args): Promise<NativeWriteResult> => {
+    const group = await resolveCampusGroup(
+      ctx,
+      args.communityId,
+      args.campusGroupName,
+    );
+    if (!group) return { handled: false, success: false, detail: "No native campus group" };
+    const plan = await findUpcomingPlan(ctx, group._id);
+    if (!plan) return { handled: false, success: false, detail: "No upcoming native plan" };
+
+    const team = await findTeamByName(ctx, group._id, args.teamName);
+    if (!team) {
+      return {
+        handled: true,
+        success: false,
+        detail: `No native team matching "${args.teamName}" in ${group.name}`,
+      };
+    }
+    const role = await findRoleByName(ctx, team._id, args.roleName);
+    if (!role) {
+      return {
+        handled: true,
+        success: false,
+        detail: `No native role "${args.roleName}" on team ${team.name}`,
+      };
+    }
+
+    const user = await resolvePersonInGroup(ctx, group._id, args.personName);
+    if (!user) {
+      return {
+        handled: true,
+        success: false,
+        detail: `Could not find "${args.personName}" as an active member of ${group.name}`,
+      };
+    }
+
+    // Idempotency: same person already on this role for this plan.
+    const existing = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_plan_role", (q) =>
+        q.eq("planId", plan._id).eq("roleId", role._id),
+      )
+      .collect();
+    if (existing.some((a) => a.userId === user._id)) {
+      return {
+        handled: true,
+        success: true,
+        detail: `${args.personName} already assigned to ${args.roleName}`,
+      };
+    }
+
+    await ctx.db.insert("roleAssignments", {
+      planId: plan._id,
+      teamId: team._id,
+      roleId: role._id,
+      userId: user._id,
+      eventDate: plan.eventDate,
+      status: "unconfirmed",
+      // Bot writes are system-level; attribute to the plan's creator (mirrors
+      // how the PCO path acts as the community, not a specific user).
+      assignedById: plan.createdById,
+      assignedAt: Date.now(),
+    });
+
+    await scheduleTeamChannelReconcile(ctx, team._id);
+
+    return {
+      handled: true,
+      success: true,
+      detail: `Assigned ${displayName(user)} as ${args.roleName} (native)`,
+    };
+  },
+});
+
+/**
+ * Remove a person (by name) from a semantic role on the upcoming native plan.
+ * Hard-deletes the matching `roleAssignments` row (the slot reopens) and
+ * schedules the team-channel reconcile — the native `unassign` behavior.
+ */
+export const nativeUnassignRole = internalMutation({
+  args: {
+    communityId: v.id("communities"),
+    campusGroupName: v.string(),
+    teamName: v.string(),
+    roleName: v.string(),
+    personName: v.string(),
+  },
+  handler: async (ctx, args): Promise<NativeWriteResult> => {
+    const group = await resolveCampusGroup(
+      ctx,
+      args.communityId,
+      args.campusGroupName,
+    );
+    if (!group) return { handled: false, success: false, detail: "No native campus group" };
+    const plan = await findUpcomingPlan(ctx, group._id);
+    if (!plan) return { handled: false, success: false, detail: "No upcoming native plan" };
+
+    const team = await findTeamByName(ctx, group._id, args.teamName);
+    const role = team ? await findRoleByName(ctx, team._id, args.roleName) : null;
+    if (!team || !role) {
+      return {
+        handled: true,
+        success: false,
+        detail: `No native team/role for ${args.teamName} / ${args.roleName}`,
+      };
+    }
+
+    const rows = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_plan_role", (q) =>
+        q.eq("planId", plan._id).eq("roleId", role._id),
+      )
+      .collect();
+
+    const needle = args.personName.trim().toLowerCase();
+    let removed: Id<"roleAssignments"> | null = null;
+    for (const a of rows) {
+      const user = await ctx.db.get(a.userId);
+      const name = displayName(user).toLowerCase();
+      if (name.includes(needle) || needle.includes(name)) {
+        await ctx.db.delete(a._id);
+        removed = a._id;
+        break;
+      }
+    }
+
+    if (!removed) {
+      return {
+        handled: true,
+        success: false,
+        detail: `No ${args.roleName} named "${args.personName}" on the native plan`,
+      };
+    }
+
+    await scheduleTeamChannelReconcile(ctx, team._id);
+    return {
+      handled: true,
+      success: true,
+      detail: `Removed ${args.personName} from ${args.roleName} (native)`,
+    };
+  },
+});
+
+/**
+ * Update a run-sheet item on the upcoming native plan, matching the item by a
+ * title pattern ("a|b|c", case-insensitive substring — same convention as the
+ * PCO path). Writes to the item's `description` or its categorized `notes`,
+ * optionally preserving named sections (e.g. keep GIVING when replacing
+ * ANNOUNCEMENTS). Native analog of `updatePlanItemCore`'s item write.
+ */
+export const nativeUpdateItem = internalMutation({
+  args: {
+    communityId: v.id("communities"),
+    campusGroupName: v.string(),
+    titlePattern: v.string(),
+    field: v.string(), // "description" | "notes"
+    content: v.string(),
+    preserveSections: v.optional(v.array(v.string())),
+    noteCategory: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<NativeWriteResult> => {
+    const group = await resolveCampusGroup(
+      ctx,
+      args.communityId,
+      args.campusGroupName,
+    );
+    if (!group) return { handled: false, success: false, detail: "No native campus group" };
+    const plan = await findUpcomingPlan(ctx, group._id);
+    if (!plan) return { handled: false, success: false, detail: "No upcoming native plan" };
+
+    const patterns = args.titlePattern
+      .split("|")
+      .map((p) => p.trim().toLowerCase())
+      .filter(Boolean);
+
+    const items = await ctx.db
+      .query("eventItems")
+      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+      .collect();
+    const item = items.find((i) =>
+      patterns.some((p) => i.title.toLowerCase().includes(p)),
+    );
+    if (!item) {
+      return {
+        handled: true,
+        success: false,
+        detail: `No native run-sheet item matching "${args.titlePattern}"`,
+      };
+    }
+
+    const field = args.field === "notes" ? "notes" : "description";
+
+    if (field === "notes") {
+      const category = args.noteCategory || "Notes";
+      await ctx.db.patch(item._id, {
+        notes: [{ category, content: args.content }],
+        updatedAt: Date.now(),
+      });
+    } else {
+      let finalContent = args.content;
+      if (args.preserveSections && args.preserveSections.length > 0) {
+        const existing = item.description ?? "";
+        const preserved = extractPreservedSections(existing, args.preserveSections);
+        if (preserved.length > 0) {
+          finalContent = `${args.content}\n\n${preserved.join("\n\n")}`;
+        }
+      }
+      await ctx.db.patch(item._id, {
+        description: finalContent,
+        updatedAt: Date.now(),
+      });
+    }
+
+    return {
+      handled: true,
+      success: true,
+      detail: `Updated "${item.title}" ${field} on the native plan`,
+    };
+  },
+});
+
+/**
+ * Pull the text of named sections out of an existing description so a replace
+ * can re-append them (e.g. keep GIVING when overwriting ANNOUNCEMENTS). Mirrors
+ * the preserve-section logic in `updatePlanItemCore`.
+ */
+function extractPreservedSections(existing: string, sections: string[]): string[] {
+  const preserved: string[] = [];
+  const allHeaders = sections.map((s) => `\\b${s}\\b`).join("|");
+  for (const section of sections) {
+    const regex = new RegExp(
+      `\\n?(\\b${section}\\b[\\s\\S]*?)(?=\\n(?:${allHeaders})|$)`,
+      "i",
+    );
+    const match = existing.match(regex);
+    if (match) preserved.push(match[1].trimEnd());
+  }
+  return preserved;
+}
+
+/**
+ * Add setlist songs to the upcoming native plan's run sheet as `song` items
+ * (native analog of `syncSetlistToPCO`). Appends each new title to the end of
+ * the "during" segment, skipping titles already present as song items so a
+ * re-sync doesn't duplicate. Returns the number actually added.
+ */
+export const nativeSyncSetlist = internalMutation({
+  args: {
+    communityId: v.id("communities"),
+    campusGroupName: v.string(),
+    songs: v.array(v.string()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<NativeWriteResult & { songsAdded?: number }> => {
+    const group = await resolveCampusGroup(
+      ctx,
+      args.communityId,
+      args.campusGroupName,
+    );
+    if (!group) return { handled: false, success: false, detail: "No native campus group" };
+    const plan = await findUpcomingPlan(ctx, group._id);
+    if (!plan) return { handled: false, success: false, detail: "No upcoming native plan" };
+
+    const existing = await ctx.db
+      .query("eventItems")
+      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+      .collect();
+
+    const existingSongTitles = new Set(
+      existing
+        .filter((i) => i.type === "song")
+        .map((i) => i.title.trim().toLowerCase()),
+    );
+    // Append new songs after the last "during" item.
+    let nextSequence =
+      existing.reduce(
+        (max, i) =>
+          (i.segment ?? "during") === "during" ? Math.max(max, i.sequence) : max,
+        -1,
+      ) + 1;
+
+    let added = 0;
+    const nowMs = Date.now();
+    for (const raw of args.songs) {
+      const title = raw.trim();
+      if (!title || existingSongTitles.has(title.toLowerCase())) continue;
+      await ctx.db.insert("eventItems", {
+        planId: plan._id,
+        communityId: group.communityId,
+        segment: "during",
+        sequence: nextSequence++,
+        type: "song",
+        title,
+        durationSec: 0,
+        createdAt: nowMs,
+        createdById: plan.createdById,
+        updatedAt: nowMs,
+      });
+      existingSongTitles.add(title.toLowerCase());
+      added += 1;
+    }
+
+    return {
+      handled: true,
+      success: true,
+      detail: `Added ${added} song${added === 1 ? "" : "s"} to the native run sheet`,
+      songsAdded: added,
+    };
+  },
+});

--- a/apps/convex/functions/slackServiceBot/pcoSync.ts
+++ b/apps/convex/functions/slackServiceBot/pcoSync.ts
@@ -26,11 +26,142 @@ import {
   PCO_COMMUNITY_ID,
   PCO_SERVICE_TYPE_IDS,
   PCO_ROLE_MAPPINGS,
+  getNativeCampusGroupName,
+  getNativeRoleMapping,
 } from "./config";
 import { ActionCtx } from "../../_generated/server";
 import { Doc } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
 
 const PCO_SERVICES_BASE = "https://api.planningcenteronline.com/services/v2";
+
+// ============================================================================
+// Native-first routing helpers
+// ============================================================================
+//
+// The bot is native-first: when the location's campus group has an upcoming
+// native `eventPlans`, reads/writes go to the native tables (see
+// `nativeSync.ts`); otherwise they fall back to the PCO path in this file. The
+// write helpers below return `{ handled }` — `handled: false` means "no native
+// plan, fall back to PCO"; `handled: true` means native owns the outcome.
+
+interface NativeWriteOutcome {
+  handled: boolean;
+  success: boolean;
+  detail: string;
+}
+
+/**
+ * Fetch native plan context for a location if the community rosters natively.
+ * Returns null when there's no native campus group / upcoming plan (⇒ PCO).
+ */
+async function fetchNativeContext(
+  ctx: ActionCtx,
+  location: string,
+  communityId: Doc<"communities">["_id"],
+): Promise<PcoContext | null> {
+  const campusGroupName = getNativeCampusGroupName(location);
+  if (!campusGroupName) return null;
+  try {
+    return await ctx.runQuery(
+      internal.functions.slackServiceBot.nativeSync.getNativeContext,
+      { communityId, campusGroupName },
+    );
+  } catch (error) {
+    console.warn("[Native Sync] getNativeContext failed:", error);
+    return null;
+  }
+}
+
+/** Native assign; `handled: false` ⇒ caller should fall back to PCO. */
+async function nativeAssign(
+  ctx: ActionCtx,
+  location: string,
+  role: string,
+  personName: string,
+  communityId: Doc<"communities">["_id"],
+): Promise<NativeWriteOutcome> {
+  const campusGroupName = getNativeCampusGroupName(location);
+  const mapping = getNativeRoleMapping(role);
+  if (!campusGroupName || !mapping) {
+    return { handled: false, success: false, detail: "No native mapping" };
+  }
+  return await ctx.runMutation(
+    internal.functions.slackServiceBot.nativeSync.nativeAssignRole,
+    {
+      communityId,
+      campusGroupName,
+      teamName: mapping.teamName,
+      roleName: mapping.roleName,
+      personName,
+    },
+  );
+}
+
+/** Native unassign; `handled: false` ⇒ caller should fall back to PCO. */
+async function nativeUnassign(
+  ctx: ActionCtx,
+  location: string,
+  role: string,
+  personName: string,
+  communityId: Doc<"communities">["_id"],
+): Promise<NativeWriteOutcome> {
+  const campusGroupName = getNativeCampusGroupName(location);
+  const mapping = getNativeRoleMapping(role);
+  if (!campusGroupName || !mapping) {
+    return { handled: false, success: false, detail: "No native mapping" };
+  }
+  return await ctx.runMutation(
+    internal.functions.slackServiceBot.nativeSync.nativeUnassignRole,
+    {
+      communityId,
+      campusGroupName,
+      teamName: mapping.teamName,
+      roleName: mapping.roleName,
+      personName,
+    },
+  );
+}
+
+/** Native run-sheet item update; `handled: false` ⇒ fall back to PCO. */
+async function nativeUpdateItem(
+  ctx: ActionCtx,
+  location: string,
+  opts: {
+    titlePattern: string;
+    field: string;
+    content: string;
+    preserveSections?: string[];
+    noteCategory?: string;
+  },
+  communityId: Doc<"communities">["_id"],
+): Promise<NativeWriteOutcome> {
+  const campusGroupName = getNativeCampusGroupName(location);
+  if (!campusGroupName) {
+    return { handled: false, success: false, detail: "No native campus group" };
+  }
+  return await ctx.runMutation(
+    internal.functions.slackServiceBot.nativeSync.nativeUpdateItem,
+    { communityId, campusGroupName, ...opts },
+  );
+}
+
+/** Native setlist sync; `handled: false` ⇒ fall back to PCO. */
+async function nativeSyncSetlist(
+  ctx: ActionCtx,
+  location: string,
+  songs: string[],
+  communityId: Doc<"communities">["_id"],
+): Promise<NativeWriteOutcome & { songsAdded?: number }> {
+  const campusGroupName = getNativeCampusGroupName(location);
+  if (!campusGroupName) {
+    return { handled: false, success: false, detail: "No native campus group" };
+  }
+  return await ctx.runMutation(
+    internal.functions.slackServiceBot.nativeSync.nativeSyncSetlist,
+    { communityId, campusGroupName, songs },
+  );
+}
 
 // ============================================================================
 // Helpers
@@ -247,6 +378,10 @@ export async function assignPersonToRoleCore(
   communityId: Id<"communities">
 ): Promise<{ success: boolean; detail: string }> {
   try {
+    // Native-first: if the community has an upcoming native plan, write there.
+    const native = await nativeAssign(ctx, location, role, personName, communityId);
+    if (native.handled) return { success: native.success, detail: native.detail };
+
     const plan = await getUpcomingSundayPlanFromConfig(ctx, location, pcoConfig, communityId);
     if (!plan) return { success: false, detail: "No upcoming plan found" };
 
@@ -292,6 +427,10 @@ export async function removePersonFromRoleCore(
   communityId: Id<"communities">
 ): Promise<{ success: boolean; detail: string }> {
   try {
+    // Native-first: if the community has an upcoming native plan, write there.
+    const native = await nativeUnassign(ctx, location, role, personName, communityId);
+    if (native.handled) return { success: native.success, detail: native.detail };
+
     const plan = await getUpcomingSundayPlanFromConfig(ctx, location, pcoConfig, communityId);
     if (!plan) return { success: false, detail: "No upcoming plan found" };
 
@@ -324,6 +463,40 @@ export interface PlanItemConfig {
 }
 
 /**
+ * Resolve the native run-sheet target (title pattern + field) for a plan-item
+ * update, mirroring the V2/V1 branches in `updatePlanItemCore`. Returns null
+ * for an unsupported V1 item type (so the PCO branch reports it).
+ */
+function resolveNativeItemSpec(
+  itemType: string,
+  itemConfig?: PlanItemConfig,
+): {
+  titlePattern: string;
+  field: string;
+  preserveSections?: string[];
+  noteCategory?: string;
+} | null {
+  if (itemConfig) {
+    return {
+      titlePattern: itemConfig.pcoItemTitlePattern,
+      field: itemConfig.pcoItemField === "notes" ? "notes" : "description",
+      preserveSections: itemConfig.preserveSections,
+    };
+  }
+  if (itemType === "preach_notes") {
+    return { titlePattern: "message|preach|sermon", field: "description" };
+  }
+  if (itemType === "announcements") {
+    return {
+      titlePattern: "announcement",
+      field: "description",
+      preserveSections: ["GIVING"],
+    };
+  }
+  return null;
+}
+
+/**
  * Core: Update a plan item (preach notes, announcements, or any V2-configured item).
  *
  * When `itemConfig` is provided (V2 path), uses its patterns for item matching
@@ -339,6 +512,20 @@ export async function updatePlanItemCore(
   itemConfig?: PlanItemConfig
 ): Promise<{ success: boolean; detail: string }> {
   try {
+    // Native-first: resolve the title pattern / field the same way the PCO
+    // branches below do, then write to the native run sheet if a native plan
+    // exists. `handled: false` falls through to the PCO path.
+    const nativeItemSpec = resolveNativeItemSpec(itemType, itemConfig);
+    if (nativeItemSpec) {
+      const native = await nativeUpdateItem(
+        ctx,
+        location,
+        { ...nativeItemSpec, content },
+        communityId,
+      );
+      if (native.handled) return { success: native.success, detail: native.detail };
+    }
+
     const plan = await getUpcomingSundayPlanFromConfig(ctx, location, pcoConfig, communityId);
     if (!plan) return { success: false, detail: "No upcoming plan found" };
 
@@ -467,6 +654,17 @@ export async function searchPcoPeopleCore(
   communityId: Id<"communities">
 ): Promise<{ results: Array<{ name: string; position: string | null }> }> {
   try {
+    // Native-first: search campus-group members when the community rosters
+    // natively. A non-null result (even empty) means native is authoritative.
+    const campusGroupName = getNativeCampusGroupName(location);
+    if (campusGroupName) {
+      const nativeResults = await ctx.runQuery(
+        internal.functions.slackServiceBot.nativeSync.searchNativePeople,
+        { communityId, campusGroupName, query },
+      );
+      if (nativeResults) return nativeResults;
+    }
+
     const accessToken = await getPcoAccessTokenFromConfig(ctx, communityId);
 
     // Search the broad PCO People directory first
@@ -526,6 +724,11 @@ export async function fetchPcoContextCore(
   communityId: Id<"communities">
 ): Promise<PcoContext | null> {
   try {
+    // Native-first: return native plan context when the community rosters
+    // natively; otherwise fall back to reading from PCO below.
+    const native = await fetchNativeContext(ctx, location, communityId);
+    if (native) return native;
+
     const plan = await getUpcomingSundayPlanFromConfig(ctx, location, pcoConfig, communityId);
     if (!plan) return null;
 
@@ -721,6 +924,20 @@ export const syncPreacherToPCO = internalAction({
   },
   handler: async (ctx, args) => {
     try {
+      // Native-first: write to the native plan when the community rosters natively.
+      const native = await nativeAssign(
+        ctx,
+        args.location,
+        "preacher",
+        args.preacherName,
+        PCO_COMMUNITY_ID as Id<"communities">,
+      );
+      if (native.handled) {
+        return native.success
+          ? { success: true, native: true, detail: native.detail }
+          : { success: false, reason: native.detail };
+      }
+
       const plan = await getUpcomingSundayPlan(ctx, args.location);
       if (!plan) return { success: false, reason: "No upcoming plan found" };
 
@@ -780,6 +997,20 @@ export const syncMeetingLeaderToPCO = internalAction({
   },
   handler: async (ctx, args) => {
     try {
+      // Native-first: write to the native plan when the community rosters natively.
+      const native = await nativeAssign(
+        ctx,
+        args.location,
+        "meetingLead",
+        args.meetingLeaderName,
+        PCO_COMMUNITY_ID as Id<"communities">,
+      );
+      if (native.handled) {
+        return native.success
+          ? { success: true, native: true, detail: native.detail }
+          : { success: false, reason: native.detail };
+      }
+
       const plan = await getUpcomingSundayPlan(ctx, args.location);
       if (!plan) return { success: false, reason: "No upcoming plan found" };
 
@@ -838,6 +1069,20 @@ export const removeFromPcoPlan = internalAction({
   },
   handler: async (ctx, args) => {
     try {
+      // Native-first: remove from the native plan when the community rosters natively.
+      const native = await nativeUnassign(
+        ctx,
+        args.location,
+        args.role,
+        args.personName,
+        PCO_COMMUNITY_ID as Id<"communities">,
+      );
+      if (native.handled) {
+        return native.success
+          ? { success: true, native: true }
+          : { success: false, reason: native.detail };
+      }
+
       const plan = await getUpcomingSundayPlan(ctx, args.location);
       if (!plan) return { success: false, reason: "No upcoming plan found" };
 
@@ -873,6 +1118,23 @@ export const syncPreachNotesToPCO = internalAction({
   },
   handler: async (ctx, args) => {
     try {
+      // Native-first: write preach notes to the native run sheet when available.
+      const native = await nativeUpdateItem(
+        ctx,
+        args.location,
+        {
+          titlePattern: "message|preach|sermon",
+          field: "description",
+          content: args.preachNotes,
+        },
+        PCO_COMMUNITY_ID as Id<"communities">,
+      );
+      if (native.handled) {
+        return native.success
+          ? { success: true, native: true, detail: native.detail }
+          : { success: false, reason: native.detail };
+      }
+
       const plan = await getUpcomingSundayPlan(ctx, args.location);
       if (!plan) return { success: false, reason: "No upcoming plan found" };
 
@@ -934,6 +1196,19 @@ export const syncSetlistToPCO = internalAction({
   },
   handler: async (ctx, args) => {
     try {
+      // Native-first: add songs to the native run sheet when available.
+      const native = await nativeSyncSetlist(
+        ctx,
+        args.location,
+        args.songs,
+        PCO_COMMUNITY_ID as Id<"communities">,
+      );
+      if (native.handled) {
+        return native.success
+          ? { success: true, native: true, songsAdded: native.songsAdded ?? 0 }
+          : { success: false, reason: native.detail };
+      }
+
       const plan = await getUpcomingSundayPlan(ctx, args.location);
       if (!plan) return { success: false, reason: "No upcoming plan found" };
 
@@ -981,6 +1256,24 @@ export const syncAnnouncementsToPCO = internalAction({
   },
   handler: async (ctx, args) => {
     try {
+      // Native-first: write announcements to the native run sheet when available.
+      const native = await nativeUpdateItem(
+        ctx,
+        args.location,
+        {
+          titlePattern: "announcement",
+          field: "description",
+          content: args.announcements,
+          preserveSections: ["GIVING"],
+        },
+        PCO_COMMUNITY_ID as Id<"communities">,
+      );
+      if (native.handled) {
+        return native.success
+          ? { success: true, native: true, detail: native.detail }
+          : { success: false, reason: native.detail };
+      }
+
       const plan = await getUpcomingSundayPlan(ctx, args.location);
       if (!plan) return { success: false, reason: "No upcoming plan found" };
 
@@ -1065,6 +1358,14 @@ export const fetchPcoContext = internalAction({
   },
   handler: async (ctx, args): Promise<PcoContext | null> => {
     try {
+      // Native-first: return native plan context when the community rosters natively.
+      const native = await fetchNativeContext(
+        ctx,
+        args.location,
+        PCO_COMMUNITY_ID as Id<"communities">,
+      );
+      if (native) return native;
+
       const plan = await getUpcomingSundayPlan(ctx, args.location);
       if (!plan) return null;
 

--- a/apps/convex/functions/slackServiceBot/pcoSync.ts
+++ b/apps/convex/functions/slackServiceBot/pcoSync.ts
@@ -26,9 +26,12 @@ import {
   PCO_COMMUNITY_ID,
   PCO_SERVICE_TYPE_IDS,
   PCO_ROLE_MAPPINGS,
-  getNativeCampusGroupName,
-  getNativeRoleMapping,
 } from "./config";
+import {
+  getNativeCampusGroupNameFromConfig,
+  getNativeRoleMappingFromConfig,
+  type NativeDbConfig,
+} from "./configDb";
 import { ActionCtx } from "../../_generated/server";
 import { Doc } from "../../_generated/dataModel";
 import { internal } from "../../_generated/api";
@@ -52,6 +55,29 @@ interface NativeWriteOutcome {
 }
 
 /**
+ * Load the community's native rostering config (the `nativeConfig` section of
+ * its `slackBotConfig` row) so the native accessors can resolve DB-configured
+ * campus groups / role mappings. Returns undefined when the community has no
+ * config row (or on error) — the accessors then fall back to the hardcoded
+ * `config.ts` constants, preserving the pre-DB behavior.
+ */
+async function loadNativeConfig(
+  ctx: ActionCtx,
+  communityId: Doc<"communities">["_id"],
+): Promise<NativeDbConfig> {
+  try {
+    const config = await ctx.runQuery(
+      internal.functions.slackServiceBot.index.getConfig,
+      { communityId },
+    );
+    return config?.nativeConfig;
+  } catch (error) {
+    console.warn("[Native Sync] loadNativeConfig failed:", error);
+    return undefined;
+  }
+}
+
+/**
  * Fetch native plan context for a location if the community rosters natively.
  * Returns null when there's no native campus group / upcoming plan (⇒ PCO).
  */
@@ -60,7 +86,8 @@ async function fetchNativeContext(
   location: string,
   communityId: Doc<"communities">["_id"],
 ): Promise<PcoContext | null> {
-  const campusGroupName = getNativeCampusGroupName(location);
+  const nativeConfig = await loadNativeConfig(ctx, communityId);
+  const campusGroupName = getNativeCampusGroupNameFromConfig(nativeConfig, location);
   if (!campusGroupName) return null;
   try {
     return await ctx.runQuery(
@@ -81,8 +108,9 @@ async function nativeAssign(
   personName: string,
   communityId: Doc<"communities">["_id"],
 ): Promise<NativeWriteOutcome> {
-  const campusGroupName = getNativeCampusGroupName(location);
-  const mapping = getNativeRoleMapping(role);
+  const nativeConfig = await loadNativeConfig(ctx, communityId);
+  const campusGroupName = getNativeCampusGroupNameFromConfig(nativeConfig, location);
+  const mapping = getNativeRoleMappingFromConfig(nativeConfig, role);
   if (!campusGroupName || !mapping) {
     return { handled: false, success: false, detail: "No native mapping" };
   }
@@ -106,8 +134,9 @@ async function nativeUnassign(
   personName: string,
   communityId: Doc<"communities">["_id"],
 ): Promise<NativeWriteOutcome> {
-  const campusGroupName = getNativeCampusGroupName(location);
-  const mapping = getNativeRoleMapping(role);
+  const nativeConfig = await loadNativeConfig(ctx, communityId);
+  const campusGroupName = getNativeCampusGroupNameFromConfig(nativeConfig, location);
+  const mapping = getNativeRoleMappingFromConfig(nativeConfig, role);
   if (!campusGroupName || !mapping) {
     return { handled: false, success: false, detail: "No native mapping" };
   }
@@ -136,7 +165,8 @@ async function nativeUpdateItem(
   },
   communityId: Doc<"communities">["_id"],
 ): Promise<NativeWriteOutcome> {
-  const campusGroupName = getNativeCampusGroupName(location);
+  const nativeConfig = await loadNativeConfig(ctx, communityId);
+  const campusGroupName = getNativeCampusGroupNameFromConfig(nativeConfig, location);
   if (!campusGroupName) {
     return { handled: false, success: false, detail: "No native campus group" };
   }
@@ -153,7 +183,8 @@ async function nativeSyncSetlist(
   songs: string[],
   communityId: Doc<"communities">["_id"],
 ): Promise<NativeWriteOutcome & { songsAdded?: number }> {
-  const campusGroupName = getNativeCampusGroupName(location);
+  const nativeConfig = await loadNativeConfig(ctx, communityId);
+  const campusGroupName = getNativeCampusGroupNameFromConfig(nativeConfig, location);
   if (!campusGroupName) {
     return { handled: false, success: false, detail: "No native campus group" };
   }
@@ -656,7 +687,8 @@ export async function searchPcoPeopleCore(
   try {
     // Native-first: search campus-group members when the community rosters
     // natively. A non-null result (even empty) means native is authoritative.
-    const campusGroupName = getNativeCampusGroupName(location);
+    const nativeConfig = await loadNativeConfig(ctx, communityId);
+    const campusGroupName = getNativeCampusGroupNameFromConfig(nativeConfig, location);
     if (campusGroupName) {
       const nativeResults = await ctx.runQuery(
         internal.functions.slackServiceBot.nativeSync.searchNativePeople,

--- a/apps/convex/functions/slackServiceBot/seedConfig.ts
+++ b/apps/convex/functions/slackServiceBot/seedConfig.ts
@@ -24,6 +24,8 @@ import {
   PCO_COMMUNITY_ID,
   PCO_SERVICE_TYPE_IDS,
   PCO_ROLE_MAPPINGS,
+  NATIVE_CAMPUS_GROUP_NAMES,
+  NATIVE_ROLE_MAPPINGS,
   OPENAI_MODEL,
 } from "./config";
 
@@ -164,6 +166,19 @@ export const seedSlackBotConfig = internalMutation({
           Object.entries(PCO_ROLE_MAPPINGS).map(([k, v]) => [
             k,
             { teamNamePattern: v.teamNamePattern, positionName: v.positionName },
+          ])
+        ),
+      },
+
+      // Native rostering config — seeded from the hardcoded config.ts
+      // constants; at runtime the DB row is the source of truth with the
+      // constants as fallback (see configDb native accessors).
+      nativeConfig: {
+        campusGroupNames: { ...NATIVE_CAMPUS_GROUP_NAMES },
+        roleMappings: Object.fromEntries(
+          Object.entries(NATIVE_ROLE_MAPPINGS).map(([k, v]) => [
+            k,
+            { teamName: v.teamName, roleName: v.roleName },
           ])
         ),
       },
@@ -310,6 +325,15 @@ export const seedSlackBotConfigForDemo = internalMutation({
           Object.entries(PCO_ROLE_MAPPINGS).map(([k, v]) => [
             k,
             { teamNamePattern: v.teamNamePattern, positionName: v.positionName },
+          ])
+        ),
+      },
+      nativeConfig: {
+        campusGroupNames: { ...NATIVE_CAMPUS_GROUP_NAMES },
+        roleMappings: Object.fromEntries(
+          Object.entries(NATIVE_ROLE_MAPPINGS).map(([k, v]) => [
+            k,
+            { teamName: v.teamName, roleName: v.roleName },
           ])
         ),
       },

--- a/apps/convex/functions/systemScoring.ts
+++ b/apps/convex/functions/systemScoring.ts
@@ -5,7 +5,7 @@
  * These scores are computed at the community level (across all groups).
  *
  * Score slots:
- *   score1 = Serving (PCO serving frequency)
+ *   score1 = Serving (serving frequency)
  *   score2 = Attendance (cross-group attendance %)
  *   score3 = Connection (leader outreach effectiveness — the primary triage score)
  *
@@ -77,7 +77,7 @@ export const SYSTEM_SCORES: SystemScoreDefinition[] = [
     slot: "score1",
     name: "Serving",
     description:
-      "PCO serving frequency in past 2 months (20pts per service, max 100)",
+      "Serving frequency in past 2 months (20pts per service, max 100)",
     variables: [
       {
         variableId: "pco_services_past_2mo",
@@ -187,7 +187,7 @@ export const SYSTEM_VARIABLE_IDS: ReadonlySet<string> = new Set([
 /**
  * Calculate the 0-100 score for a single system score by ID.
  *
- * - `sys_service`: 20 points per PCO service in the past 2 months, max 100 at 5+.
+ * - `sys_service`: 20 points per service in the past 2 months, max 100 at 5+.
  * - `sys_attendance`: Percentage of weeks (in a join-date-adjusted 60-day window) with ≥1 attendance.
  * - `sys_togather`: Consecutive misses (0-70pts, -15 per consecutive missed meeting)
  *   + Follow-up (fills remaining: in-person=100%, call=75%, text=50%, decaying over time).

--- a/apps/convex/lib/nativeServing.ts
+++ b/apps/convex/lib/nativeServing.ts
@@ -1,0 +1,174 @@
+/**
+ * Native serving helpers.
+ *
+ * The profile "Serving" score and the serving-history card are native-first:
+ * when a community uses native rostering (it has at least one `eventPlans`
+ * row), serving is computed from `roleAssignments`. Only communities with no
+ * native rostering fall back to the cached Planning Center (PCO) counts on
+ * `groups.pcoServingCounts`.
+ *
+ * "Native serving count" for a user = number of DISTINCT event plans in the
+ * past ~60 days where the user has a non-declined role assignment. This mirrors
+ * how PCO counts distinct plans served (see pcoServices/servingHistory.ts).
+ */
+
+import type { Id } from "../_generated/dataModel";
+
+/** Serving window: past ~60 days (matches TWO_MONTHS_MS in pcoServices/servingHistory.ts). */
+export const SERVING_WINDOW_MS = 60 * 24 * 60 * 60 * 1000;
+
+/** Default number of serving-history rows shown on the profile card. */
+export const SERVING_HISTORY_CAP = 15;
+
+// A non-declined role assignment means the person is/was rostered to serve.
+type AssignmentLike = {
+  planId: Id<"eventPlans">;
+  eventDate: number;
+  status: string;
+};
+
+// Minimal shape of the ctx we need — a db with query/get. Kept structural so
+// the helpers work from both query handlers and `t.run` in tests.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ReadCtx = { db: any };
+
+/**
+ * A community "uses native rostering" if it has at least one event plan.
+ * When true, serving score + history are computed from native
+ * `roleAssignments`; when false, callers fall back to cached PCO counts.
+ *
+ * O(1): a single indexed `first()` on `by_community_date`.
+ */
+export async function communityUsesNativeRostering(
+  ctx: ReadCtx,
+  communityId: Id<"communities">,
+): Promise<boolean> {
+  const plan = await ctx.db
+    .query("eventPlans")
+    .withIndex("by_community_date", (q: any) => q.eq("communityId", communityId))
+    .first();
+  return plan !== null;
+}
+
+/**
+ * Native serving count for a user, scoped to one community: number of DISTINCT
+ * event plans in the past ~60 days where the user has a non-declined role
+ * assignment AND the plan belongs to `communityId`.
+ *
+ * Scoping matters because `roleAssignments` (and its `by_user_eventDate` index)
+ * is not community-scoped — a user who serves in two native-rostering
+ * communities must not have one community's serving inflate the other's score
+ * (the PCO counts this replaces were always per-community).
+ *
+ * Takes a pre-fetched, newest-first assignment list (e.g. the archive-activity
+ * lookup) so the caller avoids a second assignment read; only the small set of
+ * in-window candidate plans is fetched to resolve their community.
+ */
+export async function countNativeServing(
+  ctx: ReadCtx,
+  assignments: AssignmentLike[],
+  nowTs: number,
+  communityId: Id<"communities">,
+): Promise<number> {
+  const cutoff = nowTs - SERVING_WINDOW_MS;
+  const candidatePlanIds = new Set<string>();
+  for (const a of assignments) {
+    if (a.status === "declined") continue;
+    if (a.eventDate < cutoff) continue;
+    candidatePlanIds.add(a.planId.toString());
+  }
+  if (candidatePlanIds.size === 0) return 0;
+  const plans = await Promise.all(
+    [...candidatePlanIds].map((id) => ctx.db.get(id as Id<"eventPlans">)),
+  );
+  let count = 0;
+  for (const plan of plans) {
+    if (plan && plan.communityId === communityId) count++;
+  }
+  return count;
+}
+
+export interface ServingHistoryRow {
+  date: string;
+  serviceTypeName: string;
+  teamName: string;
+  position: string | null;
+}
+
+/**
+ * Build the serving-history card from native `roleAssignments` for one user,
+ * scoped to `communityId` (assignments in other communities are excluded — see
+ * countNativeServing for why). Newest event first, capped at `cap`. Plan/team/
+ * role lookups are deduped to stay under Convex read limits.
+ *
+ * `date` is formatted `YYYY-MM-DD` to match the shape the PCO card produces
+ * (and stays lexicographically sortable).
+ */
+export async function nativeServingHistory(
+  ctx: ReadCtx,
+  userId: Id<"users">,
+  communityId: Id<"communities">,
+  cap: number = SERVING_HISTORY_CAP,
+): Promise<ServingHistoryRow[]> {
+  // Newest-first by event date. take(200) leaves generous headroom to skip
+  // declined + other-community rows and still fill the cap.
+  const assignments = await ctx.db
+    .query("roleAssignments")
+    .withIndex("by_user_eventDate", (q: any) => q.eq("userId", userId))
+    .order("desc")
+    .take(200);
+
+  const nonDeclined = assignments.filter((a: any) => a.status !== "declined");
+  if (nonDeclined.length === 0) return [];
+
+  // Resolve plans first so rows can be scoped to this community before capping.
+  const allPlanIds = [
+    ...new Set(nonDeclined.map((a: any) => a.planId.toString())),
+  ];
+  const allPlans = await Promise.all(
+    allPlanIds.map((id) => ctx.db.get(id as Id<"eventPlans">)),
+  );
+  const planMap = new Map(
+    allPlans.filter(Boolean).map((p: any) => [p._id.toString(), p]),
+  );
+
+  // Keep only this community's assignments (newest-first order preserved), cap.
+  const scoped = nonDeclined
+    .filter((a: any) => {
+      const plan = planMap.get(a.planId.toString());
+      return plan && plan.communityId === communityId;
+    })
+    .slice(0, cap);
+  if (scoped.length === 0) return [];
+
+  // Dedupe the remaining team/role lookups.
+  const teamIds = [...new Set(scoped.map((a: any) => a.teamId.toString()))];
+  const roleIds = [...new Set(scoped.map((a: any) => a.roleId.toString()))];
+
+  const [teams, roles] = await Promise.all([
+    Promise.all(teamIds.map((id) => ctx.db.get(id as Id<"teams">))),
+    Promise.all(roleIds.map((id) => ctx.db.get(id as Id<"teamRoles">))),
+  ]);
+  const teamMap = new Map(
+    teams.filter(Boolean).map((t: any) => [t._id.toString(), t]),
+  );
+  const roleMap = new Map(
+    roles.filter(Boolean).map((r: any) => [r._id.toString(), r]),
+  );
+
+  const rows: ServingHistoryRow[] = [];
+  for (const a of scoped) {
+    const plan = planMap.get(a.planId.toString());
+    const team = teamMap.get(a.teamId.toString());
+    const role = roleMap.get(a.roleId.toString());
+    // Prefer the plan's canonical date; fall back to the denormalized one.
+    const eventDate = plan?.eventDate ?? a.eventDate;
+    rows.push({
+      date: new Date(eventDate).toISOString().split("T")[0],
+      serviceTypeName: plan?.title ?? "",
+      teamName: team?.name ?? "",
+      position: role?.name ?? null,
+    });
+  }
+  return rows;
+}

--- a/apps/convex/lib/nativeServing.ts
+++ b/apps/convex/lib/nativeServing.ts
@@ -74,7 +74,11 @@ export async function countNativeServing(
   const candidatePlanIds = new Set<string>();
   for (const a of assignments) {
     if (a.status === "declined") continue;
-    if (a.eventDate < cutoff) continue;
+    // Past ~60 days only. Volunteers are rostered onto *upcoming* plans, so
+    // roleAssignments routinely carry future eventDates; counting those would
+    // inflate the Serving score the moment someone is scheduled ahead. The PCO
+    // value this replaces is built from past plans only.
+    if (a.eventDate < cutoff || a.eventDate > nowTs) continue;
     candidatePlanIds.add(a.planId.toString());
   }
   if (candidatePlanIds.size === 0) return 0;
@@ -109,12 +113,18 @@ export async function nativeServingHistory(
   userId: Id<"users">,
   communityId: Id<"communities">,
   cap: number = SERVING_HISTORY_CAP,
+  nowTs: number = Date.now(),
 ): Promise<ServingHistoryRow[]> {
-  // Newest-first by event date. take(200) leaves generous headroom to skip
-  // declined + other-community rows and still fill the cap.
+  // Past events only, newest-first. The index range excludes future-dated
+  // assignments (volunteers rostered onto upcoming plans) so the card shows
+  // serving history, not upcoming commitments — matching the past-only PCO
+  // card it replaces. take(200) leaves headroom to skip declined +
+  // other-community rows and still fill the cap.
   const assignments = await ctx.db
     .query("roleAssignments")
-    .withIndex("by_user_eventDate", (q: any) => q.eq("userId", userId))
+    .withIndex("by_user_eventDate", (q: any) =>
+      q.eq("userId", userId).lte("eventDate", nowTs),
+    )
     .order("desc")
     .take(200);
 

--- a/apps/convex/lib/nativeServing.ts
+++ b/apps/convex/lib/nativeServing.ts
@@ -1,15 +1,20 @@
 /**
- * Native serving helpers.
+ * Serving helpers — combined PCO + native rostering.
  *
- * The profile "Serving" score and the serving-history card are native-first:
- * when a community uses native rostering (it has at least one `eventPlans`
- * row), serving is computed from `roleAssignments`. Only communities with no
- * native rostering fall back to the cached Planning Center (PCO) counts on
- * `groups.pcoServingCounts`.
+ * The profile "Serving" score and the serving-history card show BOTH sources:
+ * the cached Planning Center (PCO) snapshot on `groups.pcoServingCounts` AND
+ * native rostering (`roleAssignments`). This gives a community mid-migration its
+ * full serving picture instead of one source hiding the other.
  *
- * "Native serving count" for a user = number of DISTINCT event plans in the
- * past ~60 days where the user has a non-declined role assignment. This mirrors
- * how PCO counts distinct plans served (see pcoServices/servingHistory.ts).
+ * De-duplication: a native plan imported from PCO carries `eventPlans.pcoPlanId`.
+ * Those plans are already represented in the PCO snapshot, so the native helpers
+ * below exclude `pcoPlanId`-linked plans — the caller then adds the PCO count /
+ * rows on top, and the two sets are disjoint (native-origin vs PCO-origin).
+ *
+ * "Native serving count" for a user = number of DISTINCT native-origin event
+ * plans in the past ~60 days where the user has a non-declined role assignment.
+ * This mirrors how PCO counts distinct plans served (see
+ * pcoServices/servingHistory.ts).
  */
 
 import type { Id } from "../_generated/dataModel";
@@ -33,36 +38,20 @@ type AssignmentLike = {
 type ReadCtx = { db: any };
 
 /**
- * A community "uses native rostering" if it has at least one event plan.
- * When true, serving score + history are computed from native
- * `roleAssignments`; when false, callers fall back to cached PCO counts.
- *
- * O(1): a single indexed `first()` on `by_community_date`.
- */
-export async function communityUsesNativeRostering(
-  ctx: ReadCtx,
-  communityId: Id<"communities">,
-): Promise<boolean> {
-  const plan = await ctx.db
-    .query("eventPlans")
-    .withIndex("by_community_date", (q: any) => q.eq("communityId", communityId))
-    .first();
-  return plan !== null;
-}
-
-/**
- * Native serving count for a user, scoped to one community: number of DISTINCT
- * event plans in the past ~60 days where the user has a non-declined role
- * assignment AND the plan belongs to `communityId`.
+ * Native-origin serving count for a user, scoped to one community: number of
+ * DISTINCT event plans in the past ~60 days where the user has a non-declined
+ * role assignment, the plan belongs to `communityId`, and the plan did NOT come
+ * from PCO (no `pcoPlanId`). The caller adds the cached PCO count on top; the
+ * two are disjoint, so this is native + PCO without double-counting.
  *
  * Scoping matters because `roleAssignments` (and its `by_user_eventDate` index)
- * is not community-scoped — a user who serves in two native-rostering
- * communities must not have one community's serving inflate the other's score
- * (the PCO counts this replaces were always per-community).
+ * is not community-scoped — a user who serves in two communities must not have
+ * one community's serving inflate the other's score (the PCO counts this
+ * augments were always per-community).
  *
  * Takes a pre-fetched, newest-first assignment list (e.g. the archive-activity
  * lookup) so the caller avoids a second assignment read; only the small set of
- * in-window candidate plans is fetched to resolve their community.
+ * in-window candidate plans is fetched to resolve community + origin.
  */
 export async function countNativeServing(
   ctx: ReadCtx,
@@ -77,7 +66,7 @@ export async function countNativeServing(
     // Past ~60 days only. Volunteers are rostered onto *upcoming* plans, so
     // roleAssignments routinely carry future eventDates; counting those would
     // inflate the Serving score the moment someone is scheduled ahead. The PCO
-    // value this replaces is built from past plans only.
+    // value this augments is built from past plans only.
     if (a.eventDate < cutoff || a.eventDate > nowTs) continue;
     candidatePlanIds.add(a.planId.toString());
   }
@@ -87,7 +76,11 @@ export async function countNativeServing(
   );
   let count = 0;
   for (const plan of plans) {
-    if (plan && plan.communityId === communityId) count++;
+    // Exclude PCO-imported plans (pcoPlanId set): already counted in the PCO
+    // snapshot the caller adds, so counting them here double-counts.
+    if (plan && plan.communityId === communityId && plan.pcoPlanId == null) {
+      count++;
+    }
   }
   return count;
 }
@@ -100,10 +93,11 @@ export interface ServingHistoryRow {
 }
 
 /**
- * Build the serving-history card from native `roleAssignments` for one user,
- * scoped to `communityId` (assignments in other communities are excluded — see
- * countNativeServing for why). Newest event first, capped at `cap`. Plan/team/
- * role lookups are deduped to stay under Convex read limits.
+ * Build the native-origin serving-history rows for one user, scoped to
+ * `communityId` and excluding PCO-imported plans (the caller merges these with
+ * the cached PCO rows via `mergeServingHistory`). Past events only, newest event
+ * first, capped at `cap`. Plan/team/role lookups are deduped to stay under
+ * Convex read limits.
  *
  * `date` is formatted `YYYY-MM-DD` to match the shape the PCO card produces
  * (and stays lexicographically sortable).
@@ -118,8 +112,8 @@ export async function nativeServingHistory(
   // Past events only, newest-first. The index range excludes future-dated
   // assignments (volunteers rostered onto upcoming plans) so the card shows
   // serving history, not upcoming commitments — matching the past-only PCO
-  // card it replaces. take(200) leaves headroom to skip declined +
-  // other-community rows and still fill the cap.
+  // card it augments. take(200) leaves headroom to skip declined,
+  // other-community, and PCO-imported rows and still fill the cap.
   const assignments = await ctx.db
     .query("roleAssignments")
     .withIndex("by_user_eventDate", (q: any) =>
@@ -131,7 +125,8 @@ export async function nativeServingHistory(
   const nonDeclined = assignments.filter((a: any) => a.status !== "declined");
   if (nonDeclined.length === 0) return [];
 
-  // Resolve plans first so rows can be scoped to this community before capping.
+  // Resolve plans first so rows can be scoped to this community + origin
+  // before capping.
   const allPlanIds = [
     ...new Set(nonDeclined.map((a: any) => a.planId.toString())),
   ];
@@ -142,11 +137,14 @@ export async function nativeServingHistory(
     allPlans.filter(Boolean).map((p: any) => [p._id.toString(), p]),
   );
 
-  // Keep only this community's assignments (newest-first order preserved), cap.
+  // Keep only this community's native-origin assignments (newest-first order
+  // preserved), cap. PCO-imported plans come from the PCO rows instead.
   const scoped = nonDeclined
     .filter((a: any) => {
       const plan = planMap.get(a.planId.toString());
-      return plan && plan.communityId === communityId;
+      return (
+        plan && plan.communityId === communityId && plan.pcoPlanId == null
+      );
     })
     .slice(0, cap);
   if (scoped.length === 0) return [];
@@ -181,4 +179,30 @@ export async function nativeServingHistory(
     });
   }
   return rows;
+}
+
+/**
+ * Merge native-origin + PCO serving-history rows into one card. Both sources are
+ * shown so a community mid-migration sees its full history. Sorted newest-first,
+ * deduped on (date, team, service, position) as a defensive guard against any
+ * overlap, capped at `cap`.
+ */
+export function mergeServingHistory(
+  nativeRows: ServingHistoryRow[],
+  pcoRows: ServingHistoryRow[],
+  cap: number = SERVING_HISTORY_CAP,
+): ServingHistoryRow[] {
+  const all = [...nativeRows, ...pcoRows].sort((a, b) =>
+    b.date.localeCompare(a.date),
+  );
+  const seen = new Set<string>();
+  const merged: ServingHistoryRow[] = [];
+  for (const r of all) {
+    const key = `${r.date}|${r.teamName.toLowerCase()}|${r.serviceTypeName.toLowerCase()}|${(r.position ?? "").toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(r);
+    if (merged.length >= cap) break;
+  }
+  return merged;
 }

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2424,6 +2424,27 @@ export default defineSchema({
       ),
     }),
 
+    // Native rostering config (native-first, PCO fallback). Mirrors pcoConfig's
+    // map representation: campusGroupNames parallels serviceTypeIds
+    // (location -> value), roleMappings parallels the PCO roleMappings record.
+    // Optional: rows created before native config was promoted to the DB (and
+    // any key omitted here) fall back to the hardcoded config.ts constants.
+    nativeConfig: v.optional(
+      v.object({
+        // location -> native campus group name (case-insensitive substring
+        // match against `groups.name`).
+        campusGroupNames: v.record(v.string(), v.string()),
+        // semantic role id -> native team + role name.
+        roleMappings: v.record(
+          v.string(),
+          v.object({
+            teamName: v.string(),
+            roleName: v.string(),
+          }),
+        ),
+      }),
+    ),
+
     // AI/Prompt config
     aiConfig: v.object({
       model: v.string(),

--- a/apps/mobile/features/leader-tools/components/CommunicationBotConfigModal.tsx
+++ b/apps/mobile/features/leader-tools/components/CommunicationBotConfigModal.tsx
@@ -1,17 +1,19 @@
 /**
  * CommunicationBotConfigModal - Configuration modal for Communication Bot
  *
- * Allows leaders to configure multiple automated messages with PCO position placeholders.
- * Messages can include placeholders like {{MANHATTAN > WORSHIP > Worship Leader}}
- * that will be resolved to @mention actual team members.
+ * Allows leaders to configure multiple automated messages with position placeholders.
+ * Messages can include placeholders like {{Worship > Worship Leader}} that resolve to
+ * the first names of whoever is scheduled. Resolution is native-first (the app's own
+ * rostering) with Planning Center as a fallback; the autocomplete offers native
+ * positions first, then PCO positions when PCO is connected.
  *
  * Features:
  * - Multiple scheduled messages support
- * - Message textarea with autocomplete for PCO positions
+ * - Message textarea with autocomplete for native + PCO positions
  * - Schedule picker (day of week + time) per message
  * - Target channel selector per message
  */
-import React, { useState, useRef, useCallback, useEffect } from "react";
+import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import {
   View,
   Text,
@@ -164,16 +166,40 @@ export function CommunicationBotConfigModal({
     visible && groupId ? { groupId, includeArchived: false } : "skip"
   );
 
-  // Fetch available positions from PCO
+  // Native rostering positions (native-first source for placeholder suggestions).
+  const nativePositionsData = useAuthenticatedQuery(
+    api.functions.scheduling.nativePlaceholders.getNativePositions,
+    visible && groupId && groupData?.communityId
+      ? { communityId: groupData.communityId, groupId }
+      : "skip"
+  );
+
+  // Fetch available positions from PCO (fallback source, only when connected)
   const getPositions = useAction(
     api.functions.pcoServices.actions.getAvailablePositions
   );
   const sendCommunicationNow = useAction(
     api.functions.groupBots.sendCommunicationNow
   );
-  const [positions, setPositions] = useState<PcoPosition[]>([]);
+  const [pcoPositions, setPcoPositions] = useState<PcoPosition[]>([]);
   const [loadingPositions, setLoadingPositions] = useState(false);
   const [sendingMessageIds, setSendingMessageIds] = useState<Set<string>>(new Set());
+
+  // Native-first merged suggestion list: native `Team > Role` positions first,
+  // then any PCO positions not already covered by a native suggestion.
+  const positions: PcoPosition[] = useMemo(() => {
+    const native: PcoPosition[] = (nativePositionsData ?? []).map((p) => ({
+      serviceTypeName: null,
+      teamName: p.teamName,
+      positionName: p.roleName,
+      displayName: p.displayName,
+    }));
+    const seen = new Set(native.map((p) => p.displayName.toLowerCase()));
+    const pco = pcoPositions.filter(
+      (p) => !seen.has(p.displayName.toLowerCase())
+    );
+    return [...native, ...pco];
+  }, [nativePositionsData, pcoPositions]);
 
   // Reset form when modal opens with new config
   useEffect(() => {
@@ -206,7 +232,7 @@ export function CommunicationBotConfigModal({
         positionName: pos.name,
         displayName: pos.displayName,
       }));
-      setPositions(flatPositions);
+      setPcoPositions(flatPositions);
     } catch (error) {
       console.error("Failed to load positions:", error);
     } finally {
@@ -522,7 +548,10 @@ export function CommunicationBotConfigModal({
           onClose={() => setEditingMessage(null)}
           onSave={handleSaveMessage}
           positions={positions}
-          loadingPositions={loadingPositions}
+          loadingPositions={
+            loadingPositions ||
+            (!!groupId && !!groupData?.communityId && nativePositionsData === undefined)
+          }
           channelOptions={channelOptions}
           primaryColor={primaryColor}
         />
@@ -777,7 +806,7 @@ function MessageEditorModal({
                   ) : filteredPositions.length === 0 ? (
                     <Text style={[styles.emptyAutocompleteText, { color: colors.textSecondary }]}>
                       {positions.length === 0
-                        ? "No positions available. Configure PCO integration first."
+                        ? "No positions available. Set up serving teams and roles (or connect Planning Center) first."
                         : "No positions match your search"}
                     </Text>
                   ) : (


### PR DESCRIPTION
## Why

Several features still depended on Planning Center (PCO) run sheets / rostering even though Togather now has native rostering (`teams` → `teamRoles` → `eventPlans` → `neededRoles` / `roleAssignments` / `eventItems`). This ports those features to the native data model. The PCO read/write paths are kept as fallbacks — no PCO code is deleted.

## What changed

### Serving score + serving cards — show BOTH PCO and native
- New `apps/convex/lib/nativeServing.ts`: `countNativeServing` (distinct **native-origin** plans served in the past ~60 days, community-scoped, excluding future-dated and PCO-imported plans) and `nativeServingHistory` + `mergeServingHistory`.
- The "Serving" score (`sys_service` / `pco_services_past_2mo`) and the serving-history card now **combine** the cached PCO snapshot AND native rostering. Native excludes plans carrying `eventPlans.pcoPlanId`, so migrated plans aren't double-counted. `computeCommunityScoresBatch`, `communityPeople`, and `memberFollowups` all updated.

### Communication bot role placeholders
- New `scheduling/nativePlaceholders.ts` resolves `{{Team > Role}}` (and legacy `{{ServiceType > Team > Position}}`) from non-declined `roleAssignments` on the group's upcoming native plan, plus a native positions source for the config autocomplete.
- `pcoServices/actions.ts` resolves native-first, falling back to PCO only for unmatched placeholders when PCO is connected. Config modal lists native positions first.

### Slack service bot
- New `slackServiceBot/nativeSync.ts` reads plan context from and writes assignments + run-sheet items to native `eventPlans` / `eventItems` / `roleAssignments`, scheduling the same team-channel reconcile jobs as human edits. `pcoSync.ts` routes every entry point native-first (falls back to PCO when there's no native plan).
- Native campus-group and role→team/role mappings are configurable via the `slackBotConfig` DB record (`nativeConfig`), with the `config.ts` constants kept as seed defaults + per-key fallback.

### Review fixes (Codex + adversarial review)
- Exclude future-dated assignments from the serving score + card (past-only, matching PCO).
- Reopen previously-declined native assignments on re-assign instead of a no-op success.
- Scope Slack "platform roles" to the Platform team (parity with the PCO path).
- Guard the native unassign hard-delete against ambiguous name matches.

## Testing
- New/updated: `native-serving`, `scheduling/nativePlaceholders`, `slackServiceBot.native`, `slackServiceBot.nativeConfig` — each covers native resolution, PCO combine/fallback, and the review-fix edge cases.
- Full Convex suite green: **141 files, 2240 tests**. Mobile suite green via pre-push hook. Typecheck clean on changed files (only pre-existing `@togather/shared` bare-`tsc` resolution noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)