### PR TITLE
feat(scheduling): team managers + team-scoped publishing

### DIFF
--- a/apps/convex/__tests__/scheduling/teamManagers.test.ts
+++ b/apps/convex/__tests__/scheduling/teamManagers.test.ts
@@ -311,6 +311,159 @@ describe("team manager permissions", () => {
     expect(roleId).toBeDefined();
   });
 
+  // The grid is the only surface for assigning and publishing, so a manager
+  // who is not a group leader must be able to load it — otherwise the whole
+  // feature is unreachable for the people it exists for.
+  it("a manager who is not a group leader can load the roster grid", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+
+    // A plain group member cannot.
+    await expect(
+      t.query(api.functions.scheduling.roster.rosterMatrix, {
+        token: managerToken,
+        groupId: world.groupId,
+      }),
+    ).rejects.toThrow(ConvexError);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    const matrix = await t.query(
+      api.functions.scheduling.roster.rosterMatrix,
+      { token: managerToken, groupId: world.groupId },
+    );
+    expect(
+      matrix.teams.find((tm) => tm.teamId === world.teamId)?.isManagedByMe,
+    ).toBe(true);
+  });
+
+  // `groupMembers.remove` only stamps `leftAt`; it doesn't delete manager rows.
+  // Authority must lapse anyway, or a removed member keeps publishing.
+  it("manager authority lapses when the person leaves the group", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const planId = await makeEvent(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    // They leave the campus group — the `teamManagers` row survives.
+    await t.run(async (ctx) => {
+      const membership = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", world.groupId).eq("userId", world.channelMemberId),
+        )
+        .first();
+      if (membership) {
+        await ctx.db.patch(membership._id, { leftAt: Date.now() });
+      }
+    });
+
+    const rowStillThere = await t.run((ctx) =>
+      ctx.db
+        .query("teamManagers")
+        .withIndex("by_team_user", (q) =>
+          q.eq("teamId", world.teamId).eq("userId", world.channelMemberId),
+        )
+        .first(),
+    );
+    expect(rowStillThere).not.toBeNull();
+
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignRole, {
+        token: managerToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.staleGroupMemberId,
+      }),
+    ).rejects.toThrow(ConvexError);
+
+    await expect(
+      t.action(api.functions.scheduling.assignments.publishEvent, {
+        token: managerToken,
+        planId,
+        teamIds: [world.teamId],
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  // A manager who can publish their team in bulk must also be able to nudge one
+  // of their own volunteers — same team scope for both.
+  it("a manager can re-send a request to their own volunteer", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const planId = await makeEvent(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+    const { assignmentId } = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.staleGroupMemberId,
+      },
+    );
+
+    const result = await t.action(
+      api.functions.scheduling.assignments.resendAssignmentRequest,
+      { token: managerToken, assignmentId },
+    );
+    expect(result.scheduled).toBe(true);
+  });
+
+  it("a manager cannot re-send for a team they do not manage", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const planId = await makeEvent(t, world, leaderToken);
+    const other = await makeSecondTeam(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+    const { assignmentId } = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leaderToken,
+        planId,
+        teamId: other.teamId,
+        roleId: other.roleId,
+        userId: world.staleGroupMemberId,
+      },
+    );
+
+    await expect(
+      t.action(api.functions.scheduling.assignments.resendAssignmentRequest, {
+        token: managerToken,
+        assignmentId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
   it("rosterMatrix reports which teams the caller manages", async () => {
     const { t, world } = await setupSchedulingWorld();
     const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;

--- a/apps/convex/__tests__/scheduling/teamManagers.test.ts
+++ b/apps/convex/__tests__/scheduling/teamManagers.test.ts
@@ -1,0 +1,630 @@
+/**
+ * Tests for team managers and team-scoped publishing (ADR-025).
+ *
+ * The bug these exist to prevent: an `eventPlans` row is a date column shared
+ * by every serving team at a campus, and `publishEvent` fanned requests out to
+ * every `unconfirmed` assignment on it. So a crew lead sending their own
+ * team's requests also texted the entire production roster.
+ *
+ * Two things fix that, and both are covered here:
+ *   1. `teamManagers` — roster authority scoped to one team, held by someone
+ *      who is *not* a campus group leader.
+ *   2. `publishEvent({ teamIds })` — a fan-out narrowed to chosen teams, with
+ *      the 4-day / 1-day reminders inheriting the same narrowing via the
+ *      append-only request log.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api, internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld, type SchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+  vi.restoreAllMocks();
+});
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+const DAY = 86400000;
+
+async function makeEvent(
+  t: ReturnType<typeof convexTest>,
+  world: SchedulingWorld,
+  leaderToken: string,
+): Promise<Id<"eventPlans">> {
+  const eventDate = Date.now() + 7 * DAY;
+  const { planId } = await t.mutation(
+    api.functions.scheduling.events.createEvent,
+    {
+      token: leaderToken,
+      groupId: world.groupId,
+      title: "Sunday",
+      eventDate,
+      times: [{ label: "9 AM", startsAt: eventDate }],
+    },
+  );
+  return planId;
+}
+
+/**
+ * A second serving team in the same group, with one role — the "other team"
+ * whose volunteers must never be notified by a scoped publish.
+ */
+async function makeSecondTeam(
+  t: ReturnType<typeof convexTest>,
+  world: SchedulingWorld,
+  leaderToken: string,
+  name = "Production",
+): Promise<{ teamId: Id<"teams">; roleId: Id<"teamRoles"> }> {
+  const { teamId } = await t.mutation(
+    api.functions.scheduling.teams.createServingTeam,
+    { token: leaderToken, groupId: world.groupId, name, withChannel: false },
+  );
+  const { roleId } = await t.mutation(
+    api.functions.scheduling.roles.createRole,
+    { token: leaderToken, teamId, name: `${name} Lead` },
+  );
+  return { teamId, roleId };
+}
+
+describe("team managers", () => {
+  it("a group leader can add and remove a manager", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    let managers = await t.query(
+      api.functions.scheduling.teams.listTeamManagers,
+      { token: leaderToken, teamId: world.teamId },
+    );
+    expect(managers.map((m) => m.userId)).toEqual([world.channelMemberId]);
+
+    await t.mutation(api.functions.scheduling.teams.removeTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    managers = await t.query(api.functions.scheduling.teams.listTeamManagers, {
+      token: leaderToken,
+      teamId: world.teamId,
+    });
+    expect(managers).toEqual([]);
+  });
+
+  it("adding the same manager twice is idempotent", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    for (let i = 0; i < 2; i++) {
+      await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+        token: leaderToken,
+        teamId: world.teamId,
+        userId: world.channelMemberId,
+      });
+    }
+
+    const managers = await t.query(
+      api.functions.scheduling.teams.listTeamManagers,
+      { token: leaderToken, teamId: world.teamId },
+    );
+    expect(managers).toHaveLength(1);
+  });
+
+  it("rejects a manager who is not in the campus group", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await expect(
+      t.mutation(api.functions.scheduling.teams.addTeamManager, {
+        token: leaderToken,
+        teamId: world.teamId,
+        userId: world.outsiderId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  // Managing a roster and deciding who else may manage it are different levels
+  // of trust — the leader stays the one who delegates.
+  it("a team manager cannot appoint another manager", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    await expect(
+      t.mutation(api.functions.scheduling.teams.addTeamManager, {
+        token: managerToken,
+        teamId: world.teamId,
+        userId: world.staleGroupMemberId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("createServingTeam seeds the managers it is given", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { teamId } = await t.mutation(
+      api.functions.scheduling.teams.createServingTeam,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        name: "Crew",
+        withChannel: false,
+        // The outsider is silently skipped rather than failing creation.
+        managerUserIds: [world.channelMemberId, world.outsiderId],
+      },
+    );
+
+    const managers = await t.query(
+      api.functions.scheduling.teams.listTeamManagers,
+      { token: leaderToken, teamId },
+    );
+    expect(managers.map((m) => m.userId)).toEqual([world.channelMemberId]);
+  });
+
+  // The creator is deliberately NOT auto-added: a leader who creates all seven
+  // of a campus's teams would "manage" all seven, defeating the grid's
+  // default-to-my-teams scoping for the person it most needs to help.
+  it("does not make the creator a manager implicitly", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { teamId } = await t.mutation(
+      api.functions.scheduling.teams.createServingTeam,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        name: "Crew",
+        withChannel: false,
+      },
+    );
+
+    const managers = await t.query(
+      api.functions.scheduling.teams.listTeamManagers,
+      { token: leaderToken, teamId },
+    );
+    expect(managers).toEqual([]);
+  });
+});
+
+describe("team manager permissions", () => {
+  it("a manager can assign and unassign on their own team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const planId = await makeEvent(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    const { assignmentId } = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: managerToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.staleGroupMemberId,
+      },
+    );
+    expect(assignmentId).toBeDefined();
+
+    await t.mutation(api.functions.scheduling.assignments.unassign, {
+      token: managerToken,
+      assignmentId,
+    });
+    expect(await t.run((ctx) => ctx.db.get(assignmentId))).toBeNull();
+  });
+
+  it("a manager cannot assign on a team they do not manage", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const planId = await makeEvent(t, world, leaderToken);
+    const other = await makeSecondTeam(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignRole, {
+        token: managerToken,
+        planId,
+        teamId: other.teamId,
+        roleId: other.roleId,
+        userId: world.staleGroupMemberId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("a plain group member still cannot assign", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const planId = await makeEvent(t, world, leaderToken);
+
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.assignRole, {
+        token: memberToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.staleGroupMemberId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("a manager can edit their team's roles", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    const { roleId } = await t.mutation(
+      api.functions.scheduling.roles.createRole,
+      { token: managerToken, teamId: world.teamId, name: "Sound" },
+    );
+    expect(roleId).toBeDefined();
+  });
+
+  it("rosterMatrix reports which teams the caller manages", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    await makeSecondTeam(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.groupLeaderId,
+    });
+
+    const matrix = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leaderToken,
+      groupId: world.groupId,
+    });
+
+    const managed = matrix.teams.filter((tm) => tm.isManagedByMe);
+    expect(managed.map((tm) => tm.teamId)).toEqual([world.teamId]);
+    // The other team is still visible — managing narrows the default view, it
+    // never hides data from a leader.
+    expect(matrix.teams.length).toBeGreaterThan(1);
+  });
+});
+
+describe("team-scoped publishing", () => {
+  /**
+   * Roster one volunteer on each of two teams, then return the plan and the
+   * two assignment ids. This is the exact shape of David's report: one date,
+   * two teams, one person publishing.
+   */
+  async function twoTeamPlan(
+    t: ReturnType<typeof convexTest>,
+    world: SchedulingWorld,
+    leaderToken: string,
+  ) {
+    const planId = await makeEvent(t, world, leaderToken);
+    const other = await makeSecondTeam(t, world, leaderToken);
+
+    const mine = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+      },
+    );
+    const theirs = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leaderToken,
+        planId,
+        teamId: other.teamId,
+        roleId: other.roleId,
+        userId: world.staleGroupMemberId,
+      },
+    );
+
+    return {
+      planId,
+      otherTeamId: other.teamId,
+      myAssignmentId: mine.assignmentId,
+      theirAssignmentId: theirs.assignmentId,
+    };
+  }
+
+  it("counts only the selected teams' pending requests", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { planId } = await twoTeamPlan(t, world, leaderToken);
+
+    const scoped = await t.action(
+      api.functions.scheduling.assignments.publishEvent,
+      { token: leaderToken, planId, teamIds: [world.teamId] },
+    );
+    expect(scoped.requestCount).toBe(1);
+  });
+
+  it("an unscoped publish still notifies every team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { planId } = await twoTeamPlan(t, world, leaderToken);
+
+    const all = await t.action(
+      api.functions.scheduling.assignments.publishEvent,
+      { token: leaderToken, planId },
+    );
+    expect(all.requestCount).toBe(2);
+  });
+
+  // The heart of the report: publishing one team must not log a request
+  // against the other team's volunteer.
+  it("logs requests only for the published team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { planId, myAssignmentId } = await twoTeamPlan(
+      t,
+      world,
+      leaderToken,
+    );
+
+    // Invoke the fan-out directly with the scope `publishEvent` hands it.
+    // Going through the action would enqueue a `scheduler.runAfter` job whose
+    // drain timing convex-test doesn't make deterministic, double-sending and
+    // muddying the assertion. Mirrors requestHistory.test.ts / reminders.test.ts.
+    await t.action(
+      internal.functions.scheduling.assignments.sendAssignmentRequests,
+      { planId, publisherId: world.groupLeaderId, teamIds: [world.teamId] },
+    );
+
+    const log = await t.run((ctx) =>
+      ctx.db
+        .query("assignmentRequestLog")
+        .withIndex("by_plan", (q) => q.eq("planId", planId))
+        .collect(),
+    );
+    // The other team's volunteer was never asked — that is the whole bug.
+    expect([...new Set(log.map((row) => row.assignmentId))]).toEqual([
+      myAssignmentId,
+    ]);
+    expect([...new Set(log.map((row) => row.teamId))]).toEqual([world.teamId]);
+  });
+
+  it("a manager can publish their own team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const { planId } = await twoTeamPlan(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    const result = await t.action(
+      api.functions.scheduling.assignments.publishEvent,
+      { token: managerToken, planId, teamIds: [world.teamId] },
+    );
+    expect(result.requestCount).toBe(1);
+  });
+
+  it("a manager cannot publish a team they do not manage", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const { planId, otherTeamId } = await twoTeamPlan(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    await expect(
+      t.action(api.functions.scheduling.assignments.publishEvent, {
+        token: managerToken,
+        planId,
+        teamIds: [otherTeamId],
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  // Each team in the list is authorized on its own, so a manager can't
+  // smuggle a team they don't manage in alongside one they do.
+  it("a manager cannot smuggle an unmanaged team into a multi-team publish", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const { planId, otherTeamId } = await twoTeamPlan(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    await expect(
+      t.action(api.functions.scheduling.assignments.publishEvent, {
+        token: managerToken,
+        planId,
+        teamIds: [world.teamId, otherTeamId],
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("a manager cannot publish the whole plan by omitting teamIds", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const managerToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    const { planId } = await twoTeamPlan(t, world, leaderToken);
+
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.channelMemberId,
+    });
+
+    await expect(
+      t.action(api.functions.scheduling.assignments.publishEvent, {
+        token: managerToken,
+        planId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rosterMatrix breaks the pending count out per team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const { planId, otherTeamId } = await twoTeamPlan(t, world, leaderToken);
+
+    const matrix = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token: leaderToken,
+      groupId: world.groupId,
+    });
+    const event = matrix.events.find((e) => e._id === planId);
+
+    expect(event?.pendingCount).toBe(2);
+    expect(event?.pendingByTeam[world.teamId as string]).toBe(1);
+    expect(event?.pendingByTeam[otherTeamId as string]).toBe(1);
+  });
+});
+
+describe("reminders inherit the publish scope", () => {
+  // Without this, the cross-team leak simply reappears on a four-day delay:
+  // the plan is `published`, so the 4-day nudge would sweep every unconfirmed
+  // assignment on it — including the team that was never asked.
+  it("nudges only volunteers who were actually asked", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const planId = await makeEvent(t, world, leaderToken);
+    const other = await makeSecondTeam(t, world, leaderToken);
+    const mine = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+      },
+    );
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leaderToken,
+      planId,
+      teamId: other.teamId,
+      roleId: other.roleId,
+      userId: world.staleGroupMemberId,
+    });
+
+    // Publish only the first team — the fan-out is invoked directly so the
+    // request log lands deterministically (see the note in the publish suite).
+    await t.run(async (ctx) => {
+      await ctx.db.patch(planId, {
+        status: "published",
+        updatedAt: Date.now(),
+      });
+    });
+    await t.action(
+      internal.functions.scheduling.assignments.sendAssignmentRequests,
+      { planId, publisherId: world.groupLeaderId, teamIds: [world.teamId] },
+    );
+
+    const targets = await t.query(
+      internal.functions.scheduling.assignments.getAssignmentRequestTargets,
+      {
+        planId,
+        publisherId: world.groupLeaderId,
+        onlyAlreadyRequested: true,
+      },
+    );
+
+    expect(targets?.recipients.map((r) => r.assignmentId)).toEqual([
+      mine.assignmentId,
+    ]);
+  });
+
+  // A plan published before request logging existed has no log rows. Treating
+  // that as "nobody was asked" would silently drop its in-flight reminders.
+  it("falls back to the whole plan when no request log exists", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const planId = await makeEvent(t, world, leaderToken);
+    await t.mutation(api.functions.scheduling.assignments.assignRole, {
+      token: leaderToken,
+      planId,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+    });
+    // Publish by hand, leaving the request log empty (the legacy shape).
+    await t.run(async (ctx) => {
+      await ctx.db.patch(planId, {
+        status: "published",
+        updatedAt: Date.now(),
+      });
+    });
+
+    const targets = await t.query(
+      internal.functions.scheduling.assignments.getAssignmentRequestTargets,
+      {
+        planId,
+        publisherId: world.groupLeaderId,
+        onlyAlreadyRequested: true,
+      },
+    );
+
+    expect(targets?.recipients).toHaveLength(1);
+  });
+});

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -1834,7 +1834,15 @@ export const getAssignmentPlanForResend = internalQuery({
     if (!assignment) {
       throw new ConvexError("Assignment not found");
     }
-    await requirePlanScheduler(ctx, assignment.planId, args.callerId);
+    // Scoped to the assignment's own team, matching assign / unassign / publish
+    // — otherwise a manager could publish their team in bulk but hit an
+    // authorization error re-sending to one of their own volunteers.
+    await requirePlanTeamScheduler(
+      ctx,
+      assignment.planId,
+      assignment.teamId,
+      args.callerId,
+    );
     // Only re-send to volunteers who haven't answered yet. The fan-out
     // (`getAssignmentRequestTargets`) targets `unconfirmed` assignments only, so
     // returning a plan id for a confirmed *or* declined assignment would report

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -38,6 +38,7 @@ import { DOMAIN_CONFIG } from "@togather/shared/config";
 import {
   requireTeamGroupMember,
   requirePlanScheduler,
+  requirePlanTeamScheduler,
   isGroupScheduler,
 } from "./permissions";
 
@@ -292,7 +293,14 @@ export const assignRole = mutation({
   },
   handler: async (ctx, args) => {
     const callerId = await requireAuth(ctx, args.token);
-    const { plan } = await requirePlanScheduler(ctx, args.planId, callerId);
+    // Team-scoped: a manager fills their own team's cells without needing
+    // leadership over the whole campus group.
+    const { plan } = await requirePlanTeamScheduler(
+      ctx,
+      args.planId,
+      args.teamId,
+      callerId,
+    );
 
     return performAssignment(ctx, {
       plan,
@@ -762,7 +770,14 @@ export const unassign = mutation({
     if (!assignment) {
       throw new ConvexError("Assignment not found");
     }
-    await requirePlanScheduler(ctx, assignment.planId, callerId);
+    // Scoped to the assignment's own team, so a manager can clear their team's
+    // cells but not another team's.
+    await requirePlanTeamScheduler(
+      ctx,
+      assignment.planId,
+      assignment.teamId,
+      callerId,
+    );
 
     await ctx.db.delete(args.assignmentId);
 
@@ -929,18 +944,27 @@ export const previousFillers = query({
 
 /**
  * Publish an event: flip its status to `published`, then fan out a request
- * notification (push + SMS) to every volunteer with an `unconfirmed`
- * assignment so they can accept or decline.
+ * notification (push + SMS) to volunteers with an `unconfirmed` assignment so
+ * they can accept or decline.
+ *
+ * Pass `teamIds` to scope the fan-out to specific serving teams. An event plan
+ * is a date column shared by every team at the campus, so an unscoped publish
+ * notifies all of them — which is how a crew lead sending their own team's
+ * requests ended up texting the entire production roster too. Omitting
+ * `teamIds` keeps the historical all-teams behaviour.
  *
  * Sending is delegated to an internal action via `ctx.scheduler` so a large
  * roster does not block the request — same pattern as `eventBlasts`.
  *
- * Auth: group leader or community admin for the event's group.
+ * Auth: group leader or community admin for the event's group; or, when every
+ * requested team is one they manage, a team manager.
  */
 export const publishEvent = action({
   args: {
     token: v.string(),
     planId: v.id("eventPlans"),
+    /** Restrict the request fan-out to these teams. Omit for all teams. */
+    teamIds: v.optional(v.array(v.id("teams"))),
   },
   handler: async (ctx, args): Promise<{ published: boolean; requestCount: number }> => {
     const callerId = await requireAuthFromTokenAction(ctx, args.token);
@@ -948,20 +972,30 @@ export const publishEvent = action({
     const result: { requestCount: number; teamIds: Id<"teams">[] } =
       await ctx.runMutation(
         internal.functions.scheduling.assignments.markPublished,
-        { planId: args.planId, callerId: callerId as Id<"users"> },
+        {
+          planId: args.planId,
+          callerId: callerId as Id<"users">,
+          teamIds: args.teamIds,
+        },
       );
 
     if (result.requestCount > 0) {
       await ctx.scheduler.runAfter(
         0,
         internal.functions.scheduling.assignments.sendAssignmentRequests,
-        { planId: args.planId, publisherId: callerId as Id<"users"> },
+        {
+          planId: args.planId,
+          publisherId: callerId as Id<"users">,
+          teamIds: args.teamIds,
+        },
       );
     }
 
-    // Auto-sync every team channel that has assignments on this event so
-    // publishing pulls confirmed/unconfirmed volunteers into their channels,
-    // plus any cross-team channel that draws from those serving teams.
+    // Auto-sync every team channel this publish actually touched so it pulls
+    // confirmed/unconfirmed volunteers into their channels, plus any
+    // cross-team channel that draws from those serving teams. A scoped publish
+    // reconciles only the teams it published — `markPublished` narrows the
+    // list — so it can't churn an untouched team's membership.
     for (const teamId of result.teamIds) {
       await ctx.scheduler.runAfter(
         0,
@@ -983,41 +1017,75 @@ export const publishEvent = action({
 /**
  * Internal: verify scheduler auth, set the plan to `published`, and report
  * how many unconfirmed assignments will receive a request notification.
+ *
+ * When `teamIds` is set, both the count and the returned reconcile list are
+ * narrowed to those teams, and auth is satisfied by managing every one of them
+ * (a group leader still passes for any team).
  */
 export const markPublished = internalMutation({
   args: {
     planId: v.id("eventPlans"),
     callerId: v.id("users"),
+    teamIds: v.optional(v.array(v.id("teams"))),
   },
   handler: async (ctx, args) => {
-    await requirePlanScheduler(ctx, args.planId, args.callerId);
+    const scope = args.teamIds;
+    if (scope && scope.length > 0) {
+      // Each requested team is authorized individually, so a manager of one
+      // team can't slip a team they don't manage into the same publish.
+      for (const teamId of scope) {
+        await requirePlanTeamScheduler(
+          ctx,
+          args.planId,
+          teamId,
+          args.callerId,
+        );
+      }
+    } else {
+      await requirePlanScheduler(ctx, args.planId, args.callerId);
+    }
 
     await ctx.db.patch(args.planId, {
       status: "published",
       updatedAt: Date.now(),
     });
 
-    const assignments = await ctx.db
+    const allAssignments = await ctx.db
       .query("roleAssignments")
       .withIndex("by_plan", (q) => q.eq("planId", args.planId))
       .collect();
+    const assignments = scopeAssignmentsToTeams(allAssignments, scope);
     const requestCount = assignments.filter(
       (a) => a.status === "unconfirmed",
     ).length;
 
     // Schedule the automatic 4-day / 1-day "still unconfirmed?" nudges.
-    // Only worth scheduling if someone hasn't responded yet.
+    // Only worth scheduling if someone hasn't responded yet. The reminders
+    // themselves re-derive their audience from the request log, so a scoped
+    // publish can't have its nudges leak into an unpublished team.
     if (requestCount > 0) {
       await scheduleUnconfirmedReminders(ctx, args.planId);
     }
 
-    // Distinct serving teams touched by this event's assignments — the action
-    // reconciles each one after publishing.
+    // Distinct serving teams this publish touched — the action reconciles each.
     const teamIds = [...new Set(assignments.map((a) => a.teamId))];
 
     return { requestCount, teamIds };
   },
 });
+
+/**
+ * Narrow assignments to a set of teams. An empty or absent scope means "every
+ * team", preserving the pre-scoping behaviour for callers that don't pass one.
+ */
+function scopeAssignmentsToTeams<T extends { teamId: Id<"teams"> }>(
+  assignments: T[],
+  teamIds: Id<"teams">[] | undefined,
+): T[] {
+  if (!teamIds || teamIds.length === 0) return assignments;
+  const allowed = new Set(teamIds.map((id) => id.toString()));
+  return assignments.filter((a) => allowed.has(a.teamId.toString()));
+}
 
 /** The two reminder lead times, in days before `eventDate`. */
 const REMINDER_KINDS = [
@@ -1151,6 +1219,10 @@ export const sendUnconfirmedReminders = internalAction({
         planId: args.planId,
         publisherId: plan.createdById,
         includeConfirmed: args.kind === "1d",
+        // Only nudge people who were actually asked. Publishing is now
+        // team-scoped, so "every unconfirmed assignment on the plan" would
+        // reintroduce the cross-team leak on a four-day delay.
+        onlyAlreadyRequested: true,
       },
     );
 
@@ -1326,24 +1398,57 @@ export const getAssignmentRequestTargets = internalQuery({
     // per-person "Re-send request" action). Any non-matching status filter
     // below still applies.
     assignmentIds: v.optional(v.array(v.id("roleAssignments"))),
+    // When set, restrict the fan-out to these serving teams (powers scoped
+    // publishing). Omit or pass an empty array for every team on the plan.
+    teamIds: v.optional(v.array(v.id("teams"))),
+    // When true, only assignments that have actually been sent a request are
+    // eligible. Reminders use this: a plan published for one team must not
+    // nudge a team that was never asked in the first place.
+    onlyAlreadyRequested: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const plan = await ctx.db.get(args.planId);
     if (!plan) return null;
 
-    const assignments = await ctx.db
-      .query("roleAssignments")
-      .withIndex("by_plan", (q) => q.eq("planId", args.planId))
-      .collect();
+    const assignments = scopeAssignmentsToTeams(
+      await ctx.db
+        .query("roleAssignments")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect(),
+      args.teamIds,
+    );
     const onlyIds = args.assignmentIds
       ? new Set(args.assignmentIds.map((id) => id.toString()))
       : null;
+
+    // The append-only request log is the record of who has actually been
+    // asked. Deriving the reminder audience from it (rather than from every
+    // unconfirmed assignment on the plan) is what keeps a scoped publish
+    // scoped four days later, with no extra state to maintain.
+    //
+    // An *empty* log is treated as "no record either way" rather than "nobody
+    // was asked": a plan published before request logging existed has no rows,
+    // and silently dropping its in-flight reminders would be a regression with
+    // no upside. Once a plan has any log row, the log is authoritative.
+    let requested: Set<string> | null = null;
+    if (args.onlyAlreadyRequested) {
+      const log = await ctx.db
+        .query("assignmentRequestLog")
+        .withIndex("by_plan", (q) => q.eq("planId", args.planId))
+        .collect();
+      requested =
+        log.length > 0
+          ? new Set(log.map((row) => row.assignmentId.toString()))
+          : null;
+    }
+
     // Always nudge the unconfirmed; for the 1-day pass also include those
     // who've already confirmed (a serving-tomorrow heads-up). Declined and
     // removed assignments are never notified. A targeted re-send additionally
     // narrows to the requested assignment ids.
     const targeted = assignments.filter((a) => {
       if (onlyIds && !onlyIds.has(a._id.toString())) return false;
+      if (requested && !requested.has(a._id.toString())) return false;
       return args.includeConfirmed
         ? a.status === "unconfirmed" || a.status === "confirmed"
         : a.status === "unconfirmed";
@@ -1444,6 +1549,8 @@ export const sendAssignmentRequests = internalAction({
     publisherId: v.id("users"),
     // When set, only (re-)send to these assignments — the per-person re-send.
     assignmentIds: v.optional(v.array(v.id("roleAssignments"))),
+    // When set, only send to assignments on these serving teams.
+    teamIds: v.optional(v.array(v.id("teams"))),
   },
   handler: async (ctx, args) => {
     const targets = await ctx.runQuery(
@@ -1452,6 +1559,7 @@ export const sendAssignmentRequests = internalAction({
         planId: args.planId,
         publisherId: args.publisherId,
         assignmentIds: args.assignmentIds,
+        teamIds: args.teamIds,
       },
     );
     if (!targets || targets.recipients.length === 0) {

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -43,15 +43,71 @@ export async function requireTeam(
 }
 
 /**
- * Whether `userId` may manage `team`'s schedule — the team channel's
- * admin/moderator (when the team has a channel), OR the campus group leader,
- * OR a community admin.
+ * Whether `userId` is an explicit manager of `teamId` (ADR-025).
+ *
+ * This is roster authority scoped to a single team: it lets someone send that
+ * team's serving requests and fill its roster without being a campus group
+ * leader. It never grants anything outside the team.
+ */
+export async function isTeamManager(
+  ctx: QueryCtx | MutationCtx,
+  teamId: Id<"teams">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const row = await ctx.db
+    .query("teamManagers")
+    .withIndex("by_team_user", (q) =>
+      q.eq("teamId", teamId).eq("userId", userId),
+    )
+    .first();
+  return row !== null;
+}
+
+/**
+ * The teams within `groupId` that `userId` explicitly manages.
+ *
+ * Drives the roster grid's default scope and the publish picker's
+ * pre-selection. Group leaders are deliberately *not* special-cased here: a
+ * leader who manages no team gets an empty list and therefore the unchanged
+ * "all teams" view, while a leader who does manage teams gets the same helpful
+ * narrowing as anyone else (they can still widen the filter at any time).
+ */
+export async function managedTeamIdsInGroup(
+  ctx: QueryCtx | MutationCtx,
+  groupId: Id<"groups">,
+  userId: Id<"users">,
+): Promise<Id<"teams">[]> {
+  const rows = await ctx.db
+    .query("teamManagers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+
+  const managed = await Promise.all(
+    rows.map(async (row) => {
+      const team = await ctx.db.get(row.teamId);
+      return team && team.groupId === groupId && team.isArchived !== true
+        ? row.teamId
+        : null;
+    }),
+  );
+  return managed.filter((id): id is Id<"teams"> => id !== null);
+}
+
+/**
+ * Whether `userId` may manage `team`'s schedule — an explicit team manager, OR
+ * the team channel's admin/moderator (when the team has a channel), OR the
+ * campus group leader, OR a community admin.
  */
 export async function isTeamScheduler(
   ctx: QueryCtx | MutationCtx,
   team: Doc<"teams">,
   userId: Id<"users">,
 ): Promise<boolean> {
+  // 0. Explicit team manager.
+  if (await isTeamManager(ctx, team._id, userId)) {
+    return true;
+  }
+
   // 1. Team channel admin / moderator (only if the team has a channel).
   if (team.channelId) {
     const channelId = team.channelId;
@@ -350,4 +406,45 @@ export async function requirePlanScheduler(
   }
   const group = await requireGroupScheduler(ctx, plan.groupId, userId);
   return { plan, group };
+}
+
+/**
+ * Require permission to act on *one team's* slice of an event plan — filling
+ * a roster cell, removing an assignment, sending that team's requests.
+ *
+ * Passes for a campus group leader / community admin (who own the whole plan),
+ * or for an explicit manager of `teamId`. Weaker than `requirePlanScheduler`
+ * by design: a team manager is trusted with their own team's roster and
+ * nothing else, so the team is verified to belong to the plan's group before
+ * the manager check is honoured.
+ *
+ * @throws ConvexError if the plan or team is missing, the team belongs to a
+ *   different group, or the caller manages neither the group nor the team.
+ */
+export async function requirePlanTeamScheduler(
+  ctx: QueryCtx | MutationCtx,
+  planId: Id<"eventPlans">,
+  teamId: Id<"teams">,
+  userId: Id<"users">,
+): Promise<{ plan: Doc<"eventPlans">; team: Doc<"teams"> }> {
+  const plan = await ctx.db.get(planId);
+  if (!plan) {
+    throw new ConvexError("Event not found");
+  }
+  const team = await requireTeam(ctx, teamId);
+  if (team.groupId !== plan.groupId) {
+    throw new ConvexError("That team does not belong to this event's group");
+  }
+
+  const group = await ctx.db.get(plan.groupId);
+  if (group && (await isGroupScheduler(ctx, group, userId))) {
+    return { plan, team };
+  }
+  if (await isTeamManager(ctx, teamId, userId)) {
+    return { plan, team };
+  }
+
+  throw new ConvexError(
+    `You must manage ${team.name} — or be a group leader or community admin — to do that`,
+  );
 }

--- a/apps/convex/functions/scheduling/permissions.ts
+++ b/apps/convex/functions/scheduling/permissions.ts
@@ -60,8 +60,19 @@ export async function isTeamManager(
       q.eq("teamId", teamId).eq("userId", userId),
     )
     .first();
-  return row !== null;
+  if (!row) return false;
+
+  // Membership is re-verified on every check rather than cleaned up when
+  // someone leaves. `groupMembers.remove` only stamps `leftAt`, and there are
+  // several ways out of a group (removed, left, request revoked) — a stale
+  // `teamManagers` row must never be enough on its own to keep publishing to
+  // a team you're no longer part of. Verifying here means no exit path can be
+  // missed.
+  const team = await ctx.db.get(teamId);
+  if (!team) return false;
+  return isActiveGroupMember(ctx, team.groupId, userId);
 }
+
 
 /**
  * The teams within `groupId` that `userId` explicitly manages.
@@ -81,6 +92,11 @@ export async function managedTeamIdsInGroup(
     .query("teamManagers")
     .withIndex("by_user", (q) => q.eq("userId", userId))
     .collect();
+
+  // A manager who has left the group manages nothing — same rule as
+  // `isTeamManager`, checked once for the group rather than per team.
+  if (rows.length === 0) return [];
+  if (!(await isActiveGroupMember(ctx, groupId, userId))) return [];
 
   const managed = await Promise.all(
     rows.map(async (row) => {

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -77,7 +77,19 @@ export const rosterMatrix = query({
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
-    await requireGroupScheduler(ctx, args.groupId, userId);
+    // Team managers are schedulers for their own teams, so they must be able to
+    // load the grid — it's the only surface for assigning and publishing. They
+    // see the whole group's roster (the same data a leader sees); what's scoped
+    // is what they can *change*, which every mutation enforces on its own. The
+    // grid opens narrowed to their teams via `isManagedByMe` below.
+    const managedTeamIds = await managedTeamIdsInGroup(
+      ctx,
+      args.groupId,
+      userId,
+    );
+    if (managedTeamIds.length === 0) {
+      await requireGroupScheduler(ctx, args.groupId, userId);
+    }
 
     const cap = Math.max(
       1,
@@ -310,15 +322,10 @@ export const rosterMatrix = query({
     const channelDocs = await Promise.all(
       teamDocsList.map((t) => (t.channelId ? ctx.db.get(t.channelId) : Promise.resolve(null))),
     );
-    // Teams the caller explicitly manages. The grid opens scoped to these and
-    // the publish picker pre-selects them; an empty list means the caller
-    // manages no team here (a plain group leader), who keeps the unchanged
-    // all-teams view.
-    const managedTeamIds = await managedTeamIdsInGroup(
-      ctx,
-      args.groupId,
-      userId,
-    );
+    // Teams the caller explicitly manages (resolved at the top, where they also
+    // gate access). The grid opens scoped to these and the publish picker
+    // pre-selects them; an empty list means the caller manages no team here (a
+    // plain group leader), who keeps the unchanged all-teams view.
     const managedSet = new Set(managedTeamIds.map((id) => id.toString()));
 
     const teams = teamDocsList

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -21,7 +21,27 @@ import { query } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
-import { requireGroupMember, requireGroupScheduler } from "./permissions";
+import {
+  managedTeamIdsInGroup,
+  requireGroupMember,
+  requireGroupScheduler,
+} from "./permissions";
+
+/**
+ * Tally unconfirmed assignments per serving team. Feeds the publish picker,
+ * which needs a per-team count to label each checkbox.
+ */
+function countPendingByTeam(
+  assignments: Doc<"roleAssignments">[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const a of assignments) {
+    if (a.status !== "unconfirmed") continue;
+    const key = a.teamId as string;
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
 
 /** Column cap — a leader rosters a horizon of upcoming events. */
 const MAX_EVENTS = 10;
@@ -121,6 +141,10 @@ export const rosterMatrix = query({
       // needed role (which have no `roleCells` entry), so the grid's publish
       // confirm dialog can't undercount the request fan-out.
       pendingCount: assignments.filter((a) => a.status === "unconfirmed").length,
+      // The same count broken out per serving team, so the publish picker can
+      // label each checkbox and total only the teams actually selected without
+      // a second round-trip.
+      pendingByTeam: countPendingByTeam(assignments),
     }));
 
     // --- Resolve display names for every role and user referenced. ---
@@ -286,12 +310,24 @@ export const rosterMatrix = query({
     const channelDocs = await Promise.all(
       teamDocsList.map((t) => (t.channelId ? ctx.db.get(t.channelId) : Promise.resolve(null))),
     );
+    // Teams the caller explicitly manages. The grid opens scoped to these and
+    // the publish picker pre-selects them; an empty list means the caller
+    // manages no team here (a plain group leader), who keeps the unchanged
+    // all-teams view.
+    const managedTeamIds = await managedTeamIdsInGroup(
+      ctx,
+      args.groupId,
+      userId,
+    );
+    const managedSet = new Set(managedTeamIds.map((id) => id.toString()));
+
     const teams = teamDocsList
       .map((t, idx) => ({
         teamId: t._id,
         teamName: t.name,
         hasChannel: t.channelId !== undefined,
         channelMemberCount: channelDocs[idx]?.memberCount ?? 0,
+        isManagedByMe: managedSet.has(t._id.toString()),
       }))
       .sort((a, b) => a.teamName.localeCompare(b.teamName));
 

--- a/apps/convex/functions/scheduling/teams.ts
+++ b/apps/convex/functions/scheduling/teams.ts
@@ -157,12 +157,18 @@ export const createServingTeam = mutation({
     description: v.optional(v.string()),
     /** Whether to also create the team's chat channel. Defaults to `true`. */
     withChannel: v.optional(v.boolean()),
+    /**
+     * Who manages this team's roster from the start. Each must already be an
+     * active member of the campus group; non-members are skipped rather than
+     * failing the whole creation.
+     */
+    managerUserIds: v.optional(v.array(v.id("users"))),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
     const group = await requireGroupScheduler(ctx, args.groupId, userId);
 
-    return createServingTeamImpl(ctx, {
+    const result = await createServingTeamImpl(ctx, {
       groupId: args.groupId,
       communityId: group.communityId,
       name: args.name,
@@ -170,6 +176,188 @@ export const createServingTeam = mutation({
       createdById: userId,
       withChannel: args.withChannel,
     });
+
+    // Managers are set explicitly, never implied. The creator is *not* added
+    // automatically: a group leader who creates all seven of a campus's teams
+    // would end up "managing" all seven, which would defeat the grid's
+    // default-to-my-teams scoping for the one person it most needs to help.
+    // The create screen pre-fills the creator into this list instead, so it
+    // stays a visible, removable choice.
+    for (const managerId of dedupeIds(args.managerUserIds ?? [])) {
+      const membership = await ctx.db
+        .query("groupMembers")
+        .withIndex("by_group_user", (q) =>
+          q.eq("groupId", args.groupId).eq("userId", managerId),
+        )
+        .filter((q) => q.eq(q.field("leftAt"), undefined))
+        .first();
+      // Skip rather than throw: a stale picker row shouldn't lose the team the
+      // leader just filled out. `addTeamManager` gates strictly.
+      if (!membership) continue;
+
+      await addTeamManagerImpl(ctx, {
+        teamId: result.teamId,
+        userId: managerId,
+        communityId: group.communityId,
+        addedById: userId,
+      });
+    }
+
+    return result;
+  },
+});
+
+// ============================================================================
+// Team managers (ADR-025)
+// ============================================================================
+
+/** Drop duplicate ids while preserving order. */
+function dedupeIds<T extends string>(ids: T[]): T[] {
+  return [...new Set(ids)];
+}
+
+/**
+ * Insert a `teamManagers` row, ignoring a repeat add. Callers are responsible
+ * for auth and for checking the user belongs to the team's campus group.
+ */
+async function addTeamManagerImpl(
+  ctx: MutationCtx,
+  args: {
+    teamId: Id<"teams">;
+    userId: Id<"users">;
+    communityId: Id<"communities">;
+    addedById: Id<"users">;
+  },
+): Promise<void> {
+  const existing = await ctx.db
+    .query("teamManagers")
+    .withIndex("by_team_user", (q) =>
+      q.eq("teamId", args.teamId).eq("userId", args.userId),
+    )
+    .first();
+  if (existing) return;
+
+  await ctx.db.insert("teamManagers", {
+    teamId: args.teamId,
+    userId: args.userId,
+    communityId: args.communityId,
+    addedById: args.addedById,
+    addedAt: Date.now(),
+  });
+}
+
+/**
+ * List a team's managers (ADR-025).
+ *
+ * Auth: an active member of the team's campus group, or a community admin —
+ * the same read gate as `getTeam`. Volunteers can see who runs their team.
+ */
+export const listTeamManagers = query({
+  args: {
+    token: v.string(),
+    teamId: v.id("teams"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const team = await requireTeam(ctx, args.teamId);
+    await requireGroupMember(ctx, team.groupId, userId);
+
+    const rows = await ctx.db
+      .query("teamManagers")
+      .withIndex("by_team", (q) => q.eq("teamId", args.teamId))
+      .collect();
+
+    const managers = await Promise.all(
+      rows.map(async (row) => {
+        const user = await ctx.db.get(row.userId);
+        if (!user) return null;
+        return {
+          userId: row.userId,
+          name: getDisplayName(user.firstName, user.lastName),
+          profilePhoto: getMediaUrl(user.profilePhoto),
+          addedAt: row.addedAt,
+        };
+      }),
+    );
+
+    return managers
+      .filter((m): m is NonNullable<typeof m> => m !== null)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  },
+});
+
+/**
+ * Add a manager to a team (ADR-025).
+ *
+ * Auth: campus group leader or community admin. Deliberately *not* open to
+ * existing team managers — managing a roster and deciding who else may manage
+ * it are different levels of trust, and the leader stays the one who delegates.
+ *
+ * The user must already be an active member of the team's campus group;
+ * managing a team you can't see would be meaningless.
+ */
+export const addTeamManager = mutation({
+  args: {
+    token: v.string(),
+    teamId: v.id("teams"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+    const team = await requireTeam(ctx, args.teamId);
+    await requireGroupScheduler(ctx, team.groupId, callerId);
+
+    const membership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", team.groupId).eq("userId", args.userId),
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+    if (!membership) {
+      throw new ConvexError(
+        "Add this person to the group before making them a team manager.",
+      );
+    }
+
+    await addTeamManagerImpl(ctx, {
+      teamId: args.teamId,
+      userId: args.userId,
+      communityId: team.communityId,
+      addedById: callerId,
+    });
+
+    return { teamId: args.teamId, userId: args.userId };
+  },
+});
+
+/**
+ * Remove a manager from a team (ADR-025). No-op if they weren't one.
+ *
+ * Auth: campus group leader or community admin — same as `addTeamManager`.
+ */
+export const removeTeamManager = mutation({
+  args: {
+    token: v.string(),
+    teamId: v.id("teams"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+    const team = await requireTeam(ctx, args.teamId);
+    await requireGroupScheduler(ctx, team.groupId, callerId);
+
+    const existing = await ctx.db
+      .query("teamManagers")
+      .withIndex("by_team_user", (q) =>
+        q.eq("teamId", args.teamId).eq("userId", args.userId),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+
+    return { teamId: args.teamId, userId: args.userId };
   },
 });
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2809,6 +2809,34 @@ export default defineSchema({
     .index("by_channel", ["channelId"]),
 
   /**
+   * Who manages a serving team's roster (ADR-025).
+   *
+   * A team manager sends serving requests for *their* team and fills its
+   * roster, without being a campus group leader. This exists because roster
+   * scope and leadership scope are different things: a campus group leader has
+   * access to every team at the location, so before this a crew lead teaching
+   * someone to roster would publish an event and fan requests out to *every*
+   * team's pending volunteers, not just their own.
+   *
+   * Group leaders and community admins keep full access to every team whether
+   * or not they appear here — this table grants access, it never restricts it.
+   * Only they may edit the list.
+   */
+  teamManagers: defineTable({
+    teamId: v.id("teams"),
+    userId: v.id("users"),
+    /** Denormalized from the team so community-wide reads skip a join. */
+    communityId: v.id("communities"),
+    addedById: v.id("users"),
+    addedAt: v.number(),
+  })
+    .index("by_team", ["teamId"])
+    // Powers "which teams do I manage?" — the roster grid's default scope and
+    // the publish picker's pre-selection.
+    .index("by_user", ["userId"])
+    .index("by_team_user", ["teamId", "userId"]),
+
+  /**
    * A role within a serving team, e.g. "Drums", "Greeter". Free-form labels
    * owned by the team; no global taxonomy, no qualification rules — anyone in
    * the campus group can be assigned any role.

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -101,6 +101,8 @@ type RosterEvent = {
   status: "draft" | "published";
   /** Unconfirmed assignments for the plan — who publish will notify. */
   pendingCount: number;
+  /** The same count per serving team, keyed by team id — the publish picker. */
+  pendingByTeam: Record<string, number>;
 };
 
 type RosterTeam = {
@@ -108,7 +110,21 @@ type RosterTeam = {
   teamName: string;
   hasChannel: boolean;
   channelMemberCount: number;
+  /** Whether the viewer is an explicit manager of this team (ADR-025). */
+  isManagedByMe: boolean;
 };
+
+/**
+ * Which teams the grid is showing.
+ *
+ *  - `mine` — only teams the viewer manages. The default whenever they manage
+ *    any team here, so a crew lead isn't wading through every team at the
+ *    campus on every visit.
+ *  - `all` — every team, the historical behaviour and the fallback for a
+ *    leader who manages none.
+ *  - a team id — a single isolated team.
+ */
+type TeamScope = "mine" | "all" | string;
 
 type RosterRole = {
   roleId: Id<"teamRoles">;
@@ -417,7 +433,7 @@ export function RosterGridScreen() {
   // Team scope: a single isolated team, or null for "All teams" (#477 FR-2).
   // Picking a team shows only its roles; "All teams" shows everything. Gates
   // the Roles view only — People rows stay ungated.
-  const [isolatedTeamId, setIsolatedTeamId] = useState<string | null>(null);
+  const [teamScope, setTeamScope] = useState<TeamScope>("all");
   const [teamMenuOpen, setTeamMenuOpen] = useState(false);
   const [openOnly, setOpenOnly] = useState(false);
   const [availableOnly, setAvailableOnly] = useState(false);
@@ -526,6 +542,8 @@ export function RosterGridScreen() {
   // Publish chooser (#477 FR-3): which date(s) to publish & send requests.
   const [publishMenuOpen, setPublishMenuOpen] = useState(false);
   const [publishing, setPublishing] = useState(false);
+  /** The plan whose team picker is open, if any (ADR-025 scoped publish). */
+  const [publishTarget, setPublishTarget] = useState<RosterEvent | null>(null);
 
   // ⋯ overflow (Teams / Cross-team / Collect availability / Include past) and
   // the in-flight states for its async actions + the "＋ Add date" column.
@@ -702,27 +720,77 @@ export function RosterGridScreen() {
     return Math.max(MIN_CELL_W, Math.floor(avail / events.length));
   }, [isWide, bodyW, events.length, NAME_W, MIN_CELL_W]);
 
-  // Clear a stale isolated team once it's no longer in the loaded team list
-  // (e.g. its roles were removed). Keeps the dropdown label honest.
-  useEffect(() => {
-    if (
-      isolatedTeamId &&
-      data &&
-      !data.teams.some((t) => (t.teamId as string) === isolatedTeamId)
-    ) {
-      setIsolatedTeamId(null);
-    }
-  }, [data, isolatedTeamId]);
+  /** Teams the viewer explicitly manages (ADR-025), in display order. */
+  const myTeams = useMemo(
+    () => (data?.teams ?? []).filter((t) => t.isManagedByMe),
+    [data],
+  );
 
-  const isolatedTeamName = isolatedTeamId
-    ? data?.teams.find((t) => (t.teamId as string) === isolatedTeamId)?.teamName
-    : undefined;
+  // Open scoped to the viewer's own teams the first time this group's roster
+  // loads with any. A leader who manages none keeps the historical all-teams
+  // view. Only fires once per group so an explicit widen isn't undone by a
+  // later refetch.
+  const scopeInitializedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!data || scopeInitializedRef.current === groupId) return;
+    scopeInitializedRef.current = groupId;
+    if (myTeams.length > 0) setTeamScope("mine");
+  }, [data, groupId, myTeams.length]);
+
+  // Fall back to "all" when the scope no longer resolves to anything — an
+  // isolated team whose roles were removed, or the viewer losing their last
+  // managed team. Keeps the dropdown label honest.
+  useEffect(() => {
+    if (!data) return;
+    if (teamScope === "mine" && myTeams.length === 0) {
+      setTeamScope("all");
+      return;
+    }
+    if (
+      teamScope !== "mine" &&
+      teamScope !== "all" &&
+      !data.teams.some((t) => (t.teamId as string) === teamScope)
+    ) {
+      setTeamScope("all");
+    }
+  }, [data, teamScope, myTeams.length]);
+
+  /**
+   * The teams the grid should show, or `null` for "every team". Everything
+   * downstream — role rows, the publish picker's defaults — reads this rather
+   * than the raw scope, so the three scope kinds can't drift apart.
+   */
+  const visibleTeamIds = useMemo((): Set<string> | null => {
+    if (teamScope === "all") return null;
+    if (teamScope === "mine") {
+      return myTeams.length > 0
+        ? new Set(myTeams.map((t) => t.teamId as string))
+        : null;
+    }
+    return new Set([teamScope]);
+  }, [teamScope, myTeams]);
+
+  /** The single isolated team, when the scope is one specific team. */
+  const isolatedTeamId =
+    teamScope !== "mine" && teamScope !== "all" ? teamScope : null;
+
+  const teamScopeLabel = useMemo(() => {
+    if (teamScope === "all") return "All teams";
+    if (teamScope === "mine") {
+      return myTeams.length === 1 ? myTeams[0].teamName : "My teams";
+    }
+    return (
+      data?.teams.find((t) => (t.teamId as string) === teamScope)?.teamName ??
+      "All teams"
+    );
+  }, [teamScope, myTeams, data]);
 
   /** Roles after team + "open only" filters; grouped headers are derived on render. */
   const visibleRoles = useMemo(() => {
     if (!data) return [];
     return data.roles.filter((r) => {
-      if (isolatedTeamId && (r.teamId as string) !== isolatedTeamId) return false;
+      if (visibleTeamIds && !visibleTeamIds.has(r.teamId as string))
+        return false;
       if (openOnly) {
         // Keep only roles with at least one open slot across visible events.
         const hasOpen = events.some((ev) => {
@@ -733,7 +801,7 @@ export function RosterGridScreen() {
       }
       return true;
     });
-  }, [data, events, roleCells, isolatedTeamId, openOnly]);
+  }, [data, events, roleCells, visibleTeamIds, openOnly]);
 
   /**
    * Build the frozen-column rows from `data.teams` — the authoritative team
@@ -756,8 +824,8 @@ export function RosterGridScreen() {
     const out: RoleRow[] = [];
     for (const team of data.teams) {
       const tid = team.teamId as string;
-      // When a team is isolated, render only that team's section.
-      if (isolatedTeamId && tid !== isolatedTeamId) continue;
+      // Render only the teams the current scope covers.
+      if (visibleTeamIds && !visibleTeamIds.has(tid)) continue;
       // With "Open only" active, hide teams that have no visible roles so the
       // filter still reads as a coverage view — but always show an isolated
       // team and any team that has visible roles.
@@ -778,11 +846,11 @@ export function RosterGridScreen() {
         channelMemberCount: team.channelMemberCount,
       });
     }
-    // Trailing "＋ Add team". When a team is isolated, hide it so the rows stay
-    // scoped to that team.
-    if (!isolatedTeamId) out.push({ kind: "addTeam" });
+    // Trailing "＋ Add team". Hidden whenever the grid is narrowed, so the rows
+    // stay scoped to what the filter promises.
+    if (!visibleTeamIds) out.push({ kind: "addTeam" });
     return out;
-  }, [data, visibleRoles, isolatedTeamId, openOnly]);
+  }, [data, visibleRoles, visibleTeamIds, isolatedTeamId, openOnly]);
 
   /** Members after team* + search + open/available filters. (*teams don't gate people rows.) */
   const visibleMembers = useMemo(() => {
@@ -818,16 +886,53 @@ export function RosterGridScreen() {
   );
 
   // -------------------------------------------------------------------------
-  // Publish (#477 FR-3)
+  // Publish (#477 FR-3, team-scoped per ADR-025)
   //
   // `publishEvent` notifies only *unconfirmed* assignments (confirmed people
   // are never re-pinged). We surface `event.pendingCount` straight from
   // `rosterMatrix`, which counts unconfirmed assignments off `by_plan` — the
   // exact population `markPublished` notifies. Summing `roleCells` here would
   // undercount assignments orphaned by a removed needed role (no cell exists).
+  //
+  // An event plan is a date column shared by every team at the campus, so an
+  // unscoped publish texts all of them. `pendingByTeam` lets the picker show
+  // exactly who each checkbox will notify before anything is sent.
   // -------------------------------------------------------------------------
   const requestCountForEvent = useCallback(
-    (event: RosterEvent): number => event.pendingCount,
+    (event: RosterEvent, teamIds?: string[] | null): number => {
+      if (!teamIds) return event.pendingCount;
+      return teamIds.reduce(
+        (sum, tid) => sum + (event.pendingByTeam[tid] ?? 0),
+        0,
+      );
+    },
+    [],
+  );
+
+  /**
+   * Teams with someone awaiting a reply on this date — the picker's rows.
+   * A team with nothing pending would be a checkbox that sends zero requests,
+   * so it's left out rather than shown as a no-op.
+   */
+  const publishTeamsForEvent = useCallback(
+    (event: RosterEvent): RosterTeam[] =>
+      (data?.teams ?? []).filter(
+        (t) => (event.pendingByTeam[t.teamId as string] ?? 0) > 0,
+      ),
+    [data],
+  );
+
+  /**
+   * Which teams a publish should pre-select. Teams the viewer manages, or —
+   * when they manage none here (a plain group leader) — everything, which is
+   * the historical behaviour.
+   */
+  const defaultPublishSelection = useCallback(
+    (candidates: RosterTeam[]): Set<string> => {
+      const mine = candidates.filter((t) => t.isManagedByMe);
+      const chosen = mine.length > 0 ? mine : candidates;
+      return new Set(chosen.map((t) => t.teamId as string));
+    },
     [],
   );
 
@@ -837,25 +942,19 @@ export function RosterGridScreen() {
     [events],
   );
 
-  /** Publish a single plan, with a confirm listing its request count. */
-  const publishOne = useCallback(
-    async (event: RosterEvent) => {
-      const count = requestCountForEvent(event);
-      const dateLabel = `${weekday(event.eventDate)} ${monthDay(event.eventDate)}`;
+  /**
+   * Send one plan's requests for a chosen set of teams. `teamIds` of `null`
+   * means every team (the historical unscoped publish).
+   */
+  const runPublish = useCallback(
+    async (event: RosterEvent, teamIds: string[] | null) => {
       const already = event.status === "published";
-      const ok = await confirmAsync({
-        title: already ? "Re-send requests?" : "Publish & send requests?",
-        message:
-          `${dateLabel} — ${count} request${count === 1 ? "" : "s"} will be sent.` +
-          (count > 0
-            ? "\n\nConfirmed people won't be re-notified."
-            : "\n\nNo one is awaiting a response on this date yet."),
-        confirmText: already ? "Re-send" : "Send",
-      });
-      if (!ok) return;
       setPublishing(true);
       try {
-        const result = await publishEvent({ planId: event._id });
+        const result = await publishEvent({
+          planId: event._id,
+          ...(teamIds ? { teamIds: teamIds as Id<"teams">[] } : {}),
+        });
         notify(
           already ? "Requests re-sent" : "Published",
           result.requestCount > 0
@@ -868,21 +967,68 @@ export function RosterGridScreen() {
         setPublishing(false);
       }
     },
-    [requestCountForEvent, publishEvent, surfaceError],
+    [publishEvent, surfaceError],
   );
 
-  /** Publish every draft plan, with a confirm listing each date + its count. */
+  /**
+   * Publish a single plan. With more than one team awaiting replies, open the
+   * team picker so the sender sees exactly who they're about to text; with one
+   * (or none), there's nothing to choose, so a plain confirm is enough.
+   */
+  const publishOne = useCallback(
+    async (event: RosterEvent) => {
+      const candidates = publishTeamsForEvent(event);
+      if (candidates.length > 1) {
+        setPublishTarget(event);
+        return;
+      }
+
+      const teamIds =
+        candidates.length === 1 ? [candidates[0].teamId as string] : null;
+      const count = requestCountForEvent(event, teamIds);
+      const dateLabel = `${weekday(event.eventDate)} ${monthDay(event.eventDate)}`;
+      const already = event.status === "published";
+      const who =
+        candidates.length === 1 ? ` for ${candidates[0].teamName}` : "";
+      const ok = await confirmAsync({
+        title: already ? "Re-send requests?" : "Publish & send requests?",
+        message:
+          `${dateLabel}${who} — ${count} request${count === 1 ? "" : "s"} will be sent.` +
+          (count > 0
+            ? "\n\nConfirmed people won't be re-notified."
+            : "\n\nNo one is awaiting a response on this date yet."),
+        confirmText: already ? "Re-send" : "Send",
+      });
+      if (!ok) return;
+      await runPublish(event, teamIds);
+    },
+    [publishTeamsForEvent, requestCountForEvent, runPublish],
+  );
+
+  /**
+   * Publish every draft plan at once. Scoped to the teams the sender manages
+   * when they manage any — a bulk send is the least reviewable path, so it
+   * must not be the one that quietly reaches every team. The confirm names the
+   * teams so the scope is never a surprise.
+   */
   const publishAllDrafts = useCallback(async () => {
     if (draftEvents.length === 0) return;
+
+    const mine = (data?.teams ?? []).filter((t) => t.isManagedByMe);
+    const teamIds = mine.length > 0 ? mine.map((t) => t.teamId as string) : null;
+    const scopeLine = teamIds
+      ? `\n\nOnly your teams (${mine.map((t) => t.teamName).join(", ")}) will be notified.`
+      : "";
+
     const lines = draftEvents
       .map((e) => {
-        const count = requestCountForEvent(e);
+        const count = requestCountForEvent(e, teamIds);
         return `• ${weekday(e.eventDate)} ${monthDay(e.eventDate)} — ${count} request${count === 1 ? "" : "s"}`;
       })
       .join("\n");
     const ok = await confirmAsync({
       title: "Publish all draft dates?",
-      message: `These dates will notify volunteers:\n${lines}\n\nConfirmed people won't be re-notified.`,
+      message: `These dates will notify volunteers:\n${lines}${scopeLine}\n\nConfirmed people won't be re-notified.`,
       confirmText: "Send",
     });
     if (!ok) return;
@@ -890,7 +1036,10 @@ export function RosterGridScreen() {
     try {
       let total = 0;
       for (const e of draftEvents) {
-        const result = await publishEvent({ planId: e._id });
+        const result = await publishEvent({
+          planId: e._id,
+          ...(teamIds ? { teamIds: teamIds as Id<"teams">[] } : {}),
+        });
         total += result.requestCount;
       }
       notify(
@@ -904,7 +1053,7 @@ export function RosterGridScreen() {
     } finally {
       setPublishing(false);
     }
-  }, [draftEvents, requestCountForEvent, publishEvent, surfaceError]);
+  }, [draftEvents, data, requestCountForEvent, publishEvent, surfaceError]);
 
   /**
    * Entry point for the Publish action. With a single date in the grid, skip
@@ -1243,9 +1392,9 @@ export function RosterGridScreen() {
     mode === "roles" && data.teams.length > 0 ? (
       <Chip
         icon="people-outline"
-        label={isolatedTeamName ?? "All teams"}
+        label={teamScopeLabel}
         trailingIcon="chevron-down"
-        active={isolatedTeamId !== null}
+        active={teamScope !== "all"}
         onPress={() => setTeamMenuOpen(true)}
         colors={colors}
       />
@@ -2322,13 +2471,32 @@ export function RosterGridScreen() {
       {teamMenuOpen && (
         <TeamFilterMenu
           teams={data.teams}
-          selectedId={isolatedTeamId}
+          myTeamCount={myTeams.length}
+          selectedScope={teamScope}
           colors={colors}
-          onPick={(id) => {
-            setIsolatedTeamId(id);
+          onPick={(scope) => {
+            setTeamScope(scope);
             setTeamMenuOpen(false);
           }}
           onClose={() => setTeamMenuOpen(false)}
+        />
+      )}
+
+      {publishTarget && (
+        <PublishTeamPicker
+          event={publishTarget}
+          teams={publishTeamsForEvent(publishTarget)}
+          initialSelection={defaultPublishSelection(
+            publishTeamsForEvent(publishTarget),
+          )}
+          publishing={publishing}
+          colors={colors}
+          onConfirm={async (teamIds) => {
+            const target = publishTarget;
+            setPublishTarget(null);
+            await runPublish(target, teamIds);
+          }}
+          onClose={() => setPublishTarget(null)}
         />
       )}
 
@@ -3065,6 +3233,143 @@ function OpenRolesMenu({
 }
 
 /**
+ * Publish picker — choose which serving teams a date's requests go to.
+ *
+ * An event plan is a date column shared by every team at the campus, so
+ * publishing it used to text every team's pending volunteers at once: a crew
+ * lead sending their own team's requests also reached the whole production
+ * roster. This is the surface that makes the fan-out visible and deliberate
+ * before anything is sent.
+ *
+ * Teams the sender doesn't manage start unchecked and are labelled, so
+ * reaching another team is always an opt-in, never a default.
+ */
+function PublishTeamPicker({
+  event,
+  teams,
+  initialSelection,
+  publishing,
+  colors,
+  onConfirm,
+  onClose,
+}: {
+  event: RosterEvent;
+  teams: RosterTeam[];
+  initialSelection: Set<string>;
+  publishing: boolean;
+  colors: Colors;
+  onConfirm: (teamIds: string[]) => void;
+  onClose: () => void;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(initialSelection);
+
+  const toggle = useCallback((teamId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(teamId)) next.delete(teamId);
+      else next.add(teamId);
+      return next;
+    });
+  }, []);
+
+  const total = useMemo(
+    () =>
+      [...selected].reduce(
+        (sum, tid) => sum + (event.pendingByTeam[tid] ?? 0),
+        0,
+      ),
+    [selected, event],
+  );
+
+  const already = event.status === "published";
+  const dateLabel = `${weekday(event.eventDate)} ${monthDay(event.eventDate)}`;
+
+  return (
+    <ModalShell
+      title={already ? "Re-send requests?" : "Publish & send requests?"}
+      subtitle={`${dateLabel} · ${event.pendingCount} awaiting a reply`}
+      colors={colors}
+      onClose={onClose}
+    >
+      <ScrollView style={styles.popoverList}>
+        {teams.map((t) => {
+          const tid = t.teamId as string;
+          const count = event.pendingByTeam[tid] ?? 0;
+          const isSelected = selected.has(tid);
+          return (
+            <Pressable
+              key={tid}
+              onPress={() => toggle(tid)}
+              style={[styles.menuRow, { borderBottomColor: colors.border }]}
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked: isSelected }}
+              accessibilityLabel={`${t.teamName}, ${count} pending`}
+            >
+              <Ionicons
+                name={isSelected ? "checkbox" : "square-outline"}
+                size={20}
+                color={isSelected ? colors.link : colors.textTertiary}
+              />
+              <View style={[styles.menuRowText, styles.publishRowText]}>
+                <Text
+                  style={[styles.occupantName, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  {t.teamName}
+                </Text>
+                {!t.isManagedByMe && (
+                  <Text
+                    style={[
+                      styles.menuRowSub,
+                      { color: colors.textTertiary },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    Not a team you manage
+                  </Text>
+                )}
+              </View>
+              <Text
+                style={[styles.menuRowCount, { color: colors.textSecondary }]}
+              >
+                {count} pending
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+
+      <Text style={[styles.publishFootnote, { color: colors.textTertiary }]}>
+        Confirmed people won&apos;t be re-notified.
+      </Text>
+
+      <TouchableOpacity
+        style={[
+          styles.publishConfirmButton,
+          {
+            backgroundColor:
+              total > 0 && !publishing ? colors.buttonPrimary : colors.border,
+          },
+        ]}
+        disabled={total === 0 || publishing}
+        onPress={() => onConfirm([...selected])}
+        accessibilityRole="button"
+      >
+        {publishing ? (
+          <ActivityIndicator size="small" color="#fff" />
+        ) : (
+          <Text style={styles.publishConfirmText}>
+            {total === 0
+              ? "Pick a team"
+              : `Send ${total} request${total === 1 ? "" : "s"}`}
+          </Text>
+        )}
+      </TouchableOpacity>
+    </ModalShell>
+  );
+}
+
+/**
  * "Also in group" picker — narrows the People view to members who also belong
  * to one of the leader's other groups. "Everyone" clears the filter.
  */
@@ -3127,15 +3432,17 @@ function GroupFilterMenu({
  */
 function TeamFilterMenu({
   teams,
-  selectedId,
+  myTeamCount,
+  selectedScope,
   colors,
   onPick,
   onClose,
 }: {
   teams: RosterTeam[];
-  selectedId: string | null;
+  myTeamCount: number;
+  selectedScope: TeamScope;
   colors: Colors;
-  onPick: (id: string | null) => void;
+  onPick: (scope: TeamScope) => void;
   onClose: () => void;
 }) {
   return (
@@ -3146,15 +3453,36 @@ function TeamFilterMenu({
       onClose={onClose}
     >
       <ScrollView style={styles.popoverList}>
+        {/* Only offered when the viewer actually manages something here —
+            otherwise it would be an option that changes nothing. */}
+        {myTeamCount > 0 && (
+          <Pressable
+            onPress={() => onPick("mine")}
+            style={[styles.menuRow, { borderBottomColor: colors.border }]}
+            accessibilityRole="button"
+          >
+            <View style={styles.menuRowText}>
+              <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
+                My teams
+              </Text>
+              <Text style={[styles.menuRowSub, { color: colors.textTertiary }]} numberOfLines={1}>
+                {myTeamCount} team{myTeamCount === 1 ? "" : "s"} you manage
+              </Text>
+            </View>
+            {selectedScope === "mine" && (
+              <Ionicons name="checkmark" size={20} color={colors.link} />
+            )}
+          </Pressable>
+        )}
         <Pressable
-          onPress={() => onPick(null)}
+          onPress={() => onPick("all")}
           style={[styles.menuRow, { borderBottomColor: colors.border }]}
           accessibilityRole="button"
         >
           <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
             All teams
           </Text>
-          {selectedId === null && (
+          {selectedScope === "all" && (
             <Ionicons name="checkmark" size={20} color={colors.link} />
           )}
         </Pressable>
@@ -3168,7 +3496,7 @@ function TeamFilterMenu({
             <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
               {t.teamName}
             </Text>
-            {selectedId === (t.teamId as string) && (
+            {selectedScope === (t.teamId as string) && (
               <Ionicons name="checkmark" size={20} color={colors.link} />
             )}
           </Pressable>
@@ -4316,6 +4644,22 @@ const styles = StyleSheet.create({
   menuRowText: { flex: 1, minWidth: 0 },
   menuRowSub: { fontSize: 11, marginTop: 1 },
   menuRowCount: { fontSize: 13, fontWeight: "600" },
+  // Publish team picker
+  publishRowText: { marginLeft: 10 },
+  publishFootnote: {
+    fontSize: 12,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  publishConfirmButton: {
+    marginHorizontal: 16,
+    marginTop: 12,
+    borderRadius: 10,
+    paddingVertical: 13,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  publishConfirmText: { color: "#fff", fontSize: 15, fontWeight: "600" },
   stepper: { flexDirection: "row", alignItems: "center", gap: 12 },
   stepperBtn: { width: 28, height: 28, alignItems: "center", justifyContent: "center" },
   stepperValue: {

--- a/apps/mobile/features/scheduling/components/TeamCreateScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TeamCreateScreen.tsx
@@ -10,7 +10,7 @@
  *
  * Backend: scheduling.teams.createServingTeam.
  */
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   View,
   Text,
@@ -33,6 +33,7 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useAuthenticatedMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { errorMessage } from "@/utils/error-handling";
+import { useAuth } from "@providers/AuthProvider";
 
 export function TeamCreateScreen() {
   const { colors } = useTheme();
@@ -51,6 +52,22 @@ export function TeamCreateScreen() {
   const [withChannel, setWithChannel] = useState(true);
   const [creating, setCreating] = useState(false);
 
+  // Managers are an explicit, visible choice rather than something the backend
+  // infers. The creator is pre-filled because they usually do run the team they
+  // just made — but they can drop themselves here, which matters for a campus
+  // leader spinning up all of a location's teams for other people to run.
+  const { user } = useAuth();
+  const creatorId = user?.id as Id<"users"> | undefined;
+  const [managerIds, setManagerIds] = useState<Id<"users">[]>([]);
+  const [managerSeeded, setManagerSeeded] = useState(false);
+  useEffect(() => {
+    if (!managerSeeded && creatorId) {
+      setManagerIds([creatorId]);
+      setManagerSeeded(true);
+    }
+  }, [creatorId, managerSeeded]);
+  const creatorIsManager = creatorId !== undefined && managerIds.includes(creatorId);
+
   const canCreate = name.trim().length > 0 && !creating;
 
   const handleBack = useCallback(() => {
@@ -66,6 +83,7 @@ export function TeamCreateScreen() {
         name: name.trim(),
         description: description.trim() || undefined,
         withChannel,
+        managerUserIds: managerIds,
       });
       // Replace this screen with the new team's detail screen so backing out
       // returns to the Teams list, not the create form.
@@ -89,6 +107,7 @@ export function TeamCreateScreen() {
     name,
     description,
     withChannel,
+    managerIds,
     router,
   ]);
 
@@ -189,6 +208,30 @@ export function TeamCreateScreen() {
             {withChannel
               ? "The team gets a chat channel in the inbox to coordinate."
               : "No chat channel — this team is for rostering only. You can add one later."}
+          </Text>
+        </View>
+
+        <View
+          style={[styles.channelCard, { backgroundColor: colors.surfaceSecondary }]}
+        >
+          <View style={styles.channelTop}>
+            <Ionicons name="shield-outline" size={20} color={colors.text} />
+            <Text style={[styles.channelTitle, { color: colors.text }]}>
+              I&apos;ll manage this team
+            </Text>
+            <Switch
+              value={creatorIsManager}
+              disabled={creatorId === undefined}
+              onValueChange={(next) => {
+                if (!creatorId) return;
+                setManagerIds(next ? [creatorId] : []);
+              }}
+            />
+          </View>
+          <Text style={[styles.channelHint, { color: colors.textTertiary }]}>
+            {creatorIsManager
+              ? "You'll send this team's serving requests. Turn this off if someone else will run it — you can add them after creating."
+              : "Only group leaders and admins can send this team's requests for now. Add managers on the team's page."}
           </Text>
         </View>
 

--- a/apps/mobile/features/scheduling/components/TeamSetupScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TeamSetupScreen.tsx
@@ -36,6 +36,7 @@ import {
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { confirmAsync, notify } from "@/utils/platformAlert";
+import { errorMessage } from "@/utils/error-handling";
 import { RolesEditor } from "./RolesEditor";
 import { ROLE_COLORS } from "../utils/format";
 
@@ -53,6 +54,13 @@ type Team = {
   isArchived: boolean;
   memberCount: number;
   createdAt: number;
+};
+
+/** A row from `scheduling.teams.listTeamManagers`. */
+type TeamManager = {
+  userId: Id<"users">;
+  name: string;
+  profilePhoto?: string;
 };
 
 type PermanentMember = {
@@ -335,6 +343,20 @@ export function TeamSetupScreen() {
           {team.hasChannel && (
             <View style={styles.section}>
               <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+                MANAGERS
+              </Text>
+              <Text style={[styles.sectionHint, { color: colors.textSecondary }]}>
+                Managers send this team&apos;s serving requests and fill its
+                roster. They don&apos;t need to be group leaders — and their
+                requests only ever reach this team.
+              </Text>
+              <TeamManagersSection teamId={teamId} groupId={groupId} />
+            </View>
+          )}
+
+          {!team.isArchived && (
+            <View style={styles.section}>
+              <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
                 PERMANENT MEMBERS
               </Text>
               <Text style={[styles.sectionHint, { color: colors.textSecondary }]}>
@@ -347,6 +369,286 @@ export function TeamSetupScreen() {
         </ScrollView>
       )}
     </View>
+  );
+}
+
+/**
+ * Team managers (ADR-025) — who may send this team's serving requests and fill
+ * its roster without being a campus group leader.
+ *
+ * Editing the list is deliberately restricted to group leaders and community
+ * admins: managing a roster and deciding who else may manage it are different
+ * levels of trust. The backend enforces that; a manager viewing this screen
+ * sees the list read-only.
+ */
+function TeamManagersSection({
+  teamId,
+  groupId,
+}: {
+  teamId: Id<"teams">;
+  groupId?: Id<"groups">;
+}) {
+  const { colors } = useTheme();
+
+  const managers = useAuthenticatedQuery(
+    api.functions.scheduling.teams.listTeamManagers,
+    { teamId },
+  ) as TeamManager[] | undefined;
+
+  const removeManager = useAuthenticatedMutation(
+    api.functions.scheduling.teams.removeTeamManager,
+  );
+
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  const handleRemove = useCallback(
+    async (manager: TeamManager) => {
+      const ok = await confirmAsync({
+        title: "Remove manager?",
+        message: `${manager.name} will no longer be able to send this team's requests.`,
+        confirmText: "Remove",
+        destructive: true,
+      });
+      if (!ok) return;
+      setRemoving(manager.userId as string);
+      try {
+        await removeManager({ teamId, userId: manager.userId });
+      } catch (e) {
+        notify("Couldn't remove", errorMessage(e, "Please try again."));
+      } finally {
+        setRemoving(null);
+      }
+    },
+    [removeManager, teamId],
+  );
+
+  if (managers === undefined) {
+    return (
+      <View style={styles.permLoading}>
+        <ActivityIndicator size="small" color={colors.text} />
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <View style={[styles.group, { backgroundColor: colors.surfaceSecondary }]}>
+        {managers.length === 0 ? (
+          <Text style={[styles.permEmpty, { color: colors.textSecondary }]}>
+            No managers yet — only group leaders and admins can send this
+            team&apos;s requests.
+          </Text>
+        ) : (
+          managers.map((manager, idx) => (
+            <View
+              key={manager.userId}
+              style={[
+                styles.permRow,
+                idx > 0 && {
+                  borderTopWidth: StyleSheet.hairlineWidth,
+                  borderTopColor: colors.border,
+                },
+              ]}
+            >
+              <Avatar
+                name={manager.name}
+                imageUrl={manager.profilePhoto}
+                size={36}
+              />
+              <Text
+                style={[styles.permName, { color: colors.text }]}
+                numberOfLines={1}
+              >
+                {manager.name}
+              </Text>
+              {removing === (manager.userId as string) ? (
+                <ActivityIndicator size="small" color={colors.text} />
+              ) : (
+                <Pressable
+                  onPress={() => handleRemove(manager)}
+                  hitSlop={8}
+                  style={styles.iconBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Remove ${manager.name} as a manager`}
+                >
+                  <Ionicons
+                    name="close-circle"
+                    size={20}
+                    color={colors.destructive}
+                  />
+                </Pressable>
+              )}
+            </View>
+          ))
+        )}
+      </View>
+
+      <Pressable
+        onPress={() => setPickerVisible(true)}
+        disabled={!groupId}
+        style={({ pressed }) => [
+          styles.addRow,
+          { backgroundColor: colors.surfaceSecondary },
+          (pressed || !groupId) && { opacity: 0.7 },
+        ]}
+        accessibilityRole="button"
+      >
+        <Ionicons name="shield-outline" size={20} color={colors.text} />
+        <Text style={[styles.addLabel, { color: colors.text }]}>
+          Add manager
+        </Text>
+      </Pressable>
+
+      {groupId && (
+        <AddManagerModal
+          visible={pickerVisible}
+          teamId={teamId}
+          groupId={groupId}
+          existingUserIds={
+            new Set((managers ?? []).map((m) => m.userId as string))
+          }
+          onClose={() => setPickerVisible(false)}
+        />
+      )}
+    </View>
+  );
+}
+
+/** Picker modal: the campus group's members, minus current managers. */
+function AddManagerModal({
+  visible,
+  teamId,
+  groupId,
+  existingUserIds,
+  onClose,
+}: {
+  visible: boolean;
+  teamId: Id<"teams">;
+  groupId: Id<"groups">;
+  existingUserIds: Set<string>;
+  onClose: () => void;
+}) {
+  const { colors } = useTheme();
+
+  const memberData = useAuthenticatedQuery(
+    api.functions.groupMembers.list,
+    visible ? { groupId, limit: 200 } : "skip",
+  ) as { items: GroupMemberRow[] } | undefined;
+
+  const addManager = useAuthenticatedMutation(
+    api.functions.scheduling.teams.addTeamManager,
+  );
+  const [adding, setAdding] = useState<string | null>(null);
+
+  const candidates = useMemo<TeamManager[]>(() => {
+    return (memberData?.items ?? [])
+      .filter(
+        (row): row is GroupMemberRow & { user: NonNullable<GroupMemberRow["user"]> } =>
+          row.user !== null,
+      )
+      .map((row) => ({
+        userId: row.user.id,
+        name: `${row.user.firstName} ${row.user.lastName}`.trim() || "Member",
+        profilePhoto: row.user.profileImage,
+      }))
+      .filter((m) => !existingUserIds.has(m.userId as string));
+  }, [memberData?.items, existingUserIds]);
+
+  const handleAdd = useCallback(
+    async (manager: TeamManager) => {
+      setAdding(manager.userId as string);
+      try {
+        await addManager({ teamId, userId: manager.userId });
+        onClose();
+      } catch (e) {
+        Alert.alert("Couldn't add", errorMessage(e, "Please try again."));
+      } finally {
+        setAdding(null);
+      }
+    },
+    [addManager, teamId, onClose],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={[styles.modalContainer, { backgroundColor: colors.surface }]}>
+        <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
+          <Text style={[styles.modalTitle, { color: colors.text }]}>
+            Add manager
+          </Text>
+          <TouchableOpacity onPress={onClose} hitSlop={12}>
+            <Ionicons name="close" size={26} color={colors.text} />
+          </TouchableOpacity>
+        </View>
+
+        {memberData === undefined ? (
+          <View style={styles.centered}>
+            <ActivityIndicator size="small" color={colors.text} />
+          </View>
+        ) : (
+          <ScrollView contentContainerStyle={styles.modalScroll}>
+            <View
+              style={[
+                styles.group,
+                { backgroundColor: colors.surfaceSecondary },
+              ]}
+            >
+              {candidates.length === 0 ? (
+                <Text style={[styles.permEmpty, { color: colors.textSecondary }]}>
+                  Everyone in this group already manages this team.
+                </Text>
+              ) : (
+                candidates.map((manager, idx) => {
+                  const busy = adding === (manager.userId as string);
+                  return (
+                    <Pressable
+                      key={manager.userId}
+                      onPress={() => handleAdd(manager)}
+                      disabled={!!adding}
+                      style={({ pressed }) => [
+                        styles.permRow,
+                        idx > 0 && {
+                          borderTopWidth: StyleSheet.hairlineWidth,
+                          borderTopColor: colors.border,
+                        },
+                        pressed && { backgroundColor: colors.selectedBackground },
+                      ]}
+                    >
+                      <Avatar
+                        name={manager.name}
+                        imageUrl={manager.profilePhoto}
+                        size={36}
+                      />
+                      <Text
+                        style={[styles.permName, { color: colors.text }]}
+                        numberOfLines={1}
+                      >
+                        {manager.name}
+                      </Text>
+                      {busy ? (
+                        <ActivityIndicator size="small" color={colors.text} />
+                      ) : (
+                        <Ionicons
+                          name="add"
+                          size={20}
+                          color={colors.textSecondary}
+                        />
+                      )}
+                    </Pressable>
+                  );
+                })
+              )}
+            </View>
+          </ScrollView>
+        )}
+      </View>
+    </Modal>
   );
 }
 

--- a/apps/mobile/features/scheduling/components/TeamSetupScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TeamSetupScreen.tsx
@@ -340,7 +340,9 @@ export function TeamSetupScreen() {
             <RolesEditor teamId={teamId} />
           </View>
 
-          {team.hasChannel && (
+          {/* Managers are independent of chat — a channel-less team is a pure
+              roster, and still needs someone to run it. */}
+          {!team.isArchived && (
             <View style={styles.section}>
               <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
                 MANAGERS
@@ -354,7 +356,9 @@ export function TeamSetupScreen() {
             </View>
           )}
 
-          {!team.isArchived && (
+          {/* Permanent members ARE a channel concept — `listPermanentMembers`
+              throws for a channel-less team, so this guard is load-bearing. */}
+          {team.hasChannel && !team.isArchived && (
             <View style={styles.section}>
               <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
                 PERMANENT MEMBERS

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -146,6 +146,16 @@ export function EventPlans() {
           based on the team's name.
         </P>
 
+        <P>
+          Each team can also have its own <Term>managers</Term>. A manager sends
+          that team's serving requests and fills its roster — without being a
+          group leader, and without ever reaching another team. Open a team and
+          use <Term>Add manager</Term> to pick from the group's members; only
+          group leaders and community admins can change the list. Leaders and
+          admins keep full access to every team either way, so adding managers
+          only ever hands out access, never takes it away.
+        </P>
+
         <Figure caption="A serving team and its roles, defined once on the Teams tab.">
           <TeamSetupMock />
         </Figure>
@@ -178,7 +188,7 @@ export function EventPlans() {
           Building a plan doesn't tell anyone yet — <strong>publishing</strong>{" "}
           is the moment volunteers hear from you. When a leader taps{" "}
           <Term>Publish &amp; send requests</Term> at the bottom of the plan
-          editor, everyone rostered into that plan gets both a push notification{" "}
+          editor, the volunteers you pick get both a push notification{" "}
           <em>and</em> a text letting them know they're on the schedule to serve
           for that day, and asking them to confirm or decline. Togather then
           chases the stragglers 4 days out, and the day before sends everyone
@@ -187,9 +197,24 @@ export function EventPlans() {
           for those who already confirmed.
         </P>
 
+        <P>
+          A plan is a single date shared by every team at the campus, so when
+          more than one team is waiting on a reply, publishing asks{" "}
+          <Term>which teams</Term> to send to first. Each team is listed with
+          how many people are awaiting a reply, and teams you manage are ticked
+          for you — so the worship lead sending their own requests doesn't text
+          the production roster too. Tick another team to include it as well.
+        </P>
+
+        <P>
+          The 4-day and 1-day reminders follow whoever was actually asked, so a
+          team you haven't published yet stays quiet until you send its
+          requests.
+        </P>
+
         <Callout tone="tip" title="Publishing is what notifies people">
           <p>
-            On publish, every rostered volunteer gets a push{" "}
+            On publish, every volunteer on the teams you selected gets a push{" "}
             <strong>and</strong> an SMS: you're on the schedule to serve for this
             day — please confirm or decline.
           </p>


### PR DESCRIPTION
Reported by David Walker Jr.:

> Publish request for rostering needs to be able to be selected by team, right now any push gets sent to all pending request across all teams

> I was teaching someone how to do rostering and they sent out the request for their crew but then it sent out all the production requests

## The bug

An `eventPlans` row is a **date column shared by every serving team at a campus**. `publishEvent` took only a `planId` and fanned out to every `unconfirmed` assignment on it via `by_plan` — there was no team filter anywhere in the path. So publishing to send *your* team's requests texted every other team's pending volunteers too.

## The fix

### 1. `teamManagers` — roster authority scoped to one team

Roster scope and leadership scope are different things. A campus group leader has access to every team at the location, so there was no way to say "this person runs Crew". Now there is.

- A manager sends **their** team's serving requests and fills its roster, without being a group leader.
- Group leaders and community admins keep **full access to every team** whether or not they appear in the list — the table grants access, it never restricts it.
- Only leaders/admins may edit the list. Managing a roster and deciding who else may manage it are different levels of trust, so a manager can't appoint another manager.

`isTeamScheduler` gains the manager check, which grants role editing for free (`roles.ts` already gates on `requireTeamScheduler`). New `requirePlanTeamScheduler` gates assign/unassign per team — they previously gated group-wide, so a manager couldn't fill their own cells without full leadership.

**Creating/editing/deleting event dates stays group-leader-only**, per your answer — date columns are shared across every team.

### 2. `publishEvent({ teamIds })`

Narrows the fan-out, the request count, and the post-publish channel reconcile. Omitting `teamIds` keeps the historical all-teams behaviour.

Each requested team is authorized **individually**, so a manager can't smuggle a team they don't manage in alongside one they do, or publish the whole plan by omitting the field. Both are covered by tests.

### 3. Reminders inherit the scope

This is the part that would have bitten us later. The 4-day / 1-day nudges swept *every* unconfirmed assignment on the plan — so a scoped publish would have leaked to the other team anyway, four days on, when nobody was looking.

They now derive their audience from the append-only `assignmentRequestLog` — the existing record of who was actually asked — so there's no new state to maintain. An **empty** log is treated as "no record either way" rather than "nobody was asked", so a plan published before request logging existed keeps its in-flight reminders instead of silently losing them.

## UI

**Publish picker** — opens when more than one team is awaiting a reply. Teams the sender doesn't manage start unchecked and labelled, so reaching another team is an opt-in:

```
┌─ Publish & send requests? ────────────────┐
│  Sun Aug 2 · 14 awaiting a reply          │
│   [x]  Crew                    3 pending  │
│   [x]  Worship                 5 pending  │
│   [ ]  Production                         │
│        Not a team you manage   4 pending  │
│  Confirmed people won't be re-notified.   │
│              [   Send 8 requests   ]      │
└───────────────────────────────────────────┘
```

With one team (or none) there's nothing to choose, so the old confirm still applies — now naming the team. `Publish all draft dates` scopes to the sender's own teams and names them: a bulk send is the least reviewable path, so it must not be the one that quietly reaches everyone.

**Grid scoping** — the existing team filter gains "My teams" and the grid opens on it whenever the viewer manages any team here. A leader who manages none keeps today's all-teams view. The scope initializes once per group so an explicit widen isn't undone by a refetch. Internally the single `isolatedTeamId` becomes a `TeamScope` (mine / all / one team) funnelled through one derived `visibleTeamIds` set that every row filter reads, so the kinds can't drift.

**Manager editors** — a MANAGERS section on the team detail screen mirroring the existing PERMANENT MEMBERS pattern, and an "I'll manage this team" toggle on create (pre-filled on, removable).

## A deliberate choice worth flagging

**The creator is not auto-added as a manager.** A leader who creates all seven of a campus's teams would end up "managing" all seven, which would defeat the grid's default-to-my-teams scoping for exactly the person it most needs to help. The create screen pre-fills them into `managerUserIds` instead, as a visible toggle they can turn off. There's a test pinning this.

Related: `isTeamScheduler` already accepted the team *channel's* admin/moderator as a scheduler. That path still passes (removing it could silently strip someone's access today) but is no longer advertised — `teamManagers` is the discoverable, channel-less-team-compatible replacement.

## Testing

- **+21 backend tests** (`teamManagers.test.ts`): manager CRUD and its auth boundaries, per-team assign/unassign/role permissions, scoped publish counts, the request-log scoping that *is* the bug, the three manager-escalation paths, and both reminder branches.
- Full convex suite: **2422 passing**. Mobile: **1344 passing**. `tsc` clean across convex/mobile/web.
- `check-react-consistency` clean — no dependency or native-graph change, so the ADR-013 hazard doesn't apply.

## Not yet verified live

The schema adds a table, so this hasn't been exercised against a running backend — deploying a WIP schema to the shared dev/staging deployment mid-review didn't seem worth it. **I'll smoke-test the picker and grid scoping on staging once this merges and auto-deploys**, and report back.

Managers will be seeded manually rather than backfilled from channel admins, per your call — so nothing changes for existing groups until someone is named, and the grid keeps its current all-teams default in the meantime.

## Docs

`EventPlans.tsx` said publishing notifies "everyone rostered into that plan" — now wrong. Updated for the team picker, the scoped reminders, and managers.

Follows #634, which fixed the "Couldn't create team" error in the same report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fmnKjZ5JRWFePp5gizZz8