### PR TITLE
fix(chat): align floating thread preview by the original message's author

### DIFF
--- a/apps/mobile/features/chat/components/GhostThreadPointer.tsx
+++ b/apps/mobile/features/chat/components/GhostThreadPointer.tsx
@@ -13,19 +13,17 @@
  * - It shows the original message's text (truncated to a couple of lines; an
  *   image-/attachment-only or deleted original falls back to a sensible
  *   placeholder rather than a blank bubble).
- * - It is aligned by the thread's LAST reply — the side that most recent thread
- *   activity came from: right (your side, no avatar) when you sent the last
- *   reply, left (with the original author's avatar + name) when someone else
- *   did. This is a deliberate change from the earlier "align by the original
- *   author" behavior: contributors asked for the preview to follow whoever
- *   replied last (see the staging feedback on this component), so a thread you
- *   were last active in sits on your side even if someone else started it.
- *   Before the replies have loaded we fall back to the original author's side
- *   to avoid a wrong-side flash.
- * - A short connector line links the echoed bubble down to the "N replies" pill
- *   on the aligned side, so the two read as one threaded unit.
+ * - It is aligned like a real message row, keyed off the ORIGINAL message's
+ *   author: right (your side, no avatar) when you wrote the original message,
+ *   left (with the original author's avatar + name) when someone else did. The
+ *   side follows who started the thread, not who replied last — so the echo
+ *   sits on the same side the real message does.
  * - The bubble uses the same own/other bubble colors as real messages, so it
  *   reads as a lightweight echo, not a brand-new message.
+ *
+ * (This component was originally built content-free and centered — "reads as a
+ * pointer, not a real message." That was deliberately reversed: it now echoes
+ * the original message and aligns by its author, as the approved spec asks.)
  *
  * Two tap targets, unchanged from before:
  * - Tapping the "N replies" pill opens the thread screen (same as the inline
@@ -40,7 +38,6 @@ import { useTheme } from '@hooks/useTheme';
 import { AppImage } from '@components/ui';
 import type { Id } from '@services/api/convex';
 import { ThreadReplies } from './ThreadReplies';
-import { useThreadReplies } from '../hooks/useThreadReplies';
 
 interface GhostThreadPointerProps {
   parentMessageId: Id<"chatMessages">;
@@ -49,11 +46,11 @@ interface GhostThreadPointerProps {
   /** The original message's text — shown truncated as the preview. */
   originalContent: string;
   /**
-   * Author of the ORIGINAL message. Drives the fallback alignment (and the
-   * avatar/name shown) before the thread's replies have loaded.
+   * Author of the ORIGINAL message. Drives the alignment (right when it's the
+   * current user, left otherwise) and the avatar/name shown on the left side.
    */
   originalSenderId: Id<"users">;
-  /** Current viewer — the preview aligns right when they sent the last reply. */
+  /** Current viewer — the preview aligns right when they authored the original. */
   currentUserId: Id<"users">;
   /** Denormalized author info, shown on the left-aligned (other-side) preview. */
   senderName?: string;
@@ -120,19 +117,11 @@ export function GhostThreadPointer({
 }: GhostThreadPointerProps) {
   const { colors } = useTheme();
 
-  // Alignment follows the thread's LAST reply (right = you sent it). Reuse the
-  // same replies query the nested pill already subscribes to (Convex dedupes
-  // it, and prefetch usually makes it instant). Pick the newest reply by
-  // createdAt rather than trusting list order. Until it loads (or if the last
-  // reply came from a bot with no senderId), fall back to the original author.
-  const { replies } = useThreadReplies(parentMessageId, 10, channelId ?? null);
-  const lastReply = replies.length > 0
-    ? replies.reduce((latest, r) => (r.createdAt > latest.createdAt ? r : latest))
-    : undefined;
-  const lastReplySenderId = lastReply?.senderId;
-  const alignRight = lastReplySenderId
-    ? lastReplySenderId === currentUserId
-    : originalSenderId === currentUserId;
+  // Aligned like a real message row: right when the current user wrote the
+  // original message, left (with the author's avatar + name) otherwise. Keyed
+  // off the ORIGINAL message's author, mirroring MessageItem's own-vs-other
+  // rule — so the echo sits on the same side the real message does.
+  const alignRight = originalSenderId === currentUserId;
 
   const { text: previewText, isPlaceholder } = getPreview(originalContent, isDeleted, attachments);
 
@@ -197,13 +186,6 @@ export function GhostThreadPointer({
             {previewText}
           </Text>
         </Pressable>
-
-        {/* Connector line: links the echoed bubble to its replies pill on the
-            aligned side, so they read as one threaded unit. */}
-        <View
-          testID={`ghost-thread-connector-${parentMessageId}`}
-          style={[styles.connector, { backgroundColor: colors.border }]}
-        />
 
         {/* The "N replies · Just now" pill — still opens the thread on tap.
             Wrapped so the column's alignItems positions it under the bubble on
@@ -273,13 +255,6 @@ const styles = StyleSheet.create({
   },
   placeholderText: {
     fontStyle: 'italic',
-  },
-  connector: {
-    width: 2,
-    height: 10,
-    borderRadius: 1,
-    marginHorizontal: 18, // indent so the line sits under the bubble, not at the edge
-    marginVertical: 1,
   },
   pillWrapper: {
     // A plain wrapper so the column's alignItems (own → flex-end, other →

--- a/apps/mobile/features/chat/components/GhostThreadPointer.tsx
+++ b/apps/mobile/features/chat/components/GhostThreadPointer.tsx
@@ -7,18 +7,25 @@
  * the thread's latest-activity slot (its `lastActivityAt`) at the bottom of the
  * chat.
  *
- * It echoes the ORIGINAL message so you can tell what the thread is about and
- * who started it:
+ * It echoes the ORIGINAL message so you can tell what the thread is about, and
+ * tapping it jumps to the real message:
  *
  * - It shows the original message's text (truncated to a couple of lines; an
  *   image-/attachment-only or deleted original falls back to a sensible
  *   placeholder rather than a blank bubble).
- * - It is aligned like a normal message bubble — right (no avatar) when the
- *   current user authored the original, left (with the author's avatar + name)
- *   when someone else did. Alignment keys off the ORIGINAL message's author,
- *   not the last replier.
+ * - It is aligned by the thread's LAST reply — the side that most recent thread
+ *   activity came from: right (your side, no avatar) when you sent the last
+ *   reply, left (with the original author's avatar + name) when someone else
+ *   did. This is a deliberate change from the earlier "align by the original
+ *   author" behavior: contributors asked for the preview to follow whoever
+ *   replied last (see the staging feedback on this component), so a thread you
+ *   were last active in sits on your side even if someone else started it.
+ *   Before the replies have loaded we fall back to the original author's side
+ *   to avoid a wrong-side flash.
+ * - A short connector line links the echoed bubble down to the "N replies" pill
+ *   on the aligned side, so the two read as one threaded unit.
  * - The bubble uses the same own/other bubble colors as real messages, so it
- *   reads as a lightweight echo of the original, not a brand-new message.
+ *   reads as a lightweight echo, not a brand-new message.
  *
  * Two tap targets, unchanged from before:
  * - Tapping the "N replies" pill opens the thread screen (same as the inline
@@ -33,6 +40,7 @@ import { useTheme } from '@hooks/useTheme';
 import { AppImage } from '@components/ui';
 import type { Id } from '@services/api/convex';
 import { ThreadReplies } from './ThreadReplies';
+import { useThreadReplies } from '../hooks/useThreadReplies';
 
 interface GhostThreadPointerProps {
   parentMessageId: Id<"chatMessages">;
@@ -40,11 +48,14 @@ interface GhostThreadPointerProps {
   replyCount: number;
   /** The original message's text — shown truncated as the preview. */
   originalContent: string;
-  /** Author of the ORIGINAL message; drives left/right alignment. */
+  /**
+   * Author of the ORIGINAL message. Drives the fallback alignment (and the
+   * avatar/name shown) before the thread's replies have loaded.
+   */
   originalSenderId: Id<"users">;
-  /** Current viewer — the preview aligns right when they authored the original. */
+  /** Current viewer — the preview aligns right when they sent the last reply. */
   currentUserId: Id<"users">;
-  /** Denormalized author info, shown on the left-aligned (other-authored) preview. */
+  /** Denormalized author info, shown on the left-aligned (other-side) preview. */
   senderName?: string;
   senderProfilePhoto?: string;
   /** Deleted original → show the deleted-message treatment instead of blank text. */
@@ -108,12 +119,26 @@ export function GhostThreadPointer({
   onScrollToOriginal,
 }: GhostThreadPointerProps) {
   const { colors } = useTheme();
-  const isOwnMessage = originalSenderId === currentUserId;
+
+  // Alignment follows the thread's LAST reply (right = you sent it). Reuse the
+  // same replies query the nested pill already subscribes to (Convex dedupes
+  // it, and prefetch usually makes it instant). Pick the newest reply by
+  // createdAt rather than trusting list order. Until it loads (or if the last
+  // reply came from a bot with no senderId), fall back to the original author.
+  const { replies } = useThreadReplies(parentMessageId, 10, channelId ?? null);
+  const lastReply = replies.length > 0
+    ? replies.reduce((latest, r) => (r.createdAt > latest.createdAt ? r : latest))
+    : undefined;
+  const lastReplySenderId = lastReply?.senderId;
+  const alignRight = lastReplySenderId
+    ? lastReplySenderId === currentUserId
+    : originalSenderId === currentUserId;
+
   const { text: previewText, isPlaceholder } = getPreview(originalContent, isDeleted, attachments);
 
   const bubbleTextColor = isPlaceholder
     ? colors.textTertiary
-    : isOwnMessage
+    : alignRight
       ? colors.chatBubbleOwnText
       : colors.chatBubbleOtherText;
 
@@ -121,11 +146,12 @@ export function GhostThreadPointer({
     <View
       style={[
         styles.row,
-        { justifyContent: isOwnMessage ? 'flex-end' : 'flex-start' },
+        { justifyContent: alignRight ? 'flex-end' : 'flex-start' },
       ]}
     >
-      {/* Author avatar — only for someone else's message, mirroring a real row. */}
-      {!isOwnMessage && (
+      {/* Author avatar — only on the left (other-side) preview, mirroring a
+          real row. Shows the ORIGINAL author (this is an echo of their message). */}
+      {!alignRight && (
         <View style={styles.avatarContainer}>
           <AppImage
             source={senderProfilePhoto}
@@ -140,9 +166,9 @@ export function GhostThreadPointer({
         </View>
       )}
 
-      <View style={[styles.content, isOwnMessage ? styles.contentOwn : styles.contentOther]}>
-        {/* Sender name — only for others' messages, like a real row. */}
-        {!isOwnMessage && (
+      <View style={[styles.content, alignRight ? styles.contentOwn : styles.contentOther]}>
+        {/* Original author's name — only on the left (other-side) preview. */}
+        {!alignRight && (
           <Text style={[styles.senderName, { color: colors.textSecondary }]} numberOfLines={1}>
             {senderName || 'Unknown'}
           </Text>
@@ -156,9 +182,9 @@ export function GhostThreadPointer({
           testID={`ghost-thread-${parentMessageId}`}
           style={({ pressed }) => [
             styles.bubble,
-            isOwnMessage ? styles.bubbleOwn : styles.bubbleOther,
+            alignRight ? styles.bubbleOwn : styles.bubbleOther,
             {
-              backgroundColor: isOwnMessage ? colors.chatBubbleOwn : colors.chatBubbleOther,
+              backgroundColor: alignRight ? colors.chatBubbleOwn : colors.chatBubbleOther,
               opacity: pressed ? 0.7 : 1,
             },
           ]}
@@ -171,6 +197,13 @@ export function GhostThreadPointer({
             {previewText}
           </Text>
         </Pressable>
+
+        {/* Connector line: links the echoed bubble to its replies pill on the
+            aligned side, so they read as one threaded unit. */}
+        <View
+          testID={`ghost-thread-connector-${parentMessageId}`}
+          style={[styles.connector, { backgroundColor: colors.border }]}
+        />
 
         {/* The "N replies · Just now" pill — still opens the thread on tap.
             Wrapped so the column's alignItems positions it under the bubble on
@@ -240,6 +273,13 @@ const styles = StyleSheet.create({
   },
   placeholderText: {
     fontStyle: 'italic',
+  },
+  connector: {
+    width: 2,
+    height: 10,
+    borderRadius: 1,
+    marginHorizontal: 18, // indent so the line sits under the bubble, not at the edge
+    marginVertical: 1,
   },
   pillWrapper: {
     // A plain wrapper so the column's alignItems (own → flex-end, other →

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -157,8 +157,8 @@ type ListItem =
       parentId: Id<"chatMessages">;
       channelId: Id<"chatChannels">;
       replyCount: number;
-      // Original message details, so the ghost can echo it. Alignment is derived
-      // in GhostThreadPointer from the thread's last reply, not from these.
+      // Original message details, so the ghost can echo it and align by author
+      // (right when senderId is the current user, left otherwise).
       content: string;
       senderId: Id<"users">;
       senderName?: string;

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -62,7 +62,7 @@ interface Message {
   mentionedUserIds?: Id<"users">[];
   threadReplyCount?: number;
   // Thread bump timestamp — later than createdAt once the message has been
-  // replied to. Drives the floating "ghost" thread pointer (see below).
+  // replied to. Positions the floating "ghost" thread pointer (see below).
   lastActivityAt?: number;
   // Denormalized sender info
   senderName?: string;
@@ -157,7 +157,8 @@ type ListItem =
       parentId: Id<"chatMessages">;
       channelId: Id<"chatChannels">;
       replyCount: number;
-      // Original message details, so the ghost can echo it and align by author.
+      // Original message details, so the ghost can echo it. Alignment is derived
+      // in GhostThreadPointer from the thread's last reply, not from these.
       content: string;
       senderId: Id<"users">;
       senderName?: string;
@@ -251,9 +252,9 @@ export function MessageList({
     const items: ListItem[] = [];
 
     // Build a thread-aware timeline: every real message stays at its createdAt
-    // slot, and each replied-to message additionally floats a content-free
-    // "ghost" pointer at its lastActivityAt slot. Date separators and sender
-    // grouping are derived while walking the ordered timeline.
+    // slot, and each replied-to message additionally floats a "ghost" pointer
+    // (an echo of the original message) at its lastActivityAt slot. Date
+    // separators and sender grouping are derived while walking the timeline.
     const timeline = buildThreadAwareTimeline(messages);
     let previousMsg: Message | undefined;
     let previousDateKey: string | undefined;

--- a/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
@@ -21,7 +21,7 @@ jest.mock('@hooks/useTheme', () => ({
 
 // Stub AppImage (the author avatar) — it pulls in native image plumbing we
 // don't need here. Expose the resolved initials name so we can assert the
-// avatar renders for other-authored previews.
+// avatar renders for other-side previews.
 jest.mock('@components/ui', () => {
   const { Text: RNText } = require('react-native');
   return {
@@ -45,6 +45,14 @@ jest.mock('../ThreadReplies', () => {
   };
 });
 
+// Mock the replies hook — alignment now keys off the thread's LAST reply, so
+// each test seeds the reply set that decides the side. `mockReplies` is the
+// (asc-ordered) reply list the component reduces over to find the newest.
+let mockReplies: Array<{ senderId?: string; createdAt: number }> = [];
+jest.mock('../../hooks/useThreadReplies', () => ({
+  useThreadReplies: () => ({ replies: mockReplies, isLoading: false, hasMore: false }),
+}));
+
 const PARENT_ID = 'msg_parent' as any;
 const CHANNEL_ID = 'chan_1' as any;
 const ME = 'user_me' as any;
@@ -59,8 +67,13 @@ const baseProps = {
   onScrollToOriginal: jest.fn(),
 };
 
+beforeEach(() => {
+  mockReplies = [];
+});
+
 describe('GhostThreadPointer', () => {
   it('shows the original message text (not just the reply count)', () => {
+    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const { getByText } = render(
       <GhostThreadPointer
         {...baseProps}
@@ -70,31 +83,62 @@ describe('GhostThreadPointer', () => {
       />,
     );
 
-    // The echoed original message text is now shown…
+    // The echoed original message text is shown…
     expect(getByText("Who's bringing snacks?")).toBeTruthy();
     // …alongside the count pill.
     expect(getByText('2 replies')).toBeTruthy();
   });
 
-  it('left-aligns with the sender avatar + name when someone else authored the original', () => {
+  it('left-aligns with the original author avatar + name when SOMEONE ELSE sent the last reply', () => {
+    // Original authored by me, but the newest reply is from someone else →
+    // the preview follows the last replier onto the LEFT, showing the original
+    // author's identity. Proves alignment keys off the replier, not the author.
+    mockReplies = [
+      { senderId: ME, createdAt: 1 },
+      { senderId: SOMEONE_ELSE, createdAt: 2 },
+    ];
     const { getByTestId, getByText } = render(
       <GhostThreadPointer
         {...baseProps}
         originalContent="Who's bringing snacks?"
-        originalSenderId={SOMEONE_ELSE}
+        originalSenderId={ME}
         senderName="Samuel Baker"
         senderProfilePhoto="https://example.com/samuel.jpg"
       />,
     );
 
-    // Avatar + sender name are shown for other-authored previews (the mock's
-    // left-aligned treatment). The own-authored test asserts the inverse.
     expect(getByText('Samuel Baker')).toBeTruthy();
     expect(getByTestId('ghost-avatar')).toBeTruthy();
   });
 
-  it('right-aligns with no avatar/name when the current user authored the original', () => {
+  it('right-aligns with no avatar/name when the CURRENT USER sent the last reply', () => {
+    // Original authored by someone else, but I sent the newest reply → the
+    // preview follows me onto the RIGHT (no avatar/name). The inverse proof.
+    mockReplies = [
+      { senderId: SOMEONE_ELSE, createdAt: 1 },
+      { senderId: ME, createdAt: 2 },
+    ];
     const { queryByTestId, queryByText, getByText } = render(
+      <GhostThreadPointer
+        {...baseProps}
+        originalContent="Who's bringing snacks?"
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
+      />,
+    );
+
+    // The text still shows…
+    expect(getByText("Who's bringing snacks?")).toBeTruthy();
+    // …but there's no avatar and no sender-name label on your own side.
+    expect(queryByTestId('ghost-avatar')).toBeNull();
+    expect(queryByText('Samuel Baker')).toBeNull();
+  });
+
+  it('falls back to the original author side before any replies have loaded', () => {
+    // No replies loaded yet → align by the original author. Here that is me,
+    // so the preview is right-aligned (no avatar/name).
+    mockReplies = [];
+    const { queryByTestId } = render(
       <GhostThreadPointer
         {...baseProps}
         originalContent="Can we move it to 7:30 instead?"
@@ -103,14 +147,25 @@ describe('GhostThreadPointer', () => {
       />,
     );
 
-    // The text still shows…
-    expect(getByText('Can we move it to 7:30 instead?')).toBeTruthy();
-    // …but there's no avatar and no sender-name label for your own message.
     expect(queryByTestId('ghost-avatar')).toBeNull();
-    expect(queryByText('Me')).toBeNull();
+  });
+
+  it('renders a connector line linking the bubble to the replies pill', () => {
+    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
+    const { getByTestId } = render(
+      <GhostThreadPointer
+        {...baseProps}
+        originalContent="Who's bringing snacks?"
+        originalSenderId={SOMEONE_ELSE}
+        senderName="Samuel Baker"
+      />,
+    );
+
+    expect(getByTestId(`ghost-thread-connector-${PARENT_ID}`)).toBeTruthy();
   });
 
   it('shows a placeholder for an image-only original', () => {
+    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const { getByText } = render(
       <GhostThreadPointer
         {...baseProps}
@@ -125,6 +180,7 @@ describe('GhostThreadPointer', () => {
   });
 
   it('shows the deleted-message treatment for a deleted original', () => {
+    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const { getByText } = render(
       <GhostThreadPointer
         {...baseProps}
@@ -139,6 +195,7 @@ describe('GhostThreadPointer', () => {
   });
 
   it('tapping the "N replies" pill opens the thread (not scroll-to-original)', () => {
+    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const onOpenThread = jest.fn();
     const onScrollToOriginal = jest.fn();
     const { getByTestId } = render(
@@ -159,6 +216,7 @@ describe('GhostThreadPointer', () => {
   });
 
   it('tapping the bubble body scrolls up to the original message', () => {
+    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const onOpenThread = jest.fn();
     const onScrollToOriginal = jest.fn();
     const { getByTestId } = render(

--- a/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/GhostThreadPointer.test.tsx
@@ -21,7 +21,7 @@ jest.mock('@hooks/useTheme', () => ({
 
 // Stub AppImage (the author avatar) — it pulls in native image plumbing we
 // don't need here. Expose the resolved initials name so we can assert the
-// avatar renders for other-side previews.
+// avatar renders for other-authored previews.
 jest.mock('@components/ui', () => {
   const { Text: RNText } = require('react-native');
   return {
@@ -45,14 +45,6 @@ jest.mock('../ThreadReplies', () => {
   };
 });
 
-// Mock the replies hook — alignment now keys off the thread's LAST reply, so
-// each test seeds the reply set that decides the side. `mockReplies` is the
-// (asc-ordered) reply list the component reduces over to find the newest.
-let mockReplies: Array<{ senderId?: string; createdAt: number }> = [];
-jest.mock('../../hooks/useThreadReplies', () => ({
-  useThreadReplies: () => ({ replies: mockReplies, isLoading: false, hasMore: false }),
-}));
-
 const PARENT_ID = 'msg_parent' as any;
 const CHANNEL_ID = 'chan_1' as any;
 const ME = 'user_me' as any;
@@ -67,13 +59,8 @@ const baseProps = {
   onScrollToOriginal: jest.fn(),
 };
 
-beforeEach(() => {
-  mockReplies = [];
-});
-
 describe('GhostThreadPointer', () => {
   it('shows the original message text (not just the reply count)', () => {
-    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const { getByText } = render(
       <GhostThreadPointer
         {...baseProps}
@@ -89,56 +76,29 @@ describe('GhostThreadPointer', () => {
     expect(getByText('2 replies')).toBeTruthy();
   });
 
-  it('left-aligns with the original author avatar + name when SOMEONE ELSE sent the last reply', () => {
-    // Original authored by me, but the newest reply is from someone else →
-    // the preview follows the last replier onto the LEFT, showing the original
-    // author's identity. Proves alignment keys off the replier, not the author.
-    mockReplies = [
-      { senderId: ME, createdAt: 1 },
-      { senderId: SOMEONE_ELSE, createdAt: 2 },
-    ];
+  it('left-aligns with the sender avatar + name when someone else authored the original', () => {
+    // Alignment keys off the ORIGINAL message's author (the approved spec):
+    // someone else wrote it → left, showing their avatar + name.
     const { getByTestId, getByText } = render(
-      <GhostThreadPointer
-        {...baseProps}
-        originalContent="Who's bringing snacks?"
-        originalSenderId={ME}
-        senderName="Samuel Baker"
-        senderProfilePhoto="https://example.com/samuel.jpg"
-      />,
-    );
-
-    expect(getByText('Samuel Baker')).toBeTruthy();
-    expect(getByTestId('ghost-avatar')).toBeTruthy();
-  });
-
-  it('right-aligns with no avatar/name when the CURRENT USER sent the last reply', () => {
-    // Original authored by someone else, but I sent the newest reply → the
-    // preview follows me onto the RIGHT (no avatar/name). The inverse proof.
-    mockReplies = [
-      { senderId: SOMEONE_ELSE, createdAt: 1 },
-      { senderId: ME, createdAt: 2 },
-    ];
-    const { queryByTestId, queryByText, getByText } = render(
       <GhostThreadPointer
         {...baseProps}
         originalContent="Who's bringing snacks?"
         originalSenderId={SOMEONE_ELSE}
         senderName="Samuel Baker"
+        senderProfilePhoto="https://example.com/samuel.jpg"
       />,
     );
 
-    // The text still shows…
-    expect(getByText("Who's bringing snacks?")).toBeTruthy();
-    // …but there's no avatar and no sender-name label on your own side.
-    expect(queryByTestId('ghost-avatar')).toBeNull();
-    expect(queryByText('Samuel Baker')).toBeNull();
+    // Avatar + sender name are shown for other-authored previews (the mock's
+    // left-aligned treatment). The own-authored test asserts the inverse.
+    expect(getByText('Samuel Baker')).toBeTruthy();
+    expect(getByTestId('ghost-avatar')).toBeTruthy();
   });
 
-  it('falls back to the original author side before any replies have loaded', () => {
-    // No replies loaded yet → align by the original author. Here that is me,
-    // so the preview is right-aligned (no avatar/name).
-    mockReplies = [];
-    const { queryByTestId } = render(
+  it('right-aligns with no avatar/name when the current user authored the original', () => {
+    // I wrote the original → right side, no avatar/name (like my own message
+    // rows). This is the inverse of the other-authored case above.
+    const { queryByTestId, queryByText, getByText } = render(
       <GhostThreadPointer
         {...baseProps}
         originalContent="Can we move it to 7:30 instead?"
@@ -147,25 +107,14 @@ describe('GhostThreadPointer', () => {
       />,
     );
 
+    // The text still shows…
+    expect(getByText('Can we move it to 7:30 instead?')).toBeTruthy();
+    // …but there's no avatar and no sender-name label for your own message.
     expect(queryByTestId('ghost-avatar')).toBeNull();
-  });
-
-  it('renders a connector line linking the bubble to the replies pill', () => {
-    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
-    const { getByTestId } = render(
-      <GhostThreadPointer
-        {...baseProps}
-        originalContent="Who's bringing snacks?"
-        originalSenderId={SOMEONE_ELSE}
-        senderName="Samuel Baker"
-      />,
-    );
-
-    expect(getByTestId(`ghost-thread-connector-${PARENT_ID}`)).toBeTruthy();
+    expect(queryByText('Me')).toBeNull();
   });
 
   it('shows a placeholder for an image-only original', () => {
-    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const { getByText } = render(
       <GhostThreadPointer
         {...baseProps}
@@ -180,7 +129,6 @@ describe('GhostThreadPointer', () => {
   });
 
   it('shows the deleted-message treatment for a deleted original', () => {
-    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const { getByText } = render(
       <GhostThreadPointer
         {...baseProps}
@@ -195,7 +143,6 @@ describe('GhostThreadPointer', () => {
   });
 
   it('tapping the "N replies" pill opens the thread (not scroll-to-original)', () => {
-    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const onOpenThread = jest.fn();
     const onScrollToOriginal = jest.fn();
     const { getByTestId } = render(
@@ -216,7 +163,6 @@ describe('GhostThreadPointer', () => {
   });
 
   it('tapping the bubble body scrolls up to the original message', () => {
-    mockReplies = [{ senderId: SOMEONE_ELSE, createdAt: 1 }];
     const onOpenThread = jest.fn();
     const onScrollToOriginal = jest.fn();
     const { getByTestId } = render(

--- a/apps/mobile/features/chat/utils/__tests__/threadTimeline.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/threadTimeline.test.ts
@@ -6,8 +6,8 @@ import {
 
 /**
  * The chat orders top-level messages by `createdAt` so replying no longer moves
- * the real message. Instead, each replied-to message floats a content-free
- * "ghost" pointer at its `lastActivityAt` slot. These tests pin down that
+ * the real message. Instead, each replied-to message floats a "ghost" pointer
+ * (an echo of the original) at its `lastActivityAt` slot. These tests pin down that
  * derivation: the real message stays put, and exactly one ghost is emitted per
  * bumped thread at the right position.
  */

--- a/apps/mobile/features/chat/utils/threadTimeline.ts
+++ b/apps/mobile/features/chat/utils/threadTimeline.ts
@@ -4,8 +4,8 @@
  * The chat now orders top-level messages by `createdAt` (see the `getMessages`
  * backend query), so replying to a message no longer floats the real message to
  * the bottom. To keep recent thread activity visible without moving the real
- * message, we float a content-free "ghost" pointer at the thread's latest
- * activity slot (`lastActivityAt`).
+ * message, we float a "ghost" pointer — an echo of the original message — at
+ * the thread's latest activity slot (`lastActivityAt`).
  *
  * This module holds the *pure* derivation so it can be unit-tested independently
  * of React / FlatList: given the server messages (already ordered by


### PR DESCRIPTION
## What & why

The floating **"ghost" thread preview** in a channel (Inbox → group → **General**) echoes a bumped thread's original message. The **approved spec** requires it to align **like a real message row, by the original message's author** — right (your side, no avatar) when *you* wrote the original, left (with the author's avatar + name) when someone else did — and explicitly says alignment "must key off the original message's author, not the last replier."

An earlier revision on this branch instead aligned by the thread's **last replier** and added a connector line, based on newer staging feedback. Code review flagged that this **reverses the approved spec** (a change that needs a maintainer's sign-off, not a silent supersede) and that the last-replier logic had a **real correctness bug**: it read the newest of only the *oldest 10* replies (`getThreadReplies` is `order("asc").take(10)`), so threads with >10 replies aligned to the wrong side.

This revision **conforms the PR to the approved spec**, which resolves both issues at once.

## How

- **Align by the original author.** `GhostThreadPointer` now computes `alignRight = originalSenderId === currentUserId` (mirroring `MessageItem`'s own-vs-other rule) and no longer fetches thread replies. Removing `useThreadReplies` eliminates the >10-reply ordering bug entirely — there is no reply window to get wrong.
- **Removed the connector line** (it was beyond the approved spec, which scoped this to original-message text + author alignment).
- Preserved from the prior change: the echoed original text (truncated to 2 lines), the image-/attachment-only placeholder, the deleted-message treatment, and both tap targets (pill → open thread; bubble body → scroll to the real original).
- Refreshed the `GhostThreadPointer` header comment and the `MessageList` comment to describe author-based alignment.

## Tests

`features/chat/components/__tests__/GhostThreadPointer.test.tsx` now asserts alignment follows **authorship** in both directions (author = current user → right, no avatar/name; author = someone else → left, with avatar + name), plus the text/placeholder/deleted/tap cases. Dropped the last-replier and connector cases and the `useThreadReplies` mock. Full mobile suite green locally (1273 passed).

## ⚠️ Note for the maintainer

The contributor's staging feedback asked for **last-reply alignment + a connector line**. That is **intentionally not implemented here**, because it contradicts the approved spec and a fix run shouldn't override an approved spec on its own. **If that behavior is what's actually wanted, it needs a spec revision** — and building it that way would also let the "true last replier" be fetched correctly (backend support for the newest reply), instead of the buggy oldest-10 reduce.

Dashboard item: bug `x97fyhqp4ccdme5588vkt7gsvh8ac91n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)