### PR TITLE
docs: postmortem + guardrails for the #548/#619 native-media regression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,44 @@ When testing the app (Playwright, iOS Simulator, etc.), use the seeded test cred
 - CI enforces this via `scripts/check-native-imports.js` — static imports of gated deps fail
 - See `docs/architecture/ADR-013-mobile-versioning-and-ota-updates.md` for full details
 
+### JS Changes Can Break Native Rendering (read before touching deps or native media)
+
+Learned the hard way from PRs #548 and #619 (see the postmortem in
+`docs/architecture/ADR-013`). These bugs are **invisible to typecheck, tests,
+and the JS bundle** (native modules are mocked; the bundle builds fine) and only
+appear on a real device — so CI cannot catch them. Rules:
+
+- **NEVER add a web-only React UI/CSS-in-JS library to `apps/mobile`** — MUI,
+  `@emotion/*`, `@material-ui/*`, `styled-components`, `react-datepicker`, etc.
+  Even when imported only from a `.web.tsx` file, its mere presence in the mobile
+  package pulls a **second React** into the shared pnpm lockfile (via
+  `autoInstallPeers`) and re-keys the Expo native-module graph
+  (`expo-modules-core`, `react-native`) to that React. On the installed native
+  binary this **breaks native Fabric rendering — video and animated GIFs render
+  blank**. A `pnpm.overrides` React pin does NOT save you (MUI/react-datepicker
+  broke it even pinned). Web-only UI must be **dependency-free** (a native
+  `<input>`) — do not reach for a component library.
+- **CI guard:** `apps/mobile/scripts/check-react-consistency.js` fails a PR if a
+  second React is keyed onto any native package, or if a denylisted lib enters
+  `apps/mobile`. Do not weaken or remove it. If a `<second React>` shows up,
+  find and remove the offending dependency — do not paper over it with an override.
+- **Native Fabric view crashes cascade.** When an Expo native *view* crashes
+  (e.g. `ViewManagerAdapter_ExpoVideo_VideoView … must be a function (received
+  undefined)`), it corrupts the Fabric view registry and **breaks other native
+  rendering too** — a crashing chat video will blank out the RSVP GIF. **"Video
+  and GIF break together" is this signature**, not two separate bugs.
+- **Do not attach effects/listeners to a native view's player/lifecycle
+  casually.** A `player.addListener('sourceLoad', …)` effect added to
+  `ExpoVideoPlayer` (to read dimensions for aspect ratio) *deterministically
+  crashed* the native `VideoView`. Prefer prop-only changes (e.g. `contentFit`)
+  for native video views.
+- **Any change touching native media/views (video, GIF, blur, `expo-*` native
+  views) or the mobile dependency graph MUST be verified on a real device /
+  staging OTA before merging** — CI is blind to it. See ADR-030 (native media
+  smoke test). When debugging a suspected regression, **bisect OTA bundles on a
+  device** (`eas update:republish` / dispatch `deploy-mobile-update.yml` on a
+  branch) and **change one variable at a time** — do not stack multiple fixes.
+
 ### Prefer Framework Features Over Custom Solutions
 
 - **Always prefer built-in framework features** over custom implementations

--- a/docs/architecture/ADR-013-mobile-versioning-and-ota-updates.md
+++ b/docs/architecture/ADR-013-mobile-versioning-and-ota-updates.md
@@ -341,6 +341,92 @@ We defend this with **three layers**:
    mocks native views, it explicitly *cannot* catch native view-registration
    failures. See ADR-030 for the full spec.
 
+### Postmortem: #548 / #619 native-media regression (2026-07)
+
+The incident that motivated the three guards above, documented precisely so the
+exact failure modes and the debugging path are reproducible.
+
+**Symptom.** On the *installed* iOS binary (app `1.0.23` / build `32`,
+`runtimeVersion` frozen at `1.0.21`, New Architecture / Fabric), native chat
+**video** fell back to a download card and animated **GIFs** rendered blank —
+while static images still worked. The device console showed:
+
+```
+Invariant Violation: View config getter callback for component
+ViewManagerAdapter_ExpoVideo_VideoView… must be a function (received undefined)
+```
+
+It reproduced only on a real native build; every CI check was green.
+
+**Root cause #1 — a web dependency broke the native graph (PR #548).** #548
+added `@mui/*` + `@emotion/*` to `apps/mobile/package.json` for a *web-only* MUI
+datepicker (`DatePicker.web.tsx`). That code never runs on native, but the
+packages' mere *presence* made pnpm's `autoInstallPeers` pull a **second React
+(19.2.7)** into the shared `pnpm-lock.yaml`. That re-keyed the mobile Expo
+native-module graph — e.g. `/expo-modules-core@3.0.29(react-native@0.81.5)(react@19.2.7)`
+instead of the `(react@19.1.0)` key the binary was built against — which breaks
+Fabric view/module registration at runtime.
+
+- Not emotion-specific: the same mechanism was later reproduced with
+  `react-datepicker` (emotion-free, yet still broke native), and could bleed
+  from `@react-email` (used for transactional email) once the graph was
+  destabilized. **Any web-only React component library in `apps/mobile` is
+  dangerous**, regardless of whether it uses CSS-in-JS.
+- A `pnpm.overrides` React pin was **not** sufficient: it collapsed the lockfile
+  to a single React key, but the library's presence still broke native at
+  runtime. The library has to be *absent* from `apps/mobile`, not merely
+  deduped.
+
+**Root cause #2 — a self-inflicted native-view crash (PR #619).** While fixing
+the regression, an aspect-ratio change added
+`player.addListener('sourceLoad', …)` (an effect touching the expo-video player)
+to `ExpoVideoPlayer`. That effect **deterministically crashed** the native
+`VideoView` and produced the `ViewManagerAdapter` error above — a second,
+independent native-rendering break layered on top of #548.
+
+**The cascade (why "video + GIF break together").** The native `VideoView`
+crash corrupts the Fabric view registry, which then **also breaks unrelated
+native rendering**. The animated GIF renders through a plain React Native
+`<Image>` whose code was **entirely unchanged**, yet it went blank purely as a
+downstream effect of the corrupted registry. Video and GIF are coupled *through
+the Fabric registry* — they were never two separate bugs, which is why fixing
+one appeared to fix the other and made the whole thing look "flaky."
+
+**Why CI never caught it.** Typecheck passes (the TS is valid), unit tests pass
+(native modules are mocked), the JS bundle builds fine, and web E2E never
+exercises Fabric. It manifests **only on a real device**. This is the exact
+structural gap ADR-030 (native media smoke test) exists to close.
+
+**Guards now in place (map to the three layers above).**
+
+- `apps/mobile/scripts/check-react-consistency.js` runs in CI (the `test-mobile`
+  job) and fails if (a) any native package — matched via prefix + `native-deps.json`
+  — is keyed to a React version other than the pinned one, or (b) a denylisted
+  library (`@mui/`, `@emotion/`, `@material-ui/`, `styled-components`,
+  `react-datepicker`) appears in `apps/mobile` deps.
+- Web-only UI in `apps/mobile` must be **dependency-free** (e.g. a native
+  `<input>` in a `.web.tsx` file), **not** a React component library.
+- ADR-030 (native media smoke test, on a real device) is the only layer that
+  catches a *novel* mechanism — the static checks above only know about the
+  mechanisms and libraries listed here.
+
+**Debugging playbook that worked (reuse this).** The bug only shows on a real
+device, so debug on one by bisecting OTA bundles:
+
+1. Publish a specific commit's bundle to the **staging** channel — either
+   `eas update:republish --group <id>` to re-point an existing bundle, or
+   dispatch `deploy-mobile-update.yml` on a branch to build+publish that
+   commit's bundle.
+2. On the device, **force-quit and reopen the app twice** to fetch and then
+   apply the staged OTA (expo-updates applies on the *next* cold start).
+3. Confirm which bundle is live and read the error from the in-app log
+   collector: **DEVICE INFO** shows the live OTA version; the **console** shows
+   the `ViewManagerAdapter` error if the native view failed to register.
+4. **Change exactly one variable per bundle and device-verify before merging to
+   prod.** Stacking multiple candidate fixes into a single test bundle is
+   precisely what made a *deterministic* bug (#619) look intermittent — you
+   can't attribute a pass/fail when two things changed at once.
+
 ## References
 
 - [Expo Updates Documentation](https://docs.expo.dev/versions/latest/sdk/updates/)

--- a/docs/architecture/ADR-030-native-media-smoke-test.md
+++ b/docs/architecture/ADR-030-native-media-smoke-test.md
@@ -3,6 +3,8 @@
 ## Status
 Proposed
 
+> Full incident writeup: ADR-013 §"Postmortem: #548 / #619 native-media regression (2026-07)".
+
 ## Context
 
 PR #548 added `@mui/*` + `@emotion/*` to `apps/mobile` for a **web-only**


### PR DESCRIPTION
Documents the native-media regression (web React lib → duplicate React → broken native Fabric rendering; native-view crash cascading to GIFs) in CLAUDE.md + ADR-013 + ADR-030, so future agents and engineers don't repeat it. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)