### PR TITLE
fix(mobile): stop two production crash/error screens (BlurView Fabric crash + raw error fallback)

### DIFF
--- a/apps/mobile/app/e/[shortId]/guests.tsx
+++ b/apps/mobile/app/e/[shortId]/guests.tsx
@@ -14,7 +14,7 @@ import { useQuery, api } from "@services/api/convex";
 import { useAuth } from "@/providers/AuthProvider";
 import { Avatar } from "@components/ui/Avatar";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
-import { BlurView } from "expo-blur";
+import { SafeBlurView } from "@components/ui/SafeBlurView";
 import {
   getEmojiForOption,
   getCleanLabel,
@@ -182,7 +182,7 @@ export default function GuestListScreen() {
 
         {/* Restricted Access Overlay - covers full content area */}
         {!hasRsvpd && (
-          <BlurView
+          <SafeBlurView
             intensity={50}
             tint="dark"
             style={styles.blurOverlay}
@@ -210,7 +210,7 @@ export default function GuestListScreen() {
                 </Text>
               </View>
             </View>
-          </BlurView>
+          </SafeBlurView>
         )}
       </View>
     </SafeAreaView>

--- a/apps/mobile/app/e/[shortId]/guests.tsx
+++ b/apps/mobile/app/e/[shortId]/guests.tsx
@@ -177,8 +177,11 @@ export default function GuestListScreen() {
 
       {/* Content Area */}
       <View style={styles.contentWrapper}>
-        {/* Guest List */}
-        {renderGuestList()}
+        {/* Guest list is only rendered for RSVP'd users. The restricted-access
+            overlay is a scrim, not a guaranteed blur (blur is disabled on the
+            native New Architecture and is inspectable in the web DOM), so we
+            must not render guest data at all until the user has access. */}
+        {hasRsvpd && renderGuestList()}
 
         {/* Restricted Access Overlay - covers full content area */}
         {!hasRsvpd && (

--- a/apps/mobile/components/ErrorBoundary.tsx
+++ b/apps/mobile/components/ErrorBoundary.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+  Linking,
+  Platform,
+} from 'react-native';
 import { router } from 'expo-router';
+import Constants from 'expo-constants';
+import * as Application from 'expo-application';
+import * as MailComposer from 'expo-mail-composer';
 import { SentryUtils } from '@providers/SentryProvider';
+
+const sadGif = require('../assets/sad.gif');
+
+/** Where "Send to developer" reports are delivered. */
+const SUPPORT_EMAIL = 'togather@supa.media';
 
 interface Props {
   children: React.ReactNode;
@@ -12,20 +28,24 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
+  /** React component stack — our best "which screen" breadcrumb. */
+  componentStack: string | null;
 }
 
 export class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, componentStack: null };
   }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
+
+    this.setState({ componentStack: errorInfo.componentStack ?? null });
 
     // Report error to Sentry with component stack trace
     SentryUtils.captureException(error, {
@@ -35,14 +55,14 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   resetError = () => {
-    this.setState({ hasError: false, error: null });
+    this.setState({ hasError: false, error: null, componentStack: null });
     if (this.props.onReset) {
       this.props.onReset();
     }
   };
 
   goHome = () => {
-    this.setState({ hasError: false, error: null });
+    this.setState({ hasError: false, error: null, componentStack: null });
     // Navigate to root and reset the navigation stack
     // Use dismissAll to close any modals, then replace to reset to root
     try {
@@ -63,20 +83,146 @@ export class ErrorBoundary extends React.Component<Props, State> {
       }
 
       return (
-        <View style={styles.container}>
-          <View style={styles.content}>
-            <Text style={styles.title}>Something went wrong</Text>
-            <Text style={styles.message}>{this.state.error.message}</Text>
-            <TouchableOpacity style={styles.button} onPress={this.goHome}>
-              <Text style={styles.buttonText}>Go Home</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
+        <DefaultErrorFallback
+          error={this.state.error}
+          componentStack={this.state.componentStack}
+          onTryAgain={this.resetError}
+          onGoHome={this.goHome}
+        />
       );
     }
 
     return this.props.children;
   }
+}
+
+interface FallbackProps {
+  error: Error;
+  componentStack: string | null;
+  onTryAgain: () => void;
+  onGoHome: () => void;
+}
+
+/**
+ * Friendly, restart-focused fallback shown for any uncaught render error.
+ *
+ * Deliberately never surfaces the raw error string to the user (it's internal
+ * and often unintelligible — e.g. a redacted Convex "Server Error"). Instead it
+ * offers a "Send to developer" action that emails the full technical details to
+ * the Togather team.
+ */
+function DefaultErrorFallback({
+  error,
+  componentStack,
+  onTryAgain,
+  onGoHome,
+}: FallbackProps) {
+  const [sendState, setSendState] = React.useState<'idle' | 'sending' | 'sent'>(
+    'idle',
+  );
+
+  const buildReport = React.useCallback(() => {
+    const appVersion = Constants.expoConfig?.version ?? 'unknown';
+    const nativeVersion = Application.nativeApplicationVersion ?? 'unknown';
+    const nativeBuild = Application.nativeBuildVersion ?? 'unknown';
+    // Trim the component stack to the top frames — enough to identify the
+    // screen without pasting the entire tree.
+    const screenTrace = (componentStack ?? 'unavailable')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(0, 12)
+      .join('\n');
+
+    const subject = `Togather error report — ${error.name || 'Error'}`;
+    const body = [
+      'Please describe what you were doing when this happened:',
+      '',
+      '',
+      '— — — — — — — — — — — — — — — — — — — —',
+      'Technical details (for the Togather team)',
+      '— — — — — — — — — — — — — — — — — — — —',
+      `Time: ${new Date().toISOString()}`,
+      `App version: ${appVersion} (native ${nativeVersion} / build ${nativeBuild})`,
+      `Platform: ${Platform.OS} ${String(Platform.Version)}`,
+      '',
+      'Screen (component trace):',
+      screenTrace,
+      '',
+      'Error:',
+      `${error.name}: ${error.message}`,
+      '',
+      'Stack:',
+      error.stack ?? 'unavailable',
+    ].join('\n');
+
+    return { subject, body };
+  }, [error, componentStack]);
+
+  const handleSendToDeveloper = React.useCallback(async () => {
+    setSendState('sending');
+    const { subject, body } = buildReport();
+    try {
+      const isAvailable = await MailComposer.isAvailableAsync();
+      if (isAvailable) {
+        await MailComposer.composeAsync({
+          recipients: [SUPPORT_EMAIL],
+          subject,
+          body,
+        });
+      } else {
+        // Fall back to the device's default mail handler.
+        const mailto = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+          subject,
+        )}&body=${encodeURIComponent(body)}`;
+        await Linking.openURL(mailto);
+      }
+      setSendState('sent');
+    } catch {
+      // Never let the report flow crash the fallback itself.
+      setSendState('idle');
+    }
+  }, [buildReport]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <Image source={sadGif} style={styles.graphic} resizeMode="contain" />
+        <Text style={styles.title}>Something went wrong</Text>
+        <Text style={styles.message}>
+          The app hit an unexpected snag. Tap Try Again — and if it keeps
+          happening, fully close the app (swipe it away) and reopen it.
+        </Text>
+
+        <TouchableOpacity
+          style={styles.primaryButton}
+          onPress={onTryAgain}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.primaryButtonText}>Try Again</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.secondaryButton}
+          onPress={handleSendToDeveloper}
+          activeOpacity={0.8}
+          disabled={sendState !== 'idle'}
+        >
+          <Text style={styles.secondaryButtonText}>
+            {sendState === 'sending'
+              ? 'Opening email…'
+              : sendState === 'sent'
+                ? 'Thanks — report ready to send'
+                : 'Send to developer'}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={onGoHome} activeOpacity={0.6}>
+          <Text style={styles.goHomeText}>Go Home</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -89,8 +235,9 @@ const styles = StyleSheet.create({
   },
   content: {
     backgroundColor: '#fff',
-    borderRadius: 8,
-    padding: 24,
+    borderRadius: 16,
+    paddingVertical: 32,
+    paddingHorizontal: 24,
     alignItems: 'center',
     maxWidth: 400,
     width: '100%',
@@ -100,28 +247,57 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 3,
   },
+  graphic: {
+    width: 120,
+    height: 120,
+    marginBottom: 8,
+  },
   title: {
-    fontSize: 20,
+    fontSize: 22,
     fontWeight: 'bold',
     color: '#333',
     marginBottom: 12,
+    textAlign: 'center',
   },
   message: {
-    fontSize: 14,
+    fontSize: 15,
     color: '#666',
     textAlign: 'center',
+    lineHeight: 22,
     marginBottom: 24,
   },
-  button: {
+  primaryButton: {
     backgroundColor: '#007AFF',
     paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
+    paddingVertical: 14,
+    borderRadius: 10,
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: 12,
   },
-  buttonText: {
+  primaryButtonText: {
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
   },
+  secondaryButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 14,
+    borderRadius: 10,
+    width: '100%',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#d0d0d0',
+    marginBottom: 16,
+  },
+  secondaryButtonText: {
+    color: '#333',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  goHomeText: {
+    color: '#888',
+    fontSize: 14,
+    fontWeight: '500',
+  },
 });
-

--- a/apps/mobile/components/ui/SafeBlurView.tsx
+++ b/apps/mobile/components/ui/SafeBlurView.tsx
@@ -1,0 +1,78 @@
+/**
+ * SafeBlurView
+ *
+ * Drop-in replacement for expo-blur's BlurView that gracefully falls back to a
+ * plain semi-opaque View when the native module's Fabric view adapter is not
+ * available (e.g., on the New Architecture, or on older native builds receiving
+ * OTA updates). Without this guard, a missing view adapter throws an Invariant
+ * Violation at render time and hard-crashes the screen:
+ * `ViewManagerAdapter_ExpoBlurView ... must be a function (received undefined)`.
+ *
+ * See ADR-013 for the native dependency gating strategy.
+ */
+
+import React from "react";
+import { View, type ViewStyle, type StyleProp } from "react-native";
+import { isBlurSupported } from "@/features/chat/utils/fileTypes";
+
+type BlurTint = "light" | "dark" | "default" | (string & {});
+
+interface SafeBlurViewProps {
+  intensity?: number;
+  tint?: BlurTint;
+  style?: StyleProp<ViewStyle>;
+  children?: React.ReactNode;
+}
+
+// Lazily resolve the real BlurView component
+let _ResolvedBlur: React.ComponentType<any> | null = null;
+let _resolved = false;
+
+function getBlurView(): React.ComponentType<any> | null {
+  if (_resolved) return _ResolvedBlur;
+  _resolved = true;
+
+  if (isBlurSupported()) {
+    try {
+      const mod = require("expo-blur");
+      _ResolvedBlur = mod.BlurView;
+    } catch {
+      _ResolvedBlur = null;
+    }
+  }
+
+  return _ResolvedBlur;
+}
+
+/**
+ * Renders expo-blur's BlurView if the native view is available, otherwise
+ * renders a plain View with a solid scrim approximating the requested tint.
+ */
+export function SafeBlurView({
+  intensity = 50,
+  tint = "default",
+  style,
+  children,
+}: SafeBlurViewProps) {
+  const RealBlur = getBlurView();
+
+  if (RealBlur) {
+    return (
+      <RealBlur intensity={intensity} tint={tint} style={style}>
+        {children}
+      </RealBlur>
+    );
+  }
+
+  // Fallback: approximate the blur with a solid scrim. Opacity scales with the
+  // requested intensity (0–100) so heavier blur reads as a darker/lighter veil.
+  const alpha = Math.min(Math.max(intensity / 100, 0), 1);
+  const fallbackColor =
+    tint === "light"
+      ? `rgba(255, 255, 255, ${alpha})`
+      : `rgba(0, 0, 0, ${alpha})`;
+
+  return (
+    <View style={[{ backgroundColor: fallbackColor }, style]}>{children}</View>
+  );
+}

--- a/apps/mobile/features/chat/utils/fileTypes.ts
+++ b/apps/mobile/features/chat/utils/fileTypes.ts
@@ -225,6 +225,7 @@ export function formatFileSize(bytes: number): string {
 let _documentPickerSupported: boolean | null = null;
 let _audioVideoSupported: boolean | null = null;
 let _linearGradientSupported: boolean | null = null;
+let _blurSupported: boolean | null = null;
 let _videoSupported: boolean | null = null;
 let _audioSupported: boolean | null = null;
 
@@ -356,6 +357,39 @@ export function isLinearGradientSupported(): boolean {
 }
 
 /**
+ * Check if expo-blur (BlurView) is available
+ *
+ * This module is only available after a native build that includes it.
+ * Returns false for OTA updates on older native builds.
+ */
+export function isBlurSupported(): boolean {
+  if (_blurSupported !== null) {
+    return _blurSupported;
+  }
+
+  // On web, BlurView renders via CSS backdrop-filter and is always available
+  if (Platform.OS === 'web') {
+    try {
+      const BlurModule = require('expo-blur');
+      _blurSupported = !!BlurModule?.BlurView;
+      return _blurSupported;
+    } catch {
+      _blurSupported = false;
+      return false;
+    }
+  }
+
+  // On native with New Architecture (Fabric), ExpoBlurView's view adapter
+  // crashes at render time even when the module registers successfully — the
+  // Fabric ViewManagerAdapter can't find the underlying view manager for this
+  // ExpoView subclass (`ViewManagerAdapter_ExpoBlurView ... must be a function
+  // (received undefined)`). Disable until expo-blur ships reliable Fabric support.
+  // See: ADR-013, MEMORY.md "Expo Modules Native Views (Fabric / New Architecture)"
+  _blurSupported = false;
+  return false;
+}
+
+/**
  * Check if expo-video is available
  *
  * This module is only available after a native build update.
@@ -437,6 +471,7 @@ export function resetModuleDetectionCache(): void {
   _documentPickerSupported = null;
   _audioVideoSupported = null;
   _linearGradientSupported = null;
+  _blurSupported = null;
   _videoSupported = null;
   _audioSupported = null;
 }

--- a/apps/mobile/native-deps.json
+++ b/apps/mobile/native-deps.json
@@ -23,7 +23,6 @@
     "expo",
     "expo-application",
     "expo-auth-session",
-    "expo-blur",
     "expo-calendar",
     "expo-clipboard",
     "expo-constants",
@@ -51,6 +50,7 @@
     "expo-web-browser"
   ],
   "gated": [
+    "expo-blur",
     "expo-linear-gradient",
     "expo-av",
     "expo-document-picker",


### PR DESCRIPTION
## Why

Two production Sentry issues, both surfacing broken full-screen states to users:

1. **`Invariant Violation: ViewManagerAdapter_ExpoBlurView … must be a function (received undefined)`** — a hard crash on the event guest-list screen (iOS, New Architecture / Fabric).
2. **`Something went wrong` with a raw `[CONVEX Q(functions/memberFollowups:getCrossGroupConfig)] … Server Error` dump** — the global `ErrorBoundary` showed internal error text to users with only a "Go Home" button.

## What changed

### 1. Guard `BlurView` behind `SafeBlurView` (crash fix)
`app/e/[shortId]/guests.tsx` statically imported `BlurView` and rendered it raw. On Fabric, ExpoBlurView's view adapter is intermittently `undefined` at render → Invariant Violation → screen crash. Same failure mode already gated for `expo-linear-gradient`.

- Reclassified `expo-blur` `core → gated` in `native-deps.json` so `check-native-imports` CI forbids static imports going forward.
- Added `isBlurSupported()` in `fileTypes.ts` (hard-disabled on native Fabric, enabled on web where BlurView is CSS-based).
- Added `SafeBlurView`, mirroring `SafeLinearGradient`: real BlurView when supported, else a solid tint-approximating scrim.
- Swapped `guests.tsx` to `SafeBlurView`.

### 2. Friendly, restart-focused global error fallback
The single global `ErrorBoundary` rendered `{error.message}` verbatim (no `__DEV__` gate). Redesigned the default fallback:

- Friendly `sad.gif` graphic + "Something went wrong" + restart-focused copy ("fully close the app and reopen it").
- **Never surfaces the raw error string to the user.**
- **Try Again** (in-place `resetError`) for transient errors.
- **Send to developer** — emails `togather@supa.media` with the failing screen (React component stack), app/native version, platform, and the full error + stack; falls back to a `mailto:` link when no mail composer is configured.

> Note: the backend throws `ConvexError` expecting a client `AuthErrorBoundary` to recover — but that component was never built, so *every* uncaught error lands in this one boundary. Building real auth-error recovery is out of scope here; this makes the catch-all graceful. The `getCrossGroupConfig` "Server Error" itself is an upstream auth throw already fixed by #411 (`requireAuth` → `ConvexError`); confirm #411 is deployed to prod Convex to convert that signature to a recoverable error.

## Verification
- `tsc --noEmit` — no new errors (pre-existing unrelated errors in `useDevToolsEscapeHatch.ts`/tasks remain).
- `check-native-imports.js` — passes; `expo-blur` now enforced as gated (7 gated deps).
- eslint clean via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iehWB8pPcVjVZsXVGUjbH