### PR TITLE
ci(secrets): auto-run 1Password→GitHub sync on allowlist change

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -1,7 +1,9 @@
 name: Sync Secrets from 1Password
 
-# Manual workflow to sync secrets from 1Password to GitHub environment secrets.
-# Run this whenever a secret is added, changed, or rotated in 1Password.
+# Syncs secrets from 1Password to GitHub environment secrets.
+# Runs automatically on merge to main when an allowlist script changes (a new
+# secret was added), and can be run manually for value rotations that don't
+# touch code.
 #
 # Prerequisites:
 #   - OP_SERVICE_ACCOUNT_TOKEN: 1Password service account token (repo secret)
@@ -19,11 +21,31 @@ on:
           - staging
           - production
           - both
+  # Auto-sync when the allowlist changes. A new secret is only synced once its
+  # key is added to these scripts' allowlists, so a merge to main that touches
+  # them means "a secret was added/changed" — re-run the sync automatically for
+  # both environments. This only fires on those file changes, so it stays well
+  # within 1Password's rate limits (unlike a frequent cron). Manual dispatch
+  # above still works for rotations that don't touch code.
+  push:
+    branches:
+      - main
+    paths:
+      - ee/scripts/sync-1password-to-github.sh
+      - ee/scripts/sync-secrets-to-convex.sh
+
+# Never let two syncs race (a manual dispatch overlapping the on-merge run).
+concurrency:
+  group: sync-secrets
+  cancel-in-progress: false
 
 jobs:
   sync:
-    name: Sync ${{ inputs.environment }} secrets
+    # On push there is no `inputs`, so default to syncing both environments.
+    name: Sync ${{ inputs.environment || 'both' }} secrets
     runs-on: ubuntu-latest
+    env:
+      TARGET_ENV: ${{ inputs.environment || 'both' }}
 
     steps:
       - name: Checkout code
@@ -49,10 +71,10 @@ jobs:
 
           chmod +x ee/scripts/sync-1password-to-github.sh
 
-          if [ "${{ inputs.environment }}" = "both" ]; then
+          if [ "$TARGET_ENV" = "both" ]; then
             ./ee/scripts/sync-1password-to-github.sh --all
           else
-            ./ee/scripts/sync-1password-to-github.sh --environment "${{ inputs.environment }}"
+            ./ee/scripts/sync-1password-to-github.sh --environment "$TARGET_ENV"
           fi
 
       - name: Verify secrets
@@ -60,12 +82,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
         run: |
           echo "=== Verifying synced secrets ==="
-          if [ "${{ inputs.environment }}" = "both" ] || [ "${{ inputs.environment }}" = "staging" ]; then
+          if [ "$TARGET_ENV" = "both" ] || [ "$TARGET_ENV" = "staging" ]; then
             echo ""
             echo "Staging secrets:"
             gh secret list --env staging
           fi
-          if [ "${{ inputs.environment }}" = "both" ] || [ "${{ inputs.environment }}" = "production" ]; then
+          if [ "$TARGET_ENV" = "both" ] || [ "$TARGET_ENV" = "production" ]; then
             echo ""
             echo "Production secrets:"
             gh secret list --env production


### PR DESCRIPTION
## Why

Today the 1Password→GitHub sync (`sync-secrets.yml`) is `workflow_dispatch`-only — someone has to remember to run it after adding a secret. This automates the common case.

1Password has no outbound webhook to detect an item change in real time, and a frequent cron would hit 1Password's rate limits (the reason the sync is manual today). But there's a reliable signal already in the repo: **a new secret only syncs once its key is added to the allowlist arrays in `ee/scripts/sync-*.sh`.** So a merge to `main` touching those scripts *is* the "a secret was added/changed" event.

## What

- Adds a `push: branches:[main], paths:[ee/scripts/sync-*.sh]` trigger. On such a merge, the sync runs automatically for **both** environments.
- Only fires on those file changes → rate-limit-safe (no cron).
- Manual `workflow_dispatch` still works for value rotations that don't touch code.
- Added a `concurrency` group so a manual run can't race the on-merge run.
- On push there's no `inputs`, so `TARGET_ENV` defaults to `both`; replaced the `${{ inputs.environment }}` references with `$TARGET_ENV`.

Scope was deliberately limited to this on-merge trigger (a nightly rotation cron and auto-deploy-after-sync were considered and declined).

## Note

Still only closes the **1Password→GitHub** hop. GitHub→Convex happens on the next Convex deploy (staging auto-deploys on merge; prod is manual per the deploy gate) — unchanged here by design.

## Test

- `yaml.safe_load` parses clean; `${{ inputs.environment || 'both' }}` resolves to `both` on push and to the chosen env on dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)