### PR TITLE
Show original message in in-channel thread preview, aligned by author

### DIFF
--- a/apps/mobile/app/e/[shortId]/EventActivity.tsx
+++ b/apps/mobile/app/e/[shortId]/EventActivity.tsx
@@ -326,6 +326,13 @@ export function EventActivity({
                     parentMessageId={msg._id}
                     channelId={msg.channelId}
                     replyCount={msg.threadReplyCount ?? 0}
+                    originalContent={msg.content ?? ""}
+                    originalSenderId={msg.senderId}
+                    currentUserId={currentUserId}
+                    senderName={msg.senderName}
+                    senderProfilePhoto={msg.senderProfilePhoto}
+                    isDeleted={msg.isDeleted}
+                    attachments={msg.attachments}
                     onOpenThread={() => handleGhostOpenThread(msg._id)}
                     onScrollToOriginal={() =>
                       handleGhostScrollToOriginal(msg._id)

--- a/apps/mobile/features/chat/components/GhostThreadPointer.tsx
+++ b/apps/mobile/features/chat/components/GhostThreadPointer.tsx
@@ -1,29 +1,36 @@
 /**
- * GhostThreadPointer - content-free "ghost" bubble for a bumped thread.
+ * GhostThreadPointer - a lightweight echo of a bumped thread's original message.
  *
  * When a message gets a reply we deliberately keep the real message in its
  * original chronological position (see `getMessages` ordering by `createdAt`).
- * To avoid losing recent thread activity off-screen, this lightweight ghost is
- * floated at the thread's latest-activity slot (its `lastActivityAt`) at the
- * bottom of the chat. It shows NO original message text — only the existing
- * "N replies" pill — and offers two tap targets:
+ * To avoid losing recent thread activity off-screen, this preview is floated at
+ * the thread's latest-activity slot (its `lastActivityAt`) at the bottom of the
+ * chat.
  *
+ * It echoes the ORIGINAL message so you can tell what the thread is about and
+ * who started it:
+ *
+ * - It shows the original message's text (truncated to a couple of lines; an
+ *   image-/attachment-only or deleted original falls back to a sensible
+ *   placeholder rather than a blank bubble).
+ * - It is aligned like a normal message bubble — right (no avatar) when the
+ *   current user authored the original, left (with the author's avatar + name)
+ *   when someone else did. Alignment keys off the ORIGINAL message's author,
+ *   not the last replier.
+ * - The bubble uses the same own/other bubble colors as real messages, so it
+ *   reads as a lightweight echo of the original, not a brand-new message.
+ *
+ * Two tap targets, unchanged from before:
  * - Tapping the "N replies" pill opens the thread screen (same as the inline
  *   indicator under the real message).
- * - Tapping the ghost body scrolls the chat up to the real original message and
- *   briefly highlights it.
- *
- * The bubble is content-free: it shows NO caption or original text, only a
- * small "jump up" icon (a non-text affordance for the body tap) and the
- * existing "N replies" pill. Styling is intentionally neutral (dashed, greyed,
- * centered — not left/right aligned) so it reads as a pointer, not a real
- * message bubble.
+ * - Tapping the bubble body scrolls the chat up to the real original message
+ *   and briefly highlights it.
  */
 
 import React from 'react';
-import { StyleSheet, Pressable } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { useTheme } from '@hooks/useTheme';
+import { AppImage } from '@components/ui';
 import type { Id } from '@services/api/convex';
 import { ThreadReplies } from './ThreadReplies';
 
@@ -31,63 +38,211 @@ interface GhostThreadPointerProps {
   parentMessageId: Id<"chatMessages">;
   channelId?: Id<"chatChannels">;
   replyCount: number;
+  /** The original message's text — shown truncated as the preview. */
+  originalContent: string;
+  /** Author of the ORIGINAL message; drives left/right alignment. */
+  originalSenderId: Id<"users">;
+  /** Current viewer — the preview aligns right when they authored the original. */
+  currentUserId: Id<"users">;
+  /** Denormalized author info, shown on the left-aligned (other-authored) preview. */
+  senderName?: string;
+  senderProfilePhoto?: string;
+  /** Deleted original → show the deleted-message treatment instead of blank text. */
+  isDeleted?: boolean;
+  /** Attachments on the original — used to label an image-/attachment-only preview. */
+  attachments?: Array<{ type: string; name?: string }>;
   /** Tap the "N replies" pill → open the thread screen. */
   onOpenThread: () => void;
-  /** Tap the ghost body → scroll up to the real original message. */
+  /** Tap the bubble body → scroll up to the real original message. */
   onScrollToOriginal: () => void;
+}
+
+/**
+ * Derive the preview text for the echo. Prefers the message text; falls back to
+ * a placeholder for attachment-only or deleted originals so the bubble is never
+ * blank. Returns `isPlaceholder` so callers can style deleted/attachment
+ * fallbacks (muted/italic) differently from real text.
+ */
+function getPreview(
+  content: string,
+  isDeleted: boolean,
+  attachments?: Array<{ type: string; name?: string }>,
+): { text: string; isPlaceholder: boolean } {
+  if (isDeleted) {
+    return { text: 'This message was deleted', isPlaceholder: true };
+  }
+  const trimmed = content.trim();
+  if (trimmed.length > 0) {
+    return { text: trimmed, isPlaceholder: false };
+  }
+  const first = attachments?.[0];
+  if (first) {
+    switch (first.type) {
+      case 'image':
+        return { text: '📷 Photo', isPlaceholder: true };
+      case 'video':
+        return { text: '🎥 Video', isPlaceholder: true };
+      case 'audio':
+        return { text: '🎤 Voice message', isPlaceholder: true };
+      case 'document':
+        return { text: first.name ? `📄 ${first.name}` : '📄 Document', isPlaceholder: true };
+      default:
+        return { text: '📎 Attachment', isPlaceholder: true };
+    }
+  }
+  return { text: 'Message', isPlaceholder: true };
 }
 
 export function GhostThreadPointer({
   parentMessageId,
   channelId,
   replyCount,
+  originalContent,
+  originalSenderId,
+  currentUserId,
+  senderName,
+  senderProfilePhoto,
+  isDeleted = false,
+  attachments,
   onOpenThread,
   onScrollToOriginal,
 }: GhostThreadPointerProps) {
   const { colors } = useTheme();
+  const isOwnMessage = originalSenderId === currentUserId;
+  const { text: previewText, isPlaceholder } = getPreview(originalContent, isDeleted, attachments);
+
+  const bubbleTextColor = isPlaceholder
+    ? colors.textTertiary
+    : isOwnMessage
+      ? colors.chatBubbleOwnText
+      : colors.chatBubbleOtherText;
 
   return (
-    <Pressable
-      onPress={onScrollToOriginal}
-      accessibilityRole="button"
-      accessibilityLabel="Jump to the original message"
-      testID={`ghost-thread-${parentMessageId}`}
-      style={({ pressed }) => [
-        styles.ghost,
-        {
-          borderColor: colors.border,
-          backgroundColor: pressed ? colors.surfaceSecondary : 'transparent',
-        },
+    <View
+      style={[
+        styles.row,
+        { justifyContent: isOwnMessage ? 'flex-end' : 'flex-start' },
       ]}
     >
-      {/* Icon-only affordance for the body tap (scroll up to the original).
-          No caption/text — the ghost stays content-free, showing only the
-          "N replies" pill below. */}
-      <Ionicons name="arrow-up-circle-outline" size={16} color={colors.textTertiary} />
+      {/* Author avatar — only for someone else's message, mirroring a real row. */}
+      {!isOwnMessage && (
+        <View style={styles.avatarContainer}>
+          <AppImage
+            source={senderProfilePhoto}
+            style={styles.avatar}
+            optimizedWidth={50}
+            placeholder={{
+              type: 'initials',
+              name: senderName || 'User',
+              backgroundColor: '#E5E5E5',
+            }}
+          />
+        </View>
+      )}
 
-      <ThreadReplies
-        parentMessageId={parentMessageId}
-        channelId={channelId}
-        replyCount={replyCount}
-        onPress={onOpenThread}
-      />
-    </Pressable>
+      <View style={[styles.content, isOwnMessage ? styles.contentOwn : styles.contentOther]}>
+        {/* Sender name — only for others' messages, like a real row. */}
+        {!isOwnMessage && (
+          <Text style={[styles.senderName, { color: colors.textSecondary }]} numberOfLines={1}>
+            {senderName || 'Unknown'}
+          </Text>
+        )}
+
+        {/* The echoed original message. Tapping it scrolls up to the real one. */}
+        <Pressable
+          onPress={onScrollToOriginal}
+          accessibilityRole="button"
+          accessibilityLabel="Jump to the original message"
+          testID={`ghost-thread-${parentMessageId}`}
+          style={({ pressed }) => [
+            styles.bubble,
+            isOwnMessage ? styles.bubbleOwn : styles.bubbleOther,
+            {
+              backgroundColor: isOwnMessage ? colors.chatBubbleOwn : colors.chatBubbleOther,
+              opacity: pressed ? 0.7 : 1,
+            },
+          ]}
+        >
+          <Text
+            style={[styles.bubbleText, { color: bubbleTextColor }, isPlaceholder && styles.placeholderText]}
+            numberOfLines={2}
+            ellipsizeMode="tail"
+          >
+            {previewText}
+          </Text>
+        </Pressable>
+
+        {/* The "N replies · Just now" pill — still opens the thread on tap.
+            Wrapped so the column's alignItems positions it under the bubble on
+            the correct side (ThreadReplies aligns itself flex-start internally). */}
+        <View style={styles.pillWrapper}>
+          <ThreadReplies
+            parentMessageId={parentMessageId}
+            channelId={channelId}
+            replyCount={replyCount}
+            onPress={onOpenThread}
+          />
+        </View>
+      </View>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  ghost: {
+  row: {
     flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    alignSelf: 'center',
-    maxWidth: '85%',
+    alignItems: 'flex-start',
     marginVertical: 6,
-    paddingVertical: 8,
     paddingHorizontal: 12,
+  },
+  avatarContainer: {
+    width: 24,
+    height: 24,
+    marginRight: 6,
+    marginTop: 18, // drop below the sender-name line so it aligns with the bubble
+    flexShrink: 0,
+  },
+  avatar: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+  },
+  content: {
+    maxWidth: '75%',
+    flexShrink: 1,
+  },
+  contentOwn: {
+    alignItems: 'flex-end',
+  },
+  contentOther: {
+    alignItems: 'flex-start',
+  },
+  senderName: {
+    fontSize: 11,
+    fontWeight: '600',
+    marginBottom: 2,
+    marginLeft: 12,
+  },
+  bubble: {
     borderRadius: 14,
-    borderWidth: 1,
-    borderStyle: 'dashed',
-    gap: 12,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+  },
+  bubbleOwn: {
+    borderBottomRightRadius: 3,
+  },
+  bubbleOther: {
+    borderBottomLeftRadius: 3,
+  },
+  bubbleText: {
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  placeholderText: {
+    fontStyle: 'italic',
+  },
+  pillWrapper: {
+    // A plain wrapper so the column's alignItems (own → flex-end, other →
+    // flex-start) positions the pill on the correct side.
   },
 });

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -152,7 +152,19 @@ function formatDateSeparator(timestamp: number): string {
 type ListItem =
   | { type: 'message'; data: Message; showSenderInfo: boolean; isOptimistic?: boolean; optimisticStatus?: string }
   | { type: 'dateSeparator'; date: string }
-  | { type: 'ghost'; parentId: Id<"chatMessages">; channelId: Id<"chatChannels">; replyCount: number };
+  | {
+      type: 'ghost';
+      parentId: Id<"chatMessages">;
+      channelId: Id<"chatChannels">;
+      replyCount: number;
+      // Original message details, so the ghost can echo it and align by author.
+      content: string;
+      senderId: Id<"users">;
+      senderName?: string;
+      senderProfilePhoto?: string;
+      isDeleted: boolean;
+      attachments?: Message['attachments'];
+    };
 
 /**
  * MessageList renders a virtualized list of messages with pagination.
@@ -265,6 +277,12 @@ export function MessageList({
           parentId: msg._id,
           channelId: msg.channelId,
           replyCount: msg.threadReplyCount ?? 0,
+          content: msg.content ?? '',
+          senderId: msg.senderId,
+          senderName: msg.senderName,
+          senderProfilePhoto: msg.senderProfilePhoto,
+          isDeleted: msg.isDeleted,
+          attachments: msg.attachments,
         });
         // A ghost visually breaks the sender-grouping run.
         previousMsg = undefined;
@@ -439,6 +457,13 @@ export function MessageList({
             parentMessageId={item.parentId}
             channelId={item.channelId}
             replyCount={item.replyCount}
+            originalContent={item.content}
+            originalSenderId={item.senderId}
+            currentUserId={currentUserId}
+            senderName={item.senderName}
+            senderProfilePhoto={item.senderProfilePhoto}
+            isDeleted={item.isDeleted}
+            attachments={item.attachments}
             onOpenThread={() => handleGhostOpenThread(item.parentId, item.channelId)}
             onScrollToOriginal={() => handleGhostScrollToOriginal(item.parentId)}
           />

--- a/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
@@ -8,11 +8,28 @@ jest.mock('@hooks/useTheme', () => ({
     colors: {
       border: '#ccc',
       surfaceSecondary: '#eee',
+      textSecondary: '#666',
       textTertiary: '#999',
       link: '#06c',
+      chatBubbleOwn: '#e0efff',
+      chatBubbleOther: '#E5E5EA',
+      chatBubbleOwnText: '#1a1a1a',
+      chatBubbleOtherText: '#1a1a1a',
     },
   }),
 }));
+
+// Stub AppImage (the author avatar) — it pulls in native image plumbing we
+// don't need here. Expose the resolved initials name so we can assert the
+// avatar renders for other-authored previews.
+jest.mock('@components/ui', () => {
+  const { Text: RNText } = require('react-native');
+  return {
+    AppImage: ({ placeholder }: { placeholder?: { name?: string } }) => (
+      <RNText testID="ghost-avatar">{`avatar:${placeholder?.name ?? ''}`}</RNText>
+    ),
+  };
+});
 
 // Stub the "N replies" pill so the test isolates the ghost's wiring (the pill
 // itself is exercised by ThreadReplies' own coverage). The stub exposes the
@@ -28,30 +45,97 @@ jest.mock('../ThreadReplies', () => {
   };
 });
 
-jest.mock('@expo/vector-icons', () => ({
-  Ionicons: () => null,
-}));
-
 const PARENT_ID = 'msg_parent' as any;
 const CHANNEL_ID = 'chan_1' as any;
+const ME = 'user_me' as any;
+const SOMEONE_ELSE = 'user_other' as any;
+
+const baseProps = {
+  parentMessageId: PARENT_ID,
+  channelId: CHANNEL_ID,
+  replyCount: 2,
+  currentUserId: ME,
+  onOpenThread: jest.fn(),
+  onScrollToOriginal: jest.fn(),
+};
 
 describe('GhostThreadPointer', () => {
-  it('is content-free: shows only the reply count, never the original message text', () => {
-    const { queryByText, getByText } = render(
+  it('shows the original message text (not just the reply count)', () => {
+    const { getByText } = render(
       <GhostThreadPointer
-        parentMessageId={PARENT_ID}
-        channelId={CHANNEL_ID}
-        replyCount={2}
-        onOpenThread={jest.fn()}
-        onScrollToOriginal={jest.fn()}
+        {...baseProps}
+        originalContent="Who's bringing snacks?"
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
       />,
     );
 
-    // The count pill is present…
+    // The echoed original message text is now shown…
+    expect(getByText("Who's bringing snacks?")).toBeTruthy();
+    // …alongside the count pill.
     expect(getByText('2 replies')).toBeTruthy();
-    // …but the original message content must NOT leak into the ghost.
-    expect(queryByText("Who's bringing snacks?")).toBeNull();
-    expect(queryByText('replies to a message')).toBeNull();
+  });
+
+  it('left-aligns with the sender avatar + name when someone else authored the original', () => {
+    const { getByTestId, getByText } = render(
+      <GhostThreadPointer
+        {...baseProps}
+        originalContent="Who's bringing snacks?"
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
+        senderProfilePhoto="https://example.com/samuel.jpg"
+      />,
+    );
+
+    // Avatar + sender name are shown for other-authored previews (the mock's
+    // left-aligned treatment). The own-authored test asserts the inverse.
+    expect(getByText('Samuel Baker')).toBeTruthy();
+    expect(getByTestId('ghost-avatar')).toBeTruthy();
+  });
+
+  it('right-aligns with no avatar/name when the current user authored the original', () => {
+    const { queryByTestId, queryByText, getByText } = render(
+      <GhostThreadPointer
+        {...baseProps}
+        originalContent="Can we move it to 7:30 instead?"
+        originalSenderId={ME}
+        senderName="Me"
+      />,
+    );
+
+    // The text still shows…
+    expect(getByText('Can we move it to 7:30 instead?')).toBeTruthy();
+    // …but there's no avatar and no sender-name label for your own message.
+    expect(queryByTestId('ghost-avatar')).toBeNull();
+    expect(queryByText('Me')).toBeNull();
+  });
+
+  it('shows a placeholder for an image-only original', () => {
+    const { getByText } = render(
+      <GhostThreadPointer
+        {...baseProps}
+        originalContent=""
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
+        attachments={[{ type: 'image' }]}
+      />,
+    );
+
+    expect(getByText('📷 Photo')).toBeTruthy();
+  });
+
+  it('shows the deleted-message treatment for a deleted original', () => {
+    const { getByText } = render(
+      <GhostThreadPointer
+        {...baseProps}
+        originalContent=""
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
+        isDeleted
+      />,
+    );
+
+    expect(getByText('This message was deleted')).toBeTruthy();
   });
 
   it('tapping the "N replies" pill opens the thread (not scroll-to-original)', () => {
@@ -59,9 +143,11 @@ describe('GhostThreadPointer', () => {
     const onScrollToOriginal = jest.fn();
     const { getByTestId } = render(
       <GhostThreadPointer
-        parentMessageId={PARENT_ID}
-        channelId={CHANNEL_ID}
+        {...baseProps}
         replyCount={3}
+        originalContent="Who's bringing snacks?"
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
         onOpenThread={onOpenThread}
         onScrollToOriginal={onScrollToOriginal}
       />,
@@ -72,14 +158,16 @@ describe('GhostThreadPointer', () => {
     expect(onScrollToOriginal).not.toHaveBeenCalled();
   });
 
-  it('tapping the ghost body scrolls up to the original message', () => {
+  it('tapping the bubble body scrolls up to the original message', () => {
     const onOpenThread = jest.fn();
     const onScrollToOriginal = jest.fn();
     const { getByTestId } = render(
       <GhostThreadPointer
-        parentMessageId={PARENT_ID}
-        channelId={CHANNEL_ID}
+        {...baseProps}
         replyCount={1}
+        originalContent="Who's bringing snacks?"
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
         onOpenThread={onOpenThread}
         onScrollToOriginal={onScrollToOriginal}
       />,


### PR DESCRIPTION
## What & why

In a group channel, when a message has thread replies the app floats a small preview near the bottom of the chat so recent thread activity isn't lost off-screen. Today that preview (`GhostThreadPointer`) is a **dashed, greyed, centered pill** showing only "N replies · Just now" — it doesn't show the original message, and because it's centered you can't tell who started the thread.

This makes two changes the contributor asked for:

1. **Show the original message** — the preview now echoes the original message's text (truncated to two lines).
2. **Align it like a real message** — **right (no avatar) when the current user authored** the original, **left (with the author's avatar + name) when someone else did**. Alignment keys off the **original message's author**, not the last replier, and reuses the same own/other bubble colors as normal messages.

The two tap targets are unchanged: tapping the "N replies" pill still opens the thread; tapping the bubble body still scrolls up to and highlights the real original message.

This deliberately reverses the component's original "content-free pointer, not a real message" design — its header comment is updated to match the new behavior.

## Rendered mock (not a device capture)

This runs on a headless Linux runner with no iOS simulator, so the image below is a **faithful rendered mock built from the real component's `StyleSheet` values and the light-theme tokens** — not a device screenshot. It covers both alignments plus the edge cases.

[After — rendered mock](https://images.togather.nyc/dev-assistant/8b8a9fdb-e4d8-4d89-a6db-253ad34ed8bd-ghost-after-mock.png)

## Edge cases handled

- **Long original** — truncates to two lines with an ellipsis.
- **Image-/attachment-only original** — shows a placeholder ("📷 Photo", "🎥 Video", "🎤 Voice message", "📄 <name>", "📎 Attachment") rather than a blank bubble.
- **Deleted original** — shows the deleted-message treatment (defensive; deleted originals don't normally float a ghost via `shouldFloatGhost`).
- **Missing avatar / long sender name** — falls back the same way normal rows do (initials placeholder, name truncated to one line).

## Changes

- `GhostThreadPointer.tsx` — echo the original message with own/other alignment + colors; carry `originalContent`/`originalSenderId`/`currentUserId`/sender info/`isDeleted`/`attachments`; keep both tap targets. Header comment rewritten.
- `MessageList.tsx` — forward the original message's text/author/sender info onto the `ghost` list item and into `GhostThreadPointer`.
- `EventActivity.tsx` — the event-activity feed's ghost usage gets the same new props.
- `__tests__/GhostThreadPointer.test.tsx` — flipped from asserting content-free to asserting the original text is shown and alignment follows authorship; added image-placeholder and deleted-message coverage. `threadTimeline` derivation is unchanged (it already carried the full message), so its tests stayed as-is.

## Verification

- `GhostThreadPointer` + `threadTimeline` unit tests pass.
- Full mobile Jest suite green (1273 passed, 9 skipped).
- `tsc` clean for the changed files; ESLint clean (only pre-existing `any` warnings in surrounding code).

Dashboard item: `x97fyhqp4ccdme5588vkt7gsvh8ac91n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8Yu7B3DEJaL6QaZxGEEqp)_