### PR TITLE
ci(secrets): retry transient failures in 1Password→GitHub sync

### DIFF
--- a/ee/scripts/sync-1password-to-github.sh
+++ b/ee/scripts/sync-1password-to-github.sh
@@ -177,6 +177,32 @@ AUTO_MERGE_DEFAULTS=(
 )
 
 # ---------------------------------------------------------------------------
+# Set a GitHub environment secret, retrying transient failures.
+# ---------------------------------------------------------------------------
+# `gh secret set` occasionally fails on a transient GitHub API 502 while
+# fetching the environment public key (seen in the auto-triggered sync). The
+# call is idempotent — setting the same value again is harmless — so retry a
+# few times with backoff before giving up. Reads the value from stdin so secret
+# values never appear in the process table. Returns non-zero only after all
+# attempts fail.
+gh_secret_set_retry() {
+  local key="$1" env="$2" value
+  value="$(cat)"
+  local attempt=1 max=3
+  while true; do
+    if printf '%s' "$value" | gh secret set "$key" --env "$env" --repo "$REPO"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max" ]; then
+      return 1
+    fi
+    echo "  (transient failure — retry $attempt/$((max - 1)) in $((attempt * 3))s)"
+    sleep $((attempt * 3))
+    attempt=$((attempt + 1))
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Sync function
 # ---------------------------------------------------------------------------
 sync_environment() {
@@ -205,7 +231,7 @@ sync_environment() {
         echo "  [dry-run] Would set $KEY"
       else
         echo -n "  Setting $KEY..."
-        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO"; then
+        if printf '%s' "$VALUE" | gh_secret_set_retry "$KEY" "$env"; then
           echo " done"
         else
           echo " FAILED"
@@ -231,7 +257,7 @@ sync_environment() {
         echo "  [dry-run] Would set $KEY"
       else
         echo -n "  Setting $KEY..."
-        if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO"; then
+        if printf '%s' "$VALUE" | gh_secret_set_retry "$KEY" "$env"; then
           echo " done"
         else
           echo " FAILED"
@@ -259,7 +285,7 @@ sync_environment() {
       echo "  [dry-run] Would set $KEY=$VALUE"
     else
       echo -n "  Setting $KEY=$VALUE..."
-      if printf '%s' "$VALUE" | gh secret set "$KEY" --env "$env" --repo "$REPO"; then
+      if printf '%s' "$VALUE" | gh_secret_set_retry "$KEY" "$env"; then
         echo " done"
       else
         echo " FAILED"
@@ -279,7 +305,7 @@ sync_environment() {
       echo "  [dry-run] Would set IMAGE_CDN_URL (alias for R2_PUBLIC_URL)"
     else
       echo -n "  Setting IMAGE_CDN_URL (alias for R2_PUBLIC_URL)..."
-      if printf '%s' "$R2_URL" | gh secret set "IMAGE_CDN_URL" --env "$env" --repo "$REPO"; then
+      if printf '%s' "$R2_URL" | gh_secret_set_retry "IMAGE_CDN_URL" "$env"; then
         echo " done"
       else
         echo " FAILED"


### PR DESCRIPTION
## Why

Now that #610 auto-runs `sync-secrets.yml` on every allowlist-file merge, a transient GitHub API 502 fails the whole run with nobody watching. This already happened once — the first auto-triggered run failed on `failed to fetch public key: HTTP 502` for a single unchanged secret (`R2_BUCKET_NAME`), even though everything else synced fine.

## What

- New `gh_secret_set_retry` helper: up to 3 attempts with linear backoff (3s, 6s), value piped via stdin so it never appears in the process table.
- Routed all four `gh secret set` call sites (common, optional, auto-merge switches, `IMAGE_CDN_URL`) through it. The operation is idempotent, so retrying the same value is safe.

## Test

- `bash -n` clean.
- Behavior-tested the helper against a mock `gh` that fails twice then succeeds — it retries and succeeds. A permanent failure still returns non-zero after 3 attempts (preserving the existing `FAILED`/counter path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)