### PR TITLE
Fix Contribute list toggle overlapping status tabs on web

### DIFF
--- a/apps/mobile/features/contribute/components/ContributeListScreen.tsx
+++ b/apps/mobile/features/contribute/components/ContributeListScreen.tsx
@@ -369,7 +369,12 @@ const styles = StyleSheet.create({
   },
   // Bounds the horizontal scroll frame to the row's free space so the status
   // tabs scroll within it rather than pushing the Mine/Everyone toggle out.
-  segmentScroll: { flex: 1 },
+  // minWidth:0 lets the ScrollView shrink below its content width on
+  // react-native-web (a flex item's default min-width is `auto`, i.e. its
+  // content size, which keeps the four-tab track from shrinking and makes it
+  // overflow into the Mine/Everyone toggle). No-op on native, where the
+  // min-width default is already 0.
+  segmentScroll: { flex: 1, minWidth: 0 },
   // Keep the track left-aligned; alignItems:center matches the row's baseline.
   segmentScrollContent: { alignItems: "center" },
   listContent: { paddingHorizontal: 16, paddingTop: 12, paddingBottom: 48 },


### PR DESCRIPTION
## What & why

On the **desktop-web** Contribute sidebar, staff/maintainers get a **Mine / Everyone** toggle beside the four status tabs (**Your turn / In progress / Done / Archived**). On web the two controls **overlapped**: the tabs spread the full width and the toggle collided with / was pushed off them. On native mobile the same row is fine.

The status tabs live in a horizontal `ScrollView` (`segmentScroll`) styled `flex: 1` so it should take only the row's *leftover* space. On **react-native-web** that isn't enough: a flex item's default `min-width` is `auto` (its content size), and RN-Web's `ScrollView` doesn't get the browser's "scroll container ⇒ auto min-size 0" relief. So the four-tab track refuses to shrink, overflows its lane, and crashes into the toggle. Native is unaffected because Yoga's `min-width` already defaults to `0`.

## The fix

One line: add `minWidth: 0` to the `segmentScroll` style — the canonical RN-Web flexbox-overflow fix. The scroll frame can now shrink below its content, so the status tabs scroll horizontally **within their own strip** and the toggle sits beside them with the existing 8px gap. **No behavior or data changes** — purely how the row is sized. No-op on native.

## Before / after

[before/after](https://images.togather.nyc/dev-assistant/3c8ffd46-168d-4ec5-95ce-aeb0ae26a739-contribute-toggle-before-after.png)

> ⚠️ This is a **rendered mock**, not a device capture — these runs have no iOS simulator. It's built from the real component's styles (`ContributeListScreen` + `SegmentedTabs`), dark mode, 340px web sidebar. **Left (before):** the four tabs fill the sidebar and the Mine/Everyone toggle is pushed off the right edge. **Right (after):** the tabs scroll within their strip and the toggle sits fully visible beside them.

## Verification

- ✅ Contribute feature tests pass (`41 passed`)
- ✅ Typecheck clean for the touched file (no new errors)
- ✅ `check-react-consistency` and `check-native-imports` guards pass
- ✅ ESLint (pre-commit) clean
- ✅ Rendered before/after mock above

## Done when (from the spec)

- [x] Web, signed in as staff: status tabs and Mine/Everyone toggle side by side with a clear gap — no overlap, nothing clipped
- [x] When the four tabs don't fit, they scroll horizontally within their strip (matching mobile)
- [x] Regular contributors (no toggle) see no visual change
- [x] Native mobile unchanged (`minWidth: 0` is a no-op there)

---

Dashboard item: `x97d467zz5anmhh18rhgzb8zwd8ajm6e` · Reported by Sayo Olujide (@Shyoh) · Fixes #626

---
_Generated by [Claude Code](https://claude.ai/code/session_011KP6GvrBbA2iRVgTTp2Wq5)_