### PR TITLE
Link previews for every page: registry-driven OG metadata + unified preview resolver

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -70,6 +70,8 @@ jobs:
           secrets-json: ${{ toJSON(secrets) }}
 
       - name: Build landing page
+        env:
+          SITE_ORIGIN: ${{ steps.env.outputs.target == 'production' && 'https://togather.nyc' || 'https://staging.togather.nyc' }}
         run: pnpm --filter @togather/web build
 
       - name: Install Wrangler

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,14 @@ What to update when a guide is affected:
 If you're unsure whether a change is "user-facing enough" to need a guide
 update, it probably is — err on the side of updating.
 
+### Link Previews / OG Metadata
+
+**Adding a static marketing page:** Add an entry to `apps/web/src/routes.tsx` with `path`, `component`, `title`, `description`, and optional `image` and `emoji`. The build script automatically generates OG metadata and images at compile time (satori + resvg for branded cards). Routes are **the only way to add a page** — the router is generated from the registry.
+
+**Adding a dynamic shareable app route:** Implement a resolver case in `apps/convex/functions/linkPreviewMeta.ts` (typed, unit-tested) to assemble preview metadata (title, description, image fallback chains, timezone formatting, etc.), then add a row to `PREVIEW_ROUTES` in `apps/link-preview/cloudflare-worker.js` to route the pattern. The worker fetches the metadata endpoint and renders the shared HTML template — **no per-type logic in the worker itself.**
+
+See ADR-009 for full architecture.
+
 ## File and Project Hygiene
 
 ### Keep the Codebase Clean

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ update, it probably is — err on the side of updating.
 
 ### Link Previews / OG Metadata
 
-**Adding a static marketing page:** Add an entry to `apps/web/src/routes.tsx` with `path`, `component`, `title`, `description`, and optional `image` and `emoji`. The build script automatically generates OG metadata and images at compile time (satori + resvg for branded cards). Routes are **the only way to add a page** — the router is generated from the registry.
+**Adding a static marketing page:** Add an entry to `apps/web/src/routes.tsx` with `path`, `element` (JSX component like `<EventsGuide />`), `title`, `description`, and optional `image` and `emoji`. The build script automatically generates OG metadata and images at compile time (satori + resvg for branded cards). Routes are **the only way to add a page** — the router is generated from the registry. For a **new top-level path** (not nested under an existing prefix like `/guides/`), you must also add it to `LANDING_PAGE_PATHS` or `LANDING_PAGE_PREFIXES` in `apps/link-preview/cloudflare-worker.js`, or the Cloudflare worker will misroute it; paths under already-listed prefixes (like `/guides/`) need no worker change.
 
 **Adding a dynamic shareable app route:** Implement a resolver case in `apps/convex/functions/linkPreviewMeta.ts` (typed, unit-tested) to assemble preview metadata (title, description, image fallback chains, timezone formatting, etc.), then add a row to `PREVIEW_ROUTES` in `apps/link-preview/cloudflare-worker.js` to route the pattern. The worker fetches the metadata endpoint and renders the shared HTML template — **no per-type logic in the worker itself.**
 

--- a/apps/convex/__tests__/linkPreviewMeta.test.ts
+++ b/apps/convex/__tests__/linkPreviewMeta.test.ts
@@ -388,6 +388,15 @@ describe("buildNearmeMeta", () => {
     expect(meta.url).toBe("https://fount.togather.nyc/nearme?type=dinner-parties");
   });
 
+  test("advertises a square 400x400 image (community-logo preview, not a 1200x630 card)", () => {
+    const meta = buildNearmeMeta(
+      { community: { name: "Demo Community", logo: "https://img/logo.jpg" }, groupType: null },
+      { canonicalUrl: "https://fount.togather.nyc/nearme" }
+    );
+    expect(meta.imageWidth).toBe(400);
+    expect(meta.imageHeight).toBe(400);
+  });
+
   test("falls back to generic group copy when no group type given", () => {
     const meta = buildNearmeMeta(
       { community: { name: "Demo Community" }, groupType: null },
@@ -432,5 +441,14 @@ describe("buildCommunityMeta", () => {
       { slug: "fount", origin: "https://togather.nyc" }
     );
     expect(meta.title).toBe("Community | Togather");
+  });
+
+  test("advertises a square 400x400 image (community-logo preview, not a 1200x630 card)", () => {
+    const meta = buildCommunityMeta(
+      { community: { name: "The Fount", logo: "https://img/logo.jpg" } },
+      { slug: "fount", origin: "https://togather.nyc" }
+    );
+    expect(meta.imageWidth).toBe(400);
+    expect(meta.imageHeight).toBe(400);
   });
 });

--- a/apps/convex/__tests__/linkPreviewMeta.test.ts
+++ b/apps/convex/__tests__/linkPreviewMeta.test.ts
@@ -120,6 +120,21 @@ describe("parseLinkPreviewTarget", () => {
   test("malformed url returns unknown instead of throwing", () => {
     expect(parseLinkPreviewTarget("not-a-url")).toEqual({ type: "unknown" });
   });
+
+  test("a percent-encoded reserved char in the query string survives a single decode", () => {
+    // The worker single-encodes the target URL when building `?url=...` for
+    // http.ts, and `url.searchParams.get("url")` in http.ts decodes it back
+    // exactly once. A `%26` in the *target's* query string (a literal "&" in
+    // `type=r&b`) must come through as-is here, not be decoded a second time
+    // (which would split the query string into `type=r` and a bogus `b` param).
+    expect(
+      parseLinkPreviewTarget("https://fount.togather.nyc/nearme?type=r%26b")
+    ).toEqual({
+      type: "nearme",
+      subdomain: "fount",
+      groupTypeSlug: "r&b",
+    });
+  });
 });
 
 describe("formatDate", () => {

--- a/apps/convex/__tests__/linkPreviewMeta.test.ts
+++ b/apps/convex/__tests__/linkPreviewMeta.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildChannelMeta,
+  buildCommunityMeta,
+  buildEventMeta,
+  buildGroupMeta,
+  buildNearmeMeta,
+  buildToolMeta,
+  formatDate,
+  parseLinkPreviewTarget,
+} from "../functions/linkPreviewMeta";
+
+describe("parseLinkPreviewTarget", () => {
+  test("dispatches /e/:shortId to event", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/e/abc123")).toEqual({
+      type: "event",
+      shortId: "abc123",
+    });
+  });
+
+  test("dispatches /g/:shortId to group", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/g/xYz789")).toEqual({
+      type: "group",
+      shortId: "xYz789",
+    });
+  });
+
+  test("dispatches /t/:shortId to tool", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/t/tool1")).toEqual({
+      type: "tool",
+      shortId: "tool1",
+    });
+  });
+
+  test("dispatches /ch/:shortId to channel", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/ch/chan1")).toEqual({
+      type: "channel",
+      shortId: "chan1",
+    });
+  });
+
+  test("handles trailing slash on shortId routes", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/e/abc123/")).toEqual({
+      type: "event",
+      shortId: "abc123",
+    });
+  });
+
+  test("rejects shortIds with invalid characters", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/e/abc-123")).toEqual({
+      type: "unknown",
+    });
+  });
+
+  test("dispatches /nearme with subdomain from hostname and type query param", () => {
+    expect(
+      parseLinkPreviewTarget("https://fount.togather.nyc/nearme?type=dinner-parties")
+    ).toEqual({
+      type: "nearme",
+      subdomain: "fount",
+      groupTypeSlug: "dinner-parties",
+    });
+  });
+
+  test("dispatches /nearme with no group type when query param absent", () => {
+    expect(parseLinkPreviewTarget("https://fount.togather.nyc/nearme")).toEqual({
+      type: "nearme",
+      subdomain: "fount",
+      groupTypeSlug: undefined,
+    });
+  });
+
+  test("/nearme with no subdomain (root domain) has null subdomain", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/nearme")).toEqual({
+      type: "nearme",
+      subdomain: null,
+      groupTypeSlug: undefined,
+    });
+  });
+
+  test("dispatches single-segment slug to community", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/fount")).toEqual({
+      type: "community",
+      slug: "fount",
+    });
+  });
+
+  test("dispatches single-segment slug with hyphens/digits to community", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/first-baptist-2")).toEqual({
+      type: "community",
+      slug: "first-baptist-2",
+    });
+  });
+
+  test("rejects slug starting with a hyphen or digit-only invalid leading char", () => {
+    // Leading char must be [a-z0-9] - a leading hyphen is invalid per the slug regex.
+    expect(parseLinkPreviewTarget("https://togather.nyc/-fount")).toEqual({
+      type: "unknown",
+    });
+  });
+
+  test("rejects uppercase single-segment paths (not a valid slug)", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/Fount")).toEqual({
+      type: "unknown",
+    });
+  });
+
+  test("multi-segment unknown paths return unknown", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/some/other/path")).toEqual({
+      type: "unknown",
+    });
+  });
+
+  test("root path returns unknown", () => {
+    expect(parseLinkPreviewTarget("https://togather.nyc/")).toEqual({
+      type: "unknown",
+    });
+  });
+
+  test("malformed url returns unknown instead of throwing", () => {
+    expect(parseLinkPreviewTarget("not-a-url")).toEqual({ type: "unknown" });
+  });
+});
+
+describe("formatDate", () => {
+  test("returns empty string for missing date", () => {
+    expect(formatDate(null, "America/New_York")).toBe("");
+    expect(formatDate(undefined, "America/New_York")).toBe("");
+  });
+
+  test("formats a known UTC instant in the given IANA timezone", () => {
+    // 2026-01-15T19:00:00Z is 2:00 PM EST (America/New_York, UTC-5 in January).
+    const result = formatDate("2026-01-15T19:00:00.000Z", "America/New_York");
+    expect(result).toBe("Thursday, January 15, 2026 at 2:00 PM EST");
+  });
+
+  test("falls back to America/New_York when timezone is missing", () => {
+    const result = formatDate("2026-01-15T19:00:00.000Z", null);
+    expect(result).toBe("Thursday, January 15, 2026 at 2:00 PM EST");
+  });
+
+  test("falls back to America/New_York when timezone is malformed", () => {
+    const result = formatDate("2026-01-15T19:00:00.000Z", "Eastern Time (US & Canada)");
+    expect(result).toBe("Thursday, January 15, 2026 at 2:00 PM EST");
+  });
+
+  test("respects a different valid IANA timezone", () => {
+    // 2026-01-15T19:00:00Z is 11:00 AM PST (America/Los_Angeles, UTC-8 in January).
+    const result = formatDate("2026-01-15T19:00:00.000Z", "America/Los_Angeles");
+    expect(result).toBe("Thursday, January 15, 2026 at 11:00 AM PST");
+  });
+});
+
+describe("buildEventMeta", () => {
+  const opts = { shortId: "abc123", origin: "https://togather.nyc" };
+
+  test("applies the full image fallback chain: cover -> group -> community logo", () => {
+    const noCover = buildEventMeta(
+      {
+        title: "Weekly Meetup",
+        communityName: "Demo Community",
+        groupImage: "https://img/group.jpg",
+        communityLogo: "https://img/logo.jpg",
+      },
+      opts
+    );
+    expect(noCover.image).toBe("https://img/group.jpg");
+
+    const onlyLogo = buildEventMeta(
+      { title: "Weekly Meetup", communityLogo: "https://img/logo.jpg" },
+      opts
+    );
+    expect(onlyLogo.image).toBe("https://img/logo.jpg");
+
+    const noImages = buildEventMeta({ title: "Weekly Meetup" }, opts);
+    expect(noImages.image).toBeNull();
+
+    const withCover = buildEventMeta(
+      {
+        title: "Weekly Meetup",
+        coverImage: "https://img/cover.jpg",
+        groupImage: "https://img/group.jpg",
+        communityLogo: "https://img/logo.jpg",
+      },
+      opts
+    );
+    expect(withCover.image).toBe("https://img/cover.jpg");
+  });
+
+  test("builds title with RSVP prefix and community suffix", () => {
+    const meta = buildEventMeta(
+      { title: "Weekly Meetup", communityName: "Demo Community" },
+      opts
+    );
+    expect(meta.title).toBe("RSVP to Weekly Meetup | Demo Community");
+  });
+
+  test("falls back to Togather brand name when community is missing", () => {
+    const meta = buildEventMeta({ title: "Weekly Meetup" }, opts);
+    expect(meta.title).toBe("RSVP to Weekly Meetup | Togather");
+    expect(meta.siteName).toBe("Togather");
+  });
+
+  test("assembles rich description from date, location, and note", () => {
+    const meta = buildEventMeta(
+      {
+        title: "Weekly Meetup",
+        scheduledAt: "2026-01-15T19:00:00.000Z",
+        timezone: "America/New_York",
+        locationOverride: "123 Main St",
+        note: "Bring a friend!",
+      },
+      opts
+    );
+    expect(meta.description).toBe(
+      "Thursday, January 15, 2026 at 2:00 PM EST - 123 Main St\n\nBring a friend!"
+    );
+  });
+
+  test("falls back to a generic join message when nothing else is available", () => {
+    const meta = buildEventMeta({ title: "Weekly Meetup", groupName: "Tech Enthusiasts" }, opts);
+    expect(meta.description).toBe("Join Tech Enthusiasts for this event");
+  });
+
+  test("truncates description to 300 characters", () => {
+    const meta = buildEventMeta(
+      { title: "Weekly Meetup", note: "x".repeat(500) },
+      opts
+    );
+    expect(meta.description.length).toBeLessThanOrEqual(300);
+  });
+
+  test("builds the canonical event url from origin + shortId", () => {
+    const meta = buildEventMeta({ title: "Weekly Meetup" }, opts);
+    expect(meta.url).toBe("https://togather.nyc/e/abc123");
+  });
+
+  test("sets imageAlt to the event title", () => {
+    const meta = buildEventMeta({ title: "Weekly Meetup" }, opts);
+    expect(meta.imageAlt).toBe("Weekly Meetup");
+  });
+});
+
+describe("buildGroupMeta", () => {
+  const opts = { shortId: "g1", origin: "https://togather.nyc" };
+
+  test("image fallback: preview -> community logo -> null", () => {
+    expect(
+      buildGroupMeta({ name: "Group", preview: "https://img/p.jpg" }, opts).image
+    ).toBe("https://img/p.jpg");
+    expect(
+      buildGroupMeta({ name: "Group", communityLogo: "https://img/logo.jpg" }, opts).image
+    ).toBe("https://img/logo.jpg");
+    expect(buildGroupMeta({ name: "Group" }, opts).image).toBeNull();
+  });
+
+  test("assembles description from type, location, members, and description", () => {
+    const meta = buildGroupMeta(
+      {
+        name: "Tech Enthusiasts",
+        groupTypeName: "Dinner Party",
+        city: "New York",
+        state: "NY",
+        memberCount: 12,
+        description: "We meet weekly.",
+      },
+      opts
+    );
+    expect(meta.description).toBe(
+      "Dinner Party - New York, NY - 12 members\n\nWe meet weekly."
+    );
+  });
+
+  test("builds title with Join prefix and community suffix", () => {
+    const meta = buildGroupMeta({ name: "Tech Enthusiasts", communityName: "Demo Community" }, opts);
+    expect(meta.title).toBe("Join Tech Enthusiasts | Demo Community");
+  });
+
+  test("builds the canonical group url", () => {
+    expect(buildGroupMeta({ name: "Group" }, opts).url).toBe("https://togather.nyc/g/g1");
+  });
+});
+
+describe("buildToolMeta", () => {
+  const opts = { shortId: "t1", origin: "https://togather.nyc" };
+
+  test("runsheet tool builds run-sheet title and falls back through group image", () => {
+    const meta = buildToolMeta(
+      {
+        toolType: "runsheet",
+        groupName: "Production Team",
+        communityName: "Demo Community",
+        groupImage: "https://img/group.jpg",
+      },
+      opts
+    );
+    expect(meta.title).toBe("Production Team - Run Sheet | Demo Community");
+    expect(meta.description).toBe("View the run sheet for Production Team");
+    expect(meta.image).toBe("https://img/group.jpg");
+  });
+
+  test("resource tool prefers resource image over group image over community logo", () => {
+    const meta = buildToolMeta(
+      {
+        toolType: "resource",
+        groupName: "Production Team",
+        resourceTitle: "Sound Check Guide",
+        resourceImage: "https://img/resource.jpg",
+        groupImage: "https://img/group.jpg",
+        communityLogo: "https://img/logo.jpg",
+      },
+      opts
+    );
+    expect(meta.title).toBe("Production Team - Sound Check Guide | Togather");
+    expect(meta.image).toBe("https://img/resource.jpg");
+  });
+
+  test("unknown tool type falls back to generic tool title", () => {
+    const meta = buildToolMeta({ groupName: "Production Team" }, opts);
+    expect(meta.title).toBe("Production Team - Tool | Togather");
+  });
+});
+
+describe("buildChannelMeta", () => {
+  const opts = { shortId: "c1", origin: "https://togather.nyc" };
+
+  test("builds join title and uses custom channel description when present", () => {
+    const meta = buildChannelMeta(
+      {
+        channelName: "prayer-requests",
+        groupName: "Small Group",
+        communityName: "Demo Community",
+        channelDescription: "Share and pray together.",
+        groupImage: "https://img/group.jpg",
+      },
+      opts
+    );
+    expect(meta.title).toBe("Join #prayer-requests in Small Group | Demo Community");
+    expect(meta.description).toBe("Share and pray together.");
+    expect(meta.image).toBe("https://img/group.jpg");
+  });
+
+  test("falls back to a generated description when channelDescription is absent", () => {
+    const meta = buildChannelMeta(
+      { channelName: "general", groupName: "Small Group", communityName: "Demo Community" },
+      opts
+    );
+    expect(meta.description).toBe(
+      "Join the #general channel in Small Group on Demo Community"
+    );
+  });
+
+  test("image fallback: group image -> community logo -> null", () => {
+    expect(
+      buildChannelMeta({ communityLogo: "https://img/logo.jpg" }, opts).image
+    ).toBe("https://img/logo.jpg");
+    expect(buildChannelMeta({}, opts).image).toBeNull();
+  });
+});
+
+describe("buildNearmeMeta", () => {
+  test("includes group type name in title/description when present", () => {
+    const meta = buildNearmeMeta(
+      {
+        community: { name: "Demo Community", logo: "https://img/logo.jpg" },
+        groupType: { name: "Dinner Party" },
+      },
+      { canonicalUrl: "https://fount.togather.nyc/nearme?type=dinner-parties" }
+    );
+    expect(meta.title).toBe("Find a Dinner Party Near You | Demo Community");
+    expect(meta.description).toBe("Discover Dinner Party groups in Demo Community");
+    expect(meta.image).toBe("https://img/logo.jpg");
+    expect(meta.url).toBe("https://fount.togather.nyc/nearme?type=dinner-parties");
+  });
+
+  test("falls back to generic group copy when no group type given", () => {
+    const meta = buildNearmeMeta(
+      { community: { name: "Demo Community" }, groupType: null },
+      { canonicalUrl: "https://fount.togather.nyc/nearme" }
+    );
+    expect(meta.title).toBe("Find a Group Near You | Demo Community");
+    expect(meta.description).toBe("Discover groups near you in Demo Community");
+    expect(meta.image).toBeNull();
+  });
+
+  test("the canonical url is the request url as-is (no /c/ rewrite)", () => {
+    const meta = buildNearmeMeta(
+      { community: { name: "Demo Community" }, groupType: null },
+      { canonicalUrl: "https://fount.togather.nyc/nearme" }
+    );
+    expect(meta.url).toBe("https://fount.togather.nyc/nearme");
+  });
+});
+
+describe("buildCommunityMeta", () => {
+  test("canonicalizes the bare slug path to /c/:slug", () => {
+    const meta = buildCommunityMeta(
+      { community: { name: "The Fount", logo: "https://img/logo.jpg" } },
+      { slug: "fount", origin: "https://togather.nyc" }
+    );
+    expect(meta.url).toBe("https://togather.nyc/c/fount");
+  });
+
+  test("builds title and description around the community name", () => {
+    const meta = buildCommunityMeta(
+      { community: { name: "The Fount" } },
+      { slug: "fount", origin: "https://togather.nyc" }
+    );
+    expect(meta.title).toBe("The Fount | Togather");
+    expect(meta.description).toBe("Join The Fount on Togather");
+    expect(meta.siteName).toBe("The Fount");
+  });
+
+  test("falls back to generic community name when missing", () => {
+    const meta = buildCommunityMeta(
+      { community: {} },
+      { slug: "fount", origin: "https://togather.nyc" }
+    );
+    expect(meta.title).toBe("Community | Togather");
+  });
+});

--- a/apps/convex/functions/linkPreviewMeta.ts
+++ b/apps/convex/functions/linkPreviewMeta.ts
@@ -1,0 +1,517 @@
+/**
+ * Link Preview Meta Resolver
+ *
+ * Single typed resolver that assembles link-preview metadata (title,
+ * description, image, canonical url, siteName) for every shareable app path.
+ * Backs `GET /link-preview/meta?url=<full request url>` in http.ts, which
+ * replaced the five per-type `/link-preview/{event,group,tool,community,channel}`
+ * endpoints. See ADR-009 for the full link-preview architecture.
+ *
+ * Design: path dispatch and per-type meta building are pure functions (no
+ * ctx, no I/O) so they're unit-testable without a Convex test DB. The only
+ * piece that talks to Convex is `resolveLinkPreviewMeta`, which dispatches on
+ * the parsed path and calls the same queries the old per-type endpoints used.
+ */
+
+import type { ActionCtx } from "../_generated/server";
+import { api } from "../_generated/api";
+import { safeSliceForJson } from "../lib/utils";
+
+const BRAND_NAME = "Togather";
+const MAX_DESCRIPTION_LENGTH = 300;
+
+// ============================================================================
+// Response types
+// ============================================================================
+
+export interface LinkPreviewMeta {
+  title: string;
+  description: string;
+  image: string | null;
+  url: string;
+  siteName: string;
+  imageAlt?: string;
+}
+
+export interface LinkPreviewError {
+  error: string;
+}
+
+export interface LinkPreviewResult {
+  status: number;
+  body: LinkPreviewMeta | LinkPreviewError;
+}
+
+// ============================================================================
+// Path dispatch
+// ============================================================================
+
+export type LinkPreviewTarget =
+  | { type: "event"; shortId: string }
+  | { type: "group"; shortId: string }
+  | { type: "tool"; shortId: string }
+  | { type: "channel"; shortId: string }
+  | { type: "nearme"; subdomain: string | null; groupTypeSlug?: string }
+  | { type: "community"; slug: string }
+  | { type: "unknown" };
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Extract the community subdomain from a hostname, e.g. "fount" from
+ * "fount.togather.nyc". Ported from getSubdomain() in
+ * apps/link-preview/cloudflare-worker.js to keep /nearme behavior identical.
+ */
+function getSubdomain(hostname: string): string | null {
+  const baseDomain = "togather.nyc";
+  const parts = hostname.split(".");
+  const mainDomain = baseDomain.split(".")[0]; // "togather"
+  if (parts.length >= 3 && parts[parts.length - 2] === mainDomain) {
+    return parts[0];
+  }
+  return null;
+}
+
+/**
+ * Parse a full request URL (pathname/host/query) into a dispatch target.
+ * Pure — no I/O. Returns `{ type: "unknown" }` for anything that doesn't
+ * match a known pattern, including a malformed `url`.
+ */
+export function parseLinkPreviewTarget(requestUrl: string): LinkPreviewTarget {
+  let parsed: URL;
+  try {
+    parsed = new URL(requestUrl);
+  } catch {
+    return { type: "unknown" };
+  }
+
+  const pathname = parsed.pathname;
+
+  const eventMatch = pathname.match(/^\/e\/([a-zA-Z0-9]+)\/?$/);
+  if (eventMatch) return { type: "event", shortId: eventMatch[1] };
+
+  const groupMatch = pathname.match(/^\/g\/([a-zA-Z0-9]+)\/?$/);
+  if (groupMatch) return { type: "group", shortId: groupMatch[1] };
+
+  const toolMatch = pathname.match(/^\/t\/([a-zA-Z0-9]+)\/?$/);
+  if (toolMatch) return { type: "tool", shortId: toolMatch[1] };
+
+  const channelMatch = pathname.match(/^\/ch\/([a-zA-Z0-9]+)\/?$/);
+  if (channelMatch) return { type: "channel", shortId: channelMatch[1] };
+
+  if (pathname === "/nearme" || pathname === "/nearme/") {
+    return {
+      type: "nearme",
+      subdomain: getSubdomain(parsed.hostname),
+      groupTypeSlug: parsed.searchParams.get("type") || undefined,
+    };
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 1 && SLUG_RE.test(segments[0])) {
+    return { type: "community", slug: segments[0] };
+  }
+
+  return { type: "unknown" };
+}
+
+// ============================================================================
+// Date formatting
+// ============================================================================
+
+/**
+ * Format an ISO date string to a human-readable string in the given IANA
+ * timezone, e.g. "Thursday, January 15, 2026 at 2:00 PM EST".
+ *
+ * Ported from formatDate() in apps/link-preview/cloudflare-worker.js. Falls
+ * back to America/New_York (the app's default, see
+ * apps/mobile/app/e/[shortId]/EventPageClient.tsx) when the timezone is
+ * missing, since a legacy/malformed IANA zone string can make
+ * toLocaleDateString throw a RangeError.
+ */
+export function formatDate(
+  isoDate: string | null | undefined,
+  timeZone: string | null | undefined
+): string {
+  if (!isoDate) return "";
+  const date = new Date(isoDate);
+  const options: Intl.DateTimeFormatOptions = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  };
+  for (const zone of [timeZone, "America/New_York"]) {
+    if (!zone) continue;
+    try {
+      return date.toLocaleDateString("en-US", { ...options, timeZone: zone });
+    } catch {
+      // Try the next zone.
+    }
+  }
+  return "";
+}
+
+// ============================================================================
+// Per-type meta builders (pure — take fetched docs, return the meta object)
+// ============================================================================
+
+function truncateDescription(text: string): string {
+  return safeSliceForJson(text, MAX_DESCRIPTION_LENGTH);
+}
+
+export interface EventPreviewSource {
+  title?: string | null;
+  scheduledAt?: string | null;
+  timezone?: string | null;
+  locationOverride?: string | null;
+  note?: string | null;
+  coverImage?: string | null;
+  groupName?: string | null;
+  groupImage?: string | null;
+  communityName?: string | null;
+  communityLogo?: string | null;
+}
+
+/**
+ * Build event preview meta. Image fallback chain: cover image -> group image
+ * -> community logo (mirrors generateEventOgHtml() in the worker; the old
+ * `/link-preview/event` endpoint's coverImageFallback/groupImageFallback were
+ * always identical to coverImage/groupImage, so they're folded away here).
+ */
+export function buildEventMeta(
+  event: EventPreviewSource,
+  opts: { shortId: string; origin: string }
+): LinkPreviewMeta {
+  const eventTitle = event.title || "Event";
+  const groupName = event.groupName || "";
+  const communityName = event.communityName || BRAND_NAME;
+  const dateStr = formatDate(event.scheduledAt, event.timezone);
+  const location = event.locationOverride || "";
+
+  let richDescription = "";
+  if (dateStr) richDescription += dateStr;
+  if (location) richDescription += richDescription ? ` - ${location}` : location;
+  if (event.note) {
+    richDescription += richDescription ? `\n\n${event.note}` : event.note;
+  }
+  if (!richDescription) {
+    richDescription = `Join ${groupName} for this event`;
+  }
+
+  const image = event.coverImage || event.groupImage || event.communityLogo || null;
+
+  return {
+    title: `RSVP to ${eventTitle} | ${communityName}`,
+    description: truncateDescription(richDescription),
+    image,
+    url: `${opts.origin}/e/${opts.shortId}`,
+    siteName: communityName,
+    imageAlt: eventTitle,
+  };
+}
+
+export interface GroupPreviewSource {
+  name?: string | null;
+  description?: string | null;
+  preview?: string | null;
+  memberCount?: number | null;
+  communityName?: string | null;
+  communityLogo?: string | null;
+  city?: string | null;
+  state?: string | null;
+  groupTypeName?: string | null;
+}
+
+/**
+ * Build group preview meta. Image fallback chain: group preview -> community
+ * logo (mirrors generateGroupOgHtml() in the worker).
+ */
+export function buildGroupMeta(
+  group: GroupPreviewSource,
+  opts: { shortId: string; origin: string }
+): LinkPreviewMeta {
+  const groupName = group.name || "Group";
+  const communityName = group.communityName || BRAND_NAME;
+  const location = group.city && group.state ? `${group.city}, ${group.state}` : "";
+  const memberCount = group.memberCount || 0;
+
+  let richDescription = "";
+  if (group.groupTypeName) richDescription = group.groupTypeName;
+  if (location) richDescription += richDescription ? ` - ${location}` : location;
+  if (memberCount > 0) {
+    richDescription += richDescription ? ` - ${memberCount} members` : `${memberCount} members`;
+  }
+  if (group.description) {
+    richDescription += richDescription ? `\n\n${group.description}` : group.description;
+  }
+  if (!richDescription) {
+    richDescription = `Join ${groupName} on ${communityName}`;
+  }
+
+  const image = group.preview || group.communityLogo || null;
+
+  return {
+    title: `Join ${groupName} | ${communityName}`,
+    description: truncateDescription(richDescription),
+    image,
+    url: `${opts.origin}/g/${opts.shortId}`,
+    siteName: communityName,
+    imageAlt: groupName,
+  };
+}
+
+export interface ToolPreviewSource {
+  toolType?: string | null;
+  groupName?: string | null;
+  communityName?: string | null;
+  groupImage?: string | null;
+  communityLogo?: string | null;
+  resourceTitle?: string | null;
+  resourceImage?: string | null;
+}
+
+/**
+ * Build tool preview meta (run sheet or resource). Mirrors
+ * generateToolOgHtml() in the worker.
+ */
+export function buildToolMeta(
+  tool: ToolPreviewSource,
+  opts: { shortId: string; origin: string }
+): LinkPreviewMeta {
+  const groupName = tool.groupName || "Group";
+  const communityName = tool.communityName || BRAND_NAME;
+
+  let title: string;
+  let description: string;
+  let image: string | null;
+
+  if (tool.toolType === "runsheet") {
+    title = `${groupName} - Run Sheet`;
+    description = `View the run sheet for ${groupName}`;
+    image = tool.groupImage || tool.communityLogo || null;
+  } else if (tool.toolType === "resource") {
+    const resourceTitle = tool.resourceTitle || "Resource";
+    title = `${groupName} - ${resourceTitle}`;
+    description = `View ${resourceTitle} from ${groupName}`;
+    image = tool.resourceImage || tool.groupImage || tool.communityLogo || null;
+  } else {
+    title = `${groupName} - Tool`;
+    description = `View this tool from ${groupName}`;
+    image = tool.groupImage || tool.communityLogo || null;
+  }
+
+  return {
+    title: `${title} | ${communityName}`,
+    description: truncateDescription(description),
+    image,
+    url: `${opts.origin}/t/${opts.shortId}`,
+    siteName: communityName,
+    imageAlt: title,
+  };
+}
+
+export interface ChannelPreviewSource {
+  channelName?: string | null;
+  channelDescription?: string | null;
+  groupName?: string | null;
+  groupImage?: string | null;
+  communityName?: string | null;
+  communityLogo?: string | null;
+}
+
+/**
+ * Build channel invite preview meta. Image fallback chain: group image ->
+ * community logo (mirrors generateChannelOgHtml() in the worker).
+ */
+export function buildChannelMeta(
+  channel: ChannelPreviewSource,
+  opts: { shortId: string; origin: string }
+): LinkPreviewMeta {
+  const channelName = channel.channelName || "Channel";
+  const groupName = channel.groupName || "Group";
+  const communityName = channel.communityName || BRAND_NAME;
+  const title = `Join #${channelName} in ${groupName}`;
+  const description =
+    channel.channelDescription ||
+    `Join the #${channelName} channel in ${groupName} on ${communityName}`;
+  const image = channel.groupImage || channel.communityLogo || null;
+
+  return {
+    title: `${title} | ${communityName}`,
+    description: truncateDescription(description),
+    image,
+    url: `${opts.origin}/ch/${opts.shortId}`,
+    siteName: communityName,
+    imageAlt: title,
+  };
+}
+
+export interface CommunityPreviewSource {
+  community: {
+    name?: string | null;
+    logo?: string | null;
+  };
+  groupType?: { name: string } | null;
+}
+
+/**
+ * Build "near me" preview meta (community + optional group type). Mirrors
+ * generateNearmeOgHtml() in the worker. Unlike the other types, /nearme's
+ * canonical url is the request url itself — the worker rendered og:url and
+ * the refresh redirect straight from the incoming request, with no `/c/`
+ * rewrite.
+ */
+export function buildNearmeMeta(
+  data: CommunityPreviewSource,
+  opts: { canonicalUrl: string }
+): LinkPreviewMeta {
+  const communityName = data.community?.name || "Community";
+  const groupTypeName = data.groupType?.name;
+
+  const title = groupTypeName ? `Find a ${groupTypeName} Near You` : "Find a Group Near You";
+  const description = groupTypeName
+    ? `Discover ${groupTypeName} groups in ${communityName}`
+    : `Discover groups near you in ${communityName}`;
+
+  return {
+    title: `${title} | ${communityName}`,
+    description: truncateDescription(description),
+    image: data.community?.logo || null,
+    url: opts.canonicalUrl,
+    siteName: communityName,
+  };
+}
+
+/**
+ * Build community landing page preview meta. Mirrors
+ * generateCommunityOgHtml() in the worker. Canonical url rewrites the bare
+ * slug path to `/c/:slug` (e.g. "/fount" -> "<origin>/c/fount"), matching the
+ * worker's redirect-humans-to-/c/:slug behavior.
+ */
+export function buildCommunityMeta(
+  data: CommunityPreviewSource,
+  opts: { slug: string; origin: string }
+): LinkPreviewMeta {
+  const communityName = data.community?.name || "Community";
+
+  return {
+    title: `${communityName} | ${BRAND_NAME}`,
+    description: truncateDescription(`Join ${communityName} on ${BRAND_NAME}`),
+    image: data.community?.logo || null,
+    url: `${opts.origin}/c/${opts.slug}`,
+    siteName: communityName,
+  };
+}
+
+// ============================================================================
+// Orchestrator (the only piece that talks to Convex)
+// ============================================================================
+
+/**
+ * Resolve `GET /link-preview/meta?url=<requestUrl>` into a typed meta
+ * response. Dispatches on the parsed path, fetches the relevant doc via the
+ * same queries the old per-type endpoints used, and builds the meta object.
+ * Returns `{ status: 404, body: { error } }` for both "known pattern, entity
+ * missing" and "no pattern matched".
+ */
+export async function resolveLinkPreviewMeta(
+  ctx: ActionCtx,
+  requestUrl: string
+): Promise<LinkPreviewResult> {
+  const target = parseLinkPreviewTarget(requestUrl);
+
+  if (target.type === "unknown") {
+    return { status: 404, body: { error: "No preview available for this URL" } };
+  }
+
+  const parsedUrl = new URL(requestUrl);
+  const origin = parsedUrl.origin;
+
+  switch (target.type) {
+    case "event": {
+      const event = await ctx.runQuery(api.functions.meetings.index.getByShortId, {
+        shortId: target.shortId,
+      });
+      if (!event) return { status: 404, body: { error: "Event not found" } };
+      return {
+        status: 200,
+        body: buildEventMeta(event, { shortId: target.shortId, origin }),
+      };
+    }
+
+    case "group": {
+      const group = await ctx.runQuery(api.functions.groups.index.getByShortId, {
+        shortId: target.shortId,
+      });
+      if (!group) return { status: 404, body: { error: "Group not found" } };
+      return {
+        status: 200,
+        body: buildGroupMeta(group, { shortId: target.shortId, origin }),
+      };
+    }
+
+    case "tool": {
+      const tool = await ctx.runQuery(api.functions.toolShortLinks.index.getByShortId, {
+        shortId: target.shortId,
+      });
+      if (!tool) return { status: 404, body: { error: "Tool not found" } };
+      return {
+        status: 200,
+        body: buildToolMeta(tool as ToolPreviewSource, { shortId: target.shortId, origin }),
+      };
+    }
+
+    case "channel": {
+      const channel = await ctx.runQuery(api.functions.messaging.channelInvites.getByShortId, {
+        shortId: target.shortId,
+      });
+      if (!channel) return { status: 404, body: { error: "Channel not found" } };
+      return {
+        status: 200,
+        body: buildChannelMeta(channel, { shortId: target.shortId, origin }),
+      };
+    }
+
+    case "nearme": {
+      if (!target.subdomain) {
+        return { status: 404, body: { error: "Community not found" } };
+      }
+      try {
+        const data = await ctx.runQuery(api.functions.groupSearch.publicLinkPreview, {
+          communitySubdomain: target.subdomain,
+          groupTypeSlug: target.groupTypeSlug,
+        });
+        return {
+          status: 200,
+          body: buildNearmeMeta(data, { canonicalUrl: parsedUrl.href }),
+        };
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("not found")) {
+          return { status: 404, body: { error: "Community not found" } };
+        }
+        throw error;
+      }
+    }
+
+    case "community": {
+      try {
+        const data = await ctx.runQuery(api.functions.groupSearch.publicLinkPreview, {
+          communitySubdomain: target.slug,
+        });
+        return {
+          status: 200,
+          body: buildCommunityMeta(data, { slug: target.slug, origin }),
+        };
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("not found")) {
+          return { status: 404, body: { error: "Community not found" } };
+        }
+        throw error;
+      }
+    }
+  }
+}

--- a/apps/convex/functions/linkPreviewMeta.ts
+++ b/apps/convex/functions/linkPreviewMeta.ts
@@ -31,6 +31,10 @@ export interface LinkPreviewMeta {
   url: string;
   siteName: string;
   imageAlt?: string;
+  // Square (400x400) community-logo previews (nearme, community) override
+  // these; the worker's renderOgHtml falls back to 1200x630 when omitted.
+  imageWidth?: number;
+  imageHeight?: number;
 }
 
 export interface LinkPreviewError {
@@ -383,6 +387,8 @@ export function buildNearmeMeta(
     image: data.community?.logo || null,
     url: opts.canonicalUrl,
     siteName: communityName,
+    imageWidth: 400,
+    imageHeight: 400,
   };
 }
 
@@ -404,6 +410,8 @@ export function buildCommunityMeta(
     image: data.community?.logo || null,
     url: `${opts.origin}/c/${opts.slug}`,
     siteName: communityName,
+    imageWidth: 400,
+    imageHeight: 400,
   };
 }
 

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -165,21 +165,24 @@ http.route({
   method: "GET",
   handler: httpAction(async (ctx, request) => {
     const url = new URL(request.url);
+    // `searchParams.get` already URL-decodes once; the worker single-encodes
+    // the target URL, so decoding again here would mangle reserved chars
+    // (e.g. `%26` -> `&`) that are legitimately part of the target's query string.
     const targetUrl = url.searchParams.get("url");
 
     if (!targetUrl) {
       return jsonResponse({ error: "Missing url parameter" }, 400);
     }
 
-    let decodedUrl: string;
+    // Validate it's a well-formed URL before handing it to the resolver.
     try {
-      decodedUrl = decodeURIComponent(targetUrl);
+      new URL(targetUrl);
     } catch {
       return jsonResponse({ error: "Invalid url encoding" }, 400);
     }
 
     try {
-      const result = await resolveLinkPreviewMeta(ctx, decodedUrl);
+      const result = await resolveLinkPreviewMeta(ctx, targetUrl);
       return jsonResponse(result.body, result.status);
     } catch (error) {
       console.error("Error resolving link preview meta:", error);

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -12,10 +12,11 @@
 
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
-import { api, internal } from "./_generated/api";
+import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 import { verifySlackSignature } from "./functions/slackServiceBot/slack";
 import { hashApiKey } from "./lib/apiKeys";
+import { resolveLinkPreviewMeta } from "./functions/linkPreviewMeta";
 import { registerRoutes } from "@supa-media/dev-assistant";
 import "./functions/devAssistant/config"; // side-effect: sets config first
 
@@ -141,303 +142,55 @@ async function verifyStripeSignature(
 }
 
 // ============================================================================
-// Link Preview Endpoints (for Cloudflare Worker)
+// Link Preview Meta Endpoint (for Cloudflare Worker)
 // ============================================================================
 
 /**
- * GET /link-preview/event?shortId=<shortId>
+ * GET /link-preview/meta?url=<urlencoded full original request URL>
  *
- * Returns event data for link preview generation (OG tags).
- * Used by the Cloudflare Worker when bots request /e/[shortId] URLs.
+ * Single typed endpoint that returns standardized preview metadata (title,
+ * description, image, canonical url, siteName) for any shareable app path
+ * (/e/:shortId, /g/:shortId, /t/:shortId, /ch/:shortId, /nearme, /:slug).
+ * Replaces the old per-type /link-preview/{event,group,tool,community,channel}
+ * endpoints — all title/description/image-fallback/date-formatting assembly
+ * now lives in functions/linkPreviewMeta.ts instead of the Cloudflare Worker.
  *
- * Response shape matches what the Cloudflare Worker expects:
- * - id, shortId, title, scheduledAt, status
- * - coverImage, coverImageFallback
- * - groupName, groupImage, groupImageFallback
- * - communityName, communityLogo
- * - locationOverride, note
+ * Response shape: { title, description, image, url, siteName, imageAlt? }
+ * on 200; { error } on 404 (unknown entity or unrecognized path).
+ *
+ * @see ADR-009 for the full link-preview architecture.
  */
 http.route({
-  path: "/link-preview/event",
+  path: "/link-preview/meta",
   method: "GET",
   handler: httpAction(async (ctx, request) => {
     const url = new URL(request.url);
-    const shortId = url.searchParams.get("shortId");
+    const targetUrl = url.searchParams.get("url");
 
-    if (!shortId) {
-      return jsonResponse({ error: "Missing shortId parameter" }, 400);
+    if (!targetUrl) {
+      return jsonResponse({ error: "Missing url parameter" }, 400);
+    }
+
+    let decodedUrl: string;
+    try {
+      decodedUrl = decodeURIComponent(targetUrl);
+    } catch {
+      return jsonResponse({ error: "Invalid url encoding" }, 400);
     }
 
     try {
-      const result = await ctx.runQuery(
-        api.functions.meetings.index.getByShortId,
-        { shortId }
-      );
-
-      if (!result) {
-        return jsonResponse({ error: "Event not found" }, 404);
-      }
-
-      // Transform to match the expected shape for API routes
-      // Include fallback fields (same as primary since we don't store separate versions)
-      return jsonResponse({
-        id: result.id,
-        shortId: result.shortId,
-        title: result.title,
-        scheduledAt: result.scheduledAt,
-        status: result.status,
-        coverImage: result.coverImage,
-        coverImageFallback: result.coverImage, // Same as coverImage
-        groupName: result.groupName,
-        groupImage: result.groupImage,
-        groupImageFallback: result.groupImage, // Same as groupImage
-        communityName: result.communityName,
-        communityLogo: result.communityLogo,
-        timezone: result.timezone,
-        locationOverride: result.locationOverride,
-        note: result.note,
-      });
+      const result = await resolveLinkPreviewMeta(ctx, decodedUrl);
+      return jsonResponse(result.body, result.status);
     } catch (error) {
-      console.error("Error fetching event for link preview:", error);
-      return jsonResponse({ error: "Failed to fetch event" }, 500);
+      console.error("Error resolving link preview meta:", error);
+      return jsonResponse({ error: "Failed to fetch preview" }, 500);
     }
   }),
 });
 
-// Handle CORS preflight for /link-preview/event
+// Handle CORS preflight for /link-preview/meta
 http.route({
-  path: "/link-preview/event",
-  method: "OPTIONS",
-  handler: httpAction(async () => handleCorsOptions()),
-});
-
-/**
- * GET /link-preview/group?shortId=<shortId>
- *
- * Returns group data needed for social sharing previews.
- * Used by the Cloudflare Worker when bots request /g/<shortId> URLs.
- *
- * Response shape:
- * - id, shortId, name, description
- * - preview (group image)
- * - memberCount
- * - communityName, communityLogo
- * - city, state (location)
- * - groupTypeName
- */
-http.route({
-  path: "/link-preview/group",
-  method: "GET",
-  handler: httpAction(async (ctx, request) => {
-    const url = new URL(request.url);
-    const shortId = url.searchParams.get("shortId");
-
-    if (!shortId) {
-      return jsonResponse({ error: "Missing shortId parameter" }, 400);
-    }
-
-    try {
-      const result = await ctx.runQuery(
-        api.functions.groups.index.getByShortId,
-        { shortId }
-      );
-
-      if (!result) {
-        return jsonResponse({ error: "Group not found" }, 404);
-      }
-
-      // Transform to match the expected shape for API routes
-      // Include fallback fields (same as primary since we don't store separate versions)
-      return jsonResponse({
-        id: result.id,
-        shortId: result.shortId,
-        name: result.name,
-        description: result.description,
-        preview: result.preview,
-        previewFallback: result.preview, // Same as preview
-        memberCount: result.memberCount,
-        communityName: result.communityName,
-        communityLogo: result.communityLogo,
-        communityLogoFallback: result.communityLogo, // Same as communityLogo
-        city: result.city,
-        state: result.state,
-        groupTypeName: result.groupTypeName,
-        isPublic: result.isPublic,
-      });
-    } catch (error) {
-      console.error("Error fetching group for link preview:", error);
-      return jsonResponse({ error: "Failed to fetch group" }, 500);
-    }
-  }),
-});
-
-// Handle CORS preflight for /link-preview/group
-http.route({
-  path: "/link-preview/group",
-  method: "OPTIONS",
-  handler: httpAction(async () => handleCorsOptions()),
-});
-
-/**
- * GET /link-preview/tool?shortId=<shortId>
- *
- * Returns tool data for link preview generation (OG tags).
- * Used by the Cloudflare Worker when bots request /t/[shortId] URLs.
- *
- * Response shape:
- * - shortId, toolType, groupId, groupName
- * - groupImage, communityName, communityLogo
- * - resourceTitle?, resourceIcon?, resourceImage? (for resource tools)
- */
-http.route({
-  path: "/link-preview/tool",
-  method: "GET",
-  handler: httpAction(async (ctx, request) => {
-    const url = new URL(request.url);
-    const shortId = url.searchParams.get("shortId");
-
-    if (!shortId) {
-      return jsonResponse({ error: "Missing shortId parameter" }, 400);
-    }
-
-    try {
-      const result = await ctx.runQuery(
-        api.functions.toolShortLinks.index.getByShortId,
-        { shortId }
-      );
-
-      if (!result) {
-        return jsonResponse({ error: "Tool not found" }, 404);
-      }
-
-      return jsonResponse(result);
-    } catch (error) {
-      console.error("Error fetching tool for link preview:", error);
-      return jsonResponse({ error: "Failed to fetch tool" }, 500);
-    }
-  }),
-});
-
-// Handle CORS preflight for /link-preview/tool
-http.route({
-  path: "/link-preview/tool",
-  method: "OPTIONS",
-  handler: httpAction(async () => handleCorsOptions()),
-});
-
-/**
- * GET /link-preview/community?communitySubdomain=<subdomain>&groupTypeSlug=<slug>
- *
- * Returns community and optional group type data for "near me" link previews.
- * Used by the Cloudflare Worker when bots request /nearme URLs.
- *
- * Response shape:
- * {
- *   community: { id, name, subdomain, logo, logoFallback },
- *   groupType: { id, name, slug, description } | null
- * }
- */
-http.route({
-  path: "/link-preview/community",
-  method: "GET",
-  handler: httpAction(async (ctx, request) => {
-    const url = new URL(request.url);
-    const communitySubdomain = url.searchParams.get("communitySubdomain");
-    const groupTypeSlug = url.searchParams.get("groupTypeSlug") || undefined;
-
-    if (!communitySubdomain) {
-      return jsonResponse(
-        { error: "Missing communitySubdomain parameter" },
-        400
-      );
-    }
-
-    try {
-      const result = await ctx.runQuery(
-        api.functions.groupSearch.publicLinkPreview,
-        { communitySubdomain, groupTypeSlug }
-      );
-
-      // Add logoFallback field (null for Convex, but worker expects it)
-      return jsonResponse({
-        community: {
-          ...result.community,
-          logoFallback: null,
-        },
-        groupType: result.groupType,
-      });
-    } catch (error) {
-      console.error("Error fetching community for link preview:", error);
-
-      // Check if it's a "not found" error
-      if (error instanceof Error && error.message.includes("not found")) {
-        return jsonResponse({ error: "Community not found" }, 404);
-      }
-
-      return jsonResponse({ error: "Failed to fetch community" }, 500);
-    }
-  }),
-});
-
-// Handle CORS preflight for /link-preview/community
-http.route({
-  path: "/link-preview/community",
-  method: "OPTIONS",
-  handler: httpAction(async () => handleCorsOptions()),
-});
-
-/**
- * GET /link-preview/channel?shortId=<shortId>
- *
- * Returns channel data for invite link preview generation (OG tags).
- * Used by the Cloudflare Worker when bots request /ch/[shortId] URLs.
- *
- * Response shape:
- * - channelName, groupName, groupImage, memberCount
- * - communityName, communityLogo
- * - joinMode
- */
-http.route({
-  path: "/link-preview/channel",
-  method: "GET",
-  handler: httpAction(async (ctx, request) => {
-    const url = new URL(request.url);
-    const shortId = url.searchParams.get("shortId");
-
-    if (!shortId) {
-      return jsonResponse({ error: "Missing shortId parameter" }, 400);
-    }
-
-    try {
-      const result = await ctx.runQuery(
-        api.functions.messaging.channelInvites.getByShortId,
-        { shortId }
-      );
-
-      if (!result) {
-        return jsonResponse({ error: "Channel not found" }, 404);
-      }
-
-      return jsonResponse({
-        channelName: result.channelName,
-        channelDescription: result.channelDescription,
-        groupName: result.groupName,
-        groupImage: result.groupImage,
-        communityName: result.communityName,
-        communityLogo: result.communityLogo,
-        memberCount: result.memberCount,
-        joinMode: result.joinMode,
-      });
-    } catch (error) {
-      console.error("Error fetching channel for link preview:", error);
-      return jsonResponse({ error: "Failed to fetch channel" }, 500);
-    }
-  }),
-});
-
-// Handle CORS preflight for /link-preview/channel
-http.route({
-  path: "/link-preview/channel",
+  path: "/link-preview/meta",
   method: "OPTIONS",
   handler: httpAction(async () => handleCorsOptions()),
 });

--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -321,151 +321,35 @@ function getConvexSiteUrl(env) {
 }
 
 /**
- * Fetch event data from Convex HTTP endpoint
+ * Fetch fully-rendered link preview metadata from the Convex HTTP endpoint.
+ *
+ * Convex owns all per-entity-type logic (events/groups/tools/channels/
+ * communities/nearme): building titles and descriptions, resolving image
+ * fallback chains, and formatting dates. The worker just renders whatever
+ * comes back — see `renderOgHtml` below.
+ *
+ * @param {string} requestUrl - The full original request URL (not just the path)
+ * @param {string} convexSiteUrl - Convex HTTP endpoint base URL
+ * @returns {Promise<Object|null>} Preview metadata, or null if unavailable
  */
-async function fetchEventData(shortId, convexSiteUrl) {
+async function fetchPreviewMeta(requestUrl, convexSiteUrl) {
   if (!convexSiteUrl) {
     console.error("CONVEX_SITE_URL not configured");
     return null;
   }
 
-  const url = `${convexSiteUrl}/link-preview/event?shortId=${encodeURIComponent(shortId)}`;
+  const metaUrl = `${convexSiteUrl}/link-preview/meta?url=${encodeURIComponent(requestUrl)}`;
 
-  try {
-    const response = await fetch(url, {
-      headers: { "Content-Type": "application/json" },
-    });
+  const response = await fetch(metaUrl, {
+    headers: { "Content-Type": "application/json" },
+  });
 
-    if (!response.ok) {
-      console.error(`Convex event fetch failed: ${response.status}`);
-      return null;
-    }
-
-    const data = await response.json();
-    return data?.error ? null : data;
-  } catch (error) {
-    console.error("Convex event fetch error:", error);
-    return null;
-  }
-}
-
-/**
- * Fetch group data from Convex HTTP endpoint
- */
-async function fetchGroupData(shortId, convexSiteUrl) {
-  if (!convexSiteUrl) {
-    console.error("CONVEX_SITE_URL not configured");
+  if (!response.ok) {
+    console.error(`Convex link-preview meta fetch failed: ${response.status}`);
     return null;
   }
 
-  const url = `${convexSiteUrl}/link-preview/group?shortId=${encodeURIComponent(shortId)}`;
-
-  try {
-    const response = await fetch(url, {
-      headers: { "Content-Type": "application/json" },
-    });
-
-    if (!response.ok) {
-      console.error(`Convex group fetch failed: ${response.status}`);
-      return null;
-    }
-
-    const data = await response.json();
-    return data?.error ? null : data;
-  } catch (error) {
-    console.error("Convex group fetch error:", error);
-    return null;
-  }
-}
-
-/**
- * Fetch tool data from Convex HTTP endpoint
- */
-async function fetchToolData(shortId, convexSiteUrl) {
-  if (!convexSiteUrl) {
-    console.error("CONVEX_SITE_URL not configured");
-    return null;
-  }
-
-  const url = `${convexSiteUrl}/link-preview/tool?shortId=${encodeURIComponent(shortId)}`;
-
-  try {
-    const response = await fetch(url, {
-      headers: { "Content-Type": "application/json" },
-    });
-
-    if (!response.ok) {
-      console.error(`Convex tool fetch failed: ${response.status}`);
-      return null;
-    }
-
-    const data = await response.json();
-    return data?.error ? null : data;
-  } catch (error) {
-    console.error("Convex tool fetch error:", error);
-    return null;
-  }
-}
-
-/**
- * Fetch community data from Convex HTTP endpoint (for /nearme)
- */
-async function fetchCommunityData(communitySubdomain, groupTypeSlug, convexSiteUrl) {
-  if (!convexSiteUrl) {
-    console.error("CONVEX_SITE_URL not configured");
-    return null;
-  }
-
-  let url = `${convexSiteUrl}/link-preview/community?communitySubdomain=${encodeURIComponent(communitySubdomain)}`;
-  if (groupTypeSlug) {
-    url += `&groupTypeSlug=${encodeURIComponent(groupTypeSlug)}`;
-  }
-
-  try {
-    const response = await fetch(url, {
-      headers: { "Content-Type": "application/json" },
-    });
-
-    if (!response.ok) {
-      console.error(`Convex community fetch failed: ${response.status}`);
-      return null;
-    }
-
-    const data = await response.json();
-    return data?.error ? null : data;
-  } catch (error) {
-    console.error("Convex community fetch error:", error);
-    return null;
-  }
-}
-
-/**
- * Fetch channel invite data from Convex HTTP endpoint
- */
-async function fetchChannelData(shortId, convexSiteUrl) {
-  if (!convexSiteUrl) {
-    console.error("CONVEX_SITE_URL not configured");
-    return null;
-  }
-
-  const url = `${convexSiteUrl}/link-preview/channel?shortId=${encodeURIComponent(shortId)}`;
-
-  try {
-    const response = await fetch(url, {
-      headers: { "Content-Type": "application/json" },
-    });
-
-    if (!response.ok) {
-      console.error(`Convex channel fetch failed: ${response.status}`);
-      return null;
-    }
-
-    const data = await response.json();
-    return data?.error ? null : data;
-  } catch (error) {
-    console.error("Convex channel fetch error:", error);
-    return null;
-  }
+  return response.json();
 }
 
 /**
@@ -479,41 +363,6 @@ function escapeHtml(str) {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
-}
-
-/**
- * Format ISO date to human-readable string in the event's timezone.
- *
- * Cloudflare Workers default to UTC, so without an explicit `timeZone` the
- * preview rendered times 4-5 hours ahead of the event's actual local time
- * (e.g. "8:45 PM EDT" showed as "12:45 AM" the next day). We anchor to the
- * event's IANA timezone, falling back to America/New_York to match the app's
- * default (see apps/mobile/app/e/[shortId]/EventPageClient.tsx).
- */
-function formatDate(isoDate, timeZone) {
-  if (!isoDate) return "";
-  const date = new Date(isoDate);
-  const options = {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    timeZoneName: "short",
-  };
-  // A legacy or malformed timezone (e.g. "Eastern Time (US & Canada)") makes
-  // toLocaleDateString throw a RangeError. Fall back to New York rather than
-  // dropping the date entirely, which is worse than showing the wrong zone.
-  for (const zone of [timeZone, "America/New_York"]) {
-    if (!zone) continue;
-    try {
-      return date.toLocaleDateString("en-US", { ...options, timeZone: zone });
-    } catch {
-      // Try the next zone.
-    }
-  }
-  return "";
 }
 
 /**
@@ -578,39 +427,26 @@ function generateHomepageOgHtml(config) {
 }
 
 /**
- * Generate event OG HTML for bots
- * @param {Object} event - Event data from Convex
- * @param {string} shortId - Event short ID
- * @param {Object} config - Environment-specific configuration
+ * Render the shared bot-preview OG HTML template from Convex-provided metadata.
+ *
+ * All entity-specific logic (event/group/tool/channel/community/nearme titles,
+ * descriptions, image fallback chains) lives in Convex — this just escapes and
+ * lays out whatever `fetchPreviewMeta` returned.
+ * @param {Object} meta - Preview metadata from the Convex `/link-preview/meta` endpoint
+ * @param {string} meta.title
+ * @param {string} meta.description
+ * @param {string|null} meta.image
+ * @param {string} meta.url - Absolute canonical destination for the meta-refresh redirect
+ * @param {string} meta.siteName
+ * @param {string} [meta.imageAlt]
  */
-function generateEventOgHtml(event, shortId, config) {
-  const eventTitle = escapeHtml(event.title || "Event");
-  const title = `RSVP to ${eventTitle}`;
-  const groupName = escapeHtml(event.groupName || "");
-  const communityName = escapeHtml(event.communityName || BRAND_NAME);
-  const dateStr = formatDate(event.scheduledAt, event.timezone);
-  const location = escapeHtml(event.locationOverride || "");
-
-  // Build a rich description
-  let richDescription = "";
-  if (dateStr) richDescription += dateStr;
-  if (location) richDescription += richDescription ? ` - ${location}` : location;
-  if (event.note) {
-    richDescription += richDescription ? `\n\n${escapeHtml(event.note)}` : escapeHtml(event.note);
-  }
-  if (!richDescription) {
-    richDescription = `Join ${groupName} for this event`;
-  }
-
-  // Fallback chain: event cover -> group preview -> community logo
-  const imageUrl =
-    event.coverImageFallback ||
-    event.coverImage ||
-    event.groupImageFallback ||
-    event.groupImage ||
-    event.communityLogo ||
-    "";
-  const eventUrl = `${config.baseUrl}/e/${shortId}`;
+function renderOgHtml(meta) {
+  const title = escapeHtml(meta.title || "");
+  const description = escapeHtml(meta.description || "");
+  const siteName = escapeHtml(meta.siteName || BRAND_NAME);
+  const imageAlt = escapeHtml(meta.imageAlt || title);
+  const imageUrl = meta.image || "";
+  const pageUrl = meta.url;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -619,430 +455,8 @@ function generateEventOgHtml(event, shortId, config) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- Primary Meta Tags -->
-  <title>${title} | ${communityName}</title>
-  <meta name="title" content="${title} | ${communityName}">
-  <meta name="description" content="${richDescription.substring(0, 200)}">
-
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="${eventUrl}">
-  <meta property="og:title" content="${title} | ${communityName}">
-  <meta property="og:description" content="${richDescription.substring(0, 200)}">
-  <meta property="og:site_name" content="${communityName}">
-  ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
-  ${imageUrl ? `<meta property="og:image:width" content="1200">` : ""}
-  ${imageUrl ? `<meta property="og:image:height" content="630">` : ""}
-
-  <!-- Twitter -->
-  <meta name="twitter:card" content="${imageUrl ? "summary_large_image" : "summary"}">
-  <meta name="twitter:url" content="${eventUrl}">
-  <meta name="twitter:title" content="${title} | ${communityName}">
-  <meta name="twitter:description" content="${richDescription.substring(0, 200)}">
-  ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta name="twitter:image:alt" content="${eventTitle}">` : ""}
-
-  <!-- Redirect real users to the app -->
-  <meta http-equiv="refresh" content="0;url=${eventUrl}">
-
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      text-align: center;
-    }
-    h1 { color: #333; }
-    p { color: #666; }
-    a { color: #8C10FE; }
-    .loading { color: #999; font-size: 14px; }
-  </style>
-</head>
-<body>
-  <h1>${title}</h1>
-  <p>${groupName}${communityName ? ` - ${communityName}` : ""}</p>
-  ${dateStr ? `<p>${dateStr}</p>` : ""}
-  ${location ? `<p>${location}</p>` : ""}
-  <p class="loading">Redirecting to the app...</p>
-  <p><a href="${eventUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate event error HTML (fallback when API fails)
- * @param {string} shortId - Event short ID
- * @param {Object} config - Environment-specific configuration
- */
-function generateEventErrorHtml(shortId, config) {
-  const eventUrl = `${config.baseUrl}/e/${shortId}`;
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Event | ${BRAND_NAME}</title>
-  <meta property="og:title" content="Event | ${BRAND_NAME}">
-  <meta property="og:description" content="View this event on ${BRAND_NAME}">
-  <meta property="og:type" content="website">
-  <meta http-equiv="refresh" content="0;url=${eventUrl}">
-</head>
-<body>
-  <p>Redirecting...</p>
-  <p><a href="${eventUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate group OG HTML for bots
- * @param {Object} group - Group data from Convex
- * @param {string} shortId - Group short ID
- * @param {Object} config - Environment-specific configuration
- */
-function generateGroupOgHtml(group, shortId, config) {
-  const groupName = escapeHtml(group.name || "Group");
-  const title = `Join ${groupName}`;
-  const communityName = escapeHtml(group.communityName || BRAND_NAME);
-  const location = group.city && group.state ? `${escapeHtml(group.city)}, ${escapeHtml(group.state)}` : "";
-  const memberCount = group.memberCount || 0;
-
-  // Build a rich description
-  let richDescription = "";
-  if (group.groupTypeName) {
-    richDescription = escapeHtml(group.groupTypeName);
-  }
-  if (location) {
-    richDescription += richDescription ? ` - ${location}` : location;
-  }
-  if (memberCount > 0) {
-    richDescription += richDescription ? ` - ${memberCount} members` : `${memberCount} members`;
-  }
-  if (group.description) {
-    richDescription += richDescription ? `\n\n${escapeHtml(group.description)}` : escapeHtml(group.description);
-  }
-  if (!richDescription) {
-    richDescription = `Join ${groupName} on ${communityName}`;
-  }
-
-  // Fallback chain: group preview -> community logo
-  const imageUrl = group.preview || group.communityLogo || "";
-  const groupUrl = `${config.baseUrl}/g/${shortId}`;
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-  <!-- Primary Meta Tags -->
-  <title>${title} | ${communityName}</title>
-  <meta name="title" content="${title} | ${communityName}">
-  <meta name="description" content="${richDescription.substring(0, 200)}">
-
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="${groupUrl}">
-  <meta property="og:title" content="${title} | ${communityName}">
-  <meta property="og:description" content="${richDescription.substring(0, 200)}">
-  <meta property="og:site_name" content="${communityName}">
-  ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
-  ${imageUrl ? `<meta property="og:image:width" content="1200">` : ""}
-  ${imageUrl ? `<meta property="og:image:height" content="630">` : ""}
-
-  <!-- Twitter -->
-  <meta name="twitter:card" content="${imageUrl ? "summary_large_image" : "summary"}">
-  <meta name="twitter:url" content="${groupUrl}">
-  <meta name="twitter:title" content="${title} | ${communityName}">
-  <meta name="twitter:description" content="${richDescription.substring(0, 200)}">
-  ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta name="twitter:image:alt" content="${groupName}">` : ""}
-
-  <!-- Redirect real users to the app -->
-  <meta http-equiv="refresh" content="0;url=${groupUrl}">
-
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      text-align: center;
-    }
-    h1 { color: #333; }
-    p { color: #666; }
-    a { color: #8C10FE; }
-    .loading { color: #999; font-size: 14px; }
-  </style>
-</head>
-<body>
-  <h1>${title}</h1>
-  <p>${communityName}</p>
-  ${location ? `<p>${location}</p>` : ""}
-  ${memberCount > 0 ? `<p>${memberCount} members</p>` : ""}
-  <p class="loading">Redirecting to the app...</p>
-  <p><a href="${groupUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate group error HTML (fallback when API fails)
- * @param {string} shortId - Group short ID
- * @param {Object} config - Environment-specific configuration
- */
-function generateGroupErrorHtml(shortId, config) {
-  const groupUrl = `${config.baseUrl}/g/${shortId}`;
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Group | ${BRAND_NAME}</title>
-  <meta property="og:title" content="Group | ${BRAND_NAME}">
-  <meta property="og:description" content="View this group on ${BRAND_NAME}">
-  <meta property="og:type" content="website">
-  <meta http-equiv="refresh" content="0;url=${groupUrl}">
-</head>
-<body>
-  <p>Redirecting...</p>
-  <p><a href="${groupUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate tool OG HTML for bots
- * @param {Object} tool - Tool data from Convex
- * @param {string} shortId - Tool short ID
- * @param {Object} config - Environment-specific configuration
- */
-function generateToolOgHtml(tool, shortId, config) {
-  const groupName = escapeHtml(tool.groupName || "Group");
-  const communityName = escapeHtml(tool.communityName || BRAND_NAME);
-
-  let title, description, imageUrl;
-
-  if (tool.toolType === "runsheet") {
-    title = `${groupName} - Run Sheet`;
-    description = `View the run sheet for ${groupName}`;
-    // Run sheet has no dedicated image — use group image or community logo
-    imageUrl = tool.groupImage || tool.communityLogo || "";
-  } else if (tool.toolType === "resource") {
-    const resourceTitle = escapeHtml(tool.resourceTitle || "Resource");
-    title = `${groupName} - ${resourceTitle}`;
-    description = `View ${resourceTitle} from ${groupName}`;
-    // Resource image > group image > community logo
-    imageUrl = tool.resourceImage || tool.groupImage || tool.communityLogo || "";
-  } else {
-    title = `${groupName} - Tool`;
-    description = `View this tool from ${groupName}`;
-    imageUrl = tool.groupImage || tool.communityLogo || "";
-  }
-
-  const toolUrl = `${config.baseUrl}/t/${shortId}`;
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-  <!-- Primary Meta Tags -->
-  <title>${title} | ${communityName}</title>
-  <meta name="title" content="${title} | ${communityName}">
-  <meta name="description" content="${escapeHtml(description).substring(0, 200)}">
-
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="${toolUrl}">
-  <meta property="og:title" content="${title} | ${communityName}">
-  <meta property="og:description" content="${escapeHtml(description).substring(0, 200)}">
-  <meta property="og:site_name" content="${communityName}">
-  ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
-  ${imageUrl ? `<meta property="og:image:width" content="1200">` : ""}
-  ${imageUrl ? `<meta property="og:image:height" content="630">` : ""}
-
-  <!-- Twitter -->
-  <meta name="twitter:card" content="${imageUrl ? "summary_large_image" : "summary"}">
-  <meta name="twitter:url" content="${toolUrl}">
-  <meta name="twitter:title" content="${title} | ${communityName}">
-  <meta name="twitter:description" content="${escapeHtml(description).substring(0, 200)}">
-  ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta name="twitter:image:alt" content="${title}">` : ""}
-
-  <!-- Redirect real users to the app -->
-  <meta http-equiv="refresh" content="0;url=${toolUrl}">
-
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      text-align: center;
-    }
-    h1 { color: #333; }
-    p { color: #666; }
-    a { color: #8C10FE; }
-    .loading { color: #999; font-size: 14px; }
-  </style>
-</head>
-<body>
-  <h1>${title}</h1>
-  <p>${communityName}</p>
-  <p class="loading">Redirecting to the app...</p>
-  <p><a href="${toolUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate tool error HTML (fallback when API fails)
- * @param {string} shortId - Tool short ID
- * @param {Object} config - Environment-specific configuration
- */
-function generateToolErrorHtml(shortId, config) {
-  const toolUrl = `${config.baseUrl}/t/${shortId}`;
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tool | ${BRAND_NAME}</title>
-  <meta property="og:title" content="Tool | ${BRAND_NAME}">
-  <meta property="og:description" content="View this tool on ${BRAND_NAME}">
-  <meta property="og:type" content="website">
-  <meta http-equiv="refresh" content="0;url=${toolUrl}">
-</head>
-<body>
-  <p>Redirecting...</p>
-  <p><a href="${toolUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate nearme OG HTML for bots
- */
-function generateNearmeOgHtml(data, originalUrl) {
-  const communityName = escapeHtml(data.community?.name || "Community");
-  const groupTypeName = data.groupType?.name;
-
-  // Build title: "Find a [GroupType] Near You" or "Find a Group Near You"
-  const title = groupTypeName
-    ? `Find a ${escapeHtml(groupTypeName)} Near You`
-    : "Find a Group Near You";
-
-  const description = groupTypeName
-    ? `Discover ${escapeHtml(groupTypeName)} groups in ${communityName}`
-    : `Discover groups near you in ${communityName}`;
-
-  const imageUrl = data.community?.logo || data.community?.logoFallback || "";
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-  <!-- Primary Meta Tags -->
-  <title>${title} | ${communityName}</title>
-  <meta name="title" content="${title} | ${communityName}">
-  <meta name="description" content="${description}">
-
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="${originalUrl}">
-  <meta property="og:title" content="${title} | ${communityName}">
-  <meta property="og:description" content="${description}">
-  <meta property="og:site_name" content="${communityName}">
-  ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
-  ${imageUrl ? `<meta property="og:image:width" content="400">` : ""}
-  ${imageUrl ? `<meta property="og:image:height" content="400">` : ""}
-
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:url" content="${originalUrl}">
-  <meta name="twitter:title" content="${title} | ${communityName}">
-  <meta name="twitter:description" content="${description}">
-  ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ""}
-
-  <!-- Redirect real users to the app -->
-  <meta http-equiv="refresh" content="0;url=${originalUrl}">
-
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      text-align: center;
-    }
-    h1 { color: #333; }
-    p { color: #666; }
-    a { color: #8C10FE; }
-    .loading { color: #999; font-size: 14px; }
-  </style>
-</head>
-<body>
-  <h1>${title}</h1>
-  <p>${communityName}</p>
-  <p class="loading">Redirecting to the app...</p>
-  <p><a href="${originalUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate nearme error HTML (fallback when API fails)
- */
-function generateNearmeErrorHtml(originalUrl) {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Find a Group Near You | ${BRAND_NAME}</title>
-  <meta property="og:title" content="Find a Group Near You | ${BRAND_NAME}">
-  <meta property="og:description" content="Discover groups near you">
-  <meta property="og:type" content="website">
-  <meta http-equiv="refresh" content="0;url=${originalUrl}">
-</head>
-<body>
-  <p>Redirecting...</p>
-  <p><a href="${originalUrl}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate community landing page OG HTML for bots
- */
-function generateCommunityOgHtml(data, slug, config) {
-  const communityName = escapeHtml(data.community?.name || "Community");
-  const title = communityName;
-  const description = `Join ${communityName} on Togather`;
-  const imageUrl = data.community?.logo || data.community?.logoFallback || "";
-  const pageUrl = `${config.baseUrl}/${slug}`;
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-  <!-- Primary Meta Tags -->
-  <title>${title} | ${BRAND_NAME}</title>
-  <meta name="title" content="${title} | ${BRAND_NAME}">
+  <title>${title}</title>
+  <meta name="title" content="${title}">
   <meta name="description" content="${description}">
 
   <!-- Open Graph / Facebook -->
@@ -1050,105 +464,7 @@ function generateCommunityOgHtml(data, slug, config) {
   <meta property="og:url" content="${pageUrl}">
   <meta property="og:title" content="${title}">
   <meta property="og:description" content="${description}">
-  <meta property="og:site_name" content="${BRAND_NAME}">
-  ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
-  ${imageUrl ? `<meta property="og:image:width" content="400">` : ""}
-  ${imageUrl ? `<meta property="og:image:height" content="400">` : ""}
-
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:url" content="${pageUrl}">
-  <meta name="twitter:title" content="${title}">
-  <meta name="twitter:description" content="${description}">
-  ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ""}
-
-  <!-- Redirect real users to the app -->
-  <meta http-equiv="refresh" content="0;url=${config.baseUrl}/c/${slug}">
-
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      text-align: center;
-    }
-    h1 { color: #333; }
-    p { color: #666; }
-    a { color: #8C10FE; }
-    .loading { color: #999; font-size: 14px; }
-  </style>
-</head>
-<body>
-  <h1>${title}</h1>
-  <p class="loading">Redirecting to the app...</p>
-  <p><a href="${config.baseUrl}/c/${slug}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate community error HTML (fallback when API fails)
- */
-function generateCommunityErrorHtml(slug, config) {
-  const pageUrl = `${config.baseUrl}/${slug}`;
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${BRAND_NAME}</title>
-  <meta property="og:title" content="${BRAND_NAME}">
-  <meta property="og:description" content="Connect with your community on Togather">
-  <meta property="og:type" content="website">
-  <meta http-equiv="refresh" content="0;url=${config.baseUrl}/c/${slug}">
-</head>
-<body>
-  <p>Redirecting...</p>
-  <p><a href="${config.baseUrl}/c/${slug}">Click here if not redirected</a></p>
-</body>
-</html>`;
-}
-
-/**
- * Generate channel invite OG HTML for bots
- * @param {Object} channel - Channel data from Convex
- * @param {string} shortId - Channel invite short ID
- * @param {Object} config - Environment-specific configuration
- */
-function generateChannelOgHtml(channel, shortId, config) {
-  const channelName = escapeHtml(channel.channelName || "Channel");
-  const groupName = escapeHtml(channel.groupName || "Group");
-  const communityName = escapeHtml(channel.communityName || BRAND_NAME);
-  const title = `Join #${channelName} in ${groupName}`;
-  const description = channel.channelDescription
-    ? escapeHtml(channel.channelDescription)
-    : `Join the #${channelName} channel in ${groupName} on ${communityName}`;
-  const memberCount = channel.memberCount || 0;
-
-  // Fallback chain: group image -> community logo
-  const imageUrl = channel.groupImage || channel.communityLogo || "";
-  const channelUrl = `${config.baseUrl}/ch/${shortId}`;
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-  <!-- Primary Meta Tags -->
-  <title>${title} | ${communityName}</title>
-  <meta name="title" content="${title} | ${communityName}">
-  <meta name="description" content="${description.substring(0, 200)}">
-
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="${channelUrl}">
-  <meta property="og:title" content="${title} | ${communityName}">
-  <meta property="og:description" content="${description.substring(0, 200)}">
-  <meta property="og:site_name" content="${communityName}">
+  <meta property="og:site_name" content="${siteName}">
   ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
   ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
   ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
@@ -1157,14 +473,14 @@ function generateChannelOgHtml(channel, shortId, config) {
 
   <!-- Twitter -->
   <meta name="twitter:card" content="${imageUrl ? "summary_large_image" : "summary"}">
-  <meta name="twitter:url" content="${channelUrl}">
-  <meta name="twitter:title" content="${title} | ${communityName}">
-  <meta name="twitter:description" content="${description.substring(0, 200)}">
+  <meta name="twitter:url" content="${pageUrl}">
+  <meta name="twitter:title" content="${title}">
+  <meta name="twitter:description" content="${description}">
   ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ""}
-  ${imageUrl ? `<meta name="twitter:image:alt" content="${title}">` : ""}
+  ${imageUrl ? `<meta name="twitter:image:alt" content="${imageAlt}">` : ""}
 
   <!-- Redirect real users to the app -->
-  <meta http-equiv="refresh" content="0;url=${channelUrl}">
+  <meta http-equiv="refresh" content="0;url=${pageUrl}">
 
   <style>
     body {
@@ -1182,54 +498,82 @@ function generateChannelOgHtml(channel, shortId, config) {
 </head>
 <body>
   <h1>${title}</h1>
-  <p>${communityName}</p>
-  ${memberCount > 0 ? `<p>${memberCount} member${memberCount !== 1 ? "s" : ""}</p>` : ""}
+  <p>${siteName}</p>
   <p class="loading">Redirecting to the app...</p>
-  <p><a href="${channelUrl}">Click here if not redirected</a></p>
+  <p><a href="${pageUrl}">Click here if not redirected</a></p>
 </body>
 </html>`;
 }
 
 /**
- * Generate channel invite error HTML (fallback when API fails)
- * @param {string} shortId - Channel invite short ID
+ * Render the shared fallback HTML for bot-preview routes when the Convex
+ * meta endpoint returns a 404 (unknown entity) or the fetch itself fails.
+ * @param {string} pathname - Original request path (e.g. "/e/abc123")
  * @param {Object} config - Environment-specific configuration
  */
-function generateChannelErrorHtml(shortId, config) {
-  const channelUrl = `${config.baseUrl}/ch/${shortId}`;
+function renderPreviewErrorHtml(pathname, config) {
+  const pageUrl = `${config.baseUrl}${pathname}`;
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Channel | ${BRAND_NAME}</title>
-  <meta property="og:title" content="Channel | ${BRAND_NAME}">
-  <meta property="og:description" content="Join this channel on ${BRAND_NAME}">
+  <title>${BRAND_NAME}</title>
+  <meta property="og:title" content="${BRAND_NAME}">
+  <meta property="og:description" content="View this on ${BRAND_NAME}">
   <meta property="og:type" content="website">
-  <meta http-equiv="refresh" content="0;url=${channelUrl}">
+  ${DEFAULT_OG_IMAGE ? `<meta property="og:image" content="${DEFAULT_OG_IMAGE}">` : ""}
+  <meta http-equiv="refresh" content="0;url=${pageUrl}">
 </head>
 <body>
   <p>Redirecting...</p>
-  <p><a href="${channelUrl}">Click here if not redirected</a></p>
+  <p><a href="${pageUrl}">Click here if not redirected</a></p>
 </body>
 </html>`;
 }
 
-/**
- * Extract subdomain from hostname (e.g., "fount" from "fount.togather.nyc")
- */
-function getSubdomain(hostname) {
-  const baseDomain = "togather.nyc";
-  const parts = hostname.split(".");
-  const domainParts = baseDomain.split(".");
-  const mainDomain = domainParts[0]; // "togather"
+// Matches /e/:shortId, /g/:shortId, /t/:shortId, /ch/:shortId (event, group,
+// tool, channel-invite short links). A trailing slash is allowed; anything
+// else (e.g. punctuation in the shortId) does not match.
+const SHORT_ID_ROUTE_PATTERN = /^\/(e|g|t|ch)\/([a-zA-Z0-9]+)\/?$/;
 
-  // Handle subdomain.togather.nyc pattern
-  if (parts.length >= 3 && parts[parts.length - 2] === mainDomain) {
-    return parts[0];
-  }
-  return null;
-}
+/**
+ * Table of bot-preview routes: paths where crawlers get server-rendered OG
+ * tags instead of the SPA shell. Every route delegates its actual preview
+ * content (title/description/image) to the Convex `/link-preview/meta`
+ * endpoint via `fetchPreviewMeta` + `renderOgHtml` — this table only decides
+ * whether a path is a preview route, and how *humans* on that path should be
+ * routed (passthrough to the app, vs. redirected to a canonical app route).
+ */
+const PREVIEW_ROUTES = [
+  // /e/:shortId, /g/:shortId, /t/:shortId, /ch/:shortId
+  {
+    match: (pathname) => SHORT_ID_ROUTE_PATTERN.test(pathname),
+    human: (request, config) => passToApp(request, config),
+  },
+  // /nearme
+  {
+    match: (pathname) => pathname === "/nearme" || pathname === "/nearme/",
+    human: (request, config) => passToApp(request, config),
+  },
+  // /:slug community landing page. Single-segment paths that aren't known
+  // app routes are assumed to be community slugs.
+  {
+    match: (pathname) => {
+      const segments = pathname.split("/").filter(Boolean);
+      if (segments.length !== 1) return false;
+      const slug = segments[0];
+      // Only handle if it looks like a slug (lowercase, digits, hyphens) and isn't a known app route
+      return /^[a-z0-9][a-z0-9-]*$/.test(slug) && !KNOWN_APP_ROUTES.has(slug);
+    },
+    // Humans get redirected to the app's /c/:slug route rather than passed through.
+    human: (request, config, url) => {
+      const slug = url.pathname.split("/").filter(Boolean)[0];
+      const redirectUrl = new URL(`/c/${slug}${url.search}`, url.origin);
+      return Response.redirect(redirectUrl.toString(), 302);
+    },
+  },
+];
 
 /**
  * Pass request to the app (EAS Hosting)
@@ -1358,216 +702,41 @@ export default {
       return passToLandingPage(request, config, envName);
     }
 
-    // 3. Handle /e/:shortId (event pages)
-    if (pathname.startsWith("/e/")) {
-      const shortIdMatch = pathname.match(/^\/e\/([a-zA-Z0-9]+)\/?$/);
-      if (shortIdMatch && isBot(userAgent)) {
-        const shortId = shortIdMatch[1];
+    // 3. Bot-preview routes: /e/:shortId, /g/:shortId, /t/:shortId,
+    // /ch/:shortId, /nearme, and community slug landing pages (/:slug).
+    // Humans get routed per-entry (passthrough or redirect); bots get a
+    // shared OG template rendered from Convex-provided metadata.
+    for (const route of PREVIEW_ROUTES) {
+      if (!route.match(pathname)) continue;
 
-        try {
-          const event = await fetchEventData(shortId, convexSiteUrl);
-
-          if (!event) {
-            return new Response(generateEventErrorHtml(shortId, config), {
-              status: 200,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
-          }
-
-          return new Response(generateEventOgHtml(event, shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        } catch (error) {
-          console.error(`Error fetching event ${shortId}:`, error);
-          return new Response(generateEventErrorHtml(shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        }
+      if (!isBot(userAgent)) {
+        return route.human(request, config, url);
       }
-      // Pass through for humans or invalid format
-      return passToApp(request, config);
-    }
 
-    // 4. Handle /g/:shortId (group pages)
-    if (pathname.startsWith("/g/")) {
-      const shortIdMatch = pathname.match(/^\/g\/([a-zA-Z0-9]+)\/?$/);
-      if (shortIdMatch && isBot(userAgent)) {
-        const shortId = shortIdMatch[1];
+      try {
+        const meta = await fetchPreviewMeta(request.url, convexSiteUrl);
 
-        try {
-          const group = await fetchGroupData(shortId, convexSiteUrl);
-
-          if (!group) {
-            return new Response(generateGroupErrorHtml(shortId, config), {
-              status: 200,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
-          }
-
-          return new Response(generateGroupOgHtml(group, shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        } catch (error) {
-          console.error(`Error fetching group ${shortId}:`, error);
-          return new Response(generateGroupErrorHtml(shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        }
-      }
-      // Pass through for humans or invalid format
-      return passToApp(request, config);
-    }
-
-    // 5. Handle /t/:shortId (tool pages)
-    if (pathname.startsWith("/t/")) {
-      const shortIdMatch = pathname.match(/^\/t\/([a-zA-Z0-9]+)\/?$/);
-      if (shortIdMatch && isBot(userAgent)) {
-        const shortId = shortIdMatch[1];
-
-        try {
-          const tool = await fetchToolData(shortId, convexSiteUrl);
-
-          if (!tool) {
-            return new Response(generateToolErrorHtml(shortId, config), {
-              status: 200,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
-          }
-
-          return new Response(generateToolOgHtml(tool, shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        } catch (error) {
-          console.error(`Error fetching tool ${shortId}:`, error);
-          return new Response(generateToolErrorHtml(shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        }
-      }
-      // Pass through for humans or invalid format
-      return passToApp(request, config);
-    }
-
-    // 6. Handle /ch/:shortId (channel invite links)
-    if (pathname.startsWith("/ch/")) {
-      const shortIdMatch = pathname.match(/^\/ch\/([a-zA-Z0-9]+)\/?$/);
-      if (shortIdMatch && isBot(userAgent)) {
-        const shortId = shortIdMatch[1];
-
-        try {
-          const channel = await fetchChannelData(shortId, convexSiteUrl);
-
-          if (!channel) {
-            return new Response(generateChannelErrorHtml(shortId, config), {
-              status: 200,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
-          }
-
-          return new Response(generateChannelOgHtml(channel, shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        } catch (error) {
-          console.error(`Error fetching channel ${shortId}:`, error);
-          return new Response(generateChannelErrorHtml(shortId, config), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        }
-      }
-      // Pass through for humans or invalid format
-      return passToApp(request, config);
-    }
-
-    // 7. Handle /nearme routes
-    if (pathname === "/nearme" || pathname === "/nearme/") {
-      if (isBot(userAgent)) {
-        const subdomain = getSubdomain(url.hostname);
-
-        if (!subdomain) {
-          // No subdomain - return generic nearme OG or pass through
-          return new Response(generateNearmeErrorHtml(url.href), {
+        if (!meta) {
+          return new Response(renderPreviewErrorHtml(pathname, config), {
             status: 200,
             headers: { "Content-Type": "text/html; charset=utf-8" },
           });
         }
 
-        // Get group type from query parameter
-        const groupTypeSlug = url.searchParams.get("type");
-
-        try {
-          const data = await fetchCommunityData(subdomain, groupTypeSlug, convexSiteUrl);
-
-          if (!data) {
-            return new Response(generateNearmeErrorHtml(url.href), {
-              status: 200,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
-          }
-
-          return new Response(generateNearmeOgHtml(data, url.href), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        } catch (error) {
-          console.error(`Error fetching nearme preview for ${subdomain}:`, error);
-          return new Response(generateNearmeErrorHtml(url.href), {
-            status: 200,
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-          });
-        }
-      }
-      // Pass through for humans
-      return passToApp(request, config);
-    }
-
-    // 8. Community landing page: /:slug
-    // Single-segment paths that aren't known app routes are assumed to be community slugs.
-    // For bots: return OG HTML with community logo and name.
-    // For humans: redirect to /c/:slug in the Expo app.
-    const segments = pathname.split("/").filter(Boolean);
-    if (segments.length === 1) {
-      const slug = segments[0];
-      // Only handle if it looks like a slug (lowercase, digits, hyphens) and isn't a known app route
-      if (/^[a-z0-9][a-z0-9-]*$/.test(slug) && !KNOWN_APP_ROUTES.has(slug)) {
-        if (isBot(userAgent)) {
-          try {
-            const data = await fetchCommunityData(slug, null, convexSiteUrl);
-
-            if (!data) {
-              return new Response(generateCommunityErrorHtml(slug, config), {
-                status: 200,
-                headers: { "Content-Type": "text/html; charset=utf-8" },
-              });
-            }
-
-            return new Response(generateCommunityOgHtml(data, slug, config), {
-              status: 200,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
-          } catch (error) {
-            console.error(`Error fetching community preview for ${slug}:`, error);
-            return new Response(generateCommunityErrorHtml(slug, config), {
-              status: 200,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
-          }
-        }
-
-        // Redirect humans to /c/:slug
-        const redirectUrl = new URL(`/c/${slug}${url.search}`, url.origin);
-        return Response.redirect(redirectUrl.toString(), 302);
+        return new Response(renderOgHtml(meta), {
+          status: 200,
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
+      } catch (error) {
+        console.error(`Error fetching link preview for ${pathname}:`, error);
+        return new Response(renderPreviewErrorHtml(pathname, config), {
+          status: 200,
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
       }
     }
 
-    // 9. All other paths - pass through to origin
+    // 4. All other paths - pass through to origin
     return passToApp(request, config);
   },
 };

--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -92,7 +92,7 @@ function generateAppleAppSiteAssociation(hostname) {
   // route needs BOTH its exact path and a `/*` variant, otherwise sub-pages
   // (e.g. /contribute/ai, /guides/branding) fall through to the `*` catch-all
   // below and get captured by the app. Keep this in sync with the web routes in
-  // apps/web/src/main.tsx and WEB_ONLY_ROOTS in apps/mobile/app/+native-intent.ts.
+  // apps/web/src/routes.tsx and WEB_ONLY_ROOTS in apps/mobile/app/+native-intent.ts.
   const excludedPaths = [
     "/",
     "/android",
@@ -730,11 +730,13 @@ export default {
         return route.human(request, config, url);
       }
 
+      const errorTarget = route.errorTarget(url, config);
+
       try {
         const meta = await fetchPreviewMeta(request.url, convexSiteUrl);
 
         if (!meta) {
-          return new Response(renderPreviewErrorHtml(pathname, config), {
+          return new Response(renderPreviewErrorHtml(errorTarget), {
             status: 200,
             headers: { "Content-Type": "text/html; charset=utf-8" },
           });
@@ -746,7 +748,7 @@ export default {
         });
       } catch (error) {
         console.error(`Error fetching link preview for ${pathname}:`, error);
-        return new Response(renderPreviewErrorHtml(pathname, config), {
+        return new Response(renderPreviewErrorHtml(errorTarget), {
           status: 200,
           headers: { "Content-Type": "text/html; charset=utf-8" },
         });

--- a/apps/link-preview/cloudflare-worker.js
+++ b/apps/link-preview/cloudflare-worker.js
@@ -439,14 +439,20 @@ function generateHomepageOgHtml(config) {
  * @param {string} meta.url - Absolute canonical destination for the meta-refresh redirect
  * @param {string} meta.siteName
  * @param {string} [meta.imageAlt]
+ * @param {number} [meta.imageWidth] - Defaults to 1200 (og:image:width) when omitted
+ * @param {number} [meta.imageHeight] - Defaults to 630 (og:image:height) when omitted
  */
 function renderOgHtml(meta) {
   const title = escapeHtml(meta.title || "");
   const description = escapeHtml(meta.description || "");
   const siteName = escapeHtml(meta.siteName || BRAND_NAME);
-  const imageAlt = escapeHtml(meta.imageAlt || title);
+  // Escape the raw fallback, not `title` (already escaped) — escaping it again
+  // would turn e.g. "&amp;" into "&amp;amp;".
+  const imageAlt = escapeHtml(meta.imageAlt || meta.title || "");
   const imageUrl = meta.image || "";
   const pageUrl = meta.url;
+  const imageWidth = meta.imageWidth || 1200;
+  const imageHeight = meta.imageHeight || 630;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -468,8 +474,8 @@ function renderOgHtml(meta) {
   ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
   ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
   ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
-  ${imageUrl ? `<meta property="og:image:width" content="1200">` : ""}
-  ${imageUrl ? `<meta property="og:image:height" content="630">` : ""}
+  ${imageUrl ? `<meta property="og:image:width" content="${imageWidth}">` : ""}
+  ${imageUrl ? `<meta property="og:image:height" content="${imageHeight}">` : ""}
 
   <!-- Twitter -->
   <meta name="twitter:card" content="${imageUrl ? "summary_large_image" : "summary"}">
@@ -508,11 +514,12 @@ function renderOgHtml(meta) {
 /**
  * Render the shared fallback HTML for bot-preview routes when the Convex
  * meta endpoint returns a 404 (unknown entity) or the fetch itself fails.
- * @param {string} pathname - Original request path (e.g. "/e/abc123")
- * @param {Object} config - Environment-specific configuration
+ * @param {string} targetUrl - Absolute URL to redirect to. Callers compute
+ *   this per-route (see `errorTarget` on each PREVIEW_ROUTES entry) so the
+ *   original query string survives and the community route can target its
+ *   canonical /c/:slug path instead of the bare slug it was matched on.
  */
-function renderPreviewErrorHtml(pathname, config) {
-  const pageUrl = `${config.baseUrl}${pathname}`;
+function renderPreviewErrorHtml(targetUrl) {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -523,11 +530,11 @@ function renderPreviewErrorHtml(pathname, config) {
   <meta property="og:description" content="View this on ${BRAND_NAME}">
   <meta property="og:type" content="website">
   ${DEFAULT_OG_IMAGE ? `<meta property="og:image" content="${DEFAULT_OG_IMAGE}">` : ""}
-  <meta http-equiv="refresh" content="0;url=${pageUrl}">
+  <meta http-equiv="refresh" content="0;url=${targetUrl}">
 </head>
 <body>
   <p>Redirecting...</p>
-  <p><a href="${pageUrl}">Click here if not redirected</a></p>
+  <p><a href="${targetUrl}">Click here if not redirected</a></p>
 </body>
 </html>`;
 }
@@ -550,11 +557,14 @@ const PREVIEW_ROUTES = [
   {
     match: (pathname) => SHORT_ID_ROUTE_PATTERN.test(pathname),
     human: (request, config) => passToApp(request, config),
+    // No canonical rewrite for short-link routes — the original request URL is the target.
+    errorTarget: (url) => url.href,
   },
   // /nearme
   {
     match: (pathname) => pathname === "/nearme" || pathname === "/nearme/",
     human: (request, config) => passToApp(request, config),
+    errorTarget: (url) => url.href,
   },
   // /:slug community landing page. Single-segment paths that aren't known
   // app routes are assumed to be community slugs.
@@ -571,6 +581,13 @@ const PREVIEW_ROUTES = [
       const slug = url.pathname.split("/").filter(Boolean)[0];
       const redirectUrl = new URL(`/c/${slug}${url.search}`, url.origin);
       return Response.redirect(redirectUrl.toString(), 302);
+    },
+    // Error fallback targets the canonical /c/:slug route (config.baseUrl,
+    // not the request's own origin) — same destination as the human redirect,
+    // just anchored to the environment's canonical domain.
+    errorTarget: (url, config) => {
+      const slug = url.pathname.split("/").filter(Boolean)[0];
+      return `${config.baseUrl}/c/${slug}${url.search}`;
     },
   },
 ];

--- a/apps/link-preview/cloudflare-worker.test.js
+++ b/apps/link-preview/cloudflare-worker.test.js
@@ -115,6 +115,69 @@ test("bot preview route without an image uses twitter:card summary (no image tag
   }
 });
 
+test("twitter:image:alt escapes the raw title fallback exactly once (not the already-escaped title)", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(mockMeta({ title: "Sam & Dean's Meetup", imageAlt: undefined })),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/e/abc123", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, {
+      CONVEX_SITE_URL: "https://example.convex.site",
+    });
+
+    const html = await res.text();
+    const [, altAttr] = html.match(/name="twitter:image:alt" content="([^"]*)"/);
+    assert.equal(altAttr, "Sam &amp; Dean&#039;s Meetup");
+    // Guard against double-escaping ("&amp;amp;") which would occur if the
+    // fallback re-escaped the already-escaped title.
+    assert.doesNotMatch(html, /&amp;amp;/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("og:image:width/height use meta.imageWidth/imageHeight when provided (400x400 community-logo preview)", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(mockMeta({ imageWidth: 400, imageHeight: 400 })),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/e/abc123", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, {
+      CONVEX_SITE_URL: "https://example.convex.site",
+    });
+
+    const html = await res.text();
+    assert.match(html, /property="og:image:width" content="400"/);
+    assert.match(html, /property="og:image:height" content="400"/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("bot preview route renders the shared error template on a 404 from Convex", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input) => {
@@ -394,6 +457,41 @@ test("bot /nearme fetches meta from Convex and returns OG tags", async () => {
     assert.ok(
       calls.some((u) => u.includes(encodeURIComponent("https://fount.togather.nyc/nearme"))),
       "expected a Convex meta fetch carrying the full nearme request URL"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot /nearme error fallback preserves the original query string in refresh/link", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(JSON.stringify({ error: "Community not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://fount.togather.nyc/nearme?type=book-club", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(
+      html,
+      /http-equiv="refresh" content="0;url=https:\/\/fount\.togather\.nyc\/nearme\?type=book-club"/
+    );
+    assert.match(
+      html,
+      /<a href="https:\/\/fount\.togather\.nyc\/nearme\?type=book-club">/
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/apps/link-preview/cloudflare-worker.test.js
+++ b/apps/link-preview/cloudflare-worker.test.js
@@ -577,6 +577,41 @@ test("human /:slug (community landing page) redirects to /c/:slug", async () => 
   }
 });
 
+test("bot /:slug error fallback targets the canonical /c/:slug path, not the bare slug", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(JSON.stringify({ error: "Community not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/fount-church?ref=share", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(
+      html,
+      /http-equiv="refresh" content="0;url=https:\/\/togather\.nyc\/c\/fount-church\?ref=share"/
+    );
+    assert.match(
+      html,
+      /<a href="https:\/\/togather\.nyc\/c\/fount-church\?ref=share">/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("known app route (e.g. /admin) is not treated as a community slug", async () => {
   const calls = [];
   const originalFetch = globalThis.fetch;

--- a/apps/link-preview/cloudflare-worker.test.js
+++ b/apps/link-preview/cloudflare-worker.test.js
@@ -7,7 +7,31 @@ import worker from "./cloudflare-worker.js";
 const APP_ORIGIN_URL = "https://togather.expo.app";
 const LANDING_PAGE_URL = "https://togather-landing.pages.dev";
 
-test("bot /e/:shortId fetches from Convex and returns OG tags", async () => {
+/**
+ * Build a mock `/link-preview/meta` response. All fields are already
+ * final/rendered per the Convex contract — the worker does no per-type
+ * logic of its own, it just lays this out in the shared OG template.
+ */
+function mockMeta(overrides = {}) {
+  return {
+    title: "RSVP to My Event Name",
+    description: "Monday, January 19, 2026 - 123 Main St",
+    image: "https://cdn.example.com/event.jpg",
+    url: "https://togather.nyc/e/abc123",
+    siteName: "My Community",
+    imageAlt: "My Event Name",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bot preview routes: content is delegated to the Convex `/link-preview/meta`
+// endpoint. These tests mock global fetch for that endpoint and assert the
+// worker renders the shared OG template (success) or the shared error
+// template (404 / network failure).
+// ---------------------------------------------------------------------------
+
+test("bot /e/:shortId fetches meta from Convex and returns OG tags", async () => {
   const calls = [];
 
   const originalFetch = globalThis.fetch;
@@ -15,25 +39,11 @@ test("bot /e/:shortId fetches from Convex and returns OG tags", async () => {
     const url = typeof input === "string" ? input : input.url;
     calls.push({ url, init });
 
-    // Convex backend fetch for event data
-    if (url.startsWith("https://example.convex.site/link-preview/event")) {
-      return new Response(
-        JSON.stringify({
-          id: "meeting_123",
-          shortId: "abc123",
-          title: "My Event Name",
-          scheduledAt: "2026-01-14T19:00:00.000Z",
-          status: "scheduled",
-          coverImage: "https://cdn.example.com/event.jpg",
-          groupName: "My Group",
-          groupImage: "https://cdn.example.com/group.jpg",
-          communityName: "My Community",
-          communityLogo: "https://cdn.example.com/community.jpg",
-          locationOverride: "123 Main St",
-          note: null,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(JSON.stringify(mockMeta()), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Fallback - should not be reached in this test
@@ -57,13 +67,110 @@ test("bot /e/:shortId fetches from Convex and returns OG tags", async () => {
     assert.match(html, /RSVP to My Event Name/);
     assert.match(html, /property="og:image"/);
     assert.match(html, /https:\/\/cdn\.example\.com\/event\.jpg/);
+    assert.match(html, /property="og:image:width" content="1200"/);
+    assert.match(html, /property="og:image:height" content="630"/);
+    assert.match(html, /name="twitter:card" content="summary_large_image"/);
+    assert.match(html, /http-equiv="refresh" content="0;url=https:\/\/togather\.nyc\/e\/abc123"/);
 
+    const expectedMetaUrl =
+      "https://example.convex.site/link-preview/meta?url=" +
+      encodeURIComponent("https://togather.nyc/e/abc123");
     assert.ok(
-      calls.some((c) =>
-        c.url === "https://example.convex.site/link-preview/event?shortId=abc123"
-      ),
-      "expected a Convex link-preview fetch"
+      calls.some((c) => c.url === expectedMetaUrl),
+      "expected a Convex link-preview meta fetch with the full request URL"
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot preview route without an image uses twitter:card summary (no image tags)", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(mockMeta({ image: null, imageAlt: undefined })),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/e/abc123", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, {
+      CONVEX_SITE_URL: "https://example.convex.site",
+    });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.doesNotMatch(html, /property="og:image"/);
+    assert.match(html, /name="twitter:card" content="summary"/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot preview route renders the shared error template on a 404 from Convex", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(JSON.stringify({ error: "Event not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/e/notfound", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, {
+      CONVEX_SITE_URL: "https://example.convex.site",
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("Content-Type"), "text/html; charset=utf-8");
+
+    const html = await res.text();
+    assert.match(html, /Togather/);
+    assert.match(html, /http-equiv="refresh" content="0;url=https:\/\/togather\.nyc\/e\/notfound"/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot preview route renders the shared error template when the Convex fetch throws", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      throw new Error("network error");
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/g/abc123", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, {
+      CONVEX_SITE_URL: "https://example.convex.site",
+    });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /Togather/);
+    assert.match(html, /http-equiv="refresh" content="0;url=https:\/\/togather\.nyc\/g\/abc123"/);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -101,6 +208,335 @@ test("non-bot /e/:shortId passes through to EAS Hosting (app)", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+// ---------------------------------------------------------------------------
+// PREVIEW_ROUTES pattern coverage: /g/, /t/, /ch/, /nearme, and community
+// slugs all share the same bot/human dispatch, exercised once each here.
+// ---------------------------------------------------------------------------
+
+test("bot /g/:shortId fetches meta from Convex and returns OG tags", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(mockMeta({ title: "Join My Group", url: "https://togather.nyc/g/g123" })),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/g/g123", {
+      headers: { "User-Agent": "facebookexternalhit/1.1" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /Join My Group/);
+    assert.ok(
+      calls.some((u) => u.includes(encodeURIComponent("https://togather.nyc/g/g123"))),
+      "expected a Convex meta fetch for the group short link"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot /t/:shortId fetches meta from Convex and returns OG tags", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(mockMeta({ title: "My Group - Run Sheet", url: "https://togather.nyc/t/t123" })),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/t/t123", {
+      headers: { "User-Agent": "Slackbot" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /My Group - Run Sheet/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot /ch/:shortId fetches meta from Convex and returns OG tags", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(
+          mockMeta({
+            title: "Join #worship-team in Sunday Service",
+            description: "Coordinate worship sets and rehearsals",
+            image: "https://cdn.example.com/group.jpg",
+            url: "https://togather.nyc/ch/xyz789",
+          })
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/ch/xyz789", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, {
+      CONVEX_SITE_URL: "https://example.convex.site",
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("Content-Type"), "text/html; charset=utf-8");
+
+    const html = await res.text();
+    assert.match(html, /property="og:title"/);
+    assert.match(html, /Join #worship-team in Sunday Service/);
+    assert.match(html, /property="og:description"/);
+    assert.match(html, /Coordinate worship sets and rehearsals/);
+    assert.match(html, /property="og:image"/);
+    assert.match(html, /https:\/\/cdn\.example\.com\/group\.jpg/);
+
+    const expectedMetaUrl =
+      "https://example.convex.site/link-preview/meta?url=" +
+      encodeURIComponent("https://togather.nyc/ch/xyz789");
+    assert.ok(calls.includes(expectedMetaUrl), "expected a Convex link-preview meta fetch");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("non-bot /ch/:shortId passes through to EAS Hosting (app)", async () => {
+  const calls = [];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push({ url, init });
+    return new Response("app content", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/ch/xyz789", {
+      headers: { "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)" },
+    });
+
+    const res = await worker.fetch(req, {
+      CONVEX_SITE_URL: "https://example.convex.site",
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "app content");
+
+    // Should pass through to EAS Hosting origin
+    assert.equal(calls.length, 1);
+    assert.ok(
+      calls[0].url.startsWith(APP_ORIGIN_URL),
+      `expected fetch to ${APP_ORIGIN_URL}, got ${calls[0].url}`
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot /nearme fetches meta from Convex and returns OG tags", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(
+          mockMeta({
+            title: "Find a Group Near You",
+            description: "Discover groups near you in Fount Church",
+            url: "https://fount.togather.nyc/nearme",
+          })
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://fount.togather.nyc/nearme", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /Find a Group Near You/);
+    assert.ok(
+      calls.some((u) => u.includes(encodeURIComponent("https://fount.togather.nyc/nearme"))),
+      "expected a Convex meta fetch carrying the full nearme request URL"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("non-bot /nearme passes through to EAS Hosting (app)", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    return new Response("app content", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    const req = new Request("https://fount.togather.nyc/nearme", {
+      headers: { "User-Agent": "Mozilla/5.0" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].startsWith(APP_ORIGIN_URL));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot /:slug (community landing page) fetches meta from Convex and returns OG tags", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    if (url.startsWith("https://example.convex.site/link-preview/meta")) {
+      return new Response(
+        JSON.stringify(mockMeta({ title: "Fount Church", url: "https://togather.nyc/c/fount-church" })),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("unexpected fetch", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/fount-church", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /Fount Church/);
+    assert.ok(
+      calls.some((u) => u.includes(encodeURIComponent("https://togather.nyc/fount-church"))),
+      "expected a Convex meta fetch for the community slug"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("human /:slug (community landing page) redirects to /c/:slug", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    return new Response("should not be called", { status: 500 });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/fount-church?ref=share", {
+      headers: { "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" },
+      redirect: "manual",
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 302);
+    assert.equal(res.headers.get("Location"), "https://togather.nyc/c/fount-church?ref=share");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("known app route (e.g. /admin) is not treated as a community slug", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    return new Response("app content", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    const req = new Request("https://togather.nyc/admin", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    // No Convex meta fetch, no redirect - straight passthrough to the app.
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].startsWith(APP_ORIGIN_URL));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("bot on an invalid short-id format passes through instead of matching a preview route", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    return new Response("app content", { status: 200, headers: { "Content-Type": "text/html" } });
+  };
+
+  try {
+    // "!" is not in [a-zA-Z0-9], so this shouldn't match SHORT_ID_ROUTE_PATTERN.
+    const req = new Request("https://togather.nyc/e/abc!123", {
+      headers: { "User-Agent": "Twitterbot" },
+    });
+
+    const res = await worker.fetch(req, { CONVEX_SITE_URL: "https://example.convex.site" });
+
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 1);
+    assert.ok(
+      calls[0].startsWith(APP_ORIGIN_URL),
+      "invalid shortId format should pass through to the app, not hit Convex"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Kept behavior: static routing, .well-known files, bot detection on the
+// homepage, and landing-page passthrough. None of this depends on the
+// Convex link-preview contract.
+// ---------------------------------------------------------------------------
 
 test("root path (/) for humans passes through to landing page", async () => {
   const calls = [];
@@ -622,223 +1058,6 @@ test("/contribute/:slug sub-pages pass through to landing page", async () => {
       calls[0].url.startsWith(LANDING_PAGE_URL),
       `expected fetch to ${LANDING_PAGE_URL}, got ${calls[0].url}`
     );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-// Channel invite link preview tests (/ch/:shortId)
-test("bot /ch/:shortId fetches from Convex and returns OG tags", async () => {
-  const calls = [];
-
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input, init) => {
-    const url = typeof input === "string" ? input : input.url;
-    calls.push({ url, init });
-
-    // Convex backend fetch for channel data
-    if (url.startsWith("https://example.convex.site/link-preview/channel")) {
-      return new Response(
-        JSON.stringify({
-          channelName: "worship-team",
-          channelDescription: "Coordinate worship sets and rehearsals",
-          groupName: "Sunday Service",
-          groupImage: "https://cdn.example.com/group.jpg",
-          communityName: "My Community",
-          communityLogo: "https://cdn.example.com/community.jpg",
-          memberCount: 12,
-          joinMode: "open",
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    // Fallback - should not be reached in this test
-    return new Response("unexpected fetch", { status: 500 });
-  };
-
-  try {
-    const req = new Request("https://togather.nyc/ch/xyz789", {
-      headers: { "User-Agent": "Twitterbot" },
-    });
-
-    const res = await worker.fetch(req, {
-      CONVEX_SITE_URL: "https://example.convex.site",
-    });
-
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("Content-Type"), "text/html; charset=utf-8");
-
-    const html = await res.text();
-    assert.match(html, /property="og:title"/);
-    assert.match(html, /Join #worship-team in Sunday Service/);
-    assert.match(html, /property="og:description"/);
-    assert.match(html, /Coordinate worship sets and rehearsals/);
-    assert.match(html, /property="og:image"/);
-    assert.match(html, /https:\/\/cdn\.example\.com\/group\.jpg/);
-    assert.match(html, /12 members/);
-
-    assert.ok(
-      calls.some((c) =>
-        c.url === "https://example.convex.site/link-preview/channel?shortId=xyz789"
-      ),
-      "expected a Convex link-preview fetch"
-    );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("bot /ch/:shortId returns error HTML when channel not found", async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input) => {
-    const url = typeof input === "string" ? input : input.url;
-
-    // Convex backend returns 404
-    if (url.startsWith("https://example.convex.site/link-preview/channel")) {
-      return new Response(
-        JSON.stringify({ error: "Channel not found" }),
-        { status: 404, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    return new Response("unexpected fetch", { status: 500 });
-  };
-
-  try {
-    const req = new Request("https://togather.nyc/ch/notfound", {
-      headers: { "User-Agent": "Slackbot" },
-    });
-
-    const res = await worker.fetch(req, {
-      CONVEX_SITE_URL: "https://example.convex.site",
-    });
-
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("Content-Type"), "text/html; charset=utf-8");
-
-    const html = await res.text();
-    assert.match(html, /Channel \| Togather/);
-    assert.match(html, /Join this channel on Togather/);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("non-bot /ch/:shortId passes through to EAS Hosting (app)", async () => {
-  const calls = [];
-
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input, init) => {
-    const url = typeof input === "string" ? input : input.url;
-    calls.push({ url, init });
-    return new Response("app content", { status: 200, headers: { "Content-Type": "text/html" } });
-  };
-
-  try {
-    const req = new Request("https://togather.nyc/ch/xyz789", {
-      headers: { "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)" },
-    });
-
-    const res = await worker.fetch(req, {
-      CONVEX_SITE_URL: "https://example.convex.site",
-    });
-
-    assert.equal(res.status, 200);
-    assert.equal(await res.text(), "app content");
-
-    // Should pass through to EAS Hosting origin
-    assert.equal(calls.length, 1);
-    assert.ok(
-      calls[0].url.startsWith(APP_ORIGIN_URL),
-      `expected fetch to ${APP_ORIGIN_URL}, got ${calls[0].url}`
-    );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("bot /ch/:shortId without description uses generated description", async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input) => {
-    const url = typeof input === "string" ? input : input.url;
-
-    if (url.startsWith("https://example.convex.site/link-preview/channel")) {
-      return new Response(
-        JSON.stringify({
-          channelName: "general",
-          channelDescription: null,
-          groupName: "Youth Group",
-          groupImage: null,
-          communityName: "My Church",
-          communityLogo: null,
-          memberCount: 5,
-          joinMode: "open",
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    return new Response("unexpected fetch", { status: 500 });
-  };
-
-  try {
-    const req = new Request("https://togather.nyc/ch/abc456", {
-      headers: { "User-Agent": "Discordbot" },
-    });
-
-    const res = await worker.fetch(req, {
-      CONVEX_SITE_URL: "https://example.convex.site",
-    });
-
-    assert.equal(res.status, 200);
-
-    const html = await res.text();
-    assert.match(html, /Join #general in Youth Group/);
-    // Should use generated description when channelDescription is null
-    assert.match(html, /Join the #general channel in Youth Group on My Church/);
-    assert.match(html, /5 members/);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("bot /e/:shortId falls back to New York when timezone is invalid", async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input) => {
-    const url = typeof input === "string" ? input : input.url;
-    if (url.startsWith("https://example.convex.site/link-preview/event")) {
-      return new Response(
-        JSON.stringify({
-          id: "meeting_123",
-          shortId: "abc123",
-          title: "My Event Name",
-          scheduledAt: "2026-06-03T19:00:00.000Z",
-          status: "scheduled",
-          groupName: "My Group",
-          // Legacy non-IANA value that makes toLocaleDateString throw.
-          timezone: "Eastern Time (US & Canada)",
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }
-    return new Response("unexpected fetch", { status: 500 });
-  };
-
-  try {
-    const req = new Request("https://togather.nyc/e/abc123", {
-      headers: { "User-Agent": "Twitterbot" },
-    });
-
-    const res = await worker.fetch(req, {
-      CONVEX_SITE_URL: "https://example.convex.site",
-    });
-
-    assert.equal(res.status, 200);
-    const html = await res.text();
-    // The date must still render (in NY time) rather than vanishing entirely.
-    assert.match(html, /June 3, 2026/);
-    assert.match(html, /EDT/);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/apps/mobile/app/(landing)/nearme/index+api.ts
+++ b/apps/mobile/app/(landing)/nearme/index+api.ts
@@ -9,7 +9,6 @@
 
 import { DOMAIN_CONFIG } from "@togather/shared";
 
-const BRAND_NAME = DOMAIN_CONFIG.brandName;
 const BASE_DOMAIN = DOMAIN_CONFIG.baseDomain;
 
 // Bot user agents that need link previews
@@ -64,42 +63,23 @@ function getSubdomain(hostname: string): string | null {
   return null;
 }
 
-interface CommunityData {
-  name?: string;
-  logo?: string;
-  logoFallback?: string;
+// Flat meta shape returned by GET /link-preview/meta — see
+// apps/convex/functions/linkPreviewMeta.ts for the source of truth. All
+// fields are already final/ready to render.
+interface LinkPreviewMeta {
+  title: string;
+  description: string;
+  image: string | null;
+  url: string;
+  siteName: string;
+  imageAlt?: string;
 }
 
-interface GroupTypeData {
-  name?: string;
-  slug?: string;
-}
-
-interface LinkPreviewData {
-  community?: CommunityData;
-  groupType?: GroupTypeData;
-  error?: string;
-}
-
-function generateNearmeOgHtml(
-  data: LinkPreviewData,
-  subdomain: string,
-  originalUrl: string
-): string {
-  const communityName = escapeHtml(data.community?.name || "Community");
-  const groupTypeName = data.groupType?.name;
-
-  // Build title: "Find a [GroupType] Near You" or "Find a Group Near You"
-  const title = groupTypeName
-    ? `Find a ${escapeHtml(groupTypeName)} Near You`
-    : "Find a Group Near You";
-
-  const description = groupTypeName
-    ? `Discover ${escapeHtml(groupTypeName)} groups in ${communityName}`
-    : `Discover groups near you in ${communityName}`;
-
-  // Use original S3 bucket URL - compressed bucket may return 403 for community logos
-  const imageUrl = data.community?.logo || data.community?.logoFallback || "";
+function generateOgHtml(meta: LinkPreviewMeta): string {
+  const title = escapeHtml(meta.title);
+  const description = escapeHtml(meta.description);
+  const siteName = escapeHtml(meta.siteName);
+  const imageUrl = meta.image || "";
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -108,16 +88,16 @@ function generateNearmeOgHtml(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- Primary Meta Tags -->
-  <title>${title} | ${communityName}</title>
-  <meta name="title" content="${title} | ${communityName}">
+  <title>${title}</title>
+  <meta name="title" content="${title}">
   <meta name="description" content="${description}">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="${originalUrl}">
-  <meta property="og:title" content="${title} | ${communityName}">
+  <meta property="og:url" content="${meta.url}">
+  <meta property="og:title" content="${title}">
   <meta property="og:description" content="${description}">
-  <meta property="og:site_name" content="${communityName}">
+  <meta property="og:site_name" content="${siteName}">
   ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ""}
   ${imageUrl ? `<meta property="og:image:secure_url" content="${imageUrl}">` : ""}
   ${imageUrl ? `<meta property="og:image:type" content="image/jpeg">` : ""}
@@ -126,13 +106,13 @@ function generateNearmeOgHtml(
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:url" content="${originalUrl}">
-  <meta name="twitter:title" content="${title} | ${communityName}">
+  <meta name="twitter:url" content="${meta.url}">
+  <meta name="twitter:title" content="${title}">
   <meta name="twitter:description" content="${description}">
   ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ""}
 
   <!-- Redirect real users to the app -->
-  <meta http-equiv="refresh" content="0;url=${originalUrl}">
+  <meta http-equiv="refresh" content="0;url=${meta.url}">
 
   <style>
     body {
@@ -151,9 +131,9 @@ function generateNearmeOgHtml(
 </head>
 <body>
   <h1>${title}</h1>
-  <p>${communityName}</p>
+  <p>${siteName}</p>
   <p class="loading">Redirecting to the app...</p>
-  <p><a href="${originalUrl}">Click here if not redirected</a></p>
+  <p><a href="${meta.url}">Click here if not redirected</a></p>
 </body>
 </html>`;
 }
@@ -200,9 +180,6 @@ export async function GET(request: Request): Promise<Response | undefined> {
     });
   }
 
-  // Get group type from query parameter
-  const groupTypeSlug = url.searchParams.get("type");
-
   // Get Convex URL from environment
   const convexCloudUrl = process.env.EXPO_PUBLIC_CONVEX_URL;
 
@@ -219,34 +196,26 @@ export async function GET(request: Request): Promise<Response | undefined> {
   const convexSiteUrl = convexCloudUrl.replace('.convex.cloud', '.convex.site');
 
   try {
-    // Build API URL with optional group type
-    let apiUrl = `${convexSiteUrl}/link-preview/community?communitySubdomain=${encodeURIComponent(subdomain)}`;
-    if (groupTypeSlug) {
-      apiUrl += `&groupTypeSlug=${encodeURIComponent(groupTypeSlug)}`;
-    }
+    // The meta endpoint dispatches on the incoming request URL itself —
+    // hostname (subdomain) and any ?type= query param carry through
+    // unchanged, so we just forward the original request URL as-is.
+    const apiUrl = `${convexSiteUrl}/link-preview/meta?url=${encodeURIComponent(originalUrl)}`;
 
     const response = await fetch(apiUrl, {
       headers: { "Content-Type": "application/json" },
     });
 
     if (!response.ok) {
-      console.error(`Convex community fetch failed: ${response.status}`);
+      console.error(`Convex link-preview fetch failed: ${response.status}`);
       return new Response(generateErrorHtml(subdomain, originalUrl), {
         status: 200,
         headers: { "Content-Type": "text/html; charset=utf-8" },
       });
     }
 
-    const data: LinkPreviewData = await response.json();
+    const meta: LinkPreviewMeta = await response.json();
 
-    if (data.error) {
-      return new Response(generateErrorHtml(subdomain, originalUrl), {
-        status: 200,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      });
-    }
-
-    return new Response(generateNearmeOgHtml(data, subdomain, originalUrl), {
+    return new Response(generateOgHtml(meta), {
       status: 200,
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });

--- a/apps/mobile/scripts/serve-with-og.js
+++ b/apps/mobile/scripts/serve-with-og.js
@@ -41,89 +41,40 @@ function escapeHtml(str) {
     .replace(/'/g, '&#039;');
 }
 
-function formatDate(isoDate) {
-  if (!isoDate) return '';
-  try {
-    const date = new Date(isoDate);
-    return date.toLocaleDateString('en-US', {
-      weekday: 'long', year: 'numeric', month: 'long',
-      day: 'numeric', hour: 'numeric', minute: '2-digit'
-    });
-  } catch {
-    return '';
-  }
-}
+// meta is the flat shape returned by GET /link-preview/meta — see
+// apps/convex/functions/linkPreviewMeta.ts. All fields are already
+// final/ready to render (title/description pre-formatted, image resolved).
+function generateOgHtml(meta) {
+  const title = escapeHtml(meta.title);
+  const description = escapeHtml(meta.description);
+  const siteName = escapeHtml(meta.siteName);
+  const imageUrl = meta.image || '';
 
-function generateEventOgHtml(event, shortId, baseUrl) {
-  const eventTitle = escapeHtml(event.title || 'Event');
-  const title = `RSVP to ${eventTitle}`;
-  const groupName = escapeHtml(event.groupName || '');
-  const communityName = escapeHtml(event.communityName || BRAND_NAME);
-  const dateStr = formatDate(event.scheduledAt);
-  const location = escapeHtml(event.locationOverride || '');
-
-  let richDescription = '';
-  if (dateStr) richDescription += dateStr;
-  if (location) richDescription += richDescription ? ` • ${location}` : location;
-  if (event.note) richDescription += richDescription ? `\n\n${escapeHtml(event.note)}` : escapeHtml(event.note);
-  if (!richDescription) richDescription = `Join ${groupName} for this event`;
-
-  const imageUrl = event.coverImageFallback || event.coverImage ||
-                   event.groupImageFallback || event.groupImage || event.communityLogo || '';
-  const eventUrl = `${baseUrl}/e/${shortId}`;
-
-  return generateOgHtml(title, communityName, richDescription, imageUrl, eventUrl, eventTitle, groupName, dateStr, location);
-}
-
-function generateGroupOgHtml(group, shortId, baseUrl) {
-  const groupName = escapeHtml(group.name || 'Group');
-  const title = `Join ${groupName}`;
-  const communityName = escapeHtml(group.communityName || BRAND_NAME);
-  const location = group.city && group.state ? `${escapeHtml(group.city)}, ${escapeHtml(group.state)}` : '';
-  const memberCount = group.memberCount || 0;
-
-  let richDescription = '';
-  if (group.groupTypeName) richDescription = escapeHtml(group.groupTypeName);
-  if (location) richDescription += richDescription ? ` • ${location}` : location;
-  if (memberCount > 0) richDescription += richDescription ? ` • ${memberCount} members` : `${memberCount} members`;
-  if (group.description) richDescription += richDescription ? `\n\n${escapeHtml(group.description)}` : escapeHtml(group.description);
-  if (!richDescription) richDescription = `Join ${groupName} on ${communityName}`;
-
-  const imageUrl = group.preview || group.communityLogo || '';
-  const groupUrl = `${baseUrl}/g/${shortId}`;
-
-  return generateOgHtml(title, communityName, richDescription, imageUrl, groupUrl, groupName, communityName,
-                        location, memberCount > 0 ? `${memberCount} members` : '');
-}
-
-function generateOgHtml(title, siteName, description, imageUrl, url, mainTitle, subtitle, line1, line2) {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${title} | ${siteName}</title>
-  <meta name="title" content="${title} | ${siteName}">
-  <meta name="description" content="${description.substring(0, 200)}">
+  <title>${title}</title>
+  <meta name="title" content="${title}">
+  <meta name="description" content="${description}">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="${url}">
-  <meta property="og:title" content="${title} | ${siteName}">
-  <meta property="og:description" content="${description.substring(0, 200)}">
+  <meta property="og:url" content="${meta.url}">
+  <meta property="og:title" content="${title}">
+  <meta property="og:description" content="${description}">
   <meta property="og:site_name" content="${siteName}">
   ${imageUrl ? `<meta property="og:image" content="${imageUrl}">` : ''}
   ${imageUrl ? `<meta property="og:image:width" content="1200">` : ''}
   ${imageUrl ? `<meta property="og:image:height" content="630">` : ''}
   <meta name="twitter:card" content="${imageUrl ? 'summary_large_image' : 'summary'}">
-  <meta name="twitter:url" content="${url}">
-  <meta name="twitter:title" content="${title} | ${siteName}">
-  <meta name="twitter:description" content="${description.substring(0, 200)}">
+  <meta name="twitter:url" content="${meta.url}">
+  <meta name="twitter:title" content="${title}">
+  <meta name="twitter:description" content="${description}">
   ${imageUrl ? `<meta name="twitter:image" content="${imageUrl}">` : ''}
 </head>
 <body>
-  <h1>${mainTitle}</h1>
-  <p>${subtitle}</p>
-  ${line1 ? `<p>${line1}</p>` : ''}
-  ${line2 ? `<p>${line2}</p>` : ''}
+  <h1>${title}</h1>
+  <p>${siteName}</p>
 </body>
 </html>`;
 }
@@ -145,7 +96,7 @@ function generateErrorHtml(type, shortId, baseUrl) {
 </html>`;
 }
 
-async function fetchData(endpoint, shortId) {
+async function fetchData(pageUrl) {
   const convexCloudUrl = process.env.EXPO_PUBLIC_CONVEX_URL;
   if (!convexCloudUrl) return null;
 
@@ -153,7 +104,7 @@ async function fetchData(endpoint, shortId) {
   const convexSiteUrl = convexCloudUrl.replace('.convex.cloud', '.convex.site');
 
   return new Promise((resolve) => {
-    const url = `${convexSiteUrl}/link-preview/${endpoint}?shortId=${encodeURIComponent(shortId)}`;
+    const url = `${convexSiteUrl}/link-preview/meta?url=${encodeURIComponent(pageUrl)}`;
     const client = url.startsWith('https') ? https : http;
 
     client.get(url, (res) => {
@@ -206,20 +157,12 @@ async function handleRequest(req, res) {
   if (isBot(userAgent) && (eventMatch || groupMatch)) {
     const shortId = eventMatch ? eventMatch[1] : groupMatch[1];
     const type = eventMatch ? 'e' : 'g';
-    const endpoint = eventMatch ? 'event' : 'group';
+    const pageUrl = `${baseUrl}/${type}/${shortId}`;
 
     console.log(`[Bot] ${userAgent?.substring(0, 30)}... requesting /${type}/${shortId}`);
 
-    const data = await fetchData(endpoint, shortId);
-    let html;
-
-    if (data) {
-      html = eventMatch
-        ? generateEventOgHtml(data, shortId, baseUrl)
-        : generateGroupOgHtml(data, shortId, baseUrl);
-    } else {
-      html = generateErrorHtml(type, shortId, baseUrl);
-    }
+    const meta = await fetchData(pageUrl);
+    const html = meta ? generateOgHtml(meta) : generateErrorHtml(type, shortId, baseUrl);
 
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     res.end(html);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && tsx scripts/generate-static-pages.tsx",
     "type-check": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -27,6 +27,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "esbuild": "^0.28.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@fontsource/plus-jakarta-sans": "^5.2.8",
+    "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
@@ -29,7 +31,9 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "satori": "^0.28.0",
     "tailwindcss": "^4.1.18",
+    "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4"

--- a/apps/web/scripts/generate-static-pages.tsx
+++ b/apps/web/scripts/generate-static-pages.tsx
@@ -17,19 +17,12 @@ import fs from "node:fs";
 import esbuild from "esbuild";
 import satori from "satori";
 import { Resvg } from "@resvg/resvg-js";
+import type { PageMeta } from "../src/routes.tsx";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const webRoot = path.resolve(__dirname, "..");
 const distDir = path.join(webRoot, "dist");
 const SITE_ORIGIN = (process.env.SITE_ORIGIN || "https://togather.nyc").replace(/\/$/, "");
-
-type PageMeta = {
-  path: string;
-  title: string;
-  description: string;
-  image?: string;
-  emoji?: string;
-};
 
 /**
  * Load the route registry (src/routes.tsx).
@@ -161,7 +154,16 @@ const TEXT_MUTED = "#78716c"; // --color-neutral-500
 const CARD_BG_FROM = "#faf7f4"; // --color-primary-50
 
 function truncate(text: string, max: number): string {
-  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
+  if (text.length <= max) return text;
+  // Mirrors safeSliceForJson in apps/convex/lib/utils.ts: slice() can split a
+  // UTF-16 surrogate pair, leaving a lone high surrogate that renders as a
+  // broken glyph on the OG card. Drop it if the cut landed mid-pair.
+  let sliced = text.slice(0, max - 1);
+  const lastCode = sliced.charCodeAt(sliced.length - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    sliced = sliced.slice(0, -1);
+  }
+  return `${sliced.trimEnd()}…`;
 }
 
 async function loadFonts() {

--- a/apps/web/scripts/generate-static-pages.tsx
+++ b/apps/web/scripts/generate-static-pages.tsx
@@ -1,0 +1,349 @@
+/**
+ * Post-build step (run after `vite build`, see package.json's "build" script).
+ *
+ * Cloudflare Pages serves any static file that exists before falling back to
+ * the SPA rewrite in public/_redirects (`/* /index.html 200`). So for every
+ * route in src/routes.tsx we write a `dist/<path>/index.html` whose <head>
+ * carries that route's real title/description/OG/Twitter tags — link
+ * previews and crawlers get correct metadata with no server, no worker, no
+ * runtime cost. The bundled JS still boots the SPA client-side as normal.
+ *
+ * We also render a branded 1200x630 OG card PNG (via satori -> resvg) for
+ * every route that doesn't supply its own bespoke `image`.
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
+import esbuild from "esbuild";
+import satori from "satori";
+import { Resvg } from "@resvg/resvg-js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.resolve(__dirname, "..");
+const distDir = path.join(webRoot, "dist");
+const SITE_ORIGIN = (process.env.SITE_ORIGIN || "https://togather.nyc").replace(/\/$/, "");
+
+type PageMeta = {
+  path: string;
+  title: string;
+  description: string;
+  image?: string;
+  emoji?: string;
+};
+
+/**
+ * Load the route registry (src/routes.tsx).
+ *
+ * That file is authored for Vite (JSX, `import.meta.env`), so it can't just
+ * be `import()`-ed under plain Node/tsx: Vite statically replaces
+ * `import.meta.env.*` at build time, which tsx's runtime doesn't do, and any
+ * page module that reads it at module scope (e.g. AndroidDownload.tsx) would
+ * throw trying to read a property off `undefined`. We bundle it with esbuild
+ * first (mirroring Vite's own `define` transform) so `import.meta.env.X`
+ * resolves to `undefined` instead of crashing. The `element: <Page />` JSX
+ * just becomes an inert `React.createElement` call we never invoke — we only
+ * read the plain metadata fields off each entry, so page component bodies
+ * never actually run.
+ */
+async function loadRoutes() {
+  const entry = path.join(webRoot, "src/routes.tsx");
+  const result = await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    format: "esm",
+    platform: "node",
+    jsx: "automatic",
+    absWorkingDir: webRoot,
+    // esbuild's `define` only accepts an identifier/entity-name or a JS
+    // literal as the replacement — not an object literal — so we point
+    // `import.meta.env` at a global stub injected via `banner` instead.
+    banner: { js: "globalThis.__importMetaEnvStub = {};" },
+    define: { "import.meta.env": "globalThis.__importMetaEnvStub" },
+    // Defensive: if a page component ever imports an asset or stylesheet at
+    // module scope, don't let bundling fail over it — we never render pages.
+    loader: { ".png": "dataurl", ".svg": "dataurl", ".jpg": "dataurl", ".jpeg": "dataurl", ".css": "empty" },
+    external: ["react", "react-dom", "react-router-dom"],
+  });
+  const bundled = result.outputFiles[0].text;
+  const tmpFile = path.join(webRoot, "node_modules/.generate-static-pages-routes.mjs");
+  fs.mkdirSync(path.dirname(tmpFile), { recursive: true });
+  fs.writeFileSync(tmpFile, bundled);
+  try {
+    const mod = (await import(pathToFileURL(tmpFile).href)) as {
+      routes: PageMeta[];
+      ogSlug: (routePath: string) => string;
+    };
+    return mod;
+  } finally {
+    fs.rmSync(tmpFile, { force: true });
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Resolve an entry's OG image to an absolute URL. */
+function resolveImageUrl(entry: PageMeta, ogSlug: (p: string) => string): string {
+  if (entry.image) {
+    return entry.image.startsWith("http") ? entry.image : `${SITE_ORIGIN}${entry.image}`;
+  }
+  return `${SITE_ORIGIN}/og/${ogSlug(entry.path)}.png`;
+}
+
+function resolveCanonicalUrl(entry: PageMeta): string {
+  return entry.path === "/" ? SITE_ORIGIN : `${SITE_ORIGIN}${entry.path}`;
+}
+
+/**
+ * Replace the generic <title>...<meta twitter:image> head block (see
+ * apps/web/index.html for the block being targeted) with one baked for this
+ * route. The theme-color value is preserved from whatever the template
+ * currently has rather than hardcoded, so this keeps working if it changes.
+ */
+function renderHeadForEntry(templateHtml: string, entry: PageMeta, ogSlug: (p: string) => string): string {
+  const themeColorMatch = templateHtml.match(/<meta name="theme-color" content="([^"]*)"/);
+  const themeColor = themeColorMatch?.[1] ?? "#D4A574";
+  const title = escapeHtml(entry.title);
+  const description = escapeHtml(entry.description);
+  const imageUrl = resolveImageUrl(entry, ogSlug);
+  const canonicalUrl = resolveCanonicalUrl(entry);
+
+  const headBlock = `<title>${title}</title>
+    <meta name="description" content="${description}" />
+    <meta name="theme-color" content="${themeColor}" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="${title}" />
+    <meta property="og:description" content="${description}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${canonicalUrl}" />
+    <meta property="og:image" content="${imageUrl}" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:secure_url" content="${imageUrl}" />
+    <meta property="og:site_name" content="Togather" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="${title}" />
+    <meta name="twitter:description" content="${description}" />
+    <meta name="twitter:image" content="${imageUrl}" />`;
+
+  const headBlockPattern = /<title>[\s\S]*?<meta name="twitter:image"[^>]*>/;
+  if (!headBlockPattern.test(templateHtml)) {
+    throw new Error(
+      "generate-static-pages: could not find the title..twitter:image head block in dist/index.html to replace — did apps/web/index.html's head markup change shape?",
+    );
+  }
+  return templateHtml.replace(headBlockPattern, headBlock);
+}
+
+function outputPathFor(routePath: string): string {
+  if (routePath === "/") return path.join(distDir, "index.html");
+  return path.join(distDir, routePath.replace(/^\//, ""), "index.html");
+}
+
+// ---------------------------------------------------------------------------
+// OG card rendering (satori -> PNG)
+
+const CARD_WIDTH = 1200;
+const CARD_HEIGHT = 630;
+const BRAND_ACCENT = "#D4A574";
+const TEXT_DARK = "#1c1917"; // --color-neutral-900
+const TEXT_MUTED = "#78716c"; // --color-neutral-500
+const CARD_BG_FROM = "#faf7f4"; // --color-primary-50
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
+}
+
+async function loadFonts() {
+  const fontDir = path.join(
+    webRoot,
+    "node_modules/@fontsource/plus-jakarta-sans/files",
+  );
+  // satori needs raw ttf/otf/woff font data — NOT woff2 — so we read the
+  // .woff files @fontsource ships alongside its .woff2 ones.
+  const read = (weight: number) => fs.readFileSync(path.join(fontDir, `plus-jakarta-sans-latin-${weight}-normal.woff`));
+  return [
+    { name: "Plus Jakarta Sans", data: read(400), weight: 400 as const, style: "normal" as const },
+    { name: "Plus Jakarta Sans", data: read(600), weight: 600 as const, style: "normal" as const },
+    { name: "Plus Jakarta Sans", data: read(700), weight: 700 as const, style: "normal" as const },
+  ];
+}
+
+async function renderOgCard(entry: PageMeta, fonts: Awaited<ReturnType<typeof loadFonts>>): Promise<Buffer> {
+  const card = {
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        width: CARD_WIDTH,
+        height: CARD_HEIGHT,
+        padding: "72px",
+        backgroundColor: CARD_BG_FROM,
+        backgroundImage: "linear-gradient(135deg, #faf7f4 0%, #ffffff 65%)",
+        fontFamily: "Plus Jakarta Sans",
+      },
+      children: [
+        // Wordmark
+        {
+          type: "div",
+          props: {
+            style: { display: "flex", alignItems: "center", gap: 12 },
+            children: [
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    width: 14,
+                    height: 14,
+                    borderRadius: 4,
+                    backgroundColor: BRAND_ACCENT,
+                  },
+                },
+              },
+              {
+                type: "div",
+                props: {
+                  style: { display: "flex", fontSize: 28, fontWeight: 700, color: TEXT_DARK },
+                  children: "Togather",
+                },
+              },
+            ],
+          },
+        },
+        // Title + description
+        {
+          type: "div",
+          props: {
+            style: { display: "flex", flexDirection: "column", maxWidth: 1000 },
+            children: [
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    fontSize: 60,
+                    fontWeight: 700,
+                    color: TEXT_DARK,
+                    lineHeight: 1.15,
+                  },
+                  children: truncate(entry.title, 90),
+                },
+              },
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    marginTop: 24,
+                    fontSize: 28,
+                    fontWeight: 400,
+                    color: TEXT_MUTED,
+                    lineHeight: 1.4,
+                  },
+                  children: truncate(entry.description, 140),
+                },
+              },
+            ],
+          },
+        },
+        // Footer accent bar + domain
+        {
+          type: "div",
+          props: {
+            style: { display: "flex", alignItems: "center", gap: 20 },
+            children: [
+              {
+                type: "div",
+                props: {
+                  style: { display: "flex", width: 100, height: 8, borderRadius: 4, backgroundColor: BRAND_ACCENT },
+                },
+              },
+              {
+                type: "div",
+                props: {
+                  style: { display: "flex", fontSize: 22, fontWeight: 600, color: TEXT_MUTED },
+                  children: "togather.nyc",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  const svg = await satori(card, { width: CARD_WIDTH, height: CARD_HEIGHT, fonts });
+  const resvg = new Resvg(svg, { fitTo: { mode: "width", value: CARD_WIDTH } });
+  return resvg.render().asPng();
+}
+
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const templatePath = path.join(distDir, "index.html");
+  if (!fs.existsSync(templatePath)) {
+    console.error(`generate-static-pages: ${templatePath} not found — run "vite build" first.`);
+    process.exit(1);
+  }
+  const templateHtml = fs.readFileSync(templatePath, "utf8");
+
+  const { routes, ogSlug } = await loadRoutes();
+  if (!Array.isArray(routes) || routes.length === 0) {
+    console.error("generate-static-pages: src/routes.tsx exported an empty routes array.");
+    process.exit(1);
+  }
+
+  const ogDir = path.join(distDir, "og");
+  fs.mkdirSync(ogDir, { recursive: true });
+  const fonts = await loadFonts();
+
+  const writtenHtmlPaths: string[] = [];
+  const generatedImagePaths: string[] = [];
+
+  for (const entry of routes) {
+    const outPath = outputPathFor(entry.path);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    const html = renderHeadForEntry(templateHtml, entry, ogSlug);
+    fs.writeFileSync(outPath, html);
+    writtenHtmlPaths.push(outPath);
+
+    if (!entry.image) {
+      const pngPath = path.join(ogDir, `${ogSlug(entry.path)}.png`);
+      const png = await renderOgCard(entry, fonts);
+      fs.writeFileSync(pngPath, png);
+      generatedImagePaths.push(pngPath);
+    }
+  }
+
+  // Self-check: every route got its HTML, every generated-image route got its PNG.
+  const missingHtml = writtenHtmlPaths.filter((p) => !fs.existsSync(p));
+  const missingPng = generatedImagePaths.filter((p) => !fs.existsSync(p));
+  if (missingHtml.length || missingPng.length) {
+    console.error("generate-static-pages: post-write verification failed.");
+    if (missingHtml.length) console.error("  Missing HTML:", missingHtml);
+    if (missingPng.length) console.error("  Missing PNG:", missingPng);
+    process.exit(1);
+  }
+
+  console.log(
+    `generate-static-pages: wrote ${writtenHtmlPaths.length} route HTML file(s) and ${generatedImagePaths.length} OG card PNG(s).`,
+  );
+}
+
+main().catch((err) => {
+  console.error("generate-static-pages: failed.", err);
+  process.exit(1);
+});

--- a/apps/web/src/components/PageHead.tsx
+++ b/apps/web/src/components/PageHead.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import type { PageMeta } from "../routes.tsx";
+
+/**
+ * Sets the document <title> and meta description for a route on client-side
+ * navigation. React 19 hoists <title>/<meta> tags rendered anywhere in the
+ * tree into <head>, so this needs no portal or effect — it just renders them
+ * alongside the page. The static tags in index.html only cover the very
+ * first paint of "/"; every navigation after that goes through here.
+ */
+export function PageHead({ meta, children }: { meta: PageMeta; children: ReactNode }) {
+  return (
+    <>
+      <title>{meta.title}</title>
+      <meta name="description" content={meta.description} />
+      {children}
+    </>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,26 +2,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
-import App from './App.tsx'
-import { PrivacyPolicy } from './pages/PrivacyPolicy.tsx'
-import { TermsOfService } from './pages/TermsOfService.tsx'
-import { AndroidDownload } from './pages/AndroidDownload.tsx'
-import { Contribute } from './pages/Contribute.tsx'
-import { ContributeAI } from './pages/ContributeAI.tsx'
-import { ReportIssue } from './pages/ReportIssue.tsx'
 import { CommunityRedirect } from './pages/CommunityRedirect.tsx'
-import { Developers } from './pages/Developers.tsx'
-import { Guides } from './pages/Guides.tsx'
-import { CreateCommunity } from './pages/guides/CreateCommunity.tsx'
-import { Pricing } from './pages/guides/Pricing.tsx'
-import { Branding } from './pages/guides/Branding.tsx'
-import { GroupTypes } from './pages/guides/GroupTypes.tsx'
-import { GroupsAndChannels } from './pages/guides/GroupsAndChannels.tsx'
-import { Events } from './pages/guides/Events.tsx'
-import { EventPlans } from './pages/guides/EventPlans.tsx'
-import { CheckIn } from './pages/guides/CheckIn.tsx'
-import { Prayer } from './pages/guides/Prayer.tsx'
 import { ScrollToTop } from './components/ScrollToTop.tsx'
+import { PageHead } from './components/PageHead.tsx'
+import { routes } from './routes.tsx'
 // Onboarding, billing, admin, and sign-in pages have been moved to the Expo web app.
 
 createRoot(document.getElementById('root')!).render(
@@ -29,27 +13,17 @@ createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <ScrollToTop />
       <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/android" element={<AndroidDownload />} />
-        <Route path="/android-staging" element={<AndroidDownload variant="staging" />} />
-        <Route path="/contribute" element={<Contribute />} />
-        <Route path="/contribute/ai" element={<ContributeAI />} />
-        <Route path="/issue" element={<ReportIssue />} />
-        <Route path="/guides" element={<Guides />} />
-        <Route path="/guides/create-your-community" element={<CreateCommunity />} />
-        <Route path="/guides/pricing" element={<Pricing />} />
-        <Route path="/guides/branding" element={<Branding />} />
-        <Route path="/guides/group-types" element={<GroupTypes />} />
-        <Route path="/guides/groups-and-channels" element={<GroupsAndChannels />} />
-        <Route path="/guides/events" element={<Events />} />
-        <Route path="/guides/event-plans" element={<EventPlans />} />
-        <Route path="/guides/check-in" element={<CheckIn />} />
-        <Route path="/guides/prayer" element={<Prayer />} />
-        <Route path="/legal/privacy" element={<PrivacyPolicy />} />
-        <Route path="/legal/terms" element={<TermsOfService />} />
-        {/* Browser-only developer docs (excluded from app links — see worker) */}
-        <Route path="/developers" element={<Developers />} />
-        {/* Catch-all: redirect /:slug to community landing page */}
+        {/* Generated from the route registry (routes.tsx) — every page there
+            structurally ships link-preview metadata (see PageMeta). */}
+        {routes.map((route) => (
+          <Route
+            key={route.path}
+            path={route.path}
+            element={<PageHead meta={route}>{route.element}</PageHead>}
+          />
+        ))}
+        {/* Catch-all: redirect /:slug to community landing page. Deliberately
+            not in the registry — it's a redirect, not a page. */}
         <Route path="/:slug" element={<CommunityRedirect />} />
       </Routes>
     </BrowserRouter>

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -1,0 +1,150 @@
+import type { ReactElement } from "react";
+import App from "./App.tsx";
+import { PrivacyPolicy } from "./pages/PrivacyPolicy.tsx";
+import { TermsOfService } from "./pages/TermsOfService.tsx";
+import { AndroidDownload } from "./pages/AndroidDownload.tsx";
+import { Contribute } from "./pages/Contribute.tsx";
+import { ContributeAI } from "./pages/ContributeAI.tsx";
+import { ReportIssue } from "./pages/ReportIssue.tsx";
+import { Developers } from "./pages/Developers.tsx";
+import { Guides } from "./pages/Guides.tsx";
+import { CreateCommunity } from "./pages/guides/CreateCommunity.tsx";
+import { Pricing } from "./pages/guides/Pricing.tsx";
+import { Branding } from "./pages/guides/Branding.tsx";
+import { GroupTypes } from "./pages/guides/GroupTypes.tsx";
+import { GroupsAndChannels } from "./pages/guides/GroupsAndChannels.tsx";
+import { Events } from "./pages/guides/Events.tsx";
+import { EventPlans } from "./pages/guides/EventPlans.tsx";
+import { CheckIn } from "./pages/guides/CheckIn.tsx";
+import { Prayer } from "./pages/guides/Prayer.tsx";
+import { guides } from "./guides/registry.ts";
+
+/**
+ * Site-wide route registry: the single source of truth for the router,
+ * per-page <head> metadata, and the build-time OG preview generation
+ * (scripts/ in this package). Adding a page here is the ONLY way to add a
+ * route, which guarantees every page ships with link-preview metadata.
+ */
+export type PageMeta = {
+  /** Route path, e.g. "/guides/branding". Static paths only — no params. */
+  path: string;
+  /** Page <title> and og:title. */
+  title: string;
+  /** Meta description and og:description. */
+  description: string;
+  /**
+   * Optional bespoke share image (root-relative like "/og-image.png" or
+   * absolute URL). When absent, the build generates a branded card at
+   * /og/<slug>.png where <slug> is the path with "/" mapped to "-"
+   * ("/" itself maps to "home").
+   */
+  image?: string;
+  /** Optional emoji shown on the generated card. */
+  emoji?: string;
+};
+
+export type RouteEntry = PageMeta & { element: ReactElement };
+
+// Guide page components, keyed by the same slug used in guides/registry.ts.
+// Title/description below are derived from that registry rather than
+// duplicated here — the registry stays the single source of truth for guide
+// copy.
+const guideComponents: Record<string, ReactElement> = {
+  "create-your-community": <CreateCommunity />,
+  pricing: <Pricing />,
+  branding: <Branding />,
+  "group-types": <GroupTypes />,
+  "groups-and-channels": <GroupsAndChannels />,
+  events: <Events />,
+  "event-plans": <EventPlans />,
+  "check-in": <CheckIn />,
+  prayer: <Prayer />,
+};
+
+const guideRoutes: RouteEntry[] = guides.map((guide) => ({
+  path: `/guides/${guide.slug}`,
+  title: `${guide.title} | Togather Guides`,
+  description: guide.summary,
+  emoji: guide.emoji,
+  element: guideComponents[guide.slug],
+}));
+
+export const routes: RouteEntry[] = [
+  {
+    path: "/",
+    title: "Togather - Connect Your Community",
+    description:
+      "Togather brings your groups, messaging, and events together in one place. The all-in-one platform for churches and communities.",
+    image: "/og-image.png",
+    element: <App />,
+  },
+  {
+    path: "/android",
+    title: "Download Togather for Android | Togather",
+    description:
+      "Togather for Android is in Google Play closed testing — join the testers group and get 3 steps from opt-in to install.",
+    element: <AndroidDownload />,
+  },
+  {
+    path: "/android-staging",
+    title: "Togather Android Staging Build | Togather",
+    description:
+      "Internal staging build of Togather for Android — download the latest APK and install instructions for testers.",
+    element: <AndroidDownload variant="staging" />,
+  },
+  {
+    path: "/contribute",
+    title: "Contribute to Togather",
+    description:
+      "Togather is built by the communities that use it. Report a bug, request a feature, or contribute code to the open-source AGPL-3.0 project.",
+    element: <Contribute />,
+  },
+  {
+    path: "/contribute/ai",
+    title: "Contribute Without Writing Code | Togather",
+    description:
+      "How Togather's AI-driven development workflow turns your bug reports and feature ideas into working code, reviewed and shipped by maintainers.",
+    element: <ContributeAI />,
+  },
+  {
+    path: "/issue",
+    title: "Report an Issue | Togather",
+    description:
+      "How to report a bug or request a feature for Togather on GitHub, with tips for writing a report the community can act on fast.",
+    element: <ReportIssue />,
+  },
+  {
+    path: "/guides",
+    title: "Togather Guides",
+    description:
+      "Step-by-step guides for setting up and running your Togather community, from creating it to enabling prayer.",
+    element: <Guides />,
+  },
+  ...guideRoutes,
+  {
+    path: "/legal/privacy",
+    title: "Privacy Policy | Togather",
+    description:
+      "How Togather collects, uses, discloses, and safeguards your information when you use the app and related services.",
+    element: <PrivacyPolicy />,
+  },
+  {
+    path: "/legal/terms",
+    title: "Terms of Service | Togather",
+    description:
+      "The terms governing your use of the Togather app, including account rules, content policy, and moderation.",
+    element: <TermsOfService />,
+  },
+  {
+    path: "/developers",
+    title: "Developer API | Togather",
+    description:
+      "A read-only HTTP API for pulling a community's group attendance data out of Togather, for dashboards and reporting.",
+    element: <Developers />,
+  },
+];
+
+/** OG image slug for a route path: "/" -> "home", "/guides/branding" -> "guides-branding". */
+export function ogSlug(path: string): string {
+  return path === "/" ? "home" : path.replace(/^\//, "").replace(/\//g, "-");
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -23,7 +23,11 @@ import { guides } from "./guides/registry.ts";
  * Site-wide route registry: the single source of truth for the router,
  * per-page <head> metadata, and the build-time OG preview generation
  * (scripts/ in this package). Adding a page here is the ONLY way to add a
- * route, which guarantees every page ships with link-preview metadata.
+ * route, which guarantees every page ships with link-preview metadata. For a
+ * NEW TOP-LEVEL path (not nested under an existing prefix like /guides/),
+ * you must also add it to LANDING_PAGE_PATHS or LANDING_PAGE_PREFIXES in
+ * apps/link-preview/cloudflare-worker.js, or the worker will misroute it
+ * (single-segment paths otherwise fall into the community-slug redirect).
  */
 export type PageMeta = {
   /** Route path, e.g. "/guides/branding". Static paths only — no params. */
@@ -61,13 +65,19 @@ const guideComponents: Record<string, ReactElement> = {
   prayer: <Prayer />,
 };
 
-const guideRoutes: RouteEntry[] = guides.map((guide) => ({
-  path: `/guides/${guide.slug}`,
-  title: `${guide.title} | Togather Guides`,
-  description: guide.summary,
-  emoji: guide.emoji,
-  element: guideComponents[guide.slug],
-}));
+const guideRoutes: RouteEntry[] = guides.map((guide) => {
+  const element = guideComponents[guide.slug];
+  if (!element) {
+    throw new Error(`No guide component registered for slug "${guide.slug}"`);
+  }
+  return {
+    path: `/guides/${guide.slug}`,
+    title: `${guide.title} | Togather Guides`,
+    description: guide.summary,
+    emoji: guide.emoji,
+    element,
+  };
+});
 
 export const routes: RouteEntry[] = [
   {

--- a/docs/architecture/ADR-009-link-preview-system.md
+++ b/docs/architecture/ADR-009-link-preview-system.md
@@ -2,22 +2,31 @@
 
 **Status:** Active
 **Created:** 2024-12-25
-**Updated:** 2025-01-21 (Added environment-specific routing, complete route table)
+**Updated:** 2026-07-19 (Refactored: static pages now pre-built with OG metadata; dynamic routes unified under single `/link-preview/meta` endpoint)
 
 ## Context
 
 Event links (`togather.nyc/e/[shortId]`) shared in iMessage, Twitter, Slack, etc. did not show rich previews. Users saw generic "Click to Load Preview" instead of event images, titles, and descriptions like Partiful does.
 
-The challenge: Expo Router with static export cannot server-render pages with dynamic meta tags. Crawlers (iMessage, Twitter, etc.) need HTML with Open Graph tags at request time.
+The challenge: Expo Router with static export cannot server-render pages with dynamic meta tags. Crawlers (iMessage, Twitter, etc.) need HTML with Open Graph tags at request time. Meanwhile, static marketing pages (guides, homepage variants) need per-page OG metadata without server infrastructure.
+
+## Amendment (2026-07-19)
+
+**Refactored to separate static and dynamic routes:**
+- **Static pages**: Now pre-built at deploy time with OG metadata baked into HTML (satori + resvg for auto-generated cards)
+- **Dynamic routes**: Consolidated from five per-type endpoints to a single `/link-preview/meta` endpoint with typed, unit-tested resolver
+- **Worker**: Simplified to thin routing layer using a PREVIEW_ROUTES table (table-driven, minimal changes needed for new preview types)
+- **Result**: No runtime OG tag generation; better performance, reduced worker complexity, clearer separation of concerns
+
+See "Static Page Registration & OG Metadata" and "Convex HTTP Routes" sections for implementation details.
 
 ## Decision
 
-Implement a link preview system using a single **Cloudflare Worker** that:
-1. Intercepts all traffic to `togather.nyc` and `*.togather.nyc`
-2. Routes static landing page traffic (/, /android, /download, static assets) to Cloudflare Pages
-3. Routes app traffic to EAS Hosting
-4. For bots on OG routes (/e/*, /g/*, /nearme, /): Returns HTML with OG meta tags
-5. For users: Passes through to appropriate origin (landing page or app)
+Two-tier link preview system:
+
+1. **Static marketing pages** (apps/web, Vite SPA on Cloudflare Pages): Every page is registered in a site-wide route registry (`apps/web/src/routes.tsx`) with preview metadata (title, description, image, emoji). A post-build script (`apps/web/scripts/generate-static-pages.tsx`) writes dist/<path>/index.html with OG meta tags baked in. For pages without a bespoke image, it generates branded 1200x630 PNG cards (satori + resvg). Cloudflare Pages serves these static files before the SPA fallback, so bots and humans get correct per-page meta with no runtime infrastructure.
+
+2. **Dynamic app routes** (/e/, /g/, /t/, /ch/, /nearme, /:slug): One Convex HTTP endpoint (`GET /link-preview/meta?url=<full request URL>`) returns typed preview metadata. A single resolver in Convex (apps/convex/functions/linkPreviewMeta) handles ALL preview assembly (title formats, rich descriptions, timezone formatting, image fallback chains). The Cloudflare Worker is now a thin, table-driven layer: it keeps existing jobs (site-vs-app routing, Universal/App Links, bot detection) but for bot requests on dynamic routes it fetches this metadata endpoint and pours the result into a shared HTML template.
 
 ## Architecture
 
@@ -39,59 +48,113 @@ Implement a link preview system using a single **Cloudflare Worker** that:
                    │  *.togather.nyc/*   │
                    └──────────┬──────────┘
                               │
-      ┌───────────────────────┼───────────────────────┐
-      │                       │                       │
-Landing Page Paths       OG Routes            Everything Else
-/, /android, /download   /e/*, /g/*, /nearme      (app paths)
-/styles.css, /script.js        │                      │
-      │                        │                      │
-      ↓                   ┌────┴────┐                 ↓
-┌─────────────┐        Bot?     User?         ┌─────────────┐
-│  Cloudflare │           │         │         │ EAS Hosting │
-│    Pages    │           ↓         ↓         │ (Expo App)  │
-│  (Landing)  │    OG HTML    Pass to App     │             │
-└─────────────┘    with tags                  └─────────────┘
+      ┌───────────┬───────────┼───────────┬───────────┐
+      │           │           │           │           │
+  Static Routes  Dynamic     App Paths   Dynamic      Everything
+  (prebuilt OG)  Routes      (/signin)   Routes       Else
+  /, /guides/*   (/e/*, etc) (users)     (/e/*, etc)
+  /download                              (bots)
+      │           │           │           │           │
+      ↓           ↓           ↓           ↓           ↓
+ ┌──────────┐    │        ┌─────────┐    │      ┌─────────┐
+ │Cloudflare│    │        │   EAS   │    └─────→│Cloudflare
+ │  Pages   │    │        │ Hosting │            │ Worker
+ │(prebuilt)│    │        │(Expo)   │            │(fetch meta)
+ └──────────┘    │        └─────────┘            │        │
+                 │                               ↓        │
+                 │                          ┌──────────┐  │
+                 └──────────────────────→  │ Convex   │  │
+                                           │/link-    │  │
+                                           │preview/  │  │
+                                           │meta      │  │
+                                           └─────────┬┘  │
+                                                     │    │
+                                                     └────┘
+                                                      │
+                                                      ↓
+                                                  ┌────────┐
+                                                  │Shared  │
+                                                  │Template│
+                                                  └────────┘
 ```
 
 ## Components
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| Cloudflare Worker | `apps/link-preview/cloudflare-worker.js` | Bot detection, routing, OG HTML generation |
-| Wrangler Config | `apps/link-preview/wrangler.toml` | Cloudflare Worker routes |
+| Route Registry | `apps/web/src/routes.tsx` | Site-wide routes with preview metadata (title, description, image, emoji) |
+| Build Script | `apps/web/scripts/generate-static-pages.tsx` | Generates prebuilt HTML + OG image cards at build time (satori + resvg) |
+| Web App | `apps/web/` | Vite SPA deployed to Cloudflare Pages; routes come from registry |
+| Link Preview Resolver | `apps/convex/functions/linkPreviewMeta.ts` | Typed resolver: all preview assembly logic (title formats, descriptions, fallback chains) |
+| Cloudflare Worker | `apps/link-preview/cloudflare-worker.js` | Thin layer: bot detection, routing, PREVIEW_ROUTES table, fetches meta endpoint, renders shared template |
+| HTML Template | `apps/link-preview/templates/preview.html` | Shared template for dynamic preview OG HTML |
+| Wrangler Config | `apps/link-preview/wrangler.toml` | Worker routes and environment config |
 | Unit Tests | `apps/link-preview/cloudflare-worker.test.js` | Worker behavior tests |
 | Deploy Workflow | `.github/workflows/deploy-link-preview.yml` | CI/CD for worker deployment |
-| Landing Page | `apps/web/` | Static landing page (deployed to Cloudflare Pages) |
 
 ## Environment Configuration
 
 The Cloudflare Worker detects environment based on hostname and routes to the appropriate origins:
 
-| Environment | Domain | App Origin (EAS) | Landing Page |
-|-------------|--------|------------------|--------------|
-| Production | `togather.nyc`, `app.togather.nyc`, `*.togather.nyc` | `https://togather.expo.app` | `https://togather-landing.pages.dev` |
-| Staging | `staging.togather.nyc` | `https://togather--staging.expo.app` | `https://togather-landing.pages.dev` |
+| Environment | Domain | App Origin (EAS) | Marketing Pages (Cloudflare Pages) |
+|-------------|--------|------------------|------------------------------------|
+| Production | `togather.nyc`, `app.togather.nyc`, `*.togather.nyc` | `https://togather.expo.app` | `https://togather-web.pages.dev` (built & deployed via `pnpm build` + `wrangler pages deploy`) |
+| Staging | `staging.togather.nyc` | `https://togather--staging.expo.app` | `https://togather-web-staging.pages.dev` |
 
 **EAS Hosting Aliases:**
 - Production: `togather.expo.app` (default alias)
 - Staging: `togather--staging.expo.app` (alias: `staging`)
 
-Deploy workflow (`.github/workflows/deploy-web.yml`) updates the appropriate alias on push.
+**Deploy workflows:**
+- App: `.github/workflows/deploy-web.yml` updates EAS alias on push to `main` or `staging`
+- Marketing pages: `.github/workflows/deploy-web.yml` also runs `pnpm build` in `apps/web/` and deploys to Cloudflare Pages (with per-build static HTML and OG images)
 
 ## Routing Logic
 
 | Path | Bot Request | User Request |
 |------|-------------|--------------|
-| `/` | OG tags HTML | Landing Page |
-| `/android`, `/download` | Landing Page | Landing Page |
-| `/styles.css`, `/script.js`, etc. | Landing Page | Landing Page |
-| `/e/:shortId` | OG tags HTML | App (EAS) |
-| `/g/:shortId` | OG tags HTML | App (EAS) |
-| `/nearme` | OG tags HTML | App (EAS) |
-| `/_expo/*` | App (EAS) | App (EAS) |
+| `/`, `/guides/*`, `/download`, etc. (static routes in registry) | Prebuilt HTML from Cloudflare Pages (OG meta baked in) | Cloudflare Pages (SPA) |
+| `/e/:shortId`, `/g/:shortId`, `/t/:toolId`, etc. (dynamic app routes) | Worker → fetch `/link-preview/meta` → render shared template | EAS Hosting (Expo App) |
+| `/nearme`, `/:slug` (community, channel routes) | Worker → fetch `/link-preview/meta` → render shared template | EAS Hosting (Expo App) |
+| `/_expo/*` | EAS Hosting | EAS Hosting |
 | `/.well-known/apple-app-site-association` | Worker (JSON) | Worker (JSON) |
 | `/.well-known/assetlinks.json` | Worker (JSON) | Worker (JSON) |
-| Everything else | App (EAS) | App (EAS) |
+| Everything else | EAS Hosting | EAS Hosting |
+
+## Static Page Registration & OG Metadata
+
+All static marketing pages (guides, homepage, etc.) are registered in a central route registry:
+
+**File:** `apps/web/src/routes.tsx`
+
+**Example entry:**
+```typescript
+export const routes: RouteEntry[] = [
+  {
+    path: '/guides/events',
+    component: EventsGuide,
+    title: 'Event Management Guide | Togather',
+    description: 'Learn how to create, schedule, and manage events...',
+    image: 'https://cdn.example.com/events-guide.png', // optional; auto-generated if omitted
+    emoji: '📅',
+  },
+  // ...
+];
+```
+
+**Build process** (`apps/web/scripts/generate-static-pages.tsx`):
+1. Runs after `vite build` during `pnpm build`
+2. For each route in registry:
+   - Writes `dist/<path>/index.html` with page's `<title>` and meta tags (og:title, og:description, twitter:card, etc.)
+   - If route has no `image` entry, generates branded 1200x630 PNG using satori + resvg (brand color #D4A574, Plus Jakarta Sans font)
+   - Saves generated images to `dist/og/<slug>.png`
+3. Cloudflare Pages deployment includes all prebuilt HTML files and images
+
+**Why this approach:**
+- Bots get correct meta tags instantly from static HTML (no runtime rendering needed)
+- Users still get the full Vite SPA experience (React routing, client-side navigation)
+- Scales to unlimited pages without additional server resources
+- Automatic OG image generation keeps visual consistency across guides
 
 ## Complete Route Table (Expo Router)
 
@@ -147,35 +210,35 @@ The Worker identifies crawlers by User-Agent:
 
 ## Convex HTTP Routes
 
-HTTP routes are defined in `convex/http.ts` and exposed at the Convex site URL:
+The link preview system uses a single unified HTTP endpoint defined in `convex/http.ts`:
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/link-preview/event` | GET | Event data for OG tags |
-| `/link-preview/group` | GET | Group data for OG tags |
-| `/link-preview/community` | GET | Community data for nearme OG tags |
-
-### Event Link Preview Endpoint
+### Link Preview Metadata Endpoint
 
 ```
-GET /link-preview/event?shortId=<shortId>
+GET /link-preview/meta?url=<full request URL>
 ```
 
 **Response:**
 ```json
 {
-  "id": "meeting_123",
-  "shortId": "abc123",
-  "title": "Weekly Meetup",
-  "scheduledAt": "2025-01-15T19:00:00.000Z",
-  "status": "scheduled",
-  "coverImage": "https://...",
-  "groupName": "Tech Enthusiasts",
-  "communityName": "Demo Community",
-  "communityLogo": "https://...",
-  "locationOverride": "123 Main St"
+  "title": "RSVP to Weekly Meetup | Demo Community",
+  "description": "Saturday, Jan 15, 2025 at 7:00 PM · Tech Enthusiasts · 123 Main St",
+  "image": "https://...",
+  "url": "https://togather.nyc/e/abc123",
+  "siteName": "Togather",
+  "imageAlt": "Weekly Meetup event cover"
 }
 ```
+
+**Resolver Logic** (`apps/convex/functions/linkPreviewMeta.ts`):
+- Parses request URL to determine resource type (event, group, tool, channel, community, etc.)
+- Loads resource from database with all related data
+- Formats title with type-specific pattern (e.g. "RSVP to [title] | [community]" for events)
+- Assembles rich description (date, time, location for events; member count for groups; etc.)
+- Applies image fallback chain (resource cover → related resource image → community logo)
+- Returns fully typed metadata object
+
+**Old endpoints removed:** `/link-preview/event`, `/link-preview/group`, `/link-preview/community`, `/link-preview/channel`, `/link-preview/tool`. All preview logic now routes through the single `/link-preview/meta` endpoint.
 
 ## Deployment
 
@@ -232,91 +295,107 @@ echo "https://your-deployment.convex.site" | npx wrangler secret put CONVEX_SITE
 
 ## Request Flow Examples
 
-### 1. Bot requests event link preview (iMessage, Twitter, etc.)
+### 1. Bot requests static guide page (Googlebot, Facebook crawler, etc.)
+```
+Googlebot → togather.nyc/guides/events
+  → Cloudflare Worker (bot detected)
+  → Worker passes to Cloudflare Pages
+  → Cloudflare Pages serves prebuilt dist/guides/events/index.html
+  → HTML includes og:title, og:description, og:image baked in by build script
+  → Google indexes rich preview (no runtime work needed)
+```
+
+### 2. Bot requests dynamic app link (iMessage, Twitter, etc.)
 ```
 iMessage crawler → togather.nyc/e/ABC123
   → Cloudflare Worker (bot detected: Applebot)
-  → Worker fetches event from Convex HTTP endpoint
+  → Worker matches /e/ABC123 against PREVIEW_ROUTES table
+  → Worker fetches GET /link-preview/meta?url=https://togather.nyc/e/ABC123
+  → Convex resolver assembles metadata (title, description, image, etc.)
+  → Worker renders shared template with metadata
   → Worker returns HTML with OG tags
   → iMessage shows rich preview
 ```
 
-### 2. User opens event link in browser
+### 3. User visits static guide page
+```
+Browser → togather.nyc/guides/events
+  → Cloudflare Worker (not a bot)
+  → Worker passes to Cloudflare Pages
+  → Cloudflare Pages loads Vite SPA (index.html fallback)
+  → React router mounts guides/events component
+```
+
+### 4. User opens event link in browser
 ```
 Browser → togather.nyc/e/ABC123
   → Cloudflare Worker (not a bot)
   → Worker passes to EAS Hosting
   → EAS serves Expo app
-  → App loads event page
-```
-
-### 3. User visits homepage
-```
-Browser → togather.nyc/
-  → Cloudflare Worker (not a bot)
-  → Worker passes to Landing Page (Cloudflare Pages)
-  → Landing page loads
-```
-
-### 4. Bot requests homepage
-```
-Googlebot → togather.nyc/
-  → Cloudflare Worker (bot detected)
-  → Worker returns OG HTML with homepage meta tags
-  → Google indexes rich preview
+  → App loads event detail page
 ```
 
 ## Troubleshooting
 
 ### Quick Diagnostics
 
-Test routes directly to bypass Cloudflare Worker:
+Test the link preview metadata endpoint:
 ```bash
-# Test EAS Hosting staging directly
-curl -s -o /dev/null -w "%{http_code}" "https://togather--staging.expo.app/signin"
+# Test metadata endpoint directly
+curl "https://your.convex.site/link-preview/meta?url=https://togather.nyc/e/ABC123"
 
-# Test through Cloudflare Worker
-curl -s -o /dev/null -w "%{http_code}" "https://staging.togather.nyc/signin"
+# Test bot response through worker
+curl -H "User-Agent: Twitterbot" "https://togather.nyc/e/ABC123"
 
-# Test bot response
-curl -H "User-Agent: Twitterbot" "https://staging.togather.nyc/e/ABC123"
+# Verify Cloudflare Pages is serving static route
+curl -I "https://togather.nyc/guides/events"
 ```
 
-### 500 Error on staging links
-**Symptom:** `ExpoError: API route GET handler resolved to a non-Response result`
+### Prebuilt static page not showing OG tags
+**Symptom:** og:title/og:description/og:image missing on a static route
 
-**Cause:** Worker is pointing to wrong EAS origin (production instead of staging)
-
-**Fix:** Check `ENVIRONMENTS.staging.appOrigin` in `cloudflare-worker.js` points to `https://togather--staging.expo.app`
-
-### 404 on valid routes
-**Symptom:** Route returns 404 even though it exists in app
-
-**Cause:**
-1. Route might not exist (e.g., `/login` vs `/signin`)
-2. EAS deployment not updated
+**Cause:** 
+1. Page not registered in `apps/web/src/routes.tsx`
+2. Build script not run (or failed silently)
+3. Cloudflare Pages serving old cache
 
 **Fix:**
-1. Check route exists: `ls apps/mobile/app/`
-2. Verify EAS deployment: Check GitHub Actions deploy-web.yml
+1. Verify page entry exists in `routes.tsx` with title, description, image fields
+2. Run `pnpm build` in `apps/web/` and check `dist/<path>/index.html` for meta tags
+3. Purge Cloudflare Pages cache or wait for next deployment
 
-### Worker routes not triggering
-- Ensure DNS records are "Proxied" (orange cloud) not "DNS Only"
-- Verify worker is deployed: `npx wrangler whoami` then check dashboard
+### Dynamic app link preview not showing
+**Symptom:** og:title/og:description/og:image missing on /e/, /g/, etc.
 
-### OG tags not showing
-- Check User-Agent is in the bot list
-- Verify Convex HTTP endpoint is responding: `curl https://your.convex.site/link-preview/event?shortId=xxx`
-- Use Facebook Debugger or Twitter Card Validator to test
+**Cause:**
+1. Route not in PREVIEW_ROUTES table in worker
+2. Resolver not handling this route type
+3. Metadata endpoint returning error
 
-### Landing page not styled
-- Verify static assets are routed to landing page (check `isLandingPagePath()`)
-- Check Cloudflare Pages deployment status
+**Fix:**
+1. Check `PREVIEW_ROUTES` in `apps/link-preview/cloudflare-worker.js` includes the route pattern
+2. Verify `apps/convex/functions/linkPreviewMeta.ts` handles the resource type
+3. Test endpoint: `curl "https://your.convex.site/link-preview/meta?url=https://togather.nyc/e/ABC123"`
+4. Use Facebook Debugger or Twitter Card Validator to test final output
 
-### Images not showing in preview
-- Check S3 object Content-Type is `image/jpeg` not `application/octet-stream`
-- Ensure image URLs are publicly accessible
-- Verify image dimensions meet platform requirements (1200x630 recommended)
+### Worker not routing to correct Cloudflare Pages
+**Symptom:** Static routes return app 404 instead of static page
+
+**Cause:** isStaticPath() doesn't match the route pattern
+
+**Fix:** Check `isStaticPath()` in `cloudflare-worker.js` includes your route
+
+### Build script not generating OG images
+**Symptom:** Pages have og:title/og:description but no og:image
+
+**Cause:** 
+1. Route entry missing `image` field
+2. satori/resvg build failed silently
+
+**Fix:**
+1. Run build with verbose logging: check `dist/og/` directory for generated images
+2. Verify route entry in `routes.tsx` omits `image` field (auto-generated) or specifies a URL
+3. Check build script stderr for satori errors
 
 ### Universal Links not opening app
 See ADR-014 for Universal Links configuration. Check:

--- a/docs/architecture/ADR-009-link-preview-system.md
+++ b/docs/architecture/ADR-009-link-preview-system.md
@@ -87,7 +87,7 @@ Two-tier link preview system:
 | Web App | `apps/web/` | Vite SPA deployed to Cloudflare Pages; routes come from registry |
 | Link Preview Resolver | `apps/convex/functions/linkPreviewMeta.ts` | Typed resolver: all preview assembly logic (title formats, descriptions, fallback chains) |
 | Cloudflare Worker | `apps/link-preview/cloudflare-worker.js` | Thin layer: bot detection, routing, PREVIEW_ROUTES table, fetches meta endpoint, renders shared template |
-| HTML Template | `apps/link-preview/templates/preview.html` | Shared template for dynamic preview OG HTML |
+| OG HTML Renderer | `apps/link-preview/cloudflare-worker.js` (inline `renderOgHtml()` function) | Shared template for dynamic preview OG HTML; no external template file |
 | Wrangler Config | `apps/link-preview/wrangler.toml` | Worker routes and environment config |
 | Unit Tests | `apps/link-preview/cloudflare-worker.test.js` | Worker behavior tests |
 | Deploy Workflow | `.github/workflows/deploy-link-preview.yml` | CI/CD for worker deployment |
@@ -132,7 +132,7 @@ All static marketing pages (guides, homepage, etc.) are registered in a central 
 export const routes: RouteEntry[] = [
   {
     path: '/guides/events',
-    component: EventsGuide,
+    element: <Events />,
     title: 'Event Management Guide | Togather',
     description: 'Learn how to create, schedule, and manage events...',
     image: 'https://cdn.example.com/events-guide.png', // optional; auto-generated if omitted
@@ -381,9 +381,9 @@ curl -I "https://togather.nyc/guides/events"
 ### Worker not routing to correct Cloudflare Pages
 **Symptom:** Static routes return app 404 instead of static page
 
-**Cause:** isStaticPath() doesn't match the route pattern
+**Cause:** `isLandingPagePath()` doesn't match the route pattern
 
-**Fix:** Check `isStaticPath()` in `cloudflare-worker.js` includes your route
+**Fix:** Check `isLandingPagePath()` in `cloudflare-worker.js` includes your route (either in `LANDING_PAGE_PATHS` array or `LANDING_PAGE_PREFIXES` array)
 
 ### Build script not generating OG images
 **Symptom:** Pages have og:title/og:description but no og:image

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,12 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.2
+      '@fontsource/plus-jakarta-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1)
@@ -523,9 +529,15 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
+      satori:
+        specifier: ^0.28.0
+        version: 0.28.0
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -4172,6 +4184,10 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /@fontsource/plus-jakarta-sans@5.2.8:
+    resolution: {integrity: sha512-P5qE49fqdeD+7DXH1KBxmMPlB17LTz1zvBhFH0tFzfnYTKVJVyb0pR6plh0ZGXxcB+Oayb54FZZw3V42/DawTw==}
+    dev: true
+
   /@gorhom/bottom-sheet@5.2.8(@types/react@19.1.17)(react-native-gesture-handler@2.28.0)(react-native-reanimated@4.1.6)(react-native@0.81.5)(react@19.1.0):
     resolution: {integrity: sha512-+N27SMpbBxXZQ/IA2nlEV6RGxL/qSFHKfdFKcygvW+HqPG5jVNb1OqehLQsGfBP+Up42i0gW5ppI+DhpB7UCzA==}
     peerDependencies:
@@ -5879,6 +5895,132 @@ packages:
     dependencies:
       nanoid: 3.3.11
 
+  /@resvg/resvg-js-android-arm-eabi@2.6.2:
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-android-arm64@2.6.2:
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-darwin-arm64@2.6.2:
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-darwin-x64@2.6.2:
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-linux-arm-gnueabihf@2.6.2:
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-linux-arm64-gnu@2.6.2:
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-linux-arm64-musl@2.6.2:
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-linux-x64-gnu@2.6.2:
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-linux-x64-musl@2.6.2:
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-win32-arm64-msvc@2.6.2:
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-win32-ia32-msvc@2.6.2:
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js-win32-x64-msvc@2.6.2:
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@resvg/resvg-js@2.6.2:
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
+    dev: true
+
   /@rolldown/pluginutils@1.0.0-beta.53:
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
     dev: true
@@ -6338,6 +6480,15 @@ packages:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     dev: false
+
+  /@shuding/opentype.js@1.4.0-beta.0:
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
+    dev: true
 
   /@sideway/address@4.1.5:
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -8069,6 +8220,11 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -8251,6 +8407,10 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  /camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+    dev: true
 
   /caniuse-lite@1.0.30001766:
     resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
@@ -8659,6 +8819,24 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  /css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+    dev: true
+
+  /css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+    dev: true
+
+  /css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /css-gradient-parser@0.0.17:
+    resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
+    engines: {node: '>=16'}
+    dev: true
+
   /css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
     dependencies:
@@ -8673,6 +8851,14 @@ packages:
       domutils: 3.2.2
       nth-check: 2.1.1
     dev: false
+
+  /css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
+    dev: true
 
   /css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
@@ -8952,6 +9138,11 @@ packages:
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
+
+  /emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
+    dev: true
 
   /emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -10209,6 +10400,10 @@ packages:
     dependencies:
       picomatch: 4.0.3
 
+  /fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+    dev: true
+
   /figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -10677,6 +10872,11 @@ packages:
     resolution: {integrity: sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==}
     dependencies:
       hermes-estree: 0.32.0
+
+  /hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
+    dev: true
 
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -12011,6 +12211,13 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+    dev: true
+
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -12966,6 +13173,10 @@ packages:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
     dev: false
 
+  /pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+    dev: true
+
   /papaparse@5.5.3:
     resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
     dev: false
@@ -12975,6 +13186,13 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
+
+  /parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
     dev: true
 
   /parse-json@5.2.0:
@@ -14297,6 +14515,23 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
+  /satori@0.28.0:
+    resolution: {integrity: sha512-FhOx2irXIrxbNpPyE0x/+k3p8G+FVWfaTPAKuwMaB4kk02PehHFumYyJ4NtiLNC7moNAspeDt06S+DqUjJ9Fsg==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.17
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-layout: 3.2.1
+    dev: true
+
   /sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
@@ -14768,6 +15003,10 @@ packages:
       strip-ansi: 7.1.2
     dev: true
 
+  /string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+    dev: true
+
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
     dependencies:
@@ -14965,6 +15204,10 @@ packages:
 
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+    dev: true
+
+  /tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
     dev: true
 
   /tinybench@2.9.0:
@@ -15346,6 +15589,13 @@ packages:
   /unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  /unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+    dev: true
 
   /unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -16026,6 +16276,10 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  /yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+    dev: true
 
   /youch@3.3.4:
     resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.1
         version: 5.1.2(vite@7.3.1)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       eslint:
         specifier: ^9.39.1
         version: 9.39.2
@@ -2788,6 +2791,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.28.1:
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.17.19:
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
     engines: {node: '>=12'}
@@ -2816,6 +2828,15 @@ packages:
 
   /@esbuild/android-arm64@0.27.2:
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.28.1:
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2858,6 +2879,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.28.1:
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.17.19:
     resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
     engines: {node: '>=12'}
@@ -2886,6 +2916,15 @@ packages:
 
   /@esbuild/android-x64@0.27.2:
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.28.1:
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2928,6 +2967,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.28.1:
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.17.19:
     resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
     engines: {node: '>=12'}
@@ -2956,6 +3004,15 @@ packages:
 
   /@esbuild/darwin-x64@0.27.2:
     resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.28.1:
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2998,6 +3055,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.28.1:
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.17.19:
     resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
     engines: {node: '>=12'}
@@ -3026,6 +3092,15 @@ packages:
 
   /@esbuild/freebsd-x64@0.27.2:
     resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.28.1:
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -3068,6 +3143,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.28.1:
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.17.19:
     resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
     engines: {node: '>=12'}
@@ -3096,6 +3180,15 @@ packages:
 
   /@esbuild/linux-arm@0.27.2:
     resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.28.1:
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -3138,6 +3231,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.28.1:
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.17.19:
     resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
     engines: {node: '>=12'}
@@ -3166,6 +3268,15 @@ packages:
 
   /@esbuild/linux-loong64@0.27.2:
     resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.28.1:
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -3208,6 +3319,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.28.1:
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.17.19:
     resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
     engines: {node: '>=12'}
@@ -3236,6 +3356,15 @@ packages:
 
   /@esbuild/linux-ppc64@0.27.2:
     resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.28.1:
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -3278,6 +3407,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.28.1:
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.17.19:
     resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
     engines: {node: '>=12'}
@@ -3306,6 +3444,15 @@ packages:
 
   /@esbuild/linux-s390x@0.27.2:
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.28.1:
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -3348,6 +3495,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.28.1:
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-arm64@0.27.0:
     resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
     engines: {node: '>=18'}
@@ -3358,6 +3514,15 @@ packages:
 
   /@esbuild/netbsd-arm64@0.27.2:
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.28.1:
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -3400,6 +3565,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.28.1:
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-arm64@0.27.0:
     resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
     engines: {node: '>=18'}
@@ -3410,6 +3584,15 @@ packages:
 
   /@esbuild/openbsd-arm64@0.27.2:
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.28.1:
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -3452,6 +3635,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.28.1:
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openharmony-arm64@0.27.0:
     resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
     engines: {node: '>=18'}
@@ -3462,6 +3654,15 @@ packages:
 
   /@esbuild/openharmony-arm64@0.27.2:
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.28.1:
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -3504,6 +3705,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.28.1:
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.17.19:
     resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
     engines: {node: '>=12'}
@@ -3532,6 +3742,15 @@ packages:
 
   /@esbuild/win32-arm64@0.27.2:
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.28.1:
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -3574,6 +3793,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.28.1:
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.17.19:
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
@@ -3602,6 +3830,15 @@ packages:
 
   /@esbuild/win32-x64@0.27.2:
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.28.1:
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -9353,6 +9590,40 @@ packages:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+    dev: true
+
+  /esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
     dev: true
 
   /escalade@3.2.0:


### PR DESCRIPTION
## Summary

Overhauls the link-preview system so **every page ships a real share preview by construction**, and adding future pages requires exactly one step.

### Static pages (`apps/web`)
- New site-wide route registry `src/routes.tsx` — `main.tsx` now generates the router from it, so a page cannot exist without title/description metadata. Guide entries derive their copy from the existing guides registry (no duplication).
- New post-build step (`scripts/generate-static-pages.tsx`, wired into `pnpm build`): writes `dist/<path>/index.html` per route with page-specific `<title>`/description/OG/Twitter tags, and renders a branded 1200×630 card (satori + resvg, Plus Jakarta Sans, `#D4A574`) at `/og/<slug>.png` for every page without a bespoke image. Cloudflare Pages serves these static files before the SPA fallback — bots get correct meta with zero runtime infrastructure.
- Previously all landing/guide pages shared the homepage's generic OG block; now all 19 pages have their own preview (18 generated cards + the homepage's bespoke image).

### Dynamic routes (`apps/convex` + `apps/link-preview`)
- One typed resolver (`functions/linkPreviewMeta.ts`) behind `GET /link-preview/meta?url=…` now assembles all preview content: title formats, rich descriptions, timezone-aware date formatting, and image fallback chains (event cover → group image → community logo). The five per-type `/link-preview/*` endpoints are removed (`/api/link-preview` chat unfurling is untouched).
- The Cloudflare worker shrinks 1,573 → 742 lines: a `PREVIEW_ROUTES` table plus one shared OG template and one shared error template. Its routing, `.well-known`, and redirect jobs are unchanged. Adding a dynamic preview = one resolver case + one table row, no worker redeploy for content changes.

### Docs
- ADR-009 rewritten for the new architecture (amendment dated 2026-07-19); CLAUDE.md documents the one-step conventions for future pages.

## Test plan
- [x] Worker: `node --test` — 34/34 passing
- [x] Convex: 45 new resolver tests (dispatch, date formatting, fallback chains, slug canonicalization); full suite green (2,361 tests / 145 files); `convex typecheck` clean
- [x] Web: type-check, lint, and full build clean; verified per-route HTML head tags and generated PNGs (1200×630, ~69–93 KB)
- [ ] After staging deploy: paste a guide link + an event link into Slack/iMessage to confirm cards render

## Deploy note
The old per-type endpoints are removed in the same change (remove-don't-deprecate). If Convex deploys before the worker, bots briefly get the generic error-fallback preview on dynamic links — seconds on staging where both deploy on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VHVFzj5sj8uq91cP7389D

---
_Generated by [Claude Code](https://claude.ai/code/session_013VHVFzj5sj8uq91cP7389D)_