### PR TITLE
Pre-allow autonomous tools so dev-assistant Routines don't hang on permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,12 @@
   },
   "permissions": {
     "allow": [
-      "mcp__Claude_Code_Remote__send_later"
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__playwright",
+      "mcp__ios-simulator",
+      "WebFetch",
+      "WebSearch",
+      "PushNotification"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,9 +7,16 @@
       "mcp__Claude_Code_Remote__send_later",
       "mcp__playwright",
       "mcp__ios-simulator",
+      "mcp__github",
       "WebFetch",
       "WebSearch",
       "PushNotification"
+    ],
+    "deny": [
+      "mcp__github__merge_pull_request",
+      "mcp__github__enable_pr_auto_merge",
+      "mcp__github__create_repository",
+      "mcp__github__delete_file"
     ]
   }
 }

--- a/docs/dev-assistant/ROUTINE-PROMPT.md
+++ b/docs/dev-assistant/ROUTINE-PROMPT.md
@@ -313,6 +313,13 @@ set the per-mode env vars.
   `WebFetch`/`WebSearch`, and `PushNotification` (the blocker-escalation
   path). If a Routine gets stuck on a new prompt, add that tool to the
   allowlist rather than working around it in the prompt.
+- **GitHub MCP tools are pre-allowed server-wide** (`mcp__github`) — review
+  runs post inline PR comments and implement runs open PRs, so a permission
+  prompt there hangs the run at the finish line. `deny` rules block the
+  operations Routines must never perform (`merge_pull_request`,
+  `enable_pr_auto_merge` — merging is Convex-side only, per Phase 3 — plus
+  `create_repository` and `delete_file`), turning the "Routines never merge"
+  prompt rule into a hard permission boundary.
 - **Reviewer identity**: routine sessions currently CANNOT submit formal
   approve/request-changes reviews — the session type blocks APPROVE, and the
   bot reviewer PAT is blocked by the org proxy (it needs the GitHub App

--- a/docs/dev-assistant/ROUTINE-PROMPT.md
+++ b/docs/dev-assistant/ROUTINE-PROMPT.md
@@ -302,6 +302,17 @@ set the per-mode env vars.
 
 ## Operational notes
 
+- **Permission prompts hang Routines.** Routine sessions run unattended, so
+  any tool call that triggers an interactive permission dialog (e.g.
+  Playwright `browser_navigate` while rendering a mock) blocks forever — the
+  "never wait on a permission prompt" instruction in the preamble can't
+  prevent it because the dialog comes from the harness, not the model. Tools
+  the Routines rely on must be pre-allowed in this repo's checked-in
+  `.claude/settings.json` (`permissions.allow`), which every session loads
+  after cloning: currently the `playwright` and `ios-simulator` MCP servers,
+  `WebFetch`/`WebSearch`, and `PushNotification` (the blocker-escalation
+  path). If a Routine gets stuck on a new prompt, add that tool to the
+  allowlist rather than working around it in the prompt.
 - **Reviewer identity**: routine sessions currently CANNOT submit formal
   approve/request-changes reviews — the session type blocks APPROVE, and the
   bot reviewer PAT is blocked by the org proxy (it needs the GitHub App

--- a/docs/dev-assistant/ROUTINE-PROMPT.md
+++ b/docs/dev-assistant/ROUTINE-PROMPT.md
@@ -307,12 +307,20 @@ set the per-mode env vars.
   Playwright `browser_navigate` while rendering a mock) blocks forever — the
   "never wait on a permission prompt" instruction in the preamble can't
   prevent it because the dialog comes from the harness, not the model. Tools
-  the Routines rely on must be pre-allowed in this repo's checked-in
-  `.claude/settings.json` (`permissions.allow`), which every session loads
-  after cloning: currently the `playwright` and `ios-simulator` MCP servers,
-  `WebFetch`/`WebSearch`, and `PushNotification` (the blocker-escalation
-  path). If a Routine gets stuck on a new prompt, add that tool to the
-  allowlist rather than working around it in the prompt.
+  the Routines rely on are pre-allowed in this repo's checked-in
+  `.claude/settings.json` (`permissions.allow`): currently the `playwright`
+  and `ios-simulator` MCP servers, `WebFetch`/`WebSearch`, and
+  `PushNotification` (the blocker-escalation path). **The checked-in
+  allowlist does not apply by itself on a fresh unattended clone**: project
+  `permissions.allow` rules are gated behind the workspace-trust dialog,
+  which non-interactive sessions never show, so the rules are read but
+  ignored (`deny` rules apply regardless). The Routine environment's setup
+  script must therefore run `scripts/setup-claude-runner-permissions.sh`
+  after cloning — it copies the allowlist into user-level settings (never
+  trust-gated) and pre-seeds workspace trust for the clone. If a Routine
+  gets stuck on a new prompt, add that tool to the checked-in allowlist
+  (the setup script picks it up automatically) rather than working around
+  it in the prompt.
 - **GitHub MCP tools are pre-allowed server-wide** (`mcp__github`) — review
   runs post inline PR comments and implement runs open PRs, so a permission
   prompt there hangs the run at the finish line. `deny` rules block the

--- a/scripts/setup-claude-runner-permissions.sh
+++ b/scripts/setup-claude-runner-permissions.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Make the repo's Claude Code permission allowlist take effect on unattended
+# runners (dev-assistant Routines / Claude Code on the web).
+#
+# Project-level permissions.allow rules in .claude/settings.json are gated
+# behind the workspace-trust dialog, and non-interactive sessions never show
+# that dialog — so on a fresh clone the allow rules are read but IGNORED,
+# while deny rules always apply. See:
+# https://code.claude.com/docs/en/permissions#project-allow-rules-and-workspace-trust
+#
+# Run this from the environment's setup script (after the clone exists). It
+# makes the checked-in allowlist effective two independent ways:
+#   1. copies it into user-level ~/.claude/settings.json, which is never
+#      trust-gated;
+#   2. pre-seeds workspace trust for the clone path, so the project settings
+#      also apply as written.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+node - "$REPO_ROOT" <<'EOF'
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = process.argv[2];
+const repoSettings = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, '.claude', 'settings.json'), 'utf8'),
+);
+const allow = repoSettings.permissions?.allow ?? [];
+
+const userSettingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+fs.mkdirSync(path.dirname(userSettingsPath), { recursive: true });
+let userSettings = {};
+try {
+  userSettings = JSON.parse(fs.readFileSync(userSettingsPath, 'utf8'));
+} catch {}
+userSettings.permissions = userSettings.permissions ?? {};
+userSettings.permissions.allow = [
+  ...new Set([...(userSettings.permissions.allow ?? []), ...allow]),
+];
+fs.writeFileSync(userSettingsPath, JSON.stringify(userSettings, null, 2) + '\n');
+
+const claudeJsonPath = path.join(os.homedir(), '.claude.json');
+let claudeJson = {};
+try {
+  claudeJson = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'));
+} catch {}
+claudeJson.projects = claudeJson.projects ?? {};
+claudeJson.projects[repoRoot] = {
+  ...(claudeJson.projects[repoRoot] ?? {}),
+  hasTrustDialogAccepted: true,
+};
+fs.writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2) + '\n');
+
+console.log(
+  `Applied ${allow.length} allow rules to ${userSettingsPath}; trusted ${repoRoot}`,
+);
+EOF


### PR DESCRIPTION
## Problem

Dev-assistant Routine runs (triggered from the Togather dev dashboard) stall mid-run on interactive permission prompts — e.g. Playwright `browser_navigate` while rendering a UI mock. The prompt comes from the Claude Code harness, not the model, so the Routine preamble's "never wait on a permission prompt" instruction cannot prevent it; with nobody watching the session, the dialog just hangs the run and blocks the contributor who triggered it.

## Fix

The repo's checked-in `.claude/settings.json` pre-allows the tools the Routine prompts actually rely on:

- `mcp__playwright` — web-build verification and rendered UI mocks (the reported hang)
- `mcp__ios-simulator` — same treatment for simulator-capable sessions
- `mcp__github` — review runs post inline PR comments and implement runs open PRs; a prompt here hangs an otherwise-finished run at the finish line
- `WebFetch` / `WebSearch` — fetching PR links, docs, screenshot URLs
- `PushNotification` — the preamble's blocker-escalation path

It also adds `deny` rules for operations Routines must never perform — `merge_pull_request`, `enable_pr_auto_merge` (merging is Convex-side only, per ADR-029 Phase 3), `create_repository`, `delete_file` — turning the "Routines never merge" prompt rule into a hard permission boundary.

**Workspace-trust caveat (flagged by Codex review, confirmed):** project-level `permissions.allow` rules are gated behind the workspace-trust dialog, which unattended sessions never show — so on a fresh clone the checked-in allowlist is read but ignored (`deny` rules apply regardless). `scripts/setup-claude-runner-permissions.sh` closes that gap: the Routine environment's setup script runs it after cloning, and it copies the checked-in allowlist into user-level settings (never trust-gated) and pre-seeds workspace trust, keeping `.claude/settings.json` as the single source of truth. Verified working on this runner class.

`docs/dev-assistant/ROUTINE-PROMPT.md` operational notes document the failure mode and the remedy (extend the checked-in allowlist; the setup script picks it up automatically).

## Notes

- Requires a one-time environment change after merge: add `scripts/setup-claude-runner-permissions.sh` to the Routine environment's setup script.
- The allow/deny rules apply to every session in this repo, including interactive ones — deliberately broad to reduce friction; tighten if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQ1ChNEVqVHgRszZ6nJJN3