### PR TITLE
Leaders' & co-leads' DMs skip the "message request" step

### DIFF
--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -127,6 +127,66 @@ async function getMember(
   });
 }
 
+async function createGroup(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+): Promise<Id<"groups">> {
+  return await t.run(async (ctx) => {
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: `sg-${Math.floor(Math.random() * 1_000_000)}`,
+      isActive: true,
+      displayOrder: 0,
+      createdAt: Date.now(),
+    });
+    return await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Test Group",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isArchived: false,
+    });
+  });
+}
+
+async function addGroupMember(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  userId: Id<"users">,
+  role: "leader" | "member",
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId,
+      role,
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+  });
+}
+
+/** Promote a user's community membership to admin (roles >= 3, active). */
+async function makeCommunityAdmin(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+): Promise<void> {
+  await t.run(async (ctx) => {
+    const row = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", userId).eq("communityId", communityId),
+      )
+      .first();
+    if (row) {
+      await ctx.db.patch(row._id, { roles: 3, status: 1 });
+    }
+  });
+}
+
 // ============================================================================
 // createOrGetDirectChannel
 // ============================================================================
@@ -1613,5 +1673,182 @@ describe("removeAdHocMember", () => {
     // B is still active — sanity: their membership is intact.
     const bMember = await getMember(t, channelId, bId);
     expect(bMember?.leftAt).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Leader / co-lead DMs skip the "message request" step
+// ============================================================================
+
+describe("createOrGetDirectChannel — leader/co-lead DMs skip the request", () => {
+  const DM = api.functions.messaging.directMessages.createOrGetDirectChannel;
+
+  test("group leader → member: recipient row is accepted, not pending", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Leader DM Community");
+    const { userId: leaderId, accessToken: leaderToken } =
+      await createUserInCommunity(t, communityId, { firstName: "Leah" });
+    const { userId: memberId } = await createUserInCommunity(t, communityId, {
+      firstName: "Mel",
+    });
+    const groupId = await createGroup(t, communityId);
+    await addGroupMember(t, groupId, leaderId, "leader");
+    await addGroupMember(t, groupId, memberId, "member");
+
+    const { channelId } = await t.mutation(DM, {
+      token: leaderToken,
+      communityId,
+      recipientUserId: memberId,
+    });
+
+    const recipient = await getMember(t, channelId, memberId);
+    expect(recipient?.requestState).toBe("accepted");
+    // Sender is always accepted.
+    const sender = await getMember(t, channelId, leaderId);
+    expect(sender?.requestState).toBe("accepted");
+  });
+
+  test("co-leader → co-leader: recipient row is accepted", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Co-lead Community");
+    const { userId: aId, accessToken: aToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Ava" },
+    );
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Ben",
+    });
+    const groupId = await createGroup(t, communityId);
+    await addGroupMember(t, groupId, aId, "leader");
+    await addGroupMember(t, groupId, bId, "leader");
+
+    const { channelId } = await t.mutation(DM, {
+      token: aToken,
+      communityId,
+      recipientUserId: bId,
+    });
+
+    expect((await getMember(t, channelId, bId))?.requestState).toBe("accepted");
+  });
+
+  test("community admin → member: recipient row is accepted", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Admin DM Community");
+    const { userId: adminId, accessToken: adminToken } =
+      await createUserInCommunity(t, communityId, { firstName: "Ada" });
+    const { userId: memberId } = await createUserInCommunity(t, communityId, {
+      firstName: "Moe",
+    });
+    await makeCommunityAdmin(t, communityId, adminId);
+
+    const { channelId } = await t.mutation(DM, {
+      token: adminToken,
+      communityId,
+      recipientUserId: memberId,
+    });
+
+    expect((await getMember(t, channelId, memberId))?.requestState).toBe(
+      "accepted",
+    );
+  });
+
+  test("member → their leader stays a request (one-way)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "One-way Community");
+    const { userId: leaderId } = await createUserInCommunity(t, communityId, {
+      firstName: "Leah",
+    });
+    const { userId: memberId, accessToken: memberToken } =
+      await createUserInCommunity(t, communityId, { firstName: "Mel" });
+    const groupId = await createGroup(t, communityId);
+    await addGroupMember(t, groupId, leaderId, "leader");
+    await addGroupMember(t, groupId, memberId, "member");
+
+    // The plain member initiates the DM to their leader.
+    const { channelId } = await t.mutation(DM, {
+      token: memberToken,
+      communityId,
+      recipientUserId: leaderId,
+    });
+
+    expect((await getMember(t, channelId, leaderId))?.requestState).toBe(
+      "pending",
+    );
+  });
+
+  test("no relationship: recipient row stays pending", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Stranger Community");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "Bob",
+    });
+
+    const { channelId } = await t.mutation(DM, {
+      token: aToken,
+      communityId,
+      recipientUserId: bId,
+    });
+
+    expect((await getMember(t, channelId, bId))?.requestState).toBe("pending");
+  });
+
+  test("a blocked leader still cannot start a DM", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Blocked Leader Community");
+    const { userId: leaderId, accessToken: leaderToken } =
+      await createUserInCommunity(t, communityId, { firstName: "Leah" });
+    const { userId: memberId } = await createUserInCommunity(t, communityId, {
+      firstName: "Mel",
+    });
+    const groupId = await createGroup(t, communityId);
+    await addGroupMember(t, groupId, leaderId, "leader");
+    await addGroupMember(t, groupId, memberId, "member");
+
+    // Member blocks the leader.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatUserBlocks", {
+        blockerId: memberId,
+        blockedId: leaderId,
+        createdAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.mutation(DM, {
+        token: leaderToken,
+        communityId,
+        recipientUserId: memberId,
+      }),
+    ).rejects.toThrow(/Cannot start chat/i);
+  });
+
+  test("leader DMs do not consume the 5-per-24h request allowance", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Leader Fanout Community");
+    const { userId: leaderId, accessToken: leaderToken } =
+      await createUserInCommunity(t, communityId, { firstName: "Leah" });
+    const groupId = await createGroup(t, communityId);
+    await addGroupMember(t, groupId, leaderId, "leader");
+
+    // Leader DMs 6 distinct members — one more than the 5-request cap. If leader
+    // DMs counted against the allowance, the 6th would throw.
+    for (let i = 0; i < 6; i++) {
+      const { userId: memberId } = await createUserInCommunity(t, communityId, {
+        firstName: `Member${i}`,
+      });
+      await addGroupMember(t, groupId, memberId, "member");
+      const { channelId } = await t.mutation(DM, {
+        token: leaderToken,
+        communityId,
+        recipientUserId: memberId,
+      });
+      expect((await getMember(t, channelId, memberId))?.requestState).toBe(
+        "accepted",
+      );
+    }
   });
 });

--- a/apps/convex/__tests__/messaging/events.test.ts
+++ b/apps/convex/__tests__/messaging/events.test.ts
@@ -1370,3 +1370,454 @@ describe("DM request email notifications", () => {
     expect(emailCall).toBeUndefined();
   });
 });
+
+// ============================================================================
+// Leader / co-lead DM notifications (first-message copy)
+// ============================================================================
+//
+// A leader/co-lead DM is created already-accepted, so its FIRST message lands
+// in the accepted branch of `sendAdHocMessageNotifications`. That first message
+// gets relationship-specific push copy (sender name title + relationship line)
+// plus a one-off heads-up email. Later messages fall back to the plain
+// accepted-DM push (sender name, no email).
+
+/** Seed an already-accepted 1:1 DM (recipient row `accepted`, not pending). */
+async function seedAcceptedDm(
+  t: ReturnType<typeof convexTest>,
+  opts: {
+    communityId: Id<"communities">;
+    senderId: Id<"users">;
+    recipientId: Id<"users">;
+  },
+): Promise<Id<"chatChannels">> {
+  const now = Date.now();
+  return await t.run(async (ctx) => {
+    const channelId = await ctx.db.insert("chatChannels", {
+      communityId: opts.communityId,
+      channelType: "dm",
+      name: "",
+      isAdHoc: true,
+      createdById: opts.senderId,
+      createdAt: now,
+      updatedAt: now,
+      isArchived: false,
+      memberCount: 2,
+    });
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: opts.senderId,
+      role: "admin",
+      joinedAt: now,
+      isMuted: false,
+      requestState: "accepted",
+    });
+    await ctx.db.insert("chatChannelMembers", {
+      channelId,
+      userId: opts.recipientId,
+      role: "member",
+      joinedAt: now,
+      isMuted: false,
+      requestState: "accepted",
+      invitedById: opts.senderId,
+    });
+    await ctx.db.insert("chatReadState", {
+      channelId,
+      userId: opts.recipientId,
+      lastReadAt: 0,
+      unreadCount: 0,
+    });
+    return channelId;
+  });
+}
+
+/** Give a recipient an email + push token so both channels are exercisable. */
+async function enableRecipientNotifications(
+  t: ReturnType<typeof convexTest>,
+  recipientId: Id<"users">,
+  email: string,
+  tokenTag: string,
+): Promise<void> {
+  const now = Date.now();
+  await t.run(async (ctx) => {
+    await ctx.db.patch(recipientId, {
+      email,
+      emailNotificationsEnabled: true,
+    });
+    await ctx.db.insert("pushTokens", {
+      userId: recipientId,
+      token: `ExponentPushToken[${tokenTag}]`,
+      platform: "ios",
+      environment: "staging",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+      lastUsedAt: now,
+    });
+  });
+}
+
+async function makeGroupWithMembers(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  members: Array<{ userId: Id<"users">; role: "leader" | "member" }>,
+): Promise<Id<"groups">> {
+  return await t.run(async (ctx) => {
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: `sg-${Math.floor(Math.random() * 1_000_000)}`,
+      isActive: true,
+      displayOrder: 0,
+      createdAt: Date.now(),
+    });
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Test Group",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isArchived: false,
+    });
+    for (const m of members) {
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId: m.userId,
+        role: m.role,
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    }
+    return groupId;
+  });
+}
+
+async function makeAdmin(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  userId: Id<"users">,
+): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("userCommunities", {
+      userId,
+      communityId,
+      roles: 3,
+      status: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+/** Insert a message and fire the onMessageSent fanout, draining schedules. */
+async function fireDmMessage(
+  t: ReturnType<typeof convexTest>,
+  opts: {
+    channelId: Id<"chatChannels">;
+    senderId: Id<"users">;
+    content: string;
+    senderName: string;
+  },
+): Promise<void> {
+  const messageId = await t.run(async (ctx) => {
+    return await ctx.db.insert("chatMessages", {
+      channelId: opts.channelId,
+      senderId: opts.senderId,
+      content: opts.content,
+      contentType: "text",
+      createdAt: Date.now(),
+      isDeleted: false,
+      senderName: opts.senderName,
+    });
+  });
+  await t.mutation(internal.functions.messaging.events.onMessageSent, {
+    messageId,
+    channelId: opts.channelId,
+    senderId: opts.senderId,
+  });
+  vi.runAllTimers();
+  await t.finishInProgressScheduledFunctions();
+}
+
+function pushFrom(fetchMock: ReturnType<typeof vi.fn>) {
+  const call = fetchMock.mock.calls.find((c) => c?.[0] === EXPO_PUSH_URL);
+  return call ? JSON.parse(String(call?.[1]?.body))[0] : undefined;
+}
+function emailFrom(fetchMock: ReturnType<typeof vi.fn>) {
+  const call = fetchMock.mock.calls.find((c) => c?.[0] === RESEND_EMAIL_URL);
+  return call ? JSON.parse(String(call?.[1]?.body)) : undefined;
+}
+
+describe("leader/co-lead DM notifications", () => {
+  test("group leader first DM: group-leader push + email", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    // seedTestData makes `userId` a leader and `user2Id` a member of the group.
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "member@example.com", "gl");
+    const channelId = await seedAcceptedDm(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: "Hey — welcome to the group!",
+      senderName: "Test User",
+    });
+
+    const push = pushFrom(fetchMock);
+    expect(push?.title).toBe("Test User");
+    expect(push?.body).toContain("Your group leader messaged you");
+    expect(push?.body).toContain("Hey — welcome to the group!");
+
+    const email = emailFrom(fetchMock);
+    expect(email?.subject).toBe("Your group leader Test User messaged you");
+  });
+
+  test("co-leader first DM: co-leader push + email (beats group-leader)", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Sender co-leads one group with the recipient AND leads another group the
+    // recipient is a plain member of → co-leader must win.
+    await makeGroupWithMembers(t, communityId, [
+      { userId, role: "leader" },
+      { userId: user2Id, role: "leader" },
+    ]);
+    // (seedTestData already added a group where userId=leader, user2Id=member.)
+
+    await enableRecipientNotifications(t, user2Id, "colead@example.com", "cl");
+    const channelId = await seedAcceptedDm(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: "Great co-leading with you!",
+      senderName: "Test User",
+    });
+
+    const push = pushFrom(fetchMock);
+    expect(push?.body).toContain("Your co-leader just messaged you");
+    const email = emailFrom(fetchMock);
+    expect(email?.subject).toBe("Your co-leader Test User messaged you");
+  });
+
+  test("community admin first DM (no group tie): community-leader copy", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const communityId = await t.run(async (ctx) =>
+      ctx.db.insert("communities", {
+        name: "Admin Community",
+        subdomain: "admin-c",
+        slug: "admin-c",
+        timezone: "America/New_York",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const adminId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Ada",
+        lastName: "Okafor",
+        phone: "+15555551111",
+        phoneVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const memberId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Moe",
+        lastName: "Member",
+        phone: "+15555552222",
+        phoneVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    await makeAdmin(t, communityId, adminId);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, memberId, "moe@example.com", "ca");
+    const channelId = await seedAcceptedDm(t, {
+      communityId,
+      senderId: adminId,
+      recipientId: memberId,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: adminId,
+      content: "Welcome to the community!",
+      senderName: "Ada Okafor",
+    });
+
+    const push = pushFrom(fetchMock);
+    expect(push?.body).toContain("Your community leader messaged you");
+    const email = emailFrom(fetchMock);
+    expect(email?.subject).toBe("Your community leader Ada Okafor messaged you");
+  });
+
+  test("precedence: group-leader + community-admin → group-leader copy", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    // userId leads a group user2Id is a member of (seedTestData).
+    const { userId, user2Id, communityId } = await seedTestData(t);
+    // ...AND userId is also a community admin. Group leadership must win.
+    await makeAdmin(t, communityId, userId);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "prec@example.com", "pr");
+    const channelId = await seedAcceptedDm(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: "Checking in",
+      senderName: "Test User",
+    });
+
+    const push = pushFrom(fetchMock);
+    expect(push?.body).toContain("Your group leader messaged you");
+    expect(push?.body).not.toContain("community leader");
+  });
+
+  test("later messages use the plain accepted push (no leader line, no email)", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "later@example.com", "lt");
+    const channelId = await seedAcceptedDm(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    // First message (leader copy) — then reset the mock and send a follow-up.
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: "First",
+      senderName: "Test User",
+    });
+    fetchMock.mockClear();
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: "Second message",
+      senderName: "Test User",
+    });
+
+    const push = pushFrom(fetchMock);
+    expect(push?.title).toBe("Test User");
+    expect(push?.body).toBe("Second message");
+    expect(push?.body).not.toContain("group leader");
+    // No email on follow-ups.
+    expect(emailFrom(fetchMock)).toBeUndefined();
+  });
+
+  test("non-leader accepted DM first message: plain push, no leader copy", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    // Two users with NO group/admin tie between them.
+    const communityId = await t.run(async (ctx) =>
+      ctx.db.insert("communities", {
+        name: "Plain Community",
+        subdomain: "plain-c",
+        slug: "plain-c",
+        timezone: "America/New_York",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const aId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Alice",
+        lastName: "A",
+        phone: "+15555553333",
+        phoneVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const bId = await t.run(async (ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Bob",
+        lastName: "B",
+        phone: "+15555554444",
+        phoneVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, bId, "bob@example.com", "np");
+    // Accepted DM but no relationship → the "recipient accepted an empty
+    // request first" case: falls through to the normal accepted push.
+    const channelId = await seedAcceptedDm(t, {
+      communityId,
+      senderId: aId,
+      recipientId: bId,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: aId,
+      content: "Hello there",
+      senderName: "Alice A",
+    });
+
+    const push = pushFrom(fetchMock);
+    expect(push?.title).toBe("Alice A");
+    expect(push?.body).toBe("Hello there");
+    expect(emailFrom(fetchMock)).toBeUndefined();
+  });
+});

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -20,6 +20,7 @@ import { requireAuth } from "../../lib/auth";
 import { checkRateLimit } from "../../lib/rateLimit";
 import { getDisplayName, getMediaUrl, normalizePhone } from "../../lib/utils";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
+import { getLeaderDmRelationship } from "../../lib/leaderDm";
 
 // ============================================================================
 // Constants
@@ -270,13 +271,28 @@ export const createOrGetDirectChannel = mutation({
       throw new Error("Recipient not found");
     }
 
-    // Rate-limit new pending DM requests.
-    await checkRateLimit(
+    // A leadership tie (sender → recipient) turns this DM into a normal,
+    // already-accepted conversation instead of a request. Evaluated after the
+    // block/membership gates and community-scoped to this DM's community.
+    const leaderRelationship = await getLeaderDmRelationship(
       ctx,
-      `dm-init:${senderId}`,
-      NEW_REQUEST_LIMIT,
-      NEW_REQUEST_WINDOW_MS,
+      args.communityId,
+      senderId,
+      args.recipientUserId,
     );
+    const isLeaderDm = leaderRelationship !== "none";
+
+    // Rate-limit new pending DM *requests*. Leader/co-lead DMs are delivered
+    // accepted (not requests), and a leader reaching their own members/co-leads
+    // is expected, so they don't count against the sender's 5-per-24h allowance.
+    if (!isLeaderDm) {
+      await checkRateLimit(
+        ctx,
+        `dm-init:${senderId}`,
+        NEW_REQUEST_LIMIT,
+        NEW_REQUEST_WINDOW_MS,
+      );
+    }
 
     const recipient = recipientUser;
     const sender = await ctx.db.get(senderId);
@@ -315,7 +331,10 @@ export const createOrGetDirectChannel = mutation({
       role: "member",
       joinedAt: now,
       isMuted: false,
-      requestState: "pending",
+      // Leader/co-lead DMs skip the request step: the recipient's row starts
+      // accepted so the thread lands in Messages, not Requests. Everyone else
+      // starts pending as before.
+      requestState: isLeaderDm ? "accepted" : "pending",
       invitedById: senderId,
       displayName: getDisplayName(recipient.firstName, recipient.lastName),
       profilePhoto: recipient.profilePhoto,

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -16,13 +16,55 @@ import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { getChannelSlug } from "../../lib/slugs";
 import { notifyBatch } from "../../lib/notifications/send";
-import { chatRequestEmail } from "../../lib/notifications/emailTemplates";
+import {
+  chatRequestEmail,
+  leaderDmEmail,
+} from "../../lib/notifications/emailTemplates";
+import {
+  getLeaderDmRelationship,
+  type LeaderDmRelationship,
+} from "../../lib/leaderDm";
 
 // ============================================================================
 // Constants
 // ============================================================================
 
 const MAX_PREVIEW_LENGTH = 100;
+
+/**
+ * First-message notification copy per leadership relationship. The push keeps
+ * the sender's name as its title and uses this relationship line (plus the
+ * message preview) as the body; the email uses the matching subject and body.
+ * Only a leader/co-lead's FIRST DM uses this copy — later messages fall back to
+ * the standard accepted-DM push. Wording is adjustable at approval.
+ */
+const LEADER_DM_COPY: Record<
+  Exclude<LeaderDmRelationship, "none">,
+  {
+    pushLine: string;
+    emailLabel: string;
+    emailBodyLine: (senderName: string) => string;
+  }
+> = {
+  co_leader: {
+    pushLine: "Your co-leader just messaged you",
+    emailLabel: "co-leader",
+    emailBodyLine: (s) =>
+      `${s}, who co-leads a group with you, just sent you a message on Togather.`,
+  },
+  group_leader: {
+    pushLine: "Your group leader messaged you",
+    emailLabel: "group leader",
+    emailBodyLine: (s) =>
+      `${s} leads a group you're in and just sent you a message on Togather.`,
+  },
+  community_admin: {
+    pushLine: "Your community leader messaged you",
+    emailLabel: "community leader",
+    emailBodyLine: (s) =>
+      `${s}, an admin of your community, just sent you a message on Togather.`,
+  },
+};
 
 // ============================================================================
 // Notification routing
@@ -348,6 +390,37 @@ export const onMessageSent = internalMutation({
           .first();
         const isInitialRequestMessage = firstMessage?._id === args.messageId;
 
+        // On the opening message of a 1:1 DM, work out whether each accepted
+        // recipient has a leadership tie to the sender. Leader/co-lead DMs are
+        // created already-accepted, so their first message is exactly
+        // `accepted && isInitialRequestMessage` — the re-check here
+        // distinguishes them from the rare "recipient accepted an empty
+        // request first" case (which returns "none" and falls through to the
+        // normal accepted push). Group DMs are out of scope, and follow-up
+        // messages never carry the special copy.
+        const leaderRelationships: Array<{
+          userId: Id<"users">;
+          relationship: "co_leader" | "group_leader" | "community_admin";
+        }> = [];
+        if (
+          isInitialRequestMessage &&
+          channel.channelType === "dm" &&
+          args.senderId &&
+          channel.communityId
+        ) {
+          for (const recipientId of acceptedRecipients) {
+            const relationship = await getLeaderDmRelationship(
+              ctx,
+              channel.communityId,
+              args.senderId,
+              recipientId,
+            );
+            if (relationship !== "none") {
+              leaderRelationships.push({ userId: recipientId, relationship });
+            }
+          }
+        }
+
         await ctx.scheduler.runAfter(
           0,
           internal.functions.messaging.events.sendAdHocMessageNotifications,
@@ -361,6 +434,7 @@ export const onMessageSent = internalMutation({
             pendingRecipients,
             acceptedRecipients,
             isInitialRequestMessage,
+            leaderRelationships,
           },
         );
       } else {
@@ -553,6 +627,23 @@ export const sendAdHocMessageNotifications = internalAction({
      * conversation doesn't email on every message.
      */
     isInitialRequestMessage: v.optional(v.boolean()),
+    /**
+     * Accepted recipients (on the opening message of a 1:1 DM) who have a
+     * leadership tie to the sender. Their first message gets relationship-
+     * specific push + email copy instead of the generic accepted-DM push.
+     */
+    leaderRelationships: v.optional(
+      v.array(
+        v.object({
+          userId: v.id("users"),
+          relationship: v.union(
+            v.literal("co_leader"),
+            v.literal("group_leader"),
+            v.literal("community_admin"),
+          ),
+        }),
+      ),
+    ),
   },
   handler: async (ctx, args) => {
     console.log(
@@ -657,16 +748,60 @@ export const sendAdHocMessageNotifications = internalAction({
       }
     }
 
-    // Accepted recipients: standard accepted-chat copy.
+    // Accepted recipients: standard accepted-chat copy, except a leader/co-lead's
+    // FIRST DM, which gets relationship-specific copy plus a one-off heads-up
+    // email (normal accepted DMs stay push-only). `leaderRelationships` is only
+    // populated on the opening message, so every later message lands here with
+    // an empty map and uses the standard push.
     if (args.acceptedRecipients.length > 0) {
+      const relationshipByUser = new Map(
+        (args.leaderRelationships ?? []).map((r) => [r.userId, r.relationship]),
+      );
       for (const userId of args.acceptedRecipients) {
-        await sendAdHocPushToUser(ctx, {
-          userId,
-          title: acceptedTitle,
-          body: previewBody,
-          data: { ...baseData, requestState: "accepted" },
-          communityId: args.communityId,
-        });
+        const relationship = args.isInitialRequestMessage
+          ? relationshipByUser.get(userId)
+          : undefined;
+
+        if (relationship) {
+          const copy = LEADER_DM_COPY[relationship];
+          // Push: sender name as the title, relationship line + preview as the
+          // body so the recipient sees why the sender is in their inbox.
+          const leaderBody =
+            previewBody.length > 0
+              ? `${copy.pushLine} · ${previewBody}`
+              : copy.pushLine;
+          const userInfo = await ctx.runQuery(
+            internal.functions.notifications.internal.getUserEmailInfo,
+            { userId },
+          );
+          const emailHtml = leaderDmEmail({
+            senderName: args.senderName,
+            relationshipLabel: copy.emailLabel,
+            bodyLine: copy.emailBodyLine(args.senderName),
+            messagePreview: args.messagePreview,
+            firstName: userInfo?.firstName,
+          });
+          await sendAdHocPushToUser(ctx, {
+            userId,
+            title: args.senderName,
+            body: leaderBody,
+            data: { ...baseData, requestState: "accepted" },
+            communityId: args.communityId,
+            requestEmail: {
+              subject: `Your ${copy.emailLabel} ${args.senderName} messaged you`,
+              htmlBody: emailHtml,
+              notificationType: "chat_request",
+            },
+          });
+        } else {
+          await sendAdHocPushToUser(ctx, {
+            userId,
+            title: acceptedTitle,
+            body: previewBody,
+            data: { ...baseData, requestState: "accepted" },
+            communityId: args.communityId,
+          });
+        }
       }
     }
   },

--- a/apps/convex/lib/leaderDm.ts
+++ b/apps/convex/lib/leaderDm.ts
@@ -1,0 +1,91 @@
+/**
+ * Leadership relationship (DM sender → recipient).
+ *
+ * Used to decide whether a 1:1 DM skips the "message request" step and which
+ * first-message notification copy to use. A DM from someone with a leadership
+ * tie to the recipient lands as a normal (accepted) DM instead of a pending
+ * request, and its first message carries relationship-specific copy so the
+ * recipient understands why the sender is suddenly in their inbox.
+ */
+
+import type { Id } from "../_generated/dataModel";
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+import { isActiveLeader, isActiveMembership } from "./helpers";
+import { isCommunityAdmin } from "./permissions";
+
+/**
+ * The kinds of leadership relationship a DM sender can have with the recipient,
+ * in precedence order (first match wins): a co-leader of a shared group beats a
+ * group leader, which beats a community admin. "none" means no relationship —
+ * the DM behaves exactly as a normal request.
+ */
+export type LeaderDmRelationship =
+  | "co_leader"
+  | "group_leader"
+  | "community_admin"
+  | "none";
+
+/**
+ * Resolve the sender's leadership relationship to the recipient within a single
+ * community. Precedence (first match wins):
+ *
+ *   1. "co_leader"       — both are active leaders of the same group.
+ *   2. "group_leader"    — sender is an active leader of a group the recipient
+ *                          is an active member of (any role).
+ *   3. "community_admin" — sender is a community admin.
+ *   4. "none"            — no relationship.
+ *
+ * Co-leader is checked before group-leader because a co-lead pair are also both
+ * *members* of the shared group (so they'd satisfy the group-leader rule too) —
+ * checking co-leader first gives the warmer peer copy. Group-leader is checked
+ * before community-admin because "community leader" reads as intimidating; it's
+ * only the fallback when there's no closer (group-level) tie.
+ *
+ * Community-scoped: only groups belonging to `communityId` are considered.
+ */
+export async function getLeaderDmRelationship(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+  senderId: Id<"users">,
+  recipientId: Id<"users">,
+): Promise<LeaderDmRelationship> {
+  // Groups in THIS community where the sender is an active leader.
+  const senderMemberships = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_user", (q) => q.eq("userId", senderId))
+    .collect();
+
+  const leaderGroupIds: Id<"groups">[] = [];
+  for (const row of senderMemberships) {
+    if (!isActiveLeader(row)) continue;
+    const group = await ctx.db.get(row.groupId);
+    // DMs are per-community; only leadership inside this community counts.
+    if (!group || group.communityId !== communityId) continue;
+    leaderGroupIds.push(row.groupId);
+  }
+
+  // Walk the sender's leader-groups once. A co-leader match (recipient is an
+  // active leader of the same group) wins outright; otherwise note whether the
+  // recipient is an active member of any of them (group-leader relationship).
+  let isGroupLeaderOfRecipient = false;
+  for (const groupId of leaderGroupIds) {
+    const recipientRow = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", groupId).eq("userId", recipientId),
+      )
+      .first();
+    if (!isActiveMembership(recipientRow)) continue;
+    if (isActiveLeader(recipientRow)) {
+      return "co_leader";
+    }
+    isGroupLeaderOfRecipient = true;
+  }
+  if (isGroupLeaderOfRecipient) return "group_leader";
+
+  if (await isCommunityAdmin(ctx, communityId, senderId)) {
+    return "community_admin";
+  }
+
+  return "none";
+}

--- a/apps/convex/lib/notifications/emailTemplates.ts
+++ b/apps/convex/lib/notifications/emailTemplates.ts
@@ -211,6 +211,48 @@ export function chatRequestEmail(data: {
 }
 
 /**
+ * First-message email for a leader/co-lead DM.
+ *
+ * Unlike `chatRequestEmail`, these DMs are already accepted (no request to
+ * accept), so the copy explains the leadership relationship and points the
+ * recipient straight at their inbox. `relationshipLabel` is the warmest,
+ * most-specific tie ("co-leader" | "group leader" | "community leader") and
+ * `bodyLine` is the one-sentence explanation of why they're hearing from the
+ * sender.
+ */
+export function leaderDmEmail(data: {
+  senderName: string;
+  relationshipLabel: string;
+  bodyLine: string;
+  messagePreview: string;
+  firstName?: string;
+}): string {
+  const greeting = data.firstName
+    ? `Hi ${escapeHtml(data.firstName)},`
+    : "Hi there,";
+  const heading = `Your ${escapeHtml(data.relationshipLabel)} ${escapeHtml(
+    data.senderName,
+  )} messaged you`;
+  const content = `
+    <p style="${baseStyles.text}">${greeting}</p>
+    <h1 style="${baseStyles.heading}">${heading}</h1>
+    <p style="${baseStyles.text}">${escapeHtml(data.bodyLine)}</p>
+    <div style="${baseStyles.messageBox}">
+      <p style="color: #1a1a1a; font-size: 15px; line-height: 24px; margin: 0;">
+        "${escapeHtml(data.messagePreview)}"
+      </p>
+    </div>
+    <p style="${baseStyles.text}">
+      It's already in your inbox — no request to accept. Open Togather to reply.
+    </p>
+    <div style="${baseStyles.buttonContainer}">
+      <a href="${DOMAIN_CONFIG.appUrl}" style="${baseStyles.button}">Open Togather</a>
+    </div>
+  `;
+  return wrapInLayout(content);
+}
+
+/**
  * Mention notification email
  */
 export function mentionEmail(data: {


### PR DESCRIPTION
## What & why

When someone with a **leadership relationship to you** sends you a direct message, it now lands as a **normal DM** — straight in your Messages inbox — instead of a "message request" you have to Accept first. The first notification/email reads a little differently so you understand *why* they're suddenly in your inbox.

Three relationships are recognized, and the copy names the **warmest, most specific** one (precedence order):

1. **Co-leader** of a group you lead together → *"Your co-leader just messaged you"*
2. **Group leader** of a group you're a member of → *"Your group leader messaged you"*
3. **Community admin** → *"Your community leader messaged you"*

Group leadership **takes precedence over** community-admin ("community leader" can read as intimidating, so it's the last resort), and co-leads beat both.

[before / after + notification variants](https://images.togather.nyc/dev-assistant/87fed572-7fea-470b-9a96-d96297cb31d0-leader-dm-mock-v2.png)

> _Rendered mock (from the spec), not a device capture — this change is backend-only, so the real screens are unchanged apart from where the thread lands and the first notification copy._

## How it works (backend only — Convex)

- **New shared helper** `getLeaderDmRelationship(ctx, communityId, sender, recipient)` (`apps/convex/lib/leaderDm.ts`) returns `co_leader → group_leader → community_admin → none`, first match wins, community-scoped. Co-leader is checked first (a co-lead pair also satisfies the group-leader rule); group-leader is checked before community-admin.
- **`createOrGetDirectChannel`** — for any non-`none` relationship, the recipient's `chatChannelMembers` row is created `accepted` instead of `pending`, so the DM appears in **Messages** immediately. Leader-initiated (accepted) DMs also **skip the 5-new-requests-per-24h rate limit** — that limit curbs spammy *requests*, and a leader reaching their own members isn't one.
- **`onMessageSent` / `sendAdHocMessageNotifications`** — on the **opening message** of a 1:1 DM, an accepted recipient with a leadership tie gets the **leader push** (sender-name title + relationship line + preview) and a **one-off heads-up email** (`leaderDmEmail` template). Every later message uses the standard accepted-DM push (sender name, no email). The `accepted && isInitialRequestMessage` discriminator plus a helper re-check cleanly separates leader DMs from normal ones.

**Unchanged:** blocking still wins in both directions, community membership still required, group DMs and already-pending DMs are out of scope, no schema change (relationship is derived at create + notify time).

## Tests

`apps/convex/__tests__/messaging/directMessages.test.ts` + `events.test.ts` (full messaging suite: **532 passing**):

- accept-vs-pending per relationship (co-lead→co-lead, leader→member, admin→member)
- one-way: member→leader still a request
- precedence: group-leader+admin → group-leader copy; co-lead+group-leader → co-lead copy
- blocked leader still cannot start a DM
- rate-limit exemption (leader DMs 6 members without hitting the 5-request cap)
- first-message notification copy per variant; later messages get the plain push with no email; non-relationship DM stays plain

---

Dashboard item: `x9753n83fj922yh7pec1b1kkr58aeghv` · reported by Seyi Olujide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMQ6f9Fgyj4ShCPKZGPrpC)_