### PR TITLE
Let admins delegate group join-request approval to leaders

### DIFF
--- a/apps/convex/__tests__/group-leader-approval.test.ts
+++ b/apps/convex/__tests__/group-leader-approval.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for the group-leader join-request approval mode.
+ *
+ * A group's `joinApprovalMode` controls who reviews its join requests:
+ *   - "admins" (default): community admins, via the admin dashboard.
+ *   - "leaders": the group's leaders, via the group-page Requests screen.
+ *
+ * These tests lock down the authorization boundary (leaders can only review
+ * when the group opts in) and the "full handoff" behavior (leaders-mode
+ * requests leave the admin dashboard).
+ */
+import { vi, expect, test, describe, beforeEach, afterEach } from "vitest";
+
+// Mock the jose library to bypass JWT verification in tests.
+// vi.mock is hoisted to the top of the file by Vitest.
+vi.mock("jose", () => ({
+  jwtVerify: vi.fn(async (token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) {
+      throw new Error("Invalid token");
+    }
+    return { payload: { userId: match[1], type: "access" } };
+  }),
+  SignJWT: vi.fn(() => ({
+    setProtectedHeader: vi.fn().mockReturnThis(),
+    setIssuedAt: vi.fn().mockReturnThis(),
+    setExpirationTime: vi.fn().mockReturnThis(),
+    sign: vi.fn().mockResolvedValue("mock-signed-token"),
+  })),
+  decodeJwt: vi.fn((token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) return null;
+    return { userId: match[1], type: "access" };
+  }),
+}));
+
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { modules } from "../test.setup";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+interface Setup {
+  communityId: Id<"communities">;
+  groupTypeId: Id<"groupTypes">;
+  groupId: Id<"groups">;
+  leaderId: Id<"users">;
+  memberId: Id<"users">;
+  requesterId: Id<"users">;
+  adminId: Id<"users">;
+  leaderToken: string;
+  memberToken: string;
+  adminToken: string;
+}
+
+async function setupData(t: ReturnType<typeof convexTest>): Promise<Setup> {
+  return await t.run(async (ctx) => {
+    const ts = Date.now();
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug: "test-community",
+      isPublic: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: "small-group",
+      isActive: true,
+      createdAt: ts,
+      displayOrder: 1,
+    });
+
+    const mkUser = async (first: string, phone: string) =>
+      ctx.db.insert("users", {
+        firstName: first,
+        lastName: "User",
+        email: `${first.toLowerCase()}@test.com`,
+        phone,
+        phoneVerified: true,
+        isActive: true,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+
+    const leaderId = await mkUser("Leader", "+12025551001");
+    const memberId = await mkUser("Member", "+12025551002");
+    const requesterId = await mkUser("Requester", "+12025551003");
+    const adminId = await mkUser("Admin", "+12025551004");
+
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Test Group",
+      isArchived: false,
+      isPublic: false,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: leaderId,
+      role: "leader",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: memberId,
+      role: "member",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+
+    // Community admin (roles >= 3).
+    await ctx.db.insert("userCommunities", {
+      userId: adminId,
+      communityId,
+      roles: 3,
+      status: 1,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    return {
+      communityId,
+      groupTypeId,
+      groupId,
+      leaderId,
+      memberId,
+      requesterId,
+      adminId,
+      leaderToken: `test-token-${leaderId}`,
+      memberToken: `test-token-${memberId}`,
+      adminToken: `test-token-${adminId}`,
+    };
+  });
+}
+
+async function createPendingRequest(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  userId: Id<"users">,
+): Promise<Id<"groupMembers">> {
+  return await t.run(async (ctx) => {
+    const ts = Date.now();
+    return ctx.db.insert("groupMembers", {
+      groupId,
+      userId,
+      role: "member",
+      joinedAt: ts,
+      leftAt: ts,
+      notificationsEnabled: true,
+      requestStatus: "pending",
+      requestedAt: ts,
+    });
+  });
+}
+
+async function setMode(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  mode: "admins" | "leaders",
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.patch(groupId, { joinApprovalMode: mode });
+  });
+}
+
+describe("Group leader approval — authorization", () => {
+  test("leader CANNOT review when mode is admins (default)", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+    const membershipId = await createPendingRequest(t, setup.groupId, setup.requesterId);
+
+    await expect(
+      t.mutation(api.functions.groupMembers.reviewGroupJoinRequest, {
+        token: setup.leaderToken,
+        groupId: setup.groupId,
+        membershipId,
+        action: "accept",
+      }),
+    ).rejects.toThrow(/not allowed/i);
+  });
+
+  test("leader CAN approve when mode is leaders", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+    await setMode(t, setup.groupId, "leaders");
+    const membershipId = await createPendingRequest(t, setup.groupId, setup.requesterId);
+
+    const result = await t.mutation(
+      api.functions.groupMembers.reviewGroupJoinRequest,
+      {
+        token: setup.leaderToken,
+        groupId: setup.groupId,
+        membershipId,
+        action: "accept",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("regular member CANNOT review even when mode is leaders", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+    await setMode(t, setup.groupId, "leaders");
+    const membershipId = await createPendingRequest(t, setup.groupId, setup.requesterId);
+
+    await expect(
+      t.mutation(api.functions.groupMembers.reviewGroupJoinRequest, {
+        token: setup.memberToken,
+        groupId: setup.groupId,
+        membershipId,
+        action: "accept",
+      }),
+    ).rejects.toThrow(/not allowed/i);
+  });
+
+  test("community admin CAN review via group page regardless of mode", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+    // default "admins" mode
+    const membershipId = await createPendingRequest(t, setup.groupId, setup.requesterId);
+
+    const result = await t.mutation(
+      api.functions.groupMembers.reviewGroupJoinRequest,
+      {
+        token: setup.adminToken,
+        groupId: setup.groupId,
+        membershipId,
+        action: "decline",
+      },
+    );
+
+    expect(result.status).toBe("declined");
+  });
+});
+
+describe("Group leader approval — listing visibility", () => {
+  test("leader sees pending requests only in leaders mode", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+    await createPendingRequest(t, setup.groupId, setup.requesterId);
+
+    // admins mode -> leader query returns empty
+    const beforeOptIn = await t.query(
+      api.functions.groupMembers.listGroupJoinRequests,
+      { token: setup.leaderToken, groupId: setup.groupId },
+    );
+    expect(beforeOptIn).toHaveLength(0);
+
+    await setMode(t, setup.groupId, "leaders");
+    const afterOptIn = await t.query(
+      api.functions.groupMembers.listGroupJoinRequests,
+      { token: setup.leaderToken, groupId: setup.groupId },
+    );
+    expect(afterOptIn).toHaveLength(1);
+    expect(afterOptIn[0].user?.id).toBe(setup.requesterId);
+  });
+
+  test("admin dashboard excludes leaders-mode requests (full handoff)", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+    await createPendingRequest(t, setup.groupId, setup.requesterId);
+
+    // admins mode -> appears in admin dashboard
+    const beforeHandoff = await t.query(
+      api.functions.admin.index.listPendingRequests,
+      { token: setup.adminToken, communityId: setup.communityId },
+    );
+    expect(beforeHandoff.length).toBe(1);
+
+    // leaders mode -> handed off, drops out of admin dashboard
+    await setMode(t, setup.groupId, "leaders");
+    const afterHandoff = await t.query(
+      api.functions.admin.index.listPendingRequests,
+      { token: setup.adminToken, communityId: setup.communityId },
+    );
+    expect(afterHandoff.length).toBe(0);
+  });
+});
+
+describe("Group leader approval — setting the mode", () => {
+  test("leader CANNOT change the approval mode", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+
+    await expect(
+      t.mutation(api.functions.groups.index.setJoinApprovalMode, {
+        token: setup.leaderToken,
+        groupId: setup.groupId,
+        mode: "leaders",
+      }),
+    ).rejects.toThrow(/admin/i);
+  });
+
+  test("community admin CAN change the approval mode", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await setupData(t);
+
+    const result = await t.mutation(
+      api.functions.groups.index.setJoinApprovalMode,
+      {
+        token: setup.adminToken,
+        groupId: setup.groupId,
+        mode: "leaders",
+      },
+    );
+    expect(result.joinApprovalMode).toBe("leaders");
+  });
+});

--- a/apps/convex/functions/admin/requests.ts
+++ b/apps/convex/functions/admin/requests.ts
@@ -8,11 +8,10 @@
 
 import { v } from "convex/values";
 import { query, mutation } from "../../_generated/server";
-import { internal } from "../../_generated/api";
 import { Id } from "../../_generated/dataModel";
 import { now, getMediaUrl, generateShortId } from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
-import { syncUserChannelMembershipsLogic } from "../sync/memberships";
+import { applyJoinRequestReview } from "../groups/joinRequestReview";
 import { initializeGroupAfterCreation } from "../groups/mutations";
 import { requireCommunityAdmin, LEADER_ROLES } from "./auth";
 
@@ -66,10 +65,18 @@ export const listPendingRequests = query({
     const groupTypeMap = new Map(groupTypes.map((gt) => [gt._id, gt]));
 
     // Get pending requests per group using compound index (much more efficient than global scan)
-    // This queries only pending requests for groups in this community
+    // This queries only pending requests for groups in this community.
+    //
+    // Groups set to "leaders" approval have handed their requests off to group
+    // leaders (they surface on the group page instead), so they are excluded
+    // from the admin dashboard. Membership counts below still consider every
+    // group, so a requester's "member of" summary stays accurate.
+    const adminApprovedGroups = groups.filter(
+      (group) => group.joinApprovalMode !== "leaders"
+    );
     const pendingRequests = (
       await Promise.all(
-        groups.map((group) =>
+        adminApprovedGroups.map((group) =>
           ctx.db
             .query("groupMembers")
             .withIndex("by_group_requestStatus", (q) =>
@@ -219,73 +226,12 @@ export const reviewPendingRequest = mutation({
       throw new Error("Request not found in this community");
     }
 
-    const timestamp = now();
+    const updatedRequest = await applyJoinRequestReview(ctx, {
+      membership: request,
+      action: args.action,
+      reviewerId: userId,
+    });
 
-    if (args.action === "accept") {
-      await ctx.db.patch(args.membershipId, {
-        requestStatus: "accepted",
-        leftAt: undefined,
-        joinedAt: timestamp,
-        requestReviewedAt: timestamp,
-        requestReviewedById: userId,
-      });
-
-      console.log(`[reviewPendingRequest] Approved join request for user ${request.userId} in group ${request.groupId}, syncing channel memberships...`);
-
-      // Sync channel memberships so the user can access group chat (transactional)
-      await syncUserChannelMembershipsLogic(ctx, request.userId, request.groupId);
-
-      console.log(`[reviewPendingRequest] Channel membership sync complete for user ${request.userId}`);
-
-      // Create/update followup score for the approved member
-      await ctx.scheduler.runAfter(
-        0,
-        internal.functions.followupScoreComputation.computeSingleMemberScore,
-        { groupId: request.groupId, groupMemberId: args.membershipId }
-      );
-
-      await ctx.scheduler.runAfter(
-        0,
-        internal.functions.communityScoreComputation.recomputeForGroupMember,
-        { groupId: request.groupId, userId: request.userId }
-      );
-
-      // Check if this is a returning member (had a previous membership before this join request)
-      // When a new member creates a join request, joinedAt, leftAt, and requestedAt are all set
-      // to the same timestamp. When a returning member creates a join request, their original
-      // joinedAt is preserved, so joinedAt !== requestedAt indicates a returning member.
-      const isReturningMember = request.joinedAt !== request.requestedAt;
-
-      // Only trigger welcome + followup bots for NEW members, not returning members (non-blocking)
-      if (!isReturningMember) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.functions.scheduledJobs.sendWelcomeMessage,
-          {
-            groupId: request.groupId,
-            userId: request.userId,
-          }
-        );
-        await ctx.scheduler.runAfter(
-          0,
-          internal.functions.scheduledJobs.assignNewMemberFollowup,
-          {
-            groupId: request.groupId,
-            userId: request.userId,
-          }
-        );
-      } else {
-        console.log(`[reviewPendingRequest] Skipping welcome message for returning member ${request.userId} in group ${request.groupId}`);
-      }
-    } else {
-      await ctx.db.patch(args.membershipId, {
-        requestStatus: "declined",
-        requestReviewedAt: timestamp,
-        requestReviewedById: userId,
-      });
-    }
-
-    const updatedRequest = await ctx.db.get(args.membershipId);
     return {
       id: updatedRequest?._id,
       status: updatedRequest?.requestStatus,

--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -1214,6 +1214,10 @@ export const listGroupJoinRequests = query({
           .filter(
             (m) =>
               !m.leftAt &&
+              // Exclude archived groups from the "current" set (they stay in
+              // requestHistory for name resolution), matching the admin
+              // dashboard's active-only "Member of" summary.
+              !groupMap.get(m.groupId)?.isArchived &&
               (m.requestStatus === null ||
                 m.requestStatus === undefined ||
                 m.requestStatus === "accepted"),

--- a/apps/convex/functions/groupMembers.ts
+++ b/apps/convex/functions/groupMembers.ts
@@ -21,6 +21,7 @@
 
 import { v } from "convex/values";
 import { query, mutation } from "../_generated/server";
+import type { QueryCtx, MutationCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Id, Doc } from "../_generated/dataModel";
 import { now, normalizePagination, getDisplayName, getMediaUrl } from "../lib/utils";
@@ -28,6 +29,7 @@ import { paginationArgs, groupRoleValidator, memberStatusValidator } from "../li
 import { requireAuth, getOptionalAuth } from "../lib/auth";
 import { isCommunityAdmin, ADMIN_ROLE_THRESHOLD } from "../lib/permissions";
 import { syncUserChannelMembershipsLogic } from "./sync/memberships";
+import { applyJoinRequestReview } from "./groups/joinRequestReview";
 import { isActiveMembership, isActiveLeader, hasLeft } from "../lib/helpers";
 import { getUsersWithNotificationsDisabled } from "../lib/notifications/enabledStatus";
 
@@ -1057,6 +1059,250 @@ export const listJoinRequests = query({
     });
 
     return requestsWithUsers.filter((r) => r.user !== null);
+  },
+});
+
+/**
+ * Whether `userId` may review (accept/decline) join requests for `group`.
+ *
+ * Community admins always may. Group leaders may only when the group has handed
+ * approval off to leaders (`joinApprovalMode === "leaders"`).
+ */
+async function canReviewGroupRequests(
+  ctx: QueryCtx | MutationCtx,
+  group: Doc<"groups">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  if (await isCommunityAdmin(ctx, group.communityId, userId)) {
+    return true;
+  }
+  if (group.joinApprovalMode !== "leaders") {
+    return false;
+  }
+  const membership = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", group._id).eq("userId", userId),
+    )
+    .first();
+  return membership ? isActiveLeader(membership) : false;
+}
+
+/**
+ * Review (accept or decline) a pending join request from the group page.
+ *
+ * Authorization: community admins always; group leaders only when the group's
+ * `joinApprovalMode === "leaders"`. Shares all accept/decline side effects
+ * (channel sync, scoring, welcome bots, approval notification) with the admin
+ * dashboard via `applyJoinRequestReview`.
+ */
+export const reviewGroupJoinRequest = mutation({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    membershipId: v.id("groupMembers"),
+    action: v.union(v.literal("accept"), v.literal("decline")),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const group = await ctx.db.get(args.groupId);
+    if (!group) {
+      throw new Error("Group not found");
+    }
+
+    if (!(await canReviewGroupRequests(ctx, group, userId))) {
+      throw new Error("You are not allowed to review requests for this group");
+    }
+
+    const request = await ctx.db.get(args.membershipId);
+    if (
+      !request ||
+      request.groupId !== args.groupId ||
+      request.requestStatus !== "pending"
+    ) {
+      throw new Error("Pending request not found");
+    }
+
+    const updated = await applyJoinRequestReview(ctx, {
+      membership: request,
+      action: args.action,
+      reviewerId: userId,
+    });
+
+    return { id: updated?._id, status: updated?.requestStatus };
+  },
+});
+
+/**
+ * List pending join requests for a single group, with the rich per-requester
+ * context the group-page Requests screen renders: profile + phone, the groups
+ * they currently belong to, membership counts by type, and their request
+ * history within this community.
+ *
+ * Authorization mirrors `reviewGroupJoinRequest`: community admins always;
+ * group leaders only when `joinApprovalMode === "leaders"`. Unauthorized callers
+ * get an empty list (so we never leak that requests exist).
+ */
+export const listGroupJoinRequests = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const group = await ctx.db.get(args.groupId);
+    if (!group) {
+      return [];
+    }
+
+    if (!(await canReviewGroupRequests(ctx, group, userId))) {
+      return [];
+    }
+
+    // Pending requests for this group only.
+    const pendingRequests = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_requestStatus", (q) =>
+        q.eq("groupId", args.groupId).eq("requestStatus", "pending"),
+      )
+      .collect();
+
+    if (pendingRequests.length === 0) {
+      return [];
+    }
+
+    // Resolve every community group + group type once for name lookups (used by
+    // current memberships and request history). Include archived groups so
+    // history entries for archived groups still render a name.
+    const communityGroups = await ctx.db
+      .query("groups")
+      .withIndex("by_community", (q) => q.eq("communityId", group.communityId))
+      .collect();
+    const groupMap = new Map(communityGroups.map((g) => [g._id, g]));
+    const communityGroupIds = new Set(communityGroups.map((g) => g._id));
+
+    const groupTypes = await ctx.db
+      .query("groupTypes")
+      .withIndex("by_community", (q) => q.eq("communityId", group.communityId))
+      .collect();
+    const groupTypeMap = new Map(groupTypes.map((gt) => [gt._id, gt]));
+
+    const groupTypeName = (groupId: Id<"groups">): string => {
+      const g = groupMap.get(groupId);
+      const gt = g?.groupTypeId ? groupTypeMap.get(g.groupTypeId) : null;
+      return gt?.name ?? "";
+    };
+
+    return await Promise.all(
+      pendingRequests.map(async (request) => {
+        const user = await ctx.db.get(request.userId);
+
+        // All of this requester's memberships (for current groups + history).
+        const allMemberships = await ctx.db
+          .query("groupMembers")
+          .withIndex("by_user", (q) => q.eq("userId", request.userId))
+          .collect();
+
+        const inCommunity = allMemberships.filter((m) =>
+          communityGroupIds.has(m.groupId),
+        );
+
+        // Active memberships (joined, not left, not a still-pending request).
+        const currentMemberships = inCommunity
+          .filter(
+            (m) =>
+              !m.leftAt &&
+              (m.requestStatus === null ||
+                m.requestStatus === undefined ||
+                m.requestStatus === "accepted"),
+          )
+          .map((m) => ({
+            groupId: m.groupId,
+            groupName: groupMap.get(m.groupId)?.name ?? "",
+            groupTypeName: groupTypeName(m.groupId),
+            role: m.role,
+          }));
+
+        const membershipCountsByType: Record<string, number> = {};
+        for (const m of currentMemberships) {
+          const key = m.groupTypeName || "Other";
+          membershipCountsByType[key] = (membershipCountsByType[key] ?? 0) + 1;
+        }
+
+        // Request history: any row that carries a request status, newest first.
+        const requestHistory = inCommunity
+          .filter((m) => !!m.requestStatus)
+          .sort(
+            (a, b) =>
+              (b.requestedAt ?? b.joinedAt) - (a.requestedAt ?? a.joinedAt),
+          )
+          .map((m) => ({
+            groupId: m.groupId,
+            groupName: groupMap.get(m.groupId)?.name ?? "",
+            groupTypeName: groupTypeName(m.groupId),
+            status: m.requestStatus ?? "",
+            requestedAt: m.requestedAt ?? m.joinedAt,
+            reviewedAt: m.requestReviewedAt ?? null,
+          }));
+
+        return {
+          membershipId: request._id,
+          requestedAt: request.requestedAt ?? request.joinedAt,
+          user: user
+            ? {
+                id: user._id,
+                firstName: user.firstName || "",
+                lastName: user.lastName || "",
+                email: user.email || "",
+                phone: user.phone || null,
+                profilePhoto: getMediaUrl(user.profilePhoto),
+              }
+            : null,
+          currentMemberships,
+          membershipCountsByType,
+          requestHistory,
+        };
+      }),
+    ).then((rows) =>
+      rows
+        .filter((r) => r.user !== null)
+        .sort((a, b) => b.requestedAt - a.requestedAt),
+    );
+  },
+});
+
+/**
+ * Lightweight count of pending join requests the caller may review for a group.
+ *
+ * Powers the "Requests" row on the group page (badge + whether to show it at
+ * all). Returns 0 for callers who cannot review this group's requests.
+ */
+export const countGroupJoinRequests = query({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+  },
+  handler: async (ctx, args): Promise<number> => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const group = await ctx.db.get(args.groupId);
+    if (!group) {
+      return 0;
+    }
+    if (!(await canReviewGroupRequests(ctx, group, userId))) {
+      return 0;
+    }
+
+    const pending = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_requestStatus", (q) =>
+        q.eq("groupId", args.groupId).eq("requestStatus", "pending"),
+      )
+      .collect();
+
+    return pending.length;
   },
 });
 

--- a/apps/convex/functions/groups/index.ts
+++ b/apps/convex/functions/groups/index.ts
@@ -35,6 +35,7 @@ export {
   updateLeaderToolbarTools,
   updateToolbarVisibility,
   setHiddenFromDiscovery,
+  setJoinApprovalMode,
 } from "./mutations";
 
 // Member queries

--- a/apps/convex/functions/groups/joinRequestReview.ts
+++ b/apps/convex/functions/groups/joinRequestReview.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared join-request review logic.
+ *
+ * A pending join request is a `groupMembers` row with `requestStatus === "pending"`.
+ * Accepting/declining one has side effects (channel sync, score recomputation,
+ * welcome + follow-up bots, and an approval notification to the requester) that
+ * must be identical no matter who performs the review. Both review surfaces call
+ * this single helper:
+ *   - admin dashboard  -> admin/requests.ts:reviewPendingRequest
+ *   - group-page leaders -> groupMembers.ts:reviewGroupJoinRequest
+ */
+
+import { internal } from "../../_generated/api";
+import type { MutationCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { now } from "../../lib/utils";
+import { syncUserChannelMembershipsLogic } from "../sync/memberships";
+
+/**
+ * Apply an accept/decline decision to a pending join request.
+ *
+ * @returns the updated membership row (or null if it vanished mid-flight).
+ */
+export async function applyJoinRequestReview(
+  ctx: MutationCtx,
+  opts: {
+    membership: Doc<"groupMembers">;
+    action: "accept" | "decline";
+    reviewerId: Id<"users">;
+  },
+): Promise<Doc<"groupMembers"> | null> {
+  const { membership, action, reviewerId } = opts;
+  const timestamp = now();
+
+  if (action === "accept") {
+    await ctx.db.patch(membership._id, {
+      requestStatus: "accepted",
+      leftAt: undefined,
+      joinedAt: timestamp,
+      requestReviewedAt: timestamp,
+      requestReviewedById: reviewerId,
+    });
+
+    // Sync channel memberships so the user can access group chat (transactional)
+    await syncUserChannelMembershipsLogic(
+      ctx,
+      membership.userId,
+      membership.groupId,
+    );
+
+    // Create/update followup score for the approved member (non-blocking)
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.followupScoreComputation.computeSingleMemberScore,
+      { groupId: membership.groupId, groupMemberId: membership._id },
+    );
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.communityScoreComputation.recomputeForGroupMember,
+      { groupId: membership.groupId, userId: membership.userId },
+    );
+
+    // Returning-member detection: for a brand-new member joinedAt, leftAt and
+    // requestedAt are all stamped together at request time, so joinedAt ===
+    // requestedAt. A returning member keeps their original joinedAt, so the two
+    // differ. Only new members get the welcome + follow-up bots.
+    const isReturningMember = membership.joinedAt !== membership.requestedAt;
+    if (!isReturningMember) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.scheduledJobs.sendWelcomeMessage,
+        { groupId: membership.groupId, userId: membership.userId },
+      );
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.scheduledJobs.assignNewMemberFollowup,
+        { groupId: membership.groupId, userId: membership.userId },
+      );
+    }
+
+    // Notify the requester that they were approved (push + email + record).
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.notifications.senders.notifyJoinRequestApproved,
+      { userId: membership.userId, groupId: membership.groupId },
+    );
+  } else {
+    await ctx.db.patch(membership._id, {
+      requestStatus: "declined",
+      requestReviewedAt: timestamp,
+      requestReviewedById: reviewerId,
+    });
+  }
+
+  return await ctx.db.get(membership._id);
+}

--- a/apps/convex/functions/groups/mutations.ts
+++ b/apps/convex/functions/groups/mutations.ts
@@ -1142,6 +1142,43 @@ export const setHiddenFromDiscovery = mutation({
 });
 
 /**
+ * Set who approves join requests for a group.
+ *
+ *   "admins"  -> community admins approve via the admin dashboard (default)
+ *   "leaders" -> group leaders approve via the group-page Requests section;
+ *                requests are handed off (removed from the admin dashboard) and
+ *                leaders receive the incoming-request push notification.
+ *
+ * Community admins only — leaders must not be able to grant themselves (or
+ * revoke) approval authority for their own group.
+ */
+export const setJoinApprovalMode = mutation({
+  args: {
+    token: v.string(),
+    groupId: v.id("groups"),
+    mode: v.union(v.literal("admins"), v.literal("leaders")),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const group = await ctx.db.get(args.groupId);
+    if (!group) {
+      throw new Error("Group not found");
+    }
+
+    // Community-admin-only gate
+    await requireCommunityAdmin(ctx, group.communityId, userId);
+
+    await ctx.db.patch(args.groupId, {
+      joinApprovalMode: args.mode,
+      updatedAt: now(),
+    });
+
+    return { success: true, joinApprovalMode: args.mode };
+  },
+});
+
+/**
  * Update a custom display name for a built-in tool.
  * Pass an empty string or undefined to reset to the default label.
  */

--- a/apps/convex/functions/groups/queries.ts
+++ b/apps/convex/functions/groups/queries.ts
@@ -153,6 +153,7 @@ export const getById = query({
         zipCode: group.zipCode,
         externalChatLink: group.externalChatLink,
         hiddenFromDiscovery: group.hiddenFromDiscovery ?? false,
+        joinApprovalMode: group.joinApprovalMode ?? "admins",
         leaderToolbarTools: group.leaderToolbarTools,
         showToolbarToMembers: group.showToolbarToMembers,
         toolVisibility: group.toolVisibility,

--- a/apps/convex/functions/notifications/internal.ts
+++ b/apps/convex/functions/notifications/internal.ts
@@ -96,6 +96,7 @@ export const getGroupInfo = internalQuery({
       groupPhotoUrl,
       communityLogoUrl,
       groupAvatarUrl,
+      joinApprovalMode: group.joinApprovalMode,
     };
   },
 });

--- a/apps/convex/functions/notifications/senders.ts
+++ b/apps/convex/functions/notifications/senders.ts
@@ -20,6 +20,7 @@ type NotificationGroupInfo = {
   groupPhotoUrl?: string;
   communityLogoUrl?: string;
   groupAvatarUrl?: string;
+  joinApprovalMode?: "admins" | "leaders";
 };
 
 function getSenderNotificationImage(groupInfo: NotificationGroupInfo): string | undefined {
@@ -33,8 +34,15 @@ function getSenderNotificationImage(groupInfo: NotificationGroupInfo): string | 
 // ============================================================================
 
 /**
- * Notify community admins when a join request is received
- * Called from createJoinRequest mutation
+ * Notify the appropriate reviewers when a join request is received.
+ *
+ * Recipients depend on the group's approval mode:
+ *   - "leaders" -> the group's leaders; the push deep-links to the group's
+ *     Requests page (/groups/{id}/requests).
+ *   - "admins" (default) -> the community admins; the push opens the admin
+ *     dashboard (default routing for the `join_request_received` type).
+ *
+ * Called from createJoinRequest mutation.
  */
 export const notifyJoinRequestReceived = internalAction({
   args: {
@@ -57,19 +65,29 @@ export const notifyJoinRequestReceived = internalAction({
         userId: args.requesterId,
       });
 
-      // Get community admins
-      const adminIds: Id<"users">[] = await ctx.runQuery(internal.functions.notifications.internal.getCommunityAdmins, {
-        communityId: groupInfo.communityId as Id<"communities">,
-      });
+      // Route to leaders when the group has handed approval off to leaders,
+      // otherwise to community admins (the default).
+      const leadersApprove = groupInfo.joinApprovalMode === "leaders";
 
-      if (adminIds.length === 0) {
-        console.log("[NotifyJoinRequest] No community admins found");
+      const recipientIds: Id<"users">[] = leadersApprove
+        ? await ctx.runQuery(internal.functions.notifications.internal.getGroupMembersForNotification, {
+            groupId: args.groupId,
+            filter: "leaders",
+          })
+        : await ctx.runQuery(internal.functions.notifications.internal.getCommunityAdmins, {
+            communityId: groupInfo.communityId as Id<"communities">,
+          });
+
+      if (recipientIds.length === 0) {
+        console.log(
+          `[NotifyJoinRequest] No ${leadersApprove ? "leaders" : "community admins"} found`,
+        );
         return { success: true, sent: 0 };
       }
 
-      // Get push tokens for all admins
+      // Get push tokens for all recipients
       const tokenResults: Array<{ userId: string; tokens: string[] }> = await ctx.runQuery(internal.functions.notifications.tokens.getActiveTokensForUsers, {
-        userIds: adminIds,
+        userIds: recipientIds,
       });
 
       // Build notifications
@@ -84,13 +102,18 @@ export const notifyJoinRequestReceived = internalAction({
             groupId: args.groupId,
             communityId: groupInfo.communityId,
             groupAvatarUrl: notificationImageUrl,
+            // Leaders deep-link straight to the group's Requests page; admins
+            // fall through to the default admin-dashboard route.
+            ...(leadersApprove
+              ? { url: `/groups/${args.groupId}/requests` }
+              : {}),
           },
           imageUrl: notificationImageUrl,
         }))
       );
 
       if (notifications.length === 0) {
-        console.log("[NotifyJoinRequest] No push tokens found for admins");
+        console.log("[NotifyJoinRequest] No push tokens found for recipients");
         return { success: true, sent: 0 };
       }
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -380,6 +380,13 @@ export default defineSchema({
     // community landing page list, search/browse). Direct share links still
     // work and existing members retain access. Community-admin toggle only.
     hiddenFromDiscovery: v.optional(v.boolean()),
+    // Who approves join requests for this (private) group.
+    //   undefined | "admins" -> community admins approve (default, admin dashboard)
+    //   "leaders"            -> group leaders approve (group-page Requests section)
+    // Only community admins can change this value.
+    joinApprovalMode: v.optional(
+      v.union(v.literal("admins"), v.literal("leaders")),
+    ),
     shortId: v.optional(v.string()), // For shareable links (/g/[shortId])
     coordinates: v.optional(
       v.object({

--- a/apps/mobile/app/groups/[group_id]/requests.tsx
+++ b/apps/mobile/app/groups/[group_id]/requests.tsx
@@ -1,0 +1,3 @@
+import { GroupRequestsScreen } from '@features/groups/components/GroupRequestsScreen';
+
+export default GroupRequestsScreen;

--- a/apps/mobile/features/groups/components/EditGroupScreen.tsx
+++ b/apps/mobile/features/groups/components/EditGroupScreen.tsx
@@ -130,6 +130,9 @@ export function EditGroupScreen() {
   const setHiddenFromDiscovery = useAuthenticatedMutation(
     api.functions.groups.index.setHiddenFromDiscovery,
   );
+  const setJoinApprovalMode = useAuthenticatedMutation(
+    api.functions.groups.index.setJoinApprovalMode,
+  );
   const [selectedImageUri, setSelectedImageUri] = useState<string | null>(null);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
 
@@ -138,10 +141,17 @@ export function EditGroupScreen() {
   const [hiddenFromDiscovery, setHiddenFromDiscoveryState] = useState(false);
   const [isSavingHidden, setIsSavingHidden] = useState(false);
 
+  // Local optimistic state for the admin-only "leaders approve requests" toggle.
+  const [leadersApprove, setLeadersApprove] = useState(false);
+  const [isSavingApproval, setIsSavingApproval] = useState(false);
+
   useEffect(() => {
     if (group) {
       setHiddenFromDiscoveryState(
         Boolean((group as any).hidden_from_discovery),
+      );
+      setLeadersApprove(
+        (group as any).join_approval_mode === "leaders",
       );
     }
   }, [group]);
@@ -362,6 +372,26 @@ export function EditGroupScreen() {
       );
     } finally {
       setIsSavingHidden(false);
+    }
+  };
+
+  const handleToggleLeadersApprove = async (next: boolean) => {
+    const previous = leadersApprove;
+    setLeadersApprove(next); // optimistic
+    setIsSavingApproval(true);
+    try {
+      await setJoinApprovalMode({
+        groupId: group_id as any,
+        mode: next ? "leaders" : "admins",
+      });
+    } catch (error) {
+      setLeadersApprove(previous); // revert
+      Alert.alert(
+        "Couldn't update approvals",
+        formatError(error, "Failed to update who approves requests"),
+      );
+    } finally {
+      setIsSavingApproval(false);
     }
   };
 
@@ -774,6 +804,28 @@ export function EditGroupScreen() {
                   value={hiddenFromDiscovery}
                   onValueChange={handleToggleHiddenFromDiscovery}
                   disabled={isSavingHidden}
+                />
+              </View>
+            </View>
+          )}
+
+          {/* Approvals Section — community admins only */}
+          {isCommunityAdmin && (
+            <View style={[styles.section, { backgroundColor: colors.surface }]}>
+              <Text style={[styles.sectionTitle, { color: colors.text }]}>Approvals</Text>
+              <View style={styles.toggleRow}>
+                <View style={styles.toggleTextWrap}>
+                  <Text style={[styles.toggleLabel, { color: colors.text }]}>Let group leaders approve requests</Text>
+                  <Text style={[styles.toggleDescription, { color: colors.textSecondary }]}>
+                    When off, community admins approve join requests. When on,
+                    the group's leaders approve them from a Requests section on
+                    the group page, and are notified of new requests.
+                  </Text>
+                </View>
+                <Switch
+                  value={leadersApprove}
+                  onValueChange={handleToggleLeadersApprove}
+                  disabled={isSavingApproval}
                 />
               </View>
             </View>

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -16,6 +16,8 @@ import {
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
+import { useAuthenticatedQuery, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
 import { DOMAIN_CONFIG } from "@togather/shared";
 import { useTheme } from "@hooks/useTheme";
 import { GroupDetailSkeleton } from "./GroupDetailSkeleton";
@@ -126,6 +128,25 @@ export function GroupDetailScreen() {
     );
   }, [group, user?.id, user?.is_admin]);
   const canArchiveGroup = isAdmin && !group?.is_announcement_group;
+
+  // Pending join requests the current user may review (0 for non-reviewers, so
+  // this both gates the "Requests" row and badges it). Populated for leaders
+  // when the group's approval mode is "leaders", and for community admins.
+  const pendingRequestCount = useAuthenticatedQuery(
+    api.functions.groupMembers.countGroupJoinRequests,
+    group?._id ? { groupId: group._id as Id<"groups"> } : "skip",
+  ) as number | undefined;
+  const hasPendingRequests = (pendingRequestCount ?? 0) > 0;
+
+  // Whether the group has ever had an event plan. Rostering keeps its inline
+  // position only once plans exist; before that it drops to a bottom group
+  // action so the tile order stays focused on the common path. Convex dedupes
+  // this subscription with RosteringSection's own listEvents query.
+  const eventPlans = useAuthenticatedQuery(
+    api.functions.scheduling.events.listEvents,
+    group?._id && isLeader ? { groupId: group._id as Id<"groups"> } : "skip",
+  ) as unknown[] | undefined;
+  const hasEventPlans = Array.isArray(eventPlans) && eventPlans.length > 0;
 
   const handleMembersPress = () => {
     if (!group?._id) return;
@@ -470,6 +491,77 @@ export function GroupDetailScreen() {
           </View>
         )}
 
+        {/* REQUESTS — the group-page review surface for the "leaders approve"
+            handoff. Shown only when the group hands approval to leaders and
+            there are pending requests the viewer may review (its leaders, plus
+            community admins). In the default "admins" mode requests live in the
+            admin dashboard instead, so this row stays hidden. Taps into the
+            full review page (also the target of the incoming-request push). */}
+        {group._id &&
+          (group as any).join_approval_mode === "leaders" &&
+          hasPendingRequests && (
+          <View style={{ paddingHorizontal: 12, marginTop: 4 }}>
+            <TouchableOpacity
+              onPress={() =>
+                router.push(`/groups/${group._id}/requests` as any)
+              }
+              activeOpacity={0.7}
+              style={[
+                styles.addPeopleTile,
+                { backgroundColor: colors.surfaceSecondary },
+              ]}
+            >
+              <View
+                style={[
+                  styles.addPeopleIcon,
+                  { backgroundColor: colors.warning + "1A" },
+                ]}
+              >
+                <Ionicons name="person-add-outline" size={18} color={colors.warning} />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={[styles.actionLabel, { color: colors.text }]}>
+                  Requests
+                </Text>
+                <Text style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
+                  {pendingRequestCount}{" "}
+                  {pendingRequestCount === 1 ? "person wants" : "people want"} to
+                  join
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* Add people — leader/admin only. Mirrors the DM chat-info pattern:
+            a standalone tile sitting just under the members card.
+            Hidden on announcement groups (membership is implicit/community-wide). */}
+        {(isLeader || isAdmin) && group._id && !group.is_announcement_group && (
+          <View style={{ paddingHorizontal: 12, marginTop: 4 }}>
+            <TouchableOpacity
+              onPress={() => setShowAddPeopleModal(true)}
+              activeOpacity={0.7}
+              style={[
+                styles.addPeopleTile,
+                { backgroundColor: colors.surfaceSecondary },
+              ]}
+            >
+              <View
+                style={[
+                  styles.addPeopleIcon,
+                  { backgroundColor: colors.link + "1A" },
+                ]}
+              >
+                <Ionicons name="person-add" size={18} color={colors.link} />
+              </View>
+              <Text style={[styles.actionLabel, { color: colors.text }]}>
+                Add people
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
         {/* Check-in — leader/admin entry point into the people health +
             follow-up tool. Shown for both regular groups and the announcement
             (community-wide) group. */}
@@ -506,42 +598,16 @@ export function GroupDetailScreen() {
           </View>
         )}
 
-        {/* Add people — leader/admin only. Mirrors the DM chat-info pattern:
-            a standalone tile sitting just under the members card.
-            Hidden on announcement groups (membership is implicit/community-wide). */}
-        {(isLeader || isAdmin) && group._id && !group.is_announcement_group && (
-          <View style={{ paddingHorizontal: 12, marginTop: 4 }}>
-            <TouchableOpacity
-              onPress={() => setShowAddPeopleModal(true)}
-              activeOpacity={0.7}
-              style={[
-                styles.addPeopleTile,
-                { backgroundColor: colors.surfaceSecondary },
-              ]}
-            >
-              <View
-                style={[
-                  styles.addPeopleIcon,
-                  { backgroundColor: colors.link + "1A" },
-                ]}
-              >
-                <Ionicons name="person-add" size={18} color={colors.link} />
-              </View>
-              <Text style={[styles.actionLabel, { color: colors.text }]}>
-                Add people
-              </Text>
-            </TouchableOpacity>
-          </View>
+        {/* ROSTERING — leader-only entry row into the rostering hub. Keeps this
+            inline position only once the group has event plans; before that it
+            drops to a bottom group action (see GROUP ACTIONS below). */}
+        {group._id && isLeader && hasEventPlans && (
+          <RosteringSection groupId={group._id} />
         )}
 
-        {/* UPCOMING EVENTS — horizontal scroll, sits between Members and
-            Channels per product design. Hidden when there are no upcoming
-            events. */}
+        {/* UPCOMING EVENTS — horizontal scroll. Hidden when there are no
+            upcoming events. */}
         {group._id && <UpcomingEventsSection groupId={group._id} />}
-
-        {/* ROSTERING — leader-only entry row into the rostering hub, with a
-            light status summary (plan count · next date · fill). */}
-        {group._id && isLeader && <RosteringSection groupId={group._id} />}
 
         {/* CHANNELS */}
         {group._id && (
@@ -681,6 +747,20 @@ export function GroupDetailScreen() {
                 icon="options-outline"
                 label="Toolbar Settings"
                 onPress={handleToolbarSettings}
+                color={colors.text}
+                iconColor={colors.icon}
+                topBorder
+                borderColor={colors.border}
+              />
+            )}
+            {/* Rostering lives here as a group action until the group has its
+                first event plan; after that it graduates to an inline section
+                above (with a live status summary). */}
+            {isLeader && eventPlans !== undefined && !hasEventPlans && (
+              <ActionRow
+                icon="calendar-outline"
+                label="Rostering"
+                onPress={() => router.push(`/rostering/${group._id}` as any)}
                 color={colors.text}
                 iconColor={colors.icon}
                 topBorder

--- a/apps/mobile/features/groups/components/GroupDetailScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupDetailScreen.tsx
@@ -138,13 +138,17 @@ export function GroupDetailScreen() {
   ) as number | undefined;
   const hasPendingRequests = (pendingRequestCount ?? 0) > 0;
 
-  // Whether the group has ever had an event plan. Rostering keeps its inline
-  // position only once plans exist; before that it drops to a bottom group
-  // action so the tile order stays focused on the common path. Convex dedupes
-  // this subscription with RosteringSection's own listEvents query.
+  // Whether the group has ever had an event plan (past OR upcoming). Rostering
+  // keeps its inline position only once plans exist; before that it drops to a
+  // bottom group action so the tile order stays focused on the common path.
+  // `includePast: true` so a group that ran events but has none scheduled ahead
+  // still counts as "has plans" (matches the "has there been a plan before?"
+  // intent rather than "is one coming up?").
   const eventPlans = useAuthenticatedQuery(
     api.functions.scheduling.events.listEvents,
-    group?._id && isLeader ? { groupId: group._id as Id<"groups"> } : "skip",
+    group?._id && isLeader
+      ? { groupId: group._id as Id<"groups">, includePast: true }
+      : "skip",
   ) as unknown[] | undefined;
   const hasEventPlans = Array.isArray(eventPlans) && eventPlans.length > 0;
 

--- a/apps/mobile/features/groups/components/GroupRequestsScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupRequestsScreen.tsx
@@ -1,0 +1,508 @@
+/**
+ * GroupRequestsScreen
+ *
+ * The leaders' (and admins') surface for reviewing pending join requests for a
+ * single group. Reached from the "Requests" row on the group page and from the
+ * incoming-request push notification (deep link /groups/[group_id]/requests).
+ *
+ * Each requester renders a rich card — profile + contact actions (message in
+ * Togather / call / text / copy number), the groups they already belong to, an
+ * expandable request history, and accept/decline buttons. The accept/decline
+ * mutation and the underlying authorization (community admins always; group
+ * leaders only when the group's approval mode is "leaders") live in
+ * `groupMembers.reviewGroupJoinRequest`.
+ */
+import React, { useState, useCallback } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  TouchableOpacity,
+  Image,
+  Alert,
+  Linking,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import * as Clipboard from "expo-clipboard";
+import { formatDistanceToNow } from "date-fns";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useStartDirectMessage } from "@features/chat/hooks/useStartDirectMessage";
+import { formatError } from "@/utils/error-handling";
+
+interface RequestHistoryEntry {
+  groupId: Id<"groups">;
+  groupName: string;
+  groupTypeName: string;
+  status: string;
+  requestedAt: number;
+  reviewedAt: number | null;
+}
+
+interface GroupJoinRequest {
+  membershipId: Id<"groupMembers">;
+  requestedAt: number;
+  user: {
+    id: Id<"users">;
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string | null;
+    profilePhoto: string | null;
+  } | null;
+  currentMemberships: Array<{
+    groupId: Id<"groups">;
+    groupName: string;
+    groupTypeName: string;
+    role: string;
+  }>;
+  membershipCountsByType: Record<string, number>;
+  requestHistory: RequestHistoryEntry[];
+}
+
+function formatDate(date: number | null): string {
+  if (!date) return "";
+  try {
+    return formatDistanceToNow(new Date(date), { addSuffix: true });
+  } catch {
+    return "";
+  }
+}
+
+// Small status pill reused for the history rows.
+function StatusBadge({ status }: { status: string }) {
+  let color = "#999";
+  if (status === "pending") color = "#FF9800";
+  else if (status === "declined") color = "#FF6B6B";
+  else if (status === "accepted" || status === "approved") color = "#4CAF50";
+
+  return (
+    <View style={[styles.statusBadge, { backgroundColor: color + "20" }]}>
+      <Text style={[styles.statusBadgeText, { color }]}>{status || "unknown"}</Text>
+    </View>
+  );
+}
+
+interface RequestCardProps {
+  request: GroupJoinRequest;
+  primaryColor: string;
+  isProcessing: boolean;
+  onAccept: (r: GroupJoinRequest) => void;
+  onDecline: (r: GroupJoinRequest) => void;
+}
+
+function RequestCard({
+  request,
+  primaryColor,
+  isProcessing,
+  onAccept,
+  onDecline,
+}: RequestCardProps) {
+  const { colors } = useTheme();
+  const { messageUser, isStarting } = useStartDirectMessage();
+  const [historyExpanded, setHistoryExpanded] = useState(false);
+
+  const user = request.user;
+  if (!user) return null;
+
+  const userName = `${user.firstName} ${user.lastName}`.trim();
+  const hasMemberships = request.currentMemberships.length > 0;
+  const membershipSummary = Object.entries(request.membershipCountsByType)
+    .map(([type, count]) => `${count} ${type}`)
+    .join(", ");
+
+  const copyPhone = async () => {
+    if (!user.phone) return;
+    await Clipboard.setStringAsync(user.phone);
+    Alert.alert("Copied", `${user.phone} copied to clipboard.`);
+  };
+
+  return (
+    <View style={[styles.userCard, { backgroundColor: colors.surface }]}>
+      {/* Header: avatar + name + membership summary */}
+      <View style={styles.userHeader}>
+        <View style={styles.userAvatar}>
+          {user.profilePhoto ? (
+            <Image source={{ uri: user.profilePhoto }} style={styles.avatarImage} />
+          ) : (
+            <View style={[styles.avatarPlaceholder, { backgroundColor: primaryColor }]}>
+              <Text style={styles.avatarInitials}>
+                {user.firstName?.[0]}
+                {user.lastName?.[0]}
+              </Text>
+            </View>
+          )}
+        </View>
+        <View style={styles.userInfo}>
+          <Text style={[styles.userName, { color: colors.text }]}>{userName}</Text>
+          {!!user.email && (
+            <Text style={[styles.userEmail, { color: colors.textSecondary }]}>
+              {user.email}
+            </Text>
+          )}
+          <Text style={[styles.requestDate, { color: colors.textTertiary }]}>
+            Requested {formatDate(request.requestedAt)}
+          </Text>
+          {hasMemberships && (
+            <Text style={[styles.membershipSummary, { color: primaryColor }]}>
+              Member of: {membershipSummary}
+            </Text>
+          )}
+        </View>
+      </View>
+
+      {/* Contact actions */}
+      <View style={[styles.contactRow, { borderTopColor: colors.borderLight }]}>
+        <TouchableOpacity
+          style={styles.contactButton}
+          onPress={() =>
+            messageUser({
+              otherUserId: user.id,
+              firstName: user.firstName,
+              displayName: userName,
+              profilePhoto: user.profilePhoto,
+            })
+          }
+          disabled={isStarting}
+        >
+          <Ionicons name="chatbubble-outline" size={18} color={primaryColor} />
+          <Text style={[styles.contactButtonText, { color: primaryColor }]}>Message</Text>
+        </TouchableOpacity>
+
+        {!!user.phone && (
+          <>
+            <TouchableOpacity
+              style={styles.contactButton}
+              onPress={() => Linking.openURL(`tel:${user.phone}`)}
+            >
+              <Ionicons name="call-outline" size={18} color={primaryColor} />
+              <Text style={[styles.contactButtonText, { color: primaryColor }]}>Call</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.contactButton}
+              onPress={() => Linking.openURL(`sms:${user.phone}`)}
+            >
+              <Ionicons name="mail-outline" size={18} color={primaryColor} />
+              <Text style={[styles.contactButtonText, { color: primaryColor }]}>Text</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.contactButton} onPress={copyPhone}>
+              <Ionicons name="copy-outline" size={18} color={primaryColor} />
+              <Text style={[styles.contactButtonText, { color: primaryColor }]}>
+                Copy #
+              </Text>
+            </TouchableOpacity>
+          </>
+        )}
+      </View>
+
+      {/* Request history (collapsible) */}
+      {request.requestHistory.length > 0 && (
+        <>
+          <TouchableOpacity
+            style={[styles.historyButton, { borderTopColor: colors.borderLight }]}
+            onPress={() => setHistoryExpanded((v) => !v)}
+          >
+            <Ionicons name="time-outline" size={16} color={primaryColor} />
+            <Text style={[styles.historyButtonText, { color: primaryColor }]}>
+              {historyExpanded ? "Hide history" : "View request history"}
+            </Text>
+            <Ionicons
+              name={historyExpanded ? "chevron-up" : "chevron-down"}
+              size={16}
+              color={primaryColor}
+            />
+          </TouchableOpacity>
+          {historyExpanded && (
+            <View style={[styles.historyList, { borderTopColor: colors.borderLight }]}>
+              {request.requestHistory.map((h, i) => (
+                <View
+                  key={`${h.groupId}-${i}`}
+                  style={[styles.historyItem, { borderBottomColor: colors.borderLight }]}
+                >
+                  <View style={styles.historyInfo}>
+                    <Text style={[styles.groupName, { color: colors.text }]}>
+                      {h.groupName}
+                    </Text>
+                    {!!h.groupTypeName && (
+                      <Text style={[styles.groupType, { color: colors.textSecondary }]}>
+                        {h.groupTypeName}
+                      </Text>
+                    )}
+                    <Text style={[styles.requestDate, { color: colors.textTertiary }]}>
+                      {formatDate(h.requestedAt)}
+                    </Text>
+                  </View>
+                  <StatusBadge status={h.status} />
+                </View>
+              ))}
+            </View>
+          )}
+        </>
+      )}
+
+      {/* Accept / decline */}
+      <View style={[styles.decisionRow, { borderTopColor: colors.borderLight }]}>
+        <TouchableOpacity
+          style={[styles.decisionButton, { backgroundColor: colors.surfaceSecondary }]}
+          onPress={() => onDecline(request)}
+          disabled={isProcessing}
+        >
+          <Ionicons name="close" size={18} color={colors.destructive} />
+          <Text style={[styles.decisionText, { color: colors.destructive }]}>Decline</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.decisionButton, { backgroundColor: `${primaryColor}20` }]}
+          onPress={() => onAccept(request)}
+          disabled={isProcessing}
+        >
+          <Ionicons name="checkmark" size={18} color={primaryColor} />
+          <Text style={[styles.decisionText, { color: primaryColor }]}>Approve</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+export function GroupRequestsScreen() {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { group_id } = useLocalSearchParams<{ group_id: string }>();
+
+  const requests = useAuthenticatedQuery(
+    api.functions.groupMembers.listGroupJoinRequests,
+    group_id ? { groupId: group_id as Id<"groups"> } : "skip",
+  ) as GroupJoinRequest[] | undefined;
+
+  const reviewRequest = useAuthenticatedMutation(
+    api.functions.groupMembers.reviewGroupJoinRequest,
+  );
+
+  const [processingId, setProcessingId] = useState<string | null>(null);
+
+  const handleBack = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else if (group_id) {
+      router.push(`/groups/${group_id}`);
+    }
+  };
+
+  const review = useCallback(
+    async (request: GroupJoinRequest, action: "accept" | "decline") => {
+      if (!group_id) return;
+      setProcessingId(String(request.membershipId));
+      try {
+        await reviewRequest({
+          groupId: group_id as Id<"groups">,
+          membershipId: request.membershipId,
+          action,
+        });
+      } catch (error) {
+        Alert.alert(
+          "Couldn't update request",
+          formatError(error, "Failed to update the request. Please try again."),
+        );
+      } finally {
+        setProcessingId(null);
+      }
+    },
+    [group_id, reviewRequest],
+  );
+
+  const handleAccept = useCallback(
+    (request: GroupJoinRequest) => review(request, "accept"),
+    [review],
+  );
+
+  const handleDecline = useCallback(
+    (request: GroupJoinRequest) => {
+      const name = request.user
+        ? `${request.user.firstName} ${request.user.lastName}`.trim()
+        : "this person";
+      Alert.alert(
+        "Decline request?",
+        `Decline ${name}'s request to join?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Decline",
+            style: "destructive",
+            onPress: () => review(request, "decline"),
+          },
+        ],
+      );
+    },
+    [review],
+  );
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.surfaceSecondary },
+      ]}
+    >
+      {/* Header */}
+      <View style={[styles.header, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <Ionicons name="arrow-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Requests</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      {requests === undefined ? (
+        <View style={styles.centered}>
+          <ActivityIndicator color={primaryColor} />
+        </View>
+      ) : requests.length === 0 ? (
+        <View style={styles.centered}>
+          <Ionicons name="checkmark-done-outline" size={40} color={colors.textTertiary} />
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            No pending requests
+          </Text>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          {requests.map((request) => (
+            <RequestCard
+              key={String(request.membershipId)}
+              request={request}
+              primaryColor={primaryColor}
+              isProcessing={processingId === String(request.membershipId)}
+              onAccept={handleAccept}
+              onDecline={handleDecline}
+            />
+          ))}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 16,
+    borderBottomWidth: 1,
+  },
+  backButton: { padding: 4 },
+  headerTitle: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: "600",
+    textAlign: "center",
+    marginRight: 32,
+  },
+  headerSpacer: { width: 32 },
+  centered: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 12,
+    padding: 24,
+  },
+  emptyText: { fontSize: 15 },
+  scrollContent: { padding: 16, gap: 16 },
+  userCard: {
+    borderRadius: 12,
+    overflow: "hidden",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  userHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 16,
+    gap: 12,
+  },
+  userAvatar: { width: 48, height: 48, borderRadius: 24, overflow: "hidden" },
+  avatarImage: { width: "100%", height: "100%" },
+  avatarPlaceholder: {
+    width: "100%",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  avatarInitials: { fontSize: 18, fontWeight: "bold", color: "#fff" },
+  userInfo: { flex: 1 },
+  userName: { fontSize: 16, fontWeight: "600" },
+  userEmail: { fontSize: 13, marginTop: 2 },
+  membershipSummary: { fontSize: 12, marginTop: 4 },
+  contactRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderTopWidth: 1,
+  },
+  contactButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+  },
+  contactButtonText: { fontSize: 13, fontWeight: "500" },
+  historyButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 8,
+    borderTopWidth: 1,
+  },
+  historyButtonText: { fontSize: 13, fontWeight: "500" },
+  historyList: { borderTopWidth: 1 },
+  historyItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 12,
+    borderBottomWidth: 1,
+  },
+  historyInfo: { flex: 1 },
+  groupName: { fontSize: 15, fontWeight: "500" },
+  groupType: { fontSize: 12, marginTop: 2 },
+  requestDate: { fontSize: 11, marginTop: 2 },
+  statusBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+  },
+  statusBadgeText: { fontSize: 11, fontWeight: "600", textTransform: "capitalize" },
+  decisionRow: {
+    flexDirection: "row",
+    gap: 12,
+    padding: 12,
+    borderTopWidth: 1,
+  },
+  decisionButton: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 10,
+    borderRadius: 10,
+  },
+  decisionText: { fontSize: 15, fontWeight: "600" },
+});

--- a/apps/mobile/features/groups/components/__tests__/GroupDetailScreen.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/GroupDetailScreen.test.tsx
@@ -17,6 +17,7 @@ jest.mock("convex/react", () => ({
 jest.mock("@services/api/convex", () => ({
   useQuery: jest.fn(),
   useMutation: jest.fn(() => jest.fn()),
+  useAuthenticatedQuery: jest.fn(),
   api: {
     functions: {
       groups: {
@@ -30,10 +31,17 @@ jest.mock("@services/api/convex", () => ({
       },
       groupMembers: {
         list: "api.functions.groupMembers.list",
+        countGroupJoinRequests:
+          "api.functions.groupMembers.countGroupJoinRequests",
       },
       groupJoinRequests: {
         create: "api.functions.groupJoinRequests.create",
         cancel: "api.functions.groupJoinRequests.cancel",
+      },
+      scheduling: {
+        events: {
+          listEvents: "api.functions.scheduling.events.listEvents",
+        },
       },
     },
   },

--- a/apps/mobile/features/groups/hooks/useGroupDetails.ts
+++ b/apps/mobile/features/groups/hooks/useGroupDetails.ts
@@ -190,6 +190,8 @@ export function useGroupDetails(groupId: string | null | undefined) {
         externalChatLink: (effectiveGroup as any)?.externalChatLink || null,
         hidden_from_discovery:
           (effectiveGroup as any)?.hiddenFromDiscovery ?? false,
+        join_approval_mode:
+          (effectiveGroup as any)?.joinApprovalMode ?? "admins",
         // Member preview for non-members (shows avatars without full access)
         member_preview: effectiveMemberPreview?.members?.map((m: any) => ({
           id: m.id || "",

--- a/apps/web/src/pages/guides/GroupsAndChannels.tsx
+++ b/apps/web/src/pages/guides/GroupsAndChannels.tsx
@@ -605,6 +605,18 @@ export function GroupsAndChannels() {
             Run the group&rsquo;s events, rostering, and follow-ups.
           </Step>
         </Steps>
+
+        <Callout tone="tip" title="Who approves people who ask to join">
+          By default, a community admin approves requests to join a group (from
+          the admin dashboard). A community admin can hand that off per group:
+          in <Term>Edit group</Term> &rarr; <Term>Approvals</Term>, turning on{" "}
+          &ldquo;Let group leaders approve requests&rdquo; moves it to the
+          leaders. When it&rsquo;s on, a <Term>Requests</Term> section appears on
+          the group page whenever someone is waiting, the group&rsquo;s leaders
+          get a notification for each new request, and those requests no longer
+          show in the admin dashboard. Only community admins can change this
+          setting.
+        </Callout>
       </Section>
 
       <Section id="make-leader" title="Making someone a leader">


### PR DESCRIPTION
## Summary

Adds a per-group **Approvals** setting so a community admin can hand join-request approval off to the group's leaders instead of keeping it at the community-admin dashboard. By default nothing changes — admins still approve. When a group is switched to "leaders approve", the group's leaders review requests from the group page and are notified of new ones.

## What changed

**Setting**
- New `groups.joinApprovalMode` (`"admins"` default | `"leaders"`) + admin-only `setJoinApprovalMode` mutation; surfaced in **Edit Group → Approvals** as an admin-only toggle ("Let group leaders approve requests").

**Leaders-approve behavior**
- A **Requests** section appears on the group page (for the group's leaders, and admins) whenever there are pending requests; it deep-links to a new `/groups/[id]/requests` screen.
- The incoming-request push now targets the group's **leaders** (deep-linking to the requests page) in leaders mode, and community admins otherwise.
- **Full handoff:** leaders-mode requests are excluded from the admin dashboard.

**Requests screen** — rich per-requester cards: request history, groups they already belong to, contact actions (message in Togather, call, text, copy number), and approve/decline.

**Group page reorder** — Members → Requests (leaders mode, when any) → Add people → Check-in → Rostering → Upcoming Events. Rostering keeps its inline slot only once the group has event plans; before that it drops to a bottom group action.

**Incidental fix** — approving a join request now actually notifies the new member. The "Welcome to the group" push/email existed but was never wired up (silent approvals); it now fires from a shared `applyJoinRequestReview` helper used by both the admin dashboard and the leader review paths.

## Authorization

- `setJoinApprovalMode`: community admins only.
- `reviewGroupJoinRequest` / `listGroupJoinRequests` / `countGroupJoinRequests`: community admins always; group leaders only when the group's mode is `"leaders"`. Non-reviewers get empty/zero (no info leak).

## Testing

- New `__tests__/group-leader-approval.test.ts`: leader can only approve in leaders mode, members never can, admins always can, leaders-mode requests leave the admin dashboard, only admins can change the mode.
- Existing Convex suites (join-request review security, membership sync, permissions, notification fallback) pass, including the newly-wired approval notification.
- Full mobile Jest suite passes (GroupDetailScreen test mock updated for the new queries); TypeScript clean on changed files.

## Docs

- Updated the `GroupsAndChannels` onboarding guide with the new admin-controlled setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BYK4uUXPhs17bQbyrw4Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_014BYK4uUXPhs17bQbyrw4Vz)_