### PR TITLE
Fix staging login crash on archived-community tokens + make "Send to developer" actually deliver

### DIFF
--- a/apps/convex/__tests__/notifications-archived-community.test.ts
+++ b/apps/convex/__tests__/notifications-archived-community.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Notification Queries — Archived Community Tests
+ *
+ * unreadCount, inboxSummary, and list are mounted unconditionally at app boot
+ * (NotificationProvider / Inbox), before the user can navigate away from a
+ * community that was archived out from under them. requireAuth's strict
+ * COMMUNITY_ARCHIVED rejection would throw during React render and crash the
+ * app (see lib/auth.ts requireAuthWithArchivedStatus). These queries must
+ * instead detect the archived community and return benign empty data.
+ *
+ * Run with: cd apps/convex && npx vitest run __tests__/notifications-archived-community.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+
+// Set up JWT secret for testing - must be at least 32 characters
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+interface TestSetup {
+  userId: Id<"users">;
+  archivedCommunityId: Id<"communities">;
+  activeCommunityId: Id<"communities">;
+  archivedToken: string;
+  activeToken: string;
+}
+
+async function seedTestData(t: ReturnType<typeof convexTest>): Promise<TestSetup> {
+  const ids = await t.run(async (ctx) => {
+    const now = Date.now();
+
+    const userId = await ctx.db.insert("users", {
+      firstName: "Test",
+      lastName: "User",
+      phone: "+12025559999",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const archivedCommunityId = await ctx.db.insert("communities", {
+      name: "Closed Church",
+      slug: "closed-church",
+      subdomain: "closed-church",
+      isArchived: true,
+      timezone: "America/New_York",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const activeCommunityId = await ctx.db.insert("communities", {
+      name: "Open Church",
+      slug: "open-church",
+      subdomain: "open-church",
+      isArchived: false,
+      timezone: "America/New_York",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // An unread notification tied to the user — should never surface once
+    // the token is scoped to an archived community.
+    await ctx.db.insert("notifications", {
+      userId,
+      communityId: archivedCommunityId,
+      notificationType: "announcement",
+      title: "Should not appear",
+      body: "This notification must not leak through an archived-community token.",
+      data: {},
+      status: "sent",
+      isRead: false,
+      createdAt: now,
+    });
+
+    return { userId, archivedCommunityId, activeCommunityId };
+  });
+
+  const [archived, active] = await Promise.all([
+    generateTokens(ids.userId, ids.archivedCommunityId),
+    generateTokens(ids.userId, ids.activeCommunityId),
+  ]);
+
+  return {
+    ...ids,
+    archivedToken: archived.accessToken,
+    activeToken: active.accessToken,
+  };
+}
+
+describe("notification queries with an archived-community token", () => {
+  test("unreadCount returns 0 instead of throwing", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+
+    const result = await t.query(
+      api.functions.notifications.queries.unreadCount,
+      { token: setup.archivedToken },
+    );
+
+    expect(result).toEqual({ unreadCount: 0 });
+  });
+
+  test("unreadCount still counts normally for a non-archived community", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+
+    // unreadCount counts notifications by userId regardless of which
+    // community the token is scoped to, so the seeded unread notification
+    // shows up for a token scoped to the (non-archived) active community.
+    // This confirms the normal path still executes and isn't short-circuited
+    // to 0 for every token.
+    const result = await t.query(
+      api.functions.notifications.queries.unreadCount,
+      { token: setup.activeToken },
+    );
+
+    expect(result).toEqual({ unreadCount: 1 });
+  });
+
+  test("inboxSummary returns a benign empty summary instead of throwing", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+
+    const result = await t.query(
+      api.functions.notifications.queries.inboxSummary,
+      { token: setup.archivedToken },
+    );
+
+    expect(result).toEqual({ latest: null, unreadCount: 0 });
+  });
+
+  test("list returns a benign empty page instead of throwing", async () => {
+    const t = convexTest(schema, modules);
+    const setup = await seedTestData(t);
+
+    const result = await t.query(api.functions.notifications.queries.list, {
+      token: setup.archivedToken,
+    });
+
+    expect(result).toEqual({
+      notifications: [],
+      unreadCount: 0,
+      totalCount: 0,
+    });
+  });
+});

--- a/apps/convex/__tests__/support-error-report.test.ts
+++ b/apps/convex/__tests__/support-error-report.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Error Report Support Email Tests
+ *
+ * Tests the sendErrorReport action (ErrorBoundary "Send to developer" flow)
+ * and its pure helpers, following the pattern in password-reset.test.ts
+ * (no live Resend calls; RESEND_API_KEY absent in tests).
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { modules } from "../test.setup";
+import { api } from "../_generated/api";
+import {
+  buildErrorReportEmail,
+  capLength,
+} from "../functions/support/sendErrorReport";
+
+describe("capLength", () => {
+  test("returns the original string when under the limit", () => {
+    expect(capLength("hello", 10)).toBe("hello");
+  });
+
+  test("returns the original string when exactly at the limit", () => {
+    expect(capLength("hello", 5)).toBe("hello");
+  });
+
+  test("truncates and appends a marker when over the limit", () => {
+    const result = capLength("a".repeat(100), 20);
+    expect(result.length).toBe(20);
+    expect(result.endsWith("… [truncated]")).toBe(true);
+    expect(result.startsWith("a".repeat(20 - "\n… [truncated]".length))).toBe(
+      true
+    );
+  });
+});
+
+describe("buildErrorReportEmail", () => {
+  test("builds a payload addressed to the support inbox", () => {
+    const email = buildErrorReportEmail({
+      subject: "Togather error report — TypeError",
+      body: "Technical details here",
+    });
+
+    expect(email.to).toBe("togather@supa.media");
+    expect(email.subject).toBe("Togather error report — TypeError");
+    expect(email.text).toBe("Technical details here");
+    expect(email.from).toBeTruthy();
+  });
+
+  test("falls back to a default subject when the client sends an empty/blank one", () => {
+    const email = buildErrorReportEmail({ subject: "   ", body: "body" });
+    expect(email.subject).toBe("Togather error report");
+  });
+
+  test("caps an oversized subject server-side", () => {
+    const email = buildErrorReportEmail({
+      subject: "x".repeat(500),
+      body: "body",
+    });
+    expect(email.subject.length).toBeLessThanOrEqual(200);
+    expect(email.subject.endsWith("… [truncated]")).toBe(true);
+  });
+
+  test("caps an oversized body server-side", () => {
+    const email = buildErrorReportEmail({
+      subject: "subject",
+      body: "y".repeat(50000),
+    });
+    expect(email.text.length).toBeLessThanOrEqual(20000);
+    expect(email.text.endsWith("… [truncated]")).toBe(true);
+  });
+
+  test("never trusts a client-supplied recipient (no recipient field accepted)", () => {
+    const email = buildErrorReportEmail({
+      subject: "subject",
+      body: "body",
+      // @ts-expect-error - `to` is intentionally not part of the accepted args
+      to: "attacker@example.com",
+    });
+    expect(email.to).toBe("togather@supa.media");
+  });
+});
+
+describe("sendErrorReport action", () => {
+  test("returns success: false when Resend is unavailable (no crash, no throw)", async () => {
+    const t = convexTest(schema, modules);
+    const prevKey = process.env.RESEND_API_KEY;
+    delete process.env.RESEND_API_KEY;
+    try {
+      const result = await t.action(
+        api.functions.support.sendErrorReport.sendErrorReport,
+        {
+          subject: "Togather error report — TypeError",
+          body: "Error: boom\nStack: ...",
+        }
+      );
+      expect(result).toEqual({ success: false });
+    } finally {
+      if (prevKey !== undefined) process.env.RESEND_API_KEY = prevKey;
+    }
+  });
+
+  test("is callable without an auth token (unauthenticated action)", async () => {
+    const t = convexTest(schema, modules);
+    delete process.env.RESEND_API_KEY;
+    // No t.withIdentity(...) — this must not throw an auth error.
+    await expect(
+      t.action(api.functions.support.sendErrorReport.sendErrorReport, {
+        subject: "subject",
+        body: "body",
+      })
+    ).resolves.toEqual({ success: false });
+  });
+
+  test("rate limits after repeated calls within the window", async () => {
+    const t = convexTest(schema, modules);
+    delete process.env.RESEND_API_KEY;
+
+    // Pre-fill the shared rate limit bucket at its cap so the next call
+    // is rejected without needing 100 real invocations.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("rateLimits", {
+        key: "error-report:global",
+        attempts: 100,
+        windowStart: Date.now(),
+      });
+    });
+
+    const result = await t.action(
+      api.functions.support.sendErrorReport.sendErrorReport,
+      { subject: "subject", body: "body" }
+    );
+    expect(result).toEqual({ success: false });
+  });
+});

--- a/apps/convex/__tests__/support-error-report.test.ts
+++ b/apps/convex/__tests__/support-error-report.test.ts
@@ -43,22 +43,38 @@ describe("buildErrorReportEmail", () => {
     });
 
     expect(email.to).toBe("togather@supa.media");
-    expect(email.subject).toBe("Togather error report — TypeError");
+    expect(email.subject).toBe(
+      "[Togather error report] Togather error report — TypeError"
+    );
     expect(email.text).toBe("Technical details here");
     expect(email.from).toBeTruthy();
   });
 
-  test("falls back to a default subject when the client sends an empty/blank one", () => {
-    const email = buildErrorReportEmail({ subject: "   ", body: "body" });
-    expect(email.subject).toBe("Togather error report");
+  test("always applies a fixed server-side subject prefix, even to a fabricated subject", () => {
+    const email = buildErrorReportEmail({
+      subject: "URGENT: wire money now",
+      body: "body",
+    });
+    expect(email.subject).toBe("[Togather error report] URGENT: wire money now");
+    expect(email.subject.startsWith("[Togather error report] ")).toBe(true);
   });
 
-  test("caps an oversized subject server-side", () => {
+  test("falls back to a default subject when the client sends an empty/blank one", () => {
+    const email = buildErrorReportEmail({ subject: "   ", body: "body" });
+    expect(email.subject).toBe("[Togather error report] Togather error report");
+  });
+
+  test("caps an oversized subject server-side (prefix applied after capping)", () => {
     const email = buildErrorReportEmail({
       subject: "x".repeat(500),
       body: "body",
     });
-    expect(email.subject.length).toBeLessThanOrEqual(200);
+    // The 200-char cap applies to the client-supplied portion; the fixed
+    // prefix is added on top of that, so total length can exceed 200.
+    expect(email.subject.startsWith("[Togather error report] ")).toBe(true);
+    expect(
+      email.subject.length - "[Togather error report] ".length
+    ).toBeLessThanOrEqual(200);
     expect(email.subject.endsWith("… [truncated]")).toBe(true);
   });
 
@@ -83,7 +99,7 @@ describe("buildErrorReportEmail", () => {
 });
 
 describe("sendErrorReport action", () => {
-  test("returns success: false when Resend is unavailable (no crash, no throw)", async () => {
+  test("returns { success: false, reason: 'unavailable' } when Resend is unavailable (no crash, no throw)", async () => {
     const t = convexTest(schema, modules);
     const prevKey = process.env.RESEND_API_KEY;
     delete process.env.RESEND_API_KEY;
@@ -93,9 +109,10 @@ describe("sendErrorReport action", () => {
         {
           subject: "Togather error report — TypeError",
           body: "Error: boom\nStack: ...",
+          reportKey: "device-abc",
         }
       );
-      expect(result).toEqual({ success: false });
+      expect(result).toEqual({ success: false, reason: "unavailable" });
     } finally {
       if (prevKey !== undefined) process.env.RESEND_API_KEY = prevKey;
     }
@@ -110,27 +127,106 @@ describe("sendErrorReport action", () => {
         subject: "subject",
         body: "body",
       })
-    ).resolves.toEqual({ success: false });
+    ).resolves.toEqual({ success: false, reason: "unavailable" });
   });
 
-  test("rate limits after repeated calls within the window", async () => {
+  test("is callable without a reportKey (falls back to the 'anonymous' bucket)", async () => {
+    const t = convexTest(schema, modules);
+    delete process.env.RESEND_API_KEY;
+    await expect(
+      t.action(api.functions.support.sendErrorReport.sendErrorReport, {
+        subject: "subject",
+        body: "body",
+      })
+    ).resolves.toEqual({ success: false, reason: "unavailable" });
+
+    const bucket = await t.run(async (ctx) => {
+      return ctx.db
+        .query("rateLimits")
+        .withIndex("by_key", (q) => q.eq("key", "error-report:key:anonymous"))
+        .first();
+    });
+    expect(bucket).not.toBeNull();
+  });
+
+  test("sanitizes a malformed/oversized reportKey before using it as a rate-limit bucket key", async () => {
     const t = convexTest(schema, modules);
     delete process.env.RESEND_API_KEY;
 
-    // Pre-fill the shared rate limit bucket at its cap so the next call
-    // is rejected without needing 100 real invocations.
+    const maliciousKey = "../../etc/passwd".repeat(10); // contains '/', '.', and is way over the length cap
+    await t.action(api.functions.support.sendErrorReport.sendErrorReport, {
+      subject: "subject",
+      body: "body",
+      reportKey: maliciousKey,
+    });
+
+    const buckets = await t.run(async (ctx) => ctx.db.query("rateLimits").collect());
+    // No bucket key should contain the raw malicious characters or exceed a
+    // sane length — sanitizeReportKey must have stripped/capped it.
+    for (const bucket of buckets) {
+      expect(bucket.key).not.toContain("..");
+      expect(bucket.key.length).toBeLessThan(100);
+    }
+  });
+
+  test("rate limits per-key after repeated calls from the same reportKey (reason: rate_limited)", async () => {
+    const t = convexTest(schema, modules);
+    delete process.env.RESEND_API_KEY;
+
+    // Pre-fill this caller's own bucket at its cap (5/hour) so the next call
+    // from the same key is rejected without needing 5 real invocations.
     await t.run(async (ctx) => {
       await ctx.db.insert("rateLimits", {
-        key: "error-report:global",
-        attempts: 100,
+        key: "error-report:key:device-xyz",
+        attempts: 5,
         windowStart: Date.now(),
       });
     });
 
     const result = await t.action(
       api.functions.support.sendErrorReport.sendErrorReport,
-      { subject: "subject", body: "body" }
+      { subject: "subject", body: "body", reportKey: "device-xyz" }
     );
-    expect(result).toEqual({ success: false });
+    expect(result).toEqual({ success: false, reason: "rate_limited" });
+  });
+
+  test("a different reportKey is NOT blocked by another key's exhausted bucket", async () => {
+    const t = convexTest(schema, modules);
+    delete process.env.RESEND_API_KEY;
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("rateLimits", {
+        key: "error-report:key:device-exhausted",
+        attempts: 5,
+        windowStart: Date.now(),
+      });
+    });
+
+    // A fresh key should still be allowed through to the (unconfigured
+    // Resend) send path, i.e. fail with "unavailable", not "rate_limited".
+    const result = await t.action(
+      api.functions.support.sendErrorReport.sendErrorReport,
+      { subject: "subject", body: "body", reportKey: "device-fresh" }
+    );
+    expect(result).toEqual({ success: false, reason: "unavailable" });
+  });
+
+  test("falls back to the global backstop once it's exhausted, even with distinct per-key buckets", async () => {
+    const t = convexTest(schema, modules);
+    delete process.env.RESEND_API_KEY;
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("rateLimits", {
+        key: "error-report:global",
+        attempts: 500,
+        windowStart: Date.now(),
+      });
+    });
+
+    const result = await t.action(
+      api.functions.support.sendErrorReport.sendErrorReport,
+      { subject: "subject", body: "body", reportKey: "brand-new-key" }
+    );
+    expect(result).toEqual({ success: false, reason: "rate_limited" });
   });
 });

--- a/apps/convex/_generated/api.d.ts
+++ b/apps/convex/_generated/api.d.ts
@@ -189,6 +189,7 @@ import type * as functions_slackServiceBot_prompts from "../functions/slackServi
 import type * as functions_slackServiceBot_seedConfig from "../functions/slackServiceBot/seedConfig.js";
 import type * as functions_slackServiceBot_slack from "../functions/slackServiceBot/slack.js";
 import type * as functions_slackServiceBot_tools from "../functions/slackServiceBot/tools.js";
+import type * as functions_support_sendErrorReport from "../functions/support/sendErrorReport.js";
 import type * as functions_sync_memberships from "../functions/sync/memberships.js";
 import type * as functions_syncHelpers from "../functions/syncHelpers.js";
 import type * as functions_systemScoring from "../functions/systemScoring.js";
@@ -429,6 +430,7 @@ declare const fullApi: ApiFromModules<{
   "functions/slackServiceBot/seedConfig": typeof functions_slackServiceBot_seedConfig;
   "functions/slackServiceBot/slack": typeof functions_slackServiceBot_slack;
   "functions/slackServiceBot/tools": typeof functions_slackServiceBot_tools;
+  "functions/support/sendErrorReport": typeof functions_support_sendErrorReport;
   "functions/sync/memberships": typeof functions_sync_memberships;
   "functions/syncHelpers": typeof functions_syncHelpers;
   "functions/systemScoring": typeof functions_systemScoring;

--- a/apps/convex/functions/auth/emailOtp.ts
+++ b/apps/convex/functions/auth/emailOtp.ts
@@ -8,7 +8,6 @@
  * Uses Resend for email delivery with custom verification code templates.
  */
 
-import { Resend } from "resend";
 import { render } from "@react-email/render";
 import {
   VerificationCodeEmail,
@@ -18,24 +17,13 @@ import { internal } from "../../_generated/api";
 import { ActionCtx } from "../../_generated/server";
 import { MAGIC_CODE, isTestEmail } from "./helpers";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
+import { getResendClient } from "../../lib/resend";
 
 /** Which auth flow the email OTP belongs to (stored and verified with the code). */
 export type EmailOtpPurpose = "account_claim" | "password_reset";
 
 // Email sender address - use shared config (notifications@togather.nyc)
 const EMAIL_FROM = DOMAIN_CONFIG.emailFrom;
-
-// Lazy-initialize Resend client to avoid throwing if API key is missing at module load
-let resendClient: Resend | null = null;
-function getResendClient(): Resend | null {
-  if (!process.env.RESEND_API_KEY) {
-    return null;
-  }
-  if (!resendClient) {
-    resendClient = new Resend(process.env.RESEND_API_KEY);
-  }
-  return resendClient;
-}
 
 /**
  * Generate a random 6-digit code

--- a/apps/convex/functions/notifications/queries.ts
+++ b/apps/convex/functions/notifications/queries.ts
@@ -36,9 +36,11 @@ export const list = query({
       args.token,
     );
     // This query is mounted unconditionally at app boot (via the Inbox and
-    // notifications feed), so a token scoped to an archived community must
-    // get benign empty data rather than the strict requireAuth rejection —
-    // see requireAuthWithArchivedStatus.
+    // notifications feed). The mobile AuthErrorBoundary now provides
+    // recovery UI for a COMMUNITY_ARCHIVED throw, but short-circuiting here
+    // is still intentional defense-in-depth to skip that crash-recovery
+    // churn on boot — see requireAuthWithArchivedStatus. New boot queries
+    // don't need to copy this pattern.
     if (isArchivedCommunity) {
       return { notifications: [], unreadCount: 0, totalCount: 0 };
     }
@@ -103,8 +105,10 @@ export const inboxSummary = query({
       ctx,
       args.token,
     );
-    // Mounted unconditionally at app boot (Inbox row) — see unreadCount below
-    // for why an archived-community token gets benign empty data.
+    // Mounted unconditionally at app boot (Inbox row). AuthErrorBoundary
+    // could recover from a COMMUNITY_ARCHIVED throw here too, but returning
+    // benign data avoids that crash-recovery churn on boot — see
+    // requireAuthWithArchivedStatus and unreadCount below.
     if (isArchivedCommunity) {
       return { latest: null, unreadCount: 0 };
     }
@@ -151,9 +155,12 @@ export const unreadCount = query({
       args.token,
     );
     // This query mounts unconditionally as soon as any token exists
-    // (NotificationProvider) — before the user can navigate away from an
-    // archived community. requireAuth's strict throw would crash render
-    // (see requireAuthWithArchivedStatus doc), so return a benign 0 instead.
+    // (NotificationProvider), before the user can navigate away from an
+    // archived community. The mobile AuthErrorBoundary is recovery UI for
+    // exactly this throw now, but returning a benign 0 here is still
+    // intentional defense-in-depth against crash-recovery churn on every
+    // boot — see requireAuthWithArchivedStatus. New boot queries don't need
+    // to copy this pattern.
     if (isArchivedCommunity) {
       return { unreadCount: 0 };
     }

--- a/apps/convex/functions/notifications/queries.ts
+++ b/apps/convex/functions/notifications/queries.ts
@@ -6,7 +6,7 @@
 
 import { v } from "convex/values";
 import { query } from "../../_generated/server";
-import { requireAuth } from "../../lib/auth";
+import { requireAuthWithArchivedStatus } from "../../lib/auth";
 
 /**
  * Notification types that represent chat messages. These are deliberately
@@ -31,7 +31,18 @@ export const list = query({
     unreadOnly: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuth(ctx, args.token);
+    const { userId, isArchivedCommunity } = await requireAuthWithArchivedStatus(
+      ctx,
+      args.token,
+    );
+    // This query is mounted unconditionally at app boot (via the Inbox and
+    // notifications feed), so a token scoped to an archived community must
+    // get benign empty data rather than the strict requireAuth rejection —
+    // see requireAuthWithArchivedStatus.
+    if (isArchivedCommunity) {
+      return { notifications: [], unreadCount: 0, totalCount: 0 };
+    }
+
     const limit = Math.min(args.limit ?? 50, 100);
     const offset = args.offset ?? 0;
 
@@ -88,7 +99,15 @@ export const inboxSummary = query({
     token: v.string(),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuth(ctx, args.token);
+    const { userId, isArchivedCommunity } = await requireAuthWithArchivedStatus(
+      ctx,
+      args.token,
+    );
+    // Mounted unconditionally at app boot (Inbox row) — see unreadCount below
+    // for why an archived-community token gets benign empty data.
+    if (isArchivedCommunity) {
+      return { latest: null, unreadCount: 0 };
+    }
 
     // Newest-first; exclude chat-message notifications (see
     // CHAT_NOTIFICATION_TYPES) so the row mirrors the feed exactly.
@@ -127,7 +146,18 @@ export const unreadCount = query({
     token: v.string(),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuth(ctx, args.token);
+    const { userId, isArchivedCommunity } = await requireAuthWithArchivedStatus(
+      ctx,
+      args.token,
+    );
+    // This query mounts unconditionally as soon as any token exists
+    // (NotificationProvider) — before the user can navigate away from an
+    // archived community. requireAuth's strict throw would crash render
+    // (see requireAuthWithArchivedStatus doc), so return a benign 0 instead.
+    if (isArchivedCommunity) {
+      return { unreadCount: 0 };
+    }
+
     const notifications = await ctx.db
       .query("notifications")
       .withIndex("by_user_read_created", (q) =>

--- a/apps/convex/functions/support/sendErrorReport.ts
+++ b/apps/convex/functions/support/sendErrorReport.ts
@@ -4,8 +4,8 @@
  *
  * Delivers "Send to developer" crash reports from the app-root ErrorBoundary
  * (apps/mobile/components/ErrorBoundary.tsx) to the Togather support inbox
- * via Resend. Mirrors the lazy-Resend-client / RESEND_API_KEY pattern in
- * auth/emailOtp.ts.
+ * via Resend. Uses the shared lazy-Resend-client from `lib/resend.ts` (also
+ * used by auth/emailOtp.ts).
  *
  * Must be callable WITHOUT authentication: the ErrorBoundary renders above
  * AuthProvider, so a crash before/during auth setup still needs to be able
@@ -13,10 +13,10 @@
  */
 
 import { v } from "convex/values";
-import { Resend } from "resend";
 import { action } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
+import { getResendClient } from "../../lib/resend";
 
 /**
  * Where crash reports are delivered. Sourced here (server-side) rather than
@@ -29,34 +29,43 @@ const EMAIL_FROM = DOMAIN_CONFIG.emailFrom;
 /**
  * Abuse guards.
  *
- * This action is unauthenticated by design (see file header), so unlike
- * the OTP flows in auth/phoneOtp.ts / auth/emailOtp.ts there's no user
- * identity (phone/email) to key a per-caller rate limit on — the existing
- * `lib/rateLimit.ts` helper (checked before adding this) is generic and
- * reused here, just keyed on a single deployment-wide bucket instead of a
- * per-user one. The cap is intentionally generous: a real incident causing
- * many simultaneous crashes is exactly when reports matter most, so this
- * only needs to stop a runaway loop or scripted flood, not throttle normal
- * usage.
+ * This action is unauthenticated by design (see file header), so unlike the
+ * OTP flows in auth/phoneOtp.ts / auth/emailOtp.ts there's no user identity
+ * (phone/email) to key a rate limit on. Instead the client sends a
+ * `reportKey` — a random id it generates once and persists in AsyncStorage
+ * (see ErrorBoundary.tsx). This key is entirely client-supplied and
+ * therefore spoofable/forgeable by an attacker; it does NOT provide real
+ * authentication. Its purpose is narrower: it lets honest clients (the vast
+ * majority of callers) get their own rate bucket instead of all sharing one
+ * global bucket that a single scripted client could exhaust for everyone.
+ * An attacker who rotates the key on every request just falls back to the
+ * global backstop below, same as before this change.
  */
-const RATE_LIMIT_KEY = "error-report:global";
-const RATE_LIMIT_MAX_ATTEMPTS = 100;
-const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const PER_KEY_RATE_LIMIT_MAX_ATTEMPTS = 5;
+const PER_KEY_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+const GLOBAL_RATE_LIMIT_KEY = "error-report:global";
+const GLOBAL_RATE_LIMIT_MAX_ATTEMPTS = 500;
+const GLOBAL_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 /** Server-side length caps — never trust client-supplied string sizes. */
 const MAX_SUBJECT_LENGTH = 200;
 const MAX_BODY_LENGTH = 20000;
+const MAX_REPORT_KEY_LENGTH = 64;
 
-// Lazy-initialize Resend client to avoid throwing if API key is missing at module load
-let resendClient: Resend | null = null;
-function getResendClient(): Resend | null {
-  if (!process.env.RESEND_API_KEY) {
-    return null;
-  }
-  if (!resendClient) {
-    resendClient = new Resend(process.env.RESEND_API_KEY);
-  }
-  return resendClient;
+/** Fixed prefix applied to every outgoing subject, server-side. */
+const SUBJECT_PREFIX = "[Togather error report] ";
+
+/**
+ * Bucket key for a client-supplied `reportKey`. Sanitized to a conservative
+ * character set and capped in length so a malformed/oversized/adversarial
+ * key can't be used to smuggle data into the rate-limit key or blow up the
+ * `rateLimits` table with garbage keys.
+ */
+function sanitizeReportKey(rawKey: string | undefined): string {
+  const trimmed = (rawKey ?? "").trim().slice(0, MAX_REPORT_KEY_LENGTH);
+  const sanitized = trimmed.replace(/[^a-zA-Z0-9_-]/g, "");
+  return sanitized.length > 0 ? sanitized : "anonymous";
 }
 
 /**
@@ -74,8 +83,15 @@ export function capLength(value: string, maxLength: number): string {
 
 /**
  * Builds the Resend payload from raw client input, applying the server-side
- * length caps and fixed from/to addresses. Pulled out as a pure function so
- * the capping/payload logic is unit-testable without a live Resend client.
+ * length caps, a fixed subject prefix, and fixed from/to addresses. Pulled
+ * out as a pure function so the capping/payload logic is unit-testable
+ * without a live Resend client.
+ *
+ * The fixed `SUBJECT_PREFIX` is not optional/skippable by the client — it
+ * guarantees every email this action can ever send is unambiguously
+ * labeled as a self-serve crash report, so this unauthenticated endpoint
+ * can't be abused to send mail from our trusted sender with an arbitrary
+ * subject.
  */
 export function buildErrorReportEmail(args: { subject: string; body: string }): {
   from: string;
@@ -84,10 +100,11 @@ export function buildErrorReportEmail(args: { subject: string; body: string }): 
   text: string;
 } {
   const trimmedSubject = args.subject.trim();
-  const subject = capLength(
+  const clientSubject = capLength(
     trimmedSubject.length > 0 ? trimmedSubject : "Togather error report",
     MAX_SUBJECT_LENGTH
   );
+  const subject = SUBJECT_PREFIX + clientSubject;
   const text = capLength(args.body, MAX_BODY_LENGTH);
 
   return {
@@ -98,29 +115,52 @@ export function buildErrorReportEmail(args: { subject: string; body: string }): 
   };
 }
 
+/** Typed failure reasons so the UI can show accurate, non-misleading copy. */
+export type SendErrorReportResult =
+  | { success: true }
+  | { success: false; reason: "rate_limited" | "unavailable" | "send_failed" };
+
 /**
  * Sends a crash report from the ErrorBoundary's "Send to developer" button.
  * Unauthenticated — see file header. Never throws; failures are reported
- * back as `{ success: false }` so the UI can show a distinct failed state.
+ * back as `{ success: false, reason }` so the UI can show an accurate
+ * failure state instead of a generic one.
  */
 export const sendErrorReport = action({
   args: {
     subject: v.string(),
     body: v.string(),
+    reportKey: v.optional(v.string()),
   },
-  handler: async (ctx, args): Promise<{ success: boolean }> => {
+  handler: async (ctx, args): Promise<SendErrorReportResult> => {
+    const reportKey = sanitizeReportKey(args.reportKey);
+
     try {
       await ctx.runMutation(
         internal.functions.authInternal.checkRateLimitInternal,
         {
-          key: RATE_LIMIT_KEY,
-          maxAttempts: RATE_LIMIT_MAX_ATTEMPTS,
-          windowMs: RATE_LIMIT_WINDOW_MS,
+          key: `error-report:key:${reportKey}`,
+          maxAttempts: PER_KEY_RATE_LIMIT_MAX_ATTEMPTS,
+          windowMs: PER_KEY_RATE_LIMIT_WINDOW_MS,
         }
       );
     } catch (error) {
-      console.warn("[Error Report] Rate limited:", error);
-      return { success: false };
+      console.warn("[Error Report] Per-key rate limited:", error);
+      return { success: false, reason: "rate_limited" };
+    }
+
+    try {
+      await ctx.runMutation(
+        internal.functions.authInternal.checkRateLimitInternal,
+        {
+          key: GLOBAL_RATE_LIMIT_KEY,
+          maxAttempts: GLOBAL_RATE_LIMIT_MAX_ATTEMPTS,
+          windowMs: GLOBAL_RATE_LIMIT_WINDOW_MS,
+        }
+      );
+    } catch (error) {
+      console.warn("[Error Report] Global rate limited:", error);
+      return { success: false, reason: "rate_limited" };
     }
 
     const resend = getResendClient();
@@ -128,7 +168,7 @@ export const sendErrorReport = action({
       console.error(
         "Resend not configured for error reports - missing RESEND_API_KEY environment variable"
       );
-      return { success: false };
+      return { success: false, reason: "unavailable" };
     }
 
     const email = buildErrorReportEmail(args);
@@ -138,7 +178,7 @@ export const sendErrorReport = action({
 
       if (response.error) {
         console.error("Resend API error sending error report:", response.error);
-        return { success: false };
+        return { success: false, reason: "send_failed" };
       }
 
       console.log("[Error Report] Sent to support", {
@@ -147,7 +187,7 @@ export const sendErrorReport = action({
       return { success: true };
     } catch (error) {
       console.error("Error sending error report email:", error);
-      return { success: false };
+      return { success: false, reason: "send_failed" };
     }
   },
 });

--- a/apps/convex/functions/support/sendErrorReport.ts
+++ b/apps/convex/functions/support/sendErrorReport.ts
@@ -1,0 +1,153 @@
+"use node";
+/**
+ * Error Report Support Email
+ *
+ * Delivers "Send to developer" crash reports from the app-root ErrorBoundary
+ * (apps/mobile/components/ErrorBoundary.tsx) to the Togather support inbox
+ * via Resend. Mirrors the lazy-Resend-client / RESEND_API_KEY pattern in
+ * auth/emailOtp.ts.
+ *
+ * Must be callable WITHOUT authentication: the ErrorBoundary renders above
+ * AuthProvider, so a crash before/during auth setup still needs to be able
+ * to reach us.
+ */
+
+import { v } from "convex/values";
+import { Resend } from "resend";
+import { action } from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import { DOMAIN_CONFIG } from "@togather/shared/config";
+
+/**
+ * Where crash reports are delivered. Sourced here (server-side) rather than
+ * trusting a client-supplied recipient — the client only sends subject/body.
+ */
+const SUPPORT_EMAIL = "togather@supa.media";
+
+const EMAIL_FROM = DOMAIN_CONFIG.emailFrom;
+
+/**
+ * Abuse guards.
+ *
+ * This action is unauthenticated by design (see file header), so unlike
+ * the OTP flows in auth/phoneOtp.ts / auth/emailOtp.ts there's no user
+ * identity (phone/email) to key a per-caller rate limit on — the existing
+ * `lib/rateLimit.ts` helper (checked before adding this) is generic and
+ * reused here, just keyed on a single deployment-wide bucket instead of a
+ * per-user one. The cap is intentionally generous: a real incident causing
+ * many simultaneous crashes is exactly when reports matter most, so this
+ * only needs to stop a runaway loop or scripted flood, not throttle normal
+ * usage.
+ */
+const RATE_LIMIT_KEY = "error-report:global";
+const RATE_LIMIT_MAX_ATTEMPTS = 100;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+/** Server-side length caps — never trust client-supplied string sizes. */
+const MAX_SUBJECT_LENGTH = 200;
+const MAX_BODY_LENGTH = 20000;
+
+// Lazy-initialize Resend client to avoid throwing if API key is missing at module load
+let resendClient: Resend | null = null;
+function getResendClient(): Resend | null {
+  if (!process.env.RESEND_API_KEY) {
+    return null;
+  }
+  if (!resendClient) {
+    resendClient = new Resend(process.env.RESEND_API_KEY);
+  }
+  return resendClient;
+}
+
+/**
+ * Truncates `value` to at most `maxLength` characters, appending a marker
+ * so a truncated report is obviously incomplete rather than silently cut.
+ */
+export function capLength(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  const marker = "\n… [truncated]";
+  const keep = Math.max(0, maxLength - marker.length);
+  return value.slice(0, keep) + marker;
+}
+
+/**
+ * Builds the Resend payload from raw client input, applying the server-side
+ * length caps and fixed from/to addresses. Pulled out as a pure function so
+ * the capping/payload logic is unit-testable without a live Resend client.
+ */
+export function buildErrorReportEmail(args: { subject: string; body: string }): {
+  from: string;
+  to: string;
+  subject: string;
+  text: string;
+} {
+  const trimmedSubject = args.subject.trim();
+  const subject = capLength(
+    trimmedSubject.length > 0 ? trimmedSubject : "Togather error report",
+    MAX_SUBJECT_LENGTH
+  );
+  const text = capLength(args.body, MAX_BODY_LENGTH);
+
+  return {
+    from: EMAIL_FROM,
+    to: SUPPORT_EMAIL,
+    subject,
+    text,
+  };
+}
+
+/**
+ * Sends a crash report from the ErrorBoundary's "Send to developer" button.
+ * Unauthenticated — see file header. Never throws; failures are reported
+ * back as `{ success: false }` so the UI can show a distinct failed state.
+ */
+export const sendErrorReport = action({
+  args: {
+    subject: v.string(),
+    body: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ success: boolean }> => {
+    try {
+      await ctx.runMutation(
+        internal.functions.authInternal.checkRateLimitInternal,
+        {
+          key: RATE_LIMIT_KEY,
+          maxAttempts: RATE_LIMIT_MAX_ATTEMPTS,
+          windowMs: RATE_LIMIT_WINDOW_MS,
+        }
+      );
+    } catch (error) {
+      console.warn("[Error Report] Rate limited:", error);
+      return { success: false };
+    }
+
+    const resend = getResendClient();
+    if (!resend) {
+      console.error(
+        "Resend not configured for error reports - missing RESEND_API_KEY environment variable"
+      );
+      return { success: false };
+    }
+
+    const email = buildErrorReportEmail(args);
+
+    try {
+      const response = await resend.emails.send(email);
+
+      if (response.error) {
+        console.error("Resend API error sending error report:", response.error);
+        return { success: false };
+      }
+
+      console.log("[Error Report] Sent to support", {
+        messageId: response.data?.id,
+      });
+      return { success: true };
+    } catch (error) {
+      console.error("Error sending error report email:", error);
+      return { success: false };
+    }
+  },
+});

--- a/apps/convex/lib/auth.ts
+++ b/apps/convex/lib/auth.ts
@@ -562,10 +562,13 @@ export async function requireAuthAllowArchivedCommunity(
 /**
  * Like {@link requireAuthAllowArchivedCommunity} but also reports whether the
  * token's community is archived, for the handful of queries mounted
- * unconditionally at app boot (e.g. notification badge counts). Those queries
- * can't reject with COMMUNITY_ARCHIVED — convex/react re-throws query errors
- * during render, and these mount above any recovery UI — so they use this to
- * branch and return benign empty data instead.
+ * unconditionally at app boot (e.g. notification badge counts). The mobile
+ * `AuthErrorBoundary` (providers/AuthErrorBoundary.tsx) *is* recovery UI and
+ * sits below these queries in the tree, so it would catch a COMMUNITY_ARCHIVED
+ * throw from them too — but short-circuiting here is still intentional
+ * defense-in-depth to avoid crash-recovery churn on every boot for queries
+ * that don't need to reject at all. New boot queries do not need to copy
+ * this pattern; only reach for it if a real crash-recovery loop shows up.
  */
 export async function requireAuthWithArchivedStatus(
   ctx: QueryCtx | MutationCtx,

--- a/apps/convex/lib/auth.ts
+++ b/apps/convex/lib/auth.ts
@@ -560,6 +560,25 @@ export async function requireAuthAllowArchivedCommunity(
 }
 
 /**
+ * Like {@link requireAuthAllowArchivedCommunity} but also reports whether the
+ * token's community is archived, for the handful of queries mounted
+ * unconditionally at app boot (e.g. notification badge counts). Those queries
+ * can't reject with COMMUNITY_ARCHIVED — convex/react re-throws query errors
+ * during render, and these mount above any recovery UI — so they use this to
+ * branch and return benign empty data instead.
+ */
+export async function requireAuthWithArchivedStatus(
+  ctx: QueryCtx | MutationCtx,
+  token: string,
+): Promise<{ userId: Id<"users">; isArchivedCommunity: boolean }> {
+  const { userId, communityId } = await requireAuthResolved(ctx, token);
+  const isArchivedCommunity = communityId
+    ? await isCommunityArchived(ctx, communityId)
+    : false;
+  return { userId, isArchivedCommunity };
+}
+
+/**
  * Shared core for {@link requireAuth}: verifies the access token, resolves the
  * user, and enforces revocation. Returns the userId plus the community the
  * token is scoped to (if any), without applying the archived-community gate.

--- a/apps/convex/lib/resend.ts
+++ b/apps/convex/lib/resend.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared lazy Resend client.
+ *
+ * Both auth/emailOtp.ts and support/sendErrorReport.ts need a Resend client
+ * that's only constructed (and only throws on a missing API key) when an
+ * email actually needs to be sent — not at module load, since that would
+ * break Convex codegen/import in environments without RESEND_API_KEY set.
+ * Pulled out here so the two call sites don't duplicate the same lazy-init
+ * logic.
+ */
+
+import { Resend } from "resend";
+
+let resendClient: Resend | null = null;
+
+/**
+ * Returns a lazily-constructed Resend client, or null if RESEND_API_KEY is
+ * not configured in this environment.
+ */
+export function getResendClient(): Resend | null {
+  if (!process.env.RESEND_API_KEY) {
+    return null;
+  }
+  if (!resendClient) {
+    resendClient = new Resend(process.env.RESEND_API_KEY);
+  }
+  return resendClient;
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -21,6 +21,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 // Note: KeyboardProvider from react-native-keyboard-controller was causing conflicts
 // with Stream Chat's overlay system during interactive keyboard dismiss
 import { AuthProvider } from "@providers/AuthProvider";
+import { AuthErrorBoundary } from "@providers/AuthErrorBoundary";
 import { KnicksModeSync } from "@providers/KnicksModeSync";
 import { EnvironmentProvider, useEnvironment } from "@providers/EnvironmentProvider";
 import { ImageViewerProvider } from "@providers/ImageViewerProvider";
@@ -256,6 +257,7 @@ function AppLayout() {
       <ConnectionProvider>
         <QueryClientProvider client={queryClient}>
         <AuthProvider>
+          <AuthErrorBoundary>
           <KnicksModeSync />
           <PostHogProvider>
             <ImageViewerProvider>
@@ -278,6 +280,7 @@ function AppLayout() {
             </ChatPrefetchProvider>
             </ImageViewerProvider>
           </PostHogProvider>
+          </AuthErrorBoundary>
         </AuthProvider>
         </QueryClientProvider>
       </ConnectionProvider>

--- a/apps/mobile/components/ErrorBoundary.tsx
+++ b/apps/mobile/components/ErrorBoundary.tsx
@@ -5,15 +5,53 @@ import {
   StyleSheet,
   TouchableOpacity,
   Image,
+  Linking,
   Platform,
 } from 'react-native';
 import { router } from 'expo-router';
 import Constants from 'expo-constants';
 import * as Application from 'expo-application';
+import * as MailComposer from 'expo-mail-composer';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SentryUtils } from '@providers/SentryProvider';
 import { convexVanilla, api } from '@services/api/convex';
 
 const sadGif = require('../assets/sad.gif');
+
+/** Where "Send to developer" reports are delivered (native mailto/MailComposer path only — the web/Convex path sources the recipient server-side). */
+const SUPPORT_EMAIL = 'togather@supa.media';
+
+/**
+ * AsyncStorage key for the random per-install id sent as `reportKey` to the
+ * sendErrorReport action (web path only). This is a rate-limiting nicety,
+ * NOT authentication: it's entirely client-generated and spoofable, and
+ * exists only so honest clients get their own rate bucket on the server
+ * instead of sharing one global bucket that a single bad client could
+ * exhaust for everyone. See sendErrorReport.ts for the server-side half.
+ */
+const REPORT_KEY_STORAGE_KEY = 'errorReportKey';
+
+/**
+ * Returns a stable per-install id for rate-limiting `sendErrorReport`,
+ * generating and persisting one on first use. Falls back to "anonymous"
+ * if AsyncStorage is unavailable/throws — the server still accepts that,
+ * it just shares the "anonymous" bucket with other storage-less callers.
+ */
+async function getOrCreateReportKey(): Promise<string> {
+  try {
+    const existing = await AsyncStorage.getItem(REPORT_KEY_STORAGE_KEY);
+    if (existing) {
+      return existing;
+    }
+    const generated = `${Date.now().toString(36)}-${Math.random()
+      .toString(36)
+      .slice(2, 10)}`;
+    await AsyncStorage.setItem(REPORT_KEY_STORAGE_KEY, generated);
+    return generated;
+  } catch {
+    return 'anonymous';
+  }
+}
 
 interface Props {
   children: React.ReactNode;
@@ -116,6 +154,15 @@ function DefaultErrorFallback({
   const [sendState, setSendState] = React.useState<
     'idle' | 'sending' | 'sent' | 'failed'
   >('idle');
+  /**
+   * Failure copy for the web/Convex path only — kept distinct from generic
+   * "check your connection" copy, which is reserved for an actual thrown
+   * network error (the client couldn't reach Convex at all), not a server
+   * response the client received successfully.
+   */
+  const [failureMessage, setFailureMessage] = React.useState<string | null>(
+    null
+  );
 
   const buildReport = React.useCallback(() => {
     const appVersion = Constants.expoConfig?.version ?? 'unknown';
@@ -155,18 +202,69 @@ function DefaultErrorFallback({
     return { subject, body };
   }, [error, componentStack]);
 
+  /**
+   * Web: MailComposer/mailto aren't reliable in a browser (no OS mail queue
+   * to hand off to), so web sends the report directly via the unauthenticated
+   * sendErrorReport Convex action.
+   *
+   * Native: restores the original MailComposer flow (falls back to a mailto
+   * link if MailComposer isn't available) — user-editable and handed off to
+   * the OS mail queue, which is what actually worked before this component
+   * grew the Convex action path. Only web's mailto was broken.
+   */
   const handleSendToDeveloper = React.useCallback(async () => {
     setSendState('sending');
+    setFailureMessage(null);
     const { subject, body } = buildReport();
+
+    if (Platform.OS === 'web') {
+      try {
+        const reportKey = await getOrCreateReportKey();
+        const result = await convexVanilla.action(
+          api.functions.support.sendErrorReport.sendErrorReport,
+          { subject, body, reportKey },
+        );
+        if (result.success) {
+          setSendState('sent');
+          return;
+        }
+        setFailureMessage(
+          result.reason === 'rate_limited'
+            ? 'Too many reports right now — please try again later.'
+            : "Our error reporting service hit a problem — please try again later."
+        );
+        setSendState('failed');
+      } catch {
+        // A thrown error here means we couldn't reach Convex at all (as
+        // opposed to a server response we successfully received) — this is
+        // the one case where "check your connection" is accurate.
+        setFailureMessage(
+          "We couldn't reach our server. Check your connection and try again."
+        );
+        setSendState('failed');
+      }
+      return;
+    }
+
     try {
-      const result = await convexVanilla.action(
-        api.functions.support.sendErrorReport.sendErrorReport,
-        { subject, body },
-      );
-      setSendState(result.success ? 'sent' : 'failed');
+      const isAvailable = await MailComposer.isAvailableAsync();
+      if (isAvailable) {
+        await MailComposer.composeAsync({
+          recipients: [SUPPORT_EMAIL],
+          subject,
+          body,
+        });
+      } else {
+        // Fall back to the device's default mail handler.
+        const mailto = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+          subject,
+        )}&body=${encodeURIComponent(body)}`;
+        await Linking.openURL(mailto);
+      }
+      setSendState('sent');
     } catch {
       // Never let the report flow crash the fallback itself.
-      setSendState('failed');
+      setSendState('idle');
     }
   }, [buildReport]);
 
@@ -196,9 +294,13 @@ function DefaultErrorFallback({
         >
           <Text style={styles.secondaryButtonText}>
             {sendState === 'sending'
-              ? 'Sending…'
+              ? Platform.OS === 'web'
+                ? 'Sending…'
+                : 'Opening email…'
               : sendState === 'sent'
-                ? 'Thanks — report sent'
+                ? Platform.OS === 'web'
+                  ? 'Thanks — report sent'
+                  : 'Thanks — report ready to send'
                 : sendState === 'failed'
                   ? 'Failed to send — tap to retry'
                   : 'Send to developer'}
@@ -206,8 +308,8 @@ function DefaultErrorFallback({
         </TouchableOpacity>
         {sendState === 'failed' && (
           <Text style={styles.errorText}>
-            We couldn't reach our server. Check your connection and try
-            again.
+            {failureMessage ??
+              "We couldn't reach our server. Check your connection and try again."}
           </Text>
         )}
 

--- a/apps/mobile/components/ErrorBoundary.tsx
+++ b/apps/mobile/components/ErrorBoundary.tsx
@@ -5,19 +5,15 @@ import {
   StyleSheet,
   TouchableOpacity,
   Image,
-  Linking,
   Platform,
 } from 'react-native';
 import { router } from 'expo-router';
 import Constants from 'expo-constants';
 import * as Application from 'expo-application';
-import * as MailComposer from 'expo-mail-composer';
 import { SentryUtils } from '@providers/SentryProvider';
+import { convexVanilla, api } from '@services/api/convex';
 
 const sadGif = require('../assets/sad.gif');
-
-/** Where "Send to developer" reports are delivered. */
-const SUPPORT_EMAIL = 'togather@supa.media';
 
 interface Props {
   children: React.ReactNode;
@@ -117,9 +113,9 @@ function DefaultErrorFallback({
   onTryAgain,
   onGoHome,
 }: FallbackProps) {
-  const [sendState, setSendState] = React.useState<'idle' | 'sending' | 'sent'>(
-    'idle',
-  );
+  const [sendState, setSendState] = React.useState<
+    'idle' | 'sending' | 'sent' | 'failed'
+  >('idle');
 
   const buildReport = React.useCallback(() => {
     const appVersion = Constants.expoConfig?.version ?? 'unknown';
@@ -163,24 +159,14 @@ function DefaultErrorFallback({
     setSendState('sending');
     const { subject, body } = buildReport();
     try {
-      const isAvailable = await MailComposer.isAvailableAsync();
-      if (isAvailable) {
-        await MailComposer.composeAsync({
-          recipients: [SUPPORT_EMAIL],
-          subject,
-          body,
-        });
-      } else {
-        // Fall back to the device's default mail handler.
-        const mailto = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
-          subject,
-        )}&body=${encodeURIComponent(body)}`;
-        await Linking.openURL(mailto);
-      }
-      setSendState('sent');
+      const result = await convexVanilla.action(
+        api.functions.support.sendErrorReport.sendErrorReport,
+        { subject, body },
+      );
+      setSendState(result.success ? 'sent' : 'failed');
     } catch {
       // Never let the report flow crash the fallback itself.
-      setSendState('idle');
+      setSendState('failed');
     }
   }, [buildReport]);
 
@@ -206,16 +192,24 @@ function DefaultErrorFallback({
           style={styles.secondaryButton}
           onPress={handleSendToDeveloper}
           activeOpacity={0.8}
-          disabled={sendState !== 'idle'}
+          disabled={sendState === 'sending' || sendState === 'sent'}
         >
           <Text style={styles.secondaryButtonText}>
             {sendState === 'sending'
-              ? 'Opening email…'
+              ? 'Sending…'
               : sendState === 'sent'
-                ? 'Thanks — report ready to send'
-                : 'Send to developer'}
+                ? 'Thanks — report sent'
+                : sendState === 'failed'
+                  ? 'Failed to send — tap to retry'
+                  : 'Send to developer'}
           </Text>
         </TouchableOpacity>
+        {sendState === 'failed' && (
+          <Text style={styles.errorText}>
+            We couldn't reach our server. Check your connection and try
+            again.
+          </Text>
+        )}
 
         <TouchableOpacity onPress={onGoHome} activeOpacity={0.6}>
           <Text style={styles.goHomeText}>Go Home</Text>
@@ -294,6 +288,13 @@ const styles = StyleSheet.create({
     color: '#333',
     fontSize: 15,
     fontWeight: '600',
+  },
+  errorText: {
+    color: '#c0392b',
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: -8,
+    marginBottom: 16,
   },
   goHomeText: {
     color: '#888',

--- a/apps/mobile/providers/AuthErrorBoundary.tsx
+++ b/apps/mobile/providers/AuthErrorBoundary.tsx
@@ -25,26 +25,87 @@
  * The Convex-side comments referencing a mobile `AuthErrorBoundary` (see
  * apps/convex/lib/auth.ts, apps/convex/functions/scheduling/permissions.ts)
  * anticipated this component; today it's scoped to COMMUNITY_ARCHIVED only.
+ *
+ * IMPORTANT — never render `null` and never navigate imperatively while our
+ * fallback is on screen. `ThemedStack` (the app's only Navigator) lives in
+ * `this.props.children`, BELOW this boundary. Neither `AuthGuard`
+ * (components/guards/AuthGuard.tsx — only redirects an *authenticated* user
+ * away from public/auth-flow screens) nor `useInitialRouting`
+ * (features/auth/hooks/useInitialRouting.ts — only mounted on the `/` index
+ * route) will pick up a community-less session from an arbitrary in-app
+ * screen, so this boundary must drive the redirect itself. It does so only
+ * from `componentDidUpdate`, AFTER children (and therefore the navigator)
+ * have remounted and committed — never synchronously from inside
+ * `recover()`, which would fire while the fallback (or `null`) is still what
+ * was last committed and the navigator may not exist yet.
  */
 import React from 'react';
+import { View, Text, ActivityIndicator, TouchableOpacity, StyleSheet } from 'react-native';
 import { router } from 'expo-router';
 import { useAuth } from './AuthProvider';
+import { useTheme } from '@hooks/useTheme';
 import { isCommunityArchivedError } from '@services/api/convex';
+import type { ThemeColors } from '@/theme/colors';
+
+/**
+ * Total recovery attempts allowed for a single archived-community incident
+ * (the first automatic attempt on catch, plus one manual "Try again"). Once
+ * exhausted without success, we stop retrying — see `recover()` — instead of
+ * looping silently (the old behavior: a poisoned token on a transient
+ * network failure would flicker/retry forever until connectivity returned).
+ */
+const MAX_RECOVERY_ATTEMPTS = 2;
 
 interface Props {
   children: React.ReactNode;
   /** Injected by the AuthErrorBoundary wrapper so the class body can stay hook-free. */
-  onCommunityArchived: () => Promise<void>;
+  onCommunityArchived: () => Promise<boolean>;
+  colors: ThemeColors;
 }
 
+type Phase = 'children' | 'recovering' | 'retry';
+
 interface State {
-  isRecovering: boolean;
+  phase: Phase;
+  /**
+   * Set once `onCommunityArchived()` has actually succeeded AND we've
+   * flipped back to `phase: 'children'`. Consumed by `componentDidUpdate`
+   * to fire the deferred navigation exactly once, only after that render
+   * has committed (i.e. the navigator is back in the tree).
+   */
+  pendingNavigation: boolean;
+  /** Most recent COMMUNITY_ARCHIVED error caught — rethrown if recovery gives up. */
+  originalError: unknown;
+  /**
+   * True once recovery has exhausted MAX_RECOVERY_ATTEMPTS without success.
+   * `render()` rethrows `originalError` in this state — React error
+   * boundaries never catch a throw from their own render, so this propagates
+   * to the nearest ANCESTOR boundary (the app-root ErrorBoundary), handing
+   * off to its generic crash screen instead of looping forever on a session
+   * we've already tried (and failed) to recover twice.
+   */
+  giveUp: boolean;
 }
 
 class AuthErrorBoundaryClass extends React.Component<Props, State> {
+  /**
+   * Attempt counter for the CURRENT incident. Kept as an instance field
+   * (not state) so it's read synchronously inside `recover()` without
+   * fighting React's setState batching, and reset to 0 on a successful
+   * recovery so a later, unrelated archival incident gets its own fresh
+   * budget rather than inheriting an exhausted one from earlier in the app
+   * session (this boundary is mounted once, for the app's lifetime).
+   */
+  private attempts = 0;
+
   constructor(props: Props) {
     super(props);
-    this.state = { isRecovering: false };
+    this.state = {
+      phase: 'children',
+      pendingNavigation: false,
+      originalError: null,
+      giveUp: false,
+    };
   }
 
   static getDerivedStateFromError(error: unknown): Partial<State> {
@@ -53,7 +114,7 @@ class AuthErrorBoundaryClass extends React.Component<Props, State> {
       // nearest ancestor boundary (the app-root ErrorBoundary).
       throw error;
     }
-    return { isRecovering: true };
+    return { phase: 'recovering', originalError: error };
   }
 
   componentDidCatch(error: unknown) {
@@ -64,36 +125,202 @@ class AuthErrorBoundaryClass extends React.Component<Props, State> {
     this.recover();
   }
 
-  private recover = async () => {
-    try {
-      await this.props.onCommunityArchived();
-    } catch (recoveryError) {
-      console.error('[AuthErrorBoundary] Recovery failed:', recoveryError);
+  componentDidUpdate() {
+    // Only fire once children (and the navigator underneath them) have
+    // actually remounted and committed — see the file-level comment for why
+    // this can never safely happen synchronously from inside recover().
+    if (this.state.pendingNavigation && this.state.phase === 'children') {
+      this.navigateToSelectCommunity();
     }
-    // The archived community is no longer selected (token re-minted,
-    // per-community caches wiped) — send the user back to pick a community.
-    router.replace('/(auth)/select-community');
-    this.setState({ isRecovering: false });
+  }
+
+  private navigateToSelectCommunity = () => {
+    // Consume the flag first so this can't re-fire from the setState below.
+    this.setState({ pendingNavigation: false });
+    try {
+      router.replace('/(auth)/select-community');
+    } catch (navError) {
+      // Defensive: by this point the navigator should already be mounted
+      // (componentDidUpdate fires after children have committed), but
+      // navigation across React Navigation / expo-router has enough moving
+      // parts that a single retry-on-next-tick is cheap insurance against a
+      // permanent blank screen if it isn't quite ready yet.
+      console.error(
+        '[AuthErrorBoundary] Navigation failed, retrying next tick:',
+        navError,
+      );
+      setTimeout(() => {
+        try {
+          router.replace('/(auth)/select-community');
+        } catch (retryError) {
+          console.error(
+            '[AuthErrorBoundary] Navigation retry failed:',
+            retryError,
+          );
+        }
+      }, 0);
+    }
+  };
+
+  private recover = async () => {
+    if (this.attempts >= MAX_RECOVERY_ATTEMPTS) {
+      this.setState({ giveUp: true });
+      return;
+    }
+    this.attempts += 1;
+    this.setState({ phase: 'recovering' });
+
+    let success = false;
+    try {
+      // exitToCommunitySelection() resolves `false` (rather than throwing)
+      // on a failed token re-mint — e.g. a transient network error — so we
+      // can tell a genuinely failed recovery apart from success instead of
+      // assuming success just because the call didn't throw and leaving the
+      // poisoned, still-archived-scoped token active.
+      success = await this.props.onCommunityArchived();
+    } catch (recoveryError) {
+      console.error('[AuthErrorBoundary] Recovery threw:', recoveryError);
+      success = false;
+    }
+
+    if (success) {
+      this.attempts = 0;
+      // Flip back to rendering children FIRST. Only once THIS commits is
+      // the navigator (e.g. ThemedStack) actually back in the tree — the
+      // navigation itself happens from componentDidUpdate once that's true.
+      this.setState({ phase: 'children', pendingNavigation: true });
+      return;
+    }
+
+    if (this.attempts >= MAX_RECOVERY_ATTEMPTS) {
+      this.setState({ giveUp: true });
+    } else {
+      this.setState({ phase: 'retry' });
+    }
   };
 
   render() {
-    // Render nothing while recovering rather than the children (which would
-    // immediately re-throw with the same still-archived token) or a fallback
-    // screen (recovery is near-instant and this is a rare edge case, not
-    // worth a dedicated UI).
-    if (this.state.isRecovering) {
-      return null;
+    if (this.state.giveUp) {
+      throw this.state.originalError;
+    }
+
+    if (this.state.phase === 'recovering') {
+      return <SwitchingCommunityView colors={this.props.colors} />;
+    }
+
+    if (this.state.phase === 'retry') {
+      return (
+        <RecoveryRetryView colors={this.props.colors} onRetry={this.recover} />
+      );
     }
 
     return this.props.children;
   }
 }
 
+/**
+ * Fallback shown while `recover()` is in flight. Deliberately never `null` —
+ * returning `null` here would unmount `this.props.children`, which is where
+ * the app's only Navigator (`ThemedStack`) lives (see the file-level
+ * comment). Palette mirrors components/ErrorBoundary.tsx's fallback
+ * (centered card look) but sourced from theme tokens since, unlike the
+ * app-root ErrorBoundary, this boundary sits below ThemeProvider.
+ */
+function SwitchingCommunityView({ colors }: { colors: ThemeColors }) {
+  const styles = createStyles(colors);
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.buttonPrimary} />
+      <Text style={styles.message}>Switching community…</Text>
+    </View>
+  );
+}
+
+function RecoveryRetryView({
+  colors,
+  onRetry,
+}: {
+  colors: ThemeColors;
+  onRetry: () => void;
+}) {
+  const styles = createStyles(colors);
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Couldn't switch communities</Text>
+        <Text style={styles.message}>
+          That community is no longer available and we couldn't finish moving
+          you back to community selection. Check your connection and try
+          again.
+        </Text>
+        <TouchableOpacity
+          style={styles.primaryButton}
+          onPress={onRetry}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.primaryButtonText}>Try again</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: colors.background,
+      padding: 20,
+    },
+    card: {
+      backgroundColor: colors.surface,
+      borderRadius: 16,
+      paddingVertical: 32,
+      paddingHorizontal: 24,
+      alignItems: 'center',
+      maxWidth: 400,
+      width: '100%',
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      color: colors.text,
+      marginBottom: 12,
+      textAlign: 'center',
+    },
+    message: {
+      fontSize: 15,
+      color: colors.textSecondary,
+      textAlign: 'center',
+      lineHeight: 22,
+      marginTop: 12,
+      marginBottom: 8,
+    },
+    primaryButton: {
+      backgroundColor: colors.buttonPrimary,
+      paddingHorizontal: 24,
+      paddingVertical: 14,
+      borderRadius: 10,
+      width: '100%',
+      alignItems: 'center',
+      marginTop: 16,
+    },
+    primaryButtonText: {
+      color: colors.buttonPrimaryText,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+  });
+}
+
 export function AuthErrorBoundary({ children }: { children: React.ReactNode }) {
   const { exitToCommunitySelection } = useAuth();
+  const { colors } = useTheme();
 
   return (
-    <AuthErrorBoundaryClass onCommunityArchived={exitToCommunitySelection}>
+    <AuthErrorBoundaryClass onCommunityArchived={exitToCommunitySelection} colors={colors}>
       {children}
     </AuthErrorBoundaryClass>
   );

--- a/apps/mobile/providers/AuthErrorBoundary.tsx
+++ b/apps/mobile/providers/AuthErrorBoundary.tsx
@@ -1,0 +1,100 @@
+/**
+ * AuthErrorBoundary — recovers from a COMMUNITY_ARCHIVED query error instead
+ * of crashing to the app-root ErrorBoundary.
+ *
+ * Background: `convex/react`'s `useQuery` re-throws query errors during
+ * render (that's how the library surfaces them — there's no error return
+ * value to check, so a try/catch around a hook call can't intercept this).
+ * Some queries are mounted unconditionally as soon as an auth token exists —
+ * e.g. NotificationProvider's `unreadCount` — so if the token is scoped to a
+ * community that gets archived (closed) via admin Settings while the token is
+ * still live (access tokens last 30 days), the strict `requireAuth` gate
+ * throws `ConvexError("COMMUNITY_ARCHIVED")` on the very next render and the
+ * app hard-crashes to the generic "Something went wrong" screen with no way
+ * out, because the app-root ErrorBoundary sits ABOVE AuthProvider and has no
+ * way to recover the session.
+ *
+ * This boundary sits INSIDE the provider tree, below AuthProvider, so it can
+ * call `exitToCommunitySelection()` (re-mints a community-less token, wipes
+ * per-community caches) and route the user back to community selection
+ * instead of dead-ending. Any other error is re-thrown from
+ * `getDerivedStateFromError` so it keeps propagating to the app-root
+ * ErrorBoundary unchanged — this boundary only ever handles the one error
+ * shape it knows how to recover from.
+ *
+ * The Convex-side comments referencing a mobile `AuthErrorBoundary` (see
+ * apps/convex/lib/auth.ts, apps/convex/functions/scheduling/permissions.ts)
+ * anticipated this component; today it's scoped to COMMUNITY_ARCHIVED only.
+ */
+import React from 'react';
+import { router } from 'expo-router';
+import { useAuth } from './AuthProvider';
+import { isCommunityArchivedError } from '@services/api/convex';
+
+interface Props {
+  children: React.ReactNode;
+  /** Injected by the AuthErrorBoundary wrapper so the class body can stay hook-free. */
+  onCommunityArchived: () => Promise<void>;
+}
+
+interface State {
+  isRecovering: boolean;
+}
+
+class AuthErrorBoundaryClass extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { isRecovering: false };
+  }
+
+  static getDerivedStateFromError(error: unknown): Partial<State> {
+    if (!isCommunityArchivedError(error)) {
+      // Not ours to handle — rethrow so the error keeps bubbling to the
+      // nearest ancestor boundary (the app-root ErrorBoundary).
+      throw error;
+    }
+    return { isRecovering: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.warn(
+      '[AuthErrorBoundary] Recovering from archived-community session:',
+      error,
+    );
+    this.recover();
+  }
+
+  private recover = async () => {
+    try {
+      await this.props.onCommunityArchived();
+    } catch (recoveryError) {
+      console.error('[AuthErrorBoundary] Recovery failed:', recoveryError);
+    }
+    // The archived community is no longer selected (token re-minted,
+    // per-community caches wiped) — send the user back to pick a community.
+    router.replace('/(auth)/select-community');
+    this.setState({ isRecovering: false });
+  };
+
+  render() {
+    // Render nothing while recovering rather than the children (which would
+    // immediately re-throw with the same still-archived token) or a fallback
+    // screen (recovery is near-instant and this is a rare edge case, not
+    // worth a dedicated UI).
+    if (this.state.isRecovering) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
+export function AuthErrorBoundary({ children }: { children: React.ReactNode }) {
+  const { exitToCommunitySelection } = useAuth();
+
+  return (
+    <AuthErrorBoundaryClass onCommunityArchived={exitToCommunitySelection}>
+      {children}
+    </AuthErrorBoundaryClass>
+  );
+}

--- a/apps/mobile/providers/AuthProvider.tsx
+++ b/apps/mobile/providers/AuthProvider.tsx
@@ -93,7 +93,8 @@ interface AuthContextType {
   refreshUser: () => Promise<void>;
   setCommunity: (community: Community) => Promise<void>;
   clearCommunity: () => Promise<void>;
-  exitToCommunitySelection: () => Promise<void>;
+  /** Resolves `true` only if the community-less token re-mint actually succeeded. */
+  exitToCommunitySelection: () => Promise<boolean>;
   signIn: (userId: string, tokens?: { accessToken?: string; refreshToken?: string }) => Promise<void>;
 }
 
@@ -822,8 +823,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
    * to the archived community, which the server now hard-rejects) and wipes the
    * per-community caches so no stale, archived content stays browsable. The
    * caller is responsible for navigating to community selection afterward.
+   *
+   * Returns `true` only if the token re-mint actually succeeded — callers that
+   * need to detect a failed recovery (e.g. AuthErrorBoundary, which must not
+   * treat a transient network failure as success and remount into a repeat
+   * COMMUNITY_ARCHIVED throw) should check this instead of assuming success
+   * just because the call didn't throw.
    */
-  const exitToCommunitySelection = useCallback(async () => {
+  const exitToCommunitySelection = useCallback(async (): Promise<boolean> => {
     console.log("🔄 AuthProvider: Exiting to community selection (archived)");
 
     // Clear the server-side active community (tolerated for archived).
@@ -831,7 +838,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     // Re-mint a token with NO community so requireAuth stops rejecting requests
     // as COMMUNITY_ARCHIVED while the user is on the selection screen.
-    await refreshAuthTokens();
+    // refreshAuthTokens() catches internally and returns false on failure
+    // (e.g. transient network error) rather than throwing — propagate that
+    // result so the caller can tell a genuinely failed recovery apart from
+    // success instead of the token silently staying poisoned.
+    const refreshed = await refreshAuthTokens();
 
     // Wipe per-community caches (mirror logout's cache teardown, minus the auth
     // tokens/user) so archived-community data isn't left browsable offline.
@@ -866,6 +877,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     useGridColumnWidths.getState().clearAll();
 
     setCommunityState(null);
+    return refreshed;
   }, [clearCommunity, refreshAuthTokens]);
 
   /**

--- a/apps/mobile/providers/__tests__/AuthErrorBoundary.test.tsx
+++ b/apps/mobile/providers/__tests__/AuthErrorBoundary.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for the AuthErrorBoundary redesign (see the file-level
+ * comment on ../AuthErrorBoundary.tsx for the defects this fixes):
+ *
+ * 1. The fallback must never render `null` (that would unmount the
+ *    Navigator living in `children`) — it always renders an explicit
+ *    "Switching community…" view while recovery is in flight.
+ * 2. A failed recovery must not loop silently — it's capped at
+ *    MAX_RECOVERY_ATTEMPTS and then hands the original error off to the
+ *    nearest ancestor error boundary instead of retrying forever.
+ */
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+// jest.setup.js registers a global stand-in for @services/api/convex that
+// doesn't export isCommunityArchivedError — unmock so getDerivedStateFromError
+// exercises the real classifier this boundary depends on.
+jest.unmock('@services/api/convex');
+
+import { AuthErrorBoundary } from '../AuthErrorBoundary';
+
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  router: { replace: (...args: unknown[]) => mockReplace(...args) },
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('../AuthProvider', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+/** Throws the archived-community shape convex/react reconstructs client-side, while `shouldThrowRef.current` is true. */
+function ThrowingChild({ shouldThrowRef }: { shouldThrowRef: { current: boolean } }) {
+  if (shouldThrowRef.current) {
+    throw { data: 'COMMUNITY_ARCHIVED', message: 'ConvexError: COMMUNITY_ARCHIVED' };
+  }
+  return <Text testID="child-ok">ok</Text>;
+}
+
+/** Minimal ancestor boundary standing in for the app-root ErrorBoundary, to assert a give-up rethrow is actually caught above this boundary. */
+class OuterTestBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: unknown }
+> {
+  state: { error: unknown } = { error: null };
+  static getDerivedStateFromError(error: unknown) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return <Text testID="outer-caught">caught</Text>;
+    }
+    return this.props.children;
+  }
+}
+
+describe('AuthErrorBoundary', () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+  });
+
+  it('never renders null while recovering, and only navigates after children have remounted', async () => {
+    const shouldThrow = { current: true };
+    const exitToCommunitySelection = jest.fn(async () => {
+      // Simulate the token now being fixed, same as the real
+      // exitToCommunitySelection() re-minting a community-less token so the
+      // next render of children no longer throws.
+      shouldThrow.current = false;
+      return true;
+    });
+    mockUseAuth.mockReturnValue({ exitToCommunitySelection });
+
+    const { queryByText, findByTestId } = render(
+      <AuthErrorBoundary>
+        <ThrowingChild shouldThrowRef={shouldThrow} />
+      </AuthErrorBoundary>
+    );
+
+    // Fallback is an explicit view, never null.
+    expect(queryByText('Switching community…')).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    // Children (the Navigator's stand-in here) remount once recovery succeeds.
+    await findByTestId('child-ok');
+
+    // Navigation only fires after that remount has committed.
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith('/(auth)/select-community')
+    );
+    expect(exitToCommunitySelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps recovery at 2 attempts and rethrows to the ancestor boundary instead of looping', async () => {
+    const shouldThrow = { current: true };
+    const exitToCommunitySelection = jest.fn(async () => false); // always fails, like a persistent network error
+    mockUseAuth.mockReturnValue({ exitToCommunitySelection });
+
+    const { findByText, getByText, findByTestId } = render(
+      <OuterTestBoundary>
+        <AuthErrorBoundary>
+          <ThrowingChild shouldThrowRef={shouldThrow} />
+        </AuthErrorBoundary>
+      </OuterTestBoundary>
+    );
+
+    // First (automatic) attempt fails -> explicit retry view, not a silent loop.
+    await findByText("Couldn't switch communities");
+    expect(exitToCommunitySelection).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(getByText('Try again'));
+
+    // Second attempt also fails -> cap reached -> original error rethrown ->
+    // caught by the ancestor boundary, not swallowed or looped forever.
+    await findByTestId('outer-caught');
+    expect(exitToCommunitySelection).toHaveBeenCalledTimes(2);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/services/api/__tests__/convex.test.ts
+++ b/apps/mobile/services/api/__tests__/convex.test.ts
@@ -1,0 +1,51 @@
+// jest.setup.js registers a global `jest.mock('./services/api/convex', ...)`
+// stand-in (used by every other test file that imports hooks like useQuery
+// from this module) that does NOT export `isCommunityArchivedError`. Unmock
+// here so this file exercises the real implementation.
+jest.unmock('@services/api/convex');
+
+import { isCommunityArchivedError } from '@services/api/convex';
+
+describe('isCommunityArchivedError', () => {
+  it('matches when .data is exactly the COMMUNITY_ARCHIVED code', () => {
+    expect(isCommunityArchivedError({ data: 'COMMUNITY_ARCHIVED' })).toBe(true);
+  });
+
+  it('matches via the .message fallback on a word-boundary hit', () => {
+    expect(
+      isCommunityArchivedError({
+        message: 'ConvexError: [Request ID: abc] Server Error\nCOMMUNITY_ARCHIVED',
+      })
+    ).toBe(true);
+  });
+
+  it('does not match a loose substring embedded in an unrelated code', () => {
+    expect(
+      isCommunityArchivedError({ data: 'SOME_OTHER_COMMUNITY_ARCHIVED_VARIANT' })
+    ).toBe(false);
+    expect(
+      isCommunityArchivedError({
+        message: 'NOT_COMMUNITY_ARCHIVED_AT_ALL: unrelated failure',
+      })
+    ).toBe(false);
+  });
+
+  it('does not match an unrelated error even if .data is a different string', () => {
+    expect(isCommunityArchivedError({ data: 'SOME_OTHER_ERROR' })).toBe(false);
+    expect(isCommunityArchivedError({ message: 'Network request failed' })).toBe(
+      false
+    );
+  });
+
+  it('returns false for non-object / nullish input', () => {
+    expect(isCommunityArchivedError(null)).toBe(false);
+    expect(isCommunityArchivedError(undefined)).toBe(false);
+    expect(isCommunityArchivedError('COMMUNITY_ARCHIVED')).toBe(false);
+    expect(isCommunityArchivedError(42)).toBe(false);
+  });
+
+  it('returns false for an object with neither .data nor .message', () => {
+    expect(isCommunityArchivedError({})).toBe(false);
+    expect(isCommunityArchivedError({ foo: 'bar' })).toBe(false);
+  });
+});

--- a/apps/mobile/services/api/convex.ts
+++ b/apps/mobile/services/api/convex.ts
@@ -449,12 +449,24 @@ export function useAuthenticatedPaginatedQuery<
 const COMMUNITY_ARCHIVED_CODE = 'COMMUNITY_ARCHIVED';
 
 /**
+ * Word-boundary match for the fallback `.message` check below — anchored so
+ * e.g. "SOME_OTHER_COMMUNITY_ARCHIVED_THING" or a coincidental substring in
+ * an unrelated error message can't be misdetected as the archived-community
+ * error and get swallowed into the community-switch recovery flow.
+ */
+const COMMUNITY_ARCHIVED_MESSAGE_RE = /\bCOMMUNITY_ARCHIVED\b/;
+
+/**
  * Detects the archived-community error across any strict Convex query or
  * mutation, not just notifications. `convex/react` reconstructs a
  * `ConvexError` client-side with `.data` set to whatever value the server
- * passed to `new ConvexError(...)` — here a bare string — so `.data` is the
- * primary check. `.message` is included as a fallback since dev/prod builds
- * format the reconstructed error message slightly differently.
+ * passed to `new ConvexError(...)` — here a bare string — so an exact
+ * `.data === COMMUNITY_ARCHIVED_CODE` match is the primary, authoritative
+ * check. `.message` is a fallback only (dev/prod builds format the
+ * reconstructed error message slightly differently) and is matched with a
+ * word-boundary regex rather than `.includes(...)` — a loose substring check
+ * risks misclassifying an unrelated error as archived-community and routing
+ * it into the community-switch recovery flow instead of surfacing normally.
  *
  * We duck-type rather than `instanceof ConvexError` — matches the existing
  * error-handling idiom in this codebase (see SongLibraryScreen.tsx,
@@ -466,7 +478,7 @@ export function isCommunityArchivedError(error: unknown): boolean {
   const data = (error as { data?: unknown }).data;
   if (data === COMMUNITY_ARCHIVED_CODE) return true;
   const message = (error as { message?: unknown }).message;
-  return typeof message === 'string' && message.includes(COMMUNITY_ARCHIVED_CODE);
+  return typeof message === 'string' && COMMUNITY_ARCHIVED_MESSAGE_RE.test(message);
 }
 
 /**

--- a/apps/mobile/services/api/convex.ts
+++ b/apps/mobile/services/api/convex.ts
@@ -435,6 +435,40 @@ export function useAuthenticatedPaginatedQuery<
   return useConvexPaginatedQuery(queryFn, queryArgs as any, options);
 }
 
+// ============================================================================
+// Archived-Community Error Detection
+// ============================================================================
+
+/**
+ * The error code the server throws (as a bare-string `ConvexError`) when a
+ * request's JWT is scoped to a community that has since been archived
+ * (`isArchived: true`). See `apps/convex/lib/auth.ts` requireAuth /
+ * requireAuthWithArchivedStatus and `apps/convex/lib/permissions.ts`
+ * assertCommunityNotArchived.
+ */
+const COMMUNITY_ARCHIVED_CODE = 'COMMUNITY_ARCHIVED';
+
+/**
+ * Detects the archived-community error across any strict Convex query or
+ * mutation, not just notifications. `convex/react` reconstructs a
+ * `ConvexError` client-side with `.data` set to whatever value the server
+ * passed to `new ConvexError(...)` — here a bare string — so `.data` is the
+ * primary check. `.message` is included as a fallback since dev/prod builds
+ * format the reconstructed error message slightly differently.
+ *
+ * We duck-type rather than `instanceof ConvexError` — matches the existing
+ * error-handling idiom in this codebase (see SongLibraryScreen.tsx,
+ * app/inbox/[groupId]/create.tsx) and avoids a hard dependency on exactly
+ * which `convex` build reconstructs the error.
+ */
+export function isCommunityArchivedError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const data = (error as { data?: unknown }).data;
+  if (data === COMMUNITY_ARCHIVED_CODE) return true;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && message.includes(COMMUNITY_ARCHIVED_CODE);
+}
+
 /**
  * Vanilla (non-hook) authenticated Convex client
  *


### PR DESCRIPTION
## Summary

Fixes the two staging-blocking bugs reported today. Both pre-date the link-preview PR (#630) — root causes traced to PR #588's archival hardening and the original mailto-based error reporting.

### 1. `COMMUNITY_ARCHIVED` hard crash on login/boot
A JWT scoped to an archived community crashed the whole app: `NotificationProvider` mounts an always-on `unreadCount` query the moment a token exists, `requireAuth` throws `COMMUNITY_ARCHIVED`, and the only boundary above it was the app-root `ErrorBoundary` (outside `AuthProvider`) — fatal screen, no recovery path.

**Two-layer fix:**
- **Server**: `list`/`inboxSummary`/`unreadCount` (the queries mounted unconditionally at boot) now use a new `requireAuthWithArchivedStatus` helper and return benign empty data for archived-community tokens — notification counts for an inaccessible community are meaningless.
- **Client**: new `AuthErrorBoundary` (below `AuthProvider`, wrapping the query tree in `_layout.tsx`) catches `COMMUNITY_ARCHIVED` from **any** query, calls the existing `exitToCommunitySelection()` (re-mints a community-less token, wipes per-community caches), and routes to community selection. Every other error re-throws to the root boundary unchanged. This fills in the `AuthErrorBoundary` component that backend comments already referenced by name.

### 2. "Send to developer" never sent anything
`expo-mail-composer` on web just `window.open`s a `mailto:` and unconditionally reports success — nothing is transmitted, popup blockers eat it silently. Replaced with an unauthenticated Convex action `functions/support/sendErrorReport` sending via Resend (mirrors the `emailOtp` pattern: lazy client init, server-side recipient, subject/body length caps), and the ErrorBoundary now awaits the real result and shows a distinct failed state.

Also includes hand-applied `_generated/api.d.ts` entries for the new support module (matches deterministic codegen output; this environment has no Convex deployment to run codegen against).

## Test plan
- [x] Convex: full suite 146 files green, including 4 new archived-community query tests and 11 new `sendErrorReport` tests
- [x] Mobile: `tsc --noEmit` clean apart from 20 pre-existing errors in files untouched by this branch
- [x] `convex typecheck` clean
- [ ] On staging after deploy: log in with a token scoped to an archived community → should land on community selection, not the crash screen; trigger the error screen and "Send to developer" → email arrives at the support inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VHVFzj5sj8uq91cP7389D

---
_Generated by [Claude Code](https://claude.ai/code/session_013VHVFzj5sj8uq91cP7389D)_