### PR TITLE
Maintainer flow: plan surface, staging redo, in-app merge & production promote

### DIFF
--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -559,8 +559,12 @@ describe("queries", () => {
       api.functions.devAssistant.contributions.myContributions,
       { token: maintainerId },
     );
-    expect(mine[0]?.lastMessageBody).toBe("## Plan\nChange the string.");
-    expect(mine[0]?.lastMessageAuthorType).toBe("assistant");
+    // The plan itself is NOT posted into the thread (it lives behind "The
+    // plan" card) — the latest turn is the plan-ready pointer.
+    expect(mine[0]?.lastMessageBody).toBe(
+      'The plan is ready — read it under "The plan" below',
+    );
+    expect(mine[0]?.lastMessageAuthorType).toBe("system");
   });
 });
 
@@ -594,7 +598,7 @@ describe("conversation thread (Phase 1.5)", () => {
     });
   });
 
-  test("spec callback stores triage fields and appends an assistant message", async () => {
+  test("spec callback stores triage fields and logs a plan-ready pointer", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
     const { maintainerId } = await seedUsers(t);
@@ -617,9 +621,12 @@ describe("conversation thread (Phase 1.5)", () => {
       api.functions.devAssistant.contributions.getThread,
       { token: maintainerId, id },
     );
-    // Report (user) then spec (assistant), oldest first.
-    expect(thread.map((m) => m.authorType)).toEqual(["user", "assistant"]);
-    expect(thread[1]?.body).toBe("## Plan\nChange the string.");
+    // Report (user) then the plan-ready pointer (system), oldest first — the
+    // spec text itself stays on the row and renders behind "The plan" card.
+    expect(thread.map((m) => m.authorType)).toEqual(["user", "system"]);
+    expect(thread[1]?.body).toBe(
+      'The plan is ready — read it under "The plan" below',
+    );
   });
 
   test("postMessage appends a user turn and fires a spec-revision dispatch while IN_REVIEW", async () => {
@@ -647,10 +654,11 @@ describe("conversation thread (Phase 1.5)", () => {
     const brief = JSON.parse(JSON.parse(init.body as string).text);
     expect(brief).toMatchObject({ mode: "spec", revision: true, bugId: id });
     expect(brief.instructions).toMatch(/REVISION ROUND/);
-    // Full thread history rides along: report, spec, and the new reply.
+    // Full thread history rides along: report, the plan-ready pointer, and
+    // the new reply (the spec text itself travels in the payload's `spec`).
     expect(
       brief.thread.map((m: { authorType: string }) => m.authorType),
-    ).toEqual(["user", "assistant", "user"]);
+    ).toEqual(["user", "system", "user"]);
     expect(brief.thread[2]?.body).toBe("Please also cover the settings tab.");
     expect(brief.thread[2]?.authorName).toBe("Connie Tributor");
 
@@ -1308,7 +1316,7 @@ describe("staging verification", () => {
     ).rejects.toThrow(/current status/);
   });
 
-  test("reportStagingIssue logs the note plus a failure marker (no dispatch)", async () => {
+  test("reportStagingIssue sends the item back through the pipeline (staging-redo dispatch)", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
     const { maintainerId } = await seedUsers(t);
@@ -1316,14 +1324,22 @@ describe("staging verification", () => {
     const id = await seedStagingBug(t, maintainerId, {
       status: "MERGED",
     });
+    // Seed the merged round's leftovers so the reset is observable.
+    await t.run(async (ctx) =>
+      ctx.db.patch(id, {
+        prUrl: "https://github.com/togathernyc/togather/pull/41",
+        reviewVerdict: "approved" as const,
+        reviewSummary: "LGTM",
+        fixRounds: 2,
+        activeRunMode: "review" as const,
+      }),
+    );
     const fetchMock = stubRoutineEnv();
 
     await t.mutation(
       api.functions.devAssistant.contributions.reportStagingIssue,
       { token: maintainerId, id, note: "The RSVP toast still says Going." },
     );
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
-    expect(fetchMock).not.toHaveBeenCalled();
 
     const thread = await t.query(
       api.functions.devAssistant.contributions.getThread,
@@ -1331,12 +1347,368 @@ describe("staging verification", () => {
     );
     expect(thread.map((m) => [m.authorType, m.body])).toEqual([
       ["user", "The RSVP toast still says Going."],
-      ["system", "Staging check failed — needs another look"],
+      ["system", "Staging check failed — sending it back to the AI to fix"],
     ]);
 
+    // The previous round's pipeline state is reset and the item re-enters the
+    // build pipeline (MERGED -> READY_FOR_IMPL -> IN_PROGRESS via dispatch).
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
     const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("IN_PROGRESS");
     expect(bug?.stagingVerifiedAt).toBeUndefined();
+    expect(bug?.verifyOnStaging).toBe(true); // re-merge reopens the window
+    expect(bug?.prUrl).toBeUndefined();
+    expect(bug?.reviewVerdict).toBeUndefined();
+    expect(bug?.reviewSummary).toBeUndefined();
+    expect(bug?.fixRounds).toBe(0);
+    expect(bug?.activeRunMode).toBe("implement");
+    // Fresh routineRunId — stale callbacks from the merged round are orphaned.
+    expect(bug?.routineRunId).toBeTruthy();
+    expect(bug?.routineRunId).not.toBe("run-staging");
+
+    // A redo-mode implement dispatch fired, carrying the conversation and the
+    // "open a NEW PR" instructions.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const brief = JSON.parse(JSON.parse(init.body as string).text);
+    expect(brief).toMatchObject({ bugId: id, redo: true });
+    expect(brief.instructions).toMatch(/REDO ROUND/);
+    expect(brief.instructions).toMatch(/NEW\s+pull request/);
+    expect(
+      brief.thread.map((m: { authorType: string }) => m.authorType),
+    ).toEqual(["user", "system"]);
+    expect(brief.thread[0]?.body).toBe("The RSVP toast still says Going.");
+  });
+});
+
+describe("in-app merge (mergeNow)", () => {
+  async function seedReadyToMerge(
+    t: ReturnType<typeof convexTest>,
+    originatorId: Id<"users">,
+    overrides: Partial<{
+      status: "CODE_REVIEW" | "READY_TO_MERGE" | "MERGED";
+      reviewVerdict: "approved" | "changes_requested";
+      prUrl: string | undefined;
+    }> = {},
+  ): Promise<Id<"devBugs">> {
+    const now = Date.now();
+    return await t.run(async (ctx) =>
+      ctx.db.insert("devBugs", {
+        originatorUserId: originatorId,
+        status: overrides.status ?? "READY_TO_MERGE",
+        kind: "bug",
+        source: "dashboard",
+        title: "Fix RSVP message",
+        body: "B",
+        routineRunId: "run-merge",
+        reviewVerdict:
+          "reviewVerdict" in overrides ? overrides.reviewVerdict : "approved",
+        prUrl:
+          "prUrl" in overrides
+            ? overrides.prUrl
+            : "https://github.com/togathernyc/togather/pull/77",
+        verifyOnStaging: true,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
+  test("merges the PR via GitHub and lands MERGED through the trusted source", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const id = await seedReadyToMerge(t, maintainerId);
+
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+      token: maintainerId,
+      id,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The GitHub merge endpoint was hit with the squash default.
+    const mergeCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/pulls/77/merge"),
+    );
+    expect(mergeCall).toBeTruthy();
+    expect(JSON.parse((mergeCall![1] as RequestInit).body as string)).toEqual({
+      merge_method: "squash",
+    });
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.status).toBe("MERGED");
+    expect(bug?.shippedAt).toBeTruthy();
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread.map((m) => m.body)).toEqual([
+      "Connie Tributor asked to merge this from the app — merging…",
+      "Merged — live on staging",
+    ]);
+  });
+
+  test("a failed GitHub merge posts the reason instead of advancing", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const id = await seedReadyToMerge(t, maintainerId);
+
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ message: "Base branch was modified" }), {
+          status: 409,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+      token: maintainerId,
+      id,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("READY_TO_MERGE");
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread[thread.length - 1]?.body).toMatch(
+      /Merge failed: GitHub merge returned 409 \(Base branch was modified\)/,
+    );
+  });
+
+  test("rejects when the item is not ready (status, verdict, or missing PR)", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId, regularUserId } = await seedUsers(t);
+
+    const notReady = await seedReadyToMerge(t, maintainerId, {
+      status: "CODE_REVIEW",
+    });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+        token: maintainerId,
+        id: notReady,
+      }),
+    ).rejects.toThrow(/isn't ready to merge/);
+
+    const notApproved = await seedReadyToMerge(t, maintainerId, {
+      reviewVerdict: "changes_requested",
+    });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+        token: maintainerId,
+        id: notApproved,
+      }),
+    ).rejects.toThrow(/hasn't approved/);
+
+    const noPr = await seedReadyToMerge(t, maintainerId, { prUrl: undefined });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+        token: maintainerId,
+        id: noPr,
+      }),
+    ).rejects.toThrow(/no pull request/);
+
+    // Non-contributors can't reach the surface at all.
+    const ready = await seedReadyToMerge(t, maintainerId);
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+        token: regularUserId,
+        id: ready,
+      }),
+    ).rejects.toThrow(/Not authorized/);
+  });
+});
+
+describe("in-app production promote (silent OTA)", () => {
+  async function seedMergedBug(
+    t: ReturnType<typeof convexTest>,
+    originatorId: Id<"users">,
+    overrides: Partial<{
+      verifyOnStaging: boolean;
+      stagingVerifiedAt: number;
+      productionRequestedAt: number;
+    }> = {},
+  ): Promise<Id<"devBugs">> {
+    const now = Date.now();
+    return await t.run(async (ctx) =>
+      ctx.db.insert("devBugs", {
+        originatorUserId: originatorId,
+        status: "MERGED",
+        kind: "bug",
+        source: "dashboard",
+        title: "Fix RSVP message",
+        body: "B",
+        verifyOnStaging: overrides.verifyOnStaging ?? true,
+        stagingVerifiedAt:
+          "stagingVerifiedAt" in overrides ? overrides.stagingVerifiedAt : now,
+        productionRequestedAt: overrides.productionRequestedAt,
+        shippedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
+  test("triggers the production workflow with silent update_mode and logs it", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const id = await seedMergedBug(t, maintainerId);
+
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.mutation(
+      api.functions.devAssistant.contributions.promoteToProduction,
+      { token: maintainerId, id },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const dispatchCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("deploy-to-production.yml/dispatches"),
+    );
+    expect(dispatchCall).toBeTruthy();
+    expect(
+      JSON.parse((dispatchCall![1] as RequestInit).body as string),
+    ).toEqual({
+      ref: "main",
+      inputs: { confirm: "deploy", update_mode: "silent" },
+    });
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.productionRequestedAt).toBeTruthy();
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread.map((m) => m.body)).toEqual([
+      "Connie Tributor triggered the production deploy (silent update)",
+      "Production deploy started — the silent update reaches users next time they open the app",
+    ]);
+  });
+
+  test("a failed workflow dispatch clears productionRequestedAt so the button returns", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const id = await seedMergedBug(t, maintainerId);
+
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ message: "Resource not accessible" }), {
+          status: 403,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.mutation(
+      api.functions.devAssistant.contributions.promoteToProduction,
+      { token: maintainerId, id },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.productionRequestedAt).toBeUndefined();
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread[thread.length - 1]?.body).toMatch(
+      /Production deploy couldn't start: GitHub workflow dispatch returned 403 \(Resource not accessible\) — needs a maintainer/,
+    );
+  });
+
+  test("gates: unmerged, staging-unverified, and double triggers are rejected", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+
+    // Staging flagged but not verified.
+    const unverified = await t.run(async (ctx) => {
+      const now = Date.now();
+      return await ctx.db.insert("devBugs", {
+        originatorUserId: maintainerId,
+        status: "MERGED",
+        kind: "bug",
+        source: "dashboard",
+        title: "T",
+        body: "B",
+        verifyOnStaging: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+    await expect(
+      t.mutation(
+        api.functions.devAssistant.contributions.promoteToProduction,
+        { token: maintainerId, id: unverified },
+      ),
+    ).rejects.toThrow(/works on staging/);
+
+    // Not merged yet.
+    const open = await t.run(async (ctx) => {
+      const now = Date.now();
+      return await ctx.db.insert("devBugs", {
+        originatorUserId: maintainerId,
+        status: "READY_TO_MERGE",
+        kind: "bug",
+        source: "dashboard",
+        title: "T",
+        body: "B",
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+    await expect(
+      t.mutation(
+        api.functions.devAssistant.contributions.promoteToProduction,
+        { token: maintainerId, id: open },
+      ),
+    ).rejects.toThrow(/Only merged changes/);
+
+    // Already triggered.
+    const done = await seedMergedBug(t, maintainerId, {
+      productionRequestedAt: Date.now(),
+    });
+    await expect(
+      t.mutation(
+        api.functions.devAssistant.contributions.promoteToProduction,
+        { token: maintainerId, id: done },
+      ),
+    ).rejects.toThrow(/already triggered/);
+
+    // Non-interactive items skip the staging gate entirely.
+    const copyOnly = await seedMergedBug(t, maintainerId, {
+      verifyOnStaging: false,
+      stagingVerifiedAt: undefined,
+    });
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await t.mutation(
+      api.functions.devAssistant.contributions.promoteToProduction,
+      { token: maintainerId, id: copyOnly },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(copyOnly)))
+        ?.productionRequestedAt,
+    ).toBeTruthy();
   });
 });
 
@@ -2698,14 +3070,15 @@ describe("run-mode callback policy", () => {
     expect(bug?.specApprovedAt).toBeUndefined();
     expect(bug?.status).toBe("IN_REVIEW");
 
-    // Thread: new plan as the assistant turn + the re-approval system line.
+    // Thread: the revision lands as ONE re-approval pointer (the plan text
+    // itself is not reposted — it renders behind "The plan" card).
     const thread = await t.query(
       api.functions.devAssistant.contributions.getThread,
       { token: maintainerId, id },
     );
     expect(thread.slice(-2).map((m) => [m.authorType, m.body])).toEqual([
-      ["assistant", "## Plan v2\nChange the string on both tabs."],
-      ["system", "Plan updated — needs your approval again"],
+      ["user", "Actually, also fix the settings tab."],
+      ["system", "Plan updated — it needs your approval again"],
     ]);
 
     // The originator was pushed about the revision (status didn't change, so

--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -1361,6 +1361,7 @@ describe("staging verification", () => {
     expect(bug?.reviewVerdict).toBeUndefined();
     expect(bug?.reviewSummary).toBeUndefined();
     expect(bug?.fixRounds).toBe(0);
+    expect(bug?.redoRounds).toBe(1); // persisted — dispatch infers redo from it
     expect(bug?.activeRunMode).toBe("implement");
     // Fresh routineRunId — stale callbacks from the merged round are orphaned.
     expect(bug?.routineRunId).toBeTruthy();
@@ -1378,6 +1379,144 @@ describe("staging verification", () => {
       brief.thread.map((m: { authorType: string }) => m.authorType),
     ).toEqual(["user", "system"]);
     expect(brief.thread[0]?.body).toBe("The RSVP toast still says Going.");
+  });
+
+  test("a retried redo dispatch keeps the redo context (inferred from redoRounds)", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { otherMaintainerId, maintainerId } = await seedUsers(t);
+
+    const id = await seedStagingBug(t, maintainerId, { status: "MERGED" });
+    // No routine env: the redo dispatch fails before markDispatched, leaving
+    // the row in READY_FOR_IMPL with lastError — the retry window.
+    await t.mutation(
+      api.functions.devAssistant.contributions.reportStagingIssue,
+      { token: maintainerId, id, note: "Still broken on staging." },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    let bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("READY_FOR_IMPL");
+    expect(bug?.lastError).toBeTruthy();
+
+    // Superuser retries once the env is back — the redo context must survive
+    // because it's inferred from the persisted redoRounds, not a dispatch arg.
+    const fetchMock = stubRoutineEnv();
+    await t.mutation(api.functions.devAssistant.bugs.retryDispatch, {
+      token: otherMaintainerId,
+      bugId: id,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const brief = JSON.parse(JSON.parse(init.body as string).text);
+    expect(brief).toMatchObject({ bugId: id, redo: true });
+    expect(brief.instructions).toMatch(/REDO ROUND/);
+    expect(brief.thread[0]?.body).toBe("Still broken on staging.");
+
+    bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("IN_PROGRESS");
+  });
+
+  test("redo dispatch carries pictures attached to thread replies", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+
+    const id = await seedStagingBug(t, maintainerId, { status: "MERGED" });
+    // Contributor screenshots the broken staging behavior in a reply…
+    await t.run(async (ctx) => {
+      await ctx.db.insert("devBugMessages", {
+        bugId: id,
+        authorType: "user",
+        userId: maintainerId,
+        body: "See the screenshot",
+        imageUrls: ["r2:devassistant/staging-broken.png"],
+        createdAt: Date.now(),
+      });
+    });
+    process.env.R2_PUBLIC_URL = "https://media.example.com";
+    const fetchMock = stubRoutineEnv();
+
+    // …then reports the staging issue.
+    await t.mutation(
+      api.functions.devAssistant.contributions.reportStagingIssue,
+      { token: maintainerId, id, note: "see the screenshot above" },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const brief = JSON.parse(JSON.parse(init.body as string).text);
+    expect(brief.redo).toBe(true);
+    expect(brief.screenshotUrls).toEqual([
+      "https://media.example.com/devassistant/staging-broken.png",
+    ]);
+    delete process.env.R2_PUBLIC_URL;
+  });
+
+  test("a stale merged-PR webhook for a previous round cannot kill the redo", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+
+    // Redo in flight: shipped once (round 1 merged), building again, no new
+    // PR yet.
+    const now = Date.now();
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert("devBugs", {
+        originatorUserId: maintainerId,
+        status: "IN_PROGRESS",
+        kind: "bug",
+        source: "dashboard",
+        title: "Fix RSVP message",
+        body: "B",
+        routineRunId: "run-redo",
+        activeRunMode: "implement" as const,
+        verifyOnStaging: true,
+        redoRounds: 1,
+        shippedAt: now - 1000,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+
+    // GitHub redelivers round 1's closed(merged) event — same branch name.
+    await t.mutation(internal.functions.devAssistant.bugs.handleGithubPrClosed, {
+      branchRef: `claude/devbug-${id}`,
+      prUrl: "https://github.com/togathernyc/togather/pull/41",
+      merged: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The redo round survives untouched.
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("IN_PROGRESS");
+
+    // Once the redo's own PR is stored, only ITS url may apply a merge.
+    await t.run(async (ctx) =>
+      ctx.db.patch(id, {
+        status: "CODE_REVIEW" as const,
+        prUrl: "https://github.com/togathernyc/togather/pull/52",
+      }),
+    );
+    await t.mutation(internal.functions.devAssistant.bugs.handleGithubPrClosed, {
+      branchRef: `claude/devbug-${id}`,
+      prUrl: "https://github.com/togathernyc/togather/pull/41", // round 1
+      merged: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect((await t.run(async (ctx) => ctx.db.get(id)))?.status).toBe(
+      "CODE_REVIEW",
+    );
+
+    // The current round's PR still merges normally.
+    await t.mutation(internal.functions.devAssistant.bugs.handleGithubPrClosed, {
+      branchRef: `claude/devbug-${id}`,
+      prUrl: "https://github.com/togathernyc/togather/pull/52",
+      merged: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect((await t.run(async (ctx) => ctx.db.get(id)))?.status).toBe("MERGED");
   });
 });
 
@@ -1428,6 +1567,19 @@ describe("in-app merge (mergeNow)", () => {
       token: maintainerId,
       id,
     });
+
+    // Server-side in-flight latch: stamped immediately so the merge card
+    // hides for every viewer and a concurrent second tap is rejected.
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.mergeRequestedAt,
+    ).toBeTruthy();
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+        token: maintainerId,
+        id,
+      }),
+    ).rejects.toThrow(/already in flight/);
+
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
     // The GitHub merge endpoint was hit with the squash default.
@@ -1476,6 +1628,9 @@ describe("in-app merge (mergeNow)", () => {
 
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.status).toBe("READY_TO_MERGE");
+    // Failure clears the in-flight latch so the merge card returns and the
+    // "try again" in the message is actually possible.
+    expect(bug?.mergeRequestedAt).toBeUndefined();
 
     const thread = await t.query(
       api.functions.devAssistant.contributions.getThread,
@@ -1484,6 +1639,43 @@ describe("in-app merge (mergeNow)", () => {
     expect(thread[thread.length - 1]?.body).toMatch(
       /Merge failed: GitHub merge returned 409 \(Base branch was modified\)/,
     );
+  });
+
+  test("losing the race to auto-merge is a success, not a spurious failure", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    const id = await seedReadyToMerge(t, maintainerId);
+
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    // The merge PUT 405s (someone else merged first), but the follow-up PR
+    // GET reports merged: true.
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (String(url).endsWith("/merge")) {
+        return new Response(
+          JSON.stringify({ message: "Pull Request is not mergeable" }),
+          { status: 405 },
+        );
+      }
+      return new Response(JSON.stringify({ merged: true }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.mutation(api.functions.devAssistant.contributions.mergeNow, {
+      token: maintainerId,
+      id,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.status).toBe("MERGED");
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    // No "Merge failed" line — the change merged, whoever's PUT landed.
+    expect(thread.some((m) => /Merge failed/.test(m.body))).toBe(false);
   });
 
   test("rejects when the item is not ready (status, verdict, or missing PR)", async () => {
@@ -1681,7 +1873,7 @@ describe("in-app production promote (silent OTA)", () => {
       ),
     ).rejects.toThrow(/Only merged changes/);
 
-    // Already triggered.
+    // Already triggered (within the cooldown).
     const done = await seedMergedBug(t, maintainerId, {
       productionRequestedAt: Date.now(),
     });
@@ -1691,6 +1883,29 @@ describe("in-app production promote (silent OTA)", () => {
         { token: maintainerId, id: done },
       ),
     ).rejects.toThrow(/already triggered/);
+
+    // Legacy row: verifyOnStaging UNSET (predates the feature) — must not
+    // grow a production trigger retroactively.
+    const legacy = await t.run(async (ctx) => {
+      const now = Date.now();
+      return await ctx.db.insert("devBugs", {
+        originatorUserId: maintainerId,
+        status: "MERGED",
+        kind: "bug",
+        source: "dashboard",
+        title: "T",
+        body: "B",
+        shippedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+    await expect(
+      t.mutation(
+        api.functions.devAssistant.contributions.promoteToProduction,
+        { token: maintainerId, id: legacy },
+      ),
+    ).rejects.toThrow(/works on staging/);
 
     // Non-interactive items skip the staging gate entirely.
     const copyOnly = await seedMergedBug(t, maintainerId, {
@@ -1709,6 +1924,29 @@ describe("in-app production promote (silent OTA)", () => {
       (await t.run(async (ctx) => ctx.db.get(copyOnly)))
         ?.productionRequestedAt,
     ).toBeTruthy();
+  });
+
+  test("the trigger latch is a cooldown: a stale request can be re-triggered", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+
+    // Triggered 16 minutes ago — the workflow run may have failed on GitHub
+    // with no callback to clear the latch; past the cooldown the maintainer
+    // may re-trigger from the app.
+    const id = await seedMergedBug(t, maintainerId, {
+      productionRequestedAt: Date.now() - 16 * 60 * 1000,
+    });
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.mutation(
+      api.functions.devAssistant.contributions.promoteToProduction,
+      { token: maintainerId, id },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -2931,7 +3169,10 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
       bugId: id,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Two calls, no retry loop: the merge PUT, then the merged-state GET that
+    // rules out a lost race before reporting a failure. No further merges.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]?.[0])).not.toMatch(/\/merge$/);
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merge blocked: GitHub merge returned 409 (Pull Request is not mergeable) — needs a maintainer",
     ]);

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -182,7 +182,15 @@ function buildGithubIssueBody(bug: {
 }
 
 export const dispatchBug = internalAction({
-  args: { bugId: v.id("devBugs"), forceRedispatch: v.optional(v.boolean()) },
+  args: {
+    bugId: v.id("devBugs"),
+    forceRedispatch: v.optional(v.boolean()),
+    // Staging-redo round (reportStagingIssue): the item's original PR is
+    // already merged, but the contributor found problems on staging. The
+    // payload carries the conversation thread + instructions to fix the
+    // reported problems and open a NEW PR against latest main.
+    stagingRedo: v.optional(v.boolean()),
+  },
   handler: async (ctx, args): Promise<void> => {
     const bug = await ctx.runQuery(internal.functions.devAssistant.bugs.getBug, {
       bugId: args.bugId,
@@ -273,6 +281,15 @@ export const dispatchBug = internalAction({
       { bugId: args.bugId },
     );
 
+    // A staging-redo run needs the conversation: the latest user messages
+    // describe what went wrong on staging.
+    const thread = args.stagingRedo
+      ? await ctx.runQuery(
+          internal.functions.devAssistant.bugs.getThreadHistory,
+          { bugId: args.bugId },
+        )
+      : null;
+
     const callbackUrl = `${process.env.CONVEX_SITE_URL}/dev-assistant/callback`;
     const payload = {
       bugId: args.bugId,
@@ -291,6 +308,26 @@ export const dispatchBug = internalAction({
       originatorName: originator?.name,
       originatorGithubUsername: originator?.githubUsername,
       callbackUrl,
+      ...(args.stagingRedo && thread
+        ? {
+            redo: true,
+            thread: thread.map((m) => ({
+              authorType: m.authorType,
+              ...(m.authorName ? { authorName: m.authorName } : {}),
+              body: m.body,
+            })),
+            instructions:
+              "REDO ROUND: an earlier PR for this item was already merged, " +
+              "but the contributor found problems while trying the change on " +
+              "staging — the latest user messages in `thread` describe " +
+              "what's wrong. Start from the latest main (the merged code is " +
+              "already in it), fix the reported problems, and open a NEW " +
+              "pull request on a fresh claude/devbug-<bugId> branch. Report " +
+              "callbacks as usual (IN_PROGRESS when you start, CODE_REVIEW " +
+              "with the new prUrl once the PR is open and CI is green). " +
+              "Never merge the PR.",
+          }
+        : {}),
     };
 
     try {
@@ -715,6 +752,36 @@ export const dispatchFix = internalAction({
 // ============================================================================
 
 /**
+ * Merge a PR via the GitHub REST API with the configured merge method
+ * (AUTO_MERGE_METHOD, default squash), retrying once with a plain merge on
+ * 405 ("merge method not allowed"). Shared by policy auto-merge and the
+ * maintainer-triggered in-app merge.
+ */
+async function mergePullRequestOnGithub(
+  prNumber: string,
+  token: string,
+): Promise<Response> {
+  const mergePr = async (mergeMethod: string): Promise<Response> =>
+    await fetch(`${GITHUB_PULLS_ENDPOINT}/${prNumber}/merge`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ merge_method: mergeMethod }),
+    });
+
+  const method = process.env.AUTO_MERGE_METHOD ?? "squash";
+  let res = await mergePr(method);
+  if (res.status === 405 && method !== "merge") {
+    res = await mergePr("merge");
+  }
+  return res;
+}
+
+/**
  * Attempt to merge a bug's PR under the Phase 3 auto-merge policy. Scheduled
  * (never inlined) whenever a gate might have just been satisfied: a genuine
  * entry into READY_TO_MERGE (applyCallback) and staging sign-off
@@ -809,25 +876,8 @@ export const attemptAutoMerge = internalAction({
       return;
     }
 
-    const mergePr = async (mergeMethod: string): Promise<Response> =>
-      await fetch(`${GITHUB_PULLS_ENDPOINT}/${prMatch[1]}/merge`, {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${mirrorToken}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ merge_method: mergeMethod }),
-      });
-
     try {
-      const method = process.env.AUTO_MERGE_METHOD ?? "squash";
-      let res = await mergePr(method);
-      // 405 covers "merge method not allowed" — retry once with plain merge.
-      if (res.status === 405 && method !== "merge") {
-        res = await mergePr("merge");
-      }
+      const res = await mergePullRequestOnGithub(prMatch[1], mirrorToken);
 
       if (res.ok) {
         await ctx.runMutation(
@@ -873,6 +923,176 @@ export const attemptAutoMerge = internalAction({
       await blocked(reason);
     } catch (error) {
       await blocked(String(error));
+    }
+  },
+});
+
+/**
+ * Maintainer-triggered merge from the app (scheduled by contributions.mergeNow).
+ * Unlike policy auto-merge this is an explicit human decision, so it skips the
+ * AUTO_MERGE_ENABLED switch and the per-user severity cap — but it re-checks
+ * the hard gates itself (READY_TO_MERGE + review approved + prUrl), so a stale
+ * tap after the state moved on is a polite thread message, not a rogue merge.
+ * Success lands MERGED through the same trusted "automerge" callback source as
+ * policy auto-merge; failure posts the reason for a maintainer.
+ */
+export const mergeFromApp = internalAction({
+  args: { bugId: v.id("devBugs") },
+  handler: async (ctx, args): Promise<void> => {
+    const bug = await ctx.runQuery(internal.functions.devAssistant.bugs.getBug, {
+      bugId: args.bugId,
+    });
+    if (!bug) return;
+
+    const failed = async (reason: string): Promise<void> => {
+      console.error("[DevAssistant] In-app merge failed:", reason, args.bugId);
+      await ctx.runMutation(
+        internal.functions.devAssistant.bugs.addSystemThreadMessage,
+        {
+          bugId: args.bugId,
+          body: `Merge failed: ${reason} — try again, or merge the PR on GitHub`,
+        },
+      );
+    };
+
+    if (
+      bug.status !== "READY_TO_MERGE" ||
+      bug.reviewVerdict !== "approved" ||
+      !bug.prUrl
+    ) {
+      await failed("the item is no longer ready to merge");
+      return;
+    }
+
+    const prMatch = /\/pull\/(\d+)/.exec(bug.prUrl);
+    if (!prMatch) {
+      await failed(`could not parse a PR number from ${bug.prUrl}`);
+      return;
+    }
+
+    const mirrorToken = githubMirrorToken();
+    if (!mirrorToken) {
+      await failed("GH_MIRROR_TOKEN not configured");
+      return;
+    }
+
+    try {
+      const res = await mergePullRequestOnGithub(prMatch[1], mirrorToken);
+
+      if (res.ok) {
+        // GitHub confirmed the merge — apply MERGED through the trusted
+        // "automerge" source (same as attemptAutoMerge) so the shipped push,
+        // system message, and chat bot message all fire; the webhook
+        // redelivery no-ops on a MERGED row.
+        if (bug.routineRunId) {
+          await ctx.runAction(
+            internal.functions.devAssistant.actions.handleRoutineCallback,
+            {
+              bugId: args.bugId,
+              routineRunId: bug.routineRunId,
+              status: "MERGED",
+              source: "automerge",
+            },
+          );
+        } else {
+          await ctx.runMutation(
+            internal.functions.devAssistant.bugs.applyCallback,
+            { bugId: args.bugId, status: "MERGED", source: "automerge" },
+          );
+        }
+        return;
+      }
+
+      let reason = `GitHub merge returned ${res.status}`;
+      try {
+        const errBody = (await res.json()) as { message?: string };
+        if (errBody?.message) reason = `${reason} (${errBody.message})`;
+      } catch {
+        // Non-JSON error body; the status code is reason enough.
+      }
+      await failed(reason);
+    } catch (error) {
+      await failed(String(error));
+    }
+  },
+});
+
+// ============================================================================
+// In-app production deploy (silent OTA)
+// ============================================================================
+
+/**
+ * The manual production pipeline's workflow_dispatch endpoint. The in-app
+ * "Ship to production" button fires the SAME workflow a maintainer would run
+ * from the GitHub Actions UI — nothing bespoke ships from here.
+ */
+const GITHUB_PROD_DEPLOY_WORKFLOW_ENDPOINT =
+  "https://api.github.com/repos/togathernyc/togather/actions/workflows/deploy-to-production.yml/dispatches";
+
+/**
+ * Trigger the production deploy workflow (scheduled by
+ * contributions.promoteToProduction). Always update_mode "silent" — the
+ * in-app button never forces a reload on users; forced updates remain a
+ * hand-run workflow decision. Requires GH_MIRROR_TOKEN to ALSO have
+ * Actions: read/write on the repo (in addition to Issues + Contents).
+ * The outcome lands in the thread via recordProductionDeployOutcome, which
+ * clears productionRequestedAt on failure so the button comes back.
+ */
+export const dispatchProductionDeploy = internalAction({
+  args: { bugId: v.id("devBugs") },
+  handler: async (ctx, args): Promise<void> => {
+    const outcome = async (ok: boolean, detail?: string): Promise<void> => {
+      if (!ok) {
+        console.error(
+          "[DevAssistant] Production deploy dispatch failed:",
+          detail,
+          args.bugId,
+        );
+      }
+      await ctx.runMutation(
+        internal.functions.devAssistant.bugs.recordProductionDeployOutcome,
+        { bugId: args.bugId, ok, detail },
+      );
+    };
+
+    const token = githubMirrorToken();
+    if (!token) {
+      await outcome(false, "GH_MIRROR_TOKEN not configured");
+      return;
+    }
+
+    try {
+      const res = await fetch(GITHUB_PROD_DEPLOY_WORKFLOW_ENDPOINT, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ref: "main",
+          // The workflow's own safety gate expects the literal "deploy";
+          // update_mode is pinned to silent by design (see doc comment).
+          inputs: { confirm: "deploy", update_mode: "silent" },
+        }),
+      });
+
+      // A successful workflow_dispatch returns 204 No Content.
+      if (res.status === 204) {
+        await outcome(true);
+        return;
+      }
+      let detail = `GitHub workflow dispatch returned ${res.status}`;
+      try {
+        const errBody = (await res.json()) as { message?: string };
+        if (errBody?.message) detail = `${detail} (${errBody.message})`;
+      } catch {
+        // Non-JSON error body; the status code is reason enough.
+      }
+      await outcome(false, detail);
+    } catch (error) {
+      await outcome(false, String(error));
     }
   },
 });

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -7,9 +7,9 @@
  */
 
 import { v } from "convex/values";
-import { internalAction } from "../../_generated/server";
+import { internalAction, type ActionCtx } from "../../_generated/server";
 import { api, internal } from "../../_generated/api";
-import { Id } from "../../_generated/dataModel";
+import { Doc, Id } from "../../_generated/dataModel";
 import { getMediaUrl } from "../../lib/utils";
 import { buildDevAssistantPrompt } from "./prompts";
 import { runAgentLoop, buildThreadMessages } from "./agent";
@@ -182,20 +182,20 @@ function buildGithubIssueBody(bug: {
 }
 
 export const dispatchBug = internalAction({
-  args: {
-    bugId: v.id("devBugs"),
-    forceRedispatch: v.optional(v.boolean()),
-    // Staging-redo round (reportStagingIssue): the item's original PR is
-    // already merged, but the contributor found problems on staging. The
-    // payload carries the conversation thread + instructions to fix the
-    // reported problems and open a NEW PR against latest main.
-    stagingRedo: v.optional(v.boolean()),
-  },
+  args: { bugId: v.id("devBugs"), forceRedispatch: v.optional(v.boolean()) },
   handler: async (ctx, args): Promise<void> => {
     const bug = await ctx.runQuery(internal.functions.devAssistant.bugs.getBug, {
       bugId: args.bugId,
     });
     if (!bug) return;
+
+    // Staging-redo round (reportStagingIssue): the item's original PR is
+    // already merged, but the contributor found problems on staging. Inferred
+    // from the PERSISTED counter — not a dispatch arg — so the redo context
+    // survives every re-entry point (including the manual "Retry dispatch").
+    // The payload carries the conversation thread + instructions to fix the
+    // reported problems and open a NEW PR against latest main.
+    const stagingRedo = (bug.redoRounds ?? 0) > 0;
 
     const { triggerUrl, token } = routineTrigger("implement");
     if (!triggerUrl || !token) {
@@ -283,11 +283,27 @@ export const dispatchBug = internalAction({
 
     // A staging-redo run needs the conversation: the latest user messages
     // describe what went wrong on staging.
-    const thread = args.stagingRedo
+    const thread = stagingRedo
       ? await ctx.runQuery(
           internal.functions.devAssistant.bugs.getThreadHistory,
           { bugId: args.bugId },
         )
+      : null;
+
+    // Redo rounds also carry every picture in play — the report's shots PLUS
+    // any attached to thread replies (contributors screenshot the broken
+    // staging behavior right before tapping "Something's off"). Mirrors
+    // dispatchSpec's resolution: de-dupe, then resolve r2: paths to public
+    // URLs the vision-capable routine can fetch.
+    const redoShots = stagingRedo
+      ? Array.from(
+          new Set([
+            ...(bug.screenshotUrls ?? []),
+            ...(thread ?? []).flatMap((m) => m.imageUrls ?? []),
+          ]),
+        )
+          .map((u) => getMediaUrl(u))
+          .filter((u): u is string => !!u)
       : null;
 
     const callbackUrl = `${process.env.CONVEX_SITE_URL}/dev-assistant/callback`;
@@ -297,7 +313,8 @@ export const dispatchBug = internalAction({
       title: bug.title,
       body: bug.body,
       repro: bug.repro,
-      screenshotUrls: bug.screenshotUrls,
+      screenshotUrls:
+        redoShots && redoShots.length > 0 ? redoShots : bug.screenshotUrls,
       // Approved spec + risk level so the Routine builds against the plan the
       // contributor signed off on (undefined for chat-originated bugs).
       spec: bug.spec,
@@ -308,7 +325,7 @@ export const dispatchBug = internalAction({
       originatorName: originator?.name,
       originatorGithubUsername: originator?.githubUsername,
       callbackUrl,
-      ...(args.stagingRedo && thread
+      ...(stagingRedo && thread
         ? {
             redo: true,
             thread: thread.map((m) => ({
@@ -320,7 +337,8 @@ export const dispatchBug = internalAction({
               "REDO ROUND: an earlier PR for this item was already merged, " +
               "but the contributor found problems while trying the change on " +
               "staging — the latest user messages in `thread` describe " +
-              "what's wrong. Start from the latest main (the merged code is " +
+              "what's wrong (screenshotUrls includes any pictures they " +
+              "attached). Start from the latest main (the merged code is " +
               "already in it), fix the reported problems, and open a NEW " +
               "pull request on a fresh claude/devbug-<bugId> branch. Report " +
               "callbacks as usual (IN_PROGRESS when you start, CODE_REVIEW " +
@@ -450,9 +468,11 @@ export const dispatchSpec = internalAction({
       '"IN_REVIEW", spec, riskLevel, aiTitle, area, scope, splitSlices?, ' +
       "verifyOnStaging }.";
     const instructions = args.revision
-      ? "REVISION ROUND: this contribution already has a spec draft, and the " +
+      ? "REVISION ROUND: this contribution already has a spec draft — the " +
+        "payload's `spec` field carries its CURRENT full text (the thread " +
+        "only contains short pointers to it, not the plan itself) — and the " +
         "contributor replied in the conversation thread (see `thread` — the " +
-        "latest user message is what you must respond to). Revise the spec " +
+        "latest user message is what you must respond to). Revise that spec " +
         "and triage accordingly. " +
         baseInstructions
       : baseInstructions;
@@ -478,6 +498,11 @@ export const dispatchSpec = internalAction({
       title: bug.title,
       body: bug.body,
       repro: bug.repro,
+      // The current spec draft, so revision rounds see the plan they're
+      // revising. The thread no longer carries the spec text (it holds only
+      // short "plan ready/updated" pointers), so omitting this would leave
+      // the reviser blind to what it's amending.
+      spec: bug.spec,
       screenshotUrls: screenshotUrls.length > 0 ? screenshotUrls : undefined,
       // Full conversation history: [{ authorType, authorName?, body }, ...].
       // (Image paths are folded into screenshotUrls above, not the thread.)
@@ -751,6 +776,34 @@ export const dispatchFix = internalAction({
 // Policy auto-merge (ADR-029 Phase 3)
 // ============================================================================
 
+/** Standard GitHub REST headers, shared by every call in this module. */
+function githubJsonHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "Content-Type": "application/json",
+  };
+}
+
+/**
+ * Human-readable failure detail from a GitHub error response:
+ * "<prefix> returned <status> (<message>)" when the body carries a message.
+ */
+async function githubErrorDetail(
+  res: Response,
+  prefix: string,
+): Promise<string> {
+  let detail = `${prefix} returned ${res.status}`;
+  try {
+    const errBody = (await res.json()) as { message?: string };
+    if (errBody?.message) detail = `${detail} (${errBody.message})`;
+  } catch {
+    // Non-JSON error body; the status code is reason enough.
+  }
+  return detail;
+}
+
 /**
  * Merge a PR via the GitHub REST API with the configured merge method
  * (AUTO_MERGE_METHOD, default squash), retrying once with a plain merge on
@@ -764,12 +817,7 @@ async function mergePullRequestOnGithub(
   const mergePr = async (mergeMethod: string): Promise<Response> =>
     await fetch(`${GITHUB_PULLS_ENDPOINT}/${prNumber}/merge`, {
       method: "PUT",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "Content-Type": "application/json",
-      },
+      headers: githubJsonHeaders(token),
       body: JSON.stringify({ merge_method: mergeMethod }),
     });
 
@@ -779,6 +827,29 @@ async function mergePullRequestOnGithub(
     res = await mergePr("merge");
   }
   return res;
+}
+
+/**
+ * Whether the PR is already merged on GitHub — the tie-breaker when a merge
+ * PUT fails: the in-app merge and policy auto-merge can race (both pass their
+ * gates while the row is still READY_TO_MERGE), and the loser's 405 must not
+ * post a "Merge failed" message for a change that actually merged. Returns
+ * null when the state can't be determined (report the original failure).
+ */
+async function fetchPrMerged(
+  prNumber: string,
+  token: string,
+): Promise<boolean | null> {
+  try {
+    const res = await fetch(`${GITHUB_PULLS_ENDPOINT}/${prNumber}`, {
+      headers: githubJsonHeaders(token),
+    });
+    if (!res.ok) return null;
+    const pr = (await res.json()) as { merged?: boolean };
+    return pr.merged === true;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -887,45 +958,54 @@ export const attemptAutoMerge = internalAction({
             body: "Auto-merged ✓ — all gates passed (low risk, review approved)",
           },
         );
-        // GitHub just confirmed the merge, so apply MERGED directly through
-        // the trusted "automerge" source instead of waiting on the webhook
-        // (which may be unconfigured or delayed and would strand the row).
-        // Route through handleRoutineCallback so the shipped push + chat bot
-        // message fire too; the webhook redelivery no-ops on a MERGED row.
-        if (bug.routineRunId) {
-          await ctx.runAction(
-            internal.functions.devAssistant.actions.handleRoutineCallback,
-            {
-              bugId: args.bugId,
-              routineRunId: bug.routineRunId,
-              status: "MERGED",
-              source: "automerge",
-            },
-          );
-        } else {
-          // No run to correlate (shouldn't happen past the gates above) —
-          // still don't lose the merge.
-          await ctx.runMutation(
-            internal.functions.devAssistant.bugs.applyCallback,
-            { bugId: args.bugId, status: "MERGED", source: "automerge" },
-          );
-        }
+        await applyGithubConfirmedMerge(ctx, bug);
         return;
       }
 
-      let reason = `GitHub merge returned ${res.status}`;
-      try {
-        const errBody = (await res.json()) as { message?: string };
-        if (errBody?.message) reason = `${reason} (${errBody.message})`;
-      } catch {
-        // Non-JSON error body; the status code is reason enough.
+      // Lost a race? The in-app merge (or a human on GitHub) may have merged
+      // the PR between this action's gates and its PUT — the resulting 405
+      // must not read as a failure for a change that actually merged.
+      if (await fetchPrMerged(prMatch[1], mirrorToken)) {
+        await applyGithubConfirmedMerge(ctx, bug);
+        return;
       }
-      await blocked(reason);
+
+      await blocked(await githubErrorDetail(res, "GitHub merge"));
     } catch (error) {
       await blocked(String(error));
     }
   },
 });
+
+/**
+ * Apply MERGED through the trusted "automerge" callback source after GitHub
+ * confirmed a merge. Routing through handleRoutineCallback makes the shipped
+ * push + chat bot message fire too; rows with no run to correlate fall back
+ * to a direct applyCallback. Idempotent on already-MERGED rows (and the
+ * webhook redelivery no-ops afterward).
+ */
+async function applyGithubConfirmedMerge(
+  ctx: ActionCtx,
+  bug: Pick<Doc<"devBugs">, "_id" | "routineRunId">,
+): Promise<void> {
+  if (bug.routineRunId) {
+    await ctx.runAction(
+      internal.functions.devAssistant.actions.handleRoutineCallback,
+      {
+        bugId: bug._id,
+        routineRunId: bug.routineRunId,
+        status: "MERGED",
+        source: "automerge",
+      },
+    );
+  } else {
+    await ctx.runMutation(internal.functions.devAssistant.bugs.applyCallback, {
+      bugId: bug._id,
+      status: "MERGED",
+      source: "automerge",
+    });
+  }
+}
 
 /**
  * Maintainer-triggered merge from the app (scheduled by contributions.mergeNow).
@@ -944,16 +1024,19 @@ export const mergeFromApp = internalAction({
     });
     if (!bug) return;
 
+    // Failure path posts the reason AND clears mergeRequestedAt so the merge
+    // card returns — the message says "try again", which must be possible.
     const failed = async (reason: string): Promise<void> => {
       console.error("[DevAssistant] In-app merge failed:", reason, args.bugId);
       await ctx.runMutation(
-        internal.functions.devAssistant.bugs.addSystemThreadMessage,
-        {
-          bugId: args.bugId,
-          body: `Merge failed: ${reason} — try again, or merge the PR on GitHub`,
-        },
+        internal.functions.devAssistant.bugs.recordMergeFromAppFailure,
+        { bugId: args.bugId, reason },
       );
     };
+
+    // Already merged (auto-merge or a human won the race before this action
+    // ran) — the tap achieved its goal; nothing to do and nothing to report.
+    if (bug.status === "MERGED") return;
 
     if (
       bug.status !== "READY_TO_MERGE" ||
@@ -979,38 +1062,19 @@ export const mergeFromApp = internalAction({
     try {
       const res = await mergePullRequestOnGithub(prMatch[1], mirrorToken);
 
-      if (res.ok) {
+      // A failed PUT can still mean "merged": policy auto-merge (scheduled on
+      // the same READY_TO_MERGE entry) or a human may have merged first, and
+      // the loser's 405 must not tell the thread a successful merge failed.
+      if (res.ok || (await fetchPrMerged(prMatch[1], mirrorToken))) {
         // GitHub confirmed the merge — apply MERGED through the trusted
         // "automerge" source (same as attemptAutoMerge) so the shipped push,
         // system message, and chat bot message all fire; the webhook
         // redelivery no-ops on a MERGED row.
-        if (bug.routineRunId) {
-          await ctx.runAction(
-            internal.functions.devAssistant.actions.handleRoutineCallback,
-            {
-              bugId: args.bugId,
-              routineRunId: bug.routineRunId,
-              status: "MERGED",
-              source: "automerge",
-            },
-          );
-        } else {
-          await ctx.runMutation(
-            internal.functions.devAssistant.bugs.applyCallback,
-            { bugId: args.bugId, status: "MERGED", source: "automerge" },
-          );
-        }
+        await applyGithubConfirmedMerge(ctx, bug);
         return;
       }
 
-      let reason = `GitHub merge returned ${res.status}`;
-      try {
-        const errBody = (await res.json()) as { message?: string };
-        if (errBody?.message) reason = `${reason} (${errBody.message})`;
-      } catch {
-        // Non-JSON error body; the status code is reason enough.
-      }
-      await failed(reason);
+      await failed(await githubErrorDetail(res, "GitHub merge"));
     } catch (error) {
       await failed(String(error));
     }
@@ -1064,12 +1128,7 @@ export const dispatchProductionDeploy = internalAction({
     try {
       const res = await fetch(GITHUB_PROD_DEPLOY_WORKFLOW_ENDPOINT, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          "Content-Type": "application/json",
-        },
+        headers: githubJsonHeaders(token),
         body: JSON.stringify({
           ref: "main",
           // The workflow's own safety gate expects the literal "deploy";
@@ -1083,14 +1142,10 @@ export const dispatchProductionDeploy = internalAction({
         await outcome(true);
         return;
       }
-      let detail = `GitHub workflow dispatch returned ${res.status}`;
-      try {
-        const errBody = (await res.json()) as { message?: string };
-        if (errBody?.message) detail = `${detail} (${errBody.message})`;
-      } catch {
-        // Non-JSON error body; the status code is reason enough.
-      }
-      await outcome(false, detail);
+      await outcome(
+        false,
+        await githubErrorDetail(res, "GitHub workflow dispatch"),
+      );
     } catch (error) {
       await outcome(false, String(error));
     }
@@ -1124,16 +1179,8 @@ export const reconcileMergedPrs = internalAction({
       const prMatch = /\/pull\/(\d+)/.exec(bug.prUrl);
       if (!prMatch) continue;
       try {
-        const res = await fetch(`${GITHUB_PULLS_ENDPOINT}/${prMatch[1]}`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-          },
-        });
-        if (!res.ok) continue;
-        const pr = (await res.json()) as { merged?: boolean };
-        if (pr.merged === true) {
+        const merged = await fetchPrMerged(prMatch[1], token);
+        if (merged === true) {
           // Reuse the webhook path: an empty branchRef falls through to the
           // prUrl-match fallback, which scans exactly these open-PR states and
           // applies MERGED idempotently.
@@ -1388,7 +1435,13 @@ export const handleRoutineCallback = internalAction({
       parentMessageId: updated.threadRootMessageId,
       mentionedUserIds,
       // Idempotency: re-delivered callbacks for the same status are dropped.
-      sourceKey: `bug:${args.bugId}:${effectiveStatus}`,
+      // Staging-redo rounds re-reach statuses from earlier rounds, so the key
+      // is scoped per round — otherwise round 2's "PR opened"/"merged" posts
+      // would be silently deduped against round 1's.
+      sourceKey:
+        (updated.redoRounds ?? 0) > 0
+          ? `bug:${args.bugId}:${effectiveStatus}:r${updated.redoRounds}`
+          : `bug:${args.bugId}:${effectiveStatus}`,
     });
   },
 });

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -144,15 +144,14 @@ const GITHUB_MERGEABLE_STATUSES: BugStatus[] = [
  * Apply a validated status transition and persist it. Throws on an illegal
  * transition. When a bug lands on READY_FOR_IMPL we schedule the dispatch
  * action immediately (event-driven, no cron) so the routine fires the instant
- * the bug is marked ready. `opts.stagingRedo` rides along to dispatchBug so a
- * staging-redo round (reportStagingIssue) carries the thread context and
- * "open a NEW PR" instructions to the routine.
+ * the bug is marked ready. Staging-redo rounds need no flag here: dispatchBug
+ * infers redo mode from the row's persisted redoRounds counter, so redo
+ * context survives retries and re-dispatches.
  */
 export async function applyStatusTransition(
   ctx: MutationCtx,
   bug: Doc<"devBugs">,
   newStatus: BugStatus,
-  opts?: { stagingRedo?: boolean },
 ): Promise<void> {
   if (!canTransition(bug.status, newStatus)) {
     throw new Error(
@@ -174,10 +173,7 @@ export async function applyStatusTransition(
     await ctx.scheduler.runAfter(
       0,
       internal.functions.devAssistant.actions.dispatchBug,
-      {
-        bugId: bug._id,
-        ...(opts?.stagingRedo ? { stagingRedo: true } : {}),
-      },
+      { bugId: bug._id },
     );
   }
 }
@@ -650,6 +646,32 @@ export const handleGithubPrClosed = internalMutation({
       // Idempotent with auto-merge's own MERGED apply (and with webhook
       // redeliveries): once merged, there is nothing left to apply.
       if (target.status === "MERGED") return;
+      // Staging-redo guard: MERGED is no longer terminal, so the early-return
+      // above no longer catches a REDELIVERED merge event for a PREVIOUS
+      // round's PR (the branch name claude/devbug-<bugId> is identical every
+      // round, so branch correlation alone can't tell rounds apart). A stale
+      // event applied mid-redo would falsely flip the in-flight round back to
+      // MERGED and orphan its new PR. Two checks:
+      //  - the event names a PR that isn't the row's current one → stale;
+      //  - the row has no current PR but has already shipped once → it's in
+      //    a redo round before its new PR opened; only a stale event can
+      //    reference it. (Never-shipped rows keep the legacy behavior: a PR
+      //    merged before the CODE_REVIEW callback landed must still apply.)
+      //    A redo PR merged in that same pre-callback window is not lost —
+      //    the reconcile cron applies it once the callback stores prUrl.
+      if (args.prUrl) {
+        const staleForCurrentRound = target.prUrl
+          ? target.prUrl !== args.prUrl
+          : !!target.shippedAt;
+        if (staleForCurrentRound) {
+          console.log(
+            "[DevAssistant] Ignoring stale PR-merged event for a previous round",
+            target._id,
+            args.prUrl,
+          );
+          return;
+        }
+      }
       if (target.routineRunId) {
         await ctx.scheduler.runAfter(
           0,
@@ -856,16 +878,42 @@ export const recordProductionDeployOutcome = internalMutation({
         "system",
         "Production deploy started — the silent update reaches users next time they open the app",
       );
+      await ctx.db.patch(args.bugId, { updatedAt: Date.now() });
     } else {
-      await ctx.db.patch(args.bugId, { productionRequestedAt: undefined });
       await insertThreadMessage(
         ctx,
         args.bugId,
         "system",
         `Production deploy couldn't start${args.detail ? `: ${args.detail}` : ""} — needs a maintainer`,
       );
+      await ctx.db.patch(args.bugId, {
+        productionRequestedAt: undefined,
+        updatedAt: Date.now(),
+      });
     }
-    await ctx.db.patch(args.bugId, { updatedAt: Date.now() });
+  },
+});
+
+/**
+ * Record that an in-app merge attempt (actions.mergeFromApp) failed: post the
+ * reason and clear mergeRequestedAt so the merge card comes back — the
+ * message tells the maintainer to "try again", which must be possible.
+ */
+export const recordMergeFromAppFailure = internalMutation({
+  args: { bugId: v.id("devBugs"), reason: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const bug = await ctx.db.get(args.bugId);
+    if (!bug) return;
+    await insertThreadMessage(
+      ctx,
+      args.bugId,
+      "system",
+      `Merge failed: ${args.reason} — try again, or merge the PR on GitHub`,
+    );
+    await ctx.db.patch(args.bugId, {
+      mergeRequestedAt: undefined,
+      updatedAt: Date.now(),
+    });
   },
 });
 
@@ -1327,7 +1375,11 @@ export const getThreadContext = internalQuery({
         (b) =>
           b.threadRootMessageId === threadRootMessageId &&
           b.status !== "MERGED" &&
-          b.status !== "REJECTED",
+          b.status !== "REJECTED" &&
+          // A shipped bug in a staging-redo round is non-terminal again, but
+          // its brief is the payload-of-record for an in-flight rebuild — a
+          // new chat mention must file a fresh bug, not mutate the redo.
+          !b.shippedAt,
       )
       .sort((a, b) => b.createdAt - a.createdAt)[0];
 

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -99,6 +99,16 @@ type BugStatus = Doc<"devBugs">["status"];
  * webhook (ADR-029 Phase 2) reports that merge. Still monotonic. Note that
  * MERGED is only reachable via webhook/auto-merge callback sources (or the
  * human markBugMerged) — applyCallback rejects routine-claimed merges.
+ *
+ * MERGED -> READY_FOR_IMPL is the ONE deliberate cycle: the staging-redo loop
+ * (reportStagingIssue). A contributor who finds the merged change broken on
+ * staging sends the item back through the whole pipeline — a fresh implement
+ * run opens a NEW PR against latest main. It is human-triggered only (never
+ * reachable from a callback: applyCallback still rejects routine MERGEDs and
+ * no run mode may deliver READY_FOR_IMPL), so stale-callback protection is
+ * unaffected. Redo rounds re-reach later statuses, so the chat sourceKey
+ * dedupe suppresses repeat bot messages for chat-originated items — an
+ * accepted trade-off (the staging window only opens for dashboard items).
  */
 const ALLOWED_TRANSITIONS: Record<BugStatus, BugStatus[]> = {
   DRAFT: ["IN_REVIEW", "REJECTED"],
@@ -107,7 +117,7 @@ const ALLOWED_TRANSITIONS: Record<BugStatus, BugStatus[]> = {
   IN_PROGRESS: ["CODE_REVIEW", "REJECTED"],
   CODE_REVIEW: ["READY_TO_MERGE", "MERGED", "REJECTED"],
   READY_TO_MERGE: ["MERGED", "REJECTED"],
-  MERGED: [],
+  MERGED: ["READY_FOR_IMPL"],
   REJECTED: [],
 };
 
@@ -134,12 +144,15 @@ const GITHUB_MERGEABLE_STATUSES: BugStatus[] = [
  * Apply a validated status transition and persist it. Throws on an illegal
  * transition. When a bug lands on READY_FOR_IMPL we schedule the dispatch
  * action immediately (event-driven, no cron) so the routine fires the instant
- * the bug is marked ready.
+ * the bug is marked ready. `opts.stagingRedo` rides along to dispatchBug so a
+ * staging-redo round (reportStagingIssue) carries the thread context and
+ * "open a NEW PR" instructions to the routine.
  */
 export async function applyStatusTransition(
   ctx: MutationCtx,
   bug: Doc<"devBugs">,
   newStatus: BugStatus,
+  opts?: { stagingRedo?: boolean },
 ): Promise<void> {
   if (!canTransition(bug.status, newStatus)) {
     throw new Error(
@@ -161,7 +174,10 @@ export async function applyStatusTransition(
     await ctx.scheduler.runAfter(
       0,
       internal.functions.devAssistant.actions.dispatchBug,
-      { bugId: bug._id },
+      {
+        bugId: bug._id,
+        ...(opts?.stagingRedo ? { stagingRedo: true } : {}),
+      },
     );
   }
 }
@@ -817,6 +833,42 @@ export const addSystemThreadMessage = internalMutation({
   },
 });
 
+/**
+ * Record the outcome of an in-app production deploy trigger
+ * (actions.dispatchProductionDeploy). Success just logs the progress line; a
+ * failure ALSO clears productionRequestedAt so the dashboard's "Ship to
+ * production" button comes back instead of stranding the item in a
+ * "triggered" state that never happened.
+ */
+export const recordProductionDeployOutcome = internalMutation({
+  args: {
+    bugId: v.id("devBugs"),
+    ok: v.boolean(),
+    detail: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const bug = await ctx.db.get(args.bugId);
+    if (!bug) return;
+    if (args.ok) {
+      await insertThreadMessage(
+        ctx,
+        args.bugId,
+        "system",
+        "Production deploy started — the silent update reaches users next time they open the app",
+      );
+    } else {
+      await ctx.db.patch(args.bugId, { productionRequestedAt: undefined });
+      await insertThreadMessage(
+        ctx,
+        args.bugId,
+        "system",
+        `Production deploy couldn't start${args.detail ? `: ${args.detail}` : ""} — needs a maintainer`,
+      );
+    }
+    await ctx.db.patch(args.bugId, { updatedAt: Date.now() });
+  },
+});
+
 /** Max characters of reviewSummary quoted in the thread's system message. */
 const REVIEW_SUMMARY_THREAD_LIMIT = 200;
 
@@ -1078,20 +1130,21 @@ export const applyCallback = internalMutation({
       );
     }
 
-    // Spec text lands in the conversation as the assistant's turn. Comparing
-    // against the previously stored spec is the idempotency guard for
-    // re-delivered callbacks (and skips no-op revisions). When the change
-    // invalidated an approval, say so right below the new plan.
+    // A delivered spec is announced with a short pointer, NOT pasted into the
+    // conversation — the full plan renders once behind "The plan" card, which
+    // opens its own screen/panel. (Earlier versions appended the whole spec as
+    // an assistant turn on every revision, so a few revision rounds buried the
+    // thread under repeated walls of text.) Comparing against the previously
+    // stored spec is the idempotency guard for re-delivered callbacks (and
+    // skips no-op revisions).
     if (args.spec !== undefined && args.spec !== bug.spec) {
-      await insertThreadMessage(ctx, args.bugId, "assistant", args.spec);
-      if (bug.specApprovedAt) {
-        await insertThreadMessage(
-          ctx,
-          args.bugId,
-          "system",
-          "Plan updated — needs your approval again",
-        );
-      }
+      const pointer =
+        bug.spec === undefined
+          ? "The plan is ready — read it under \"The plan\" below"
+          : bug.specApprovedAt
+            ? "Plan updated — it needs your approval again"
+            : "Plan updated — the latest version is under \"The plan\" below";
+      await insertThreadMessage(ctx, args.bugId, "system", pointer);
     }
 
     // Review verdict lands as a system turn, before the status progress line

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -558,10 +558,13 @@ export const confirmStaging = mutation({
 
 /**
  * Contributor hit a problem while checking staging. Same validity window as
- * confirmStaging. Logs the note as their "user" turn plus a system marker —
- * no automated re-fix dispatch (the spec-revision path only exists for
- * DRAFT/IN_REVIEW, and the item is past that); a maintainer picks it up from
- * the thread.
+ * confirmStaging. Logs the note as their "user" turn, then sends the item
+ * BACK THROUGH THE PIPELINE (the staging-redo loop): the review-cycle state
+ * is reset and the MERGED -> READY_FOR_IMPL transition dispatches a fresh
+ * implement run in redo mode — it carries the conversation thread (the note
+ * is the latest user turn) and opens a NEW PR against latest main, since the
+ * original PR is already merged. The re-merge reopens the staging window
+ * (verifyOnStaging stays set, stagingVerifiedAt stays unset).
  */
 export const reportStagingIssue = mutation({
   args: { token: v.string(), id: v.id("devBugs"), note: v.string() },
@@ -580,10 +583,145 @@ export const reportStagingIssue = mutation({
       ctx,
       args.id,
       "system",
-      "Staging check failed — needs another look",
+      "Staging check failed — sending it back to the AI to fix",
     );
 
+    // Reset the previous round's pipeline state so the redo starts clean:
+    // the merged PR is history (a redo opens a new one), the old verdict and
+    // fix-round budget belong to that PR, and clearing routineRunId orphans
+    // any stale callbacks from finished runs while the redo dispatch stamps
+    // a fresh id.
+    await ctx.db.patch(args.id, {
+      prUrl: undefined,
+      reviewVerdict: undefined,
+      reviewSummary: undefined,
+      fixRounds: 0,
+      routineRunId: undefined,
+      activeRunMode: undefined,
+      lastError: undefined,
+      updatedAt: Date.now(),
+    });
+
+    const fresh = await ctx.db.get(args.id);
+    if (fresh) {
+      // MERGED -> READY_FOR_IMPL schedules dispatchBug({ stagingRedo: true }).
+      await applyStatusTransition(ctx, fresh, "READY_FOR_IMPL", {
+        stagingRedo: true,
+      });
+    }
+
+    await notifyOriginatorUnlessSelf(ctx, bug, user._id, {
+      title: "Back to the shop",
+      body: `"${bug.title}" didn't pass the staging check — the AI is working on a fix.`,
+      status: "READY_FOR_IMPL",
+    });
+
+    return { ok: true };
+  },
+});
+
+/**
+ * Merge the change from the app (ADR-029 follow-up): any dev maintainer can
+ * merge once the AI review approved the PR, instead of going to GitHub. The
+ * actual GitHub merge happens in an action (actions.mergeFromApp), which
+ * re-checks every gate itself and reports the outcome into the thread; the
+ * MERGED transition lands through the same trusted callback path as policy
+ * auto-merge.
+ */
+export const mergeNow = mutation({
+  args: { token: v.string(), id: v.id("devBugs") },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const user = await requireContributor(ctx, args.token);
+
+    const bug = await ctx.db.get(args.id);
+    if (!bug) throw new ConvexError("Contribution not found");
+    assertNotArchived(bug);
+    if (bug.status !== "READY_TO_MERGE") {
+      throw new ConvexError(
+        `This item isn't ready to merge (current status: ${bug.status})`,
+      );
+    }
+    if (bug.reviewVerdict !== "approved") {
+      throw new ConvexError("Code review hasn't approved this change yet");
+    }
+    if (!bug.prUrl) {
+      throw new ConvexError("This item has no pull request to merge");
+    }
+
+    const name =
+      `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || "A maintainer";
+    await insertThreadMessage(
+      ctx,
+      args.id,
+      "system",
+      `${name} asked to merge this from the app — merging…`,
+    );
     await ctx.db.patch(args.id, { updatedAt: Date.now() });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.devAssistant.actions.mergeFromApp,
+      { bugId: args.id },
+    );
+
+    return { ok: true };
+  },
+});
+
+/**
+ * Ship the merged (and staging-verified, when required) change to production
+ * from the app. Always a SILENT OTA — users pick the update up on their next
+ * app open, no forced reload; anything needing a forced update still goes
+ * through the GitHub workflow UI by hand. Triggers the existing
+ * deploy-to-production.yml workflow, which ships everything currently on
+ * `main` (i.e. staging), not just this one item. productionRequestedAt is
+ * stamped up front so the button can't be double-tapped; the dispatch action
+ * clears it again if the trigger fails.
+ */
+export const promoteToProduction = mutation({
+  args: { token: v.string(), id: v.id("devBugs") },
+  handler: async (ctx, args): Promise<{ ok: true }> => {
+    const user = await requireContributor(ctx, args.token);
+
+    const bug = await ctx.db.get(args.id);
+    if (!bug) throw new ConvexError("Contribution not found");
+    assertNotArchived(bug);
+    if (bug.status !== "MERGED") {
+      throw new ConvexError(
+        `Only merged changes can ship to production (current status: ${bug.status})`,
+      );
+    }
+    if (bug.verifyOnStaging && !bug.stagingVerifiedAt) {
+      throw new ConvexError(
+        "Confirm the change works on staging before shipping it to production",
+      );
+    }
+    if (bug.productionRequestedAt) {
+      throw new ConvexError(
+        "A production deploy was already triggered for this item",
+      );
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(args.id, {
+      productionRequestedAt: now,
+      updatedAt: now,
+    });
+
+    const name =
+      `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || "A maintainer";
+    await insertThreadMessage(
+      ctx,
+      args.id,
+      "system",
+      `${name} triggered the production deploy (silent update)`,
+    );
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.devAssistant.actions.dispatchProductionDeploy,
+      { bugId: args.id },
+    );
 
     return { ok: true };
   },
@@ -597,13 +735,37 @@ export const reportStagingIssue = mutation({
 export type ContributionListItem = Doc<"devBugs"> & {
   lastMessageBody: string | undefined;
   lastMessageAuthorType: "user" | "assistant" | "system" | undefined;
+  /** Who started the conversation — the "Everyone" view shows this. */
+  originatorName: string | undefined;
 };
 
-/** Attach the most recent thread message (indexed .first() per item). */
+/** Display name for a user id, or undefined when unknown/empty. */
+async function originatorDisplayName(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+): Promise<string | undefined> {
+  const user = await ctx.db.get(userId);
+  if (!user) return undefined;
+  return `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || undefined;
+}
+
+/**
+ * Attach the most recent thread message (indexed .first() per item) and the
+ * originator's display name (resolved once per distinct user).
+ */
 async function withLastMessage(
   ctx: QueryCtx,
   bugs: Doc<"devBugs">[],
 ): Promise<ContributionListItem[]> {
+  const names = new Map<Id<"users">, string | undefined>();
+  for (const bug of bugs) {
+    if (!names.has(bug.originatorUserId)) {
+      names.set(
+        bug.originatorUserId,
+        await originatorDisplayName(ctx, bug.originatorUserId),
+      );
+    }
+  }
   return await Promise.all(
     bugs.map(async (bug) => {
       const last = await ctx.db
@@ -615,6 +777,7 @@ async function withLastMessage(
         ...bug,
         lastMessageBody: last?.body,
         lastMessageAuthorType: last?.authorType,
+        originatorName: names.get(bug.originatorUserId),
       };
     }),
   );
@@ -672,8 +835,16 @@ export const listAll = query({
 /** A single contribution — any dev maintainer may view any item. */
 export const getContribution = query({
   args: { token: v.string(), id: v.id("devBugs") },
-  handler: async (ctx, args): Promise<Doc<"devBugs"> | null> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<(Doc<"devBugs"> & { originatorName?: string }) | null> => {
     await requireContributor(ctx, args.token);
-    return await ctx.db.get(args.id);
+    const bug = await ctx.db.get(args.id);
+    if (!bug) return null;
+    return {
+      ...bug,
+      originatorName: await originatorDisplayName(ctx, bug.originatorUserId),
+    };
   },
 });

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -120,6 +120,11 @@ async function notifyOriginatorUnlessSelf(
   );
 }
 
+/** "First Last" for thread/system messages, with a role-appropriate fallback. */
+function displayName(user: Doc<"users">, fallback: string): string {
+  return `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || fallback;
+}
+
 /**
  * Triage gate (ADR-029 P1.5), shared by approveSpec and startBuild:
  * non-buildable items must not enter the build pipeline as-is — the spec body
@@ -537,8 +542,7 @@ export const confirmStaging = mutation({
     const now = Date.now();
     await ctx.db.patch(args.id, { stagingVerifiedAt: now, updatedAt: now });
 
-    const name =
-      `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || "A contributor";
+    const name = displayName(user, "A contributor");
     await insertThreadMessage(
       ctx,
       args.id,
@@ -590,12 +594,15 @@ export const reportStagingIssue = mutation({
     // the merged PR is history (a redo opens a new one), the old verdict and
     // fix-round budget belong to that PR, and clearing routineRunId orphans
     // any stale callbacks from finished runs while the redo dispatch stamps
-    // a fresh id.
+    // a fresh id. The PERSISTED redoRounds counter is what makes this a redo:
+    // dispatchBug infers redo mode from it (so retryDispatch keeps the redo
+    // context) and chat idempotency keys are scoped per round.
     await ctx.db.patch(args.id, {
       prUrl: undefined,
       reviewVerdict: undefined,
       reviewSummary: undefined,
       fixRounds: 0,
+      redoRounds: (bug.redoRounds ?? 0) + 1,
       routineRunId: undefined,
       activeRunMode: undefined,
       lastError: undefined,
@@ -604,10 +611,8 @@ export const reportStagingIssue = mutation({
 
     const fresh = await ctx.db.get(args.id);
     if (fresh) {
-      // MERGED -> READY_FOR_IMPL schedules dispatchBug({ stagingRedo: true }).
-      await applyStatusTransition(ctx, fresh, "READY_FOR_IMPL", {
-        stagingRedo: true,
-      });
+      // MERGED -> READY_FOR_IMPL schedules the redo dispatch.
+      await applyStatusTransition(ctx, fresh, "READY_FOR_IMPL");
     }
 
     await notifyOriginatorUnlessSelf(ctx, bug, user._id, {
@@ -647,16 +652,24 @@ export const mergeNow = mutation({
     if (!bug.prUrl) {
       throw new ConvexError("This item has no pull request to merge");
     }
+    // Server-side in-flight latch: hides the merge card for EVERY viewer
+    // (not just the tapping device) and blocks a concurrent second merge.
+    // mergeFromApp's failure path clears it so "try again" works.
+    if (bug.mergeRequestedAt) {
+      throw new ConvexError("A merge is already in flight for this item");
+    }
 
-    const name =
-      `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || "A maintainer";
+    const name = displayName(user, "A maintainer");
     await insertThreadMessage(
       ctx,
       args.id,
       "system",
       `${name} asked to merge this from the app — merging…`,
     );
-    await ctx.db.patch(args.id, { updatedAt: Date.now() });
+    await ctx.db.patch(args.id, {
+      mergeRequestedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
 
     await ctx.scheduler.runAfter(
       0,
@@ -669,14 +682,28 @@ export const mergeNow = mutation({
 });
 
 /**
- * Ship the merged (and staging-verified, when required) change to production
- * from the app. Always a SILENT OTA — users pick the update up on their next
- * app open, no forced reload; anything needing a forced update still goes
- * through the GitHub workflow UI by hand. Triggers the existing
- * deploy-to-production.yml workflow, which ships everything currently on
- * `main` (i.e. staging), not just this one item. productionRequestedAt is
- * stamped up front so the button can't be double-tapped; the dispatch action
- * clears it again if the trigger fails.
+ * The production trigger acts as a COOLDOWN, not a one-shot: a 204 from
+ * workflow_dispatch only means "queued", and the workflow run itself can
+ * still fail on GitHub with no callback to clear the latch. After the
+ * cooldown the button returns so a maintainer can re-trigger from the app
+ * instead of being stranded at "deploy triggered" forever. The mobile card
+ * mirrors this constant.
+ */
+export const PRODUCTION_RETRIGGER_COOLDOWN_MS = 15 * 60 * 1000;
+
+/**
+ * Ship the merged, staging-verified change to production from the app.
+ * Always a SILENT OTA — users pick the update up on their next app open, no
+ * forced reload; anything needing a forced update still goes through the
+ * GitHub workflow UI by hand. Triggers the existing deploy-to-production.yml
+ * workflow, which ships everything currently on `main` (i.e. staging), not
+ * just this one item.
+ *
+ * Staging gate: an explicit sign-off (stagingVerifiedAt) is required unless
+ * the AI triaged the item as non-interactive (verifyOnStaging === false).
+ * Legacy rows with verifyOnStaging UNSET don't qualify — they predate this
+ * feature and are usually long since shipped, so they must not grow a live
+ * "Ship to production" button retroactively.
  */
 export const promoteToProduction = mutation({
   args: { token: v.string(), id: v.id("devBugs") },
@@ -691,25 +718,27 @@ export const promoteToProduction = mutation({
         `Only merged changes can ship to production (current status: ${bug.status})`,
       );
     }
-    if (bug.verifyOnStaging && !bug.stagingVerifiedAt) {
+    if (bug.verifyOnStaging !== false && !bug.stagingVerifiedAt) {
       throw new ConvexError(
         "Confirm the change works on staging before shipping it to production",
       );
     }
-    if (bug.productionRequestedAt) {
+    const now = Date.now();
+    if (
+      bug.productionRequestedAt &&
+      now - bug.productionRequestedAt < PRODUCTION_RETRIGGER_COOLDOWN_MS
+    ) {
       throw new ConvexError(
-        "A production deploy was already triggered for this item",
+        "A production deploy was already triggered for this item — give it a few minutes",
       );
     }
 
-    const now = Date.now();
     await ctx.db.patch(args.id, {
       productionRequestedAt: now,
       updatedAt: now,
     });
 
-    const name =
-      `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || "A maintainer";
+    const name = displayName(user, "A maintainer");
     await insertThreadMessage(
       ctx,
       args.id,
@@ -757,15 +786,15 @@ async function withLastMessage(
   ctx: QueryCtx,
   bugs: Doc<"devBugs">[],
 ): Promise<ContributionListItem[]> {
-  const names = new Map<Id<"users">, string | undefined>();
-  for (const bug of bugs) {
-    if (!names.has(bug.originatorUserId)) {
-      names.set(
-        bug.originatorUserId,
-        await originatorDisplayName(ctx, bug.originatorUserId),
-      );
-    }
-  }
+  const distinctIds = [...new Set(bugs.map((b) => b.originatorUserId))];
+  const names = new Map<Id<"users">, string | undefined>(
+    await Promise.all(
+      distinctIds.map(
+        async (id) =>
+          [id, await originatorDisplayName(ctx, id)] as const,
+      ),
+    ),
+  );
   return await Promise.all(
     bugs.map(async (bug) => {
       const last = await ctx.db

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2264,6 +2264,10 @@ export default defineSchema({
     // change on staging before merge; false for pure copy/color tweaks.
     verifyOnStaging: v.optional(v.boolean()),
     stagingVerifiedAt: v.optional(v.number()), // set by confirmStaging
+    // Stamped when a maintainer triggers the production deploy from the app
+    // (promoteToProduction — always a silent OTA). Cleared again if the
+    // GitHub workflow dispatch fails, so the button reappears.
+    productionRequestedAt: v.optional(v.number()),
     // AI review cycle: verdict reported by the review-mode routine via the
     // signed callback after it reviews the PR ("approved" promotes the bug to
     // READY_TO_MERGE; "changes_requested" leaves it in CODE_REVIEW). Cleared

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2266,8 +2266,17 @@ export default defineSchema({
     stagingVerifiedAt: v.optional(v.number()), // set by confirmStaging
     // Stamped when a maintainer triggers the production deploy from the app
     // (promoteToProduction — always a silent OTA). Cleared again if the
-    // GitHub workflow dispatch fails, so the button reappears.
+    // GitHub workflow dispatch fails; treated as a cooldown (not a one-shot)
+    // so a workflow run that fails AFTER dispatch doesn't strand the item.
     productionRequestedAt: v.optional(v.number()),
+    // Stamped when a maintainer asks to merge from the app (mergeNow) so the
+    // merge card hides for EVERY viewer while the merge is in flight; cleared
+    // by mergeFromApp's failure path so "try again" is actually possible.
+    mergeRequestedAt: v.optional(v.number()),
+    // How many staging-redo rounds (reportStagingIssue) this item has been
+    // through. Drives redo-mode dispatch and round-scoped chat idempotency
+    // keys (bug:<id>:<status>:r<N>).
+    redoRounds: v.optional(v.number()),
     // AI review cycle: verdict reported by the review-mode routine via the
     // signed callback after it reviews the PR ("approved" promotes the bug to
     // READY_TO_MERGE; "changes_requested" leaves it in CODE_REVIEW). Cleared

--- a/apps/mobile/app/(user)/dev/plan/[id].tsx
+++ b/apps/mobile/app/(user)/dev/plan/[id].tsx
@@ -1,0 +1,14 @@
+/**
+ * Plan Route
+ *
+ * Route: /dev/plan/[id]
+ * The AI plan for one contribution, full-screen (phones / narrow web). On
+ * desktop web the plan opens as a right-side panel inside the conversation
+ * instead (see ContributionDetailScreen), so this route is effectively the
+ * narrow-viewport presentation — parseDevRoute treats it as a standalone
+ * surface (no sidebar).
+ */
+
+import { PlanScreen } from "@features/contribute/components/PlanView";
+
+export default PlanScreen;

--- a/apps/mobile/components/ui/Markdown/Markdown.tsx
+++ b/apps/mobile/components/ui/Markdown/Markdown.tsx
@@ -34,12 +34,14 @@
  * ─────────────────────────────────────────────────────────────────────────────
  */
 import React, { useMemo } from 'react';
-import { View, Text, Linking, StyleSheet } from 'react-native';
+import { View, Text, Linking, Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@hooks/useTheme';
 import type { ThemeColors } from '@/theme/colors';
 import { AppImage } from '@components/ui/AppImage';
 import { VideoPlayer } from '@features/chat/components/VideoPlayer';
+import { ImageViewerManager } from '@/providers/ImageViewerProvider';
+import { getMediaUrl } from '@/utils/media';
 
 interface MarkdownProps {
   source: string;
@@ -352,6 +354,10 @@ function renderBlock(
   key: number,
   colors: ThemeColors,
   styles: ReturnType<typeof createStyles>,
+  // All image URLs in the document (resolved) + this block's position among
+  // them, so tapping an image opens the viewer with swipe-through paging.
+  imageUrls: string[],
+  imageOrdinal: number,
 ): React.ReactNode {
   switch (block.kind) {
     case 'heading': {
@@ -449,7 +455,15 @@ function renderBlock(
 
     case 'image':
       return (
-        <View key={key} style={styles.mediaBlock}>
+        <Pressable
+          key={key}
+          style={styles.mediaBlock}
+          onPress={() => ImageViewerManager.show(imageUrls, imageOrdinal)}
+          accessibilityRole="imagebutton"
+          accessibilityLabel={
+            block.alt ? `${block.alt} — tap to view full screen` : 'Image — tap to view full screen'
+          }
+        >
           <AppImage
             source={block.src}
             style={styles.image}
@@ -458,7 +472,7 @@ function renderBlock(
             optimizedWidth={1200}
             placeholder={{ type: 'icon', icon: 'image-outline' }}
           />
-        </View>
+        </Pressable>
       );
 
     case 'video':
@@ -485,11 +499,26 @@ export function Markdown({ source }: MarkdownProps) {
   const styles = useMemo(() => createStyles(colors), [colors]);
   const blocks = useMemo(() => parseBlocks(source ?? ''), [source]);
 
+  // Every image in the document, resolved to a fetchable URL, so a tapped
+  // image opens the full-screen viewer at its own slide with paging through
+  // the rest.
+  const imageUrls = useMemo(
+    () =>
+      blocks
+        .filter((b): b is Extract<Block, { kind: 'image' }> => b.kind === 'image')
+        .map((b) => getMediaUrl(b.src) ?? b.src),
+    [blocks],
+  );
+
   if (blocks.length === 0) return null;
 
+  let imageOrdinal = -1;
   return (
     <View>
-      {blocks.map((block, idx) => renderBlock(block, idx, colors, styles))}
+      {blocks.map((block, idx) => {
+        if (block.kind === 'image') imageOrdinal += 1;
+        return renderBlock(block, idx, colors, styles, imageUrls, imageOrdinal);
+      })}
     </View>
   );
 }

--- a/apps/mobile/features/contribute/components/ContributeListScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributeListScreen.tsx
@@ -86,10 +86,13 @@ function ConversationRow({
   item,
   onPress,
   selected = false,
+  showOriginator = false,
 }: {
   item: ContributionListItem;
   onPress: () => void;
   selected?: boolean;
+  /** "Everyone" view: show who's driving this conversation. */
+  showOriginator?: boolean;
 }) {
   const { colors } = useTheme();
   return (
@@ -112,6 +115,17 @@ function ConversationRow({
             {formatDistanceToNow(new Date(item.updatedAt), { addSuffix: true })}
           </Text>
         </View>
+        {showOriginator && item.originatorName ? (
+          <View style={styles.rowOriginator}>
+            <Ionicons name="person-outline" size={11} color={colors.textTertiary} />
+            <Text
+              style={[styles.rowOriginatorText, { color: colors.textTertiary }]}
+              numberOfLines={1}
+            >
+              {item.originatorName}
+            </Text>
+          </View>
+        ) : null}
         <Text style={[styles.rowSnippet, { color: colors.textSecondary }]} numberOfLines={1}>
           {snippetFor(item)}
         </Text>
@@ -249,6 +263,7 @@ export function ContributeListScreen({
             <ConversationRow
               item={item}
               selected={item._id === selectedId}
+              showOriginator={showEveryone}
               onPress={() =>
                 onSelectConversation
                   ? onSelectConversation(item._id)
@@ -376,6 +391,8 @@ const styles = StyleSheet.create({
   },
   rowTitle: { fontSize: 15, fontWeight: "600", flex: 1 },
   rowTime: { fontSize: 12 },
+  rowOriginator: { flexDirection: "row", alignItems: "center", gap: 3 },
+  rowOriginatorText: { fontSize: 12, fontWeight: "500" },
   rowSnippet: { fontSize: 13, lineHeight: 18 },
   emptyState: {
     alignItems: "center",

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -52,6 +52,7 @@ import {
   useStartBuild,
   useUnarchiveContribution,
 } from "../hooks/useContributionMutations";
+import { LOOKS_LIKE_CONVEX_ID } from "../utils/devRoute";
 import {
   displayTitle,
   isBuildableScope,
@@ -221,15 +222,88 @@ function SplitSlicesCard({ contribution }: { contribution: Contribution }) {
 }
 
 /**
- * Cheap shape check for a Convex document id. Convex ids are opaque and can't
- * be truly validated client-side, but a clearly malformed deep link (e.g.
- * /dev/foo) would make getContribution/getThread throw an
- * ArgumentValidationError through render and land on the root error boundary
- * instead of this screen's not-found state. Skipping the queries for
- * malformed ids covers that case; a well-formed-but-wrong id already returns
- * null from the query, which renders the same not-found state.
+ * Mirror of the server's production re-trigger cooldown
+ * (contributions.PRODUCTION_RETRIGGER_COOLDOWN_MS): while a trigger is
+ * fresh the card shows "deploy triggered"; after the cooldown the ship
+ * button returns, because a 204 dispatch only means "queued" and the
+ * workflow run itself can still fail with no callback to clear the latch.
  */
-const LOOKS_LIKE_CONVEX_ID = /^[a-z0-9]{16,64}$/;
+const PRODUCTION_RETRIGGER_COOLDOWN_MS = 15 * 60 * 1000;
+
+/** Card shell shared by the merge / staging / production action cards. */
+function ActionCard({
+  icon,
+  tint,
+  borderTint,
+  title,
+  children,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  tint: string;
+  /** Border color when it should differ from the header tint. */
+  borderTint?: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[
+        styles.stagingCard,
+        { backgroundColor: colors.surface, borderColor: borderTint ?? tint },
+      ]}
+    >
+      <View style={styles.specHeader}>
+        <Ionicons name={icon} size={16} color={tint} />
+        <Text style={[styles.specHeaderText, { color: tint }]}>{title}</Text>
+      </View>
+      {children}
+    </View>
+  );
+}
+
+/** Primary action button with the shared busy-spinner treatment. */
+function BusyButton({
+  label,
+  icon,
+  color,
+  busy,
+  disabled = false,
+  onPress,
+  grow = false,
+}: {
+  label: string;
+  icon?: keyof typeof Ionicons.glyphMap;
+  color: string;
+  busy: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+  /** flex:1 inside a button row. */
+  grow?: boolean;
+}) {
+  return (
+    <TouchableOpacity
+      style={[
+        styles.primaryButton,
+        { backgroundColor: color },
+        grow && styles.stagingButton,
+        (busy || disabled) && styles.buttonDisabled,
+      ]}
+      onPress={onPress}
+      disabled={busy || disabled}
+      activeOpacity={0.8}
+    >
+      {busy ? (
+        <ActivityIndicator color="#ffffff" />
+      ) : (
+        <>
+          {icon ? <Ionicons name={icon} size={20} color="#ffffff" /> : null}
+          <Text style={styles.primaryButtonText}>{label}</Text>
+        </>
+      )}
+    </TouchableOpacity>
+  );
+}
 
 export interface ContributionDetailScreenProps {
   /**
@@ -284,9 +358,7 @@ export function ContributionDetailScreen({
   // Desktop web shows the plan in a right-side panel next to the thread;
   // phones push the /dev/plan/[id] screen instead.
   const [planOpen, setPlanOpen] = useState(false);
-  // Local double-tap guard for the merge button (the real gates live in the
-  // backend); the card disappears once the MERGED status streams in.
-  const [mergeRequested, setMergeRequested] = useState(false);
+  const handleClosePlan = useCallback(() => setPlanOpen(false), []);
   const scrollRef = useRef<ScrollView>(null);
   const images = useImageAttachments();
 
@@ -375,8 +447,9 @@ export function ContributionDetailScreen({
     if (!confirmed) return;
     setBusy(true);
     try {
+      // The in-flight latch is server-side (mergeRequestedAt): the card hides
+      // for every viewer and comes back if the async merge fails.
       await mergeNow({ id });
-      setMergeRequested(true);
     } catch (error) {
       notify("Couldn't merge", formatError(error));
     } finally {
@@ -471,6 +544,14 @@ export function ContributionDetailScreen({
     return !(first?.authorType === "user" && first.body.trim() === contribution.body.trim());
   }, [contribution, messages]);
 
+  // Hoisted out of the message loop: plans are long and this component
+  // re-renders per composer keystroke — don't re-trim a multi-KB string per
+  // assistant message per keystroke.
+  const trimmedSpec = useMemo(
+    () => contribution?.spec?.trim(),
+    [contribution?.spec],
+  );
+
   // No `id` means the queries were skipped (missing or malformed route
   // param) — fall through to the not-found state instead of spinning forever.
   if (accessLoading || (hasAccess && id && contribution === undefined)) {
@@ -517,18 +598,28 @@ export function ContributionDetailScreen({
   const showStagingCard = !archived && needsStagingVerify(contribution);
   // In-app merge: review approved but not yet merged (auto-merge didn't take
   // it — higher risk than the originator's cap, or the feature is off).
+  // mergeRequestedAt is the server-side in-flight latch: it hides the card
+  // for every viewer and is cleared again if the async merge fails.
   const showMergeCard =
     !archived &&
-    !mergeRequested &&
+    !contribution.mergeRequestedAt &&
     contribution.status === "READY_TO_MERGE" &&
     contribution.reviewVerdict === "approved" &&
     !!contribution.prUrl;
-  // In-app production promote: merged and past the staging gate (or the item
-  // never needed one). Always a silent update.
+  // In-app production promote: merged and past the staging gate. An explicit
+  // sign-off is required unless the AI triaged the item as non-interactive
+  // (verifyOnStaging === false); legacy rows with the field UNSET predate
+  // this feature and must not grow a live production button retroactively.
   const stagingCleared =
-    !contribution.verifyOnStaging || !!contribution.stagingVerifiedAt;
+    contribution.verifyOnStaging === false || !!contribution.stagingVerifiedAt;
   const showProductionCard =
     !archived && contribution.status === "MERGED" && stagingCleared;
+  // Fresh trigger → "deploy triggered" card; past the cooldown the button
+  // returns (the dispatch only queues the workflow — the run can still fail).
+  const productionRecentlyRequested =
+    !!contribution.productionRequestedAt &&
+    Date.now() - contribution.productionRequestedAt <
+      PRODUCTION_RETRIGGER_COOLDOWN_MS;
   const awaitingSpec =
     (contribution.status === "DRAFT" || contribution.status === "IN_REVIEW") &&
     !contribution.spec;
@@ -651,8 +742,8 @@ export function ContributionDetailScreen({
             // into a one-line caption instead of a wall of text.
             if (
               message.authorType === "assistant" &&
-              contribution.spec &&
-              message.body.trim() === contribution.spec.trim()
+              trimmedSpec &&
+              message.body.trim() === trimmedSpec
             ) {
               return (
                 <SystemCaption
@@ -682,21 +773,13 @@ export function ContributionDetailScreen({
               Read the plan and confirm it says what you meant — you're checking
               the idea, not the code. If something's off, just reply below.
             </Text>
-            <TouchableOpacity
-              style={[styles.primaryButton, { backgroundColor: primaryColor }, busy && styles.buttonDisabled]}
+            <BusyButton
+              label="Approve spec"
+              icon="checkmark-circle-outline"
+              color={primaryColor}
+              busy={busy}
               onPress={handleApprove}
-              disabled={busy}
-              activeOpacity={0.8}
-            >
-              {busy ? (
-                <ActivityIndicator color="#ffffff" />
-              ) : (
-                <>
-                  <Ionicons name="checkmark-circle-outline" size={20} color="#ffffff" />
-                  <Text style={styles.primaryButtonText}>Approve spec</Text>
-                </>
-              )}
-            </TouchableOpacity>
+            />
           </View>
         ) : null}
 
@@ -706,78 +789,34 @@ export function ContributionDetailScreen({
               You've approved the plan. Because this change touches more of the
               app, it needs an explicit go-ahead to start building.
             </Text>
-            <TouchableOpacity
-              style={[styles.primaryButton, { backgroundColor: primaryColor }, busy && styles.buttonDisabled]}
+            <BusyButton
+              label="Start build"
+              icon="rocket-outline"
+              color={primaryColor}
+              busy={busy}
               onPress={handleStartBuild}
-              disabled={busy}
-              activeOpacity={0.8}
-            >
-              {busy ? (
-                <ActivityIndicator color="#ffffff" />
-              ) : (
-                <>
-                  <Ionicons name="rocket-outline" size={20} color="#ffffff" />
-                  <Text style={styles.primaryButtonText}>Start build</Text>
-                </>
-              )}
-            </TouchableOpacity>
+            />
           </View>
         ) : null}
 
         {showMergeCard ? (
-          <View
-            style={[
-              styles.stagingCard,
-              { backgroundColor: colors.surface, borderColor: PALETTE.yourTurn },
-            ]}
-          >
-            <View style={styles.specHeader}>
-              <Ionicons name="git-merge-outline" size={16} color={PALETTE.yourTurn} />
-              <Text style={[styles.specHeaderText, { color: PALETTE.yourTurn }]}>
-                Ready to merge
-              </Text>
-            </View>
+          <ActionCard icon="git-merge-outline" tint={PALETTE.yourTurn} title="Ready to merge">
             <Text style={[styles.hint, { color: colors.textSecondary }]}>
               Code review passed. Merging lands the change on main and puts it
               on the staging app — no trip to GitHub needed.
             </Text>
-            <TouchableOpacity
-              style={[
-                styles.primaryButton,
-                { backgroundColor: primaryColor },
-                busy && styles.buttonDisabled,
-              ]}
+            <BusyButton
+              label="Merge & put it on staging"
+              icon="git-merge-outline"
+              color={primaryColor}
+              busy={busy}
               onPress={handleMergeNow}
-              disabled={busy}
-              activeOpacity={0.8}
-            >
-              {busy ? (
-                <ActivityIndicator color="#ffffff" />
-              ) : (
-                <>
-                  <Ionicons name="git-merge-outline" size={20} color="#ffffff" />
-                  <Text style={styles.primaryButtonText}>
-                    Merge & put it on staging
-                  </Text>
-                </>
-              )}
-            </TouchableOpacity>
-          </View>
+            />
+          </ActionCard>
         ) : null}
 
         {showStagingCard ? (
-          <View
-            style={[
-              styles.stagingCard,
-              { backgroundColor: colors.surface, borderColor: PALETTE.yourTurn },
-            ]}
-          >
-            <View style={styles.specHeader}>
-              <Ionicons name="flask-outline" size={16} color={PALETTE.yourTurn} />
-              <Text style={[styles.specHeaderText, { color: PALETTE.yourTurn }]}>
-                Ready for you to try
-              </Text>
-            </View>
+          <ActionCard icon="flask-outline" tint={PALETTE.yourTurn} title="Ready for you to try">
             <Text style={[styles.hint, { color: colors.textSecondary }]}>
               Your change is now merged and live on the staging app. Open it,
               try the thing you reported, and tell us how it went — your
@@ -812,44 +851,25 @@ export function ContributionDetailScreen({
                       Cancel
                     </Text>
                   </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[
-                      styles.primaryButton,
-                      styles.stagingButton,
-                      { backgroundColor: primaryColor },
-                      (busy || !issueNote.trim()) && styles.buttonDisabled,
-                    ]}
+                  <BusyButton
+                    label="Send"
+                    color={primaryColor}
+                    busy={busy}
+                    disabled={!issueNote.trim()}
                     onPress={handleReportIssue}
-                    disabled={busy || !issueNote.trim()}
-                    activeOpacity={0.8}
-                  >
-                    {busy ? (
-                      <ActivityIndicator color="#ffffff" />
-                    ) : (
-                      <Text style={styles.primaryButtonText}>Send</Text>
-                    )}
-                  </TouchableOpacity>
+                    grow
+                  />
                 </View>
               </>
             ) : (
               <View style={styles.stagingButtonRow}>
-                <TouchableOpacity
-                  style={[
-                    styles.primaryButton,
-                    styles.stagingButton,
-                    { backgroundColor: PALETTE.shipped },
-                    busy && styles.buttonDisabled,
-                  ]}
+                <BusyButton
+                  label="✓ Works — ship it"
+                  color={PALETTE.shipped}
+                  busy={busy}
                   onPress={handleConfirmStaging}
-                  disabled={busy}
-                  activeOpacity={0.8}
-                >
-                  {busy ? (
-                    <ActivityIndicator color="#ffffff" />
-                  ) : (
-                    <Text style={styles.primaryButtonText}>✓ Works — ship it</Text>
-                  )}
-                </TouchableOpacity>
+                  grow
+                />
                 <TouchableOpacity
                   style={[styles.secondaryButton, { borderColor: colors.border }]}
                   onPress={() => setIssueMode(true)}
@@ -862,72 +882,41 @@ export function ContributionDetailScreen({
                 </TouchableOpacity>
               </View>
             )}
-          </View>
+          </ActionCard>
         ) : null}
 
         {showProductionCard ? (
-          contribution.productionRequestedAt ? (
-            <View
-              style={[
-                styles.stagingCard,
-                { backgroundColor: colors.surface, borderColor: colors.border },
-              ]}
+          productionRecentlyRequested ? (
+            <ActionCard
+              icon="checkmark-circle-outline"
+              tint={PALETTE.shipped}
+              borderTint={colors.border}
+              title="Production deploy triggered"
             >
-              <View style={styles.specHeader}>
-                <Ionicons
-                  name="checkmark-circle-outline"
-                  size={16}
-                  color={PALETTE.shipped}
-                />
-                <Text style={[styles.specHeaderText, { color: PALETTE.shipped }]}>
-                  Production deploy triggered
-                </Text>
-              </View>
               <Text style={[styles.hint, { color: colors.textSecondary }]}>
                 The silent update rolls out as users open the app — no forced
                 reload.
               </Text>
-            </View>
+            </ActionCard>
           ) : (
-            <View
-              style={[
-                styles.stagingCard,
-                { backgroundColor: colors.surface, borderColor: PALETTE.shipped },
-              ]}
+            <ActionCard
+              icon="rocket-outline"
+              tint={PALETTE.shipped}
+              title="Ready for production"
             >
-              <View style={styles.specHeader}>
-                <Ionicons name="rocket-outline" size={16} color={PALETTE.shipped} />
-                <Text style={[styles.specHeaderText, { color: PALETTE.shipped }]}>
-                  Ready for production
-                </Text>
-              </View>
               <Text style={[styles.hint, { color: colors.textSecondary }]}>
                 Ships everything currently on staging as a silent update —
                 users get it next time they open the app. Forced updates still
                 go through the GitHub workflow by hand.
               </Text>
-              <TouchableOpacity
-                style={[
-                  styles.primaryButton,
-                  { backgroundColor: PALETTE.shipped },
-                  busy && styles.buttonDisabled,
-                ]}
+              <BusyButton
+                label="Ship to production (silent update)"
+                icon="rocket-outline"
+                color={PALETTE.shipped}
+                busy={busy}
                 onPress={handlePromoteToProduction}
-                disabled={busy}
-                activeOpacity={0.8}
-              >
-                {busy ? (
-                  <ActivityIndicator color="#ffffff" />
-                ) : (
-                  <>
-                    <Ionicons name="rocket-outline" size={20} color="#ffffff" />
-                    <Text style={styles.primaryButtonText}>
-                      Ship to production (silent update)
-                    </Text>
-                  </>
-                )}
-              </TouchableOpacity>
-            </View>
+              />
+            </ActionCard>
           )
         ) : null}
 
@@ -1056,7 +1045,7 @@ export function ContributionDetailScreen({
     </KeyboardAvoidingView>
 
     {isDesktopWeb && planOpen && contribution.spec ? (
-      <PlanPanel contribution={contribution} onClose={() => setPlanOpen(false)} />
+      <PlanPanel contribution={contribution} onClose={handleClosePlan} />
     ) : null}
     </View>
   );

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -31,9 +31,10 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Clipboard from "expo-clipboard";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
-import { Markdown } from "@components/ui/Markdown";
+import { useIsDesktopWeb } from "@hooks/useIsDesktopWeb";
 import { formatError } from "@/utils/error-handling";
 import { confirmAsync, notify } from "@/utils/platformAlert";
+import { ImageViewerManager } from "@/providers/ImageViewerProvider";
 import type { Id } from "@services/api/convex";
 import { useDevAccess } from "../hooks/useDevAccess";
 import { useContribution } from "../hooks/useContribution";
@@ -44,7 +45,9 @@ import {
   useApproveSpec,
   useArchiveContribution,
   useConfirmStaging,
+  useMergeNow,
   usePostMessage,
+  usePromoteToProduction,
   useReportStagingIssue,
   useStartBuild,
   useUnarchiveContribution,
@@ -59,53 +62,71 @@ import {
 } from "../utils/status";
 import { AttachmentStrip } from "./AttachmentStrip";
 import { FromChatTag, KindPill, RiskBadge, StatusChip } from "./ContributionBadges";
+import { PlanPanel } from "./PlanView";
 import { SystemCaption, ThreadMessageBubble, UserBubble } from "./ThreadBubbles";
 import type { Contribution, SplitSlice } from "../types";
 
 /**
- * The latest AI plan, rendered once at the bottom of the thread. When the AI
- * judged the item too big to build in one go (scope "split"/"design_needed"),
- * it becomes a "Too big for one build" card and approval is off the table.
+ * Compact pointer to the latest AI plan, pinned at the bottom of the thread.
+ * Plans are long, so the full text no longer renders inline — tapping the
+ * card opens it on its own screen (phones) or in a right-side panel (desktop
+ * web). When the AI judged the item too big to build in one go (scope
+ * "split"/"design_needed") the card flags that and approval is off the table.
  */
-function SpecCard({ contribution }: { contribution: Contribution }) {
+function SpecCard({
+  contribution,
+  onOpenPlan,
+}: {
+  contribution: Contribution;
+  onOpenPlan: () => void;
+}) {
   const { colors } = useTheme();
-  const spec = contribution.spec;
-  if (!spec) return null;
+  const { primaryColor } = useCommunityTheme();
+  if (!contribution.spec) return null;
 
-  if (!isBuildableScope(contribution.scope)) {
-    return (
-      <View
-        style={[
-          styles.specCard,
-          { backgroundColor: colors.surface, borderColor: PALETTE.aiWorking },
-        ]}
-      >
-        <View style={styles.specHeader}>
-          <Ionicons name="git-branch-outline" size={16} color={PALETTE.aiWorking} />
-          <Text style={[styles.specHeaderText, { color: PALETTE.aiWorking }]}>
-            Too big for one build
-          </Text>
-        </View>
-        <Text style={[styles.specSubtitle, { color: colors.textSecondary }]}>
-          {contribution.scope === "design_needed"
-            ? "This one needs some design thinking before anything gets built. Here's the AI's take:"
-            : "This one covers more than a single build can safely take on. Here's how the AI suggests breaking it up:"}
-        </Text>
-        <Markdown source={spec} />
-      </View>
-    );
-  }
+  const nonBuildable = !isBuildableScope(contribution.scope);
+  const tint = nonBuildable ? PALETTE.aiWorking : colors.textSecondary;
 
   return (
-    <View style={[styles.specCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+    <TouchableOpacity
+      style={[
+        styles.specCard,
+        {
+          backgroundColor: colors.surface,
+          borderColor: nonBuildable ? PALETTE.aiWorking : colors.border,
+        },
+      ]}
+      onPress={onOpenPlan}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel="Read the plan"
+    >
       <View style={styles.specHeader}>
-        <Ionicons name="reader-outline" size={16} color={colors.textSecondary} />
-        <Text style={[styles.specHeaderText, { color: colors.textSecondary }]}>
-          The plan{contribution.specApprovedAt ? " — approved" : ""}
+        <Ionicons
+          name={nonBuildable ? "git-branch-outline" : "reader-outline"}
+          size={16}
+          color={tint}
+        />
+        <Text style={[styles.specHeaderText, { color: tint }]}>
+          {nonBuildable
+            ? "Too big for one build"
+            : `The plan${contribution.specApprovedAt ? " — approved" : ""}`}
         </Text>
       </View>
-      <Markdown source={spec} />
-    </View>
+      <Text style={[styles.specSubtitle, { color: colors.textSecondary }]}>
+        {nonBuildable
+          ? contribution.scope === "design_needed"
+            ? "This one needs some design thinking before anything gets built — the AI explains in the plan."
+            : "This one is too big for a single build — the AI's reasoning is in the plan, and the proposed pieces are below."
+          : "The full write-up of what will change and how you'll know it worked."}
+      </Text>
+      <View style={styles.specOpenRow}>
+        <Text style={[styles.specOpenText, { color: primaryColor }]}>
+          Read the plan
+        </Text>
+        <Ionicons name="chevron-forward" size={15} color={primaryColor} />
+      </View>
+    </TouchableOpacity>
   );
 }
 
@@ -249,14 +270,23 @@ export function ContributionDetailScreen({
   const postMessage = usePostMessage();
   const confirmStaging = useConfirmStaging();
   const reportStagingIssue = useReportStagingIssue();
+  const mergeNow = useMergeNow();
+  const promoteToProduction = usePromoteToProduction();
   const archiveContribution = useArchiveContribution();
   const unarchiveContribution = useUnarchiveContribution();
+  const isDesktopWeb = useIsDesktopWeb();
 
   const [busy, setBusy] = useState(false);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [issueMode, setIssueMode] = useState(false);
   const [issueNote, setIssueNote] = useState("");
+  // Desktop web shows the plan in a right-side panel next to the thread;
+  // phones push the /dev/plan/[id] screen instead.
+  const [planOpen, setPlanOpen] = useState(false);
+  // Local double-tap guard for the merge button (the real gates live in the
+  // backend); the card disappears once the MERGED status streams in.
+  const [mergeRequested, setMergeRequested] = useState(false);
   const scrollRef = useRef<ScrollView>(null);
   const images = useImageAttachments();
 
@@ -324,6 +354,55 @@ export function ContributionDetailScreen({
       setBusy(false);
     }
   }, [id, issueNote, reportStagingIssue]);
+
+  const handleOpenPlan = useCallback(() => {
+    if (isDesktopWeb) {
+      setPlanOpen(true);
+      return;
+    }
+    if (id) router.push(`/(user)/dev/plan/${id}`);
+  }, [isDesktopWeb, id, router]);
+
+  const handleMergeNow = useCallback(async () => {
+    if (!id) return;
+    const confirmed = await confirmAsync({
+      title: "Merge this change?",
+      message:
+        "It lands on main and deploys to the staging app — you can try it there right after.",
+      confirmText: "Merge",
+      cancelText: "Not yet",
+    });
+    if (!confirmed) return;
+    setBusy(true);
+    try {
+      await mergeNow({ id });
+      setMergeRequested(true);
+    } catch (error) {
+      notify("Couldn't merge", formatError(error));
+    } finally {
+      setBusy(false);
+    }
+  }, [id, mergeNow]);
+
+  const handlePromoteToProduction = useCallback(async () => {
+    if (!id) return;
+    const confirmed = await confirmAsync({
+      title: "Ship to production?",
+      message:
+        "This ships everything currently on staging as a silent update — users get it next time they open the app.",
+      confirmText: "Ship it",
+      cancelText: "Not yet",
+    });
+    if (!confirmed) return;
+    setBusy(true);
+    try {
+      await promoteToProduction({ id });
+    } catch (error) {
+      notify("Couldn't start the deploy", formatError(error));
+    } finally {
+      setBusy(false);
+    }
+  }, [id, promoteToProduction]);
 
   const handleSend = useCallback(async () => {
     if (!id || sending || images.uploading) return;
@@ -436,6 +515,20 @@ export function ContributionDetailScreen({
     contribution.status === "IN_REVIEW" &&
     isBuildableScope(contribution.scope);
   const showStagingCard = !archived && needsStagingVerify(contribution);
+  // In-app merge: review approved but not yet merged (auto-merge didn't take
+  // it — higher risk than the originator's cap, or the feature is off).
+  const showMergeCard =
+    !archived &&
+    !mergeRequested &&
+    contribution.status === "READY_TO_MERGE" &&
+    contribution.reviewVerdict === "approved" &&
+    !!contribution.prUrl;
+  // In-app production promote: merged and past the staging gate (or the item
+  // never needed one). Always a silent update.
+  const stagingCleared =
+    !contribution.verifyOnStaging || !!contribution.stagingVerifiedAt;
+  const showProductionCard =
+    !archived && contribution.status === "MERGED" && stagingCleared;
   const awaitingSpec =
     (contribution.status === "DRAFT" || contribution.status === "IN_REVIEW") &&
     !contribution.spec;
@@ -462,8 +555,11 @@ export function ContributionDetailScreen({
     : contribution.body;
 
   return (
+    // Desktop web can open the plan as a right-side panel beside the thread;
+    // the row wrapper is inert (single flex child) everywhere else.
+    <View style={[styles.detailRow, { backgroundColor: colors.background }]}>
     <KeyboardAvoidingView
-      style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
+      style={[styles.container, { paddingTop: insets.top }]}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
       // This screen opens as an iOS sheet (the `(user)` route group is a modal),
       // where "padding" alone doesn't lift the composer above the keyboard — it
@@ -498,6 +594,11 @@ export function ContributionDetailScreen({
             </Text>
           </View>
         ) : null}
+        {contribution.originatorName ? (
+          <Text style={[styles.startedBy, { color: colors.textTertiary }]}>
+            Started by {contribution.originatorName}
+          </Text>
+        ) : null}
       </View>
 
       <ScrollView
@@ -521,8 +622,21 @@ export function ContributionDetailScreen({
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.screenshotRow}
           >
-            {contribution.screenshotUrls.map((url) => (
-              <Image key={url} source={{ uri: url }} style={styles.screenshot} />
+            {contribution.screenshotUrls.map((url, index) => (
+              <TouchableOpacity
+                key={url}
+                onPress={() =>
+                  ImageViewerManager.show(
+                    contribution.screenshotUrls as string[],
+                    index,
+                  )
+                }
+                activeOpacity={0.85}
+                accessibilityRole="imagebutton"
+                accessibilityLabel="Screenshot — tap to view full screen"
+              >
+                <Image source={{ uri: url }} style={styles.screenshot} />
+              </TouchableOpacity>
             ))}
           </ScrollView>
         ) : null}
@@ -530,16 +644,35 @@ export function ContributionDetailScreen({
         {messages === undefined ? (
           <ActivityIndicator style={styles.threadSpinner} color={colors.textSecondary} />
         ) : (
-          messages.map((message) => (
-            <ThreadMessageBubble key={message._id} message={message} />
-          ))
+          messages.map((message) => {
+            // Older backends pasted the full plan into the thread as an
+            // assistant turn on every revision. The plan now lives behind
+            // "The plan" card, so collapse the copy matching the current plan
+            // into a one-line caption instead of a wall of text.
+            if (
+              message.authorType === "assistant" &&
+              contribution.spec &&
+              message.body.trim() === contribution.spec.trim()
+            ) {
+              return (
+                <SystemCaption
+                  key={message._id}
+                  body={'Plan posted — read it under "The plan" below'}
+                  createdAt={message.createdAt}
+                />
+              );
+            }
+            return <ThreadMessageBubble key={message._id} message={message} />;
+          })
         )}
 
         {awaitingSpec ? (
           <SystemCaption body="The AI is reading your report and drafting a plan — it'll reply here." />
         ) : null}
 
-        {contribution.spec ? <SpecCard contribution={contribution} /> : null}
+        {contribution.spec ? (
+          <SpecCard contribution={contribution} onOpenPlan={handleOpenPlan} />
+        ) : null}
 
         <SplitSlicesCard contribution={contribution} />
 
@@ -585,6 +718,47 @@ export function ContributionDetailScreen({
                 <>
                   <Ionicons name="rocket-outline" size={20} color="#ffffff" />
                   <Text style={styles.primaryButtonText}>Start build</Text>
+                </>
+              )}
+            </TouchableOpacity>
+          </View>
+        ) : null}
+
+        {showMergeCard ? (
+          <View
+            style={[
+              styles.stagingCard,
+              { backgroundColor: colors.surface, borderColor: PALETTE.yourTurn },
+            ]}
+          >
+            <View style={styles.specHeader}>
+              <Ionicons name="git-merge-outline" size={16} color={PALETTE.yourTurn} />
+              <Text style={[styles.specHeaderText, { color: PALETTE.yourTurn }]}>
+                Ready to merge
+              </Text>
+            </View>
+            <Text style={[styles.hint, { color: colors.textSecondary }]}>
+              Code review passed. Merging lands the change on main and puts it
+              on the staging app — no trip to GitHub needed.
+            </Text>
+            <TouchableOpacity
+              style={[
+                styles.primaryButton,
+                { backgroundColor: primaryColor },
+                busy && styles.buttonDisabled,
+              ]}
+              onPress={handleMergeNow}
+              disabled={busy}
+              activeOpacity={0.8}
+            >
+              {busy ? (
+                <ActivityIndicator color="#ffffff" />
+              ) : (
+                <>
+                  <Ionicons name="git-merge-outline" size={20} color="#ffffff" />
+                  <Text style={styles.primaryButtonText}>
+                    Merge & put it on staging
+                  </Text>
                 </>
               )}
             </TouchableOpacity>
@@ -689,6 +863,72 @@ export function ContributionDetailScreen({
               </View>
             )}
           </View>
+        ) : null}
+
+        {showProductionCard ? (
+          contribution.productionRequestedAt ? (
+            <View
+              style={[
+                styles.stagingCard,
+                { backgroundColor: colors.surface, borderColor: colors.border },
+              ]}
+            >
+              <View style={styles.specHeader}>
+                <Ionicons
+                  name="checkmark-circle-outline"
+                  size={16}
+                  color={PALETTE.shipped}
+                />
+                <Text style={[styles.specHeaderText, { color: PALETTE.shipped }]}>
+                  Production deploy triggered
+                </Text>
+              </View>
+              <Text style={[styles.hint, { color: colors.textSecondary }]}>
+                The silent update rolls out as users open the app — no forced
+                reload.
+              </Text>
+            </View>
+          ) : (
+            <View
+              style={[
+                styles.stagingCard,
+                { backgroundColor: colors.surface, borderColor: PALETTE.shipped },
+              ]}
+            >
+              <View style={styles.specHeader}>
+                <Ionicons name="rocket-outline" size={16} color={PALETTE.shipped} />
+                <Text style={[styles.specHeaderText, { color: PALETTE.shipped }]}>
+                  Ready for production
+                </Text>
+              </View>
+              <Text style={[styles.hint, { color: colors.textSecondary }]}>
+                Ships everything currently on staging as a silent update —
+                users get it next time they open the app. Forced updates still
+                go through the GitHub workflow by hand.
+              </Text>
+              <TouchableOpacity
+                style={[
+                  styles.primaryButton,
+                  { backgroundColor: PALETTE.shipped },
+                  busy && styles.buttonDisabled,
+                ]}
+                onPress={handlePromoteToProduction}
+                disabled={busy}
+                activeOpacity={0.8}
+              >
+                {busy ? (
+                  <ActivityIndicator color="#ffffff" />
+                ) : (
+                  <>
+                    <Ionicons name="rocket-outline" size={20} color="#ffffff" />
+                    <Text style={styles.primaryButtonText}>
+                      Ship to production (silent update)
+                    </Text>
+                  </>
+                )}
+              </TouchableOpacity>
+            </View>
+          )
         ) : null}
 
         {contribution.githubIssueUrl ? (
@@ -814,10 +1054,16 @@ export function ContributionDetailScreen({
         </>
       )}
     </KeyboardAvoidingView>
+
+    {isDesktopWeb && planOpen && contribution.spec ? (
+      <PlanPanel contribution={contribution} onClose={() => setPlanOpen(false)} />
+    ) : null}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  detailRow: { flex: 1, flexDirection: "row" },
   container: { flex: 1 },
   centered: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24, gap: 12 },
   lockedText: { fontSize: 15, lineHeight: 22, textAlign: "center" },
@@ -862,6 +1108,9 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
   },
   specSubtitle: { fontSize: 13, lineHeight: 19 },
+  specOpenRow: { flexDirection: "row", alignItems: "center", gap: 2 },
+  specOpenText: { fontSize: 14, fontWeight: "600" },
+  startedBy: { fontSize: 11, alignSelf: "center", marginLeft: 2 },
   sliceRow: {
     gap: 8,
     borderTopWidth: StyleSheet.hairlineWidth,

--- a/apps/mobile/features/contribute/components/PlanView.tsx
+++ b/apps/mobile/features/contribute/components/PlanView.tsx
@@ -29,11 +29,9 @@ import { Markdown } from "@components/ui/Markdown";
 import type { Id } from "@services/api/convex";
 import { useDevAccess } from "../hooks/useDevAccess";
 import { useContribution } from "../hooks/useContribution";
+import { LOOKS_LIKE_CONVEX_ID } from "../utils/devRoute";
 import { displayTitle, isBuildableScope, PALETTE } from "../utils/status";
 import type { Contribution } from "../types";
-
-/** Mirrors the malformed-deep-link guard in ContributionDetailScreen. */
-const LOOKS_LIKE_CONVEX_ID = /^[a-z0-9]{16,64}$/;
 
 /** The plan body: approval/scope context + the spec markdown. */
 export function PlanContent({ contribution }: { contribution: Contribution }) {
@@ -77,9 +75,11 @@ export function PlanContent({ contribution }: { contribution: Contribution }) {
 
 /**
  * Desktop-web right panel: rendered by ContributionDetailScreen beside the
- * conversation when the plan is open.
+ * conversation when the plan is open. Memoized — the parent re-renders on
+ * every composer keystroke, and reconciling a long markdown tree per
+ * keystroke would jank typing.
  */
-export function PlanPanel({
+export const PlanPanel = React.memo(function PlanPanel({
   contribution,
   onClose,
 }: {
@@ -111,7 +111,7 @@ export function PlanPanel({
       </ScrollView>
     </View>
   );
-}
+});
 
 /** Phone route: /dev/plan/[id] — the plan as its own full screen. */
 export function PlanScreen() {

--- a/apps/mobile/features/contribute/components/PlanView.tsx
+++ b/apps/mobile/features/contribute/components/PlanView.tsx
@@ -1,0 +1,212 @@
+/**
+ * PlanView — the AI plan (the doc's `spec`) on its own surface.
+ *
+ * Plans are long, so they no longer render inline in the conversation (that
+ * buried the thread under walls of text). Instead the thread shows a compact
+ * "The plan" card and the full plan opens here:
+ *
+ *  - PlanScreen: the phone route (/dev/plan/[id]) — full-screen with a back
+ *    button.
+ *  - PlanPanel: the desktop-web presentation — a right-side panel beside the
+ *    conversation (ContributionDetailScreen toggles it).
+ *  - PlanContent: the shared body (approval state, scope explanation, and the
+ *    markdown itself).
+ */
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  TouchableOpacity,
+} from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { Markdown } from "@components/ui/Markdown";
+import type { Id } from "@services/api/convex";
+import { useDevAccess } from "../hooks/useDevAccess";
+import { useContribution } from "../hooks/useContribution";
+import { displayTitle, isBuildableScope, PALETTE } from "../utils/status";
+import type { Contribution } from "../types";
+
+/** Mirrors the malformed-deep-link guard in ContributionDetailScreen. */
+const LOOKS_LIKE_CONVEX_ID = /^[a-z0-9]{16,64}$/;
+
+/** The plan body: approval/scope context + the spec markdown. */
+export function PlanContent({ contribution }: { contribution: Contribution }) {
+  const { colors } = useTheme();
+  if (!contribution.spec) {
+    return (
+      <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+        No plan yet — the AI is still drafting it.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.content}>
+      {contribution.specApprovedAt ? (
+        <View style={styles.stateRow}>
+          <Ionicons name="checkmark-circle" size={15} color={PALETTE.shipped} />
+          <Text style={[styles.stateText, { color: PALETTE.shipped }]}>
+            Approved plan
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.stateRow}>
+          <Ionicons name="reader-outline" size={15} color={colors.textSecondary} />
+          <Text style={[styles.stateText, { color: colors.textSecondary }]}>
+            Not approved yet
+          </Text>
+        </View>
+      )}
+      {!isBuildableScope(contribution.scope) ? (
+        <Text style={[styles.scopeNote, { color: colors.textSecondary }]}>
+          {contribution.scope === "design_needed"
+            ? "This one needs some design thinking before anything gets built. Here's the AI's take:"
+            : "This one covers more than a single build can safely take on. Here's how the AI suggests breaking it up:"}
+        </Text>
+      ) : null}
+      <Markdown source={contribution.spec} />
+    </View>
+  );
+}
+
+/**
+ * Desktop-web right panel: rendered by ContributionDetailScreen beside the
+ * conversation when the plan is open.
+ */
+export function PlanPanel({
+  contribution,
+  onClose,
+}: {
+  contribution: Contribution;
+  onClose: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[
+        styles.panel,
+        { backgroundColor: colors.background, borderLeftColor: colors.border },
+      ]}
+    >
+      <View style={[styles.panelHeader, { borderBottomColor: colors.border }]}>
+        <Text style={[styles.panelTitle, { color: colors.text }]} numberOfLines={1}>
+          The plan
+        </Text>
+        <TouchableOpacity
+          onPress={onClose}
+          style={styles.closeBtn}
+          accessibilityLabel="Close the plan"
+        >
+          <Ionicons name="close" size={22} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+      <ScrollView contentContainerStyle={styles.panelScroll}>
+        <PlanContent contribution={contribution} />
+      </ScrollView>
+    </View>
+  );
+}
+
+/** Phone route: /dev/plan/[id] — the plan as its own full screen. */
+export function PlanScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const params = useLocalSearchParams<{ id: string }>();
+  const rawId = (params.id || null) as Id<"devBugs"> | null;
+  const id = rawId && LOOKS_LIKE_CONVEX_ID.test(rawId) ? rawId : null;
+
+  const { hasAccess, isLoading: accessLoading } = useDevAccess();
+  const { contribution } = useContribution(hasAccess ? id : null);
+
+  if (accessLoading || (hasAccess && id && contribution === undefined)) {
+    return (
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.text} />
+      </View>
+    );
+  }
+
+  if (!hasAccess || !contribution) {
+    return (
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.textSecondary }}>
+          We couldn't find this plan.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.screen,
+        { backgroundColor: colors.background, paddingTop: insets.top },
+      ]}
+    >
+      <View style={styles.headerRow}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+          <Ionicons name="chevron-back" size={26} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]} numberOfLines={1}>
+          {displayTitle(contribution)}
+        </Text>
+        <View style={styles.backBtn} />
+      </View>
+      <ScrollView
+        contentContainerStyle={[
+          styles.screenScroll,
+          { paddingBottom: Math.max(insets.bottom, 24) },
+        ]}
+      >
+        <PlanContent contribution={contribution} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  centered: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24 },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+  },
+  backBtn: { width: 40, height: 40, justifyContent: "center", alignItems: "center" },
+  headerTitle: { fontSize: 17, fontWeight: "600", flex: 1, textAlign: "center" },
+  screenScroll: { paddingHorizontal: 16 },
+  content: { gap: 8 },
+  stateRow: { flexDirection: "row", alignItems: "center", gap: 5 },
+  stateText: {
+    fontSize: 12,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  scopeNote: { fontSize: 13, lineHeight: 19 },
+  emptyText: { fontSize: 14, padding: 16, textAlign: "center" },
+  panel: {
+    width: 400,
+    borderLeftWidth: 1,
+  },
+  panelHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  panelTitle: { fontSize: 16, fontWeight: "600" },
+  closeBtn: { width: 32, height: 32, alignItems: "center", justifyContent: "center" },
+  panelScroll: { padding: 16, paddingBottom: 32 },
+});

--- a/apps/mobile/features/contribute/components/ThreadBubbles.tsx
+++ b/apps/mobile/features/contribute/components/ThreadBubbles.tsx
@@ -9,11 +9,12 @@
  * chat plumbing.
  */
 import React from "react";
-import { View, Text, Image, StyleSheet } from "react-native";
+import { View, Text, Image, StyleSheet, TouchableOpacity } from "react-native";
 import { format } from "date-fns";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import { Markdown } from "@components/ui/Markdown";
+import { ImageViewerManager } from "@/providers/ImageViewerProvider";
 import { PALETTE } from "../utils/status";
 import type { ThreadMessage } from "../types";
 
@@ -21,19 +22,28 @@ function bubbleTime(createdAt: number): string {
   return format(new Date(createdAt), "MMM d, h:mm a");
 }
 
-/** Attached pictures on a contributor message, stacked above the text. */
+/**
+ * Attached pictures on a contributor message, stacked above the text. Tapping
+ * one opens the full-screen viewer (zoom + swipe between the message's shots).
+ */
 function BubbleImages({ imageUrls }: { imageUrls: string[] }) {
   const { colors } = useTheme();
   return (
     <View style={styles.imageStack}>
-      {imageUrls.map((uri) => (
-        <Image
+      {imageUrls.map((uri, index) => (
+        <TouchableOpacity
           key={uri}
-          source={{ uri }}
-          style={[styles.bubbleImage, { backgroundColor: colors.surfaceSecondary }]}
-          resizeMode="contain"
-          accessibilityLabel="Attached screenshot"
-        />
+          onPress={() => ImageViewerManager.show(imageUrls, index)}
+          activeOpacity={0.85}
+          accessibilityRole="imagebutton"
+          accessibilityLabel="Attached screenshot — tap to view full screen"
+        >
+          <Image
+            source={{ uri }}
+            style={[styles.bubbleImage, { backgroundColor: colors.surfaceSecondary }]}
+            resizeMode="contain"
+          />
+        </TouchableOpacity>
       ))}
     </View>
   );

--- a/apps/mobile/features/contribute/hooks/useContributionMutations.ts
+++ b/apps/mobile/features/contribute/hooks/useContributionMutations.ts
@@ -40,9 +40,23 @@ export function useConfirmStaging() {
   return useAuthenticatedMutation(contributions.confirmStaging);
 }
 
-/** Report that the staging build isn't right, with a short note. */
+/**
+ * Report that the staging build isn't right, with a short note. Sends the
+ * item back through the build pipeline — a fresh AI run fixes the reported
+ * problems and opens a new PR.
+ */
 export function useReportStagingIssue() {
   return useAuthenticatedMutation(contributions.reportStagingIssue);
+}
+
+/** Merge the review-approved PR from the app (ships it to staging). */
+export function useMergeNow() {
+  return useAuthenticatedMutation(contributions.mergeNow);
+}
+
+/** Trigger the production deploy from the app (always a silent update). */
+export function usePromoteToProduction() {
+  return useAuthenticatedMutation(contributions.promoteToProduction);
 }
 
 /** Archive (set aside) a conversation the contributor is abandoning. */

--- a/apps/mobile/features/contribute/types.ts
+++ b/apps/mobile/features/contribute/types.ts
@@ -75,9 +75,19 @@ export interface Contribution {
   verifyOnStaging?: boolean;
   /** Set once the contributor confirmed the change works on staging. */
   stagingVerifiedAt?: number;
+  /**
+   * Set when a maintainer triggered the production deploy from the app
+   * (always a silent OTA); cleared again if the workflow dispatch failed.
+   */
+  productionRequestedAt?: number;
+  /** AI review verdict on the open PR — "approved" unlocks the in-app merge. */
+  reviewVerdict?: "approved" | "changes_requested";
+  reviewSummary?: string;
   prUrl?: string;
   githubIssueUrl?: string;
   screenshotUrls?: string[];
+  /** Display name of whoever started the conversation (getContribution). */
+  originatorName?: string;
   /** Set when the contributor set the conversation aside (abandoned/not doable). */
   archivedAt?: number;
   createdAt: number;
@@ -92,6 +102,8 @@ export interface Contribution {
 export interface ContributionListItem extends Contribution {
   lastMessageBody?: string;
   lastMessageAuthorType?: MessageAuthorType;
+  /** Who started the conversation — shown in the "Everyone" view. */
+  originatorName?: string;
 }
 
 /** One message in a contribution's conversation thread (getThread, ascending). */

--- a/apps/mobile/features/contribute/types.ts
+++ b/apps/mobile/features/contribute/types.ts
@@ -78,15 +78,24 @@ export interface Contribution {
   /**
    * Set when a maintainer triggered the production deploy from the app
    * (always a silent OTA); cleared again if the workflow dispatch failed.
+   * Acts as a cooldown, not a one-shot (see promoteToProduction).
    */
   productionRequestedAt?: number;
+  /**
+   * Set while an in-app merge (mergeNow) is in flight; cleared if the merge
+   * failed so the merge card can offer a retry.
+   */
+  mergeRequestedAt?: number;
   /** AI review verdict on the open PR — "approved" unlocks the in-app merge. */
   reviewVerdict?: "approved" | "changes_requested";
   reviewSummary?: string;
   prUrl?: string;
   githubIssueUrl?: string;
   screenshotUrls?: string[];
-  /** Display name of whoever started the conversation (getContribution). */
+  /**
+   * Display name of whoever started the conversation — attached by both
+   * getContribution (detail header) and the list queries ("Everyone" view).
+   */
   originatorName?: string;
   /** Set when the contributor set the conversation aside (abandoned/not doable). */
   archivedAt?: number;
@@ -102,8 +111,6 @@ export interface Contribution {
 export interface ContributionListItem extends Contribution {
   lastMessageBody?: string;
   lastMessageAuthorType?: MessageAuthorType;
-  /** Who started the conversation — shown in the "Everyone" view. */
-  originatorName?: string;
 }
 
 /** One message in a contribution's conversation thread (getThread, ascending). */

--- a/apps/mobile/features/contribute/utils/devRoute.ts
+++ b/apps/mobile/features/contribute/utils/devRoute.ts
@@ -14,10 +14,12 @@
  */
 import type { Id } from "@services/api/convex";
 
-// A Convex document id is 16–64 lowercase alphanumerics. Mirrors the guard in
-// ContributionDetailScreen so a non-id segment (e.g. "submit", "feature-flags")
-// never masquerades as an open conversation.
-const LOOKS_LIKE_CONVEX_ID = /^[a-z0-9]{16,64}$/;
+// A Convex document id is 16–64 lowercase alphanumerics — the shared guard
+// for every contribute surface that takes an id from a URL, so a non-id
+// segment (e.g. "submit", "feature-flags") or malformed deep link never
+// reaches the Convex queries (which would throw an ArgumentValidationError
+// through render).
+export const LOOKS_LIKE_CONVEX_ID = /^[a-z0-9]{16,64}$/;
 
 export interface DevRoute {
   /** The open conversation id (for the sidebar row highlight), or null. */

--- a/docs/architecture/ADR-029-contributor-dev-dashboard.md
+++ b/docs/architecture/ADR-029-contributor-dev-dashboard.md
@@ -402,6 +402,42 @@ Owner-requested follow-up to make filing feel like chatting and to turn a
   build prompt straight into a fresh dev session. See
   `docs/dev-assistant/ROUTINE-PROMPT.md`.
 
+## Phase 1.8 — maintainer flow: plan surface, staging redo, in-app merge & production promote (Accepted)
+
+Follow-ups from maintainer feedback on the conversation flow:
+
+- **The plan gets its own surface.** Spec callbacks no longer paste the full
+  plan into the thread as an assistant turn (revision rounds were burying the
+  conversation under repeated walls of text) — the thread gets a one-line
+  "plan ready/updated" system pointer, and the pinned "The plan" card is a
+  compact summary that opens the full plan on its own screen (phones,
+  `/dev/plan/[id]`) or in a right-side panel beside the thread (desktop web).
+  The detail screen collapses legacy full-spec assistant bubbles that match
+  the current plan into a caption.
+- **"Something's off" is a redo, not a dead end.** `reportStagingIssue` now
+  resets the review-cycle state (prUrl, verdict, fixRounds, routineRunId) and
+  applies the ONE deliberate cycle in the otherwise-monotonic status machine:
+  `MERGED -> READY_FOR_IMPL`. That re-dispatches the implement Routine with
+  `redo: true` + the conversation thread; it opens a NEW PR against latest
+  main and the item re-enters the normal review → merge → staging loop. The
+  transition is human-triggered only — callbacks still can't move a row
+  backward.
+- **In-app merge.** `mergeNow` lets any dev maintainer merge a
+  review-approved `READY_TO_MERGE` item from the conversation (via the same
+  GitHub REST path as policy auto-merge, `GH_MIRROR_TOKEN`), skipping the
+  auto-merge switch/severity cap because it's an explicit human decision.
+- **In-app production promote (silent only).** `promoteToProduction` — gated
+  on MERGED + staging sign-off (when required) — fires the existing
+  `deploy-to-production.yml` workflow with `update_mode: silent`, pinned:
+  forced updates stay a hand-run workflow decision. Requires the PAT to have
+  Actions: read/write (new `devBugs.productionRequestedAt` tracks the
+  trigger; cleared on dispatch failure).
+- **Team visibility.** List queries attach `originatorName`; the "Everyone"
+  view shows who's driving each conversation and the detail header shows
+  "Started by …".
+- **Clickable images.** Thread attachments, report screenshots, and markdown
+  images (plans included) open the app's full-screen image viewer.
+
 ## Deliberately out of scope (v1)
 
 - GitHub OAuth / verified account linking (`githubUsername` is honor-system).

--- a/docs/dev-assistant/ROUTINE-PROMPT.md
+++ b/docs/dev-assistant/ROUTINE-PROMPT.md
@@ -214,6 +214,14 @@ Callbacks as you progress: status "IN_PROGRESS" when you start,
 Routine is dispatched automatically from that callback — do NOT review,
 approve, or merge your own PR, and do not poll the PR afterward; your run
 ends at the CODE_REVIEW callback.
+
+If the payload has `redo: true`, this is a STAGING-REDO round: an earlier
+PR for this item was already merged, but the contributor found problems
+while trying the change on staging. The payload includes the full
+conversation `thread` — the latest user messages describe what's wrong.
+Start from the latest main (the merged code is already in it), fix the
+reported problems, and open a NEW pull request on a fresh
+claude/devbug-<bugId> branch. Same callbacks as a normal run.
 ```
 
 ---
@@ -347,7 +355,23 @@ set the per-mode env vars.
   uses the `GH_MIRROR_TOKEN` PAT — which therefore needs **Contents:
   read/write** in addition to Issues — behind the `AUTO_MERGE_ENABLED`
   master switch (merge method from `AUTO_MERGE_METHOD`, default squash).
-  Routines never merge PRs in any mode.
+  Routines never merge PRs in any mode. The **in-app merge button**
+  (`contributions.mergeNow` → `actions.mergeFromApp`) reuses the same PAT and
+  merge path but is an explicit maintainer decision, so it skips the
+  `AUTO_MERGE_ENABLED` switch and the per-user severity cap (the hard gates —
+  review approved + READY_TO_MERGE — are still re-checked server-side).
+- **In-app production deploy** (`contributions.promoteToProduction` →
+  `actions.dispatchProductionDeploy`) fires the existing
+  `deploy-to-production.yml` workflow via `workflow_dispatch`, always with
+  `update_mode: silent` (forced updates remain a hand-run workflow decision).
+  For this, `GH_MIRROR_TOKEN` ALSO needs **Actions: read/write** on the repo;
+  without it the trigger fails and the thread shows "Production deploy
+  couldn't start", clearing the request so the button returns.
+- **Staging-redo rounds** (`reportStagingIssue`): a contributor rejecting the
+  staging check no longer dead-ends — the item transitions MERGED →
+  READY_FOR_IMPL and re-dispatches the implement Routine with `redo: true`
+  (see the dev-implement prompt), which opens a NEW PR against latest main
+  and re-enters the normal review → merge → staging cycle.
 - Until the three-Routine split is done, one Routine with all three prompt
   sections and a `mode` switch ("spec" / "implement" / "review") works — the
   per-mode trigger URLs fall back to `CLAUDE_ROUTINES_TRIGGER_URL`.

--- a/docs/dev-assistant/ROUTINE-PROMPT.md
+++ b/docs/dev-assistant/ROUTINE-PROMPT.md
@@ -181,10 +181,12 @@ Callback: { bugId, routineRunId, status: "IN_REVIEW", spec, riskLevel,
 aiTitle, area, scope, splitSlices?, verifyOnStaging, screenshots? }.
 
 If the payload has `revision: true`, this is a revision round: the payload
-includes the full conversation thread. Respond to the latest user message,
-re-check the code where their correction demands it, and return the COMPLETE
-updated spec (not a diff), updating any triage fields that changed. Keep
-aiTitle stable unless the item's nature changed.
+includes the full conversation thread AND the current spec draft in its
+`spec` field (the thread itself only carries short "plan ready/updated"
+pointers, never the plan text). Respond to the latest user message, re-check
+the code where their correction demands it, and return the COMPLETE updated
+spec (not a diff), updating any triage fields that changed. Keep aiTitle
+stable unless the item's nature changed.
 ```
 
 ---
@@ -218,7 +220,8 @@ ends at the CODE_REVIEW callback.
 If the payload has `redo: true`, this is a STAGING-REDO round: an earlier
 PR for this item was already merged, but the contributor found problems
 while trying the change on staging. The payload includes the full
-conversation `thread` — the latest user messages describe what's wrong.
+conversation `thread` — the latest user messages describe what's wrong —
+and `screenshotUrls` includes any pictures they attached to thread replies.
 Start from the latest main (the merged code is already in it), fix the
 reported problems, and open a NEW pull request on a fresh
 claude/devbug-<bugId> branch. Same callbacks as a normal run.


### PR DESCRIPTION
Follow-ups from maintainer feedback on the dev-dashboard conversation flow (ADR-029 Phase 1.8).

## What changed

- **Plans no longer flood the thread.** Spec callbacks post a one-line pointer instead of the full spec (revision rounds used to repost the whole plan every time). The pinned "The plan" card is now a compact summary that opens the plan on its own screen on phones (`/dev/plan/[id]`) or in a right-side panel on desktop web. Legacy full-spec bubbles matching the current plan collapse into a caption.
- **"Something's off" is a redo, not a dead end.** `reportStagingIssue` resets the review-cycle state and applies the one deliberate cycle in the otherwise-monotonic status machine (`MERGED → READY_FOR_IMPL`), re-dispatching the implement Routine with `redo: true` + the conversation thread. The redo run fixes the reported problems and opens a **new PR** against latest main, re-entering the normal review → merge → staging loop.
- **In-app merge.** `mergeNow` lets a dev maintainer merge a review-approved `READY_TO_MERGE` item from the conversation, via the same GitHub REST path as policy auto-merge. Explicit human decision, so it skips the auto-merge switch and severity cap; hard gates re-checked server-side.
- **In-app production promote (silent only).** `promoteToProduction` fires the existing `deploy-to-production.yml` workflow with `update_mode` pinned to `silent`, gated on MERGED + staging sign-off. Failures clear `productionRequestedAt` so the button returns. ⚠️ Requires `GH_MIRROR_TOKEN` to gain **Actions: read/write**.
- **Team visibility.** List queries attach `originatorName`; the "Everyone" view shows who's driving each conversation; the detail header shows "Started by …".
- **Clickable images.** Thread attachments, report screenshots, and markdown images (plans included) open the full-screen image viewer.

## Testing

- `apps/convex` vitest: 129 passing, including 6 new tests covering the staging-redo dispatch (payload carries `redo: true` + thread, state reset, fresh routineRunId), in-app merge (success, GitHub failure, gate rejections), and production promote (silent inputs, failure rollback, gates).
- Mobile jest (contribute + routing + ui components) and eslint pass; tsc clean for touched files.
- Not exercised against a live Convex deployment (no deployment credentials in the sandbox).

## Notes for reviewers

- The Routine bootstrap prompt reads `docs/dev-assistant/ROUTINE-PROMPT.md` from `origin/main`, so the new redo instructions go live on merge; before that, redo payloads carry inline `instructions` so behavior is correct either way.
- The `MERGED → READY_FOR_IMPL` transition is human-triggered only; callbacks still can't move a row backward (routine-claimed MERGED remains rejected, no run mode may deliver READY_FOR_IMPL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRyfWmrajD3STXt7FD2U7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRyfWmrajD3STXt7FD2U7d)_