### PR TITLE
Allow the send_later scheduling MCP tool without a permission prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,9 @@
     "ralph-loop@claude-plugins-official": true
   },
   "permissions": {
-    "dangerouslySkipPermissions": true
+    "dangerouslySkipPermissions": true,
+    "allow": [
+      "mcp__Claude_Code_Remote__send_later"
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,6 @@
     "ralph-loop@claude-plugins-official": true
   },
   "permissions": {
-    "dangerouslySkipPermissions": true,
     "allow": [
       "mcp__Claude_Code_Remote__send_later"
     ]


### PR DESCRIPTION
## Why

Agents (e.g. babysitting a PR to green) use the `send_later` tool from the `Claude_Code_Remote` MCP server to schedule their own follow-up check-ins. Today that triggers a permission prompt in every session.

The repo's `.claude/settings.json` sets `dangerouslySkipPermissions: true`, but that isn't a recognized settings key, so it has no effect — the prompt still fires. The supported mechanism is an explicit `permissions.allow` entry.

## What changed

Adds `mcp__Claude_Code_Remote__send_later` to `permissions.allow` in the committed `.claude/settings.json`, so future cloud/web agent sessions (which start from a fresh clone of `main`) inherit the allowlist and no longer prompt for it.

Scope is intentionally limited to just `send_later`. If you'd rather silence every tool from that MCP server (`create_trigger`, `fire_trigger`, etc.), the rule can be broadened to `mcp__Claude_Code_Remote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCZSrgwPYFHe1DnbzUHf67)_