### PR TITLE
Compact People cards + remove search-bar whitespace

### DIFF
--- a/apps/mobile/features/admin/components/AdminScreen.tsx
+++ b/apps/mobile/features/admin/components/AdminScreen.tsx
@@ -138,7 +138,7 @@ export function AdminScreen() {
           // whole roster (showAllMembers), and reach per-member admin controls
           // (role, transfer primary admin, remove) via the person's detail
           // screen. Replaces the old standalone PeopleContent list.
-          <PeopleTabScreen showAllMembers />
+          <PeopleTabScreen showAllMembers embedded />
         ) : activeTab === "stats" ? (
           <StatsContent />
         ) : (

--- a/apps/mobile/features/leader-tools/components/FollowupMobileCards.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupMobileCards.tsx
@@ -592,9 +592,17 @@ function MemberCard({
           </Pressable>
         </View>
 
-        {/* Row 2: assignee + reason */}
-        <Pressable onPress={onAssign} hitSlop={6} style={styles.cardSubRow}>
-          <View style={styles.cardSubAssignee}>{assigneeNode}</View>
+        {/* Row 2: assignee (tap to assign) + follow-up reason. Only the
+            assignee is pressable; tapping the reason falls through to the
+            card's onPress (opens the person), matching the old footer. */}
+        <View style={styles.cardSubRow}>
+          <Pressable
+            onPress={onAssign}
+            hitSlop={6}
+            style={styles.cardSubAssignee}
+          >
+            {assigneeNode}
+          </Pressable>
           <Text style={[styles.cardSubDivider, { color: colors.textTertiary }]}>
             ·
           </Text>
@@ -604,7 +612,7 @@ function MemberCard({
           >
             {reasonLine}
           </Text>
-        </Pressable>
+        </View>
 
         {/* Row 3: scores as an inline strip */}
         <View style={styles.scoresRow}>

--- a/apps/mobile/features/leader-tools/components/FollowupMobileCards.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupMobileCards.tsx
@@ -107,6 +107,7 @@ export function FollowupMobileCards({
   enforcedAssigneeUserId,
   returnTo,
   hideHeader = false,
+  embedded = false,
 }: {
   groupId: string;
   enforcedAssigneeUserId?: string;
@@ -114,6 +115,10 @@ export function FollowupMobileCards({
   // Tab surfaces (Admin → People) hide the "Check-in" title/back header so the
   // search bar sits at the top; the group-scoped check-in keeps it for nav.
   hideHeader?: boolean;
+  // True when rendered inside a parent that already applies the top safe-area
+  // inset (e.g. the Admin header). Suppresses our own top inset so it isn't
+  // applied twice, which otherwise leaves a large empty gap above the search bar.
+  embedded?: boolean;
 }) {
   const { colors } = useTheme();
   const router = useRouter();
@@ -364,7 +369,11 @@ export function FollowupMobileCards({
         style={[
           styles.searchWrap,
           { borderBottomColor: colors.border },
-          hideHeader && { paddingTop: insets.top + 8 },
+          // Only add the top safe-area inset when we're the top-most element on
+          // screen (standalone People tab route). When embedded under a parent
+          // header (Admin → People), the parent already applies it — adding it
+          // here too produced the empty white gap above the search bar.
+          hideHeader && !embedded && { paddingTop: insets.top + 8 },
         ]}
       >
         <View
@@ -500,6 +509,50 @@ function MemberCard({
   const connectionLabel =
     connection < 40 ? "low" : connection < 70 ? "watch" : "strong";
 
+  // Assignee state, rendered inline on the sub-row. Three cases: unassigned,
+  // assigned to a group leader (star), or assigned community-only (warning).
+  const assigneeNode =
+    assigneeIds.length === 0 ? (
+      <Text
+        style={[styles.assigneeText, { color: colors.textTertiary }]}
+        numberOfLines={1}
+      >
+        Unassigned · tap to assign
+      </Text>
+    ) : groupLeaderAssignees.length > 0 ? (
+      <View style={styles.assigneeRow}>
+        <Ionicons name="star" size={11} color={primaryColor} />
+        <Text
+          style={[styles.assigneeText, { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
+          {groupLeaderAssignees
+            .map((id) => {
+              const l = leaderMap.get(id);
+              return l ? `${l.firstName} ${l.lastName}`.trim() : "";
+            })
+            .filter(Boolean)
+            .join(", ")}
+          {communityOnlyAssignees.length > 0 &&
+            `  +${communityOnlyAssignees.length} community`}
+        </Text>
+      </View>
+    ) : (
+      <View style={styles.assigneeRow}>
+        <Ionicons
+          name="alert-circle-outline"
+          size={11}
+          color={colors.warning}
+        />
+        <Text
+          style={[styles.assigneeText, { color: colors.warning }]}
+          numberOfLines={1}
+        >
+          No group leader · {leaderMap.get(communityOnlyAssignees[0])?.firstName ?? "community"}
+        </Text>
+      </View>
+    );
+
   return (
     <TouchableOpacity
       activeOpacity={0.7}
@@ -509,71 +562,53 @@ function MemberCard({
         { backgroundColor: colors.surface, borderColor: colors.border },
       ]}
     >
-      {/* Top row: avatar + name + assignee chip */}
-      <View style={styles.cardTopRow}>
-        <Avatar
-          name={`${member.firstName} ${member.lastName}`.trim()}
-          imageUrl={member.avatarUrl}
-          size={40}
-        />
-        <View style={styles.cardTopRowText}>
+      <Avatar
+        name={`${member.firstName} ${member.lastName}`.trim()}
+        imageUrl={member.avatarUrl}
+        size={42}
+      />
+
+      <View style={styles.cardBody}>
+        {/* Row 1: full name + reach out */}
+        <View style={styles.cardTitleRow}>
           <Text
             style={[styles.cardName, { color: colors.text }]}
             numberOfLines={1}
           >
             {member.firstName} {member.lastName}
           </Text>
-          <Pressable onPress={onAssign} hitSlop={6}>
-            {assigneeIds.length === 0 ? (
-              <Text
-                style={[styles.assigneeUnassigned, { color: colors.textTertiary }]}
-              >
-                Unassigned · tap to assign
-              </Text>
-            ) : groupLeaderAssignees.length > 0 ? (
-              <View style={styles.assigneeRow}>
-                <Ionicons name="star" size={11} color={primaryColor} />
-                <Text
-                  style={[styles.assigneeText, { color: colors.textSecondary }]}
-                  numberOfLines={1}
-                >
-                  {groupLeaderAssignees
-                    .map((id) => {
-                      const l = leaderMap.get(id);
-                      return l ? `${l.firstName} ${l.lastName}`.trim() : "";
-                    })
-                    .filter(Boolean)
-                    .join(", ")}
-                  {communityOnlyAssignees.length > 0 &&
-                    `  +${communityOnlyAssignees.length} community`}
-                </Text>
-              </View>
-            ) : (
-              <View style={styles.assigneeRow}>
-                <Ionicons
-                  name="alert-circle-outline"
-                  size={11}
-                  color={colors.warning}
-                />
-                <Text
-                  style={[styles.assigneeText, { color: colors.warning }]}
-                  numberOfLines={1}
-                >
-                  No group leader · {leaderMap.get(communityOnlyAssignees[0])?.firstName ?? "community"}
-                </Text>
-              </View>
-            )}
+          <Pressable
+            onPress={onReachOut}
+            style={[
+              styles.reachOutBtn,
+              { backgroundColor: primaryColor + "1A", borderColor: primaryColor },
+            ]}
+            hitSlop={4}
+          >
+            <Text style={[styles.reachOutBtnText, { color: primaryColor }]}>
+              Reach out
+            </Text>
+            <Ionicons name="arrow-forward" size={12} color={primaryColor} />
           </Pressable>
         </View>
-      </View>
 
-      {/* Scores */}
-      <View style={styles.scoresRow}>
-        <View style={styles.scoreCol}>
-          <Text style={[styles.scoreLabel, { color: colors.textTertiary }]}>
-            Connection
+        {/* Row 2: assignee + reason */}
+        <Pressable onPress={onAssign} hitSlop={6} style={styles.cardSubRow}>
+          <View style={styles.cardSubAssignee}>{assigneeNode}</View>
+          <Text style={[styles.cardSubDivider, { color: colors.textTertiary }]}>
+            ·
           </Text>
-          <View style={styles.scoreValueRow}>
+          <Text
+            style={[styles.reasonLine, { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            {reasonLine}
+          </Text>
+        </Pressable>
+
+        {/* Row 3: scores as an inline strip */}
+        <View style={styles.scoresRow}>
+          <View style={styles.metric}>
             <View
               style={[
                 styles.scoreDot,
@@ -581,74 +616,39 @@ function MemberCard({
               ]}
             />
             <Text
-              style={[
-                styles.scoreValueHero,
-                { color: scoreColor(connection, colors) },
-              ]}
+              style={[styles.metricValue, { color: scoreColor(connection, colors) }]}
             >
               {Math.round(connection)}
             </Text>
+            <Text
+              style={[styles.metricTag, { color: scoreColor(connection, colors) }]}
+            >
+              {connectionLabel}
+            </Text>
           </View>
-          <Text
-            style={[
-              styles.scoreSubLabel,
-              { color: scoreColor(connection, colors) },
-            ]}
-          >
-            {connectionLabel}
-          </Text>
-        </View>
 
-        <View style={styles.scoreCol}>
-          <Text style={[styles.scoreLabel, { color: colors.textTertiary }]}>
-            Attendance
-          </Text>
-          <Text
-            style={[
-              styles.scoreValueSecondary,
-              { color: scoreColor(attendance, colors) },
-            ]}
-          >
-            {Math.round(attendance)}%
-          </Text>
-        </View>
+          <View style={styles.metric}>
+            <Text
+              style={[styles.metricValue, { color: scoreColor(attendance, colors) }]}
+            >
+              {Math.round(attendance)}%
+            </Text>
+            <Text style={[styles.metricLabel, { color: colors.textTertiary }]}>
+              att
+            </Text>
+          </View>
 
-        <View style={styles.scoreCol}>
-          <Text style={[styles.scoreLabel, { color: colors.textTertiary }]}>
-            Serving
-          </Text>
-          <Text
-            style={[
-              styles.scoreValueSecondary,
-              { color: scoreColor(service, colors) },
-            ]}
-          >
-            {Math.round(service)}%
-          </Text>
+          <View style={styles.metric}>
+            <Text
+              style={[styles.metricValue, { color: scoreColor(service, colors) }]}
+            >
+              {Math.round(service)}%
+            </Text>
+            <Text style={[styles.metricLabel, { color: colors.textTertiary }]}>
+              serve
+            </Text>
+          </View>
         </View>
-      </View>
-
-      {/* Reason + reach out */}
-      <View style={styles.cardFooter}>
-        <Text
-          style={[styles.reasonLine, { color: colors.textSecondary }]}
-          numberOfLines={1}
-        >
-          {reasonLine}
-        </Text>
-        <Pressable
-          onPress={onReachOut}
-          style={[
-            styles.reachOutBtn,
-            { backgroundColor: primaryColor + "1A", borderColor: primaryColor },
-          ]}
-          hitSlop={4}
-        >
-          <Text style={[styles.reachOutBtnText, { color: primaryColor }]}>
-            Reach out
-          </Text>
-          <Ionicons name="arrow-forward" size={12} color={primaryColor} />
-        </Pressable>
       </View>
     </TouchableOpacity>
   );
@@ -1094,50 +1094,26 @@ const styles = StyleSheet.create({
   sectionHeaderLeft: { flexDirection: "row", alignItems: "center", gap: 6 },
   sectionTitle: { fontSize: 11, fontWeight: "700", letterSpacing: 0.5 },
   cardList: { gap: 8 },
+  // Compact card: avatar on the left, a three-row body (name+action,
+  // assignee+reason, inline scores) on the right. Roughly half the height of
+  // the old stacked-column layout so more people are visible at once.
   card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 11,
     borderRadius: 14,
     borderWidth: StyleSheet.hairlineWidth,
-    padding: 12,
-    gap: 10,
+    padding: 11,
   },
-  cardTopRow: { flexDirection: "row", alignItems: "center", gap: 10 },
-  cardTopRowText: { flex: 1 },
-  cardName: { fontSize: 15, fontWeight: "600" },
-  assigneeUnassigned: { fontSize: 12, marginTop: 2 },
-  assigneeRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    marginTop: 2,
-  },
+  cardBody: { flex: 1, gap: 3 },
+  cardTitleRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  cardName: { flex: 1, fontSize: 15, fontWeight: "600" },
+  cardSubRow: { flexDirection: "row", alignItems: "center", gap: 5 },
+  cardSubAssignee: { flexShrink: 1 },
+  cardSubDivider: { fontSize: 12 },
+  assigneeRow: { flexDirection: "row", alignItems: "center", gap: 4 },
   assigneeText: { fontSize: 12, flexShrink: 1 },
-  scoresRow: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    justifyContent: "space-between",
-    gap: 12,
-    paddingHorizontal: 4,
-  },
-  scoreCol: { flex: 1, alignItems: "flex-start" },
-  scoreLabel: {
-    fontSize: 10,
-    fontWeight: "600",
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-    marginBottom: 2,
-  },
-  scoreValueRow: { flexDirection: "row", alignItems: "center", gap: 6 },
-  scoreDot: { width: 6, height: 6, borderRadius: 3 },
-  scoreValueHero: { fontSize: 26, fontWeight: "700", lineHeight: 30 },
-  scoreSubLabel: { fontSize: 10, fontWeight: "600", marginTop: 0 },
-  scoreValueSecondary: { fontSize: 16, fontWeight: "600", marginTop: 2 },
-  cardFooter: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 8,
-  },
-  reasonLine: { fontSize: 12, flex: 1 },
+  reasonLine: { fontSize: 12, flexShrink: 1 },
   reachOutBtn: {
     flexDirection: "row",
     alignItems: "center",
@@ -1148,6 +1124,31 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
   },
   reachOutBtnText: { fontSize: 12, fontWeight: "600" },
+  scoresRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 16,
+    marginTop: 2,
+  },
+  metric: { flexDirection: "row", alignItems: "center", gap: 5 },
+  scoreDot: { width: 6, height: 6, borderRadius: 3 },
+  metricValue: {
+    fontSize: 15,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  metricLabel: {
+    fontSize: 10,
+    fontWeight: "600",
+    letterSpacing: 0.3,
+    textTransform: "uppercase",
+  },
+  metricTag: {
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+    textTransform: "uppercase",
+  },
 
   // Modal / sheet
   modalBackdrop: {

--- a/apps/mobile/features/people/components/PeopleTabScreen.tsx
+++ b/apps/mobile/features/people/components/PeopleTabScreen.tsx
@@ -8,12 +8,17 @@ import { FollowupMobileCards } from "@features/leader-tools/components/FollowupM
 
 export function PeopleTabScreen({
   showAllMembers = false,
+  embedded = false,
 }: {
   // Leader-tools People tab (default) pins the roster to the current leader's
   // assigned members. The admin "People" surface passes showAllMembers so
   // admins see the whole community roster (this is the merged Admin → People
   // view — the same check-in roster, unfiltered).
   showAllMembers?: boolean;
+  // True when rendered inside the Admin screen, which already applies the top
+  // safe-area inset via its header. Forwarded to the native card list so it
+  // doesn't add the inset a second time.
+  embedded?: boolean;
 } = {}) {
   const { user, community } = useAuth();
   const currentUserId = user?.id;
@@ -59,6 +64,7 @@ export function PeopleTabScreen({
       enforcedAssigneeUserId={enforcedAssigneeUserId}
       returnTo={returnTo}
       hideHeader
+      embedded={embedded}
     />
   );
 }


### PR DESCRIPTION
## What & why

The **Admin → People** roster wasted vertical space: a large empty gap above the search bar, and tall person cards that showed only ~2–3 people per screen. This reworks the native card layout so ~5–6 people are visible at once, with the same information per person.

## Changes

**1. Remove the empty white gap above the search bar**
The gap came from applying the top safe-area inset **twice**. `FollowupMobileCards` added `paddingTop: insets.top` in the `hideHeader` case, but on the Admin → People surface it renders *under* `AdminScreen`'s header, which already consumes the inset. Removing it outright would break the standalone `(tabs)/people` route (reachable via deep links / `returnTo`), which renders the card list at the very top of the screen and genuinely needs the inset. So this adds an `embedded` prop:

- `FollowupMobileCards` only applies the top inset when `hideHeader && !embedded` (i.e. it's the top-most element).
- `PeopleTabScreen` forwards a new `embedded` prop through.
- `AdminScreen` renders `<PeopleTabScreen showAllMembers embedded />`.

**2. Thinner `MemberCard` — same info, ~half the height**
The old card stacked three tall blocks (avatar+name row → big score columns → footer). It's now the avatar beside a compact three-row body:

- **Row 1:** full name + `Reach out` (top-right)
- **Row 2:** assignee state (`Unassigned · tap to assign` / `★ leader` / `⚠ no group leader`) · follow-up reason
- **Row 3:** the three scores as one inline strip — `● 0 low · 0% att · 0% serve`

The 26px hero connection number becomes a 15px inline value but keeps its color-coded dot and `low/watch/strong` tag; attendance and serving stay color-coded by health. Nothing was dropped — avatar, full name, all three scores, assignee, reason, and Reach out are all still there.

The web `FollowupDesktopTable` is a separate table presentation with neither issue, so it's unchanged.

## Verification

- `tsc --noEmit` — clean for all three changed files (pre-existing repo-wide `@togather/shared`/chat/tasks errors are unrelated).
- `eslint` — 0 errors on the changed files.
- Full mobile test suite via the pre-push hook — **1243 passed / 133 suites / 2 snapshots**; `AdminScreen` tests pass.
- `check-native-imports.js` — passes (no new native deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBFJYzXyAom6whGQX6pAuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBFJYzXyAom6whGQX6pAuQ)_