### PR TITLE
Dev-assistant: observe real staging/production deploy state (deploying → live)

### DIFF
--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -474,9 +474,10 @@ describe("shipped", () => {
     expect(notifications).toHaveLength(0);
 
     // The webhook source (GitHub reported the merge) stamps shippedAt and
-    // records the merged/live-on-staging notification. This item isn't
-    // interactive (verifyOnStaging unset), so the push is the honest "live on
-    // staging" note, not a "shipped to production" claim.
+    // starts deploy observation (stagingDeploy pending) — but a merge only
+    // *triggers* the staging deploy, so NO "live on staging" push fires yet.
+    // That push waits for the workflow_run webhook (see deploy-observation
+    // tests).
     await t.action(
       internal.functions.devAssistant.actions.handleRoutineCallback,
       { bugId: id, routineRunId: "run-ship", status: "MERGED", source: "webhook" },
@@ -485,7 +486,9 @@ describe("shipped", () => {
     bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.status).toBe("MERGED");
     expect(bug?.shippedAt).toBeTruthy();
+    expect(bug?.stagingDeploy?.state).toBe("pending");
 
+    // No staging push at merge time — the deploy isn't live yet.
     notifications = await t.run(async (ctx) =>
       ctx.db.query("notifications").collect(),
     );
@@ -493,7 +496,7 @@ describe("shipped", () => {
       notifications.some(
         (n) => n.userId === maintainerId && /staging/i.test(n.title),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 
@@ -850,11 +853,11 @@ describe("conversation thread (Phase 1.5)", () => {
     expect(thread.map((m) => m.body)).toEqual([
       "Pull request opened",
       "Ready to merge",
-      "Merged — live on staging",
+      "Merged — deploying to staging…",
     ]);
   });
 
-  test("the 'test on staging' push fires on MERGED (not CODE_REVIEW) when verifyOnStaging is set", async () => {
+  test("the 'test on staging' push waits for the staging deploy to go live, not the merge", async () => {
     const t = convexTest(schema, modules);
     activeHandle = t;
     const { maintainerId } = await seedUsers(t);
@@ -898,7 +901,8 @@ describe("conversation thread (Phase 1.5)", () => {
       notifications.some((n) => n.title === "Your contribution is in code review"),
     ).toBe(true);
 
-    // MERGED (auto-deployed to staging): now the "try it on staging" push fires.
+    // MERGED only *triggers* the staging deploy — still NO staging push, and
+    // stagingDeploy is pending (correlated by the merge commit SHA).
     await t.action(
       internal.functions.devAssistant.actions.handleRoutineCallback,
       {
@@ -914,8 +918,33 @@ describe("conversation thread (Phase 1.5)", () => {
         routineRunId: "run-staging-push",
         status: "MERGED",
         source: "webhook",
+        mergeCommitSha: "sha-staging-push",
       },
     );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    notifications = await t.run(async (ctx) =>
+      ctx.db.query("notifications").collect(),
+    );
+    expect(
+      notifications.filter(
+        (n) => n.userId === maintainerId && /staging/i.test(n.title),
+      ),
+    ).toHaveLength(0);
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.stagingDeploy?.state,
+    ).toBe("pending");
+
+    // The staging deploy workflow finishing (workflow_run success) is the
+    // honest moment: the change is up, so NOW the "try it on staging" push
+    // fires.
+    await t.mutation(internal.functions.devAssistant.bugs.handleWorkflowRunEvent, {
+      action: "completed",
+      name: "Deploy Convex",
+      conclusion: "success",
+      headSha: "sha-staging-push",
+      headBranch: "main",
+    });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
     notifications = await t.run(async (ctx) =>
@@ -926,6 +955,9 @@ describe("conversation thread (Phase 1.5)", () => {
     );
     expect(stagingPush).toHaveLength(1);
     expect(stagingPush[0]?.title).toBe("Ready to test on staging");
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.stagingDeploy?.state,
+    ).toBe("live");
   });
 });
 
@@ -1657,7 +1689,7 @@ describe("in-app merge (mergeNow)", () => {
     );
     expect(thread.map((m) => m.body)).toEqual([
       "Connie Tributor asked to merge this from the app — merging…",
-      "Merged — live on staging",
+      "Merged — deploying to staging…",
     ]);
   });
 
@@ -1837,6 +1869,8 @@ describe("in-app production promote (silent OTA)", () => {
 
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.productionRequestedAt).toBeTruthy();
+    // A successful dispatch starts production deploy observation.
+    expect(bug?.productionDeploy?.state).toBe("pending");
 
     const thread = await t.query(
       api.functions.devAssistant.contributions.getThread,
@@ -1844,7 +1878,7 @@ describe("in-app production promote (silent OTA)", () => {
     );
     expect(thread.map((m) => m.body)).toEqual([
       "Connie Tributor triggered the production deploy (silent update)",
-      "Production deploy started — the silent update reaches users next time they open the app",
+      "Deploying to production…",
     ]);
   });
 
@@ -2500,18 +2534,18 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
       { token: maintainerId, id },
     );
     expect(thread.map((m) => [m.authorType, m.body])).toEqual([
-      ["system", "Merged — live on staging"],
+      ["system", "Merged — deploying to staging…"],
     ]);
 
-    // The originator got the merged/live-on-staging push (dashboard item, no
-    // chat thread). Non-interactive item, so it's the "live on staging" note,
-    // not a "shipped to production" claim.
-    const shippedPushes = async () =>
+    // A merge only *triggers* the staging deploy: stagingDeploy is pending and
+    // NO staging push fires yet (the "try it" ask waits for the workflow_run).
+    expect(bug?.stagingDeploy?.state).toBe("pending");
+    const stagingPushes = async () =>
       (await t.run(async (ctx) => ctx.db.query("notifications").collect()))
         .filter((n) => n.userId === maintainerId && /staging/i.test(n.title));
-    expect(await shippedPushes()).toHaveLength(1);
+    expect(await stagingPushes()).toHaveLength(0);
 
-    // Replayed delivery: no double system message, no double push.
+    // Replayed delivery: no double system message, still no push.
     const replay = await postWebhook(
       t,
       mergedPrPayload(`claude/devbug-${id}`, true),
@@ -2524,7 +2558,7 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
       { token: maintainerId, id },
     );
     expect(replayedThread).toHaveLength(1);
-    expect(await shippedPushes()).toHaveLength(1);
+    expect(await stagingPushes()).toHaveLength(0);
   });
 
   test("merge done on GitHub while still in CODE_REVIEW correlates via prUrl fallback", async () => {
@@ -2570,7 +2604,7 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
       { token: maintainerId, id },
     );
     expect(thread.map((m) => [m.authorType, m.body])).toEqual([
-      ["system", "Merged — live on staging"],
+      ["system", "Merged — deploying to staging…"],
     ]);
   });
 
@@ -2638,6 +2672,316 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
       ctx.db.query("devBugMessages").collect(),
     );
     expect(messages).toHaveLength(0);
+  });
+
+  // ---- workflow_run: staging/production deploy observation ----
+
+  function workflowRunPayload(
+    name: string,
+    action: string,
+    conclusion: string | null,
+    headSha: string,
+    headBranch = "main",
+  ): Record<string, unknown> {
+    return {
+      action,
+      workflow_run: {
+        name,
+        status: action === "completed" ? "completed" : "in_progress",
+        conclusion,
+        head_sha: headSha,
+        head_branch: headBranch,
+      },
+    };
+  }
+
+  async function seedDeployingBug(
+    t: ReturnType<typeof convexTest>,
+    originatorId: Id<"users">,
+    sha: string,
+    overrides: {
+      verifyOnStaging?: boolean;
+      workflows?: { name: string; conclusion?: string }[];
+    } = {},
+  ): Promise<Id<"devBugs">> {
+    const now = Date.now();
+    return await t.run(async (ctx) =>
+      ctx.db.insert("devBugs", {
+        originatorUserId: originatorId,
+        status: "MERGED",
+        kind: "bug",
+        source: "dashboard",
+        title: "Fix typo",
+        body: "B",
+        verifyOnStaging: overrides.verifyOnStaging,
+        mergeCommitSha: sha,
+        shippedAt: now,
+        stagingDeploy: {
+          state: "pending",
+          workflows: overrides.workflows ?? [],
+          updatedAt: now,
+        },
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
+  async function stagingPushCount(
+    t: ReturnType<typeof convexTest>,
+    userId: Id<"users">,
+  ): Promise<number> {
+    const notifications = await t.run(async (ctx) =>
+      ctx.db.query("notifications").collect(),
+    );
+    return notifications.filter(
+      (n) => n.userId === userId && /staging/i.test(n.title),
+    ).length;
+  }
+
+  test("a successful staging workflow_run flips the deploy live and fires the try-it push", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    const id = await seedDeployingBug(t, maintainerId, "sha-live", {
+      verifyOnStaging: true,
+    });
+
+    // requested → tracked, still pending, no push.
+    let res = await postWebhook(
+      t,
+      workflowRunPayload("Deploy Convex", "requested", null, "sha-live"),
+      "workflow_run",
+    );
+    expect(res.status).toBe(200);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.stagingDeploy?.state,
+    ).toBe("pending");
+    expect(await stagingPushCount(t, maintainerId)).toBe(0);
+
+    // completed success → the only tracked workflow succeeded, so live.
+    res = await postWebhook(
+      t,
+      workflowRunPayload("Deploy Convex", "completed", "success", "sha-live"),
+      "workflow_run",
+    );
+    expect(res.status).toBe(200);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.stagingDeploy?.state).toBe("live");
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread.map((m) => m.body)).toContain(
+      "Live on staging — ready to try it",
+    );
+    expect(await stagingPushCount(t, maintainerId)).toBe(1);
+  });
+
+  test("staging deploy stays pending until EVERY triggered workflow succeeds", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    // Both Convex and mobile were triggered (both paths changed).
+    const id = await seedDeployingBug(t, maintainerId, "sha-both", {
+      verifyOnStaging: true,
+      workflows: [
+        { name: "Deploy Convex" },
+        { name: "Deploy Mobile Update" },
+      ],
+    });
+
+    // First workflow succeeds — the other is still running, so NOT live.
+    await postWebhook(
+      t,
+      workflowRunPayload("Deploy Convex", "completed", "success", "sha-both"),
+      "workflow_run",
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.stagingDeploy?.state,
+    ).toBe("pending");
+    expect(await stagingPushCount(t, maintainerId)).toBe(0);
+
+    // Second workflow succeeds — now all tracked workflows are green → live.
+    await postWebhook(
+      t,
+      workflowRunPayload(
+        "Deploy Mobile Update",
+        "completed",
+        "success",
+        "sha-both",
+      ),
+      "workflow_run",
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.stagingDeploy?.state,
+    ).toBe("live");
+    expect(await stagingPushCount(t, maintainerId)).toBe(1);
+  });
+
+  test("a failed staging workflow flips to failed with a contact-the-lead-maintainer line and no push", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    const id = await seedDeployingBug(t, maintainerId, "sha-fail", {
+      verifyOnStaging: true,
+      workflows: [
+        { name: "Deploy Convex" },
+        { name: "Deploy Mobile Update" },
+      ],
+    });
+
+    // Even though the OTHER workflow hasn't reported, one failure fails the
+    // whole deploy immediately.
+    await postWebhook(
+      t,
+      workflowRunPayload("Deploy Convex", "completed", "failure", "sha-fail"),
+      "workflow_run",
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const bug = await t.run(async (ctx) => ctx.db.get(id));
+    expect(bug?.stagingDeploy?.state).toBe("failed");
+    expect(bug?.stagingDeploy?.failedWorkflow).toBe("Deploy Convex");
+
+    const thread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id },
+    );
+    expect(thread.map((m) => m.body)).toContain(
+      "Staging deploy failed (Deploy Convex) — contact the lead maintainer.",
+    );
+    // Never invite the contributor to test something that isn't up.
+    expect(await stagingPushCount(t, maintainerId)).toBe(0);
+  });
+
+  test("staging workflow_run for an unrelated SHA / non-main branch / already-settled deploy is a no-op", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    const id = await seedDeployingBug(t, maintainerId, "sha-real", {
+      verifyOnStaging: true,
+    });
+
+    // Different SHA — correlates to nothing.
+    await postWebhook(
+      t,
+      workflowRunPayload("Deploy Convex", "completed", "success", "sha-other"),
+      "workflow_run",
+    );
+    // Right SHA but a feature branch, not main.
+    await postWebhook(
+      t,
+      workflowRunPayload(
+        "Deploy Convex",
+        "completed",
+        "success",
+        "sha-real",
+        "feature/x",
+      ),
+      "workflow_run",
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.stagingDeploy?.state,
+    ).toBe("pending");
+    expect(await stagingPushCount(t, maintainerId)).toBe(0);
+  });
+
+  test("a production workflow_run moves every pending-prod bug (success → live, failure → failed)", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_WEBHOOK_SECRET = WEBHOOK_SECRET;
+
+    const now = Date.now();
+    const seedProd = async (): Promise<Id<"devBugs">> =>
+      await t.run(async (ctx) =>
+        ctx.db.insert("devBugs", {
+          originatorUserId: maintainerId,
+          status: "MERGED",
+          kind: "bug",
+          source: "dashboard",
+          title: "Fix typo",
+          body: "B",
+          shippedAt: now,
+          stagingVerifiedAt: now,
+          productionDeploy: { state: "pending", updatedAt: now },
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+
+    // Success path.
+    const liveId = await seedProd();
+    await postWebhook(
+      t,
+      // Prod runs deploy everything on main — the SHA/branch are irrelevant to
+      // correlation (global-by-state).
+      workflowRunPayload("Deploy to Production", "completed", "success", "any"),
+      "workflow_run",
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const live = await t.run(async (ctx) => ctx.db.get(liveId));
+    expect(live?.productionDeploy?.state).toBe("live");
+    const liveThread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id: liveId },
+    );
+    expect(liveThread.map((m) => m.body)).toContain("Live in production 🎉");
+
+    // Failure path — a fresh pending-prod bug.
+    const failId = await seedProd();
+    await postWebhook(
+      t,
+      workflowRunPayload("Deploy to Production", "completed", "failure", "any"),
+      "workflow_run",
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const failed = await t.run(async (ctx) => ctx.db.get(failId));
+    expect(failed?.productionDeploy?.state).toBe("failed");
+    const failThread = await t.query(
+      api.functions.devAssistant.contributions.getThread,
+      { token: maintainerId, id: failId },
+    );
+    expect(failThread.map((m) => m.body)).toContain(
+      "Production deploy failed — contact the lead maintainer.",
+    );
+    // The already-live bug from the success path isn't touched by the failure.
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(liveId)))?.productionDeploy?.state,
+    ).toBe("live");
+  });
+
+  test("the webhook accepts and schedules a workflow_run event (endpoint wiring)", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    const id = await seedDeployingBug(t, maintainerId, "sha-wire");
+
+    const res = await postWebhook(
+      t,
+      workflowRunPayload("Deploy Convex", "completed", "success", "sha-wire"),
+      "workflow_run",
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("received");
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    // Non-interactive item: goes live, honest "live on staging" note.
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(id)))?.stagingDeploy?.state,
+    ).toBe("live");
   });
 });
 
@@ -3126,7 +3470,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
 
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Merged — live on staging",
+      "Merged — deploying to staging…",
     ]);
     // GitHub confirmed the merge, so the action applies MERGED itself via
     // the trusted "automerge" source — the row must not strand at
@@ -3145,7 +3489,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     await t.finishAllScheduledFunctions(vi.runAllTimers);
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Merged — live on staging",
+      "Merged — deploying to staging…",
     ]);
   });
 
@@ -3167,7 +3511,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Merged — live on staging",
+      "Merged — deploying to staging…",
     ]);
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.status).toBe("MERGED");
@@ -3203,7 +3547,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
     });
     expect(await threadBodies(t, maintainerId, id)).toEqual([
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Merged — live on staging",
+      "Merged — deploying to staging…",
     ]);
   });
 
@@ -3288,7 +3632,7 @@ describe("policy auto-merge (ADR-029 Phase 3)", () => {
       "Code review passed ✓",
       "Ready to merge",
       "Auto-merged ✓ — all gates passed (low risk, review approved)",
-      "Merged — live on staging",
+      "Merged — deploying to staging…",
     ]);
     const bug = await t.run(async (ctx) => ctx.db.get(id));
     expect(bug?.status).toBe("MERGED");

--- a/apps/convex/__tests__/dev-contributions.test.ts
+++ b/apps/convex/__tests__/dev-contributions.test.ts
@@ -1295,6 +1295,10 @@ describe("staging verification", () => {
       status: "DRAFT" | "IN_REVIEW" | "IN_PROGRESS" | "CODE_REVIEW" | "READY_TO_MERGE" | "MERGED";
       verifyOnStaging: boolean;
       stagingVerifiedAt: number;
+      stagingDeploy: {
+        state: "pending" | "live" | "failed";
+        updatedAt: number;
+      };
     }> = {},
   ): Promise<Id<"devBugs">> {
     const now = Date.now();
@@ -1310,6 +1314,8 @@ describe("staging verification", () => {
         routineRunId: "run-staging",
         verifyOnStaging: overrides.verifyOnStaging ?? true,
         stagingVerifiedAt: overrides.stagingVerifiedAt,
+        // Omitted → legacy-undefined, treated as live (backward-compat).
+        stagingDeploy: overrides.stagingDeploy,
         createdAt: now,
         updatedAt: now,
       }),
@@ -1402,6 +1408,57 @@ describe("staging verification", () => {
         id: preMergeId,
       }),
     ).rejects.toThrow(/current status/);
+  });
+
+  test("confirmStaging is gated server-side on the staging deploy actually being live", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+
+    // Merged, but the staging deploy is still running — the UI hides the card,
+    // but a stale/hand-rolled client must be rejected server-side too.
+    const pendingId = await seedStagingBug(t, maintainerId, {
+      stagingDeploy: { state: "pending", updatedAt: Date.now() },
+    });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.confirmStaging, {
+        token: maintainerId,
+        id: pendingId,
+      }),
+    ).rejects.toThrow(/still running/);
+
+    // Deploy failed — there's nothing on staging to confirm.
+    const failedId = await seedStagingBug(t, maintainerId, {
+      stagingDeploy: { state: "failed", updatedAt: Date.now() },
+    });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.confirmStaging, {
+        token: maintainerId,
+        id: failedId,
+      }),
+    ).rejects.toThrow(/staging deploy failed/i);
+
+    // Live → allowed.
+    const liveId = await seedStagingBug(t, maintainerId, {
+      stagingDeploy: { state: "live", updatedAt: Date.now() },
+    });
+    await t.mutation(api.functions.devAssistant.contributions.confirmStaging, {
+      token: maintainerId,
+      id: liveId,
+    });
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(liveId)))?.stagingVerifiedAt,
+    ).toBeTruthy();
+
+    // Legacy row (no stagingDeploy) → treated as live, still confirmable.
+    const legacyId = await seedStagingBug(t, maintainerId);
+    await t.mutation(api.functions.devAssistant.contributions.confirmStaging, {
+      token: maintainerId,
+      id: legacyId,
+    });
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(legacyId)))?.stagingVerifiedAt,
+    ).toBeTruthy();
   });
 
   test("reportStagingIssue sends the item back through the pipeline (staging-redo dispatch)", async () => {
@@ -1818,6 +1875,10 @@ describe("in-app production promote (silent OTA)", () => {
       verifyOnStaging: boolean;
       stagingVerifiedAt: number;
       productionRequestedAt: number;
+      stagingDeploy: {
+        state: "pending" | "live" | "failed";
+        updatedAt: number;
+      };
     }> = {},
   ): Promise<Id<"devBugs">> {
     const now = Date.now();
@@ -1833,6 +1894,8 @@ describe("in-app production promote (silent OTA)", () => {
         stagingVerifiedAt:
           "stagingVerifiedAt" in overrides ? overrides.stagingVerifiedAt : now,
         productionRequestedAt: overrides.productionRequestedAt,
+        // Omitted → legacy-undefined, treated as live (backward-compat).
+        stagingDeploy: overrides.stagingDeploy,
         shippedAt: now,
         createdAt: now,
         updatedAt: now,
@@ -2036,6 +2099,61 @@ describe("in-app production promote (silent OTA)", () => {
       { token: maintainerId, id },
     );
     await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("promoteToProduction is gated server-side on the staging deploy being live", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_MIRROR_TOKEN = "gh-token";
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Non-interactive item (skips the sign-off gate) but its staging deploy is
+    // still running — must NOT be shippable to production.
+    const pending = await seedMergedBug(t, maintainerId, {
+      verifyOnStaging: false,
+      stagingVerifiedAt: undefined,
+      stagingDeploy: { state: "pending", updatedAt: Date.now() },
+    });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.promoteToProduction, {
+        token: maintainerId,
+        id: pending,
+      }),
+    ).rejects.toThrow(/still running/);
+
+    // Staging deploy failed — nothing is up, so production is blocked.
+    const failed = await seedMergedBug(t, maintainerId, {
+      verifyOnStaging: false,
+      stagingVerifiedAt: undefined,
+      stagingDeploy: { state: "failed", updatedAt: Date.now() },
+    });
+    await expect(
+      t.mutation(api.functions.devAssistant.contributions.promoteToProduction, {
+        token: maintainerId,
+        id: failed,
+      }),
+    ).rejects.toThrow(/staging deploy failed/i);
+
+    // Nothing was dispatched to GitHub for the blocked promotions.
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Live staging deploy → the promotion goes through.
+    const live = await seedMergedBug(t, maintainerId, {
+      verifyOnStaging: false,
+      stagingVerifiedAt: undefined,
+      stagingDeploy: { state: "live", updatedAt: Date.now() },
+    });
+    await t.mutation(
+      api.functions.devAssistant.contributions.promoteToProduction,
+      { token: maintainerId, id: live },
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(live)))?.productionDeploy?.state,
+    ).toBe("pending");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
@@ -2682,6 +2800,7 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
     conclusion: string | null,
     headSha: string,
     headBranch = "main",
+    runStartedAt?: string,
   ): Record<string, unknown> {
     return {
       action,
@@ -2691,6 +2810,7 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
         conclusion,
         head_sha: headSha,
         head_branch: headBranch,
+        ...(runStartedAt ? { run_started_at: runStartedAt } : {}),
       },
     };
   }
@@ -2961,6 +3081,61 @@ describe("POST /github/webhook (ADR-029 Phase 2)", () => {
     expect(
       (await t.run(async (ctx) => ctx.db.get(liveId)))?.productionDeploy?.state,
     ).toBe("live");
+  });
+
+  test("a production run only settles bugs requested before it started (A/B race)", async () => {
+    const t = convexTest(schema, modules);
+    activeHandle = t;
+    const { maintainerId } = await seedUsers(t);
+    process.env.GH_WEBHOOK_SECRET = WEBHOOK_SECRET;
+
+    const now = Date.now();
+    const runStarted = now; // item A's run begins here.
+    const seedProdAt = async (requestedAt: number): Promise<Id<"devBugs">> =>
+      await t.run(async (ctx) =>
+        ctx.db.insert("devBugs", {
+          originatorUserId: maintainerId,
+          status: "MERGED",
+          kind: "bug",
+          source: "dashboard",
+          title: "Fix typo",
+          body: "B",
+          shippedAt: now,
+          stagingVerifiedAt: now,
+          productionDeploy: { state: "pending", requestedAt, updatedAt: requestedAt },
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+
+    // A requested before the run started; B requested a minute AFTER it started
+    // (a second promotion while A's deploy was still in flight).
+    const aId = await seedProdAt(runStarted - 60_000);
+    const bId = await seedProdAt(runStarted + 60_000);
+
+    // A's run completes — it covers A but NOT B.
+    await postWebhook(
+      t,
+      workflowRunPayload(
+        "Deploy to Production",
+        "completed",
+        "success",
+        "any",
+        "main",
+        new Date(runStarted).toISOString(),
+      ),
+      "workflow_run",
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(aId)))?.productionDeploy?.state,
+    ).toBe("live");
+    // B was requested after A's run began — it must still be pending, waiting
+    // for its OWN run.
+    expect(
+      (await t.run(async (ctx) => ctx.db.get(bId)))?.productionDeploy?.state,
+    ).toBe("pending");
   });
 
   test("the webhook accepts and schedules a workflow_run event (endpoint wiring)", async () => {

--- a/apps/convex/functions/devAssistant/actions.ts
+++ b/apps/convex/functions/devAssistant/actions.ts
@@ -842,25 +842,50 @@ async function mergePullRequestOnGithub(
 }
 
 /**
- * Whether the PR is already merged on GitHub — the tie-breaker when a merge
- * PUT fails: the in-app merge and policy auto-merge can race (both pass their
- * gates while the row is still READY_TO_MERGE), and the loser's 405 must not
- * post a "Merge failed" message for a change that actually merged. Returns
- * null when the state can't be determined (report the original failure).
+ * Whether the PR is already merged on GitHub (plus its merge commit SHA) — the
+ * tie-breaker when a merge PUT fails: the in-app merge and policy auto-merge
+ * can race (both pass their gates while the row is still READY_TO_MERGE), and
+ * the loser's 405 must not post a "Merge failed" message for a change that
+ * actually merged. The `merge_commit_sha` correlates the staging deploy
+ * observation (ADR-029 follow-up). Returns null when the state can't be
+ * determined (report the original failure).
  */
 async function fetchPrMerged(
   prNumber: string,
   token: string,
-): Promise<boolean | null> {
+): Promise<{ merged: boolean; mergeCommitSha?: string } | null> {
   try {
     const res = await fetch(`${GITHUB_PULLS_ENDPOINT}/${prNumber}`, {
       headers: githubJsonHeaders(token),
     });
     if (!res.ok) return null;
-    const pr = (await res.json()) as { merged?: boolean };
-    return pr.merged === true;
+    const pr = (await res.json()) as {
+      merged?: boolean;
+      merge_commit_sha?: string;
+    };
+    return {
+      merged: pr.merged === true,
+      mergeCommitSha:
+        typeof pr.merge_commit_sha === "string"
+          ? pr.merge_commit_sha
+          : undefined,
+    };
   } catch {
     return null;
+  }
+}
+
+/**
+ * Parse the `sha` (the squash-merge commit) from a successful GitHub merge PUT
+ * response body. Best-effort — a missing/garbled body just yields undefined
+ * (the reconcile cron + workflow_run correlation degrade gracefully without it).
+ */
+async function readMergeCommitSha(res: Response): Promise<string | undefined> {
+  try {
+    const body = (await res.json()) as { sha?: string };
+    return typeof body.sha === "string" ? body.sha : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -963,6 +988,7 @@ export const attemptAutoMerge = internalAction({
       const res = await mergePullRequestOnGithub(prMatch[1], mirrorToken);
 
       if (res.ok) {
+        const mergeCommitSha = await readMergeCommitSha(res);
         await ctx.runMutation(
           internal.functions.devAssistant.bugs.addSystemThreadMessage,
           {
@@ -970,15 +996,16 @@ export const attemptAutoMerge = internalAction({
             body: "Auto-merged ✓ — all gates passed (low risk, review approved)",
           },
         );
-        await applyGithubConfirmedMerge(ctx, bug);
+        await applyGithubConfirmedMerge(ctx, bug, mergeCommitSha);
         return;
       }
 
       // Lost a race? The in-app merge (or a human on GitHub) may have merged
       // the PR between this action's gates and its PUT — the resulting 405
       // must not read as a failure for a change that actually merged.
-      if (await fetchPrMerged(prMatch[1], mirrorToken)) {
-        await applyGithubConfirmedMerge(ctx, bug);
+      const raced = await fetchPrMerged(prMatch[1], mirrorToken);
+      if (raced?.merged) {
+        await applyGithubConfirmedMerge(ctx, bug, raced.mergeCommitSha);
         return;
       }
 
@@ -999,6 +1026,7 @@ export const attemptAutoMerge = internalAction({
 async function applyGithubConfirmedMerge(
   ctx: ActionCtx,
   bug: Pick<Doc<"devBugs">, "_id" | "routineRunId">,
+  mergeCommitSha?: string,
 ): Promise<void> {
   if (bug.routineRunId) {
     await ctx.runAction(
@@ -1008,6 +1036,7 @@ async function applyGithubConfirmedMerge(
         routineRunId: bug.routineRunId,
         status: "MERGED",
         source: "automerge",
+        mergeCommitSha,
       },
     );
   } else {
@@ -1015,6 +1044,7 @@ async function applyGithubConfirmedMerge(
       bugId: bug._id,
       status: "MERGED",
       source: "automerge",
+      mergeCommitSha,
     });
   }
 }
@@ -1077,12 +1107,17 @@ export const mergeFromApp = internalAction({
       // A failed PUT can still mean "merged": policy auto-merge (scheduled on
       // the same READY_TO_MERGE entry) or a human may have merged first, and
       // the loser's 405 must not tell the thread a successful merge failed.
-      if (res.ok || (await fetchPrMerged(prMatch[1], mirrorToken))) {
+      if (res.ok) {
         // GitHub confirmed the merge — apply MERGED through the trusted
         // "automerge" source (same as attemptAutoMerge) so the shipped push,
         // system message, and chat bot message all fire; the webhook
         // redelivery no-ops on a MERGED row.
-        await applyGithubConfirmedMerge(ctx, bug);
+        await applyGithubConfirmedMerge(ctx, bug, await readMergeCommitSha(res));
+        return;
+      }
+      const raced = await fetchPrMerged(prMatch[1], mirrorToken);
+      if (raced?.merged) {
+        await applyGithubConfirmedMerge(ctx, bug, raced.mergeCommitSha);
         return;
       }
 
@@ -1192,13 +1227,19 @@ export const reconcileMergedPrs = internalAction({
       if (!prMatch) continue;
       try {
         const merged = await fetchPrMerged(prMatch[1], token);
-        if (merged === true) {
+        if (merged?.merged) {
           // Reuse the webhook path: an empty branchRef falls through to the
           // prUrl-match fallback, which scans exactly these open-PR states and
-          // applies MERGED idempotently.
+          // applies MERGED idempotently. Carry the merge SHA so deploy
+          // observation can correlate the staging workflow_run events.
           await ctx.runMutation(
             internal.functions.devAssistant.bugs.handleGithubPrClosed,
-            { branchRef: "", prUrl: bug.prUrl, merged: true },
+            {
+              branchRef: "",
+              prUrl: bug.prUrl,
+              merged: true,
+              mergeCommitSha: merged.mergeCommitSha,
+            },
           );
         }
       } catch (error) {
@@ -1265,27 +1306,17 @@ function contributorPushForStatus(
       // later, maintainer-facing step) — pushing here and not on READY_TO_MERGE
       // means one "PR opened" push, not two. Nothing is on staging yet (the PR
       // is still open), so this stays an honest "in code review" note — the
-      // "try it on staging" ask waits for MERGED (ADR-029).
+      // "try it on staging" ask waits until the staging deploy actually goes
+      // live (bugs.ts stagingLivePush, fired by handleWorkflowRunEvent).
       return {
         title: "Your contribution is in code review",
         body: `A pull request is open for "${bug.title}".`,
       };
-    case "MERGED":
-      // The change is merged to `main` and auto-deployed to staging. For
-      // interactive items, this is the moment to ask the originator to try it
-      // on staging — their sign-off then gates the manual production deploy
-      // (ADR-029). Non-interactive items (copy/colour) just get an honest
-      // "it's live on staging" note, not a "shipped to production" claim.
-      if (bug.verifyOnStaging) {
-        return {
-          title: "Ready to test on staging",
-          body: `"${bug.title}" is merged and live on staging — try it and confirm it works.`,
-        };
-      }
-      return {
-        title: "Your contribution is live on staging",
-        body: `"${bug.title}" was merged and is now live on the staging app.`,
-      };
+    // NOTE: MERGED intentionally returns null. A merge only *triggers* the
+    // staging deploy — the "live on staging"/"try it" push now fires from
+    // handleWorkflowRunEvent (bugs.ts) once the deploy workflows actually
+    // succeed, so we never invite a contributor to test something that isn't
+    // up yet.
     default:
       return null;
   }
@@ -1301,6 +1332,9 @@ export const handleRoutineCallback = internalAction({
     // forwards this field, so external callers always land as "routine" —
     // the only source applyCallback's MERGED gate rejects.
     source: v.optional(callbackSourceValidator),
+    // Only meaningful on a MERGED apply — the squash-merge commit SHA, stored
+    // so the staging workflow_run events correlate to this bug.
+    mergeCommitSha: v.optional(v.string()),
     prUrl: v.optional(v.string()),
     screenshots: v.optional(v.array(v.string())),
     message: v.optional(v.string()),
@@ -1335,6 +1369,7 @@ export const handleRoutineCallback = internalAction({
         bugId: args.bugId,
         status: args.status,
         source: args.source,
+        mergeCommitSha: args.mergeCommitSha,
         prUrl: args.prUrl,
         screenshots: args.screenshots,
         spec: args.spec,

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -909,7 +909,10 @@ export const recordProductionDeployOutcome = internalMutation({
       );
       const now = Date.now();
       await ctx.db.patch(args.bugId, {
-        productionDeploy: { state: "pending", updatedAt: now },
+        // requestedAt time-bounds settlement: a "Deploy to Production" run only
+        // settles bugs requested before it started, so a later dispatch isn't
+        // marked done by an earlier run (see handleWorkflowRunEvent).
+        productionDeploy: { state: "pending", requestedAt: now, updatedAt: now },
         updatedAt: now,
       });
     } else {
@@ -1403,9 +1406,11 @@ function stagingLivePush(bug: {
  *    "live on staging" line and fires the moved "try it" push.
  *
  * PRODUCTION (name === "Deploy to Production", completed): prod deploys ship
- * everything on `main`, so the run can't be correlated to one bug by SHA — all
- * bugs whose `productionDeploy.state === "pending"` move together (accepted for
- * v1; correlation is inherently ambiguous for a global deploy).
+ * everything on `main`, so the run can't be correlated to one bug by SHA. It
+ * settles every bug whose `productionDeploy.state === "pending"` — but only
+ * those requested BEFORE this run started (`requestedAt <= runStartedAt`), so a
+ * deploy dispatched WHILE this run was in flight (covering later work) is not
+ * wrongly marked done by it and waits for its own run.
  */
 export const handleWorkflowRunEvent = internalMutation({
   args: {
@@ -1415,6 +1420,9 @@ export const handleWorkflowRunEvent = internalMutation({
     conclusion: v.optional(v.string()),
     headSha: v.string(),
     headBranch: v.optional(v.string()),
+    // workflow_run.run_started_at (ms) — bounds which pending-prod bugs a
+    // production run settles (see the doc comment).
+    runStartedAt: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<void> => {
     const now = Date.now();
@@ -1434,6 +1442,19 @@ export const handleWorkflowRunEvent = internalMutation({
         .collect();
       for (const bug of merged) {
         if (bug.productionDeploy?.state !== "pending") continue;
+        // Only settle bugs this run actually covers: those requested before it
+        // started. A bug requested after the run began (or with no requestedAt
+        // we can compare against, when run_started_at is missing) waits for its
+        // own run. Missing requestedAt on the bug is a legacy pending row —
+        // settle it (best effort, backward-compat).
+        const requestedAt = bug.productionDeploy.requestedAt;
+        if (
+          args.runStartedAt !== undefined &&
+          requestedAt !== undefined &&
+          requestedAt > args.runStartedAt
+        ) {
+          continue;
+        }
         if (succeeded) {
           await ctx.db.patch(bug._id, {
             productionDeploy: { state: "live", updatedAt: now },

--- a/apps/convex/functions/devAssistant/bugs.ts
+++ b/apps/convex/functions/devAssistant/bugs.ts
@@ -213,10 +213,21 @@ const STATUS_SYSTEM_MESSAGES: Partial<Record<BugStatus, string>> = {
   IN_PROGRESS: "Build started",
   CODE_REVIEW: "Pull request opened",
   READY_TO_MERGE: "Ready to merge",
-  // Merge auto-deploys to staging; production is a separate manual step, so the
-  // honest line is "live on staging", not "shipped" (ADR-029).
-  MERGED: "Merged — live on staging",
+  // A merge only *triggers* the staging deploy workflows (a few minutes) — it
+  // isn't live yet. The honest line is "deploying to staging…"; the
+  // workflow_run webhook posts "Live on staging" once the deploy actually
+  // finishes (handleWorkflowRunEvent). See MERGED_DEPLOYING_MESSAGE.
+  MERGED: "Merged — deploying to staging…",
 };
+
+/**
+ * System thread line posted the moment a merge is observed (also used by the
+ * no-routine merge path). Kept in sync with STATUS_SYSTEM_MESSAGES.MERGED.
+ */
+export const MERGED_DEPLOYING_MESSAGE = "Merged — deploying to staging…";
+
+/** System thread line posted once the staging deploy actually goes live. */
+export const STAGING_LIVE_MESSAGE = "Live on staging — ready to try it";
 
 export type ThreadHistoryEntry = {
   authorType: "user" | "assistant" | "system";
@@ -594,10 +605,13 @@ export const PR_CLOSED_UNMERGED_MESSAGE =
  * merged === true replays the bug's own routineRunId through the existing
  * handleRoutineCallback machinery with source "webhook" (the trusted channel
  * allowed to apply MERGED), which validates the transition, stamps shippedAt,
- * logs the "Merged — live on staging" system turn, pushes the originator, and
- * (for chat items) posts the sourceKey-idempotent bot message. The early-return on an
- * already-MERGED bug makes replayed webhooks — and the race with the
- * auto-merge action's own MERGED apply — no-ops.
+ * stores mergeCommitSha, starts staging deploy observation (stagingDeploy
+ * pending), logs the "Merged — deploying to staging…" system turn, and (for
+ * chat items) posts the sourceKey-idempotent bot message. The "try it on
+ * staging" push no longer fires here — it waits for the workflow_run webhook
+ * to report the staging deploy actually live (handleWorkflowRunEvent). The
+ * early-return on an already-MERGED bug makes replayed webhooks — and the race
+ * with the auto-merge action's own MERGED apply — no-ops.
  *
  * merged === false leaves the status untouched and posts a system thread
  * message flagging the item for a maintainer (deduped against an immediate
@@ -608,6 +622,9 @@ export const handleGithubPrClosed = internalMutation({
     branchRef: v.string(),
     prUrl: v.optional(v.string()),
     merged: v.boolean(),
+    // The squash-merge commit SHA (pull_request.merge_commit_sha) — stored on
+    // the bug so the staging `workflow_run` events correlate back to it.
+    mergeCommitSha: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<void> => {
     // Primary correlation: the implementation Routine names its branch
@@ -685,6 +702,7 @@ export const handleGithubPrClosed = internalMutation({
             // it may do so from any PR-live state — including IN_PROGRESS,
             // where an early merge would otherwise strand the row.
             source: "webhook",
+            mergeCommitSha: args.mergeCommitSha,
           },
         );
       } else {
@@ -692,16 +710,24 @@ export const handleGithubPrClosed = internalMutation({
         // merge: apply the transition (stamps shippedAt) + progress line.
         // Same ground-truth rule as above: any PR-live state may merge.
         if (GITHUB_MERGEABLE_STATUSES.includes(target.status)) {
+          const now = Date.now();
           await ctx.db.patch(target._id, {
             status: "MERGED",
-            ...(target.shippedAt ? {} : { shippedAt: Date.now() }),
-            updatedAt: Date.now(),
+            ...(target.shippedAt ? {} : { shippedAt: now }),
+            // Start deploy observation: the merge only *triggers* the staging
+            // deploy (see handleWorkflowRunEvent). Store the SHA so the
+            // workflow_run events correlate back here.
+            ...(args.mergeCommitSha
+              ? { mergeCommitSha: args.mergeCommitSha }
+              : {}),
+            stagingDeploy: { state: "pending", workflows: [], updatedAt: now },
+            updatedAt: now,
           });
           await insertThreadMessage(
             ctx,
             target._id,
             "system",
-            "Merged — live on staging",
+            MERGED_DEPLOYING_MESSAGE,
           );
         } else {
           console.error(
@@ -857,10 +883,13 @@ export const addSystemThreadMessage = internalMutation({
 
 /**
  * Record the outcome of an in-app production deploy trigger
- * (actions.dispatchProductionDeploy). Success just logs the progress line; a
- * failure ALSO clears productionRequestedAt so the dashboard's "Ship to
- * production" button comes back instead of stranding the item in a
- * "triggered" state that never happened.
+ * (actions.dispatchProductionDeploy). Success starts deploy observation
+ * (productionDeploy = pending) and logs "Deploying to production…" — the
+ * workflow_run webhook flips it to live/failed once the deploy actually
+ * finishes (handleWorkflowRunEvent). A failure to even DISPATCH the workflow
+ * ALSO clears productionRequestedAt so the dashboard's "Ship to production"
+ * button comes back instead of stranding the item in a "triggered" state that
+ * never happened.
  */
 export const recordProductionDeployOutcome = internalMutation({
   args: {
@@ -876,9 +905,13 @@ export const recordProductionDeployOutcome = internalMutation({
         ctx,
         args.bugId,
         "system",
-        "Production deploy started — the silent update reaches users next time they open the app",
+        "Deploying to production…",
       );
-      await ctx.db.patch(args.bugId, { updatedAt: Date.now() });
+      const now = Date.now();
+      await ctx.db.patch(args.bugId, {
+        productionDeploy: { state: "pending", updatedAt: now },
+        updatedAt: now,
+      });
     } else {
       await insertThreadMessage(
         ctx,
@@ -985,6 +1018,9 @@ export const applyCallback = internalMutation({
     // least-trusted source, and the only one reachable from the public HTTP
     // callback — which never forwards this field).
     source: v.optional(callbackSourceValidator),
+    // The squash-merge commit SHA — only meaningful on a MERGED apply; stored so
+    // the staging workflow_run events correlate to this bug.
+    mergeCommitSha: v.optional(v.string()),
     prUrl: v.optional(v.string()),
     screenshots: v.optional(v.array(v.string())),
     spec: v.optional(v.string()),
@@ -1109,6 +1145,17 @@ export const applyCallback = internalMutation({
     }
     if (targetStatus === "MERGED" && !bug.shippedAt) {
       patch.shippedAt = now;
+    }
+    // A GENUINE merge starts deploy observation: the merge only *triggers* the
+    // staging deploy workflows (handleWorkflowRunEvent flips this to live/failed
+    // as the workflow_run webhook arrives). Reset on every genuine merge so a
+    // staging-redo round's re-merge observes its own fresh deploy. Idempotent
+    // re-applies (already MERGED) leave the in-flight deploy state untouched.
+    if (targetStatus === "MERGED" && genuineTransition) {
+      if (args.mergeCommitSha !== undefined) {
+        patch.mergeCommitSha = args.mergeCommitSha;
+      }
+      patch.stagingDeploy = { state: "pending", workflows: [], updatedAt: now };
     }
 
     // Stale approval guard: a REVISED spec invalidates an existing sign-off —
@@ -1282,6 +1329,248 @@ export const applyCallback = internalMutation({
     }
 
     return await ctx.db.get(args.bugId);
+  },
+});
+
+// ============================================================================
+// Deploy observation (ADR-029 follow-up) — GitHub workflow_run webhook
+// ============================================================================
+
+/**
+ * The `name:` of the two workflows that deploy to STAGING on a push to `main`.
+ * deploy-convex only runs when apps/convex or packages/shared changed, and
+ * deploy-mobile-update only when apps/mobile or packages changed — so a given
+ * merge triggers one, the other, or both. A merge's staging deploy is "live"
+ * only once every workflow it actually triggered has succeeded.
+ */
+const STAGING_DEPLOY_WORKFLOW_NAMES = ["Deploy Convex", "Deploy Mobile Update"];
+
+/** The `name:` of the manual production deploy workflow. */
+const PRODUCTION_DEPLOY_WORKFLOW_NAME = "Deploy to Production";
+
+/**
+ * workflow_run conclusions that mean the deploy did NOT succeed. GitHub reports
+ * "success" | "failure" | "cancelled" | "timed_out" | "skipped" | ...; anything
+ * in this set fails the deploy (a "skipped" conclusion — e.g. a path filter that
+ * matched at trigger time but a job that self-skipped — is treated as neither
+ * success nor failure and simply doesn't advance the deploy).
+ */
+const FAILED_WORKFLOW_CONCLUSIONS = [
+  "failure",
+  "cancelled",
+  "timed_out",
+  "startup_failure",
+];
+
+type StagingWorkflow = { name: string; conclusion?: string };
+
+/**
+ * Push copy fired when the staging deploy actually goes live — the "try it on
+ * staging" ask that used to (incorrectly) fire on merge. Interactive items get
+ * a "confirm it works" ask that gates the production deploy; non-interactive
+ * items (copy/color) get an honest "it's live on staging" note.
+ */
+function stagingLivePush(bug: {
+  title: string;
+  verifyOnStaging?: boolean;
+}): { title: string; body: string } {
+  if (bug.verifyOnStaging) {
+    return {
+      title: "Ready to test on staging",
+      body: `"${bug.title}" is live on staging — try it and confirm it works.`,
+    };
+  }
+  return {
+    title: "Your contribution is live on staging",
+    body: `"${bug.title}" is now live on the staging app.`,
+  };
+}
+
+/**
+ * Apply a GitHub `workflow_run` webhook event (POST /github/webhook). Replaces
+ * the dashboard's old lie that a merge is instantly "live on staging": it flips
+ * a merged bug's `stagingDeploy` (and, for production runs, `productionDeploy`)
+ * through pending → live/failed as the real deploy workflows report in.
+ *
+ * STAGING (head_branch "main", name is a staging deploy workflow): correlates
+ * to bug(s) by `mergeCommitSha === head_sha` that are still deploying
+ * (`stagingDeploy.state === "pending"`).
+ *  - requested/in_progress → track the workflow (conclusion still unknown).
+ *  - completed → record its conclusion, then: any failure ⇒ state "failed"
+ *    (+ "contact the lead maintainer", no test-it push); success ⇒ state
+ *    "live" ONLY once every tracked workflow has succeeded (a merge may trigger
+ *    both Convex + mobile, so one success isn't enough), which posts the
+ *    "live on staging" line and fires the moved "try it" push.
+ *
+ * PRODUCTION (name === "Deploy to Production", completed): prod deploys ship
+ * everything on `main`, so the run can't be correlated to one bug by SHA — all
+ * bugs whose `productionDeploy.state === "pending"` move together (accepted for
+ * v1; correlation is inherently ambiguous for a global deploy).
+ */
+export const handleWorkflowRunEvent = internalMutation({
+  args: {
+    action: v.string(),
+    name: v.string(),
+    status: v.optional(v.string()),
+    conclusion: v.optional(v.string()),
+    headSha: v.string(),
+    headBranch: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const now = Date.now();
+
+    // ---- Production runs: global, correlated by state (not SHA) ----
+    if (args.name === PRODUCTION_DEPLOY_WORKFLOW_NAME) {
+      if (args.action !== "completed") return;
+      const succeeded = args.conclusion === "success";
+      const failed =
+        !!args.conclusion &&
+        FAILED_WORKFLOW_CONCLUSIONS.includes(args.conclusion);
+      if (!succeeded && !failed) return;
+
+      const merged = await ctx.db
+        .query("devBugs")
+        .withIndex("by_status", (q) => q.eq("status", "MERGED"))
+        .collect();
+      for (const bug of merged) {
+        if (bug.productionDeploy?.state !== "pending") continue;
+        if (succeeded) {
+          await ctx.db.patch(bug._id, {
+            productionDeploy: { state: "live", updatedAt: now },
+            updatedAt: now,
+          });
+          await insertThreadMessage(
+            ctx,
+            bug._id,
+            "system",
+            "Live in production 🎉",
+          );
+        } else {
+          await ctx.db.patch(bug._id, {
+            productionDeploy: {
+              state: "failed",
+              failedWorkflow: args.name,
+              updatedAt: now,
+            },
+            updatedAt: now,
+          });
+          await insertThreadMessage(
+            ctx,
+            bug._id,
+            "system",
+            "Production deploy failed — contact the lead maintainer.",
+          );
+        }
+      }
+      return;
+    }
+
+    // ---- Staging runs: correlated by merge commit SHA ----
+    if (
+      args.headBranch !== "main" ||
+      !STAGING_DEPLOY_WORKFLOW_NAMES.includes(args.name)
+    ) {
+      return;
+    }
+
+    const candidates = await ctx.db
+      .query("devBugs")
+      .withIndex("by_mergeCommitSha", (q) =>
+        q.eq("mergeCommitSha", args.headSha),
+      )
+      .collect();
+
+    for (const bug of candidates) {
+      if (bug.stagingDeploy?.state !== "pending") continue;
+      const workflows: StagingWorkflow[] = [
+        ...(bug.stagingDeploy.workflows ?? []),
+      ];
+
+      // Ensure this workflow is tracked (idempotent by name).
+      let entry = workflows.find((w) => w.name === args.name);
+      if (!entry) {
+        entry = { name: args.name };
+        workflows.push(entry);
+      }
+
+      if (args.action !== "completed") {
+        // requested / in_progress — just make sure it's in the tracked set so
+        // the completeness check below waits for it.
+        await ctx.db.patch(bug._id, {
+          stagingDeploy: { ...bug.stagingDeploy, workflows, updatedAt: now },
+          updatedAt: now,
+        });
+        continue;
+      }
+
+      // Completed: record this workflow's conclusion.
+      entry.conclusion = args.conclusion;
+
+      const failed =
+        !!args.conclusion &&
+        FAILED_WORKFLOW_CONCLUSIONS.includes(args.conclusion);
+      if (failed) {
+        await ctx.db.patch(bug._id, {
+          stagingDeploy: {
+            state: "failed",
+            workflows,
+            failedWorkflow: args.name,
+            updatedAt: now,
+          },
+          updatedAt: now,
+        });
+        await insertThreadMessage(
+          ctx,
+          bug._id,
+          "system",
+          `Staging deploy failed (${args.name}) — contact the lead maintainer.`,
+        );
+        continue;
+      }
+
+      // Success: the deploy is live only once EVERY tracked workflow has a
+      // conclusion and all are "success" (a merge may trigger both Convex and
+      // mobile — one success isn't enough). Otherwise stay pending.
+      const allSucceeded =
+        workflows.length > 0 &&
+        workflows.every((w) => w.conclusion === "success");
+      if (!allSucceeded) {
+        await ctx.db.patch(bug._id, {
+          stagingDeploy: { ...bug.stagingDeploy, workflows, updatedAt: now },
+          updatedAt: now,
+        });
+        continue;
+      }
+
+      await ctx.db.patch(bug._id, {
+        stagingDeploy: { state: "live", workflows, updatedAt: now },
+        updatedAt: now,
+      });
+      await insertThreadMessage(
+        ctx,
+        bug._id,
+        "system",
+        STAGING_LIVE_MESSAGE,
+      );
+
+      // Fire the moved "try it on staging" push — dashboard items only (chat
+      // items notify their channel via the bot message posted at merge). This
+      // is the honest moment: the change is actually up now.
+      if (!bug.channelId) {
+        const push = stagingLivePush(bug);
+        await ctx.scheduler.runAfter(
+          0,
+          internal.functions.notifications.actions.sendPushNotification,
+          {
+            userId: bug.originatorUserId,
+            title: push.title,
+            body: push.body,
+            notificationType: "dev_contribution_update",
+            data: { bugId: bug._id, status: bug.status },
+          },
+        );
+      }
+    }
   },
 });
 

--- a/apps/convex/functions/devAssistant/contributions.ts
+++ b/apps/convex/functions/devAssistant/contributions.ts
@@ -501,11 +501,38 @@ export const postMessage = mutation({
 });
 
 /**
+ * The staging deploy for a merged item has actually finished (deploy
+ * observation, ADR-029 follow-up). A merge only *triggers* the staging deploy
+ * workflows, so "merged" ≠ "live". Legacy rows merged before deploy observation
+ * carry no `stagingDeploy` — treat them as live (they're long since deployed).
+ * Mirrors the mobile `isStagingDeployLive`; the two must agree.
+ */
+function isStagingDeployLive(bug: Doc<"devBugs">): boolean {
+  return bug.stagingDeploy === undefined || bug.stagingDeploy.state === "live";
+}
+
+/**
+ * Throw unless the staging deploy is actually live. The mobile UI already
+ * hides the try-it / ship actions until the deploy finishes, but the UI gate
+ * is NOT authoritative — a stale or hand-rolled client could act while the
+ * deploy is still pending or has failed, so the server enforces it too.
+ */
+function assertStagingDeployLive(bug: Doc<"devBugs">): void {
+  if (isStagingDeployLive(bug)) return;
+  throw new ConvexError(
+    bug.stagingDeploy?.state === "failed"
+      ? "The staging deploy failed — contact the lead maintainer instead."
+      : "The staging deploy is still running — wait for it to finish.",
+  );
+}
+
+/**
  * Guard shared by confirmStaging/reportStagingIssue: the staging-check window.
  * Nothing reaches staging until the PR is merged to `main` (deploys auto-run on
- * merge), so the window opens at MERGED — not while the PR is still open. The
- * change is then live on staging and awaiting the contributor's try-it, which
- * in turn gates the manual production deploy (ADR-029).
+ * merge), so the window opens at MERGED — not while the PR is still open — AND
+ * only once that deploy actually finishes (isStagingDeployLive). The change is
+ * then live on staging and awaiting the contributor's try-it, which in turn
+ * gates the manual production deploy (ADR-029).
  */
 function assertStagingWindow(bug: Doc<"devBugs">): void {
   if (!bug.verifyOnStaging) {
@@ -519,6 +546,7 @@ function assertStagingWindow(bug: Doc<"devBugs">): void {
       `Staging can only be checked once the change is merged and live on staging (current status: ${bug.status})`,
     );
   }
+  assertStagingDeployLive(bug);
 }
 
 /**
@@ -723,6 +751,11 @@ export const promoteToProduction = mutation({
         "Confirm the change works on staging before shipping it to production",
       );
     }
+    // Deploy observation (ADR-029 follow-up): even a non-interactive item
+    // (verifyOnStaging === false, which skips the sign-off gate above) must
+    // wait for its staging deploy to actually finish before it can ship to
+    // production — never promote from a still-pending or failed staging deploy.
+    assertStagingDeployLive(bug);
     const now = Date.now();
     if (
       bug.productionRequestedAt &&

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -1464,6 +1464,7 @@ http.route({
         conclusion?: string | null;
         head_sha?: string;
         head_branch?: string;
+        run_started_at?: string;
       };
     };
     try {
@@ -1498,6 +1499,13 @@ http.route({
           headSha: run.head_sha,
           headBranch:
             typeof run.head_branch === "string" ? run.head_branch : undefined,
+          // ISO timestamp → ms; bounds which pending-prod bugs a production run
+          // settles (a run only covers work requested before it started).
+          runStartedAt:
+            typeof run.run_started_at === "string" &&
+            !Number.isNaN(Date.parse(run.run_started_at))
+              ? Date.parse(run.run_started_at)
+              : undefined,
         }
       );
       return new Response(JSON.stringify({ received: true }), {

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -1392,13 +1392,24 @@ async function verifyGithubSignature(
  * shippedAt, thread message, push) even when the merge happened directly on
  * GitHub; a PR closed without merging flags the item for a maintainer.
  *
- * Only `pull_request` events with action "closed" do anything — everything
- * else (ping, other events, other actions) returns 200 "ignored" fast.
- * Correlation to a devBug happens in the scheduled internalMutation
+ * Two events do work: a closed `pull_request` (a merge flips the correlated
+ * devBug to MERGED and starts staging deploy observation) and a `workflow_run`
+ * (the staging/production deploy actually finishing → the dashboard shows
+ * deploying → live, or a failure telling the contributor to contact the lead
+ * maintainer). Everything else (ping, other events/actions) returns 200
+ * "ignored" fast.
+ *
+ * NOTE: the repo webhook must subscribe to BOTH "Pull requests" and "Workflow
+ * runs" events — a webhook sending only pull_request never delivers the deploy
+ * observation, so the dashboard would sit at "deploying…" until the reconcile
+ * cron backstop or a manual check.
+ *
+ * PR correlation happens in the scheduled internalMutation
  * (handleGithubPrClosed): primarily by the Routine's `claude/devbug-<bugId>`
  * head-branch convention, falling back to matching html_url against stored
- * prUrl. Responds 200 immediately after scheduling (async-schedule-then-200,
- * like the Slack handler).
+ * prUrl. workflow_run correlation (handleWorkflowRunEvent) is by the merge
+ * commit SHA for staging, and global-by-state for production. Responds 200
+ * immediately after scheduling (async-schedule-then-200, like Slack).
  */
 http.route({
   path: "/github/webhook",
@@ -1431,9 +1442,11 @@ http.route({
       return new Response("Invalid signature", { status: 401 });
     }
 
-    // Only closed pull requests matter; ack everything else immediately.
+    // Two event types do work: a closed `pull_request` (merge → MERGED) and a
+    // `workflow_run` (deploy observation, ADR-029 follow-up). Everything else
+    // (ping, other events/actions) acks immediately.
     const event = request.headers.get("x-github-event");
-    if (event !== "pull_request") {
+    if (event !== "pull_request" && event !== "workflow_run") {
       return new Response("ignored", { status: 200 });
     }
 
@@ -1441,8 +1454,16 @@ http.route({
       action?: string;
       pull_request?: {
         merged?: boolean;
+        merge_commit_sha?: string;
         html_url?: string;
         head?: { ref?: string };
+      };
+      workflow_run?: {
+        name?: string;
+        status?: string;
+        conclusion?: string | null;
+        head_sha?: string;
+        head_branch?: string;
       };
     };
     try {
@@ -1451,6 +1472,41 @@ http.route({
       return new Response("Invalid JSON", { status: 400 });
     }
 
+    // ---- workflow_run: staging/production deploy observation ----
+    if (event === "workflow_run") {
+      const run = payload.workflow_run;
+      if (
+        !payload.action ||
+        !run ||
+        typeof run.name !== "string" ||
+        typeof run.head_sha !== "string"
+      ) {
+        // Malformed (or a workflow_run without the fields we need) — ack and
+        // ignore rather than error.
+        return new Response("ignored", { status: 200 });
+      }
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.devAssistant.bugs.handleWorkflowRunEvent,
+        {
+          action: payload.action,
+          name: run.name,
+          status: typeof run.status === "string" ? run.status : undefined,
+          // GitHub sends `conclusion: null` until the run completes.
+          conclusion:
+            typeof run.conclusion === "string" ? run.conclusion : undefined,
+          headSha: run.head_sha,
+          headBranch:
+            typeof run.head_branch === "string" ? run.head_branch : undefined,
+        }
+      );
+      return new Response(JSON.stringify({ received: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // ---- pull_request: only closed PRs matter ----
     if (payload.action !== "closed") {
       return new Response("ignored", { status: 200 });
     }
@@ -1468,6 +1524,11 @@ http.route({
         branchRef,
         prUrl: typeof pr.html_url === "string" ? pr.html_url : undefined,
         merged: pr.merged,
+        // The squash-merge commit correlates the staging deploy observation.
+        mergeCommitSha:
+          typeof pr.merge_commit_sha === "string"
+            ? pr.merge_commit_sha
+            : undefined,
       }
     );
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2351,6 +2351,11 @@ export default defineSchema({
           v.literal("failed"),
         ),
         failedWorkflow: v.optional(v.string()),
+        // When the in-app deploy was dispatched. A "Deploy to Production" run
+        // only settles bugs requested BEFORE it started (requestedAt <=
+        // run_started_at), so a later dispatch isn't wrongly marked done by an
+        // earlier, still-running deploy.
+        requestedAt: v.optional(v.number()),
         updatedAt: v.number(),
       }),
     ),

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2305,6 +2305,55 @@ export default defineSchema({
     githubIssueNumber: v.optional(v.number()),
     githubIssueUrl: v.optional(v.string()),
     shippedAt: v.optional(v.number()), // set when status reaches MERGED
+
+    // Deploy observation (ADR-029 follow-up). A merge only *triggers* the
+    // staging deploy workflows (a few minutes); production is a separate manual
+    // dispatch. These fields let the dashboard show "deploying → live" and, on
+    // failure, tell the contributor the deploy failed instead of inviting them
+    // to test something that isn't up. Driven by the GitHub `workflow_run`
+    // webhook (see http.ts + bugs.ts handleWorkflowRunEvent).
+
+    // The squash-merge commit SHA — correlates the staging `workflow_run` events
+    // (head_sha) back to this bug. Stored the moment the merge is observed.
+    mergeCommitSha: v.optional(v.string()),
+    // Staging deploy state for this merge. `workflows` tracks each triggered
+    // staging workflow ("Deploy Convex" / "Deploy Mobile Update") we've seen and
+    // its conclusion; the deploy is "live" only once every tracked workflow
+    // succeeded, "failed" the moment any one fails.
+    stagingDeploy: v.optional(
+      v.object({
+        state: v.union(
+          v.literal("pending"),
+          v.literal("live"),
+          v.literal("failed"),
+        ),
+        workflows: v.optional(
+          v.array(
+            v.object({
+              name: v.string(),
+              conclusion: v.optional(v.string()),
+            }),
+          ),
+        ),
+        failedWorkflow: v.optional(v.string()),
+        updatedAt: v.number(),
+      }),
+    ),
+    // Production deploy state, set when a maintainer ships from the app. Prod
+    // deploys are global (they ship everything on `main`), so the "Deploy to
+    // Production" workflow_run can't be correlated to one bug by SHA — all
+    // pending-prod bugs move together (see handleWorkflowRunEvent).
+    productionDeploy: v.optional(
+      v.object({
+        state: v.union(
+          v.literal("pending"),
+          v.literal("live"),
+          v.literal("failed"),
+        ),
+        failedWorkflow: v.optional(v.string()),
+        updatedAt: v.number(),
+      }),
+    ),
     // Contributor set the conversation aside (abandoned it, or the scope was
     // judged not doable) — ADR-029. Orthogonal to `status`: an item can be
     // archived from any pipeline state and unarchived to restore it. Archived
@@ -2338,7 +2387,8 @@ export default defineSchema({
     .index("by_status", ["status"])
     .index("by_channel", ["channelId"])
     .index("by_originator", ["originatorUserId"])
-    .index("by_routineRunId", ["routineRunId"]),
+    .index("by_routineRunId", ["routineRunId"])
+    .index("by_mergeCommitSha", ["mergeCommitSha"]),
 
   /**
    * Conversation thread on a devBugs item (contributor dev dashboard,

--- a/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributionDetailScreen.tsx
@@ -57,6 +57,7 @@ import {
   displayTitle,
   isBuildableScope,
   isFromChat,
+  isStagingDeployLive,
   needsSpecApproval,
   needsStagingVerify,
   PALETTE,
@@ -596,6 +597,15 @@ export function ContributionDetailScreen({
     contribution.status === "IN_REVIEW" &&
     isBuildableScope(contribution.scope);
   const showStagingCard = !archived && needsStagingVerify(contribution);
+  // Deploy observation (ADR-029 follow-up): a merge only *triggers* the staging
+  // deploy. While it's running or if it failed, show an honest status card
+  // instead of the try-it/production actions — never invite a contributor to
+  // test something that isn't up.
+  const stagingDeployState = contribution.stagingDeploy?.state;
+  const showStagingDeploying =
+    !archived && contribution.status === "MERGED" && stagingDeployState === "pending";
+  const showStagingFailed =
+    !archived && contribution.status === "MERGED" && stagingDeployState === "failed";
   // In-app merge: review approved but not yet merged (auto-merge didn't take
   // it — higher risk than the originator's cap, or the feature is off).
   // mergeRequestedAt is the server-side in-flight latch: it hides the card
@@ -612,8 +622,15 @@ export function ContributionDetailScreen({
   // this feature and must not grow a live production button retroactively.
   const stagingCleared =
     contribution.verifyOnStaging === false || !!contribution.stagingVerifiedAt;
+  // Production actions require the staging deploy to have actually finished —
+  // a non-interactive item (verifyOnStaging === false) clears the try-it gate
+  // immediately, but must still wait for its staging deploy to go live.
   const showProductionCard =
-    !archived && contribution.status === "MERGED" && stagingCleared;
+    !archived &&
+    contribution.status === "MERGED" &&
+    stagingCleared &&
+    isStagingDeployLive(contribution);
+  const productionDeployState = contribution.productionDeploy?.state;
   // Fresh trigger → "deploy triggered" card; past the cooldown the button
   // returns (the dispatch only queues the workflow — the run can still fail).
   const productionRecentlyRequested =
@@ -815,6 +832,37 @@ export function ContributionDetailScreen({
           </ActionCard>
         ) : null}
 
+        {showStagingDeploying ? (
+          <ActionCard
+            icon="cloud-upload-outline"
+            tint={PALETTE.aiWorking}
+            borderTint={colors.border}
+            title="Deploying to staging"
+          >
+            <Text style={[styles.hint, { color: colors.textSecondary }]}>
+              Merged — the staging deploy is running now (usually a few minutes).
+              We'll let you know the moment it's live so you can try it.
+            </Text>
+          </ActionCard>
+        ) : null}
+
+        {showStagingFailed ? (
+          <ActionCard
+            icon="alert-circle-outline"
+            tint="#FF3B30"
+            title="Staging deploy failed"
+          >
+            <Text style={[styles.hint, { color: colors.textSecondary }]}>
+              The change merged, but the staging deploy didn't finish
+              {contribution.stagingDeploy?.failedWorkflow
+                ? ` (${contribution.stagingDeploy.failedWorkflow})`
+                : ""}
+              . It isn't live on staging yet — please contact the lead
+              maintainer.
+            </Text>
+          </ActionCard>
+        ) : null}
+
         {showStagingCard ? (
           <ActionCard icon="flask-outline" tint={PALETTE.yourTurn} title="Ready for you to try">
             <Text style={[styles.hint, { color: colors.textSecondary }]}>
@@ -886,16 +934,41 @@ export function ContributionDetailScreen({
         ) : null}
 
         {showProductionCard ? (
-          productionRecentlyRequested ? (
+          productionDeployState === "live" ? (
             <ActionCard
               icon="checkmark-circle-outline"
               tint={PALETTE.shipped}
-              borderTint={colors.border}
-              title="Production deploy triggered"
+              title="Live in production 🎉"
             >
               <Text style={[styles.hint, { color: colors.textSecondary }]}>
-                The silent update rolls out as users open the app — no forced
-                reload.
+                The silent update is out — users pick it up next time they open
+                the app.
+              </Text>
+            </ActionCard>
+          ) : productionDeployState === "failed" ? (
+            <ActionCard
+              icon="alert-circle-outline"
+              tint="#FF3B30"
+              title="Production deploy failed"
+            >
+              <Text style={[styles.hint, { color: colors.textSecondary }]}>
+                The production deploy didn't finish
+                {contribution.productionDeploy?.failedWorkflow
+                  ? ` (${contribution.productionDeploy.failedWorkflow})`
+                  : ""}
+                . Nothing shipped to users — please contact the lead maintainer.
+              </Text>
+            </ActionCard>
+          ) : productionDeployState === "pending" || productionRecentlyRequested ? (
+            <ActionCard
+              icon="cloud-upload-outline"
+              tint={PALETTE.aiWorking}
+              borderTint={colors.border}
+              title="Deploying to production"
+            >
+              <Text style={[styles.hint, { color: colors.textSecondary }]}>
+                The silent update is rolling out — users get it next time they
+                open the app, no forced reload.
               </Text>
             </ActionCard>
           ) : (

--- a/apps/mobile/features/contribute/types.ts
+++ b/apps/mobile/features/contribute/types.ts
@@ -34,6 +34,28 @@ export type ContributionScope = "buildable" | "split" | "design_needed";
 /** Who wrote a thread message. */
 export type MessageAuthorType = "user" | "assistant" | "system";
 
+/** Deploy-observation state (ADR-029 follow-up): deploying → live, or failed. */
+export type DeployState = "pending" | "live" | "failed";
+
+/**
+ * Staging deploy state for a merged contribution. `workflows` tracks each
+ * triggered staging workflow ("Deploy Convex" / "Deploy Mobile Update") and its
+ * conclusion; the deploy is "live" only once all tracked workflows succeeded.
+ */
+export interface StagingDeploy {
+  state: DeployState;
+  workflows?: { name: string; conclusion?: string }[];
+  failedWorkflow?: string;
+  updatedAt: number;
+}
+
+/** Production deploy state for a shipped contribution. */
+export interface ProductionDeploy {
+  state: DeployState;
+  failedWorkflow?: string;
+  updatedAt: number;
+}
+
 /**
  * One buildable slice of a "split" contribution — a short title plus a
  * self-contained prompt a maintainer can paste into a fresh dev session.
@@ -104,6 +126,17 @@ export interface Contribution {
   /** AI review verdict on the open PR — "approved" unlocks the in-app merge. */
   reviewVerdict?: "approved" | "changes_requested";
   reviewSummary?: string;
+  /** Squash-merge commit SHA (correlates staging deploy observation). */
+  mergeCommitSha?: string;
+  /**
+   * Staging deploy state after a merge — drives "deploying → live" on the
+   * dashboard, and a "deploy failed — contact the lead maintainer" state so we
+   * never invite a contributor to test something that isn't up. Undefined on
+   * legacy merged rows that predate deploy observation (treat as live).
+   */
+  stagingDeploy?: StagingDeploy;
+  /** Production deploy state after an in-app "Ship to production". */
+  productionDeploy?: ProductionDeploy;
   prUrl?: string;
   githubIssueUrl?: string;
   /** User's own report screenshots (set at submit). */

--- a/apps/mobile/features/contribute/types.ts
+++ b/apps/mobile/features/contribute/types.ts
@@ -53,6 +53,8 @@ export interface StagingDeploy {
 export interface ProductionDeploy {
   state: DeployState;
   failedWorkflow?: string;
+  /** When the in-app deploy was dispatched (bounds which run settles it). */
+  requestedAt?: number;
   updatedAt: number;
 }
 

--- a/apps/mobile/features/contribute/utils/status.test.ts
+++ b/apps/mobile/features/contribute/utils/status.test.ts
@@ -5,8 +5,10 @@
 import {
   isArchived,
   isInProgress,
-  isRerun,
+  isStagingDeployLive,
   isYourTurn,
+  needsStagingVerify,
+  isRerun,
   statusPresentation,
 } from "./status";
 import type { Contribution } from "../types";
@@ -19,6 +21,8 @@ type StatusInput = Pick<
   | "scope"
   | "verifyOnStaging"
   | "stagingVerifiedAt"
+  | "stagingDeploy"
+  | "productionDeploy"
   | "fixRounds"
   | "redoRounds"
   | "activeRunMode"
@@ -109,6 +113,123 @@ describe("isInProgress", () => {
     });
     expect(isYourTurn(approved)).toBe(true);
     expect(isInProgress(approved)).toBe(false);
+  });
+});
+
+describe("deploy observation — MERGED sub-states", () => {
+  it("isStagingDeployLive: undefined (legacy) or 'live' is live; pending/failed is not", () => {
+    expect(isStagingDeployLive({})).toBe(true);
+    expect(
+      isStagingDeployLive({ stagingDeploy: { state: "live", updatedAt: 1 } }),
+    ).toBe(true);
+    expect(
+      isStagingDeployLive({ stagingDeploy: { state: "pending", updatedAt: 1 } }),
+    ).toBe(false);
+    expect(
+      isStagingDeployLive({ stagingDeploy: { state: "failed", updatedAt: 1 } }),
+    ).toBe(false);
+  });
+
+  it("needsStagingVerify only once the staging deploy is live", () => {
+    const base = make({ status: "MERGED", verifyOnStaging: true });
+    // Deploy still running / failed → don't invite a try-it yet.
+    expect(
+      needsStagingVerify({
+        ...base,
+        stagingDeploy: { state: "pending", updatedAt: 1 },
+      }),
+    ).toBe(false);
+    expect(
+      needsStagingVerify({
+        ...base,
+        stagingDeploy: { state: "failed", updatedAt: 1 },
+      }),
+    ).toBe(false);
+    // Live (or legacy undefined) → the try-it window is open.
+    expect(
+      needsStagingVerify({
+        ...base,
+        stagingDeploy: { state: "live", updatedAt: 1 },
+      }),
+    ).toBe(true);
+    expect(needsStagingVerify(base)).toBe(true);
+  });
+
+  it("statusPresentation reflects the staging deploy state on a merged item", () => {
+    expect(
+      statusPresentation(
+        make({
+          status: "MERGED",
+          verifyOnStaging: true,
+          stagingDeploy: { state: "pending", updatedAt: 1 },
+        }),
+      ).label,
+    ).toBe("Deploying to staging…");
+    expect(
+      statusPresentation(
+        make({
+          status: "MERGED",
+          verifyOnStaging: true,
+          stagingDeploy: { state: "failed", updatedAt: 1 },
+        }),
+      ).label,
+    ).toBe("Staging deploy failed");
+    // Live interactive item → the existing "ready to try" label.
+    expect(
+      statusPresentation(
+        make({
+          status: "MERGED",
+          verifyOnStaging: true,
+          stagingDeploy: { state: "live", updatedAt: 1 },
+        }),
+      ).label,
+    ).toBe("On staging — ready for you to try");
+    // Legacy merged row with no deploy record still reads as live-on-staging.
+    expect(statusPresentation(make({ status: "MERGED" })).label).toBe(
+      "Live on staging",
+    );
+  });
+
+  it("statusPresentation surfaces the production deploy state", () => {
+    expect(
+      statusPresentation(
+        make({
+          status: "MERGED",
+          stagingVerifiedAt: 1,
+          productionDeploy: { state: "pending", updatedAt: 1 },
+        }),
+      ).label,
+    ).toBe("Deploying to production…");
+    expect(
+      statusPresentation(
+        make({
+          status: "MERGED",
+          stagingVerifiedAt: 1,
+          productionDeploy: { state: "live", updatedAt: 1 },
+        }),
+      ).label,
+    ).toBe("Live in production");
+    expect(
+      statusPresentation(
+        make({
+          status: "MERGED",
+          stagingVerifiedAt: 1,
+          productionDeploy: { state: "failed", updatedAt: 1 },
+        }),
+      ).label,
+    ).toBe("Production deploy failed");
+  });
+
+  it("a pending staging deploy keeps an interactive merged item OFF 'your turn'", () => {
+    const item = make({
+      status: "MERGED",
+      verifyOnStaging: true,
+      stagingDeploy: { state: "pending", updatedAt: 1 },
+    });
+    // Not the contributor's turn (nothing to try yet) and not "in progress"
+    // either — it's a merged item waiting on its deploy.
+    expect(isYourTurn(item)).toBe(false);
+    expect(isInProgress(item)).toBe(false);
   });
 });
 

--- a/apps/mobile/features/contribute/utils/status.ts
+++ b/apps/mobile/features/contribute/utils/status.ts
@@ -56,19 +56,41 @@ export function needsSpecApproval(
 }
 
 /**
+ * The staging deploy for a merged item is actually up. A merge only *triggers*
+ * the staging deploy workflows (a few minutes), so "merged" ≠ "live". Legacy
+ * merged rows predate deploy observation and carry no `stagingDeploy` — treat
+ * them as live (they're long since deployed). A pending or failed deploy is
+ * explicitly NOT live, so we never invite a contributor to test something that
+ * isn't up.
+ */
+export function isStagingDeployLive(
+  contribution: Pick<Contribution, "stagingDeploy">,
+): boolean {
+  return (
+    contribution.stagingDeploy === undefined ||
+    contribution.stagingDeploy.state === "live"
+  );
+}
+
+/**
  * The contributor should try the change on the staging app: it's flagged for
- * staging verification, not yet verified, and merged. Nothing reaches staging
- * until the PR merges to `main` (deploys auto-run on merge), so the try-it
- * window opens at MERGED — never while the PR is still open. The sign-off then
- * gates the manual production deploy (ADR-029).
+ * staging verification, not yet verified, merged, AND the staging deploy has
+ * actually finished. Nothing reaches staging until the PR merges to `main` and
+ * the deploy workflows run, so the try-it window opens once the deploy goes
+ * live — never on merge alone. The sign-off then gates the manual production
+ * deploy (ADR-029).
  */
 export function needsStagingVerify(
-  contribution: Pick<Contribution, "status" | "verifyOnStaging" | "stagingVerifiedAt">,
+  contribution: Pick<
+    Contribution,
+    "status" | "verifyOnStaging" | "stagingVerifiedAt" | "stagingDeploy"
+  >,
 ): boolean {
   return (
     !!contribution.verifyOnStaging &&
     !contribution.stagingVerifiedAt &&
-    contribution.status === "MERGED"
+    contribution.status === "MERGED" &&
+    isStagingDeployLive(contribution)
   );
 }
 
@@ -107,7 +129,7 @@ export function needsBuildStart(
 export function isYourTurn(
   contribution: Pick<
     Contribution,
-    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
+    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt" | "stagingDeploy"
   >,
 ): boolean {
   return (
@@ -127,7 +149,7 @@ export function isYourTurn(
 export function isInProgress(
   contribution: Pick<
     Contribution,
-    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
+    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt" | "stagingDeploy"
   >,
 ): boolean {
   return (
@@ -141,7 +163,7 @@ export function isInProgress(
 export function conversationDotColor(
   contribution: Pick<
     Contribution,
-    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt"
+    "status" | "spec" | "specApprovedAt" | "scope" | "verifyOnStaging" | "stagingVerifiedAt" | "stagingDeploy"
   >,
 ): string {
   if (isYourTurn(contribution)) return PALETTE.yourTurn;
@@ -246,6 +268,8 @@ export function statusPresentation(
     | "scope"
     | "verifyOnStaging"
     | "stagingVerifiedAt"
+    | "stagingDeploy"
+    | "productionDeploy"
     | "fixRounds"
     | "redoRounds"
     | "activeRunMode"
@@ -291,10 +315,31 @@ export function statusPresentation(
     case "READY_TO_MERGE":
       // Reviewed and approved, but not merged — still nothing on staging.
       return { label: "Awaiting merge", color: "#FF9500", icon: "git-merge-outline" };
-    case "MERGED":
-      // A merge auto-deploys to staging; production is a separate manual step.
-      // For interactive items the contributor tries it on staging first (their
-      // turn), then a maintainer ships to production (ADR-029).
+    case "MERGED": {
+      // Production deploy state wins once a ship has been triggered — it's the
+      // latest truth about where the change is.
+      const prod = contribution.productionDeploy;
+      if (prod?.state === "live") {
+        return { label: "Live in production", color: "#34C759", icon: "checkmark-circle-outline" };
+      }
+      if (prod?.state === "failed") {
+        return { label: "Production deploy failed", color: "#FF3B30", icon: "alert-circle-outline" };
+      }
+      if (prod?.state === "pending") {
+        return { label: "Deploying to production…", color: "#FF9500", icon: "cloud-upload-outline" };
+      }
+      // A merge only *triggers* the staging deploy — be honest about its real
+      // state instead of claiming "live on staging" the instant it merges.
+      const staging = contribution.stagingDeploy;
+      if (staging?.state === "pending") {
+        return { label: "Deploying to staging…", color: "#FF9500", icon: "cloud-upload-outline" };
+      }
+      if (staging?.state === "failed") {
+        return { label: "Staging deploy failed", color: "#FF3B30", icon: "alert-circle-outline" };
+      }
+      // Deploy is live (or a legacy row with no deploy record). For interactive
+      // items the contributor tries it on staging first (their turn), then a
+      // maintainer ships to production (ADR-029).
       if (contribution.verifyOnStaging && !contribution.stagingVerifiedAt) {
         return {
           label: "On staging — ready for you to try",
@@ -309,7 +354,8 @@ export function statusPresentation(
           icon: "checkmark-circle-outline",
         };
       }
-      return { label: "Merged — live on staging", color: "#34C759", icon: "checkmark-circle-outline" };
+      return { label: "Live on staging", color: "#34C759", icon: "checkmark-circle-outline" };
+    }
     case "REJECTED":
       return { label: "Not planned", color: "#999999", icon: "close-circle-outline" };
     case "DRAFT":


### PR DESCRIPTION
## Why

The dev-assistant dashboard **lied about deploy state**. The instant a PR merged it said "merged and live on staging" and the "go test on staging" push fired immediately — but a merge only *triggers* the staging deploy workflows (a few minutes). Same for production: the in-app "Ship to production" dispatch got a `204 queued` and immediately claimed "deploy started", never observing the actual run.

This builds **real deploy observation** so the dashboard shows **deploying → live**, and on failure tells the contributor the deploy failed and to **contact the lead maintainer** — never inviting them to test something that isn't up.

Uses a GitHub **`workflow_run` webhook** (not polling). The existing `reconcileMergedPrs` cron is untouched (still the merge backstop).

## ⚠️ Required manual enablement step

**The GitHub repo webhook that points at `/github/webhook` currently only subscribes to `pull_request`. You must add the "Workflow runs" event to its subscription — otherwise none of this fires** and the dashboard sits at "Deploying to staging…" forever (the merge itself still works via the existing `pull_request` handler).

- Repo → Settings → Webhooks → the Convex `/github/webhook` endpoint → **Let me select individual events** → check **Workflow runs** (keep **Pull requests** checked).
- The webhook already signs with `GH_WEBHOOK_SECRET` (falls back to `DEV_ASSISTANT_CALLBACK_SECRET`); `workflow_run` events verify identically. No new secret.

## What it does

**At merge** (webhook + in-app/auto-merge paths): store `mergeCommitSha`, set `stagingDeploy = pending`, post **"Merged — deploying to staging…"**. The "try it on staging" push is **moved off** the merge moment.

**`workflow_run` webhook** (`http.ts` → `handleWorkflowRunEvent`):
- **Staging** (`head_branch === "main"`, name ∈ {`Deploy Convex`, `Deploy Mobile Update`}), correlated by `mergeCommitSha === head_sha`:
  - `requested`/`in_progress` → track the workflow.
  - `completed` + failure → `stagingDeploy = failed`, post **"Staging deploy failed (&lt;name&gt;) — contact the lead maintainer."**, no push.
  - `completed` + success → live **only once every tracked workflow succeeded** (a merge may trigger Convex, mobile, or both); posts **"Live on staging — ready to try it"** and fires the moved push.
- **Production** (name === `Deploy to Production`, completed): prod ships everything on `main`, so it can't be SHA-correlated to one bug — **all `productionDeploy === pending` bugs move together** (accepted for v1). success → **"Live in production 🎉"**; failure → **"Production deploy failed — contact the lead maintainer."**

**Production dispatch**: on a successful `204`, set `productionDeploy = pending` and post **"Deploying to production…"** (cooldown latch behavior kept).

**Mobile UI**: `statusPresentation` reflects the deploy sub-states (deploying / failed / live) for both staging and production; the staging "try it" card and the production card only render when the deploy is actually **live**, showing honest "deploying…" / "failed — contact the lead maintainer" states otherwise. Consistent with existing card styling (StyleSheet + TouchableOpacity, no NativeWind, no Pressable function-style).

## Schema (`devBugs`)

- `mergeCommitSha` (+ `by_mergeCommitSha` index) — squash-merge SHA for correlation.
- `stagingDeploy { state: pending|live|failed, workflows[{name, conclusion?}], failedWorkflow?, updatedAt }`.
- `productionDeploy { state: pending|live|failed, failedWorkflow?, updatedAt }`.

All optional/additive; legacy merged rows (no `stagingDeploy`) are treated as live.

## Tests

- **Backend** (`dev-contributions.test.ts`, +6 workflow_run tests; existing merge/push/message tests updated): success flips staging live only when all tracked workflows succeed and fires the push; failure flips to failed with the contact-the-maintainer message and no push; unrelated SHA / non-main branch / already-settled deploys are no-ops; production success/failure moves pending-prod bugs. **All 106 pass.** Full Convex suite: **2303 pass.**
- **Mobile** (`status.test.ts`, +deploy-observation describe): `isStagingDeployLive`, `needsStagingVerify` gating, and MERGED staging/production sub-state labels. **28 pass.** `tsc --noEmit` clean.

## Caveats

- **Staging completeness** = all *tracked* workflows done. If a `completed` arrives before a co-triggered workflow's `requested` (out-of-order delivery), the deploy could read live slightly early. GitHub creates all triggered runs (and their `requested` events) at push time, so this is rare; accepted for v1.
- **Production correlation is global** (by state, not SHA) — a prod deploy ships everything on `main`, so a single run legitimately settles all pending-prod bugs.
- Could not exercise the live app end-to-end (no running Convex deployment / real GitHub webhook in this environment); validated via the convex-test suite + mobile jest + tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)