### PR TITLE
Pick which events a "Collect availability" link asks about

### DIFF
--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -199,6 +199,13 @@ function monthDay(ms: number): string {
   });
 }
 
+/** Local midnight today — the cutoff for "upcoming" events (mirrors the backend). */
+function startOfTodayMs(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
 /**
  * Web-only right-click prop bag. RN-Web forwards unknown DOM props onto the
  * host node, so `onContextMenu` lands on the underlying <div>. The RN types
@@ -515,6 +522,10 @@ export function RosterGridScreen() {
   // the in-flight states for its async actions + the "＋ Add date" column.
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [sharingLink, setSharingLink] = useState(false);
+  // Event picker for "Collect availability": lists the group's upcoming events
+  // with checkboxes so the leader chooses exactly which ones the link asks
+  // about, before the OS share sheet opens.
+  const [availPickerOpen, setAvailPickerOpen] = useState(false);
   const [creatingEvent, setCreatingEvent] = useState(false);
   const [settingUp, setSettingUp] = useState(false);
 
@@ -906,30 +917,61 @@ export function RosterGridScreen() {
   // rostering home now, so these actions live here).
   // -------------------------------------------------------------------------
 
-  // Generate a public, app-optional availability link and hand it to the OS
-  // share sheet. People open it in a browser (no app needed) and their
-  // response is matched to their account when they later sign up.
-  const handleShareLink = useCallback(async () => {
-    if (sharingLink) return;
-    setSharingLink(true);
-    try {
-      const { publicToken } = await createAvailabilityLink({ groupId });
-      const url = DOMAIN_CONFIG.availabilityLinkUrl(publicToken);
-      await Share.share({
-        message: `Let us know when you can serve: ${url}`,
-      });
-    } catch (e) {
-      const err = e as { data?: { message?: string }; message?: string };
+  // The group's upcoming events (today onward), soonest first — the picker's
+  // list and the snapshot order the backend uses for a link's events.
+  const upcomingEvents = useMemo(
+    () =>
+      events
+        .filter((e) => e.eventDate >= startOfTodayMs())
+        .sort((a, b) => a.eventDate - b.eventDate),
+    [events],
+  );
+
+  // Open the event picker for "Collect availability". If the group has no
+  // upcoming events, keep today's behavior: surface the "add an event first"
+  // error instead of an empty picker.
+  const handleCollectAvailability = useCallback(() => {
+    if (upcomingEvents.length === 0) {
       Alert.alert(
         "Couldn't create link",
-        err?.data?.message ??
-          err?.message ??
-          "Add an upcoming event plan first, then try again.",
+        "Add an upcoming event plan first, then try again.",
       );
-    } finally {
-      setSharingLink(false);
+      return;
     }
-  }, [sharingLink, createAvailabilityLink, groupId]);
+    setAvailPickerOpen(true);
+  }, [upcomingEvents]);
+
+  // Generate a public, app-optional availability link for the picked events and
+  // hand it to the OS share sheet. People open it in a browser (no app needed)
+  // and their response is matched to their account when they later sign up.
+  const handleShareLink = useCallback(
+    async (planIds: Id<"eventPlans">[]) => {
+      if (sharingLink) return;
+      setSharingLink(true);
+      try {
+        const { publicToken } = await createAvailabilityLink({
+          groupId,
+          planIds,
+        });
+        const url = DOMAIN_CONFIG.availabilityLinkUrl(publicToken);
+        setAvailPickerOpen(false);
+        await Share.share({
+          message: `Let us know when you can serve: ${url}`,
+        });
+      } catch (e) {
+        const err = e as { data?: { message?: string }; message?: string };
+        Alert.alert(
+          "Couldn't create link",
+          err?.data?.message ??
+            err?.message ??
+            "Add an upcoming event plan first, then try again.",
+        );
+      } finally {
+        setSharingLink(false);
+      }
+    },
+    [sharingLink, createAvailabilityLink, groupId],
+  );
 
   // Create a new draft plan at the neutral default date (next Sunday 9 AM, same
   // as the editor's default). The reactive rosterMatrix self-refreshes → a new
@@ -2307,7 +2349,7 @@ export function RosterGridScreen() {
           }}
           onCollectAvailability={() => {
             setOverflowOpen(false);
-            void handleShareLink();
+            handleCollectAvailability();
           }}
           onChangePastLimit={(delta) =>
             setPastLimit((n) => Math.max(0, Math.min(n + delta, MAX_PAST_DATES)))
@@ -2331,6 +2373,16 @@ export function RosterGridScreen() {
             void publishAllDrafts();
           }}
           onClose={() => setPublishMenuOpen(false)}
+        />
+      )}
+
+      {availPickerOpen && (
+        <AvailabilityPicker
+          events={upcomingEvents}
+          sharingLink={sharingLink}
+          colors={colors}
+          onShare={(planIds) => void handleShareLink(planIds)}
+          onClose={() => setAvailPickerOpen(false)}
         />
       )}
     </View>
@@ -3177,6 +3229,119 @@ function PublishMenu({
           </Text>
         </Pressable>
       )}
+    </ModalShell>
+  );
+}
+
+/**
+ * "Collect availability" event picker — lists the group's upcoming events with
+ * checkboxes so the leader chooses exactly which ones the shared link asks
+ * about. All events start checked (matching the old all-upcoming default). The
+ * "Share link" action is disabled until at least one is checked and shows the
+ * selected count; sharing creates the link for exactly those events, then the
+ * caller opens the OS share sheet.
+ */
+export function AvailabilityPicker({
+  events,
+  sharingLink,
+  colors,
+  onShare,
+  onClose,
+}: {
+  events: RosterEvent[];
+  sharingLink: boolean;
+  colors: Colors;
+  onShare: (planIds: Id<"eventPlans">[]) => void;
+  onClose: () => void;
+}) {
+  // Seed every upcoming event as checked so the default matches today's
+  // behavior (a link that covers all upcoming events).
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(events.map((e) => e._id as string)),
+  );
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+  const count = selected.size;
+  const disabled = count === 0 || sharingLink;
+
+  return (
+    <ModalShell
+      title="Collect availability"
+      subtitle="Pick the events to ask about"
+      colors={colors}
+      onClose={onClose}
+    >
+      <ScrollView style={styles.popoverList}>
+        {events.map((ev) => {
+          const checked = selected.has(ev._id as string);
+          return (
+            <Pressable
+              key={ev._id}
+              onPress={() => toggle(ev._id as string)}
+              style={[styles.menuRow, { borderBottomColor: colors.border }]}
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked }}
+              accessibilityLabel={`${ev.title}, ${weekday(ev.eventDate)} ${monthDay(ev.eventDate)}`}
+            >
+              <Ionicons
+                name={checked ? "checkbox" : "square-outline"}
+                size={20}
+                color={checked ? colors.link : colors.textTertiary}
+              />
+              <View style={styles.menuRowText}>
+                <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+                  {weekday(ev.eventDate)} {monthDay(ev.eventDate)}
+                </Text>
+                <Text style={[styles.menuRowSub, { color: colors.textTertiary }]} numberOfLines={1}>
+                  {ev.title}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+      <Pressable
+        onPress={() => {
+          if (disabled) return;
+          onShare(
+            events.filter((e) => selected.has(e._id as string)).map((e) => e._id),
+          );
+        }}
+        disabled={disabled}
+        style={[
+          styles.addBtn,
+          { borderColor: disabled ? colors.border : colors.link, opacity: disabled ? 0.5 : 1 },
+        ]}
+        accessibilityRole="button"
+        accessibilityState={{ disabled }}
+        accessibilityLabel={`Share link for ${count} event${count === 1 ? "" : "s"}`}
+      >
+        {sharingLink ? (
+          <ActivityIndicator size="small" color={colors.link} />
+        ) : (
+          <>
+            <Ionicons
+              name="share-outline"
+              size={16}
+              color={count === 0 ? colors.textTertiary : colors.link}
+            />
+            <Text
+              style={[
+                styles.addBtnText,
+                { color: count === 0 ? colors.textTertiary : colors.link },
+              ]}
+            >
+              Share link · {count} event{count === 1 ? "" : "s"}
+            </Text>
+          </>
+        )}
+      </Pressable>
     </ModalShell>
   );
 }

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -74,8 +74,23 @@ import { TeamChannelToggle } from "./TeamChannelToggle";
  */
 const MAX_PAST_DATES = 10;
 
+/**
+ * How many upcoming events a "Collect availability" link can cover. Mirrors
+ * `MAX_EVENTS` in `scheduling/publicAvailability.ts` — the backend slices a
+ * request to the earliest 12 — so the picker never lists (or counts) more
+ * events than a link can actually snapshot.
+ */
+const MAX_AVAILABILITY_EVENTS = 12;
+
 type Availability = "available" | "unavailable" | "no_response";
 type AssignmentStatus = "confirmed" | "unconfirmed" | "declined";
+
+/** Minimal upcoming-event shape the availability picker lists and shares. */
+type UpcomingEvent = {
+  _id: Id<"eventPlans">;
+  title: string;
+  eventDate: number;
+};
 
 type RosterEvent = {
   _id: Id<"eventPlans">;
@@ -197,13 +212,6 @@ function monthDay(ms: number): string {
     month: "short",
     day: "numeric",
   });
-}
-
-/** Local midnight today — the cutoff for "upcoming" events (mirrors the backend). */
-function startOfTodayMs(): number {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  return d.getTime();
 }
 
 /**
@@ -918,13 +926,20 @@ export function RosterGridScreen() {
   // -------------------------------------------------------------------------
 
   // The group's upcoming events (today onward), soonest first — the picker's
-  // list and the snapshot order the backend uses for a link's events.
+  // list and the snapshot order the backend uses for a link's events. Sourced
+  // from `listEvents` (its own upcoming-only, ascending query) rather than the
+  // grid's `events`: `events` comes from `rosterMatrix`, which caps its columns
+  // at MAX_PAST_DATES and can lead the grid with past plans when "Previous
+  // dates" is set — either of which would silently drop upcoming events from
+  // the link. Capped to the backend's MAX_AVAILABILITY_EVENTS so the picker
+  // never lists (or counts) more events than a link can actually cover.
+  const upcomingData = useAuthenticatedQuery(
+    api.functions.scheduling.events.listEvents,
+    groupId ? { groupId } : "skip",
+  ) as UpcomingEvent[] | undefined;
   const upcomingEvents = useMemo(
-    () =>
-      events
-        .filter((e) => e.eventDate >= startOfTodayMs())
-        .sort((a, b) => a.eventDate - b.eventDate),
-    [events],
+    () => (upcomingData ?? []).slice(0, MAX_AVAILABILITY_EVENTS),
+    [upcomingData],
   );
 
   // Open the event picker for "Collect availability". If the group has no
@@ -2334,7 +2349,6 @@ export function RosterGridScreen() {
         <OverflowMenu
           colors={colors}
           pastLimit={pastLimit}
-          sharingLink={sharingLink}
           onTeams={() => {
             setOverflowOpen(false);
             router.push(`/rostering/${groupId}/teams` as never);
@@ -2665,7 +2679,11 @@ function ModalShell({
       <Pressable style={styles.backdrop} onPress={onClose}>
         <Pressable
           style={[styles.popover, { backgroundColor: colors.surface, borderColor: colors.border }]}
-          onPress={(e) => e.stopPropagation()}
+          // Swallow the tap so it doesn't reach the backdrop's onClose. The
+          // event is always present in RN; guard it anyway so a bubbled press
+          // (e.g. RNTL routing a disabled child's press to this parent) can't
+          // throw on a missing event.
+          onPress={(e) => e?.stopPropagation?.()}
         >
           {head}
           {children}
@@ -3248,7 +3266,7 @@ export function AvailabilityPicker({
   onShare,
   onClose,
 }: {
-  events: RosterEvent[];
+  events: UpcomingEvent[];
   sharingLink: boolean;
   colors: Colors;
   onShare: (planIds: Id<"eventPlans">[]) => void;
@@ -3267,7 +3285,17 @@ export function AvailabilityPicker({
       return next;
     });
   }, []);
-  const count = selected.size;
+  // Derive the shared set from the live `events` prop, not the once-seeded
+  // `selected` set. `events` is a reactive-query derivative and can change while
+  // the sheet stays mounted (a co-leader deletes/reschedules an event, or one
+  // ages past today). Reading count/disabled off the stale seed would let the
+  // button overstate the count, or — if every selected event dropped out — stay
+  // enabled and share `[]`, which the backend treats as "all upcoming."
+  const selectedIds = useMemo(
+    () => events.filter((e) => selected.has(e._id as string)).map((e) => e._id),
+    [events, selected],
+  );
+  const count = selectedIds.length;
   const disabled = count === 0 || sharingLink;
 
   return (
@@ -3309,9 +3337,7 @@ export function AvailabilityPicker({
       <Pressable
         onPress={() => {
           if (disabled) return;
-          onShare(
-            events.filter((e) => selected.has(e._id as string)).map((e) => e._id),
-          );
+          onShare(selectedIds);
         }}
         disabled={disabled}
         style={[
@@ -3354,7 +3380,6 @@ export function AvailabilityPicker({
 function OverflowMenu({
   colors,
   pastLimit,
-  sharingLink,
   onTeams,
   onCrossTeam,
   onTemplates,
@@ -3364,7 +3389,6 @@ function OverflowMenu({
 }: {
   colors: Colors;
   pastLimit: number;
-  sharingLink: boolean;
   onTeams: () => void;
   onCrossTeam: () => void;
   onTemplates: () => void;
@@ -3411,15 +3435,10 @@ function OverflowMenu({
         </Pressable>
         <Pressable
           onPress={onCollectAvailability}
-          disabled={sharingLink}
           style={[styles.menuRow, { borderBottomColor: colors.border }]}
           accessibilityRole="button"
         >
-          {sharingLink ? (
-            <ActivityIndicator size="small" color={colors.textSecondary} />
-          ) : (
-            <Ionicons name="share-outline" size={20} color={colors.text} />
-          )}
+          <Ionicons name="share-outline" size={20} color={colors.text} />
           <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
             Collect availability
           </Text>

--- a/apps/mobile/features/scheduling/components/__tests__/AvailabilityPicker.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/AvailabilityPicker.test.tsx
@@ -71,6 +71,22 @@ describe("AvailabilityPicker", () => {
     expect(getByLabelText("Share link for 2 events")).toBeTruthy();
   });
 
+  it("shares every checked event, in ascending order", () => {
+    const onShare = jest.fn();
+    const { getByLabelText } = render(
+      <AvailabilityPicker
+        events={EVENTS}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    // Nothing unchecked → both ids flow through in the picker's order.
+    fireEvent.press(getByLabelText("Share link for 2 events"));
+    expect(onShare).toHaveBeenCalledWith(["plan-1", "plan-2"]);
+  });
+
   it("shares exactly the events left checked, in order", () => {
     const onShare = jest.fn();
     const { getByLabelText } = render(
@@ -88,7 +104,7 @@ describe("AvailabilityPicker", () => {
     expect(onShare).toHaveBeenCalledWith(["plan-1"]);
   });
 
-  it("disables Share and does not fire onShare when nothing is checked", () => {
+  it("disables Share and swallows the press when nothing is checked", () => {
     const onShare = jest.fn();
     const { getByLabelText } = render(
       <AvailabilityPicker
@@ -101,10 +117,87 @@ describe("AvailabilityPicker", () => {
     );
     fireEvent.press(getByLabelText("Sunday Service, Sun Jul 19"));
     fireEvent.press(getByLabelText("Sunday Service, Sun Jul 26"));
-    // With nothing checked the Share button reports 0 and is disabled, so a tap
-    // can't create a link (the backend also rejects an empty set).
+    // With nothing checked the Share button reports 0 and is disabled. Actually
+    // press it: RNTL's fireEvent.press ignores `disabled` on Pressable, so this
+    // exercises the internal `if (disabled) return;` guard, not just the render.
     const shareBtn = getByLabelText("Share link for 0 events");
     expect(shareBtn.props.accessibilityState.disabled).toBe(true);
+    fireEvent.press(shareBtn);
+    expect(onShare).not.toHaveBeenCalled();
+  });
+
+  it("shows a spinner and blocks a second submit while a link is being created", () => {
+    const onShare = jest.fn();
+    const { getByLabelText } = render(
+      <AvailabilityPicker
+        events={EVENTS}
+        sharingLink={true}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    // While `sharingLink` is true the button is disabled (spinner shown), so a
+    // second tap can't fire another createAvailabilityLink.
+    const shareBtn = getByLabelText("Share link for 2 events");
+    expect(shareBtn.props.accessibilityState.disabled).toBe(true);
+    fireEvent.press(shareBtn);
+    expect(onShare).not.toHaveBeenCalled();
+  });
+
+  it("recomputes the shared set from the live events when one drops out", () => {
+    const onShare = jest.fn();
+    const { getByLabelText, rerender } = render(
+      <AvailabilityPicker
+        events={EVENTS}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    // The sheet stays mounted; the reactive events prop loses the second event
+    // (a co-leader deletes it, or it ages past today). The seed set still holds
+    // plan-2, but count/disabled and the shared ids must track the live list.
+    rerender(
+      <AvailabilityPicker
+        events={[EVENTS[0]] as any}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    fireEvent.press(getByLabelText("Share link for 1 event"));
+    expect(onShare).toHaveBeenCalledWith(["plan-1"]);
+  });
+
+  it("disables Share when every selected event leaves the live list", () => {
+    const onShare = jest.fn();
+    const { getByLabelText, rerender } = render(
+      <AvailabilityPicker
+        events={EVENTS}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    // Every seeded-selected event drops out. Without deriving count from the
+    // live list the button would stay enabled and share [], which the backend
+    // treats as "all upcoming" — the opposite of nothing selected.
+    rerender(
+      <AvailabilityPicker
+        events={[] as any}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    const shareBtn = getByLabelText("Share link for 0 events");
+    expect(shareBtn.props.accessibilityState.disabled).toBe(true);
+    fireEvent.press(shareBtn);
     expect(onShare).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/features/scheduling/components/__tests__/AvailabilityPicker.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/AvailabilityPicker.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+// AvailabilityPicker lives in RosterGridScreen, which pulls in Convex, router,
+// theming, and several heavy sibling components at import time. The picker
+// itself only needs RN + Ionicons + ModalShell + styles, so we stub the heavy
+// modules so the module can load in isolation.
+jest.mock("@services/api/convex", () => ({
+  api: { functions: {} },
+  useAuthenticatedQuery: jest.fn(),
+  useAuthenticatedMutation: jest.fn(() => jest.fn()),
+  useAuthenticatedAction: jest.fn(() => jest.fn()),
+}));
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn(), canGoBack: () => false }),
+  useLocalSearchParams: () => ({ group_id: "group-1" }),
+}));
+jest.mock("@hooks/useTheme", () => ({ useTheme: () => ({ colors: {} }) }));
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
+}));
+jest.mock("../AssignSheet", () => ({ AssignSheet: () => null }));
+jest.mock("../GridPresenceBar", () => ({ GridPresenceBar: () => null }));
+jest.mock("../EventEditorPanel", () => ({ EventEditorPanel: () => null }));
+jest.mock("../DateColumnHeaderEditor", () => ({ DateColumnHeaderEditor: () => null }));
+jest.mock("../TeamChannelToggle", () => ({ TeamChannelToggle: () => null }));
+
+import { AvailabilityPicker } from "../RosterGridScreen";
+
+const COLORS = {
+  text: "#000",
+  textSecondary: "#555",
+  textTertiary: "#999",
+  surface: "#fff",
+  border: "#ccc",
+  link: "#2563EB",
+} as any;
+
+// Two upcoming events; the picker treats `_id` as the plan id it hands back.
+const EVENTS = [
+  {
+    _id: "plan-1",
+    title: "Sunday Service",
+    eventDate: new Date("2026-07-19T09:00:00").getTime(),
+    times: [{ label: "9:00 AM", startsAt: 0 }],
+    status: "draft",
+    pendingCount: 0,
+  },
+  {
+    _id: "plan-2",
+    title: "Sunday Service",
+    eventDate: new Date("2026-07-26T09:00:00").getTime(),
+    times: [{ label: "9:00 AM", startsAt: 0 }],
+    status: "draft",
+    pendingCount: 0,
+  },
+] as any;
+
+describe("AvailabilityPicker", () => {
+  it("starts with every event checked and the count on the Share button", () => {
+    const { getByLabelText } = render(
+      <AvailabilityPicker
+        events={EVENTS}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    // All upcoming events checked by default → button reflects the full count.
+    expect(getByLabelText("Share link for 2 events")).toBeTruthy();
+  });
+
+  it("shares exactly the events left checked, in order", () => {
+    const onShare = jest.fn();
+    const { getByLabelText } = render(
+      <AvailabilityPicker
+        events={EVENTS}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    // Uncheck the second event, then share.
+    fireEvent.press(getByLabelText("Sunday Service, Sun Jul 26"));
+    fireEvent.press(getByLabelText("Share link for 1 event"));
+    expect(onShare).toHaveBeenCalledWith(["plan-1"]);
+  });
+
+  it("disables Share and does not fire onShare when nothing is checked", () => {
+    const onShare = jest.fn();
+    const { getByLabelText } = render(
+      <AvailabilityPicker
+        events={EVENTS}
+        sharingLink={false}
+        colors={COLORS}
+        onShare={onShare}
+        onClose={jest.fn()}
+      />,
+    );
+    fireEvent.press(getByLabelText("Sunday Service, Sun Jul 19"));
+    fireEvent.press(getByLabelText("Sunday Service, Sun Jul 26"));
+    // With nothing checked the Share button reports 0 and is disabled, so a tap
+    // can't create a link (the backend also rejects an empty set).
+    const shareBtn = getByLabelText("Share link for 0 events");
+    expect(shareBtn.props.accessibilityState.disabled).toBe(true);
+    expect(onShare).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What & why

Tapping **Collect availability** in the rostering grid's ⋯ menu used to instantly build a shareable link covering **every** upcoming event and open the OS share sheet. There was no way to say "only ask about these two Sundays."

Now tapping **Collect availability** opens a small picker sheet listing the group's upcoming events, each with a checkbox. **All upcoming events start checked** (so the default matches today's behavior). The leader unchecks any they don't want, then taps **Share link · N events** — which creates the link for exactly those events and opens the share sheet as before.

Addresses dashboard item / issue #617 (reported by **Seyi Olujide** / @lilseyi).

## Before / after

The mock below is a **rendered mock built from the component's real modal styles** — not a device screenshot (this CI runner has no iOS simulator).

[Before / after — Collect availability event picker](https://images.togather.nyc/dev-assistant/3c5f8d99-df0f-4bff-b99f-c9d8b3ad7286-availability-picker-mock.png)

## Scope: frontend-only

The backend already supports this. `createAvailabilityLink` (`apps/convex/functions/scheduling/publicAvailability.ts`) already takes an optional `planIds` array, validates each belongs to the group, and snapshots exactly those events onto the request. Every downstream reader — the chat card (`getAvailabilityRequestByToken`) and the public `/a/` page (`getPublicAvailabilityRequest`) — already renders only the request's snapshotted `planIds`. The only gap was that the mobile button never passed `planIds`. **No backend, schema, or migration work.**

## Changes

`apps/mobile/features/scheduling/components/RosterGridScreen.tsx`:
- New `AvailabilityPicker` sheet (mirrors the existing `PublishMenu` inside `ModalShell`) — checkbox rows for each upcoming event, seeded all-checked, with a primary **Share link · N events** action.
- `handleShareLink` now takes the picked `planIds` and passes them to `createAvailabilityLink({ groupId, planIds })`.
- New `handleCollectAvailability` opens the picker; when the group has **no upcoming events** it keeps the existing "add an event first" error instead of showing an empty picker.
- `upcomingEvents` derives the list from the in-scope `events` (`eventDate >= today`, sorted ascending — matching the backend's snapshot order).

`apps/mobile/features/scheduling/components/__tests__/AvailabilityPicker.test.tsx`:
- Unit tests: all events checked by default; sharing passes exactly the checked ids in order; **Share** is disabled and shows a `0` count when nothing is checked.

## Legacy links

No migration. Existing links already snapshotted their event set at creation time, and the readers render that stored snapshot — so old links keep showing the events they were created with, unchanged.

## Verification

- `AvailabilityPicker.test.tsx` — 3 new tests pass.
- Full mobile suite green via the pre-push hook (140 suites, 1323 passed).
- Lint clean on the changed file (0 errors).
- No iOS simulator on the runner, so the UI is shown as a rendered mock above (built from the real `ModalShell` / `menuRow` / `addBtn` styles).

## Done when

- [x] Tapping **Collect availability** opens a picker listing upcoming events, each with a checkbox, all checked by default.
- [x] Leader can check/uncheck individual events.
- [x] **Share link** is disabled when nothing is checked and shows the selected count.
- [x] Sharing creates a link whose `planIds` are exactly the checked events, then opens the share sheet.
- [x] The resulting `/a/` link (chat card + public page) shows only the picked events (already handled by the snapshot readers — unchanged).
- [x] Links created before this change are unaffected.
- [x] Groups with no upcoming events still show the existing "add an event first" error.

Co-authored-by: Seyi Olujide <lilseyi@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UxgmNy65AESKCVxTjNEJN

---
_Generated by [Claude Code](https://claude.ai/code/session_011UxgmNy65AESKCVxTjNEJN)_