### PR TITLE
Show cross-team groups in the serving-mode inbox

### DIFF
--- a/apps/convex/__tests__/scheduling/crossTeamChannels.test.ts
+++ b/apps/convex/__tests__/scheduling/crossTeamChannels.test.ts
@@ -779,3 +779,150 @@ describe("cross-team channel — serving-mode inbox resolution", () => {
     expect(ids).not.toContain(world.crossChannelId);
   });
 });
+
+/** Does the serving-mode inbox contain the given channel for this user? */
+async function servingInboxHasChannel(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  planId: Id<"eventPlans">,
+  channelId: Id<"chatChannels">,
+): Promise<boolean> {
+  const token = (await generateTokens(userId)).accessToken;
+  const inbox = await t.query(
+    api.functions.messaging.channels.getInboxChannels,
+    { token, servingPlanId: planId },
+  );
+  return inbox.some((s) => s.channels.some((c) => c._id === channelId));
+}
+
+/**
+ * End-to-end serving-inbox coverage: `getInboxChannels` in serving mode must
+ * surface a cross-team group the volunteer belongs to, for BOTH topologies —
+ * a same-group channel whose owning group the volunteer isn't a member of, and
+ * a cross-GROUP channel that lives in another group entirely. These exercise
+ * the two independent backend gaps together: the `cross_team` supplement branch
+ * in `getInboxChannels` and the community-wide resolution in
+ * `resolveServingChannelIds`.
+ */
+describe("cross-team channel — serving-mode inbox (getInboxChannels)", () => {
+  it("surfaces a same-group cross-team channel to a serving volunteer who is not in the owning group", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 3);
+    // techUserId is rostered on the tech team (tying it to the plan) but is not
+    // a groupMembers member of the channel's owning group — membership on the
+    // cross-team channel arrives purely via the auto-sync below.
+    await insertAssignment(t, world, {
+      planId,
+      teamId: world.techTeamId,
+      roleId: world.techRoleId,
+      userId: world.techUserId,
+      eventDate: Date.now() + 3 * DAY,
+      status: "confirmed",
+    });
+    await reconcileCross(t, world);
+
+    // Precondition: the volunteer really isn't a member of the owning group, so
+    // the channel can only reach the inbox via the cross-team supplement path.
+    const groupMembership = await t.run((ctx) =>
+      ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", world.techUserId),
+        )
+        .first(),
+    );
+    expect(groupMembership).toBeNull();
+    expect(
+      (await crossMemberIds(t, world)).has(world.techUserId),
+    ).toBe(true);
+
+    expect(
+      await servingInboxHasChannel(
+        t,
+        world.techUserId,
+        planId,
+        world.crossChannelId,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not surface the cross-team channel to a volunteer who is not a synced member", async () => {
+    const { t, world } = await setupCrossTeamWorld();
+    const planId = await insertPlan(t, world, 3);
+    // techUserId is rostered (so the channel resolves into the plan's serving
+    // set), but the outsider has no synced membership row for it.
+    await insertAssignment(t, world, {
+      planId,
+      teamId: world.techTeamId,
+      roleId: world.techRoleId,
+      userId: world.techUserId,
+      eventDate: Date.now() + 3 * DAY,
+      status: "confirmed",
+    });
+    await reconcileCross(t, world);
+
+    expect(
+      await servingInboxHasChannel(
+        t,
+        world.outsiderId,
+        planId,
+        world.crossChannelId,
+      ),
+    ).toBe(false);
+  });
+
+  it("surfaces a cross-GROUP cross-team channel (channel lives in another group) in serving mode", async () => {
+    const { t, base, groupBId, teamBId, roleBId, groupBRosteredId } =
+      await setupCrossGroupWorld();
+    const { accessToken } = await generateTokens(base.groupLeaderId);
+
+    // A cross-team channel created in the BASE group but sourcing team B, which
+    // lives in group B. It's shared into group B; the plan below is in group B.
+    const { channelId } = await t.mutation(
+      api.functions.scheduling.crossTeamChannels.createCrossTeamChannel,
+      {
+        token: accessToken,
+        groupId: base.groupId,
+        name: "Broadcast",
+        selectors: [{ sourceTeamId: teamBId, roleId: roleBId }],
+      },
+    );
+
+    const eventDate = Date.now() + 3 * DAY;
+    const planBId = await t.run(async (ctx) => {
+      const planId = await ctx.db.insert("eventPlans", {
+        groupId: groupBId,
+        communityId: base.communityId,
+        title: "Sunday Service",
+        eventDate,
+        times: [{ label: "9 AM", startsAt: eventDate }],
+        status: "draft",
+        createdById: base.groupLeaderId,
+        createdAt: ts(),
+        updatedAt: ts(),
+      });
+      await ctx.db.insert("roleAssignments", {
+        planId,
+        teamId: teamBId,
+        roleId: roleBId,
+        userId: groupBRosteredId,
+        eventDate,
+        status: "confirmed",
+        assignedById: base.groupLeaderId,
+        assignedAt: Date.now(),
+      });
+      return planId;
+    });
+    await t.mutation(
+      internal.functions.scheduling.teamChannelSync.reconcileCrossTeamChannel,
+      { channelId },
+    );
+
+    // The plan is in group B but the channel is owned by the base group — only
+    // the community-wide resolution in resolveServingChannelIds lets it into the
+    // plan's serving set, so the serving flatten can keep it.
+    expect(
+      await servingInboxHasChannel(t, groupBRosteredId, planBId, channelId),
+    ).toBe(true);
+  });
+});

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1622,9 +1622,11 @@ export const getInboxChannels = query({
     // Find shared channels from user's memberships that aren't already in allChannels.
     // These are channels owned by other groups but shared with one of the user's groups.
     const allChannelIds = new Set(allChannels.map((ch) => ch._id));
-    // Track event channels picked up from chatChannelMembers so we can ensure
-    // their owning group appears in validGroups / groupRoleMap below.
-    const eventChannelsToInclude: Doc<"chatChannels">[] = [];
+    // Channels picked up from chatChannelMembers whose owning group the user is
+    // NOT in (event channels always; cross-team channels only in serving mode),
+    // so we can ensure that owning group appears in validGroups / groupRoleMap
+    // below and the grouping step picks the channel up.
+    const nonGroupChannelsToInclude: Doc<"chatChannels">[] = [];
     for (const membership of userChannelMemberships) {
       if (allChannelIds.has(membership.channelId)) continue;
       const candidateChannel = await ctx.db.get(membership.channelId);
@@ -1644,7 +1646,26 @@ export const getInboxChannels = query({
         const lastMessageAt = candidateChannel.lastMessageAt ?? 0;
         if (lastMessageAt <= 0) continue;
         if (lastMessageAt < inboxQueryNow - INBOX_EVENT_HIDE_AFTER_MS) continue;
-        eventChannelsToInclude.push(candidateChannel);
+        nonGroupChannelsToInclude.push(candidateChannel);
+        continue;
+      }
+
+      // Cross-team channels in SERVING MODE: membership is auto-synced from
+      // serving-role assignments (a rostered volunteer gets a chatChannelMembers
+      // row without being a member of the channel's home group), so a same-group
+      // channel the volunteer isn't a group member of never arrives via the
+      // group-owned fetch above. When it's one of this plan's resolved serving
+      // channels, pull it into the candidate list so the serving flatten can
+      // surface it. This branch is gated on serving mode (`servingChannelIds`)
+      // so the normal inbox is left byte-for-byte unchanged — outside serving
+      // mode a cross-team channel still falls through to the isShared branch
+      // below exactly as before. The flatten still filters by servingChannelIds
+      // and this loop only ever sees channels the user has an active membership
+      // row for, so nothing leaks to a non-member.
+      if (candidateChannel.channelType === "cross_team" && servingChannelIds) {
+        if (servingChannelIds.has(candidateChannel._id)) {
+          nonGroupChannelsToInclude.push(candidateChannel);
+        }
         continue;
       }
 
@@ -1680,11 +1701,11 @@ export const getInboxChannels = query({
       }
     }
 
-    // Event channels: surface every enabled event channel the user is a member
-    // of, even when they're not a member of the owning group. We fetch the
-    // owning group (and its group type) on demand and add it to validGroups
-    // so the normal grouping step picks the channel up.
-    for (const eventChannel of eventChannelsToInclude) {
+    // Surface each collected channel (enabled event channels always; serving
+    // cross-team channels) even when the user isn't a member of the owning
+    // group. We fetch the owning group (and its group type) on demand and add
+    // it to validGroups so the normal grouping step picks the channel up.
+    for (const eventChannel of nonGroupChannelsToInclude) {
       if (!eventChannel.groupId) continue; // Skip ad-hoc channels (DM/group_dm)
       const ecGroupId = eventChannel.groupId;
       const owningGroup = allGroups.find((g) => g && g._id === ecGroupId)

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -94,18 +94,19 @@ export async function resolveServingChannelIds(
   // (c) Cross-team channels that draw from any team on this plan. Their
   // membership is auto-synced (syncSource "event_plan") from the same
   // roleAssignments, so a rostered member belongs in the serving inbox too.
-  // Scoped to the plan's group via `by_group_type` (cross-team channels live
-  // in the same group as the plan's teams) to avoid a full-table scan. This is
-  // membership-agnostic like the team-channel branch above: the serving
-  // flatten in messaging/channels.ts only iterates channels already in the
-  // per-user, active-membership-gated result, so widening this Set leaks
-  // nothing — only users with an active chatChannelMembers row actually see
-  // the channel.
+  // Resolved community-wide by the channel's `crossTeamSync.selectors[]`
+  // `sourceTeamId` matching a team on the plan — NOT scoped to `plan.groupId`,
+  // because a cross-team channel can be created in one group while sourcing a
+  // team that lives in another group, so a plan-group scope would drop those
+  // cross-group channels. This mirrors the sibling `getServingUpcomingChannels`
+  // (cross-team channels are rare, so a filtered scan is fine). It's
+  // membership-agnostic like the team-channel branch above: the serving flatten
+  // in messaging/channels.ts only iterates channels already in the per-user,
+  // active-membership-gated result, so widening this Set leaks nothing — only
+  // users with an active chatChannelMembers row actually see the channel.
   const crossTeamChannels = await ctx.db
     .query("chatChannels")
-    .withIndex("by_group_type", (q) =>
-      q.eq("groupId", plan.groupId).eq("channelType", "cross_team"),
-    )
+    .filter((q) => q.eq(q.field("channelType"), "cross_team"))
     .collect();
   for (const ch of crossTeamChannels) {
     if (ch.isArchived === true) continue;


### PR DESCRIPTION
## What this fixes

**Serving Mode** is the focused, day-of view a volunteer switches into on the day they're serving — it replaces the normal Inbox with a slimmed-down list of just the group chats that matter for *today's* event.

A **cross-team group** is a special group chat whose members are pulled from *several* serving teams at once (e.g. a "Service Leads" chat that automatically includes the leaders of the Worship Team and the Tech Team). Its membership is auto-synced from who's rostered — nobody adds people by hand.

Today these cross-team groups **did not appear in the serving-mode inbox**, even when the volunteer belonged to one and it was tied to the event they were serving — leaving them without a chat they expected to see on the busiest part of their day. This PR makes the cross-team group show up as one more row in the serving inbox, styled exactly like the other team-chat rows. **No new UI** — a row that should have been there now is.

## Why it happened — two independent backend gaps, both closed

1. **Candidate never included** — `getInboxChannels` (`apps/convex/functions/messaging/channels.ts`) builds the inbox from the groups the user belongs to, then supplements it with channels the user is a member of but whose owning group they're *not* in. That supplement had branches for `event` and `isShared` channels but **none for `cross_team`**, so a same-group cross-team channel the volunteer wasn't a group member of never entered the candidate list — and the serving flatten (which only re-filters that list) couldn't bring it back. Added a `cross_team` branch **gated on serving mode**, so the normal (non-serving) inbox is left byte-for-byte unchanged.

2. **Allow-set was group-scoped** — `resolveServingChannelIds` (`apps/convex/functions/scheduling/serving.ts`) built the set of channels allowed into the serving inbox by scanning cross-team channels **scoped to the plan's group**. A cross-team channel can be created in one group while sourcing a team in *another* group, so such a cross-group channel was never in the allow-set and got filtered out. Now resolved **community-wide** by the channel's `crossTeamSync` selectors' `sourceTeamId` matching a team on the plan — mirroring the sibling `getServingUpcomingChannels` helper.

## Safety / edge cases

- **Membership gating unchanged** — the serving flatten only ever iterates channels the user has an active `chatChannelMembers` row for, so a non-member still can't see the chat.
- **Archived** cross-team channels stay hidden (existing `isArchived` guard).
- **No normal-inbox regression** — the new branch is gated on serving mode; outside serving mode a cross-team channel still falls through to the `isShared` branch exactly as before. Verified by the pre-existing normal-inbox test (which caught an early version of this change and now passes).

## Tests

Added serving-mode `getInboxChannels` coverage in `crossTeamChannels.test.ts`:
- same-group cross-team channel surfaced to a volunteer **not** in the owning group,
- cross-**group** cross-team channel surfaced (channel lives in another group),
- non-member negative case (does not see it).

All convex suites pass (865 tests) and type-check is clean; the mobile suite ran clean on push (1273 tests).

## Verification

This is a backend change to the inbox query; the tests drive the exact `getInboxChannels` serving-mode paths end-to-end for both topologies. The environment has no iOS simulator, so no device capture — the before/after of the row appearing matches the originator's attached mock (a rendered approximation of the serving-inbox layout, not a device screenshot).

Dashboard item: `x97dwheqxp6b6tg52f7tymdk198acrga`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM9v2CJy58xqSX5q6ns657)_