### PR TITLE
Harden community archival: full lockout, type-to-confirm, community-only exit

### DIFF
--- a/apps/convex/__tests__/community-archival.test.ts
+++ b/apps/convex/__tests__/community-archival.test.ts
@@ -220,11 +220,44 @@ describe("archiveCommunity mutation", () => {
       communityId: setup.communityId,
     });
 
-    const after = await t.query(api.functions.admin.settings.getCommunitySettings, {
+    // Once archived, even the admin settings endpoints reject by id — the
+    // community is inaccessible. Verify the flag directly instead.
+    await expect(
+      t.query(api.functions.admin.settings.getCommunitySettings, {
+        token: setup.primaryAdminToken,
+        communityId: setup.communityId,
+      })
+    ).rejects.toThrow("COMMUNITY_ARCHIVED");
+    const community = await t.run((ctx) => ctx.db.get(setup.communityId));
+    expect(community?.isArchived).toBe(true);
+  });
+
+  test("admin-by-id paths reject an archived community", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+
+    await t.mutation(api.functions.admin.settings.archiveCommunity, {
       token: setup.primaryAdminToken,
       communityId: setup.communityId,
     });
-    expect(after.isArchived).toBe(true);
+
+    // Editing settings by id is blocked even with a valid admin token that is
+    // NOT scoped to the archived community (requireCommunityAdmin gate).
+    await expect(
+      t.mutation(api.functions.admin.settings.updateCommunitySettings, {
+        token: setup.primaryAdminToken,
+        communityId: setup.communityId,
+        name: "Renamed",
+      })
+    ).rejects.toThrow("COMMUNITY_ARCHIVED");
+
+    // Browsing the member list by id is likewise blocked.
+    await expect(
+      t.query(api.functions.communities.getMembers, {
+        token: setup.memberToken,
+        communityId: setup.communityId,
+      })
+    ).rejects.toThrow("COMMUNITY_ARCHIVED");
   });
 });
 

--- a/apps/convex/__tests__/community-archival.test.ts
+++ b/apps/convex/__tests__/community-archival.test.ts
@@ -403,3 +403,81 @@ describe("archived communities block additional entry paths", () => {
     ).rejects.toThrow("not available");
   });
 });
+
+// ============================================================================
+// A live session scoped to an archived community is hard-blocked
+// ============================================================================
+
+describe("archived communities are inaccessible to a live session", () => {
+  test("requireAuth rejects a request scoped to an archived community", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+    // A real login mints a token scoped to the active community.
+    const scopedToken = (
+      await generateTokens(setup.memberId, setup.communityId)
+    ).accessToken;
+
+    // Works before archiving.
+    await t.mutation(api.functions.users.recordActivity, { token: scopedToken });
+
+    await t.mutation(api.functions.admin.settings.archiveCommunity, {
+      token: setup.primaryAdminToken,
+      communityId: setup.communityId,
+    });
+
+    // Any community-scoped request is now hard-blocked, even with a still-valid
+    // 30-day access token.
+    await expect(
+      t.mutation(api.functions.users.recordActivity, { token: scopedToken })
+    ).rejects.toThrow("COMMUNITY_ARCHIVED");
+  });
+
+  test("escape hatches still work with an archived-scoped token", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+    const scopedToken = (
+      await generateTokens(setup.memberId, setup.communityId)
+    ).accessToken;
+
+    await t.mutation(api.functions.admin.settings.archiveCommunity, {
+      token: setup.primaryAdminToken,
+      communityId: setup.communityId,
+    });
+
+    // Listing communities and clearing the active community must still work so
+    // the stuck user can get to community selection.
+    await expect(
+      t.query(api.functions.communities.listForUser, { token: scopedToken })
+    ).resolves.toBeDefined();
+    await expect(
+      t.mutation(api.functions.users.clearActiveCommunity, { token: scopedToken })
+    ).resolves.toEqual({ success: true });
+  });
+
+  test("users.me hides an archived active community and flags it", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+    // Point the member's stored active community at the one we'll archive.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(setup.memberId, {
+        activeCommunityId: setup.communityId,
+      });
+    });
+
+    await t.mutation(api.functions.admin.settings.archiveCommunity, {
+      token: setup.primaryAdminToken,
+      communityId: setup.communityId,
+    });
+
+    const me = await t.query(api.functions.users.me, {
+      token: setup.memberToken,
+    });
+    expect(me?.activeCommunityArchived).toBe(true);
+    expect(me?.activeCommunityId).toBeNull();
+    expect(
+      (me?.communityMemberships ?? []).some(
+        (m: any) => m.communityId === setup.communityId
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/convex/auth.ts
+++ b/apps/convex/auth.ts
@@ -16,6 +16,7 @@
 // Re-export auth helpers from lib/auth.ts
 export {
   requireAuth,
+  requireAuthAllowArchivedCommunity,
   requireAuthIgnoringRevocation,
   getOptionalAuth,
   requireAuthUser,

--- a/apps/convex/functions/authInternal.ts
+++ b/apps/convex/functions/authInternal.ts
@@ -16,7 +16,11 @@ import {
 } from "../_generated/server";
 import { api, internal } from "../_generated/api";
 import { now, normalizePhone, getMediaUrl, buildSearchText } from "../lib/utils";
-import { requireAuth, requireAuthIgnoringRevocation } from "../auth";
+import {
+  requireAuth,
+  requireAuthAllowArchivedCommunity,
+  requireAuthIgnoringRevocation,
+} from "../auth";
 import {
   isRevokedForJwtSubject,
   REFRESH_TOKEN_MAX_AGE_MS,
@@ -1051,7 +1055,9 @@ export const selectCommunityForUser = mutation({
     communityId: string;
     communityName: string;
   }> => {
-    const userId = await requireAuth(ctx, args.token);
+    // Escape hatch: allow switching away even when the caller's current token
+    // is scoped to an archived community. The target is archived-checked below.
+    const userId = await requireAuthAllowArchivedCommunity(ctx, args.token);
 
     // Verify community exists
     const community = await ctx.db.get(args.communityId);

--- a/apps/convex/functions/communities.ts
+++ b/apps/convex/functions/communities.ts
@@ -10,7 +10,7 @@ import { api, internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { now, normalizePagination } from "../lib/utils";
 import { paginationArgs } from "../lib/validators";
-import { requireAuth } from "../lib/auth";
+import { requireAuth, requireAuthAllowArchivedCommunity } from "../lib/auth";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ADMIN_THRESHOLD, PRIMARY_ADMIN_ROLE } from "../lib/permissions";
 import { syncUserChannelMembershipsLogic, syncAnnouncementGroupMembership } from "./sync/memberships";
@@ -245,7 +245,9 @@ export const listForUser = query({
     ...paginationArgs,
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuth(ctx, args.token);
+    // Escape hatch: a user whose active community was archived must still be
+    // able to list their communities to switch away.
+    const userId = await requireAuthAllowArchivedCommunity(ctx, args.token);
     const { limit } = normalizePagination(args);
 
     // Only get active memberships (status=1)
@@ -432,7 +434,9 @@ export const join = mutation({
       communityId: args.communityId,
     });
 
-    const userId = await requireAuth(ctx, args.token);
+    // Escape hatch: allow a user whose active community was archived to join a
+    // different community. The target is still archived-checked below.
+    const userId = await requireAuthAllowArchivedCommunity(ctx, args.token);
     const timestamp = now();
 
     console.log("[communities.join] Authenticated user", {
@@ -775,7 +779,8 @@ export const leave = mutation({
     communityId: v.id("communities"),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuth(ctx, args.token);
+    // Escape hatch: a user can leave a community even if it's archived.
+    const userId = await requireAuthAllowArchivedCommunity(ctx, args.token);
 
     const membership = await ctx.db
       .query("userCommunities")

--- a/apps/convex/functions/communities.ts
+++ b/apps/convex/functions/communities.ts
@@ -11,6 +11,7 @@ import { Id } from "../_generated/dataModel";
 import { now, normalizePagination } from "../lib/utils";
 import { paginationArgs } from "../lib/validators";
 import { requireAuth, requireAuthAllowArchivedCommunity } from "../lib/auth";
+import { assertCommunityNotArchived } from "../lib/permissions";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ADMIN_THRESHOLD, PRIMARY_ADMIN_ROLE } from "../lib/permissions";
 import { syncUserChannelMembershipsLogic, syncAnnouncementGroupMembership } from "./sync/memberships";
@@ -309,6 +310,9 @@ export const getMembers = query({
   handler: async (ctx, args) => {
     // Require authentication
     const userId = await requireAuth(ctx, args.token);
+
+    // Archived (closed) communities are inaccessible even by id.
+    await assertCommunityNotArchived(ctx, args.communityId);
 
     // Verify caller is a member of this community
     const callerMembership = await ctx.db

--- a/apps/convex/functions/communityPeople.ts
+++ b/apps/convex/functions/communityPeople.ts
@@ -50,6 +50,12 @@ async function requireCommunityMember(
     throw new ConvexError("Not a community member");
   }
 
+  // Archived (closed) communities are inaccessible even to members.
+  const community = await ctx.db.get(communityId);
+  if (community?.isArchived) {
+    throw new ConvexError("COMMUNITY_ARCHIVED");
+  }
+
   return membership;
 }
 

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -246,6 +246,11 @@ export async function requireCommunityMember(
   if (!membership || membership.status !== 1) {
     throw new ConvexError("You must be a member of this community");
   }
+  // Archived (closed) communities are inaccessible even to members.
+  const community = await ctx.db.get(communityId);
+  if (community?.isArchived) {
+    throw new ConvexError("COMMUNITY_ARCHIVED");
+  }
 }
 
 /**

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -15,7 +15,11 @@ import { query, mutation, internalMutation, internalQuery } from "../_generated/
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 import { now, normalizePhone, getMediaUrl, buildSearchText } from "../lib/utils";
-import { requireAuth, getOptionalAuth } from "../lib/auth";
+import {
+  requireAuth,
+  requireAuthAllowArchivedCommunity,
+  getOptionalAuth,
+} from "../lib/auth";
 import { parseDate } from "../lib/validation";
 import { COMMUNITY_ROLES, COMMUNITY_ADMIN_THRESHOLD } from "../lib/permissions";
 import { adjustEnabledCounter } from "../lib/notifications/enabledCounter";
@@ -529,7 +533,9 @@ export const update = mutation({
 export const clearActiveCommunity = mutation({
   args: { token: v.string() },
   handler: async (ctx, args) => {
-    const userId = await requireAuth(ctx, args.token);
+    // Escape hatch: dropping the active community must work even when that
+    // community is archived (this is how a stuck user gets to selection).
+    const userId = await requireAuthAllowArchivedCommunity(ctx, args.token);
 
     await ctx.db.patch(userId, {
       activeCommunityId: undefined,
@@ -642,6 +648,9 @@ export const me = query({
       memberships.map(async (membership) => {
         const community = await ctx.db.get(membership.communityId);
         if (!community) return null;
+        // Archived (closed) communities are hidden — never listed as one of the
+        // user's communities, so the switcher/selection can't re-enter them.
+        if (community.isArchived) return null;
         const roleLevel = membership.roles ?? COMMUNITY_ROLES.MEMBER;
         return {
           communityId: community._id,
@@ -662,10 +671,19 @@ export const me = query({
     let activeCommunityPrimaryColor: string | null = null;
     let activeCommunitySecondaryColor: string | null = null;
     let activeCommunityChurchFeatures: { prayerEnabled: boolean } | null = null;
+    // When the active community has been archived (closed), surface it as if the
+    // user has no active community, so the client drops to community selection
+    // instead of resuming into a dead community. `activeCommunityArchived` lets
+    // the client react explicitly (clear it + navigate to selection).
+    let activeCommunityArchived = false;
+    let effectiveActiveCommunityId = user.activeCommunityId || null;
 
     if (user.activeCommunityId) {
       const activeCommunity = await ctx.db.get(user.activeCommunityId);
-      if (activeCommunity) {
+      if (activeCommunity?.isArchived) {
+        activeCommunityArchived = true;
+        effectiveActiveCommunityId = null;
+      } else if (activeCommunity) {
         activeCommunityName = activeCommunity.name || null;
         activeCommunityPrimaryColor = activeCommunity.primaryColor || null;
         activeCommunitySecondaryColor = activeCommunity.secondaryColor || null;
@@ -716,13 +734,16 @@ export const me = query({
       birthdayMonth: user.birthdayMonth ?? null,
       birthdayDay: user.birthdayDay ?? null,
       location: user.location ?? null,
-      activeCommunityId: user.activeCommunityId || null,
+      activeCommunityId: effectiveActiveCommunityId,
       activeCommunityName,
       activeCommunityPrimaryColor,
       activeCommunitySecondaryColor,
       // Legacy field name, kept for old-client back-compat (see comment above).
       activeCommunityKnicksMode: knicksMode,
       activeCommunityChurchFeatures,
+      // True when the user's stored active community has been archived — the
+      // client should clear it and route to community selection.
+      activeCommunityArchived,
       communityMemberships: communityMemberships.filter(Boolean),
     };
   },

--- a/apps/convex/lib/auth.ts
+++ b/apps/convex/lib/auth.ts
@@ -529,6 +529,45 @@ export async function requireAuth(
   ctx: QueryCtx | MutationCtx,
   token: string,
 ): Promise<Id<"users">> {
+  const { userId, communityId } = await requireAuthResolved(ctx, token);
+
+  // Reject any request whose session is scoped to an archived (closed)
+  // community. Archived communities must be inaccessible in every way — not
+  // just un-enterable — so a still-live JWT (access tokens last 30 days) can't
+  // keep reading/writing community data. Users escape by switching or leaving,
+  // which use requireAuthAllowArchivedCommunity below.
+  if (communityId && (await isCommunityArchived(ctx, communityId))) {
+    throw new ConvexError("COMMUNITY_ARCHIVED");
+  }
+
+  return userId;
+}
+
+/**
+ * Like {@link requireAuth} but does NOT reject when the token is scoped to an
+ * archived community. Use ONLY for the handful of "escape hatch" operations a
+ * user stuck in an archived community needs to get out — listing their
+ * communities, clearing/switching the active community, leaving, or joining a
+ * different (non-archived) community. Every one of those still independently
+ * rejects an archived *target* community, so this does not weaken the block.
+ */
+export async function requireAuthAllowArchivedCommunity(
+  ctx: QueryCtx | MutationCtx,
+  token: string,
+): Promise<Id<"users">> {
+  const { userId } = await requireAuthResolved(ctx, token);
+  return userId;
+}
+
+/**
+ * Shared core for {@link requireAuth}: verifies the access token, resolves the
+ * user, and enforces revocation. Returns the userId plus the community the
+ * token is scoped to (if any), without applying the archived-community gate.
+ */
+async function requireAuthResolved(
+  ctx: QueryCtx | MutationCtx,
+  token: string,
+): Promise<{ userId: Id<"users">; communityId?: string }> {
   if (!token) {
     throw new ConvexError("Not authenticated");
   }
@@ -549,7 +588,24 @@ export async function requireAuth(
     throw new ConvexError("Not authenticated");
   }
 
-  return userId;
+  return { userId, communityId: payload.communityId };
+}
+
+/**
+ * Whether the given community id (a string from a JWT) points to an archived
+ * community. Tolerates malformed ids by returning false — a bad id fails other
+ * checks, and we never want to mistakenly hard-block a valid session.
+ */
+async function isCommunityArchived(
+  ctx: QueryCtx | MutationCtx,
+  communityId: string,
+): Promise<boolean> {
+  try {
+    const community = await ctx.db.get(communityId as Id<"communities">);
+    return community?.isArchived === true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/apps/convex/lib/permissions.ts
+++ b/apps/convex/lib/permissions.ts
@@ -12,6 +12,7 @@
  * - communityWideEvents.ts
  */
 
+import { ConvexError } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 
 // ============================================================================
@@ -59,6 +60,28 @@ export const LEADER_ROLES = ["leader"] as const;
 // ============================================================================
 // Permission Check Helpers
 // ============================================================================
+
+/**
+ * Throw if the target community has been archived (closed).
+ *
+ * The universal `requireAuth` gate (lib/auth.ts) already rejects any request
+ * whose JWT is *scoped* to an archived community, which covers all normal
+ * sessions. This helper closes the complementary by-id vector: a caller holding
+ * a community-less or other-community token that passes an archived community's
+ * id as an argument. It's wired into the shared authorization helpers below
+ * (admin/member checks) so those paths reject archived communities regardless
+ * of token scope. Throws the same `COMMUNITY_ARCHIVED` error the client uses to
+ * route users back to community selection.
+ */
+export async function assertCommunityNotArchived(
+  ctx: { db: any },
+  communityId: Id<"communities">
+): Promise<void> {
+  const community = await ctx.db.get(communityId);
+  if (community?.isArchived) {
+    throw new ConvexError("COMMUNITY_ARCHIVED");
+  }
+}
 
 /**
  * Check if user is a community admin (Admin or Primary Admin).
@@ -129,6 +152,8 @@ export async function requireCommunityAdmin(
   if (!isAdmin) {
     throw new Error("Community admin role required");
   }
+  // Even an admin cannot act on an archived (closed) community.
+  await assertCommunityNotArchived(ctx, communityId);
 }
 
 /**

--- a/apps/mobile/features/admin/components/ArchiveCommunityModal.tsx
+++ b/apps/mobile/features/admin/components/ArchiveCommunityModal.tsx
@@ -1,0 +1,194 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { CustomModal } from "@/components/ui/Modal";
+import { useTheme } from "@hooks/useTheme";
+
+interface ArchiveCommunityModalProps {
+  visible: boolean;
+  communityName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+/**
+ * Destructive confirmation for archiving (closing) a whole community. Requires
+ * the admin to type the community's exact name before the Archive button
+ * enables — a deliberate friction gate because archiving is permanent and
+ * locks everyone (including them) out.
+ */
+export function ArchiveCommunityModal({
+  visible,
+  communityName,
+  onCancel,
+  onConfirm,
+  isLoading = false,
+}: ArchiveCommunityModalProps) {
+  const { colors } = useTheme();
+  const [typedName, setTypedName] = useState("");
+
+  // Reset the field whenever the modal is (re)opened so a prior attempt's text
+  // never lingers.
+  useEffect(() => {
+    if (visible) setTypedName("");
+  }, [visible]);
+
+  const matches =
+    typedName.trim().toLowerCase() === communityName.trim().toLowerCase() &&
+    communityName.trim().length > 0;
+  const canArchive = matches && !isLoading;
+
+  return (
+    <CustomModal
+      visible={visible}
+      onClose={onCancel}
+      withoutCloseBtn
+      contentPadding="24"
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <View style={styles.content}>
+          <View style={styles.iconContainer}>
+            <Ionicons name="warning" size={48} color={colors.error} />
+          </View>
+
+          <Text style={[styles.title, { color: colors.text }]}>
+            Archive {communityName}?
+          </Text>
+
+          <Text style={[styles.description, { color: colors.textSecondary }]}>
+            This closes the community permanently. No one — including you — will
+            be able to log in, and it will disappear from search. This cannot be
+            undone from the app.
+          </Text>
+
+          <Text style={[styles.prompt, { color: colors.textSecondary }]}>
+            Type <Text style={[styles.promptName, { color: colors.text }]}>{communityName}</Text> to confirm.
+          </Text>
+
+          <TextInput
+            style={[
+              styles.input,
+              {
+                backgroundColor: colors.inputBackground,
+                color: colors.text,
+                borderColor: matches ? colors.error : colors.inputBorder,
+              },
+            ]}
+            value={typedName}
+            onChangeText={setTypedName}
+            placeholder={communityName}
+            placeholderTextColor={colors.inputPlaceholder}
+            autoCapitalize="none"
+            autoCorrect={false}
+            editable={!isLoading}
+          />
+
+          <View style={styles.buttonRow}>
+            <TouchableOpacity
+              style={[styles.cancelButton, { backgroundColor: colors.surfaceSecondary }]}
+              onPress={onCancel}
+              disabled={isLoading}
+            >
+              <Text style={[styles.cancelButtonText, { color: colors.text }]}>Cancel</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[
+                styles.archiveButton,
+                { backgroundColor: colors.error },
+                !canArchive && styles.buttonDisabled,
+              ]}
+              onPress={onConfirm}
+              disabled={!canArchive}
+            >
+              {isLoading ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <Text style={styles.archiveButtonText}>Archive Community</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </CustomModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: "center",
+  },
+  iconContainer: {
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  description: {
+    fontSize: 15,
+    textAlign: "center",
+    lineHeight: 22,
+    marginBottom: 20,
+  },
+  prompt: {
+    fontSize: 14,
+    textAlign: "center",
+    marginBottom: 8,
+    alignSelf: "stretch",
+  },
+  promptName: {
+    fontWeight: "700",
+  },
+  input: {
+    alignSelf: "stretch",
+    borderRadius: 8,
+    borderWidth: 1,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 24,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    alignSelf: "stretch",
+    gap: 12,
+  },
+  cancelButton: {
+    flex: 1,
+    borderRadius: 8,
+    padding: 14,
+    alignItems: "center",
+  },
+  cancelButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  archiveButton: {
+    flex: 1,
+    borderRadius: 8,
+    padding: 14,
+    alignItems: "center",
+  },
+  archiveButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#fff",
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+});

--- a/apps/mobile/features/admin/components/SettingsContent.tsx
+++ b/apps/mobile/features/admin/components/SettingsContent.tsx
@@ -33,6 +33,7 @@ import { ImagePicker } from "@components/ui";
 import * as Linking from "expo-linking";
 import { useCommunitySettings, useGroupTypes, GroupType } from "../hooks";
 import { GroupTypeEditModal } from "./GroupTypeEditModal";
+import { ArchiveCommunityModal } from "./ArchiveCommunityModal";
 import { useAvailableIntegrations } from "../../integrations/hooks/useIntegrations";
 import { ColorPicker } from "./ColorPicker";
 import { ColorPreview } from "./ColorPreview";
@@ -70,7 +71,7 @@ export function SettingsContent() {
   } = useGroupTypes();
 
   // Billing data
-  const { community, token, user, logout } = useAuth();
+  const { community, token, user, exitToCommunitySelection } = useAuth();
   const isPrimaryAdmin = user?.is_primary_admin ?? false;
   const billing = useQuery(
     api.functions.ee.billing.getSubscriptionStatus,
@@ -116,6 +117,7 @@ export function SettingsContent() {
 
   // Archive (close) community state
   const [isArchiving, setIsArchiving] = useState(false);
+  const [showArchiveModal, setShowArchiveModal] = useState(false);
 
   // Populate form with current settings
   useEffect(() => {
@@ -280,46 +282,17 @@ export function SettingsContent() {
     setIsArchiving(true);
     try {
       await archiveCommunity();
-      // The community is now closed for everyone, including this admin, so
-      // there's nowhere to return to — sign out and drop back to login.
-      Alert.alert(
-        "Community Archived",
-        "This community has been archived. You'll now be signed out.",
-        [{ text: "OK", onPress: () => logout() }],
-      );
+      // Archiving closes the community for everyone, but it should only sign
+      // the admin out of *this community*, not the whole app. Drop them to
+      // community selection (re-mints a community-less token + clears caches).
+      await exitToCommunitySelection();
+      setShowArchiveModal(false);
+      router.replace("/(auth)/select-community");
     } catch (error: any) {
-      setIsArchiving(false);
       Alert.alert("Error", formatError(error, "Failed to archive community"));
+    } finally {
+      setIsArchiving(false);
     }
-  };
-
-  const handleArchiveCommunity = () => {
-    const communityName = settings?.name || "this community";
-    // Two-step confirmation — archiving is permanent and locks everyone out.
-    Alert.alert(
-      "Archive Community?",
-      `Archiving "${communityName}" closes it permanently. No one — including you — will be able to log in, and it will disappear from search. This cannot be undone from the app.`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Continue",
-          style: "destructive",
-          onPress: () =>
-            Alert.alert(
-              "Are you absolutely sure?",
-              `This will archive "${communityName}" for everyone. There is no in-app way to reopen it.`,
-              [
-                { text: "Cancel", style: "cancel" },
-                {
-                  text: "Archive Community",
-                  style: "destructive",
-                  onPress: performArchive,
-                },
-              ],
-            ),
-        },
-      ],
-    );
   };
 
   const toggleExploreGroupType = (groupTypeId: string) => {
@@ -961,7 +934,7 @@ export function SettingsContent() {
             </Text>
             <TouchableOpacity
               style={[styles.dangerButton, { borderColor: colors.error }, isArchiving && styles.saveButtonDisabled]}
-              onPress={handleArchiveCommunity}
+              onPress={() => setShowArchiveModal(true)}
               disabled={isArchiving}
             >
               {isArchiving ? (
@@ -1009,6 +982,17 @@ export function SettingsContent() {
         }}
         onSave={handleSaveGroupType}
         isSaving={isUpdatingGroupType || isCreating}
+      />
+
+      {/* Archive Community confirmation (type-to-confirm) */}
+      <ArchiveCommunityModal
+        visible={showArchiveModal}
+        communityName={settings?.name || ""}
+        onCancel={() => {
+          if (!isArchiving) setShowArchiveModal(false);
+        }}
+        onConfirm={performArchive}
+        isLoading={isArchiving}
       />
     </View>
   );

--- a/apps/mobile/providers/AuthProvider.tsx
+++ b/apps/mobile/providers/AuthProvider.tsx
@@ -92,6 +92,7 @@ interface AuthContextType {
   refreshUser: () => Promise<void>;
   setCommunity: (community: Community) => Promise<void>;
   clearCommunity: () => Promise<void>;
+  exitToCommunitySelection: () => Promise<void>;
   signIn: (userId: string, tokens?: { accessToken?: string; refreshToken?: string }) => Promise<void>;
 }
 
@@ -812,6 +813,57 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [queryClient, token]);
 
   /**
+   * Leave the current community WITHOUT logging out of the app — used when the
+   * active community becomes archived (closed). Unlike `clearCommunity`, this
+   * also re-mints a community-less access token (so requests stop being scoped
+   * to the archived community, which the server now hard-rejects) and wipes the
+   * per-community caches so no stale, archived content stays browsable. The
+   * caller is responsible for navigating to community selection afterward.
+   */
+  const exitToCommunitySelection = useCallback(async () => {
+    console.log("🔄 AuthProvider: Exiting to community selection (archived)");
+
+    // Clear the server-side active community (tolerated for archived).
+    await clearCommunity();
+
+    // Re-mint a token with NO community so requireAuth stops rejecting requests
+    // as COMMUNITY_ARCHIVED while the user is on the selection screen.
+    await refreshAuthTokens();
+
+    // Wipe per-community caches (mirror logout's cache teardown, minus the auth
+    // tokens/user) so archived-community data isn't left browsable offline.
+    await clearCachedProfile();
+    await Promise.all(
+      [
+        "inbox-cache",
+        "message-cache",
+        "group-cache",
+        "channels-cache",
+        "runsheet-cache",
+        "serving-runsheet-cache",
+        "serving-tasks-cache",
+        "serving-task-queue",
+        "grid-column-widths",
+      ].map((key) =>
+        AsyncStorage.removeItem(key).catch((err) =>
+          console.warn(`Failed to remove ${key}:`, err)
+        )
+      )
+    );
+    useInboxCache.getState().clear();
+    useMessageCache.getState().clearAll();
+    useGroupCache.getState().clearAll();
+    useChannelsCache.getState().clearAll();
+    useRunSheetCache.getState().clearAll();
+    useServingRunSheetCache.getState().clearAll();
+    useServingTasksCache.getState().clearAll();
+    useServingTaskQueue.getState().clear();
+    useGridColumnWidths.getState().clearAll();
+
+    setCommunityState(null);
+  }, [clearCommunity, refreshAuthTokens]);
+
+  /**
    * Initialize auth state on mount
    */
   useEffect(() => {
@@ -1088,6 +1140,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       refreshUser,
       setCommunity,
       clearCommunity,
+      exitToCommunitySelection,
       signIn,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- token excluded to prevent app-wide re-renders on JWT refresh
@@ -1100,6 +1153,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       refreshUser,
       setCommunity,
       clearCommunity,
+      exitToCommunitySelection,
       signIn,
     ]
   );
@@ -1137,6 +1191,9 @@ export function useAuth() {
         throw new Error("AuthProvider not available");
       },
       clearCommunity: async () => {
+        throw new Error("AuthProvider not available");
+      },
+      exitToCommunitySelection: async () => {
         throw new Error("AuthProvider not available");
       },
       signIn: async () => {


### PR DESCRIPTION
Follow-up to #580 fixing three gaps in the archive-community flow.

## 1. Type-to-confirm before archiving
Replaces the two-step `Alert` with a new `ArchiveCommunityModal` that requires the admin to type the community's **exact name** before the Archive button enables (GitHub-delete-repo style friction).

## 2. Archiving exits the community, not the whole app
Previously archiving called `logout()`. Now it drops the admin to **community selection** while keeping them signed in: a new `AuthProvider.exitToCommunitySelection()` clears the active community, re-mints a **community-less** access token, and wipes the per-community caches (Zustand stores + AsyncStorage + cached profile), then the screen navigates to `/(auth)/select-community`.

## 3. Archived communities are truly inaccessible, not just un-enterable
The prior change blocked *entering* an archived community but a session already scoped to one could still read its data — access tokens live **30 days**, so that window was large.

- **`requireAuth`** now rejects any request whose JWT is scoped to an archived community (`COMMUNITY_ARCHIVED`). A new **`requireAuthAllowArchivedCommunity`** is used only by the "escape hatch" operations a stuck user needs — `listForUser`, `clearActiveCommunity`, `leave`, `join`, `selectCommunityForUser` — each of which still archived-checks its *target* community, so the block isn't weakened.
- **`users.me`** no longer surfaces an archived community: it's dropped from the memberships list and the active community resolves to `null`, with a new `activeCommunityArchived` flag. So a resumed session (or re-login) lands in community selection instead of back inside the dead community.

## Tests
Adds coverage for the live-session hard block (`COMMUNITY_ARCHIVED`), the escape hatches still working with an archived-scoped token, and `users.me` hiding the archived active community. **Full convex suite: 2246 passing.** Mobile AuthProvider tests: 40 passing; full mobile suite green on pre-push.

## Notes
- The escape-hatch allowlist is the only nuance of the `requireAuth` change; the full suite passing confirms no legitimate flow is caught by the new gate (a healthy session's token is never scoped to an archived community).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtiydC3XvDyW2dPvoiqcnH)_