### PR TITLE
Redesign Step 1 onboarding info box into scannable guidance cards

### DIFF
--- a/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
+++ b/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
@@ -680,7 +680,7 @@ function StepAboutChurch({
         </View>
       </View>
 
-      {/* Informational callout — guidance, not an input. */}
+      {/* Capacity note — guidance, not an input. */}
       <View
         style={[styles.guideCard, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}
       >
@@ -690,25 +690,50 @@ function StepAboutChurch({
           </View>
           <Text style={[styles.guideTitle, { color: colors.text }]}>Good to know</Text>
         </View>
-
         <Text style={[styles.guideText, { color: colors.textSecondary }]}>
-          One community can hold up to{" "}
-          <Text style={{ color: colors.text, fontWeight: "600" }}>1,000,000 people</Text>
-          {" "}— but this demo is capped at 100 sample members so it stays fast
-          to explore.
+          One community holds up to{" "}
+          <Text style={{ color: colors.text, fontWeight: "600" }}>1M people</Text>
+          {" "}— this demo is capped at 100 members so it stays fast to explore.
         </Text>
+      </View>
 
-        <View style={[styles.guideDivider, { backgroundColor: colors.borderLight }]} />
+      {/* Decision guidance: one community vs. several, split so each scenario
+          is a scannable card rather than one dense paragraph. */}
+      <Text style={[styles.guideSectionLabel, { color: colors.text }]}>
+        One community, or several?
+      </Text>
 
-        <Text style={[styles.guideHeading, { color: colors.text }]}>
-          One community, or several?
-        </Text>
+      <View
+        style={[styles.guideCard, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}
+      >
+        <View style={styles.guideHeader}>
+          <View style={[styles.guideIconBadge, { backgroundColor: colors.success + "1A" }]}>
+            <Ionicons name="checkmark-circle" size={18} color={colors.success} />
+          </View>
+          <Text style={[styles.guideTitle, { color: colors.text }]}>
+            Keep it as ONE community
+          </Text>
+        </View>
         <Text style={[styles.guideText, { color: colors.textSecondary }]}>
-          Put campuses people can reasonably commute between in ONE community
-          (e.g. Brooklyn / Queens / Manhattan, or DC / Maryland / Virginia), and
-          keep the community name broad enough to cover them all. If locations
-          are far apart — different states or regions like Maryland vs. New York
-          — create SEPARATE communities instead.
+          Campuses people can commute between — e.g. Brooklyn / Queens /
+          Manhattan. Use one broad name that covers them all.
+        </Text>
+      </View>
+
+      <View
+        style={[styles.guideCard, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}
+      >
+        <View style={styles.guideHeader}>
+          <View style={[styles.guideIconBadge, { backgroundColor: colors.warning + "1A" }]}>
+            <Ionicons name="git-branch" size={18} color={colors.warning} />
+          </View>
+          <Text style={[styles.guideTitle, { color: colors.text }]}>
+            Make SEPARATE communities
+          </Text>
+        </View>
+        <Text style={[styles.guideText, { color: colors.textSecondary }]}>
+          Locations far apart — different states or regions, like Maryland vs.
+          New York. Give each its own community.
         </Text>
       </View>
     </>
@@ -1262,16 +1287,13 @@ const styles = StyleSheet.create({
   guideTitle: {
     fontSize: 15,
     fontWeight: "700",
+    flex: 1,
   },
-  guideDivider: {
-    height: StyleSheet.hairlineWidth,
-    marginTop: 14,
-    marginBottom: 14,
-  },
-  guideHeading: {
-    fontSize: 14,
-    fontWeight: "600",
-    marginBottom: 5,
+  guideSectionLabel: {
+    fontSize: 15,
+    fontWeight: "700",
+    marginTop: 4,
+    marginBottom: 12,
   },
   guideText: {
     fontSize: 13.5,

--- a/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
+++ b/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
@@ -682,25 +682,34 @@ function StepAboutChurch({
 
       {/* Informational callout — guidance, not an input. */}
       <View
-        style={[styles.callout, { backgroundColor: colors.surfaceSecondary, borderColor: colors.borderLight }]}
+        style={[styles.guideCard, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}
       >
-        <Ionicons name="information-circle-outline" size={20} color={colors.textSecondary} style={styles.calloutIcon} />
-        <View style={{ flex: 1 }}>
-          <Text style={[styles.calloutText, { color: colors.textSecondary }]}>
-            One community can hold up to 1,000,000 people — but this demo is
-            capped at 100 sample members so it stays fast to explore.
-          </Text>
-          <Text style={[styles.calloutHeading, { color: colors.text }]}>
-            One community, or several?
-          </Text>
-          <Text style={[styles.calloutText, { color: colors.textSecondary }]}>
-            Put campuses people can reasonably commute between in ONE community
-            (e.g. Brooklyn / Queens / Manhattan, or DC / Maryland / Virginia),
-            and keep the community name broad enough to cover them all. If
-            locations are far apart — different states or regions like Maryland
-            vs. New York — create SEPARATE communities instead.
-          </Text>
+        <View style={styles.guideHeader}>
+          <View style={[styles.guideIconBadge, { backgroundColor: colors.link + "1A" }]}>
+            <Ionicons name="information-circle" size={18} color={colors.link} />
+          </View>
+          <Text style={[styles.guideTitle, { color: colors.text }]}>Good to know</Text>
         </View>
+
+        <Text style={[styles.guideText, { color: colors.textSecondary }]}>
+          One community can hold up to{" "}
+          <Text style={{ color: colors.text, fontWeight: "600" }}>1,000,000 people</Text>
+          {" "}— but this demo is capped at 100 sample members so it stays fast
+          to explore.
+        </Text>
+
+        <View style={[styles.guideDivider, { backgroundColor: colors.borderLight }]} />
+
+        <Text style={[styles.guideHeading, { color: colors.text }]}>
+          One community, or several?
+        </Text>
+        <Text style={[styles.guideText, { color: colors.textSecondary }]}>
+          Put campuses people can reasonably commute between in ONE community
+          (e.g. Brooklyn / Queens / Manhattan, or DC / Maryland / Virginia), and
+          keep the community name broad enough to cover them all. If locations
+          are far apart — different states or regions like Maryland vs. New York
+          — create SEPARATE communities instead.
+        </Text>
       </View>
     </>
   );
@@ -1229,6 +1238,44 @@ const styles = StyleSheet.create({
   calloutText: {
     fontSize: 13,
     lineHeight: 19,
+  },
+  // Richer guidance card (Step 1) — header badge + divided sections.
+  guideCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 18,
+    marginBottom: 20,
+  },
+  guideHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 12,
+  },
+  guideIconBadge: {
+    width: 30,
+    height: 30,
+    borderRadius: 9,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  guideTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  guideDivider: {
+    height: StyleSheet.hairlineWidth,
+    marginTop: 14,
+    marginBottom: 14,
+  },
+  guideHeading: {
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 5,
+  },
+  guideText: {
+    fontSize: 13.5,
+    lineHeight: 20,
   },
   fieldGroup: {
     marginBottom: 16,


### PR DESCRIPTION
## What & why

The demo onboarding "About your church" step (`DemoCommunityScreen.tsx`, Step 1) showed its guidance in a flat grey-on-grey callout with a tiny floating icon. The capacity note and the "One community, or several?" advice ran together as one dense paragraph with no visual hierarchy — it read as an ugly wall of text.

## Changes

- **"Good to know" card** — clean surface card with a tinted info-icon badge and header. Shortened `1,000,000` → **1M** and trimmed to a single sentence.
- **Two decision cards** — the "One community, or several?" paragraph is split into two scannable cards under a section label:
  - ✓ **Keep it as ONE community** (green icon) — campuses within commuting distance, one broad name.
  - ⇄ **Make SEPARATE communities** (amber icon) — locations far apart (different states/regions).
  - Neutral card surfaces with **icon-only** accent colors keep the screen calm while letting people self-identify their situation at a glance.
- Removed the now-unused `guideDivider` / `guideHeading` styles; added `guideSectionLabel`. Uses only existing theme tokens (`surface`, `link`, `success`, `warning`, `text`, `textSecondary`, `borderLight`), so it adapts across light, dark, and Knicks palettes.

Scoped entirely to Step 1 — the simpler Step 3 (service times) callout is untouched.

## Verification

Rendered a static mock of the React Native styles to confirm layout, icon rendering, and spacing across the three cards. Not driven in-app (the demo screen needs an authenticated session + seeded Convex backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8KwMrH6aUzLpwm3N9ZQUC

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8KwMrH6aUzLpwm3N9ZQUC)_