### PR TITLE
Emoji reactions on prayers, updates & praise reports

### DIFF
--- a/apps/convex/__tests__/prayers/reactions.test.ts
+++ b/apps/convex/__tests__/prayers/reactions.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tests for emoji reactions on prayers and prayer follow-ups.
+ *
+ * Covers: toggle add/remove, the curated-emoji allowlist, access control
+ * (author + prayed-for allowed, non-member and non-prayer rejected), follow-up
+ * targets, folding into getDetail (no extra round-trip), cross-user
+ * aggregation, and the "who reacted" details query.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { api } from "../../_generated/api";
+import { generateTokens } from "../../lib/auth";
+import type { Id } from "../../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+const HEART = "❤️";
+const PRAY = "🙏";
+
+interface Seeded {
+  communityId: Id<"communities">;
+  prayerId: Id<"prayers">;
+  followUpId: Id<"prayerFollowUps">;
+  authorId: Id<"users">;
+  authorToken: string;
+}
+
+async function makeUser(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  firstName: string,
+  phone: string,
+  { member = true }: { member?: boolean } = {},
+): Promise<{ userId: Id<"users">; token: string }> {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert("users", {
+      firstName,
+      lastName: "Tester",
+      phone,
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+  if (member) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("userCommunities", {
+        userId,
+        communityId,
+        status: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+  }
+  const { accessToken } = await generateTokens(userId);
+  return { userId, token: accessToken };
+}
+
+async function seed(t: ReturnType<typeof convexTest>): Promise<Seeded> {
+  const communityId = await t.run(async (ctx) => {
+    return await ctx.db.insert("communities", {
+      name: "Test Community",
+      subdomain: "test",
+      slug: "test",
+      timezone: "America/New_York",
+      churchFeatures: { prayerEnabled: true },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const { userId: authorId, token: authorToken } = await makeUser(
+    t,
+    communityId,
+    "Author",
+    "+15555550001",
+  );
+
+  const prayerId = await t.run(async (ctx) => {
+    return await ctx.db.insert("prayers", {
+      communityId,
+      authorUserId: authorId,
+      isAnonymous: false,
+      bodyText: "Please pray for my mom's surgery",
+      status: "active",
+      prayedForCount: 0,
+      moderationStatus: "approved",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+
+  const followUpId = await t.run(async (ctx) => {
+    return await ctx.db.insert("prayerFollowUps", {
+      prayerId,
+      authorUserId: authorId,
+      kind: "praise_report",
+      bodyText: "Surgery went perfectly!",
+      createdAt: Date.now(),
+    });
+  });
+
+  return { communityId, prayerId, followUpId, authorId, authorToken };
+}
+
+/** Give a user a prayerResponses row so they pass the "hasPrayed" gate. */
+async function recordPrayed(
+  t: ReturnType<typeof convexTest>,
+  prayerId: Id<"prayers">,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("prayerResponses", {
+      prayerId,
+      userId,
+      communityId,
+      prayedAt: Date.now(),
+    });
+  });
+}
+
+describe("prayer reactions", () => {
+  test("author can add a reaction; toggling again removes it", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId, authorToken } = await seed(t);
+
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: authorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: HEART,
+    });
+
+    let rows = await t.run(async (ctx) =>
+      ctx.db.query("prayerReactions").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].emoji).toBe(HEART);
+    expect(rows[0].targetType).toBe("prayer");
+
+    // Toggle off
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: authorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: HEART,
+    });
+    rows = await t.run(async (ctx) =>
+      ctx.db.query("prayerReactions").collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("double add of the same emoji nets to one row then none", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId, authorToken } = await seed(t);
+
+    // Two toggles = add then remove = zero rows, never two.
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: authorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: PRAY,
+    });
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: authorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: PRAY,
+    });
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("prayerReactions").collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("rejects an emoji outside the curated allowlist", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId, authorToken } = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.prayers.reactions.toggleReaction, {
+        token: authorToken,
+        targetType: "prayer",
+        targetId: prayerId,
+        emoji: "💩",
+      }),
+    ).rejects.toThrow(/invalid_reaction_emoji/);
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("prayerReactions").collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("a member who has not prayed cannot react", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId, communityId } = await seed(t);
+    const { token } = await makeUser(
+      t,
+      communityId,
+      "Bystander",
+      "+15555550002",
+    );
+
+    await expect(
+      t.mutation(api.functions.prayers.reactions.toggleReaction, {
+        token,
+        targetType: "prayer",
+        targetId: prayerId,
+        emoji: HEART,
+      }),
+    ).rejects.toThrow(/prayer_not_accessible/);
+  });
+
+  test("a non-member cannot react even after (impossibly) prayed", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId } = await seed(t);
+    // User in NO community.
+    const nonMemberId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Outsider",
+        phone: "+15555550003",
+        phoneVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const { accessToken } = await generateTokens(nonMemberId);
+
+    await expect(
+      t.mutation(api.functions.prayers.reactions.toggleReaction, {
+        token: accessToken,
+        targetType: "prayer",
+        targetId: prayerId,
+        emoji: HEART,
+      }),
+    ).rejects.toThrow(/prayer_not_accessible/);
+  });
+
+  test("a member who prayed can react on the request and a follow-up", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId, followUpId, communityId } = await seed(t);
+    const { userId, token } = await makeUser(
+      t,
+      communityId,
+      "Prayed",
+      "+15555550004",
+    );
+    await recordPrayed(t, prayerId, communityId, userId);
+
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: HEART,
+    });
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token,
+      targetType: "followUp",
+      targetId: followUpId,
+      emoji: PRAY,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("prayerReactions").collect(),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.targetType).sort()).toEqual([
+      "followUp",
+      "prayer",
+    ]);
+  });
+
+  test("getDetail folds aggregated reactions onto the request and follow-ups", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId, followUpId, communityId, authorId, authorToken } =
+      await seed(t);
+    const { userId: reactorId, token: reactorToken } = await makeUser(
+      t,
+      communityId,
+      "Reactor",
+      "+15555550005",
+    );
+    await recordPrayed(t, prayerId, communityId, reactorId);
+
+    // Author + reactor both heart the request; reactor prays on the follow-up.
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: authorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: HEART,
+    });
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: reactorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: HEART,
+    });
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: reactorToken,
+      targetType: "followUp",
+      targetId: followUpId,
+      emoji: PRAY,
+    });
+
+    // Reactor's view: shared count of 2, hasReacted true on the request.
+    const detail = await t.query(api.functions.prayers.getDetail, {
+      token: reactorToken,
+      prayerId,
+    });
+    expect(detail).not.toBeNull();
+    expect(detail!.reactions).toEqual([
+      { emoji: HEART, count: 2, hasReacted: true },
+    ]);
+    expect(detail!.followUps[0].reactions).toEqual([
+      { emoji: PRAY, count: 1, hasReacted: true },
+    ]);
+
+    // Author's view: same shared count, but hasReacted false on the follow-up.
+    const authorView = await t.query(api.functions.prayers.getDetail, {
+      token: authorToken,
+      prayerId,
+    });
+    expect(authorView!.reactions).toEqual([
+      { emoji: HEART, count: 2, hasReacted: true },
+    ]);
+    expect(authorView!.followUps[0].reactions).toEqual([
+      { emoji: PRAY, count: 1, hasReacted: false },
+    ]);
+    expect(authorId).toBeDefined();
+  });
+
+  test("getReactionDetails lists who reacted with an emoji", async () => {
+    const t = convexTest(schema, modules);
+    const { prayerId, communityId, authorToken } = await seed(t);
+    const { userId: reactorId, token: reactorToken } = await makeUser(
+      t,
+      communityId,
+      "Grace",
+      "+15555550006",
+    );
+    await recordPrayed(t, prayerId, communityId, reactorId);
+
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: authorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: HEART,
+    });
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: reactorToken,
+      targetType: "prayer",
+      targetId: prayerId,
+      emoji: HEART,
+    });
+
+    const reactors = await t.query(
+      api.functions.prayers.reactions.getReactionDetails,
+      {
+        token: reactorToken,
+        targetType: "prayer",
+        targetId: prayerId,
+        emoji: HEART,
+      },
+    );
+    expect(reactors).toHaveLength(2);
+    const names = reactors.map((r) => r.displayName).sort();
+    expect(names).toEqual(["Author Tester", "Grace Tester"]);
+  });
+});

--- a/apps/convex/__tests__/prayers/reactions.test.ts
+++ b/apps/convex/__tests__/prayers/reactions.test.ts
@@ -337,6 +337,196 @@ describe("prayer reactions", () => {
     expect(authorId).toBeDefined();
   });
 
+  test("anonymous prayer's author cannot react to their own request (no unmasking)", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId } = await seed(t);
+    const { userId: anonAuthorId, token: anonAuthorToken } = await makeUser(
+      t,
+      communityId,
+      "Anon",
+      "+15555550007",
+    );
+    const anonPrayerId = await t.run(async (ctx) =>
+      ctx.db.insert("prayers", {
+        communityId,
+        authorUserId: anonAuthorId,
+        isAnonymous: true,
+        bodyText: "Please pray, but keep me anonymous",
+        status: "active",
+        prayedForCount: 0,
+        moderationStatus: "approved",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    await expect(
+      t.mutation(api.functions.prayers.reactions.toggleReaction, {
+        token: anonAuthorToken,
+        targetType: "prayer",
+        targetId: anonPrayerId,
+        emoji: HEART,
+      }),
+    ).rejects.toThrow(/anonymous_author_cannot_react/);
+
+    // No row was created, so the author can never surface in the reactor list.
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("prayerReactions").collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("anonymous prayer's author cannot react to their own follow-up", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId } = await seed(t);
+    const { userId: anonAuthorId, token: anonAuthorToken } = await makeUser(
+      t,
+      communityId,
+      "Anon",
+      "+15555550008",
+    );
+    const { anonFollowUpId } = await t.run(async (ctx) => {
+      const anonPrayerId = await ctx.db.insert("prayers", {
+        communityId,
+        authorUserId: anonAuthorId,
+        isAnonymous: true,
+        bodyText: "Anonymous prayer with an update",
+        status: "active",
+        prayedForCount: 0,
+        moderationStatus: "approved",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      const anonFollowUpId = await ctx.db.insert("prayerFollowUps", {
+        prayerId: anonPrayerId,
+        authorUserId: anonAuthorId,
+        kind: "update",
+        bodyText: "A small update",
+        createdAt: Date.now(),
+      });
+      return { anonFollowUpId };
+    });
+
+    await expect(
+      t.mutation(api.functions.prayers.reactions.toggleReaction, {
+        token: anonAuthorToken,
+        targetType: "followUp",
+        targetId: anonFollowUpId,
+        emoji: PRAY,
+      }),
+    ).rejects.toThrow(/anonymous_author_cannot_react/);
+  });
+
+  test("a prayed-for viewer can still react to an anonymous prayer (only the author is blocked)", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId } = await seed(t);
+    const { userId: anonAuthorId } = await makeUser(
+      t,
+      communityId,
+      "Anon",
+      "+15555550009",
+    );
+    const anonPrayerId = await t.run(async (ctx) =>
+      ctx.db.insert("prayers", {
+        communityId,
+        authorUserId: anonAuthorId,
+        isAnonymous: true,
+        bodyText: "Anonymous prayer others can react to",
+        status: "active",
+        prayedForCount: 0,
+        moderationStatus: "approved",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const { userId: reactorId, token: reactorToken } = await makeUser(
+      t,
+      communityId,
+      "Reactor",
+      "+15555550010",
+    );
+    await recordPrayed(t, anonPrayerId, communityId, reactorId);
+
+    await t.mutation(api.functions.prayers.reactions.toggleReaction, {
+      token: reactorToken,
+      targetType: "prayer",
+      targetId: anonPrayerId,
+      emoji: HEART,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("prayerReactions").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(reactorId);
+  });
+
+  test("a non-author cannot react to a prayer that was later rejected", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId } = await seed(t);
+    const { userId: rejectedAuthorId } = await makeUser(
+      t,
+      communityId,
+      "RejectedAuthor",
+      "+15555550011",
+    );
+    const rejectedPrayerId = await t.run(async (ctx) =>
+      ctx.db.insert("prayers", {
+        communityId,
+        authorUserId: rejectedAuthorId,
+        isAnonymous: false,
+        bodyText: "This prayer was moderated out",
+        status: "active",
+        prayedForCount: 0,
+        moderationStatus: "rejected",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const { userId: viewerId, token: viewerToken } = await makeUser(
+      t,
+      communityId,
+      "Viewer",
+      "+15555550012",
+    );
+    // The viewer prayed for it before it was rejected (stale deep link).
+    await recordPrayed(t, rejectedPrayerId, communityId, viewerId);
+
+    await expect(
+      t.mutation(api.functions.prayers.reactions.toggleReaction, {
+        token: viewerToken,
+        targetType: "prayer",
+        targetId: rejectedPrayerId,
+        emoji: HEART,
+      }),
+    ).rejects.toThrow(/prayer_not_accessible/);
+  });
+
+  test("a malformed targetId denies cleanly instead of raising a raw id error", async () => {
+    const t = convexTest(schema, modules);
+    const { authorToken } = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.prayers.reactions.toggleReaction, {
+        token: authorToken,
+        targetType: "prayer",
+        targetId: "not-a-real-id",
+        emoji: HEART,
+      }),
+    ).rejects.toThrow(/prayer_not_accessible/);
+
+    const reactors = await t.query(
+      api.functions.prayers.reactions.getReactionDetails,
+      {
+        token: authorToken,
+        targetType: "prayer",
+        targetId: "not-a-real-id",
+        emoji: HEART,
+      },
+    );
+    expect(reactors).toEqual([]);
+  });
+
   test("getReactionDetails lists who reacted with an emoji", async () => {
     const t = convexTest(schema, modules);
     const { prayerId, communityId, authorToken } = await seed(t);

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -139,6 +139,7 @@ import type * as functions_peopleSavedViews from "../functions/peopleSavedViews.
 import type * as functions_posters from "../functions/posters.js";
 import type * as functions_prayers from "../functions/prayers.js";
 import type * as functions_prayers_notifications from "../functions/prayers/notifications.js";
+import type * as functions_prayers_reactions from "../functions/prayers/reactions.js";
 import type * as functions_proposals from "../functions/proposals.js";
 import type * as functions_publicApi from "../functions/publicApi.js";
 import type * as functions_resources from "../functions/resources.js";
@@ -372,6 +373,7 @@ declare const fullApi: ApiFromModules<{
   "functions/posters": typeof functions_posters;
   "functions/prayers": typeof functions_prayers;
   "functions/prayers/notifications": typeof functions_prayers_notifications;
+  "functions/prayers/reactions": typeof functions_prayers_reactions;
   "functions/proposals": typeof functions_proposals;
   "functions/publicApi": typeof functions_publicApi;
   "functions/resources": typeof functions_resources;

--- a/apps/convex/functions/prayers.ts
+++ b/apps/convex/functions/prayers.ts
@@ -25,6 +25,7 @@ import { requireAuth } from "../lib/auth";
 import { now } from "../lib/utils";
 import { moderatePrayerText, type ModerationResult } from "../lib/moderation/prayer";
 import { notify, notifyBatch, notifyCommunityAdmins } from "../lib/notifications/send";
+import { aggregateReactionsForTargets } from "./prayers/reactions";
 
 const MAX_BODY_LENGTH = 500;
 const FEED_LIMIT = 3;
@@ -417,6 +418,18 @@ export const getDetail = query({
       .collect();
     followUps.sort((a, b) => a.createdAt - b.createdAt);
 
+    // Fold emoji reactions for the request card + every follow-up card into
+    // this one query so both detail screens render reaction badges without an
+    // extra round-trip (no per-card N+1). Aggregated to { emoji, count,
+    // hasReacted }, the same shape chat returns.
+    const reactionsByTarget = await aggregateReactionsForTargets(ctx, userId, [
+      { targetType: "prayer", targetId: prayer._id },
+      ...followUps.map((f) => ({
+        targetType: "followUp" as const,
+        targetId: f._id,
+      })),
+    ]);
+
     // Author display: shown only when the prayer is not anonymous. The
     // author themselves always sees themselves; prayed-for viewers see
     // "First L." for non-anon prayers and nothing for anonymous ones.
@@ -435,6 +448,7 @@ export const getDetail = query({
       isAuthor,
       authorDisplayName,
       crisisFlag: prayer.crisisFlag === true,
+      reactions: reactionsByTarget[prayer._id] ?? [],
       // Only include author-only fields when caller is the author. The
       // moderationDetail (with category + admin note) is for author
       // transparency on rejected/pending prayers — never leaked to viewers.
@@ -450,6 +464,7 @@ export const getDetail = query({
         kind: f.kind,
         bodyText: f.bodyText,
         createdAt: f.createdAt,
+        reactions: reactionsByTarget[f._id] ?? [],
       })),
     };
   },

--- a/apps/convex/functions/prayers/reactions.ts
+++ b/apps/convex/functions/prayers/reactions.ts
@@ -54,10 +54,13 @@ export interface AggregatedReaction {
 /**
  * Resolve the `prayers` row that owns a reaction target and confirm the caller
  * may see it. Returns the prayer when the caller is a member of its community
- * and is either the author or has a `prayerResponses` row; otherwise `null`.
+ * and is either the author or has a `prayerResponses` row on an **approved**
+ * prayer; otherwise `null`.
  *
  * This is the same gate `prayers.getDetail` enforces — reactions are strictly
- * a subset of "can view this prayer detail".
+ * a subset of "can view this prayer detail" — plus a moderation guard so a
+ * stale detail screen or deep link can't keep reacting to a prayer that was
+ * later admin-rejected (see below).
  */
 async function resolveAccessiblePrayer(
   ctx: QueryCtx,
@@ -65,11 +68,19 @@ async function resolveAccessiblePrayer(
   targetType: PrayerReactionTargetType,
   targetId: string,
 ): Promise<Doc<"prayers"> | null> {
+  // `targetId` is a bare string (the target is polymorphic, so it can't be a
+  // typed `v.id`). `normalizeId` returns null for a malformed id instead of
+  // letting `ctx.db.get` throw Convex's "invalid id" error — a bad id should
+  // deny cleanly, not surface a raw 500.
   let prayer: Doc<"prayers"> | null;
   if (targetType === "prayer") {
-    prayer = await ctx.db.get(targetId as Id<"prayers">);
+    const prayerId = ctx.db.normalizeId("prayers", targetId);
+    if (!prayerId) return null;
+    prayer = await ctx.db.get(prayerId);
   } else {
-    const followUp = await ctx.db.get(targetId as Id<"prayerFollowUps">);
+    const followUpId = ctx.db.normalizeId("prayerFollowUps", targetId);
+    if (!followUpId) return null;
+    const followUp = await ctx.db.get(followUpId);
     if (!followUp) return null;
     prayer = await ctx.db.get(followUp.prayerId);
   }
@@ -98,7 +109,16 @@ async function resolveAccessiblePrayer(
       q.eq("prayerId", prayer!._id).eq("userId", userId),
     )
     .first());
-  return hasPrayed ? prayer : null;
+  if (!hasPrayed) return null;
+
+  // Non-author viewers may only react to (or read reactors of) an approved
+  // prayer. The feed and `myPrayedFor` already hide rejected/pending prayers,
+  // but a previously-prayed prayer that was later admin-rejected could still be
+  // reached via a stale detail screen or notification deep link — without this
+  // guard, removed/moderated content would keep accumulating visible
+  // reactions. The author keeps access to their own prayer (matching
+  // getDetail) regardless of moderation state.
+  return prayer.moderationStatus === "approved" ? prayer : null;
 }
 
 // ============================================================================
@@ -188,6 +208,18 @@ export const toggleReaction = mutation({
     );
     if (!prayer) {
       throw new ConvexError("prayer_not_accessible");
+    }
+
+    // Anonymity guard: the author of an *anonymous* prayer must not react to
+    // their own request or follow-ups. Reactors are attributed by real name in
+    // the "who reacted" list, so a self-reaction would surface the author's
+    // identity there (and via `hasReacted`/counts) and defeat the prayer's
+    // anonymity. Reacting to *other* people's prayers is unaffected; this only
+    // blocks a self-reaction that would unmask an anonymous author. The mobile
+    // UI hides the reaction affordance on an anonymous author's own cards, so
+    // this is defense in depth against a stale client or deep link.
+    if (prayer.isAnonymous && prayer.authorUserId === userId) {
+      throw new ConvexError("anonymous_author_cannot_react");
     }
 
     const existing = await ctx.db

--- a/apps/convex/functions/prayers/reactions.ts
+++ b/apps/convex/functions/prayers/reactions.ts
@@ -1,0 +1,273 @@
+/**
+ * Emoji reactions on prayer requests and their follow-ups.
+ *
+ * Mirrors `messaging/reactions.ts`, but the target is polymorphic: a reaction
+ * lives on either a `prayers` row (`targetType: "prayer"`) or a
+ * `prayerFollowUps` row (`targetType: "followUp"`). See the `prayerReactions`
+ * table in schema.ts.
+ *
+ * Two differences from chat reactions, both deliberate for the tender prayer
+ * context:
+ *   1. `emoji` is validated against a small server-side allowlist
+ *      (`PRAYER_REACTION_EMOJIS`) — only the curated set is accepted.
+ *   2. Access reuses the exact prayer visibility gate from `getDetail`: only a
+ *      community member who is the author or who has already prayed for the
+ *      prayer may react (or read the reactor list).
+ */
+
+import { v, ConvexError } from "convex/values";
+import { query, mutation, type QueryCtx } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { requireAuth } from "../../lib/auth";
+import { now } from "../../lib/utils";
+
+/**
+ * Curated reaction set for prayers — a warm, tight 6, narrower than chat's 14
+ * because prayer is a more tender context than group chat. This is the single
+ * source of truth for both the picker bar (frontend imports it) and the
+ * server-side allowlist. Adjusting the product choice is a one-line edit here.
+ */
+export const PRAYER_REACTION_EMOJIS = [
+  "❤️", // Love & support — "I'm with you"
+  "🙏", // Praying with you / amen
+  "🎉", // Celebrate — answered prayers & praise reports
+  "🙌", // Praise / hallelujah
+  "🕊️", // Peace & comfort
+  "🥹", // Deeply moved / touched
+] as const;
+
+const ALLOWED_EMOJIS = new Set<string>(PRAYER_REACTION_EMOJIS);
+
+export type PrayerReactionTargetType = "prayer" | "followUp";
+
+/** Aggregated reaction shape returned to the client (mirrors chat's shape). */
+export interface AggregatedReaction {
+  emoji: string;
+  count: number;
+  hasReacted: boolean;
+}
+
+// ============================================================================
+// Access control (mirrors prayers.getDetail's gate)
+// ============================================================================
+
+/**
+ * Resolve the `prayers` row that owns a reaction target and confirm the caller
+ * may see it. Returns the prayer when the caller is a member of its community
+ * and is either the author or has a `prayerResponses` row; otherwise `null`.
+ *
+ * This is the same gate `prayers.getDetail` enforces — reactions are strictly
+ * a subset of "can view this prayer detail".
+ */
+async function resolveAccessiblePrayer(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+  targetType: PrayerReactionTargetType,
+  targetId: string,
+): Promise<Doc<"prayers"> | null> {
+  let prayer: Doc<"prayers"> | null;
+  if (targetType === "prayer") {
+    prayer = await ctx.db.get(targetId as Id<"prayers">);
+  } else {
+    const followUp = await ctx.db.get(targetId as Id<"prayerFollowUps">);
+    if (!followUp) return null;
+    prayer = await ctx.db.get(followUp.prayerId);
+  }
+  if (!prayer) return null;
+
+  // Community must still have prayer enabled and the caller must still be a
+  // member — same deep-link safety check as getDetail.
+  const community = await ctx.db.get(prayer.communityId);
+  if (!community?.churchFeatures?.prayerEnabled) return null;
+
+  const membership = await ctx.db
+    .query("userCommunities")
+    .withIndex("by_user_community", (q) =>
+      q.eq("userId", userId).eq("communityId", prayer!.communityId),
+    )
+    .filter((q) => q.eq(q.field("status"), 1))
+    .first();
+  if (!membership) return null;
+
+  const isAuthor = prayer.authorUserId === userId;
+  if (isAuthor) return prayer;
+
+  const hasPrayed = !!(await ctx.db
+    .query("prayerResponses")
+    .withIndex("by_prayer_user", (q) =>
+      q.eq("prayerId", prayer!._id).eq("userId", userId),
+    )
+    .first());
+  return hasPrayed ? prayer : null;
+}
+
+// ============================================================================
+// Aggregation helper (shared with prayers.getDetail)
+// ============================================================================
+
+/**
+ * Aggregate reactions for a batch of targets in one round-trip (one index scan
+ * per target — the same shape as chat's `getReactionsForMessages`). Returns a
+ * map keyed by `targetId` to the `{ emoji, count, hasReacted }[]` list. Used by
+ * `getDetail` so both prayer detail screens fetch the request card + every
+ * follow-up card's reactions without an extra query.
+ */
+export async function aggregateReactionsForTargets(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+  targets: Array<{ targetType: PrayerReactionTargetType; targetId: string }>,
+): Promise<Record<string, AggregatedReaction[]>> {
+  const result: Record<string, AggregatedReaction[]> = {};
+
+  await Promise.all(
+    targets.map(async ({ targetType, targetId }) => {
+      const rows = await ctx.db
+        .query("prayerReactions")
+        .withIndex("by_target", (q) =>
+          q.eq("targetType", targetType).eq("targetId", targetId),
+        )
+        .collect();
+
+      const emojiMap = new Map<string, { count: number; hasReacted: boolean }>();
+      for (const row of rows) {
+        const existing = emojiMap.get(row.emoji);
+        if (existing) {
+          existing.count++;
+          if (row.userId === userId) existing.hasReacted = true;
+        } else {
+          emojiMap.set(row.emoji, {
+            count: 1,
+            hasReacted: row.userId === userId,
+          });
+        }
+      }
+
+      // Order by the curated emoji list so badges render consistently.
+      result[targetId] = PRAYER_REACTION_EMOJIS.filter((e) =>
+        emojiMap.has(e),
+      ).map((emoji) => {
+        const data = emojiMap.get(emoji)!;
+        return { emoji, count: data.count, hasReacted: data.hasReacted };
+      });
+    }),
+  );
+
+  return result;
+}
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+/**
+ * Toggle a reaction on a prayer request or one of its follow-ups. Inserts the
+ * row if the caller hasn't reacted with this emoji on this target, deletes it
+ * if they have. One row per (target, user, emoji).
+ *
+ * No notification is sent — reactions are silent in v1, like chat.
+ */
+export const toggleReaction = mutation({
+  args: {
+    token: v.string(),
+    targetType: v.union(v.literal("prayer"), v.literal("followUp")),
+    targetId: v.string(),
+    emoji: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    if (!ALLOWED_EMOJIS.has(args.emoji)) {
+      throw new ConvexError("invalid_reaction_emoji");
+    }
+
+    const prayer = await resolveAccessiblePrayer(
+      ctx,
+      userId,
+      args.targetType,
+      args.targetId,
+    );
+    if (!prayer) {
+      throw new ConvexError("prayer_not_accessible");
+    }
+
+    const existing = await ctx.db
+      .query("prayerReactions")
+      .withIndex("by_target_user", (q) =>
+        q
+          .eq("targetType", args.targetType)
+          .eq("targetId", args.targetId)
+          .eq("userId", userId),
+      )
+      .filter((q) => q.eq(q.field("emoji"), args.emoji))
+      .first();
+
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    } else {
+      await ctx.db.insert("prayerReactions", {
+        communityId: prayer.communityId,
+        targetType: args.targetType,
+        targetId: args.targetId,
+        userId,
+        emoji: args.emoji,
+        createdAt: now(),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+/**
+ * Who reacted with a given emoji on a target — powers the long-press "who
+ * reacted" list, mirroring chat's `getReactionDetails`. Attribution is by
+ * design: reacting is a social action and is never anonymous, independent of
+ * the prayer author's own anonymity.
+ */
+export const getReactionDetails = query({
+  args: {
+    token: v.string(),
+    targetType: v.union(v.literal("prayer"), v.literal("followUp")),
+    targetId: v.string(),
+    emoji: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const prayer = await resolveAccessiblePrayer(
+      ctx,
+      userId,
+      args.targetType,
+      args.targetId,
+    );
+    if (!prayer) return [];
+
+    const reactions = await ctx.db
+      .query("prayerReactions")
+      .withIndex("by_target", (q) =>
+        q.eq("targetType", args.targetType).eq("targetId", args.targetId),
+      )
+      .filter((q) => q.eq(q.field("emoji"), args.emoji))
+      .collect();
+
+    const users = await Promise.all(
+      reactions.map(async (reaction) => {
+        const user = await ctx.db.get(reaction.userId);
+        if (!user) return null;
+        const displayName =
+          [user.firstName, user.lastName].filter(Boolean).join(" ") ||
+          user.username ||
+          "Unknown";
+        return {
+          userId: reaction.userId,
+          displayName,
+          profilePhoto: user.profilePhoto ?? null,
+        };
+      }),
+    );
+
+    return users.filter((u): u is NonNullable<typeof u> => u !== null);
+  },
+});

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3641,6 +3641,29 @@ export default defineSchema({
   }).index("by_prayer", ["prayerId"]),
 
   /**
+   * Lightweight emoji reactions on a prayer request or one of its follow-ups
+   * (updates / praise reports). Mirrors `chatMessageReactions`, but because a
+   * reaction can target two different row kinds, the target is polymorphic:
+   * `targetType` picks the table and `targetId` holds the string id of a
+   * `prayers` or `prayerFollowUps` row. One row per (target, user, emoji);
+   * uniqueness is enforced in the mutation via `by_target_user`. `emoji` is
+   * validated against a server-side allowlist before insert.
+   *
+   * `communityId` is denormalized for scoping and to make cleanup/queries
+   * cheap without joining back through the prayer.
+   */
+  prayerReactions: defineTable({
+    communityId: v.id("communities"),
+    targetType: v.union(v.literal("prayer"), v.literal("followUp")),
+    targetId: v.string(), // a prayers._id or prayerFollowUps._id
+    userId: v.id("users"),
+    emoji: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_target", ["targetType", "targetId"])
+    .index("by_target_user", ["targetType", "targetId", "userId"]),
+
+  /**
    * Member-filed reports against a published prayer — the last-line
    * defense after our LLM and any author-side nudges. Each report is one
    * (prayer, reporter) pair; we enforce uniqueness in the mutation via

--- a/apps/mobile/features/prayer/components/MyPrayerDetailScreen.tsx
+++ b/apps/mobile/features/prayer/components/MyPrayerDetailScreen.tsx
@@ -216,6 +216,7 @@ export function MyPrayerDetailScreen() {
             targetType="prayer"
             targetId={detail.id}
             reactions={detail.reactions}
+            canReact={!(detail as any).isAnonymous}
           />
         </View>
 
@@ -276,6 +277,7 @@ export function MyPrayerDetailScreen() {
                 targetType="followUp"
                 targetId={f.id}
                 reactions={f.reactions}
+                canReact={!(detail as any).isAnonymous}
               />
             </View>
           ))

--- a/apps/mobile/features/prayer/components/MyPrayerDetailScreen.tsx
+++ b/apps/mobile/features/prayer/components/MyPrayerDetailScreen.tsx
@@ -26,6 +26,7 @@ import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useAuthenticatedQuery, useAuthenticatedMutation, api } from '@services/api/convex';
 import { formatError } from '@/utils/error-handling';
 import { CrisisResourceCard } from './CrisisResourceCard';
+import { PrayerReactions } from './PrayerReactions';
 import type { Id } from '@services/api/convex';
 
 // Human-readable copy for moderation outcomes shown on the author's detail
@@ -211,6 +212,11 @@ export function MyPrayerDetailScreen() {
               {new Date(detail.createdAt).toLocaleDateString()}
             </Text>
           </View>
+          <PrayerReactions
+            targetType="prayer"
+            targetId={detail.id}
+            reactions={detail.reactions}
+          />
         </View>
 
         {/* Author-only lifecycle actions */}
@@ -266,6 +272,11 @@ export function MyPrayerDetailScreen() {
                 </Text>
               </View>
               <Text style={[styles.followUpBody, { color: colors.text }]}>{f.bodyText}</Text>
+              <PrayerReactions
+                targetType="followUp"
+                targetId={f.id}
+                reactions={f.reactions}
+              />
             </View>
           ))
         )}

--- a/apps/mobile/features/prayer/components/PrayedPrayerDetailScreen.tsx
+++ b/apps/mobile/features/prayer/components/PrayedPrayerDetailScreen.tsx
@@ -25,6 +25,7 @@ import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useAuthenticatedQuery, api } from '@services/api/convex';
 import type { Id } from '@services/api/convex';
 import { CrisisResourceCard } from './CrisisResourceCard';
+import { PrayerReactions } from './PrayerReactions';
 
 const COMPLETED_GREEN = '#34C759';
 
@@ -120,6 +121,11 @@ export function PrayedPrayerDetailScreen() {
               {new Date(detail.createdAt).toLocaleDateString()}
             </Text>
           </View>
+          <PrayerReactions
+            targetType="prayer"
+            targetId={detail.id}
+            reactions={detail.reactions}
+          />
         </View>
 
         <Text style={[styles.sectionTitle, { color: colors.text }]}>Updates</Text>
@@ -155,6 +161,11 @@ export function PrayedPrayerDetailScreen() {
                 </Text>
               </View>
               <Text style={[styles.followUpBody, { color: colors.text }]}>{f.bodyText}</Text>
+              <PrayerReactions
+                targetType="followUp"
+                targetId={f.id}
+                reactions={f.reactions}
+              />
             </View>
           ))
         )}

--- a/apps/mobile/features/prayer/components/PrayerReactionDetailsModal.tsx
+++ b/apps/mobile/features/prayer/components/PrayerReactionDetailsModal.tsx
@@ -1,0 +1,146 @@
+/**
+ * PrayerReactionDetailsModal — "who reacted with this emoji" list for a prayer
+ * request or follow-up. Mirrors the chat `ReactionDetailsModal`, but reads from
+ * `prayers.reactions.getReactionDetails` (polymorphic target) instead of the
+ * chat-message query.
+ */
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  Pressable,
+  FlatList,
+  ActivityIndicator,
+} from 'react-native';
+import { Avatar } from '@components/ui';
+import { useTheme } from '@hooks/useTheme';
+import { useAuthenticatedQuery, api } from '@services/api/convex';
+import type { PrayerReactionTargetType } from './PrayerReactions';
+
+interface Reactor {
+  userId: string;
+  displayName: string;
+  profilePhoto: string | null;
+}
+
+interface PrayerReactionDetailsModalProps {
+  visible: boolean;
+  emoji: string | null;
+  targetType: PrayerReactionTargetType;
+  targetId: string;
+  onClose: () => void;
+}
+
+export function PrayerReactionDetailsModal({
+  visible,
+  emoji,
+  targetType,
+  targetId,
+  onClose,
+}: PrayerReactionDetailsModalProps) {
+  const { colors } = useTheme();
+
+  const users = useAuthenticatedQuery(
+    api.functions.prayers.reactions.getReactionDetails,
+    visible && emoji ? { targetType, targetId, emoji } : 'skip',
+  ) as Reactor[] | undefined;
+  const isLoading = users === undefined;
+
+  const renderUserItem = ({ item }: { item: Reactor }) => (
+    <View style={styles.userItem}>
+      <Avatar name={item.displayName} imageUrl={item.profilePhoto} size={40} />
+      <Text style={[styles.userName, { color: colors.text }]} numberOfLines={1}>
+        {item.displayName}
+      </Text>
+    </View>
+  );
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.link} />
+        </View>
+      );
+    }
+    if (users.length === 0) {
+      return (
+        <View style={styles.emptyContainer}>
+          <Text style={[styles.emptyText, { color: colors.textTertiary }]}>
+            No reactions found
+          </Text>
+        </View>
+      );
+    }
+    return (
+      <FlatList
+        data={users}
+        renderItem={renderUserItem}
+        keyExtractor={(item) => item.userId}
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+      />
+    );
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable
+        style={[styles.backdrop, { backgroundColor: colors.overlay }]}
+        onPress={onClose}
+      >
+        <Pressable
+          style={[styles.modalContainer, { backgroundColor: colors.modalBackground }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={styles.header}>
+            <Text style={styles.headerEmoji}>{emoji}</Text>
+            {!isLoading && (
+              <Text style={[styles.headerText, { color: colors.text }]}>
+                {users.length} {users.length === 1 ? 'reaction' : 'reactions'}
+              </Text>
+            )}
+          </View>
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          {renderContent()}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  modalContainer: {
+    borderRadius: 16,
+    width: '80%',
+    maxWidth: 320,
+    maxHeight: '60%',
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+  },
+  headerEmoji: { fontSize: 28, marginRight: 8 },
+  headerText: { fontSize: 16, fontWeight: '600' },
+  divider: { height: 1 },
+  loadingContainer: { paddingVertical: 40, alignItems: 'center', justifyContent: 'center' },
+  emptyContainer: { paddingVertical: 40, alignItems: 'center', justifyContent: 'center' },
+  emptyText: { fontSize: 14 },
+  list: { flexShrink: 1 },
+  listContent: { paddingVertical: 8 },
+  userItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+  },
+  userName: { flex: 1, fontSize: 15, fontWeight: '500', marginLeft: 12 },
+});

--- a/apps/mobile/features/prayer/components/PrayerReactions.tsx
+++ b/apps/mobile/features/prayer/components/PrayerReactions.tsx
@@ -55,12 +55,22 @@ interface PrayerReactionsProps {
   targetType: PrayerReactionTargetType;
   targetId: string;
   reactions: AggregatedReaction[];
+  /**
+   * Whether the current viewer may add/toggle a reaction. Defaults to true.
+   * Set to false on an anonymous prayer's author's *own* cards: reacting there
+   * would attribute the author by real name in the "who reacted" list and
+   * defeat the prayer's anonymity (the server enforces the same block). When
+   * false, existing badges still render and long-press "who reacted" still
+   * works, but the ＋ picker is hidden and tapping a badge does not toggle.
+   */
+  canReact?: boolean;
 }
 
 export function PrayerReactions({
   targetType,
   targetId,
   reactions,
+  canReact = true,
 }: PrayerReactionsProps) {
   const { colors } = useTheme();
   const toggleReaction = useAuthenticatedMutation(
@@ -121,7 +131,7 @@ export function PrayerReactions({
               borderColor: OWN_REACTION_BORDER,
             },
           ]}
-          onPress={() => handleToggle(reaction.emoji)}
+          onPress={canReact ? () => handleToggle(reaction.emoji) : undefined}
           onLongPress={() => setDetailsEmoji(reaction.emoji)}
           delayLongPress={300}
         >
@@ -134,16 +144,19 @@ export function PrayerReactions({
         </Pressable>
       ))}
 
-      {/* ＋ button opens the curated reaction bar */}
-      <Pressable
-        ref={addButtonRef}
-        onPress={openPicker}
-        style={[styles.addButton, { borderColor: colors.border }]}
-        accessibilityRole="button"
-        accessibilityLabel="Add a reaction"
-      >
-        <Ionicons name="add" size={16} color={colors.textTertiary} />
-      </Pressable>
+      {/* ＋ button opens the curated reaction bar (hidden when the viewer may
+          not react — e.g. an anonymous prayer's author on their own card). */}
+      {canReact && (
+        <Pressable
+          ref={addButtonRef}
+          onPress={openPicker}
+          style={[styles.addButton, { borderColor: colors.border }]}
+          accessibilityRole="button"
+          accessibilityLabel="Add a reaction"
+        >
+          <Ionicons name="add" size={16} color={colors.textTertiary} />
+        </Pressable>
+      )}
 
       {/* Picker popover */}
       <Modal

--- a/apps/mobile/features/prayer/components/PrayerReactions.tsx
+++ b/apps/mobile/features/prayer/components/PrayerReactions.tsx
@@ -1,0 +1,244 @@
+/**
+ * PrayerReactions — the reaction row that hangs off the bottom of a prayer
+ * request card or a follow-up (update / praise report) card on the prayer
+ * detail screens.
+ *
+ * Mirrors the chat reactions UX (badge pills + a ＋ picker + a "who reacted"
+ * long-press modal) but is self-contained for the prayer surface: it reads the
+ * aggregated `{ emoji, count, hasReacted }[]` that `prayers.getDetail` already
+ * folds in, and writes through `prayers.reactions.toggleReaction`. Convex
+ * reactivity re-renders the detail screen after each toggle, so no local
+ * optimistic state is needed.
+ */
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Modal,
+  TouchableOpacity,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import { useAuthenticatedMutation, api } from '@services/api/convex';
+import { PrayerReactionDetailsModal } from './PrayerReactionDetailsModal';
+
+export type PrayerReactionTargetType = 'prayer' | 'followUp';
+
+/**
+ * Curated reaction set shown in the picker — the display mirror of the
+ * server-side allowlist `PRAYER_REACTION_EMOJIS` in
+ * apps/convex/functions/prayers/reactions.ts. Keep the two in sync: the server
+ * rejects anything not on its list, so adding an emoji here alone does nothing.
+ */
+export const PRAYER_REACTION_EMOJIS = [
+  '❤️', // Love & support
+  '🙏', // Praying with you / amen
+  '🎉', // Celebrate
+  '🙌', // Praise / hallelujah
+  '🕊️', // Peace & comfort
+  '🥹', // Deeply moved
+] as const;
+
+// Chat's blue "your own reaction" highlight, reused verbatim for consistency.
+const OWN_REACTION_BG = '#E3F2FD';
+const OWN_REACTION_BORDER = '#1976D2';
+
+interface AggregatedReaction {
+  emoji: string;
+  count: number;
+  hasReacted: boolean;
+}
+
+interface PrayerReactionsProps {
+  targetType: PrayerReactionTargetType;
+  targetId: string;
+  reactions: AggregatedReaction[];
+}
+
+export function PrayerReactions({
+  targetType,
+  targetId,
+  reactions,
+}: PrayerReactionsProps) {
+  const { colors } = useTheme();
+  const toggleReaction = useAuthenticatedMutation(
+    api.functions.prayers.reactions.toggleReaction,
+  );
+
+  const addButtonRef = useRef<View>(null);
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [pickerPos, setPickerPos] = useState<{ top: number; left: number } | null>(
+    null,
+  );
+  const [detailsEmoji, setDetailsEmoji] = useState<string | null>(null);
+
+  const handleToggle = useCallback(
+    (emoji: string) => {
+      // Fire-and-forget; Convex reactivity refreshes getDetail. Swallow errors
+      // (e.g. a race where access was revoked) rather than crashing the screen.
+      void toggleReaction({ targetType, targetId, emoji }).catch(() => {});
+    },
+    [toggleReaction, targetType, targetId],
+  );
+
+  const openPicker = useCallback(() => {
+    const node = addButtonRef.current;
+    if (node) {
+      node.measureInWindow((x, y) => {
+        // Anchor the bar just above the ＋ button, nudged left so the 6-emoji
+        // row stays on-screen.
+        setPickerPos({ top: Math.max(y - 60, 40), left: Math.max(x - 120, 12) });
+        setPickerVisible(true);
+      });
+    } else {
+      setPickerVisible(true);
+    }
+  }, []);
+
+  const handlePickEmoji = useCallback(
+    (emoji: string) => {
+      setPickerVisible(false);
+      handleToggle(emoji);
+    },
+    [handleToggle],
+  );
+
+  return (
+    <View style={styles.row}>
+      {reactions.map((reaction) => (
+        <Pressable
+          key={reaction.emoji}
+          style={[
+            styles.badge,
+            {
+              backgroundColor: colors.surfaceSecondary,
+              borderColor: colors.border,
+            },
+            reaction.hasReacted && {
+              backgroundColor: OWN_REACTION_BG,
+              borderColor: OWN_REACTION_BORDER,
+            },
+          ]}
+          onPress={() => handleToggle(reaction.emoji)}
+          onLongPress={() => setDetailsEmoji(reaction.emoji)}
+          delayLongPress={300}
+        >
+          <Text style={styles.badgeEmoji}>{reaction.emoji}</Text>
+          {reaction.count > 1 && (
+            <Text style={[styles.badgeCount, { color: colors.textSecondary }]}>
+              {reaction.count}
+            </Text>
+          )}
+        </Pressable>
+      ))}
+
+      {/* ＋ button opens the curated reaction bar */}
+      <Pressable
+        ref={addButtonRef}
+        onPress={openPicker}
+        style={[styles.addButton, { borderColor: colors.border }]}
+        accessibilityRole="button"
+        accessibilityLabel="Add a reaction"
+      >
+        <Ionicons name="add" size={16} color={colors.textTertiary} />
+      </Pressable>
+
+      {/* Picker popover */}
+      <Modal
+        visible={pickerVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setPickerVisible(false)}
+      >
+        <Pressable style={styles.pickerBackdrop} onPress={() => setPickerVisible(false)}>
+          <View
+            style={[
+              styles.pickerBar,
+              { backgroundColor: colors.surface, borderColor: colors.border },
+              pickerPos
+                ? { position: 'absolute', top: pickerPos.top, left: pickerPos.left }
+                : null,
+            ]}
+          >
+            {PRAYER_REACTION_EMOJIS.map((emoji) => (
+              <TouchableOpacity
+                key={emoji}
+                style={styles.pickerButton}
+                onPress={() => handlePickEmoji(emoji)}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.pickerEmoji}>{emoji}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </Pressable>
+      </Modal>
+
+      {/* Long-press "who reacted" list */}
+      <PrayerReactionDetailsModal
+        visible={detailsEmoji !== null}
+        emoji={detailsEmoji}
+        targetType={targetType}
+        targetId={targetId}
+        onClose={() => setDetailsEmoji(null)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 14,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    marginRight: 6,
+    marginBottom: 6,
+    borderWidth: 1,
+  },
+  badgeEmoji: { fontSize: 15 },
+  badgeCount: { fontSize: 12, fontWeight: '600', marginLeft: 5 },
+  addButton: {
+    width: 32,
+    height: 30,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 6,
+  },
+  pickerBackdrop: { flex: 1 },
+  pickerBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 24,
+    borderWidth: 1,
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+    // Centered fallback when we couldn't measure the ＋ button.
+    alignSelf: 'center',
+    marginTop: 120,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  pickerButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pickerEmoji: { fontSize: 24 },
+});

--- a/apps/web/src/pages/guides/Prayer.tsx
+++ b/apps/web/src/pages/guides/Prayer.tsx
@@ -110,6 +110,15 @@ export function Prayer() {
           request get to share the joy.
         </P>
         <P>
+          Praying a full session is a meaningful, deliberate act — but people
+          also want a lighter way to say "I'm with you." On a prayer's detail
+          view, everyone who prayed can add an emoji <Term>reaction</Term> to
+          the request and to each update or praise report: tap the{" "}
+          <Term>＋</Term> to pick from a small, warm set (❤️ 🙏 🎉 🙌 🕊️ 🥹),
+          tap a reaction again to remove it, and long-press one to see who
+          reacted. Reactions are quiet — they don't send a notification.
+        </P>
+        <P>
           Once a request has run its course, the author can <Term>Archive</Term>{" "}
           it — that hides it from the feed but keeps it under their own My
           Prayers list. Older requests are tidied away on their own over time,


### PR DESCRIPTION
## What this adds

A lightweight way to respond to a prayer without completing a full 3-minute pray session. Members can now react with a small, curated set of emoji to:

1. **Prayer requests** (the original post)
2. **Updates** (author follow-ups)
3. **Praise reports** (author follow-ups celebrating answered prayer)

Reactions appear as badge pills under each card on both prayer **detail** screens (`PrayedPrayerDetailScreen`, `MyPrayerDetailScreen`). A **＋** button opens a popover of the 6 curated emoji; tapping a badge you gave toggles it off; long-pressing a badge shows who reacted. The "pray now" deck (`PrayerScreen`) intentionally gets no reactions — you react from the detail view.

**Curated set (6):** ❤️ love · 🙏 praying/amen · 🎉 celebrate · 🙌 praise · 🕊️ peace · 🥹 moved. This is the one product-flavored choice and it's a single constant (`PRAYER_REACTION_EMOJIS`) in both `apps/convex/functions/prayers/reactions.ts` (server allowlist) and `apps/mobile/features/prayer/components/PrayerReactions.tsx` (picker) — trivial to adjust.

## Rendered mock (not a device capture)

This run executes on a headless Linux runner with no iOS simulator, so the image below is a **faithful mock rendered from the real component styles**, not a screenshot from a device.

[Prayer reactions — before/after](https://images.togather.nyc/dev-assistant/f50d8198-5235-405b-800a-f89584408c8c-prayer-reactions-after.png)

## How it works

**Backend** — mirrors the chat reactions pattern:
- New polymorphic `prayerReactions` table (`targetType: "prayer" | "followUp"`, `targetId`, `userId`, `emoji`, denormalized `communityId`), indexed `by_target` and `by_target_user`.
- `prayers.reactions.toggleReaction({ targetType, targetId, emoji })` — inserts/deletes one row per (target, user, emoji). Guards: the **emoji must be on the server-side allowlist**, and the caller must pass the **same visibility gate `getDetail` enforces** (community member who authored the prayer or already has a `prayerResponses` row).
- `prayers.reactions.getReactionDetails` — the "who reacted" list.
- `getDetail` now **folds aggregated `{ emoji, count, hasReacted }` reactions** onto the request card and every follow-up in one round-trip (no per-card N+1).
- **No notifications** are sent on reaction — silent, like chat.

**Frontend** — self-contained prayer components (the chat reaction hooks are hard-wired to `chatMessages` IDs, so duplicating the small presentational pieces was cleaner than generalizing chat internals):
- `PrayerReactions` — badge pills (count hidden at 1, own reaction highlighted blue like chat), the ＋ picker popover, and toggle wiring. Convex reactivity refreshes `getDetail` after each toggle.
- `PrayerReactionDetailsModal` — the long-press "who reacted" modal.

## Edge cases handled

- **Anonymity** — reacting is a social action and is attributed to the reactor; the prayer author's own anonymity is untouched.
- **Access** — reactions can only be fetched/created for prayers the caller can already see; hidden/rejected prayers can't be reacted to (they never reach `getDetail`).
- **Toggle idempotency** — double-tapping the same emoji nets to add-then-remove, never two rows (enforced via `by_target_user`).

## Tests

- New `apps/convex/__tests__/prayers/reactions.test.ts` (8 tests): toggle add/remove, double-add idempotency, allowlist rejection, non-member rejected, member-who-hasn't-prayed rejected, author + prayed-for allowed on request and follow-up, `getDetail` folding with shared cross-user counts + per-viewer `hasReacted`, and `getReactionDetails`.
- Existing chat reactions tests still pass (21/21 across both suites). Convex + mobile prayer files typecheck; native-import gating and lint pass.

## Docs

- Updated `apps/web/src/pages/guides/Prayer.tsx` ("Answered prayers & follow-ups") to describe the new reactions.

---

Dev dashboard item: `x978hjbfpafkgh2hpe4vxjm1xs8a8f9h` (requested by Seyi Olujide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TX9Xp1cx7kMVJo7F5bTR5W)_