### PR TITLE
Include unconfirmed volunteers in serving mode

### DIFF
--- a/apps/convex/__tests__/scheduling/eventTasks.test.ts
+++ b/apps/convex/__tests__/scheduling/eventTasks.test.ts
@@ -1219,3 +1219,85 @@ describe("serving eligibility", () => {
     expect(result.activePlan).toBeNull();
   });
 });
+
+/** Assign a user to the world's Drums role WITHOUT confirming (stays unconfirmed). */
+async function assignOnly(
+  t: ReturnType<typeof convexTest>,
+  world: Awaited<ReturnType<typeof buildSchedulingWorld>>,
+  leaderToken: string,
+  planId: Id<"eventPlans">,
+  userId: Id<"users">,
+) {
+  const { assignmentId } = await t.mutation(
+    api.functions.scheduling.assignments.assignRole,
+    { token: leaderToken, planId, teamId: world.teamId, roleId: world.roleId, userId },
+  );
+  return assignmentId;
+}
+
+describe("unconfirmed volunteers reach serving-mode tasks/crew", () => {
+  it("shows an unconfirmed volunteer their assigned role's tasks in Mine", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+
+    // Member is assigned to Drums but has NOT accepted yet.
+    await assignOnly(t, world, leaderToken, planId, world.channelMemberId);
+
+    await t.mutation(api.functions.scheduling.eventTasks.createTask, {
+      token: leaderToken,
+      planId,
+      teamIds: [world.teamId],
+      roleIds: [world.roleId],
+      segment: "before",
+      title: "Set up drums",
+      howToType: "none",
+    });
+
+    const mine = await t.query(
+      api.functions.scheduling.eventTasks.getMyServingTasks,
+      { token: memberToken, planId },
+    );
+    // They can now enter serving mode, so they see the role's tasks even while
+    // still unconfirmed.
+    expect(mine.before.map((x) => x.title)).toContain("Set up drums");
+  });
+
+  it("includes unconfirmed teammates in the crew, tagged as unconfirmed", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+
+    // Caller (member) is confirmed; a teammate (moderator) is only unconfirmed;
+    // a third (admin) declined and must not appear.
+    await assignAndConfirm(t, world, leaderToken, planId, world.channelMemberId);
+    await assignOnly(t, world, leaderToken, planId, world.channelModeratorId);
+    const declinedId = await assignOnly(
+      t,
+      world,
+      leaderToken,
+      planId,
+      world.channelAdminId,
+    );
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: (await generateTokens(world.channelAdminId)).accessToken,
+      assignmentId: declinedId,
+      status: "declined",
+    });
+
+    const crew = await t.query(
+      api.functions.scheduling.eventTasks.getCrewTasks,
+      { token: memberToken, planId },
+    );
+
+    const me = crew.find((c) => c.isCurrentUser)!;
+    expect(me.status).toBe("confirmed");
+    const mod = crew.find((c) => c.userId === world.channelModeratorId)!;
+    expect(mod).toBeDefined();
+    expect(mod.status).toBe("unconfirmed");
+    // The declined admin is excluded entirely.
+    expect(crew.some((c) => c.userId === world.channelAdminId)).toBe(false);
+  });
+});

--- a/apps/convex/__tests__/scheduling/eventTasks.test.ts
+++ b/apps/convex/__tests__/scheduling/eventTasks.test.ts
@@ -1300,4 +1300,69 @@ describe("unconfirmed volunteers reach serving-mode tasks/crew", () => {
     // The declined admin is excluded entirely.
     expect(crew.some((c) => c.userId === world.channelAdminId)).toBe(false);
   });
+
+  it("lets an unconfirmed teammate toggle a shared team task, but not a declined one", async () => {
+    // The shared-task auth gate moved from confirmed-only to non-declined, so an
+    // unconfirmed volunteer (who now serves) may flip a team-wide shared task,
+    // while a declined member still cannot. The existing reject test uses an
+    // UNassigned user, which rejects regardless — this pins the assigned-declined
+    // boundary specifically.
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+
+    // Moderator is only unconfirmed; admin is assigned then declines.
+    await assignOnly(t, world, leaderToken, planId, world.channelModeratorId);
+    const declinedId = await assignOnly(
+      t,
+      world,
+      leaderToken,
+      planId,
+      world.channelAdminId,
+    );
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: (await generateTokens(world.channelAdminId)).accessToken,
+      assignmentId: declinedId,
+      status: "declined",
+    });
+
+    // A team-level (roleIds: []) shared task on the world's team.
+    const { taskId } = await t.mutation(
+      api.functions.scheduling.eventTasks.createTask,
+      {
+        token: leaderToken,
+        planId,
+        teamIds: [world.teamId],
+        roleIds: [],
+        segment: "before",
+        title: "Set the stage",
+        howToType: "none",
+      },
+    );
+
+    // Unconfirmed teammate can flip it.
+    await t.mutation(api.functions.scheduling.eventTasks.toggleSharedTeamTask, {
+      token: (await generateTokens(world.channelModeratorId)).accessToken,
+      planId,
+      taskId,
+      completed: true,
+    });
+    const shared = await t.run(async (ctx) =>
+      ctx.db
+        .query("sharedTaskCompletions")
+        .withIndex("by_task", (q) => q.eq("taskId", taskId))
+        .collect(),
+    );
+    expect(shared).toHaveLength(1);
+
+    // Declined teammate is rejected.
+    await expect(
+      t.mutation(api.functions.scheduling.eventTasks.toggleSharedTeamTask, {
+        token: (await generateTokens(world.channelAdminId)).accessToken,
+        planId,
+        taskId,
+        completed: false,
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/apps/convex/__tests__/scheduling/serving.test.ts
+++ b/apps/convex/__tests__/scheduling/serving.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for serving-mode queries (serving.ts) — focused on the "Team" roster
- * grid (`getServingTeamRoster`): the who's-serving payload behind the pinned
- * Team card in the serving inbox. Verifies plan/team grouping, confirmed-only
- * filtering, the same-day eligibility window, per-person fields (name, role,
- * phone, isSelf), and de-duplication.
+ * Tests for serving-mode queries (serving.ts) — the "Team" roster grid
+ * (`getServingTeamRoster`) and serving eligibility (`getServingEligibility`).
+ * Verifies plan/team grouping, the non-declined predicate (unconfirmed people
+ * appear, badged; only declined are hidden), the same-day eligibility window,
+ * per-person fields (name, role, phone, isSelf, status), de-duplication, and
+ * that unconfirmed volunteers are eligible-to-enter but never auto-entered.
  */
 
 import { describe, it, expect, afterEach } from "vitest";
@@ -114,7 +115,7 @@ async function insertAssignment(
 }
 
 describe("getServingTeamRoster", () => {
-  it("groups confirmed volunteers by plan then team, with name/role/phone/isSelf", async () => {
+  it("groups volunteers by plan then team, with name/role/phone/isSelf/status", async () => {
     const { t, world } = await setup();
     const meTok = (await generateTokens(world.channelMemberId)).accessToken;
 
@@ -145,7 +146,7 @@ describe("getServingTeamRoster", () => {
       eventDate: today,
       status: "confirmed",
     });
-    // An UNCONFIRMED assignment must be excluded from the grid.
+    // An UNCONFIRMED assignment is now INCLUDED, tagged status "unconfirmed".
     await insertAssignment(t, world, {
       planId: plan,
       teamId: production,
@@ -167,12 +168,17 @@ describe("getServingTeamRoster", () => {
     expect(p.teams.map((tm) => tm.name)).toEqual(["Production", "Worship Team"]);
 
     const prod = p.teams.find((tm) => tm.name === "Production")!;
-    // Only the confirmed camera op — the unconfirmed leader is excluded.
-    expect(prod.people).toHaveLength(1);
-    expect(prod.people[0].displayName).toBe("Adminda Test");
-    expect(prod.people[0].roleName).toBe("Camera");
-    expect(prod.people[0].roleColor).toBe("#7C3AED");
-    expect(prod.people[0].isSelf).toBe(false);
+    // Both the confirmed camera op AND the unconfirmed leader now appear.
+    expect(prod.people).toHaveLength(2);
+    const admin = prod.people.find((x) => x.displayName === "Adminda Test")!;
+    expect(admin.roleName).toBe("Camera");
+    expect(admin.roleColor).toBe("#7C3AED");
+    expect(admin.isSelf).toBe(false);
+    expect(admin.status).toBe("confirmed");
+    // The unconfirmed leader is shown, carrying the "unconfirmed" signifier.
+    const leader = prod.people.find((x) => x.status === "unconfirmed")!;
+    expect(leader).toBeDefined();
+    expect(leader.roleName).toBe("Camera");
 
     const wor = p.teams.find((tm) => tm.name === "Worship Team")!;
     expect(wor.people).toHaveLength(1);
@@ -180,6 +186,44 @@ describe("getServingTeamRoster", () => {
     expect(wor.people[0].roleName).toBe("Drums");
     expect(wor.people[0].phone).toBe("+12025550003");
     expect(wor.people[0].isSelf).toBe(true);
+    expect(wor.people[0].status).toBe("confirmed");
+  });
+
+  it("shows the unconfirmed caller their own plan and excludes declined people", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Sunday Service", today);
+
+    // Caller is only UNCONFIRMED — they still reach the roster (badged).
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "unconfirmed",
+    });
+    // A DECLINED teammate on the same team must NOT appear.
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelAdminId,
+      eventDate: today,
+      status: "declined",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: meTok },
+    );
+
+    expect(res.plans).toHaveLength(1);
+    const team = res.plans[0].teams[0];
+    expect(team.people).toHaveLength(1);
+    expect(team.people[0].isSelf).toBe(true);
+    expect(team.people[0].status).toBe("unconfirmed");
   });
 
   it("returns every eligible plan the user serves and excludes out-of-window plans", async () => {
@@ -240,12 +284,58 @@ describe("getServingTeamRoster", () => {
     expect(team.people).toHaveLength(1);
   });
 
-  it("returns no plans when the user has no confirmed assignments", async () => {
+  it("returns no plans when the user's only assignment is declined", async () => {
     const { t, world } = await setup();
     const meTok = (await generateTokens(world.channelMemberId)).accessToken;
     const today = Date.now();
     const plan = await insertPlan(t, world, "Service", today);
-    // Only an unconfirmed assignment — not eligible.
+    // A declined assignment doesn't count — the user isn't serving.
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "declined",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: meTok },
+    );
+    expect(res.plans).toEqual([]);
+  });
+});
+
+describe("getServingEligibility", () => {
+  it("makes a confirmed volunteer eligible AND auto-entered on the day", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Service", today);
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "confirmed",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingEligibility,
+      { token: meTok },
+    );
+    expect(res.eligible).toBe(true);
+    expect(res.autoEnter).toBe(true);
+    expect(res.plans).toHaveLength(1);
+  });
+
+  it("makes an unconfirmed volunteer eligible but NOT auto-entered", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Service", today);
     await insertAssignment(t, world, {
       planId: plan,
       teamId: world.teamId,
@@ -256,9 +346,36 @@ describe("getServingTeamRoster", () => {
     });
 
     const res = await t.query(
-      api.functions.scheduling.serving.getServingTeamRoster,
+      api.functions.scheduling.serving.getServingEligibility,
       { token: meTok },
     );
+    // Eligible to enter (the chip lights up) but never auto-forced in before
+    // they accept.
+    expect(res.eligible).toBe(true);
+    expect(res.autoEnter).toBe(false);
+    expect(res.plans).toHaveLength(1);
+  });
+
+  it("does not make a declined volunteer eligible", async () => {
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Service", today);
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "declined",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingEligibility,
+      { token: meTok },
+    );
+    expect(res.eligible).toBe(false);
+    expect(res.autoEnter).toBe(false);
     expect(res.plans).toEqual([]);
   });
 });

--- a/apps/convex/__tests__/scheduling/serving.test.ts
+++ b/apps/convex/__tests__/scheduling/serving.test.ts
@@ -114,6 +114,68 @@ async function insertAssignment(
   );
 }
 
+/**
+ * Insert a fresh user who was once in the group but has since left
+ * (`groupMembers.leftAt` set) — the only membership row they hold.
+ */
+async function insertFormerGroupMember(
+  t: ReturnType<typeof convexTest>,
+  world: Awaited<ReturnType<typeof setup>>["world"],
+) {
+  return (await t.run(async (ctx: any) => {
+    const userId = await ctx.db.insert("users", {
+      firstName: "Former",
+      lastName: "Member",
+      phone: "+12025559999",
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId: world.groupId,
+      userId,
+      role: "member",
+      joinedAt: Date.now(),
+      leftAt: Date.now(),
+      notificationsEnabled: true,
+    });
+    return userId;
+  })) as Id<"users">;
+}
+
+describe("serving access after leaving the group", () => {
+  it("excludes a former group member with a stale unconfirmed assignment", async () => {
+    // `groupMembers.remove` soft-deletes (sets leftAt) but leaves the
+    // roleAssignments row intact. A never-answered assignment stays
+    // "unconfirmed", so widening serving to non-declined must NOT re-grant
+    // serving access (and teammate phone numbers) to someone who left.
+    const { t, world } = await setup();
+    const formerId = await insertFormerGroupMember(t, world);
+    const formerTok = (await generateTokens(formerId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Sunday Service", today);
+
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: formerId,
+      eventDate: today,
+      status: "unconfirmed",
+    });
+
+    const eligibility = await t.query(
+      api.functions.scheduling.serving.getServingEligibility,
+      { token: formerTok },
+    );
+    expect(eligibility.eligible).toBe(false);
+    expect(eligibility.plans).toEqual([]);
+
+    const roster = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: formerTok },
+    );
+    expect(roster.plans).toEqual([]);
+  });
+});
+
 describe("getServingTeamRoster", () => {
   it("groups volunteers by plan then team, with name/role/phone/isSelf/status", async () => {
     const { t, world } = await setup();
@@ -307,6 +369,54 @@ describe("getServingTeamRoster", () => {
   });
 });
 
+describe("getServingUpcomingChannels", () => {
+  it("resolves a coming-soon team channel for an unconfirmed volunteer", async () => {
+    // Team-chat membership already mirrors non-declined volunteers into channels,
+    // so an unconfirmed volunteer's "coming soon" channels resolve the same way.
+    // The group leader is a group member but not yet a channel member, so the
+    // team channel surfaces as upcoming.
+    const { t, world } = await setup();
+    const leaderTok = (await generateTokens(world.groupLeaderId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Sunday Service", today);
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.groupLeaderId,
+      eventDate: today,
+      status: "unconfirmed",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingUpcomingChannels,
+      { token: leaderTok, planIds: [plan] },
+    );
+    expect(res.map((c) => c.channelId)).toContain(world.channelId);
+  });
+
+  it("excludes a declined volunteer's channels", async () => {
+    const { t, world } = await setup();
+    const leaderTok = (await generateTokens(world.groupLeaderId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Sunday Service", today);
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.groupLeaderId,
+      eventDate: today,
+      status: "declined",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingUpcomingChannels,
+      { token: leaderTok, planIds: [plan] },
+    );
+    expect(res).toEqual([]);
+  });
+});
+
 describe("getServingEligibility", () => {
   it("makes a confirmed volunteer eligible AND auto-entered on the day", async () => {
     const { t, world } = await setup();
@@ -354,6 +464,73 @@ describe("getServingEligibility", () => {
     expect(res.eligible).toBe(true);
     expect(res.autoEnter).toBe(false);
     expect(res.plans).toHaveLength(1);
+  });
+
+  it("auto-enters a confirmed volunteer even with an unconfirmed assignment on another same-day plan", async () => {
+    // Regression: the global autoEnter must count only *auto-eligible*
+    // (confirmed, in-window) plans, not every non-declined plan. A volunteer
+    // confirmed on plan A who also holds an unrelated unconfirmed assignment on
+    // same-day plan B must still be auto-entered into A (spec: confirmed
+    // auto-entry is unchanged).
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const planA = await insertPlan(t, world, "Confirmed Service", today);
+    const planB = await insertPlan(t, world, "Unconfirmed Service", today);
+    await insertAssignment(t, world, {
+      planId: planA,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "confirmed",
+    });
+    await insertAssignment(t, world, {
+      planId: planB,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "unconfirmed",
+    });
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingEligibility,
+      { token: meTok },
+    );
+    // Both plans are eligible, but only the confirmed one is auto-eligible, so
+    // auto-entry still fires (unambiguous single auto-eligible plan).
+    expect(res.eligible).toBe(true);
+    expect(res.plans).toHaveLength(2);
+    expect(res.autoEnter).toBe(true);
+  });
+
+  it("does not auto-enter when two same-day plans are both confirmed (ambiguous)", async () => {
+    // Two auto-eligible plans → the choice is ambiguous → no auto-entry (the
+    // client offers a manual chip). Pins that the fix didn't loosen this.
+    const { t, world } = await setup();
+    const meTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const planA = await insertPlan(t, world, "Service A", today);
+    const planB = await insertPlan(t, world, "Service B", today);
+    for (const plan of [planA, planB]) {
+      await insertAssignment(t, world, {
+        planId: plan,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+        eventDate: today,
+        status: "confirmed",
+      });
+    }
+
+    const res = await t.query(
+      api.functions.scheduling.serving.getServingEligibility,
+      { token: meTok },
+    );
+    expect(res.eligible).toBe(true);
+    expect(res.plans).toHaveLength(2);
+    expect(res.autoEnter).toBe(false);
   });
 
   it("does not make a declined volunteer eligible", async () => {

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -601,8 +601,8 @@ export const reorderTasks = mutation({
  * only for "during" tasks (one completion per service time).
  *
  * Team-level tasks (roleId == null) are REJECTED here — they are team-wide and
- * must go through `toggleSharedTeamTask` (which gates on confirmed team
- * membership); this per-user path only checks group membership.
+ * must go through `toggleSharedTeamTask` (which gates on serving/non-declined
+ * team membership); this per-user path only checks group membership.
  *
  * Auth: any authenticated user (completion is personal). We still verify the
  * caller can see the plan.
@@ -621,8 +621,8 @@ export const toggleTaskCompletion = mutation({
       throw new ConvexError("Task not found");
     }
     // Team-level tasks (no roles) are TEAM-WIDE and must be completed through
-    // `toggleSharedTeamTask`, which gates on confirmed TEAM membership. This
-    // per-user path only checks GROUP membership, so accepting a team-level
+    // `toggleSharedTeamTask`, which gates on serving (non-declined) TEAM
+    // membership. This per-user path only checks GROUP membership, so accepting a team-level
     // completion here would let a non-teammate (or a stale/direct caller) mark it
     // done and bypass the team gate. The mobile client already routes team-level
     // tasks to the Shared tab and excludes them from "Mine".
@@ -883,14 +883,17 @@ export const getMyServingTasks = query({
       ServingTaskItem[]
     > = { before: [], during: [], after: [] };
 
-    // The roles / teams the user is confirmed for on this plan.
+    // The roles / teams the user is on (non-declined) for this plan. An
+    // unconfirmed volunteer can now enter serving mode, so they see the tasks
+    // for the role they're assigned to regardless of their own accept state —
+    // only a *declined* assignment drops its role's tasks.
     const myAssignments = await ctx.db
       .query("roleAssignments")
       .withIndex("by_plan", (q) => q.eq("planId", args.planId))
       .filter((q) => q.eq(q.field("userId"), userId))
       .collect();
-    const myConfirmed = myAssignments.filter((a) => a.status === "confirmed");
-    const confirmedRoleIds = new Set(myConfirmed.map((a) => a.roleId as string));
+    const myServing = myAssignments.filter((a) => a.status !== "declined");
+    const myRoleIds = new Set(myServing.map((a) => a.roleId as string));
 
     // (a) Assigned template tasks.
     const tasks = await ctx.db
@@ -915,11 +918,11 @@ export const getMyServingTasks = query({
       // Team-level tasks (no roles) are team-wide, single-source on
       // `sharedTaskCompletions`, and belong to the Shared surface only — they
       // are no longer listed in this personal "Mine" view. A role task appears
-      // here when the user is confirmed for ANY of its roles (plus their
-      // personal tasks).
+      // here when the user is assigned (non-declined) to ANY of its roles (plus
+      // their personal tasks).
       const roleIds = taskRoleIds(task);
       if (roleIds.length === 0) continue;
-      if (!roleIds.some((r) => confirmedRoleIds.has(r as string))) continue;
+      if (!roleIds.some((r) => myRoleIds.has(r as string))) continue;
 
       const base = {
         title: task.title,
@@ -1003,8 +1006,14 @@ async function resolveUserName(
   return `${u?.firstName ?? ""} ${u?.lastName ?? ""}`.trim() || "Someone";
 }
 
-/** The current user's confirmed role assignments on a plan. */
-async function myConfirmedAssignments(
+/**
+ * The current user's *serving* role assignments on a plan: everything they
+ * haven't declined (unconfirmed or confirmed). An assigned-but-unconfirmed
+ * volunteer can now enter serving mode and reach the same day-of resources, so
+ * the serving surfaces gate on "non-declined" — the same predicate team chat and
+ * leader fill counts already use — not on "confirmed".
+ */
+async function myServingAssignments(
   ctx: QueryCtx | MutationCtx,
   planId: Id<"eventPlans">,
   userId: Id<"users">,
@@ -1014,7 +1023,7 @@ async function myConfirmedAssignments(
     .withIndex("by_plan", (q) => q.eq("planId", planId))
     .filter((q) => q.eq(q.field("userId"), userId))
     .collect();
-  return rows.filter((a) => a.status === "confirmed");
+  return rows.filter((a) => a.status !== "declined");
 }
 
 /**
@@ -1042,17 +1051,18 @@ type SharedTeamTaskItem = {
 
 /**
  * The "Shared" surface: team-level tasks (roleId == null) for the CURRENT
- * user's confirmed team(s) on a plan. These are "the whole team is responsible,
- * no single assignee" — so completion is TEAM-WIDE (`sharedTaskCompletions`),
- * not per-user: any confirmed teammate marking it done marks it done for
- * everyone. Completion is single-source on `sharedTaskCompletions` — a task
+ * user's serving team(s) (non-declined) on a plan. These are "the whole team is
+ * responsible, no single assignee" — so completion is TEAM-WIDE
+ * (`sharedTaskCompletions`), not per-user: any serving teammate marking it done
+ * marks it done for everyone. Completion is single-source on
+ * `sharedTaskCompletions` — a task
  * shows done iff a shared row exists (pre-migration per-user completions were
  * snapshotted into `sharedTaskCompletions` by a one-time backfill).
  * Returned as a flat array (each item carries its `segment`), ordered
  * before → during → after, then by the task's sortOrder.
  *
  * Auth: an active member of the plan's group (community read gate). Only the
- * user's own confirmed teams are included.
+ * user's own serving teams (non-declined) are included.
  */
 export const getSharedTeamTasks = query({
   args: { token: v.string(), planId: v.id("eventPlans") },
@@ -1065,8 +1075,8 @@ export const getSharedTeamTasks = query({
     if (!plan) return [];
     await requireGroupMember(ctx, plan.groupId, userId);
 
-    const confirmed = await myConfirmedAssignments(ctx, args.planId, userId);
-    const myTeamIds = new Set(confirmed.map((a) => a.teamId as string));
+    const serving = await myServingAssignments(ctx, args.planId, userId);
+    const myTeamIds = new Set(serving.map((a) => a.teamId as string));
     if (myTeamIds.size === 0) return [];
 
     const [tasks, sharedRows] = await Promise.all([
@@ -1154,7 +1164,8 @@ export const getSharedTeamTasks = query({
  * marking done writes only the shared row, but un-checking also deletes any
  * legacy `eventTaskCompletions` rows for the task.
  *
- * Auth: the caller must be a confirmed member of the task's team on the plan.
+ * Auth: the caller must be serving (non-declined — unconfirmed or confirmed) on
+ * the task's team on the plan.
  */
 export const toggleSharedTeamTask = mutation({
   args: {
@@ -1177,10 +1188,12 @@ export const toggleSharedTeamTask = mutation({
     const plan = await requirePlan(ctx, args.planId);
     await requireGroupMember(ctx, plan.groupId, userId);
 
-    // Gate: the caller must be a confirmed member of ANY of THIS task's teams.
+    // Gate: the caller must be serving (non-declined) on ANY of THIS task's
+    // teams. Unconfirmed volunteers serve alongside confirmed ones, so they can
+    // flip a shared team task too.
     const taskTeams = new Set(taskTeamIds(task) as string[]);
-    const confirmed = await myConfirmedAssignments(ctx, args.planId, userId);
-    const onTeam = confirmed.some((a) => taskTeams.has(a.teamId as string));
+    const serving = await myServingAssignments(ctx, args.planId, userId);
+    const onTeam = serving.some((a) => taskTeams.has(a.teamId as string));
     if (!onTeam) {
       throw new ConvexError("You must be serving on this team to update it");
     }
@@ -1387,6 +1400,11 @@ type CrewMemberEntry = {
   teamName: string;
   /** True for the current viewer's own row. */
   isCurrentUser: boolean;
+  /**
+   * Whether this teammate has accepted. Declined people aren't crew, so this is
+   * always `"confirmed"` or `"unconfirmed"`; the client badges the unconfirmed.
+   */
+  status: "confirmed" | "unconfirmed";
   /** Completed / total completion "slots" (per-user, matching the personal view). */
   done: number;
   total: number;
@@ -1401,11 +1419,13 @@ type CrewMemberEntry = {
 };
 
 /**
- * The "Crew" surface: the current user's confirmed teammates (and the user
+ * The "Crew" surface: the current user's serving teammates (and the user
  * themselves) on a plan, with each person's ROLE-assigned tasks, READ-ONLY.
+ * Includes non-declined teammates — unconfirmed people are shown (carrying
+ * `status: "unconfirmed"` so the client badges them), only declined are hidden.
  * One entry per (member, role). "Assigned tasks" are the plan's role tasks
- * (`eventTasks.roleId` set) whose role the member is confirmed for — team-level
- * tasks live on the Shared surface, not here.
+ * (`eventTasks.roleId` set) whose role the member holds — team-level tasks live
+ * on the Shared surface, not here.
  *
  * `done`/`total` count completion the same way the personal `getMyServingTasks`
  * view does: per-user `eventTaskCompletions`, with "during" tasks counted once
@@ -1414,7 +1434,7 @@ type CrewMemberEntry = {
  * are done.
  *
  * Auth: an active member of the plan's group. Only teams the current user is
- * confirmed for are included.
+ * serving on (non-declined) are included.
  */
 export const getCrewTasks = query({
   args: { token: v.string(), planId: v.id("eventPlans") },
@@ -1427,8 +1447,8 @@ export const getCrewTasks = query({
     if (!plan) return [];
     await requireGroupMember(ctx, plan.groupId, userId);
 
-    const myConfirmed = await myConfirmedAssignments(ctx, args.planId, userId);
-    const myTeamIds = new Set(myConfirmed.map((a) => a.teamId as string));
+    const myServing = await myServingAssignments(ctx, args.planId, userId);
+    const myTeamIds = new Set(myServing.map((a) => a.teamId as string));
     if (myTeamIds.size === 0) return [];
 
     const [allAssignments, tasks] = await Promise.all([
@@ -1457,9 +1477,10 @@ export const getCrewTasks = query({
 
     const timesCount = Math.max(1, plan.times.length);
 
-    // Crew = confirmed assignments on a team the current user is confirmed for.
+    // Crew = non-declined assignments on a team the current user is serving on.
+    // Unconfirmed teammates are included (and badged); only declined are hidden.
     const crew = allAssignments.filter(
-      (a) => a.status === "confirmed" && myTeamIds.has(a.teamId as string),
+      (a) => a.status !== "declined" && myTeamIds.has(a.teamId as string),
     );
 
     const teamNames = new Map<string, string>();
@@ -1554,6 +1575,7 @@ export const getCrewTasks = query({
         teamId: teamKey,
         teamName: teamNames.get(teamKey)!,
         isCurrentUser: a.userId === userId,
+        status: a.status === "confirmed" ? "confirmed" : "unconfirmed",
         done: doneCount,
         total: totalCount,
         tasks: taskList,

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -494,7 +494,12 @@ export const updateTask = mutation({
           assignments
             .filter(
               (a) =>
-                a.status === "confirmed" && nextSet.has(a.roleId as string),
+                // Non-declined (not confirmed-only): unconfirmed volunteers can
+                // now hold completions on their assigned role's tasks, so a
+                // still-assigned unconfirmed user must count as covered — else
+                // removing an unrelated role would wrongly orphan their
+                // completion. Matches the rest of this PR's predicate.
+                a.status !== "declined" && nextSet.has(a.roleId as string),
             )
             .map((a) => a.userId as string),
         );

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -161,6 +161,41 @@ export async function requireGroupScheduler(
 }
 
 /**
+ * Boolean form of {@link requireGroupMember}: is `userId` an active member of
+ * `groupId` (or a community admin)? Returns `false` instead of throwing, so
+ * callers iterating over many groups (e.g. the serving-eligibility/roster
+ * queries) can filter out groups the user has left rather than aborting the
+ * whole query. A missing group returns `false`.
+ */
+export async function isActiveGroupMember(
+  ctx: QueryCtx | MutationCtx,
+  groupId: Id<"groups">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const group = await ctx.db.get(groupId);
+  if (!group) {
+    return false;
+  }
+
+  const membership = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", groupId).eq("userId", userId),
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+  const isActiveMember = !!(
+    membership &&
+    (!membership.requestStatus || membership.requestStatus === "accepted")
+  );
+  if (isActiveMember) {
+    return true;
+  }
+
+  return await isCommunityAdmin(ctx, group.communityId, userId);
+}
+
+/**
  * Require that `userId` may *view* a campus group's serving-team data — an
  * active member of the group OR a community admin. This is a read-level gate
  * (weaker than `requireGroupScheduler`, which demands leadership) used by
@@ -179,22 +214,7 @@ export async function requireGroupMember(
     throw new ConvexError("Group not found");
   }
 
-  const membership = await ctx.db
-    .query("groupMembers")
-    .withIndex("by_group_user", (q) =>
-      q.eq("groupId", groupId).eq("userId", userId),
-    )
-    .filter((q) => q.eq(q.field("leftAt"), undefined))
-    .first();
-  const isActiveMember = !!(
-    membership &&
-    (!membership.requestStatus || membership.requestStatus === "accepted")
-  );
-  if (isActiveMember) {
-    return group;
-  }
-
-  if (await isCommunityAdmin(ctx, group.communityId, userId)) {
+  if (await isActiveGroupMember(ctx, groupId, userId)) {
     return group;
   }
 

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -170,15 +170,20 @@ type ServingPlan = {
 
 /**
  * Every plan the current user can currently enter Serving Mode for. A plan is a
- * candidate when the user has a `confirmed` role assignment on it and "now"
- * falls inside the plan's serving window; multiple plans can be active at once
- * (e.g. two campuses on the same morning), so the client can render one entry
- * per event and the volunteer picks which one they're serving. `plans` is sorted
- * soonest-first; `activePlan` is the soonest (kept for the inbox chip / runsheet
- * consumers). `autoEnter` is true only when exactly one plan is active (auto and
- * eligibility now share the same same-day window) — with multiple active plans
- * the choice is ambiguous, so we never auto-enter and the client offers a
- * manual chip instead.
+ * candidate when the user has a non-declined (`unconfirmed` or `confirmed`) role
+ * assignment on it and "now" falls inside the plan's serving window; multiple
+ * plans can be active at once (e.g. two campuses on the same morning), so the
+ * client can render one entry per event and the volunteer picks which one
+ * they're serving. `plans` is sorted soonest-first; `activePlan` is the soonest
+ * (kept for the inbox chip / runsheet consumers).
+ *
+ * `autoEnter` is true only when exactly one plan is active AND the user holds a
+ * `confirmed` assignment on it (auto and eligibility share the same same-day
+ * window). An assigned-but-*unconfirmed* volunteer is therefore *eligible* to
+ * enter (they get the serving chip and can tap in) but is never auto-forced into
+ * "you're serving now" before they've accepted — the nudge to accept stays
+ * meaningful without locking them out. With multiple active plans the choice is
+ * ambiguous, so we never auto-enter and the client offers a manual chip instead.
  *
  * Auth: any authenticated user.
  */
@@ -188,14 +193,15 @@ export const getServingEligibility = query({
     const userId = await requireAuth(ctx, args.token);
     const now = Date.now();
 
-    // All plans the user is confirmed for (may hold multiple roles per plan).
-    const confirmed = await ctx.db
+    // All plans the user hasn't declined (may hold multiple roles per plan).
+    // Unconfirmed people "count but haven't accepted" — the same predicate the
+    // rest of the app uses (team chat membership, leader fill counts).
+    const myAssignments = await ctx.db
       .query("roleAssignments")
-      .withIndex("by_user_status", (q) =>
-        q.eq("userId", userId).eq("status", "confirmed"),
-      )
+      .withIndex("by_user", (q) => q.eq("userId", userId))
       .collect();
-    const planIds = [...new Set(confirmed.map((a) => a.planId as string))];
+    const nonDeclined = myAssignments.filter((a) => a.status !== "declined");
+    const planIds = [...new Set(nonDeclined.map((a) => a.planId as string))];
 
     const entries: (ServingPlan & { autoEnter: boolean })[] = [];
 
@@ -210,20 +216,20 @@ export const getServingEligibility = query({
       // Must be within the broader same-day window to be eligible at all.
       if (now < sameDayStart || now > endsAt) continue;
 
-      const autoEnter = now >= startsAt - AUTO_ENTER_LEAD_MS && now <= endsAt;
+      // The user's assignments on this plan (any status), from the set above.
+      const planAssignments = nonDeclined.filter(
+        (a) => (a.planId as string) === planIdStr,
+      );
+      // Auto-entry stays confirmed-only: only drop a *confirmed* volunteer
+      // straight into serving mode. Unconfirmed people are eligible but must
+      // tap in themselves.
+      const hasConfirmed = planAssignments.some((a) => a.status === "confirmed");
+      const autoEnter =
+        hasConfirmed && now >= startsAt - AUTO_ENTER_LEAD_MS && now <= endsAt;
 
-      // Team ids the user is confirmed for on this plan.
-      const planAssignments = await ctx.db
-        .query("roleAssignments")
-        .withIndex("by_plan", (q) => q.eq("planId", plan._id))
-        .filter((q) => q.eq(q.field("userId"), userId))
-        .collect();
+      // Team ids the user is on (non-declined) for this plan.
       const teamIds = [
-        ...new Set(
-          planAssignments
-            .filter((a) => a.status === "confirmed")
-            .map((a) => a.teamId as string),
-        ),
+        ...new Set(planAssignments.map((a) => a.teamId as string)),
       ];
 
       const { teamChannelIds, meetingChannelIds } = await servingChannelArrays(
@@ -310,13 +316,16 @@ export const getServingUpcomingChannels = query({
       if (!plan) continue;
       await requireGroupMember(ctx, plan.groupId, userId);
 
-      // The user's confirmed assignments on this plan → the teams they'll be in.
+      // The user's non-declined assignments on this plan → the teams they'll be
+      // in. Unconfirmed volunteers are mirrored into team channels too (team
+      // chat membership already includes everyone who hasn't declined), so their
+      // "coming soon" channels should resolve the same way.
       const planAssignments = await ctx.db
         .query("roleAssignments")
         .withIndex("by_plan", (q) => q.eq("planId", planId))
         .filter((q) => q.eq(q.field("userId"), userId))
         .collect();
-      const confirmed = planAssignments.filter((a) => a.status === "confirmed");
+      const confirmed = planAssignments.filter((a) => a.status !== "declined");
       if (confirmed.length === 0) continue;
 
       const availableAt = plan.eventDate - ADD_DAYS_BEFORE * MS_PER_DAY;
@@ -403,6 +412,12 @@ type ServingTeamPerson = {
   phone: string | null;
   /** True for the current user's own card (no message/text actions on self). */
   isSelf: boolean;
+  /**
+   * Whether this person has accepted their assignment. Declined people are
+   * never included, so this is always `"confirmed"` or `"unconfirmed"`; the
+   * client badges the unconfirmed ones.
+   */
+  status: "confirmed" | "unconfirmed";
 };
 
 /** One team column in a plan's Team roster grid. */
@@ -423,14 +438,20 @@ type ServingTeamPlan = {
 /**
  * Serving-mode "Team" grid: who is serving alongside the current user, grouped
  * by plan then by team. For EVERY plan the user can currently serve (same
- * eligibility window as `getServingEligibility` — a `confirmed` assignment plus
+ * eligibility window as `getServingEligibility` — a non-declined assignment plus
  * "now" inside the plan's same-day window), returns each team that has at least
- * one confirmed volunteer as a column, and each volunteer as a card (name, the
- * role they fill, avatar, and phone for the day-of "Text" action).
+ * one non-declined volunteer as a column, and each volunteer as a card (name,
+ * the role they fill, avatar, phone for the day-of "Text" action, and their
+ * accept `status` so the client can badge the unconfirmed ones).
  *
- * One card per (user, role) confirmed assignment — a person filling two roles on
- * the same team shows two cards. `isSelf` flags the current user's own cards so
- * the client can suppress the message/text actions on them.
+ * Includes people who are still *unconfirmed* (assigned but not yet accepted) —
+ * they're "more than likely to still come," so they belong on the day-of
+ * roster, tagged as unconfirmed. Only *declined* people are hidden.
+ *
+ * One card per (user, role) non-declined assignment — a person filling two roles
+ * on the same team shows two cards (each with its own status, so one role can
+ * read confirmed while the other reads unconfirmed). `isSelf` flags the current
+ * user's own cards so the client can suppress the message/text actions on them.
  *
  * Membership is already implied by the confirmed assignment, so there is no
  * extra group-member gate here. Phone numbers are surfaced only among people
@@ -445,14 +466,14 @@ export const getServingTeamRoster = query({
     const userId = await requireAuth(ctx, args.token);
     const now = Date.now();
 
-    // Plans the user is confirmed for (mirrors getServingEligibility's window).
-    const confirmed = await ctx.db
+    // Plans the user is on, non-declined (mirrors getServingEligibility's
+    // window and predicate — unconfirmed people count, declined don't).
+    const myAssignments = await ctx.db
       .query("roleAssignments")
-      .withIndex("by_user_status", (q) =>
-        q.eq("userId", userId).eq("status", "confirmed"),
-      )
+      .withIndex("by_user", (q) => q.eq("userId", userId))
       .collect();
-    const planIds = [...new Set(confirmed.map((a) => a.planId as string))];
+    const nonDeclined = myAssignments.filter((a) => a.status !== "declined");
+    const planIds = [...new Set(nonDeclined.map((a) => a.planId as string))];
 
     const eligiblePlans: Doc<"eventPlans">[] = [];
     for (const planIdStr of planIds) {
@@ -493,9 +514,9 @@ export const getServingTeamRoster = query({
           .query("roleAssignments")
           .withIndex("by_plan", (q) => q.eq("planId", plan._id))
           .collect()
-      ).filter((a) => a.status === "confirmed");
+      ).filter((a) => a.status !== "declined");
 
-      // Group confirmed assignments by team, de-duping identical (user, role)
+      // Group non-declined assignments by team, de-duping identical (user, role)
       // rows so a double-written assignment can't produce a duplicate card.
       const byTeam = new Map<string, typeof assignments>();
       const seen = new Set<string>();
@@ -527,6 +548,7 @@ export const getServingTeamRoster = query({
             profilePhoto: user?.profilePhoto ?? null,
             phone: user?.phone ?? null,
             isSelf: (a.userId as string) === (userId as string),
+            status: a.status === "confirmed" ? "confirmed" : "unconfirmed",
           });
         }
         people.sort((x, y) => x.displayName.localeCompare(y.displayName));

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -18,7 +18,7 @@ import type { QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { getDisplayName } from "../../lib/utils";
-import { requireGroupMember } from "./permissions";
+import { isActiveGroupMember, requireGroupMember } from "./permissions";
 import { ADD_DAYS_BEFORE } from "./teamChannelSync";
 
 /** Milliseconds in one day. */
@@ -216,6 +216,15 @@ export const getServingEligibility = query({
       // Must be within the broader same-day window to be eligible at all.
       if (now < sameDayStart || now > endsAt) continue;
 
+      // A stale assignment can outlive group membership: `groupMembers.remove`
+      // soft-deletes (sets `leftAt`) but leaves the `roleAssignments` row
+      // intact. Since we now admit *unconfirmed* assignments, skip any plan
+      // whose group the user has since left — otherwise a former member with a
+      // never-answered assignment would regain serving access (and the roster's
+      // teammate phone numbers). Confirmed-only never surfaced this because an
+      // unanswered assignment is unconfirmed.
+      if (!(await isActiveGroupMember(ctx, plan.groupId, userId))) continue;
+
       // The user's assignments on this plan (any status), from the set above.
       const planAssignments = nonDeclined.filter(
         (a) => (a.planId as string) === planIdStr,
@@ -257,7 +266,14 @@ export const getServingEligibility = query({
       ({ autoEnter: _autoEnter, ...plan }) => plan,
     );
     const activePlan: ServingPlan | null = plans[0] ?? null;
-    const autoEnter = entries.length === 1 && entries[0].autoEnter;
+    // Auto-enter only when exactly ONE plan is auto-eligible (confirmed + inside
+    // the auto-enter window). Gating on the count of auto-eligible entries — not
+    // the total non-declined plan count — keeps a confirmed volunteer's
+    // auto-entry unchanged even when they also hold an unrelated *unconfirmed*
+    // assignment on a different same-day plan (which is eligible but never
+    // auto-entered).
+    const autoEntries = entries.filter((e) => e.autoEnter);
+    const autoEnter = autoEntries.length === 1;
 
     return {
       eligible: plans.length > 0,
@@ -286,11 +302,12 @@ type UpcomingChannel = {
  * (membership-filtered) serving inbox. The serving inbox renders these as
  * non-tappable "ghost" cards showing when the channel opens.
  *
- * Scope is the user's OWN teams on the plan — their `confirmed` role
- * assignments — not every team on the plan:
- *   - team channels: `teams.channelId` for each team the user is confirmed on;
+ * Scope is the user's OWN teams on the plan — their non-declined role
+ * assignments (unconfirmed included, mirroring team-chat membership) — not
+ * every team on the plan:
+ *   - team channels: `teams.channelId` for each team the user is assigned to;
  *   - cross-team channels (`channelType === "cross_team"`): any whose
- *     `crossTeamSync.selectors` match one of the user's confirmed assignments
+ *     `crossTeamSync.selectors` match one of the user's non-declined assignments
  *     (same `sourceTeamId`, and matching `roleId` when the selector pins one).
  * Channels the user is already an active member of (`chatChannelMembers` with
  * `leftAt === undefined`) are excluded — those render as real rows.
@@ -325,8 +342,8 @@ export const getServingUpcomingChannels = query({
         .withIndex("by_plan", (q) => q.eq("planId", planId))
         .filter((q) => q.eq(q.field("userId"), userId))
         .collect();
-      const confirmed = planAssignments.filter((a) => a.status !== "declined");
-      if (confirmed.length === 0) continue;
+      const serving = planAssignments.filter((a) => a.status !== "declined");
+      if (serving.length === 0) continue;
 
       const availableAt = plan.eventDate - ADD_DAYS_BEFORE * MS_PER_DAY;
 
@@ -334,8 +351,8 @@ export const getServingUpcomingChannels = query({
       // are filtered out below).
       const candidates: Array<Omit<UpcomingChannel, "availableAt">> = [];
 
-      // (a) Team channels — one per team the user is confirmed on.
-      const teamIds = new Set<string>(confirmed.map((a) => a.teamId as string));
+      // (a) Team channels — one per team the user is assigned to (non-declined).
+      const teamIds = new Set<string>(serving.map((a) => a.teamId as string));
       for (const teamId of teamIds) {
         const team = await ctx.db.get(teamId as Id<"teams">);
         if (team?.channelId && team.isArchived !== true) {
@@ -347,9 +364,9 @@ export const getServingUpcomingChannels = query({
         }
       }
 
-      // (b) Cross-team channels whose selectors match one of the user's confirmed
-      // assignments. Cross-team channels are rare, so a filtered scan is fine
-      // (mirrors `reconcileCrossTeamChannelsForSource`).
+      // (b) Cross-team channels whose selectors match one of the user's
+      // non-declined assignments. Cross-team channels are rare, so a filtered
+      // scan is fine (mirrors `reconcileCrossTeamChannelsForSource`).
       const crossChannels = await ctx.db
         .query("chatChannels")
         .filter((q) => q.eq(q.field("channelType"), "cross_team"))
@@ -357,7 +374,7 @@ export const getServingUpcomingChannels = query({
       for (const ch of crossChannels) {
         if (ch.isArchived === true) continue;
         const selectors = ch.crossTeamSync?.selectors ?? [];
-        const willBeMember = confirmed.some((a) =>
+        const willBeMember = serving.some((a) =>
           selectors.some(
             (s) =>
               (s.sourceTeamId as string) === (a.teamId as string) &&
@@ -453,10 +470,10 @@ type ServingTeamPlan = {
  * read confirmed while the other reads unconfirmed). `isSelf` flags the current
  * user's own cards so the client can suppress the message/text actions on them.
  *
- * Membership is already implied by the confirmed assignment, so there is no
- * extra group-member gate here. Phone numbers are surfaced only among people
- * confirmed to serve the same event — the day-of coordination context the grid
- * exists for.
+ * Plans whose group the caller has since left are skipped (a soft-deleted
+ * membership can outlive an unconfirmed assignment), so a former member can't
+ * reach the roster. Phone numbers are surfaced only among people serving the
+ * same event — the day-of coordination context the grid exists for.
  *
  * Auth: any authenticated user.
  */
@@ -482,6 +499,10 @@ export const getServingTeamRoster = query({
       const startsAt = planStartsAt(plan);
       const endsAt = planEndsAt(plan);
       if (now < startsAt - SAME_DAY_LEAD_MS || now > endsAt) continue;
+      // Skip plans whose group the user has left (stale unconfirmed assignment)
+      // — mirrors getServingEligibility so a former member can't reach the
+      // roster and its teammate phone numbers. See the note there.
+      if (!(await isActiveGroupMember(ctx, plan.groupId, userId))) continue;
       eligiblePlans.push(plan);
     }
     // Soonest-first so the grid's plan sections read in event order.

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -144,6 +144,8 @@ type CrewMember = {
   teamId: string;
   teamName: string;
   isCurrentUser: boolean;
+  /** "unconfirmed" teammates are shown with a badge; declined aren't returned. */
+  status: "confirmed" | "unconfirmed";
   done: number;
   total: number;
   tasks: CrewTask[];
@@ -1692,6 +1694,17 @@ function CrewMemberRow({
                 <Text style={styles.youChipText}>You</Text>
               </View>
             ) : null}
+            {member.status === "unconfirmed" ? (
+              <View
+                style={[
+                  styles.unconfirmedChip,
+                  { backgroundColor: colors.warning },
+                ]}
+              >
+                <Ionicons name="time-outline" size={11} color="#fff" />
+                <Text style={styles.youChipText}>Unconfirmed</Text>
+              </View>
+            ) : null}
           </View>
           <Text style={[styles.expandSub, { color: colors.textTertiary }]} numberOfLines={1}>
             {member.roleName}
@@ -2206,6 +2219,14 @@ const styles = StyleSheet.create({
     borderRadius: 999,
   },
   youChipText: { fontSize: 10, fontWeight: "700", color: "#fff", letterSpacing: 0.3 },
+  unconfirmedChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 3,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    borderRadius: 999,
+  },
 
   // Read-only task lists (inside expanded crew/team rows)
   readonlyList: { marginTop: 12, gap: 10 },

--- a/apps/mobile/features/serving/components/ServingTeamScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTeamScreen.tsx
@@ -50,6 +50,11 @@ type RosterPerson = {
   profilePhoto: string | null;
   phone: string | null;
   isSelf: boolean;
+  /**
+   * Accept status. Declined people are never returned, so this is always
+   * "confirmed" or "unconfirmed" — unconfirmed cards get an "Unconfirmed" pill.
+   */
+  status: "confirmed" | "unconfirmed";
 };
 
 /** Column width for each team — wide enough for a name + role, snug on mobile. */
@@ -179,7 +184,7 @@ export function ServingTeamScreen() {
             color={colors.textTertiary}
           />
           <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-            No one else is confirmed to serve yet.
+            No one else is on the team yet.
           </Text>
         </View>
       ) : (
@@ -206,7 +211,7 @@ export function ServingTeamScreen() {
                 <Text
                   style={[styles.planEmpty, { color: colors.textTertiary }]}
                 >
-                  No confirmed volunteers yet.
+                  No one on this team yet.
                 </Text>
               ) : (
                 <ScrollView
@@ -300,11 +305,12 @@ function PersonCard({
       ]}
       accessibilityRole={actionable ? "button" : "text"}
       accessibilityLabel={
-        person.isSelf
+        (person.isSelf
           ? `${person.displayName} (you), ${person.roleName}`
           : actionable
             ? `Message ${person.displayName}, ${person.roleName}`
-            : `${person.displayName}, ${person.roleName}`
+            : `${person.displayName}, ${person.roleName}`) +
+        (person.status === "unconfirmed" ? ", unconfirmed" : "")
       }
     >
       <View style={styles.personTop}>
@@ -330,7 +336,28 @@ function PersonCard({
           {person.roleName}
         </Text>
       </View>
+      {person.status === "unconfirmed" ? (
+        <UnconfirmedBadge colors={colors} />
+      ) : null}
     </TouchableOpacity>
+  );
+}
+
+/**
+ * A small "Unconfirmed" pill for a teammate who's assigned but hasn't accepted
+ * yet. Reuses the leader roster's "awaiting" vocabulary (`colors.warning` + a
+ * clock icon) so unconfirmed reads the same everywhere in the app.
+ */
+function UnconfirmedBadge({
+  colors,
+}: {
+  colors: ReturnType<typeof useTheme>["colors"];
+}) {
+  return (
+    <View style={[styles.unconfirmedBadge, { backgroundColor: colors.warning }]}>
+      <Ionicons name="time-outline" size={11} color="#fff" />
+      <Text style={styles.unconfirmedText}>Unconfirmed</Text>
+    </View>
   );
 }
 
@@ -385,4 +412,19 @@ const styles = StyleSheet.create({
   roleRow: { flexDirection: "row", alignItems: "center", gap: 6 },
   roleDot: { width: 8, height: 8, borderRadius: 4 },
   roleText: { fontSize: 12, fontWeight: "500", flexShrink: 1 },
+  unconfirmedBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    gap: 3,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 6,
+  },
+  unconfirmedText: {
+    fontSize: 10,
+    fontWeight: "700",
+    color: "#fff",
+    letterSpacing: 0.2,
+  },
 });


### PR DESCRIPTION
## What & why

When a leader assigns someone to serve, that person starts **unconfirmed** until they tap "accept". Today the volunteer-facing **serving-mode** surfaces only showed and admitted *confirmed* people — so an assigned-but-unconfirmed volunteer was invisible on the Team roster and **couldn't even enter Serving Mode**, even though (as the reporter put it) they're "more than likely to still come, they just haven't accepted."

This brings the serving surfaces onto the same **`status !== "declined"`** predicate the rest of the app already uses (team-chat membership, leader fill counts): include everyone who hasn't declined, and clearly mark the unconfirmed ones. **Declined stays hidden. Leader-facing counts are untouched.**

Dashboard item / issue: #631

## Before / after (Team roster)

> ⚠️ **Rendered mock, not a device capture** — built from the real `ServingTeamScreen` styles and the light-theme color tokens (`colors.warning` `#FF9500`, surface/border/text). This environment is a headless Linux runner with no iOS simulator.

[Serving Team roster before/after](https://images.togather.nyc/dev-assistant/2512c0c7-5021-4ddb-8ef8-93d7173a24d4-serving-unconfirmed-before-after.png)

Before, the unconfirmed teammate is absent. After, they appear with an amber **"Unconfirmed"** pill (clock icon), reusing the leader roster's "awaiting" vocabulary.

## Changes

**Backend — `apps/convex/functions/scheduling/`**
- `serving.ts`
  - `getServingEligibility`: an assigned-but-**unconfirmed** volunteer is now *eligible* to enter, but **`autoEnter` is still computed from confirmed assignments only** — eligible-but-not-auto-entered, so the nudge to accept stays meaningful without locking them out.
  - `getServingTeamRoster`: includes non-declined people and returns each person's accept `status` so the client can badge unconfirmed ones (one card per (user, role), so a person confirmed on one role and unconfirmed on another reads correctly).
  - `getServingUpcomingChannels`: resolves "coming soon" channels for non-declined assignments too (team chat already mirrors unconfirmed members into channels).
- `eventTasks.ts`
  - `getMyServingTasks`: an unconfirmed volunteer sees the tasks for the role they're assigned to (they can now enter and serve).
  - `getCrewTasks`: includes non-declined teammates and carries their `status`.
  - `myConfirmedAssignments` → renamed/widened to **`myServingAssignments`** (non-declined), so Shared/Crew reads and the shared-task-toggle gate admit unconfirmed teammates.
  - **Unchanged:** leader-facing readiness/fill math (`assigneesForTask`, `roster.ts`, `events.ts`) stays confirmed-only.

**Frontend — `apps/mobile/features/serving/`**
- `ServingTeamScreen.tsx`: a small **"Unconfirmed"** pill on unconfirmed person cards; empty-state copy no longer says "confirmed" ("No one else is on the team yet.").
- `ServingTasksScreen.tsx`: an **"Unconfirmed"** chip on unconfirmed crew rows.
- `ChatInboxScreen.tsx`: **no change needed** — the serving chip already keys off `eligible` and the auto-enter effect off `autoEnter`, so newly-eligible unconfirmed users get the manual chip but are never auto-entered.

> Note: these serving screens have no separate `.web.tsx` — they're single cross-platform files (rendered on web via react-native-web), so "web parity" is automatic. `ServingRunsheetScreen` is a launcher into the Rostering run sheet and renders no teammate list of its own, so it needed no per-row change; unconfirmed users reach it via the widened eligibility.

## Tests
- `serving.test.ts`: unconfirmed people appear on the roster (badged), declined stay hidden, unconfirmed callers reach their own plan, and `getServingEligibility` is `eligible: true / autoEnter: false` for unconfirmed, `true/true` for confirmed, `false/false` for declined.
- `eventTasks.test.ts`: an unconfirmed volunteer sees their role's tasks in "Mine"; `getCrewTasks` includes an unconfirmed teammate tagged `unconfirmed` and excludes a declined one.
- Full `apps/convex/__tests__/scheduling` suite green (358 passing); convex typecheck clean; mobile eslint/typecheck clean on touched files.

## Review call-outs
- Phone-number exposure in the Team roster already applies to teammates on the same event; this extends it to **unconfirmed** teammates on the same event — consistent with the existing behavior, but worth a look.
- The shared-task-toggle gate now admits unconfirmed teammates (they can flip a team-wide shared task). Intentional per the "reach the same resources" goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156x8CChUz3vD1mq2tYwima

---
_Generated by [Claude Code](https://claude.ai/code/session_0156x8CChUz3vD1mq2tYwima)_