### PR TITLE
Keep replied-to messages in place; float a ghost thread pointer

### DIFF
--- a/apps/convex/__tests__/messaging/getMessages-benchmark.test.ts
+++ b/apps/convex/__tests__/messaging/getMessages-benchmark.test.ts
@@ -9,7 +9,7 @@
  *   - Document reads = total messages in channel
  *
  * AFTER (index-driven pagination):
- *   - Reads only ~3x the page size via by_channel_lastActivityAt index
+ *   - Reads only ~3x the page size via by_channel_createdAt index
  *   - Document reads ≈ page_size * 3 (over-fetch to account for deleted/blocked)
  *
  * Run with:

--- a/apps/convex/__tests__/messaging/messages.test.ts
+++ b/apps/convex/__tests__/messaging/messages.test.ts
@@ -1576,7 +1576,7 @@ describe("Thread Reply Count in Message List", () => {
 // ============================================================================
 
 describe("Thread Bump (lastActivityAt)", () => {
-  test("replying to a thread bumps it to most recent position", async () => {
+  test("replying to a message keeps it in its chronological position (does not move it)", async () => {
     vi.useFakeTimers();
     const t = convexTest(schema, modules);
     const { channelId, accessToken } = await seedTestData(t);
@@ -1603,7 +1603,7 @@ describe("Thread Bump (lastActivityAt)", () => {
 
     vi.advanceTimersByTime(100);
 
-    // Reply to A — should bump A's lastActivityAt
+    // Reply to A — bumps A's lastActivityAt but must NOT move A in the list
     await t.mutation(api.functions.messaging.messages.sendMessage, {
       token: accessToken,
       channelId,
@@ -1613,16 +1613,24 @@ describe("Thread Bump (lastActivityAt)", () => {
     vi.runAllTimers();
     await t.finishInProgressScheduledFunctions();
 
-    // Fetch messages — A should appear AFTER B (most recent) in chronological order
     const result = await t.query(api.functions.messaging.messages.getMessages, {
       token: accessToken,
       channelId,
     });
 
-    // Chronological order (oldest activity first): B first, then A (bumped)
+    // Messages are ordered by createdAt, so A (created first) stays before B
+    // even though A was just replied to. The client floats a "ghost" pointer
+    // at A's lastActivityAt slot instead of moving the real message.
     expect(result.messages).toHaveLength(2);
-    expect(result.messages[0]._id).toBe(msgB);
-    expect(result.messages[1]._id).toBe(msgA);
+    expect(result.messages[0]._id).toBe(msgA);
+    expect(result.messages[1]._id).toBe(msgB);
+
+    // The bump still happened on the field, so the client can derive a ghost:
+    // A's lastActivityAt is now later than B's createdAt.
+    const returnedA = result.messages.find((m: { _id: typeof msgA }) => m._id === msgA);
+    const returnedB = result.messages.find((m: { _id: typeof msgB }) => m._id === msgB);
+    expect(returnedA?.lastActivityAt).toBeGreaterThan(returnedA!.createdAt);
+    expect(returnedA?.lastActivityAt).toBeGreaterThan(returnedB!.createdAt);
   });
 
   test("lastActivityAt is set on parent message after a reply", async () => {

--- a/apps/convex/__tests__/messaging/messages.test.ts
+++ b/apps/convex/__tests__/messaging/messages.test.ts
@@ -1213,6 +1213,65 @@ describe("Get Messages", () => {
 
     expect(result2.hasMore).toBe(false);
   });
+
+  test("paginates correctly when many messages share the same createdAt (tie-break at a page boundary)", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, channelId, accessToken } = await seedTestData(t);
+
+    // Insert 6 top-level messages that ALL share an identical createdAt, so the
+    // page boundary lands inside a run of tied timestamps. The cursor encodes
+    // `createdAt:seenIds` precisely to skip already-returned ids at that shared
+    // timestamp — this exercises that seenIds skip path directly.
+    const SHARED_TS = 1_700_000_000_000;
+    const TOTAL = 6;
+    const insertedIds = await t.run(async (ctx) => {
+      const ids: Id<"chatMessages">[] = [];
+      for (let i = 0; i < TOTAL; i++) {
+        ids.push(
+          await ctx.db.insert("chatMessages", {
+            channelId,
+            senderId: userId,
+            content: `Tied message ${i}`,
+            contentType: "text",
+            createdAt: SHARED_TS,
+            isDeleted: false,
+            lastActivityAt: SHARED_TS,
+          })
+        );
+      }
+      return ids;
+    });
+
+    // Page through with a limit smaller than the tie run so a boundary falls
+    // between tied messages, collecting every returned id.
+    const seen: string[] = [];
+    let cursor: string | undefined = undefined;
+    let guard = 0;
+    while (guard++ < 20) {
+      const page: {
+        messages: Array<{ _id: Id<"chatMessages"> }>;
+        hasMore: boolean;
+        cursor?: string;
+      } = await t.query(api.functions.messaging.messages.getMessages, {
+        token: accessToken,
+        channelId,
+        limit: 2,
+        cursor,
+      });
+      for (const m of page.messages) seen.push(m._id);
+      if (!page.hasMore || !page.cursor) break;
+      cursor = page.cursor;
+    }
+
+    // Complete: every inserted message is returned exactly once.
+    expect(seen).toHaveLength(TOTAL);
+    // Disjoint: no message appears on two pages.
+    expect(new Set(seen).size).toBe(TOTAL);
+    // Every inserted id is present.
+    for (const id of insertedIds) {
+      expect(seen).toContain(id);
+    }
+  });
 });
 
 // ============================================================================

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -413,10 +413,17 @@ export const getMessages = query({
 
     const blockedUserIds = new Set(blockedUsers.map((b) => b.blockedId));
 
-    // --- Index-driven pagination using by_channel_lastActivityAt ---
+    // --- Index-driven pagination using by_channel_createdAt ---
     // Instead of .collect() on ALL messages, scan the index in desc order
     // and only read enough to fill one page. This is O(page_size) instead
     // of O(total_messages).
+    //
+    // Ordering is keyed on `createdAt` (not `lastActivityAt`) so a replied-to
+    // message keeps its original chronological position — replying no longer
+    // floats the parent to the bottom of the chat. `lastActivityAt` is still
+    // returned on each message; the client uses it to float a content-free
+    // "ghost" thread pointer at the bottom (see MessageList). Inbox room
+    // ordering, which relies on the `lastActivityAt` bump, is unaffected.
 
     // Decode cursor: "timestamp:seenIds" for correct tie-breaking.
     // seenIds is a comma-separated list of message IDs already returned at the
@@ -445,13 +452,13 @@ export const getMessages = query({
     // Fetch in batches until we have enough accepted messages or run out
     let candidates = await ctx.db
       .query("chatMessages")
-      .withIndex("by_channel_lastActivityAt", (q) => {
+      .withIndex("by_channel_createdAt", (q) => {
         const q1 = q.eq("channelId", args.channelId);
         // Use lte to include messages at the cursor timestamp (we skip
         // already-seen ones by ID below). This avoids dropping messages
         // that share the same timestamp as the cursor.
         if (scanCursorTime !== undefined) {
-          return q1.lte("lastActivityAt", scanCursorTime);
+          return q1.lte("createdAt", scanCursorTime);
         }
         return q1;
       })
@@ -500,12 +507,12 @@ export const getMessages = query({
 
       // Advance scan cursor to the last candidate's timestamp for next batch
       const lastCandidate = candidates[candidates.length - 1];
-      scanCursorTime = lastCandidate.lastActivityAt ?? lastCandidate.createdAt;
+      scanCursorTime = lastCandidate.createdAt;
 
       candidates = await ctx.db
         .query("chatMessages")
-        .withIndex("by_channel_lastActivityAt", (q) =>
-          q.eq("channelId", args.channelId).lte("lastActivityAt", scanCursorTime!)
+        .withIndex("by_channel_createdAt", (q) =>
+          q.eq("channelId", args.channelId).lte("createdAt", scanCursorTime!)
         )
         .order("desc")
         .take(fetchBatch);
@@ -515,20 +522,19 @@ export const getMessages = query({
     const pageMessages = accepted.slice(0, limit);
 
     // Encode cursor: "timestamp:id1,id2,..." — includes all message IDs at the
-    // last page entry's timestamp so the next page can skip them correctly.
+    // last page entry's createdAt so the next page can skip them correctly.
     let cursor: string | undefined;
     if (pageMessages.length > 0) {
       const lastMsg = pageMessages[pageMessages.length - 1];
-      const lastActivityAt = lastMsg.lastActivityAt ?? lastMsg.createdAt;
+      const boundaryTime = lastMsg.createdAt;
       // Collect all accepted message IDs at the boundary timestamp
       const boundaryIds: string[] = [];
       for (const m of pageMessages) {
-        const t = m.lastActivityAt ?? m.createdAt;
-        if (t === lastActivityAt) {
+        if (m.createdAt === boundaryTime) {
           boundaryIds.push(m._id);
         }
       }
-      cursor = `${lastActivityAt}:${boundaryIds.join(",")}`;
+      cursor = `${boundaryTime}:${boundaryIds.join(",")}`;
     }
 
     // Reverse to chronological order (oldest first, newest at bottom)

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -528,13 +528,21 @@ export const getMessages = query({
       const lastMsg = pageMessages[pageMessages.length - 1];
       const boundaryTime = lastMsg.createdAt;
       // Collect all accepted message IDs at the boundary timestamp
-      const boundaryIds: string[] = [];
+      const boundaryIds = new Set<string>();
       for (const m of pageMessages) {
         if (m.createdAt === boundaryTime) {
-          boundaryIds.push(m._id);
+          boundaryIds.add(m._id);
         }
       }
-      cursor = `${boundaryTime}:${boundaryIds.join(",")}`;
+      // Carry forward IDs already returned at this timestamp on EARLIER pages.
+      // When a run of messages shares one createdAt and spans more than two
+      // pages, the incoming cursor's seenIds (at the same boundaryTime) must be
+      // preserved — otherwise messages returned two-or-more pages ago would be
+      // re-served (the boundary-id list only covers the current page).
+      if (cursorTime === boundaryTime && cursorSeenIds) {
+        for (const id of cursorSeenIds) boundaryIds.add(id);
+      }
+      cursor = `${boundaryTime}:${[...boundaryIds].join(",")}`;
     }
 
     // Reverse to chronological order (oldest first, newest at bottom)

--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -16,24 +16,29 @@
  * an enabled option). The backend is authoritative — this is just UI gating.
  */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
   TouchableOpacity,
   ActivityIndicator,
   StyleSheet,
+  ScrollView,
+  findNodeHandle,
 } from "react-native";
 import {
   useQuery,
   api,
   type Id,
 } from "@services/api/convex";
+import { useRouter } from "expo-router";
 import { useTheme } from "@hooks/useTheme";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { ReactionsProvider } from "@/features/chat/context/ReactionsContext";
 import { useReadState } from "@/features/chat/hooks/useReadState";
 import { dismissChannelNotifications } from "@features/notifications/utils/dismissChannelNotifications";
+import { buildThreadAwareTimeline } from "@features/chat/utils/threadTimeline";
+import { GhostThreadPointer } from "@features/chat/components/GhostThreadPointer";
 import { Ionicons } from "@expo/vector-icons";
 import { EventComment } from "./EventComment";
 import { EventCommentSheet } from "./EventCommentSheet";
@@ -55,6 +60,9 @@ export interface EventActivityProps {
   /** Pre-resolved channel id (if the channel exists). Null = still materializing. */
   channelId: Id<"chatChannels"> | null;
   authToken: string;
+  /** Outer page ScrollView (owned by EventPageClient). Used to scroll up to
+   *  the real original comment when a thread "ghost" pointer is tapped. */
+  outerScrollRef?: React.RefObject<ScrollView | null>;
 }
 
 export function EventActivity({
@@ -67,8 +75,10 @@ export function EventActivity({
   isChatEnabled,
   channelId,
   authToken,
+  outerScrollRef,
 }: EventActivityProps) {
   const { colors } = useTheme();
+  const router = useRouter();
 
   // Fetch messages (single-page, ascending). Re-queries reactively as new
   // messages come in since we're watching the latest page.
@@ -183,6 +193,70 @@ export function EventActivity({
     setLoadOlderCursor(olderCursor);
   }, [olderCursor, hasMoreOlder, isLoadingOlder]);
 
+  // -------------------- Thread ghost pointers --------------------
+  // Mirror the chat surface (MessageList): replying keeps the real comment in
+  // its chronological place, and a content-free "ghost" pointer floats at the
+  // thread's latest-activity slot. The derivation is the same pure helper.
+  const timelineEntries = useMemo(
+    () => buildThreadAwareTimeline(messages).reverse(), // newest-first for display
+    [messages]
+  );
+
+  // Per-comment view refs (for measureLayout) + a transient highlight target.
+  const rowRefs = useRef<Map<string, View | null>>(new Map());
+  const [highlightedId, setHighlightedId] = useState<Id<"chatMessages"> | null>(
+    null
+  );
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+    },
+    []
+  );
+
+  // Tap the ghost's "N replies" pill → open the event-scoped thread page
+  // (same target as EventComment's Reply button).
+  const handleGhostOpenThread = useCallback(
+    (parentId: Id<"chatMessages">) => {
+      router.push(
+        `/e/${shortId}/thread/${parentId}?groupId=${groupId}&channelName=${encodeURIComponent(
+          eventTitle
+        )}` as any
+      );
+    },
+    [router, shortId, groupId, eventTitle]
+  );
+
+  // Tap the ghost body → scroll the page up to the real original comment and
+  // briefly highlight it. The original is always loaded (the ghost is derived
+  // from it), so no catch-up paging is needed here. Highlight fires regardless
+  // of whether the native measurement succeeds, so the affordance never no-ops.
+  const handleGhostScrollToOriginal = useCallback(
+    (parentId: Id<"chatMessages">) => {
+      const row = rowRefs.current.get(parentId);
+      const scrollNode = outerScrollRef?.current;
+      if (row && scrollNode) {
+        const handle = findNodeHandle(scrollNode);
+        if (handle != null) {
+          row.measureLayout(
+            handle,
+            (_x, y) => {
+              scrollNode.scrollTo({ y: Math.max(y - 80, 0), animated: true });
+            },
+            () => {
+              // Measurement gap — highlight still applies below.
+            }
+          );
+        }
+      }
+      setHighlightedId(parentId);
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+      highlightTimerRef.current = setTimeout(() => setHighlightedId(null), 2000);
+    },
+    [outerScrollRef]
+  );
+
   // -------------------- Render --------------------
   if (!canAccess) return null;
 
@@ -191,10 +265,6 @@ export function EventActivity({
   // "no channel yet" state, not a spinner case.
   const isLoadingMessages =
     channelId !== null && canAccess && messagesResult === undefined;
-
-  // Partiful-style: newest first. The paginated query returns ascending; reverse
-  // for display without mutating the source array.
-  const displayMessages = [...messages].reverse();
 
   return (
     <View style={styles.root}>
@@ -235,7 +305,7 @@ export function EventActivity({
           <View style={styles.loadingBlock}>
             <ActivityIndicator size="small" color={DEFAULT_PRIMARY_COLOR} />
           </View>
-        ) : displayMessages.length === 0 ? (
+        ) : timelineEntries.length === 0 ? (
           <View style={styles.emptyBlock}>
             <Text
               style={[styles.emptyText, { color: colors.textSecondary }]}
@@ -247,31 +317,63 @@ export function EventActivity({
           </View>
         ) : (
           <View style={styles.messagesList}>
-            {displayMessages.map((msg: any) => (
-              <EventComment
-                key={msg._id}
-                message={{
-                  _id: msg._id,
-                  channelId: msg.channelId,
-                  senderId: msg.senderId,
-                  content: msg.content || "",
-                  contentType: msg.contentType || "text",
-                  attachments: msg.attachments,
-                  createdAt: msg.createdAt,
-                  editedAt: msg.editedAt,
-                  isDeleted: msg.isDeleted,
-                  senderName: msg.senderName,
-                  senderProfilePhoto: msg.senderProfilePhoto,
-                  mentionedUserIds: msg.mentionedUserIds,
-                  threadReplyCount: msg.threadReplyCount,
-                  blastId: msg.blastId,
-                }}
-                currentUserId={currentUserId}
-                groupId={groupId}
-                eventShortId={shortId}
-                eventTitle={eventTitle}
-              />
-            ))}
+            {timelineEntries.map((entry) => {
+              const msg: any = entry.message;
+              if (entry.kind === "ghost") {
+                return (
+                  <GhostThreadPointer
+                    key={`ghost-${msg._id}`}
+                    parentMessageId={msg._id}
+                    channelId={msg.channelId}
+                    replyCount={msg.threadReplyCount ?? 0}
+                    onOpenThread={() => handleGhostOpenThread(msg._id)}
+                    onScrollToOriginal={() =>
+                      handleGhostScrollToOriginal(msg._id)
+                    }
+                  />
+                );
+              }
+              return (
+                <View
+                  key={msg._id}
+                  ref={(r) => {
+                    if (r) rowRefs.current.set(msg._id, r);
+                    else rowRefs.current.delete(msg._id);
+                  }}
+                  style={
+                    highlightedId === msg._id
+                      ? [
+                          styles.highlightedRow,
+                          { backgroundColor: colors.surfaceSecondary },
+                        ]
+                      : undefined
+                  }
+                >
+                  <EventComment
+                    message={{
+                      _id: msg._id,
+                      channelId: msg.channelId,
+                      senderId: msg.senderId,
+                      content: msg.content || "",
+                      contentType: msg.contentType || "text",
+                      attachments: msg.attachments,
+                      createdAt: msg.createdAt,
+                      editedAt: msg.editedAt,
+                      isDeleted: msg.isDeleted,
+                      senderName: msg.senderName,
+                      senderProfilePhoto: msg.senderProfilePhoto,
+                      mentionedUserIds: msg.mentionedUserIds,
+                      threadReplyCount: msg.threadReplyCount,
+                      blastId: msg.blastId,
+                    }}
+                    currentUserId={currentUserId}
+                    groupId={groupId}
+                    eventShortId={shortId}
+                    eventTitle={eventTitle}
+                  />
+                </View>
+              );
+            })}
           </View>
         )}
       </ReactionsProvider>
@@ -365,5 +467,9 @@ const styles = StyleSheet.create({
   },
   messagesList: {
     // EventComment owns its own padding. Newest comment on top.
+  },
+  // Transient highlight when a thread ghost pointer jumps to the original.
+  highlightedRow: {
+    borderRadius: 10,
   },
 });

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   View,
   Text,
@@ -144,6 +144,9 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   const router = useRouter();
   const segments = useSegments();
   const insets = useSafeAreaInsets();
+  // Outer scroll container ref — passed to EventActivity so tapping a thread
+  // "ghost" pointer can scroll the page up to the real original comment.
+  const scrollRef = useRef<ScrollView>(null);
   const { isAuthenticated, refreshUser, setCommunity, community, user } = useAuth();
 
   // Get user's timezone (default to America/New_York if not set)
@@ -774,6 +777,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
       </View>
 
       <ScrollView
+        ref={scrollRef}
         style={styles.scroll}
         contentContainerStyle={[
           styles.scrollContent,
@@ -1022,6 +1026,7 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
                 isChatEnabled={isChatEnabled}
                 channelId={resolvedChannelId}
                 authToken={authToken}
+                outerScrollRef={scrollRef}
               />
             )}
 

--- a/apps/mobile/features/chat/components/GhostThreadPointer.tsx
+++ b/apps/mobile/features/chat/components/GhostThreadPointer.tsx
@@ -1,0 +1,103 @@
+/**
+ * GhostThreadPointer - content-free "ghost" bubble for a bumped thread.
+ *
+ * When a message gets a reply we deliberately keep the real message in its
+ * original chronological position (see `getMessages` ordering by `createdAt`).
+ * To avoid losing recent thread activity off-screen, this lightweight ghost is
+ * floated at the thread's latest-activity slot (its `lastActivityAt`) at the
+ * bottom of the chat. It shows NO original message text — only the existing
+ * "N replies" pill — and offers two tap targets:
+ *
+ * - Tapping the "N replies" pill opens the thread screen (same as the inline
+ *   indicator under the real message).
+ * - Tapping the ghost body scrolls the chat up to the real original message and
+ *   briefly highlights it.
+ *
+ * Styling is intentionally neutral (dashed, greyed, centered — not left/right
+ * aligned) so it reads as a pointer, not a real message bubble.
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@hooks/useTheme';
+import type { Id } from '@services/api/convex';
+import { ThreadReplies } from './ThreadReplies';
+
+interface GhostThreadPointerProps {
+  parentMessageId: Id<"chatMessages">;
+  channelId?: Id<"chatChannels">;
+  replyCount: number;
+  /** Tap the "N replies" pill → open the thread screen. */
+  onOpenThread: () => void;
+  /** Tap the ghost body → scroll up to the real original message. */
+  onScrollToOriginal: () => void;
+}
+
+export function GhostThreadPointer({
+  parentMessageId,
+  channelId,
+  replyCount,
+  onOpenThread,
+  onScrollToOriginal,
+}: GhostThreadPointerProps) {
+  const { colors } = useTheme();
+
+  return (
+    <Pressable
+      onPress={onScrollToOriginal}
+      accessibilityRole="button"
+      accessibilityLabel="Jump to the original message"
+      testID={`ghost-thread-${parentMessageId}`}
+      style={({ pressed }) => [
+        styles.ghost,
+        {
+          borderColor: colors.border,
+          backgroundColor: pressed ? colors.surfaceSecondary : 'transparent',
+        },
+      ]}
+    >
+      <View style={styles.labelRow}>
+        <Ionicons name="arrow-undo-outline" size={13} color={colors.textTertiary} />
+        <Text style={[styles.label, { color: colors.textTertiary }]} numberOfLines={1}>
+          replies to a message
+        </Text>
+      </View>
+
+      <ThreadReplies
+        parentMessageId={parentMessageId}
+        channelId={channelId}
+        replyCount={replyCount}
+        onPress={onOpenThread}
+      />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  ghost: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    alignSelf: 'center',
+    maxWidth: '85%',
+    marginVertical: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    gap: 12,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    flexShrink: 1,
+  },
+  label: {
+    fontSize: 12,
+    fontStyle: 'italic',
+    flexShrink: 1,
+  },
+});

--- a/apps/mobile/features/chat/components/GhostThreadPointer.tsx
+++ b/apps/mobile/features/chat/components/GhostThreadPointer.tsx
@@ -13,12 +13,15 @@
  * - Tapping the ghost body scrolls the chat up to the real original message and
  *   briefly highlights it.
  *
- * Styling is intentionally neutral (dashed, greyed, centered — not left/right
- * aligned) so it reads as a pointer, not a real message bubble.
+ * The bubble is content-free: it shows NO caption or original text, only a
+ * small "jump up" icon (a non-text affordance for the body tap) and the
+ * existing "N replies" pill. Styling is intentionally neutral (dashed, greyed,
+ * centered — not left/right aligned) so it reads as a pointer, not a real
+ * message bubble.
  */
 
 import React from 'react';
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { StyleSheet, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@hooks/useTheme';
 import type { Id } from '@services/api/convex';
@@ -57,12 +60,10 @@ export function GhostThreadPointer({
         },
       ]}
     >
-      <View style={styles.labelRow}>
-        <Ionicons name="arrow-undo-outline" size={13} color={colors.textTertiary} />
-        <Text style={[styles.label, { color: colors.textTertiary }]} numberOfLines={1}>
-          replies to a message
-        </Text>
-      </View>
+      {/* Icon-only affordance for the body tap (scroll up to the original).
+          No caption/text — the ghost stays content-free, showing only the
+          "N replies" pill below. */}
+      <Ionicons name="arrow-up-circle-outline" size={16} color={colors.textTertiary} />
 
       <ThreadReplies
         parentMessageId={parentMessageId}
@@ -88,16 +89,5 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderStyle: 'dashed',
     gap: 12,
-  },
-  labelRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    flexShrink: 1,
-  },
-  label: {
-    fontSize: 12,
-    fontStyle: 'italic',
-    flexShrink: 1,
   },
 });

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -26,11 +26,14 @@ import {
   InteractionManager,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
 import type { Id } from '@services/api/convex';
 import { useMessages } from '../hooks/useMessages';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useTheme } from '@hooks/useTheme';
 import { MessageItem } from './MessageItem';
+import { GhostThreadPointer } from './GhostThreadPointer';
+import { buildThreadAwareTimeline } from '../utils/threadTimeline';
 import { ReactionsProvider } from '../context/ReactionsContext';
 import { useChatPrefetch } from '../context/ChatPrefetchContext';
 
@@ -58,9 +61,14 @@ interface Message {
   }>;
   mentionedUserIds?: Id<"users">[];
   threadReplyCount?: number;
+  // Thread bump timestamp — later than createdAt once the message has been
+  // replied to. Drives the floating "ghost" thread pointer (see below).
+  lastActivityAt?: number;
   // Denormalized sender info
   senderName?: string;
   senderProfilePhoto?: string;
+  // Decorated by getMessages (attachSenderNotifsDisabled) — used to badge the row.
+  senderNotificationsDisabled?: boolean;
   // Link preview control
   hideLinkPreview?: boolean;
   // Reach out request reference
@@ -140,10 +148,11 @@ function formatDateSeparator(timestamp: number): string {
   return `${month} ${day}`;
 }
 
-// List item type (message or date separator)
+// List item type (message, date separator, or floating "ghost" thread pointer)
 type ListItem =
   | { type: 'message'; data: Message; showSenderInfo: boolean; isOptimistic?: boolean; optimisticStatus?: string }
-  | { type: 'dateSeparator'; date: string };
+  | { type: 'dateSeparator'; date: string }
+  | { type: 'ghost'; parentId: Id<"chatMessages">; channelId: Id<"chatChannels">; replyCount: number };
 
 /**
  * MessageList renders a virtualized list of messages with pagination.
@@ -167,8 +176,16 @@ export function MessageList({
 }: MessageListProps) {
   const { primaryColor } = useCommunityTheme();
   const { colors: themeColors } = useTheme();
+  const router = useRouter();
   const listRef = useRef<FlatList<ListItem>>(null);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
+  // Internal scroll-to-original target for tapping a "ghost" thread pointer.
+  // Kept separate from the `highlightMessageId` prop (inbox search) but funneled
+  // through the same anchor/scroll/highlight machinery. The nonce lets tapping
+  // the same ghost re-scroll. The prop always wins when both are set.
+  const [ghostTarget, setGhostTarget] = useState<{ id: Id<"chatMessages">; nonce: number } | null>(null);
+  const effectiveHighlightId = highlightMessageId ?? ghostTarget?.id ?? null;
 
   // Wait for navigation animation to complete before loading messages
   // This prevents choppy animations when entering the chat
@@ -192,14 +209,14 @@ export function MessageList({
   // Fetch messages with pagination (live query for updates)
   // Start immediately if we have prefetched data, otherwise wait for animation
   const shouldStartQuery = hasPrefetchedMessages || isAnimationComplete;
-  // Larger page size while jumping to a search result so the anchor catch-up
-  // reaches older messages in fewer round-trips.
-  const pageSize = highlightMessageId ? 40 : 20;
+  // Larger page size while jumping to a message (inbox search OR a ghost tap)
+  // so the anchor catch-up reaches older messages in fewer round-trips.
+  const pageSize = effectiveHighlightId ? 40 : 20;
   const { messages: liveMessages, loadMore, hasMore, isLoading: liveIsLoading, isStale } = useMessages(
     shouldStartQuery ? channelId : null,
     pageSize,
     groupId ?? null,
-    highlightMessageId ?? null
+    effectiveHighlightId
   );
 
   // Use prefetched messages while live query is loading
@@ -221,30 +238,43 @@ export function MessageList({
   const listItems = useMemo<ListItem[]>(() => {
     const items: ListItem[] = [];
 
-    // Process messages in chronological order first to determine grouping
-    messages.forEach((msg, index) => {
-      const previousMsg = index > 0 ? messages[index - 1] : undefined;
+    // Build a thread-aware timeline: every real message stays at its createdAt
+    // slot, and each replied-to message additionally floats a content-free
+    // "ghost" pointer at its lastActivityAt slot. Date separators and sender
+    // grouping are derived while walking the ordered timeline.
+    const timeline = buildThreadAwareTimeline(messages);
+    let previousMsg: Message | undefined;
+    let previousDateKey: string | undefined;
 
-      // Date separator goes BEFORE the first message of each date
-      const isFirstOfDate = !previousMsg ||
-        new Date(msg.createdAt).toDateString() !== new Date(previousMsg.createdAt).toDateString();
+    timeline.forEach((entry) => {
+      const msg = entry.message;
+      // A ghost is positioned by the thread's latest activity; a message by its
+      // own createdAt.
+      const ts = entry.kind === 'ghost' ? msg.lastActivityAt ?? msg.createdAt : msg.createdAt;
 
-      // Show sender info if previous message is from different sender
-      const showSenderInfo = !previousMsg || msg.senderId !== previousMsg.senderId;
-
-      // Add date separator before the first message of each date
-      if (isFirstOfDate) {
-        items.push({
-          type: 'dateSeparator',
-          date: formatDateSeparator(msg.createdAt),
-        });
+      // Date separator goes BEFORE the first entry of each date.
+      const dateKey = new Date(ts).toDateString();
+      if (dateKey !== previousDateKey) {
+        items.push({ type: 'dateSeparator', date: formatDateSeparator(ts) });
+        previousDateKey = dateKey;
       }
 
-      items.push({
-        type: 'message',
-        data: msg,
-        showSenderInfo,
-      });
+      if (entry.kind === 'ghost') {
+        items.push({
+          type: 'ghost',
+          parentId: msg._id,
+          channelId: msg.channelId,
+          replyCount: msg.threadReplyCount ?? 0,
+        });
+        // A ghost visually breaks the sender-grouping run.
+        previousMsg = undefined;
+        return;
+      }
+
+      // Show sender info if previous message is from a different sender.
+      const showSenderInfo = !previousMsg || msg.senderId !== previousMsg.senderId;
+      items.push({ type: 'message', data: msg, showSenderInfo });
+      previousMsg = msg;
     });
 
     // Append optimistic messages at the end (newest, after all server messages)
@@ -295,22 +325,28 @@ export function MessageList({
     return items.reverse();
   }, [messages, optimisticMessages]);
 
-  // Scroll to and highlight a target message (e.g. tapped from inbox search).
-  // The hook auto-loads older pages until the message is present; this runs
-  // once it appears in listItems. Tracked per-anchor so it fires exactly once.
+  // Scroll to and highlight a target message — either from inbox search
+  // (`highlightMessageId` prop) or from tapping a ghost thread pointer
+  // (`ghostTarget`). The hook auto-loads older pages until the message is
+  // present; this runs once it appears in listItems. Tracked per-anchor (the
+  // ghost nonce makes re-tapping the same ghost re-scroll) so it fires once.
   const scrolledAnchorRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!highlightMessageId) {
+    const anchorId = highlightMessageId ?? ghostTarget?.id ?? null;
+    if (!anchorId) {
       scrolledAnchorRef.current = null;
       return;
     }
-    if (scrolledAnchorRef.current === highlightMessageId) return;
+    const anchorKey = highlightMessageId
+      ? `hl:${highlightMessageId}`
+      : `ghost:${ghostTarget!.id}:${ghostTarget!.nonce}`;
+    if (scrolledAnchorRef.current === anchorKey) return;
     const targetIndex = listItems.findIndex(
-      (it) => it.type === 'message' && it.data._id === highlightMessageId
+      (it) => it.type === 'message' && it.data._id === anchorId
     );
     if (targetIndex < 0) return; // not loaded yet — catch-up loop will fetch more
 
-    scrolledAnchorRef.current = highlightMessageId;
+    scrolledAnchorRef.current = anchorKey;
     const handle = InteractionManager.runAfterInteractions(() => {
       try {
         listRef.current?.scrollToIndex({
@@ -323,7 +359,32 @@ export function MessageList({
       }
     });
     return () => handle.cancel();
-  }, [highlightMessageId, listItems]);
+  }, [highlightMessageId, ghostTarget, listItems]);
+
+  // Tap a ghost's "N replies" pill → open the thread screen. Group channels and
+  // DMs have parallel routes (mirrors MessageItem.handleThreadPress).
+  const handleGhostOpenThread = useCallback(
+    (parentId: Id<"chatMessages">, ghostChannelId: Id<"chatChannels">) => {
+      if (groupId) {
+        router.push({
+          pathname: `/inbox/${groupId}/thread/${parentId}` as any,
+          params: { channelName: channelName || 'general' },
+        });
+      } else {
+        router.push({
+          pathname: `/inbox/dm/${ghostChannelId}/thread/${parentId}` as any,
+        });
+      }
+    },
+    [router, groupId, channelName]
+  );
+
+  // Tap a ghost's body → scroll up to the real original message and highlight
+  // it. Funnels through the shared anchor machinery, which auto-loads older
+  // pages first if the original is above the currently loaded window.
+  const handleGhostScrollToOriginal = useCallback((parentId: Id<"chatMessages">) => {
+    setGhostTarget((prev) => ({ id: parentId, nonce: (prev?.nonce ?? 0) + 1 }));
+  }, []);
 
   // Handle scroll to detect if user is near bottom (for scroll-to-bottom button)
   // In inverted list, "near bottom" means near index 0
@@ -369,6 +430,18 @@ export function MessageList({
             <Text style={[styles.dateSeparatorText, { color: themeColors.textTertiary }]}>{item.date}</Text>
             <View style={[styles.dateSeparatorLine, { backgroundColor: themeColors.border }]} />
           </View>
+        );
+      }
+
+      if (item.type === 'ghost') {
+        return (
+          <GhostThreadPointer
+            parentMessageId={item.parentId}
+            channelId={item.channelId}
+            replyCount={item.replyCount}
+            onOpenThread={() => handleGhostOpenThread(item.parentId, item.channelId)}
+            onScrollToOriginal={() => handleGhostScrollToOriginal(item.parentId)}
+          />
         );
       }
 
@@ -421,17 +494,20 @@ export function MessageList({
           optimisticStatus={item.optimisticStatus as any}
           onRetry={item.isOptimistic && onRetryMessage ? () => onRetryMessage(String(message._id)) : undefined}
           onAvatarPress={onAvatarPress}
-          isHighlighted={highlightMessageId != null && message._id === highlightMessageId}
+          isHighlighted={effectiveHighlightId != null && message._id === effectiveHighlightId}
         />
       );
     },
-    [currentUserId, groupId, channelName, prefetchState, onMessageReply, onMessageReact, onMessageDelete, onMessageLongPress, onMessageDoubleTap, onRetryMessage, onAvatarPress, highlightMessageId]
+    [currentUserId, groupId, channelName, prefetchState, onMessageReply, onMessageReact, onMessageDelete, onMessageLongPress, onMessageDoubleTap, onRetryMessage, onAvatarPress, effectiveHighlightId, handleGhostOpenThread, handleGhostScrollToOriginal]
   );
 
   // Key extractor
   const keyExtractor = useCallback(
-    (item: ListItem, index: number) =>
-      item.type === 'dateSeparator' ? `date-${item.date}-${index}` : `msg-${item.data._id}`,
+    (item: ListItem, index: number) => {
+      if (item.type === 'dateSeparator') return `date-${item.date}-${index}`;
+      if (item.type === 'ghost') return `ghost-${item.parentId}`;
+      return `msg-${item.data._id}`;
+    },
     []
   );
 

--- a/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { GhostThreadPointer } from '../GhostThreadPointer';
+
+// Theme stub — GhostThreadPointer only reads a handful of color tokens.
+jest.mock('@hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      border: '#ccc',
+      surfaceSecondary: '#eee',
+      textTertiary: '#999',
+      link: '#06c',
+    },
+  }),
+}));
+
+// Stub the "N replies" pill so the test isolates the ghost's wiring (the pill
+// itself is exercised by ThreadReplies' own coverage). The stub exposes the
+// count text and forwards its onPress so we can assert the open-thread target.
+jest.mock('../ThreadReplies', () => {
+  const { Text: RNText, Pressable: RNPressable } = require('react-native');
+  return {
+    ThreadReplies: ({ replyCount, onPress }: { replyCount: number; onPress?: () => void }) => (
+      <RNPressable testID="thread-replies-pill" onPress={onPress}>
+        <RNText>{`${replyCount} replies`}</RNText>
+      </RNPressable>
+    ),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+const PARENT_ID = 'msg_parent' as any;
+const CHANNEL_ID = 'chan_1' as any;
+
+describe('GhostThreadPointer', () => {
+  it('is content-free: shows only the reply count, never the original message text', () => {
+    const { queryByText, getByText } = render(
+      <GhostThreadPointer
+        parentMessageId={PARENT_ID}
+        channelId={CHANNEL_ID}
+        replyCount={2}
+        onOpenThread={jest.fn()}
+        onScrollToOriginal={jest.fn()}
+      />,
+    );
+
+    // The count pill is present…
+    expect(getByText('2 replies')).toBeTruthy();
+    // …but the original message content must NOT leak into the ghost.
+    expect(queryByText("Who's bringing snacks?")).toBeNull();
+    expect(queryByText('replies to a message')).toBeNull();
+  });
+
+  it('tapping the "N replies" pill opens the thread (not scroll-to-original)', () => {
+    const onOpenThread = jest.fn();
+    const onScrollToOriginal = jest.fn();
+    const { getByTestId } = render(
+      <GhostThreadPointer
+        parentMessageId={PARENT_ID}
+        channelId={CHANNEL_ID}
+        replyCount={3}
+        onOpenThread={onOpenThread}
+        onScrollToOriginal={onScrollToOriginal}
+      />,
+    );
+
+    fireEvent.press(getByTestId('thread-replies-pill'));
+    expect(onOpenThread).toHaveBeenCalledTimes(1);
+    expect(onScrollToOriginal).not.toHaveBeenCalled();
+  });
+
+  it('tapping the ghost body scrolls up to the original message', () => {
+    const onOpenThread = jest.fn();
+    const onScrollToOriginal = jest.fn();
+    const { getByTestId } = render(
+      <GhostThreadPointer
+        parentMessageId={PARENT_ID}
+        channelId={CHANNEL_ID}
+        replyCount={1}
+        onOpenThread={onOpenThread}
+        onScrollToOriginal={onScrollToOriginal}
+      />,
+    );
+
+    // The bubble body carries a stable testID derived from the parent id.
+    fireEvent.press(getByTestId(`ghost-thread-${PARENT_ID}`));
+    expect(onScrollToOriginal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/features/chat/utils/__tests__/threadTimeline.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/threadTimeline.test.ts
@@ -1,0 +1,121 @@
+import {
+  buildThreadAwareTimeline,
+  shouldFloatGhost,
+  type ThreadTimelineMessage,
+} from "../threadTimeline";
+
+/**
+ * The chat orders top-level messages by `createdAt` so replying no longer moves
+ * the real message. Instead, each replied-to message floats a content-free
+ * "ghost" pointer at its `lastActivityAt` slot. These tests pin down that
+ * derivation: the real message stays put, and exactly one ghost is emitted per
+ * bumped thread at the right position.
+ */
+
+type Msg = ThreadTimelineMessage & { id: string; senderId?: string };
+
+const msg = (overrides: Partial<Msg> & { id: string; createdAt: number }): Msg => ({
+  isDeleted: false,
+  ...overrides,
+});
+
+// Compact view of the derived timeline for readable assertions.
+const shape = (entries: ReturnType<typeof buildThreadAwareTimeline<Msg>>) =>
+  entries.map((e) => `${e.kind === "ghost" ? "ghost" : "msg"}:${e.message.id}`);
+
+describe("shouldFloatGhost", () => {
+  it("floats a ghost when a message has replies and was bumped", () => {
+    expect(
+      shouldFloatGhost({ createdAt: 100, isDeleted: false, threadReplyCount: 2, lastActivityAt: 300 }),
+    ).toBe(true);
+  });
+
+  it("does not float a ghost when there are no replies", () => {
+    expect(
+      shouldFloatGhost({ createdAt: 100, isDeleted: false, threadReplyCount: 0, lastActivityAt: 300 }),
+    ).toBe(false);
+    expect(shouldFloatGhost({ createdAt: 100, isDeleted: false })).toBe(false);
+  });
+
+  it("does not float a ghost when lastActivityAt equals createdAt (never bumped)", () => {
+    expect(
+      shouldFloatGhost({ createdAt: 100, isDeleted: false, threadReplyCount: 1, lastActivityAt: 100 }),
+    ).toBe(false);
+  });
+
+  it("does not float a ghost for a deleted original", () => {
+    expect(
+      shouldFloatGhost({ createdAt: 100, isDeleted: true, threadReplyCount: 3, lastActivityAt: 300 }),
+    ).toBe(false);
+  });
+});
+
+describe("buildThreadAwareTimeline", () => {
+  it("keeps a replied-to message in its original position and floats one ghost at the bottom", () => {
+    // A (created first, then replied to → bumped to t=300), B (created at t=200).
+    const a = msg({ id: "A", createdAt: 100, threadReplyCount: 2, lastActivityAt: 300 });
+    const b = msg({ id: "B", createdAt: 200 });
+
+    const timeline = buildThreadAwareTimeline([a, b]);
+
+    // A stays before B (createdAt order), and A's ghost floats after B (t=300).
+    expect(shape(timeline)).toEqual(["msg:A", "msg:B", "ghost:A"]);
+  });
+
+  it("emits exactly one ghost per thread no matter how many replies", () => {
+    // Multiple replies only bump lastActivityAt / threadReplyCount on the one
+    // parent, so there is still a single ghost.
+    const a = msg({ id: "A", createdAt: 100, threadReplyCount: 5, lastActivityAt: 900 });
+    const b = msg({ id: "B", createdAt: 200 });
+
+    const timeline = buildThreadAwareTimeline([a, b]);
+
+    expect(timeline.filter((e) => e.kind === "ghost")).toHaveLength(1);
+    expect(shape(timeline)).toEqual(["msg:A", "msg:B", "ghost:A"]);
+  });
+
+  it("positions each ghost independently at its own lastActivityAt", () => {
+    // A replied to at t=250 (between B and C), C replied to at t=500 (last).
+    const a = msg({ id: "A", createdAt: 100, threadReplyCount: 1, lastActivityAt: 250 });
+    const b = msg({ id: "B", createdAt: 200 });
+    const c = msg({ id: "C", createdAt: 300, threadReplyCount: 1, lastActivityAt: 500 });
+
+    const timeline = buildThreadAwareTimeline([a, b, c]);
+
+    expect(shape(timeline)).toEqual([
+      "msg:A",
+      "msg:B",
+      "ghost:A",
+      "msg:C",
+      "ghost:C",
+    ]);
+  });
+
+  it("produces no ghosts when nothing has been replied to", () => {
+    const a = msg({ id: "A", createdAt: 100 });
+    const b = msg({ id: "B", createdAt: 200 });
+
+    const timeline = buildThreadAwareTimeline([a, b]);
+
+    expect(shape(timeline)).toEqual(["msg:A", "msg:B"]);
+  });
+
+  it("does not float a ghost for a deleted original", () => {
+    const a = msg({ id: "A", createdAt: 100, isDeleted: true, threadReplyCount: 2, lastActivityAt: 300 });
+    const b = msg({ id: "B", createdAt: 200 });
+
+    const timeline = buildThreadAwareTimeline([a, b]);
+
+    expect(shape(timeline)).toEqual(["msg:A", "msg:B"]);
+  });
+
+  it("orders a real message before a ghost sharing the same timestamp", () => {
+    // A's bump lands exactly on C's createdAt — the real message wins the slot.
+    const a = msg({ id: "A", createdAt: 100, threadReplyCount: 1, lastActivityAt: 300 });
+    const c = msg({ id: "C", createdAt: 300 });
+
+    const timeline = buildThreadAwareTimeline([a, c]);
+
+    expect(shape(timeline)).toEqual(["msg:A", "msg:C", "ghost:A"]);
+  });
+});

--- a/apps/mobile/features/chat/utils/threadTimeline.ts
+++ b/apps/mobile/features/chat/utils/threadTimeline.ts
@@ -1,0 +1,74 @@
+/**
+ * Thread-aware chat timeline derivation.
+ *
+ * The chat now orders top-level messages by `createdAt` (see the `getMessages`
+ * backend query), so replying to a message no longer floats the real message to
+ * the bottom. To keep recent thread activity visible without moving the real
+ * message, we float a content-free "ghost" pointer at the thread's latest
+ * activity slot (`lastActivityAt`).
+ *
+ * This module holds the *pure* derivation so it can be unit-tested independently
+ * of React / FlatList: given the server messages (already ordered by
+ * `createdAt`), it returns an ordered timeline of "message" and "ghost" entries.
+ * The component layer adds date separators, sender grouping, optimistic
+ * messages, and inverts the list for rendering.
+ */
+
+/** Minimal message shape the derivation needs. */
+export interface ThreadTimelineMessage {
+  createdAt: number;
+  isDeleted: boolean;
+  threadReplyCount?: number;
+  lastActivityAt?: number;
+}
+
+export type ThreadTimelineEntry<M> =
+  | { kind: 'message'; message: M }
+  | { kind: 'ghost'; message: M };
+
+/**
+ * A message floats a ghost pointer when it has at least one reply AND its
+ * `lastActivityAt` is later than its own `createdAt` (i.e. it was actually
+ * bumped by a reply). Deleted originals never float a ghost — the thread
+ * pointer would dangle with no message to scroll back to.
+ */
+export function shouldFloatGhost(msg: ThreadTimelineMessage): boolean {
+  return (
+    !msg.isDeleted &&
+    (msg.threadReplyCount ?? 0) > 0 &&
+    msg.lastActivityAt !== undefined &&
+    msg.lastActivityAt > msg.createdAt
+  );
+}
+
+/**
+ * Build the ordered timeline of message + ghost entries.
+ *
+ * - Every message stays at its `createdAt` position (input order is preserved
+ *   for messages since the server already sorts by `createdAt`).
+ * - Each eligible message additionally emits ONE ghost entry positioned at its
+ *   `lastActivityAt` (deduplicated — replying multiple times never stacks
+ *   ghosts, because the count/bump live on the single parent message).
+ * - At an equal timestamp a real message sorts before a ghost; ties beyond that
+ *   preserve input order for stability.
+ */
+export function buildThreadAwareTimeline<M extends ThreadTimelineMessage>(
+  messages: M[],
+): Array<ThreadTimelineEntry<M>> {
+  const events: Array<{ ts: number; order: number; entry: ThreadTimelineEntry<M> }> = [];
+
+  messages.forEach((message, order) => {
+    events.push({ ts: message.createdAt, order, entry: { kind: 'message', message } });
+    if (shouldFloatGhost(message)) {
+      events.push({ ts: message.lastActivityAt!, order, entry: { kind: 'ghost', message } });
+    }
+  });
+
+  events.sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts - b.ts;
+    if (a.entry.kind !== b.entry.kind) return a.entry.kind === 'message' ? -1 : 1;
+    return a.order - b.order;
+  });
+
+  return events.map((e) => e.entry);
+}


### PR DESCRIPTION
## What this changes

Today, replying to a message **yanks the original message down to the bottom of the chat**, scrambling the flow of conversation. That happened because top-level messages were sorted by *most-recent activity*, so any message you replied to floated down to the newest slot.

Now the real message **stays exactly where it was said**. In its place, a lightweight, content-free **"ghost" pointer** floats at the bottom to represent the thread's recent activity — so you don't lose track of it — without moving the real message.

A thread with replies is now shown in **two** places:
- the **real message**, sitting in its original spot, with its usual **"N replies"** count beneath it, and
- a **content-free ghost bubble** floating at the bottom (dashed/greyed, no message text) showing only **"N replies"**.

### The ghost's two tap targets
- **Tap the "N replies" pill** → opens the thread (existing thread screen).
- **Tap the ghost bubble body** → scrolls the chat up to the real original message and briefly highlights it (auto-loading older messages first if the original is above the loaded window).

## Before / after

> **Note:** this is a *rendered mock* built from the real component styles (`GhostThreadPointer` + `ThreadReplies` + the theme palette), **not** a device screenshot — this run executes on a headless Linux runner with no iOS simulator.

[before/after](https://images.togather.nyc/dev-assistant/e54c5f16-4205-4a1c-8d4e-58d464887137-ghost-before-after.png)

- **Before:** replying floats Ada's "Who's bringing snacks?" to the bottom, breaking the order.
- **After:** Ada's message stays put and shows "2 replies"; a dashed ghost bubble sits at the bottom showing only "2 replies", with the two tap targets above.

## How it works

**Backend — `apps/convex/functions/messaging/messages.ts` (`getMessages`)**
- Orders/paginates top-level messages on the existing **`by_channel_createdAt`** index instead of `by_channel_lastActivityAt`, and keys the pagination cursor on `createdAt`, so a replied-to message keeps its original position.
- The `lastActivityAt` bump in `sendMessage` is **kept** — it positions the ghost and drives **Inbox room ordering, which is unchanged**. `threadReplyCount` still increments and both fields are still returned per message.

**Frontend — `apps/mobile/features/chat/...`**
- `utils/threadTimeline.ts` — a **pure, unit-tested** derivation that walks the server messages (already ordered by `createdAt`) and emits one ghost entry per replied-to message, positioned at its `lastActivityAt`. Exactly one ghost per thread (replying multiple times doesn't stack ghosts).
- `components/GhostThreadPointer.tsx` — the neutral dashed bubble containing the existing `ThreadReplies` "N replies" pill.
- `components/MessageList.tsx` — builds the thread-aware timeline into list items and wires the two tap targets, reusing the existing inbox-search `scrollToIndex` / `highlightMessageId` anchor machinery (which auto-loads older pages). The original message keeps its inline reply count.

### Edge cases handled
- **Deleted original** never floats a ghost (deleted messages are already filtered out of `getMessages`, plus a guard in the derivation).
- **`threadReplyCount > 0` but `lastActivityAt === createdAt`** (never actually bumped) → no ghost.
- **Original far above the loaded window** → tapping the ghost triggers the existing catch-up load before scrolling/highlighting.
- **Reply to your own message** → ghost still renders with neutral styling.
- **Offline / web** — ghost derivation is pure client-side from message fields already present in the read-cache (`threadReplyCount`, `lastActivityAt`); `MessageList` is the single cross-platform implementation (no web variant needed).

## Tests
- Rewrote the backend thread-bump ordering test to assert the message **stays in its chronological position** while `lastActivityAt` is still bumped (so the client can derive a ghost). All 39 messaging tests + 7 benchmark tests pass.
- Added `threadTimeline` unit tests (10) covering ordering, single-ghost-per-thread, per-thread positioning, deleted originals, and equal-timestamp tie-breaking.

## Done when checklist
- [x] Replying no longer moves the original — ordered by `createdAt` in every chat type (group channel, DM, event chat all use `getMessages` + `MessageList`).
- [x] Original message shows a "N replies" count in place (existing `MessageItem.renderThreadReplies`).
- [x] Content-free ghost bubble (dashed/greyed, no original text) floats at the bottom showing only "N replies".
- [x] Tapping the ghost's "N replies" opens the thread screen.
- [x] Tapping the ghost bubble scrolls up to the original and highlights it (auto-loading older messages first if needed).
- [x] One ghost per thread.
- [x] Inbox room ordering unchanged (the `lastActivityAt` bump is retained).
- [x] Works offline from cache and on web; type-checks clean for touched files; existing chat tests pass, with new tests covering ordering + ghost derivation.

---

Dashboard item (dev-assistant): `x97f7rtk26cq8gse9qyc9q746n8abswe` — reported by Seyi Olujide.

---
_Generated by [Claude Code](https://claude.ai/code/session_016QHSe1ga8Ad8Fq4VUWrQnF)_