### PR TITLE
Add 📖 Bible reaction to chat reaction bar

### DIFF
--- a/apps/mobile/features/chat/components/MessageActionsOverlay.tsx
+++ b/apps/mobile/features/chat/components/MessageActionsOverlay.tsx
@@ -33,6 +33,7 @@ export const REACTIONS = [
   { type: "sad", emoji: "😢" },
   { type: "touched", emoji: "🥹" },
   { type: "pray", emoji: "🙏" },
+  { type: "bible", emoji: "📖" },
   { type: "fire", emoji: "🔥" },
   { type: "clap", emoji: "👏" },
   { type: "celebrate", emoji: "🎉" },

--- a/apps/mobile/features/chat/components/__tests__/MessageActionsOverlay.reactions.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageActionsOverlay.reactions.test.tsx
@@ -1,0 +1,47 @@
+import { REACTIONS } from '../MessageActionsOverlay';
+
+/**
+ * The chat reaction bar is a single fixed list shared by both the
+ * press-and-hold reaction bar on chat messages and the event-comment
+ * reaction picker (EventComment.tsx). These tests lock in the contents so
+ * an accidental reorder/removal — or a duplicate emoji — is caught early.
+ */
+describe('chat REACTIONS list', () => {
+  it('includes a Bible (book) reaction next to pray', () => {
+    const bible = REACTIONS.find((r) => r.emoji === '📖');
+    expect(bible).toEqual({ type: 'bible', emoji: '📖' });
+
+    // 📖 sits directly after 🙏 so the two faith reactions stay together.
+    const prayIndex = REACTIONS.findIndex((r) => r.emoji === '🙏');
+    const bibleIndex = REACTIONS.findIndex((r) => r.emoji === '📖');
+    expect(bibleIndex).toBe(prayIndex + 1);
+  });
+
+  it('has no duplicate emojis or types', () => {
+    const emojis = REACTIONS.map((r) => r.emoji);
+    const types = REACTIONS.map((r) => r.type);
+    expect(new Set(emojis).size).toBe(emojis.length);
+    expect(new Set(types).size).toBe(types.length);
+  });
+
+  it('preserves the existing reactions', () => {
+    const emojis = REACTIONS.map((r) => r.emoji);
+    expect(emojis).toEqual([
+      '👍',
+      '❤️',
+      '😂',
+      '‼️',
+      '😮',
+      '😢',
+      '🥹',
+      '🙏',
+      '📖',
+      '🔥',
+      '👏',
+      '🎉',
+      '💯',
+      '👀',
+      '😍',
+    ]);
+  });
+});


### PR DESCRIPTION
## What & why

When someone shares a word (a scripture or an encouraging message) in a chat, people want to react with a **book emoji (📖)** that stands for the Bible — the same way they can already tap ❤️, 🙏, or 🔥.

"Sharing a word" isn't a special message type in the app — it's a normal chat message — so this is purely about the **reactions** available on any message. This adds one reaction, 📖, to the shared chat reaction list.

## The change

A single new entry in the `REACTIONS` list in `apps/mobile/features/chat/components/MessageActionsOverlay.tsx`, placed directly after 🙏 (pray) so the two faith reactions sit together:

```ts
{ type: "pray", emoji: "🙏" },
{ type: "bible", emoji: "📖" },   // ← added
{ type: "fire", emoji: "🔥" },
```

Because that same list also powers the reaction picker on **event comments** (`apps/mobile/app/e/[shortId]/EventComment.tsx` imports `REACTIONS`), 📖 shows up in both places automatically. The chat backend stores whatever emoji is tapped (`toggleReaction` takes `emoji: v.string()` with no allowlist), so **no server, schema, or database change is needed**.

Tapping 📖 works exactly like every other reaction: it adds/removes a 📖 badge under the message, tapping again toggles it off, and it shows the correct count and reactor list in the reaction-details view.

## Out of scope

- **Prayer reactions** are intentionally untouched — that feature has a *separate*, allowlist-enforced reaction set (front-end + back-end) and would be its own change.
- No new "share a word" / scripture message type.
- No other reactions were added, removed, or reordered.

## Verification

- Added a unit test (`MessageActionsOverlay.reactions.test.tsx`) locking in the list: 📖 is present as `{ type: "bible", emoji: "📖" }`, sits directly after 🙏, there are no duplicate emojis/types, and the full ordered list is asserted. **3/3 passing.**
- ESLint clean (pre-commit hook).
- Type-check: no new errors introduced by this change (the pre-existing `@togather/shared/config` resolution errors are unrelated to this diff).

These runs execute on a headless Linux runner with no iOS simulator, so the before/after below is a **rendered mock built from the real reaction-bar styles** (`MessageActionsOverlay.tsx` `reactionsContainer`/`reactionButton`/`reactionEmoji`), **not a device screenshot**. Top = today's bar; bottom = the same bar with 📖 added and highlighted.

[Before/after reaction bar with 📖 added next to 🙏](https://images.togather.nyc/dev-assistant/dee97bfd-c50e-425e-b727-bfd1e8dc213f-bible-reaction-mock.png)

## Done when

- [x] Press-and-hold on a chat message shows 📖 in the reaction bar alongside the existing reactions.
- [x] Tapping 📖 adds a 📖 badge under the message; tapping again removes it (shared toggle path — unchanged).
- [x] 📖 shows the correct count and reactor list in the reaction-details view (shared aggregation path — unchanged).
- [x] 📖 also appears in the event-comment reaction picker (shared `REACTIONS` list).
- [x] No change to prayer reactions; no other reactions added, removed, or reordered.

---

Dev dashboard item: `x977ff05bw866jtcc0ka60ym0s8abn2w` · reported by Angel Navarrete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123mWUWuu3w6VLrjhv1xKyy

---
_Generated by [Claude Code](https://claude.ai/code/session_0123mWUWuu3w6VLrjhv1xKyy)_