### PR TITLE
WhatsApp shell slice 2 (flag-gated): invite kit + QR, Chats hygiene, Group info page

### DIFF
--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -4429,3 +4429,67 @@ describe("muted members and unread bookkeeping", () => {
     expect(readState?.unreadCount).toBe(1);
   });
 });
+
+describe("getInboxChannels — isMuted", () => {
+  test("surfaces the caller's own isMuted for each channel", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId, userId, accessToken } = await seedTestData(t);
+    const { accessToken: leaderToken } = await createLeaderUser(
+      t,
+      communityId,
+      groupId
+    );
+
+    // Main channel the seeded user is a member of by default (unmuted).
+    const mainChannelId = await t.run(async (ctx) => {
+      const chId = await ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "general",
+        channelType: "main",
+        name: "General",
+        createdById: userId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId: chId,
+        userId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+      return chId;
+    });
+
+    // A second, custom channel the user mutes via the real mutation.
+    const { channelId: customChannelId } = await t.mutation(
+      api.functions.messaging.channels.createCustomChannel,
+      { token: leaderToken, groupId, name: "Quiet Channel" }
+    );
+    await t.mutation(api.functions.messaging.channels.joinDiscoverableChannel, {
+      token: accessToken,
+      channelId: customChannelId,
+    });
+    await t.mutation(api.functions.messaging.channels.setChannelMuted, {
+      token: accessToken,
+      channelId: customChannelId,
+      muted: true,
+    });
+
+    const result = await t.query(api.functions.messaging.channels.getInboxChannels, {
+      token: accessToken,
+      communityId,
+    });
+
+    const groupEntry = result.find((g) => g.group._id === groupId);
+    expect(groupEntry).toBeDefined();
+
+    const mainChannel = groupEntry?.channels.find((c) => c._id === mainChannelId);
+    const customChannel = groupEntry?.channels.find((c) => c._id === customChannelId);
+
+    expect(mainChannel?.isMuted).toBe(false);
+    expect(customChannel?.isMuted).toBe(true);
+  });
+});

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1602,6 +1602,18 @@ export const getInboxChannels = query({
 
     const userChannelIds = new Set(userChannelMemberships.map((m) => m.channelId));
 
+    // Channels this user has muted (chatChannelMembers.isMuted), keyed by
+    // channelId. Every channel the inbox can show the user is one they hold a
+    // membership row for, so a miss here safely defaults to "not muted" below.
+    // Mirrors how `listGroupChannels` surfaces `isMuted` from the membership
+    // row (see `isMuted: membership?.isMuted` above) — flag-gated inbox
+    // hygiene (docs/plans/church-migration-ui-redesign/README.md, "Channel
+    // hygiene") uses this to sink muted channels out of sub-rows and the
+    // group's aggregated unread badge.
+    const mutedChannelIds = new Set(
+      userChannelMemberships.filter((m) => m.isMuted).map((m) => m.channelId)
+    );
+
     // Get read states for all user's channels
     const unreadCounts = new Map<string, number>();
     for (const membership of userChannelMemberships) {
@@ -1818,6 +1830,14 @@ export const getInboxChannels = query({
         unreadCount: number;
         isShared: boolean | undefined;
         isEnabled: boolean | undefined;
+        /**
+         * Whether the current user has muted this channel
+         * (`chatChannelMembers.isMuted`). Additive field for the flag-gated
+         * Chats-list hygiene rules (cluster caps + muted sink) — see
+         * docs/plans/church-migration-ui-redesign/README.md, "Channel
+         * hygiene".
+         */
+        isMuted: boolean;
         meetingId: Id<"meetings"> | undefined;
         meetingScheduledAt: number | null;
         /**
@@ -1937,6 +1957,7 @@ export const getInboxChannels = query({
           unreadCount: unreadCounts.get(ch._id) || 0,
           isShared: ch.isShared || undefined,
           isEnabled: ch.isEnabled,
+          isMuted: mutedChannelIds.has(ch._id),
           meetingId: ch.meetingId,
           meetingScheduledAt:
             ch.channelType === "event" && ch.meetingId

--- a/apps/mobile/app/(user)/community.tsx
+++ b/apps/mobile/app/(user)/community.tsx
@@ -1,5 +1,12 @@
+import { Redirect } from 'expo-router';
 import { CommunityPageScreen } from '@features/community/components/CommunityPageScreen';
+import { useWhatsappShellState } from '@hooks/useWhatsappShell';
 
 export default function CommunityRoute() {
+  // Defense in depth: honor the flag at the route itself, not just its
+  // entry points (deep links / stale navigation state can bypass entries).
+  const { enabled, loaded } = useWhatsappShellState();
+  if (!loaded) return null;
+  if (!enabled) return <Redirect href="/(tabs)/chat" />;
   return <CommunityPageScreen />;
 }

--- a/apps/mobile/app/(user)/invite.tsx
+++ b/apps/mobile/app/(user)/invite.tsx
@@ -1,5 +1,14 @@
+import { Redirect } from 'expo-router';
 import { InviteKitScreen } from '@features/invite/components/InviteKitScreen';
+import { useWhatsappShellState } from '@hooks/useWhatsappShell';
 
 export default function InviteRoute() {
+  // Defense in depth: entry points are flag-gated, but a deep link or stale
+  // navigation state could still reach this route — honor the flag (and its
+  // kill switch) here too. Wait for `loaded` so flag-on users aren't bounced
+  // during the initial flag fetch.
+  const { enabled, loaded } = useWhatsappShellState();
+  if (!loaded) return null;
+  if (!enabled) return <Redirect href="/(tabs)/profile" />;
   return <InviteKitScreen />;
 }

--- a/apps/mobile/app/(user)/invite.tsx
+++ b/apps/mobile/app/(user)/invite.tsx
@@ -1,0 +1,5 @@
+import { InviteKitScreen } from '@features/invite/components/InviteKitScreen';
+
+export default function InviteRoute() {
+  return <InviteKitScreen />;
+}

--- a/apps/mobile/app/__tests__/group-route-flag.test.tsx
+++ b/apps/mobile/app/__tests__/group-route-flag.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * The group route is the whatsapp-shell branch point: flag on renders the
+ * W13 GroupInfoScreen, flag off must render the untouched GroupDetailScreen.
+ * This file exists to pin the PR's core claim (flag-off = identical).
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+const mockUseWhatsappShell = jest.fn(() => false);
+jest.mock("@hooks/useWhatsappShell", () => ({
+  useWhatsappShell: () => mockUseWhatsappShell(),
+}));
+jest.mock("@features/groups/components/GroupDetailScreen", () => ({
+  GroupDetailScreen: () => {
+    const { Text } = require("react-native");
+    return <Text>detail-screen</Text>;
+  },
+}));
+jest.mock("@features/groups/components/GroupInfoScreen", () => ({
+  GroupInfoScreen: () => {
+    const { Text } = require("react-native");
+    return <Text>info-screen</Text>;
+  },
+}));
+
+import GroupRoute from "../groups/[group_id]/index";
+
+describe("groups/[group_id] route flag branch", () => {
+  test("flag off renders GroupDetailScreen", () => {
+    mockUseWhatsappShell.mockReturnValue(false);
+    const { getByText, queryByText } = render(<GroupRoute />);
+    expect(getByText("detail-screen")).toBeTruthy();
+    expect(queryByText("info-screen")).toBeNull();
+  });
+
+  test("flag on renders GroupInfoScreen", () => {
+    mockUseWhatsappShell.mockReturnValue(true);
+    const { getByText, queryByText } = render(<GroupRoute />);
+    expect(getByText("info-screen")).toBeTruthy();
+    expect(queryByText("detail-screen")).toBeNull();
+  });
+});

--- a/apps/mobile/app/groups/[group_id]/index.tsx
+++ b/apps/mobile/app/groups/[group_id]/index.tsx
@@ -1,3 +1,11 @@
 import { GroupDetailScreen } from "@features/groups/components/GroupDetailScreen";
+import { GroupInfoScreen } from "@features/groups/components/GroupInfoScreen";
+import { useWhatsappShell } from "@hooks/useWhatsappShell";
 
-export default GroupDetailScreen;
+// Flag-gated per docs/plans/church-migration-ui-redesign/README.md §9.5:
+// whatsapp-shell on renders the W13 Group info page; off renders the
+// existing, untouched GroupDetailScreen.
+export default function GroupRoute() {
+  const whatsappShell = useWhatsappShell();
+  return whatsappShell ? <GroupInfoScreen /> : <GroupDetailScreen />;
+}

--- a/apps/mobile/app/inbox/[groupId]/channels.tsx
+++ b/apps/mobile/app/inbox/[groupId]/channels.tsx
@@ -10,10 +10,10 @@
  * pending). Leaders get a footer link to the existing create-channel screen.
  *
  * Reached from the group page's CHANNELS card ("See all channels", flag-gated
- * on whatsapp-shell) and, per the redesign brief, the inbox's "N more
- * channels" collapse row. The route itself is harmless when unlinked, so it
- * isn't flag-gated — only its entry points are (per the redesign's rollout
- * rule: new routes are safe to ship unlinked).
+ * on whatsapp-shell) and the inbox's "N more channels" collapse row. The
+ * route also guards itself (defense in depth): deep links or stale
+ * navigation state bypass flag-gated entry points, so the wrapper below
+ * redirects when the shell is off.
  */
 import React, { useCallback, useEffect, useState } from "react";
 import {
@@ -25,7 +25,7 @@ import {
   ActivityIndicator,
   Alert,
 } from "react-native";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import {
@@ -40,6 +40,7 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { errorMessage } from "@/utils/error-handling";
 import { useGroupChannels } from "@features/groups/hooks/useGroupChannels";
+import { useWhatsappShellState } from "@hooks/useWhatsappShell";
 
 type JoinableChannel = {
   channelId: Id<"chatChannels">;
@@ -49,7 +50,20 @@ type JoinableChannel = {
   hasPendingRequest: boolean;
 };
 
-export default function ChannelDirectoryScreen() {
+export default function ChannelDirectoryRoute() {
+  // Defense in depth: honor the flag at the route itself, not just its
+  // flag-gated entry points (deep links can bypass entries). Wrapper keeps
+  // the screen's hook order intact across flag flips.
+  const { groupId } = useLocalSearchParams<{ groupId: string }>();
+  const { enabled, loaded } = useWhatsappShellState();
+  if (!loaded) return null;
+  if (!enabled) {
+    return <Redirect href={(groupId ? `/inbox/${groupId}` : "/inbox") as any} />;
+  }
+  return <ChannelDirectoryScreen />;
+}
+
+function ChannelDirectoryScreen() {
   const { groupId } = useLocalSearchParams<{ groupId: string }>();
   const router = useRouter();
   const insets = useSafeAreaInsets();

--- a/apps/mobile/components/ui/QrCode.tsx
+++ b/apps/mobile/components/ui/QrCode.tsx
@@ -1,0 +1,98 @@
+/**
+ * QrCode — renders a QR code with plain `View`s (no `react-native-svg`,
+ * no native dependency). Used by the Invite Kit (features/invite) to show
+ * a scannable code for the community link and group short links.
+ *
+ * Each row's consecutive dark modules are run-length-encoded into a single
+ * `View` segment (instead of one `View` per module) to keep the render
+ * tree small — a version-10 QR is 57x57 modules, which would otherwise be
+ * 3,249 individual views.
+ */
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { qrModules } from '@utils/qrcodegen';
+
+interface QrCodeProps {
+  /** The text/URL to encode. */
+  value: string;
+  /** Overall rendered size (including quiet zone), in points. Default 200. */
+  size?: number;
+  /**
+   * Color of the dark modules. Defaults to pure black — QR scanners rely
+   * on strong light/dark contrast to lock onto finder patterns, so this is
+   * the one place in the app that intentionally hardcodes a color instead
+   * of using a theme token (a themed "primary color" could be too light,
+   * or too close to the white background, to reliably scan).
+   */
+  color?: string;
+  /** Background (light module + quiet zone) color. Default white. */
+  backgroundColor?: string;
+}
+
+interface RunSegment {
+  row: number;
+  startCol: number;
+  runLength: number;
+}
+
+export function QrCode({
+  value,
+  size = 200,
+  color = '#000000',
+  backgroundColor = '#ffffff',
+}: QrCodeProps) {
+  const modules = useMemo(() => qrModules(value), [value]);
+  const moduleCount = modules.length;
+
+  const runs = useMemo(() => {
+    const segments: RunSegment[] = [];
+    for (let row = 0; row < moduleCount; row++) {
+      let col = 0;
+      while (col < moduleCount) {
+        if (!modules[row][col]) {
+          col++;
+          continue;
+        }
+        const startCol = col;
+        while (col < moduleCount && modules[row][col]) col++;
+        segments.push({ row, startCol, runLength: col - startCol });
+      }
+    }
+    return segments;
+  }, [modules, moduleCount]);
+
+  // Quiet zone: 4 modules of background on every side, per the QR spec.
+  const quietZoneModules = 4;
+  const totalModules = moduleCount + quietZoneModules * 2;
+  const moduleSize = size / totalModules;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { width: size, height: size, backgroundColor },
+      ]}
+    >
+      {runs.map((run, i) => (
+        <View
+          key={i}
+          style={{
+            position: 'absolute',
+            left: (quietZoneModules + run.startCol) * moduleSize,
+            top: (quietZoneModules + run.row) * moduleSize,
+            width: run.runLength * moduleSize,
+            height: moduleSize,
+            backgroundColor: color,
+          }}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+});

--- a/apps/mobile/features/__tests__/safe-area-insets.test.tsx
+++ b/apps/mobile/features/__tests__/safe-area-insets.test.tsx
@@ -96,6 +96,12 @@ const mockRouter = {
   replace: jest.fn(),
 };
 
+// Flag off = the behavior this suite asserts; the real hook reaches PostHog +
+// a Convex query the partial api mocks here don't provide.
+jest.mock('@hooks/useWhatsappShell', () => ({
+  useWhatsappShell: () => false,
+}));
+
 jest.mock('expo-router', () => ({
   useRouter: () => mockRouter,
   useLocalSearchParams: jest.fn(() => ({

--- a/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
+++ b/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
@@ -58,9 +58,14 @@ const KNOWN_FLAGS: Array<{ key: string; description: string }> = [
       "Themes the whole app in New York Knicks orange & blue, overriding every community's brand colors. Applies to all users across all communities. Off: communities use their own brand colors.",
   },
   {
+    key: "whatsapp-shell-on",
+    description:
+      "Force-enables the WhatsApp-style shell (Chats-first tabs, community page, group info page, channel directory, mute) for ALL users system-wide — no PostHog needed. Use for staging or before PostHog targeting is set up; whatsapp-shell-kill still wins if both are on.",
+  },
+  {
     key: "whatsapp-shell-kill",
     description:
-      "Kill switch: forces the WhatsApp-style shell off everywhere, overriding the whatsapp-shell PostHog flag. Off: the PostHog flag alone decides.",
+      "Kill switch: forces the WhatsApp-style shell off everywhere, overriding both the whatsapp-shell PostHog flag and whatsapp-shell-on. Off: the other two decide.",
   },
 ];
 

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -81,6 +81,12 @@ type InboxChannel = {
   unreadCount: number;
   isShared?: boolean;
   isEnabled?: boolean;
+  /**
+   * Whether the current user has muted this channel. Drives the flag-gated
+   * Chats-list hygiene in `GroupedInboxItem` (cluster caps + muted sink) —
+   * see docs/plans/church-migration-ui-redesign/README.md, "Channel hygiene".
+   */
+  isMuted?: boolean;
   meetingId?: Id<"meetings">;
   meetingScheduledAt?: number | null;
   /**
@@ -151,9 +157,15 @@ export function ChatInboxScreen({
   const { primaryColor } = useCommunityTheme();
   const { colors } = useTheme();
   const hasCommunity = !!community?.id;
+  const whatsappShellEnabled = useWhatsappShell();
   // Community page entry point (W2, docs/plans/church-migration-ui-redesign
   // /README.md) — flag-gated, zero change when off.
-  const showCommunityEntry = useWhatsappShell() && hasCommunity;
+  const showCommunityEntry = whatsappShellEnabled && hasCommunity;
+  // Chats-first retitle (W1, same doc) — only the collapsing header's large
+  // and small titles change; the plain fallback header used by the loading/
+  // no-community states is left as "Inbox", mirroring showCommunityEntry's
+  // scope above.
+  const collapsingHeaderTitle = whatsappShellEnabled ? "Chats" : "Inbox";
   const { isGroupExpanded, toggleGroupExpanded } = useExpandedGroups();
   const { getInboxChannels, setInboxChannels } = useInboxCache();
   // Device network state. Drives the loading strategy: online we hold for a
@@ -624,14 +636,14 @@ export function ChatInboxScreen({
           style={[styles.largeTitleWrap, largeTitleStyle]}
           pointerEvents="none"
         >
-          <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+          <Text style={[styles.headerTitle, { color: colors.text }]}>{collapsingHeaderTitle}</Text>
         </Animated.View>
         <Animated.Text
           style={[styles.smallTitle, { color: colors.text }, smallTitleStyle]}
           numberOfLines={1}
           pointerEvents="none"
         >
-          Inbox
+          {collapsingHeaderTitle}
         </Animated.Text>
         {showCommunityEntry && (
           <Pressable

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -26,6 +26,7 @@ import { useAuth } from "@providers/AuthProvider";
 import { AppImage } from "@components/ui";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
+import { useWhatsappShell } from "@hooks/useWhatsappShell";
 import { getGroupTypeColorScheme } from "../../../constants/groupTypes";
 import type { Id } from "@services/api/convex";
 import { useAwaitPrefetch, useTriggerPrefetch } from "../hooks/usePrefetchChannel";
@@ -46,6 +47,14 @@ interface ChannelData {
   isEnabled?: boolean;
   meetingId?: Id<"meetings">;
   meetingScheduledAt?: number | null;
+  /**
+   * Whether the current user has muted this channel
+   * (`chatChannelMembers.isMuted`, surfaced additively by `getInboxChannels`).
+   * Drives the flag-gated Channel hygiene rules below — muted channels never
+   * occupy a sub-row slot and are excluded from the aggregated unread badge.
+   * See docs/plans/church-migration-ui-redesign/README.md, "Channel hygiene".
+   */
+  isMuted?: boolean;
 }
 
 // Type for group data from getInboxChannels query
@@ -129,6 +138,11 @@ function getServingChannelLabel(teamName: string, channel: ChannelData): string 
   }
 }
 
+// Channel hygiene cluster cap (flag-gated, whatsapp-shell only): the main
+// channel plus at most this many sub-rows. See docs/plans/church-migration
+// -ui-redesign/README.md, "Channel hygiene".
+const MAX_SECONDARY_CHANNELS = 2;
+
 // Helper to get badge colors dynamically for any group type ID
 function getBadgeColors(typeId: string): { bg: string; text: string } {
   // Convert Convex ID to a numeric hash for color scheme lookup
@@ -184,6 +198,10 @@ function GroupedInboxItemInner({
   const { colors, isDark } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const isDesktopWeb = useIsDesktopWeb();
+  // Chats-list hygiene (cluster caps, muted sink, N-more collapse) — flag-gated
+  // per docs/plans/church-migration-ui-redesign/README.md, "Channel hygiene".
+  // Flag off leaves every behavior below byte-identical to before.
+  const whatsappShellEnabled = useWhatsappShell();
   const userId = user?.id as Id<"users"> | undefined;
   const isLeader = userRole === "leader";
   const badgeColors = getBadgeColors(group.groupTypeId);
@@ -267,10 +285,28 @@ function GroupedInboxItemInner({
     [userId]
   );
 
-  // Calculate total unread count for the group
-  const totalUnread = useMemo(
-    () => channels.reduce((sum, ch) => sum + ch.unreadCount, 0),
-    [channels]
+  // Calculate total unread count for the group. Flag on: muted channels are
+  // excluded from the aggregate (Channel hygiene rule 2) — a muted channel's
+  // unread never bumps the group's number.
+  const totalUnread = useMemo(() => {
+    if (!whatsappShellEnabled) {
+      return channels.reduce((sum, ch) => sum + ch.unreadCount, 0);
+    }
+    return channels.reduce(
+      (sum, ch) => sum + (ch.isMuted ? 0 : ch.unreadCount),
+      0
+    );
+  }, [channels, whatsappShellEnabled]);
+
+  // True only when every channel with unread activity is muted — the badge
+  // above hides that unread, so a quiet dot signals "something happened here"
+  // without a number, rather than the row looking fully caught-up.
+  const hasMutedOnlyUnread = useMemo(
+    () =>
+      whatsappShellEnabled &&
+      totalUnread === 0 &&
+      channels.some((ch) => ch.isMuted && ch.unreadCount > 0),
+    [whatsappShellEnabled, totalUnread, channels]
   );
 
   // Check if this group has multiple channels (can be expanded)
@@ -502,15 +538,40 @@ function GroupedInboxItemInner({
     return null;
   }
 
-  // Show secondary channels if expanded, if they have unread messages, or if one is
-  // the channel the user is currently viewing. The active check keeps the selected
-  // channel visible when another channel is promoted into the main spot, so the
-  // currently-open channel never silently disappears from the row.
-  const secondaryChannels = channels.filter(
-    (ch) =>
-      ch._id !== mainChannel._id &&
-      (isExpanded || ch.unreadCount > 0 || (isActiveGroup && activeChannelSlug === ch.slug))
-  );
+  // Secondary (sub-row) channel selection.
+  //
+  // Flag off: show secondary channels if expanded, if they have unread
+  // messages, or if one is the channel the user is currently viewing. The
+  // active check keeps the selected channel visible when another channel is
+  // promoted into the main spot, so the currently-open channel never
+  // silently disappears from the row. Unchanged from before this slice.
+  //
+  // Flag on: Channel hygiene rule 1 (cluster caps) — the main channel plus at
+  // most MAX_SECONDARY_CHANNELS more, chosen unread-first then most-recent
+  // activity. Rule 2 (muted sink) — a muted channel never occupies a sub-row
+  // slot. Anything not shown (cap overflow or muted) is counted for the
+  // "N more channels" row below.
+  let secondaryChannels: ChannelData[];
+  let hiddenChannelCount = 0;
+  if (whatsappShellEnabled) {
+    const others = channels.filter((ch) => ch._id !== mainChannel._id);
+    const unmutedCandidates = others.filter((ch) => !ch.isMuted);
+    const ranked = [...unmutedCandidates].sort((a, b) => {
+      const aUnread = a.unreadCount > 0 ? 1 : 0;
+      const bUnread = b.unreadCount > 0 ? 1 : 0;
+      if (aUnread !== bUnread) return bUnread - aUnread;
+      return (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0);
+    });
+    secondaryChannels = ranked.slice(0, MAX_SECONDARY_CHANNELS);
+    const shownIds = new Set(secondaryChannels.map((c) => c._id));
+    hiddenChannelCount = others.filter((ch) => !shownIds.has(ch._id)).length;
+  } else {
+    secondaryChannels = channels.filter(
+      (ch) =>
+        ch._id !== mainChannel._id &&
+        (isExpanded || ch.unreadCount > 0 || (isActiveGroup && activeChannelSlug === ch.slug))
+    );
+  }
   const mainHasUnread = mainChannel.unreadCount > 0;
 
   return (
@@ -579,7 +640,9 @@ function GroupedInboxItemInner({
           </View>
         </View>
 
-        {/* Loading or Unread indicator */}
+        {/* Loading or Unread indicator. When hygiene is on and every unread
+            channel is muted, show a quiet dot instead of a numeric badge
+            (Channel hygiene rule 2) rather than looking fully caught-up. */}
         {loadingChannelId === mainChannel._id ? (
           <ActivityIndicator size="small" color={primaryColor} style={styles.loadingIndicator} />
         ) : totalUnread > 0 ? (
@@ -588,6 +651,11 @@ function GroupedInboxItemInner({
               {totalUnread > 99 ? "99+" : totalUnread}
             </Text>
           </View>
+        ) : hasMutedOnlyUnread ? (
+          <View
+            style={[styles.mutedUnreadDot, { backgroundColor: colors.textTertiary }]}
+            accessibilityLabel="Muted unread activity"
+          />
         ) : null}
       </Pressable>
 
@@ -642,6 +710,36 @@ function GroupedInboxItemInner({
           </View>
         );
       })}
+
+      {/* "N more channels" collapse row — Channel hygiene rule: whatever the
+          cap/mute rules above hid still needs a way out, to the channel
+          directory (W17). Flag-gated; never renders when off. */}
+      {whatsappShellEnabled && hiddenChannelCount > 0 && (
+        <View style={styles.subChannelContainer}>
+          <View style={styles.connectorContainer}>
+            <View style={[styles.connectorVertical, { backgroundColor: colors.border }]} />
+            <View style={[styles.connectorHorizontal, { backgroundColor: colors.border }]} />
+          </View>
+          <Pressable
+            onPress={() => router.push(`/inbox/${group._id}/channels` as any)}
+            style={({ pressed }) => [
+              styles.subChannelCard,
+              { backgroundColor: colors.surfaceSecondary, borderColor: "transparent" },
+              pressed && { backgroundColor: isDark ? colors.border : "#E8E8E8" },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={`${hiddenChannelCount} more channel${hiddenChannelCount === 1 ? "" : "s"}`}
+          >
+            <Text
+              style={[styles.subChannelPreview, { color: colors.textSecondary, flex: 1 }]}
+              numberOfLines={1}
+            >
+              {hiddenChannelCount} more channel{hiddenChannelCount === 1 ? "" : "s"}
+            </Text>
+            <Ionicons name="chevron-forward" size={14} color={colors.textSecondary} />
+          </Pressable>
+        </View>
+      )}
 
       {/* Resource sub-rows */}
       {resourceRows}
@@ -739,6 +837,14 @@ const styles = StyleSheet.create({
     fontWeight: "700",
   },
   loadingIndicator: {
+    marginLeft: 8,
+  },
+  // Muted-unread indicator (Channel hygiene rule 2): a quiet dot in place of
+  // the numeric badge when only muted channels have unread activity.
+  mutedUnreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
     marginLeft: 8,
   },
 

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -416,7 +416,13 @@ function GroupedInboxItemInner({
 
   // Single channel display - simple row (same layout as original ChatInboxScreen)
   if (isSingleChannel && primaryChannel) {
-    const hasUnread = primaryChannel.unreadCount > 0;
+    // Under the whatsapp shell, a muted channel's unread doesn't light up the
+    // row or show a numeric badge — a quiet dot marks the activity instead
+    // (hygiene rule 2), mirroring the multi-channel cluster path below.
+    const primaryMuted =
+      whatsappShellEnabled && primaryChannel.isMuted === true;
+    const hasUnread = primaryChannel.unreadCount > 0 && !primaryMuted;
+    const hasMutedUnread = primaryMuted && primaryChannel.unreadCount > 0;
     const isActive = isActiveGroup && activeChannelSlug === primaryChannel.slug;
     // In serving mode a team's channels are flattened into separate rows, so
     // title each by its own `#team-channel` identity rather than the shared
@@ -521,6 +527,10 @@ function GroupedInboxItemInner({
               {primaryChannel.unreadCount > 99 ? "99+" : primaryChannel.unreadCount}
             </Text>
           </View>
+        ) : hasMutedUnread ? (
+          <View
+            style={[styles.mutedUnreadDot, { backgroundColor: colors.textTertiary }]}
+          />
         ) : null}
       </Pressable>
       {resourceRows}
@@ -572,7 +582,11 @@ function GroupedInboxItemInner({
         (isExpanded || ch.unreadCount > 0 || (isActiveGroup && activeChannelSlug === ch.slug))
     );
   }
-  const mainHasUnread = mainChannel.unreadCount > 0;
+  // Under the whatsapp shell a muted main channel's unread must not bold or
+  // highlight the row (hygiene rule 2) — the quiet dot below covers it.
+  const mainHasUnread =
+    mainChannel.unreadCount > 0 &&
+    !(whatsappShellEnabled && mainChannel.isMuted === true);
 
   return (
     <View style={[styles.groupedContainer, { backgroundColor: colors.surface }]}>

--- a/apps/mobile/features/groups/components/GroupInfoScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupInfoScreen.tsx
@@ -559,7 +559,11 @@ export function GroupInfoScreen() {
             (announcement-group + non-member guard). */}
         {((group.members && group.members.length > 0) ||
           (group.leaders && group.leaders.length > 0) ||
-          (group.members_count && group.members_count > 0)) && (
+          (group.members_count && group.members_count > 0) ||
+          // Never let pending requests vanish just because membership
+          // signals are empty — GroupDetailScreen shows its Requests tile
+          // independently of the members card.
+          showRequestsBadge) && (
           <View style={sectionStyles.section}>
             <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>
               MEMBERS{group.members_count ? ` · ${group.members_count}` : ""}

--- a/apps/mobile/features/groups/components/GroupInfoScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupInfoScreen.tsx
@@ -1,0 +1,1080 @@
+/**
+ * GroupInfoScreen — W13 "Group info page"
+ *
+ * docs/plans/church-migration-ui-redesign/README.md ("W13 — Group info page")
+ * + FEATURE-MAP.md §3-4 (field-by-field mapping and gates).
+ *
+ * The WhatsApp-shell consolidation of today's group settings, which are
+ * split across `EditGroupScreen`, `GroupDetailScreen`'s GROUP ACTIONS card,
+ * and the `leader-tools/**` subtree. This screen is pure composition: every
+ * data fetch, mutation, and section below is an existing hook/component
+ * reused as-is (see the imports) — no new backend surface.
+ *
+ * Rendered only behind the `whatsapp-shell` flag (see
+ * `app/groups/[group_id]/index.tsx`); `GroupDetailScreen` is untouched and
+ * keeps rendering when the flag is off.
+ *
+ * Deferred from the full W13 spec (out of scope for this composition pass):
+ *   - Hero photo tap-to-viewer, cadence, description, and the edit pencil
+ *     all come for free from the existing `GroupHeader` component.
+ *   - "Search" in the icon action row (README's icon list) — the task's
+ *     explicit v1 scope is Share + Invite only.
+ *   - Events section (README lists it between Channels and Leader tools) —
+ *     not in this task's explicit numbered scope; left for a follow-up pass.
+ *   - Pinned-channel reorder mode and per-channel mute — `ChannelsSection`
+ *     is rendered unmodified, so it ships whatever that component already
+ *     supports today.
+ *   - `isOnBreak` / `isPublic` settings rows — FEATURE-MAP §3 flags these as
+ *     "schema-only, no UI today" backlog items, not part of this page yet.
+ */
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+  RefreshControl,
+  Modal,
+  Linking,
+  Platform,
+  Share,
+  ActionSheetIOS,
+  Switch,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { DOMAIN_CONFIG } from "@togather/shared";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useAuth } from "@providers/AuthProvider";
+import { useUserData } from "@features/profile/hooks/useUserData";
+import {
+  useGroupDetails,
+  useLeaveGroup,
+  useJoinGroup,
+  useArchiveGroup,
+} from "../hooks";
+import { useWithdrawJoinRequest } from "../hooks/useWithdrawJoinRequest";
+import { useMyPendingJoinRequests } from "../hooks/useMyPendingJoinRequests";
+import { PendingRequestLimitModal } from "./PendingRequestLimitModal";
+import { GroupDetailSkeleton } from "./GroupDetailSkeleton";
+import { GroupHeader } from "./GroupHeader";
+import { MembersRow } from "./MembersRow";
+import { GroupNonMemberView } from "./GroupNonMemberView";
+import { ChannelsSection } from "./ChannelsSection";
+import { GroupBotsSection } from "./GroupBotsSection";
+import { sectionStyles } from "./sectionStyles";
+import { isGroupMember, formatCadence } from "../utils";
+import { formatError } from "@/utils/error-handling";
+import {
+  getExternalChatInfo,
+  openExternalChatLink,
+} from "@features/chat/utils/externalChat";
+
+export function GroupInfoScreen() {
+  // Router param name/shape matches the route file
+  // (`app/groups/[group_id]/index.tsx`) exactly, same as GroupDetailScreen.
+  const params = useLocalSearchParams<{ group_id: string }>();
+  const group_id = params.group_id;
+  const router = useRouter();
+  const { user } = useAuth();
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const [showJoinSuccessModal, setShowJoinSuccessModal] = useState(false);
+  const [showPendingLimitModal, setShowPendingLimitModal] = useState(false);
+
+  const {
+    isAtLimit: isAtPendingLimit,
+    isLoading: isPendingLimitLoading,
+  } = useMyPendingJoinRequests();
+
+  const {
+    data: group,
+    isLoading,
+    error,
+    refetch,
+    isRefetching,
+  } = useGroupDetails(group_id);
+  const { data: userData } = useUserData(!!user);
+
+  const groupIdentifier = group?._id || group_id;
+
+  const leaveGroupMutation = useLeaveGroup();
+  const joinGroupMutation = useJoinGroup(groupIdentifier);
+  const withdrawMutation = useWithdrawJoinRequest(groupIdentifier);
+  const archiveGroupMutation = useArchiveGroup(groupIdentifier);
+
+  const handleRefresh = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  // ---------------------------------------------------------------------
+  // Membership + role derivations — copied verbatim from GroupDetailScreen
+  // so the two screens agree on who sees what.
+  // ---------------------------------------------------------------------
+  const isMember = useMemo(() => {
+    if (!group || !user?.id) {
+      return false;
+    }
+    if (group.user_request_status === "accepted") {
+      return true;
+    }
+    if (group.user_role && group.user_role !== null) {
+      return true;
+    }
+    const memberCheck = isGroupMember(group, user.id);
+    if (memberCheck) {
+      return true;
+    }
+    if (
+      userData?.group_memberships &&
+      Array.isArray(userData.group_memberships)
+    ) {
+      const hasMembership = userData.group_memberships.some(
+        (membership: any) => membership.group?._id === group._id,
+      );
+      if (hasMembership) {
+        return true;
+      }
+    }
+    return false;
+  }, [group, user?.id, userData?.group_memberships]);
+
+  const isAdmin = user?.is_admin === true;
+  const isLeader = group?.user_role === "leader";
+  const canEditGroup = useMemo(() => {
+    if (!group || !user?.id) return false;
+    if (user.is_admin === true) return true;
+    return (
+      group.leaders?.some((leader) => String(leader.id) === String(user.id)) ||
+      false
+    );
+  }, [group, user?.id, user?.is_admin]);
+  const canArchiveGroup = isAdmin && !group?.is_announcement_group;
+
+  // Requests badge (item 4): only meaningful in leader-approval mode.
+  const pendingRequestCount = useAuthenticatedQuery(
+    api.functions.groupMembers.countGroupJoinRequests,
+    group?._id ? { groupId: group._id as Id<"groups"> } : "skip",
+  ) as number | undefined;
+  const hasPendingRequests = (pendingRequestCount ?? 0) > 0;
+  const showRequestsBadge =
+    (group as any)?.join_approval_mode === "leaders" && hasPendingRequests;
+
+  // ---------------------------------------------------------------------
+  // Mute toggle (item 3) — the exact per-group notification mutation/query
+  // NotificationPreferencesSection uses, promoted to the group page per
+  // FEATURE-MAP §2/§3.
+  // ---------------------------------------------------------------------
+  const groupNotifPref = useAuthenticatedQuery(
+    api.functions.notifications.preferences.getGroupNotifications,
+    group?._id ? { groupId: group._id as Id<"groups"> } : "skip",
+  );
+  const setGroupNotifications = useAuthenticatedMutation(
+    api.functions.notifications.preferences.setGroupNotifications,
+  );
+  const [isSavingMute, setIsSavingMute] = useState(false);
+  const isMuted = !(groupNotifPref?.notificationsEnabled ?? true);
+
+  const handleToggleMuted = async (nextMuted: boolean) => {
+    if (!group?._id) return;
+    setIsSavingMute(true);
+    try {
+      await setGroupNotifications({
+        groupId: group._id as Id<"groups">,
+        enabled: !nextMuted,
+      });
+    } catch (e) {
+      Alert.alert("Error", formatError(e, "Failed to update notification setting"));
+    } finally {
+      setIsSavingMute(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------
+  // Admin-only settings (item 9) — the exact mutations EditGroupScreen uses.
+  // ---------------------------------------------------------------------
+  const setHiddenFromDiscovery = useAuthenticatedMutation(
+    api.functions.groups.index.setHiddenFromDiscovery,
+  );
+  const setJoinApprovalMode = useAuthenticatedMutation(
+    api.functions.groups.index.setJoinApprovalMode,
+  );
+  const [hiddenFromDiscovery, setHiddenFromDiscoveryState] = useState(false);
+  const [isSavingHidden, setIsSavingHidden] = useState(false);
+  const [leadersApprove, setLeadersApprove] = useState(false);
+  const [isSavingApproval, setIsSavingApproval] = useState(false);
+
+  useEffect(() => {
+    if (group) {
+      setHiddenFromDiscoveryState(Boolean((group as any).hidden_from_discovery));
+      setLeadersApprove((group as any).join_approval_mode === "leaders");
+    }
+  }, [group]);
+
+  const handleToggleHiddenFromDiscovery = async (next: boolean) => {
+    if (!group?._id) return;
+    const previous = hiddenFromDiscovery;
+    setHiddenFromDiscoveryState(next); // optimistic
+    setIsSavingHidden(true);
+    try {
+      await setHiddenFromDiscovery({ groupId: group._id as Id<"groups">, hidden: next });
+    } catch (error) {
+      setHiddenFromDiscoveryState(previous); // revert
+      Alert.alert(
+        "Couldn't update visibility",
+        formatError(error, "Failed to update discovery visibility"),
+      );
+    } finally {
+      setIsSavingHidden(false);
+    }
+  };
+
+  const handleToggleLeadersApprove = async (next: boolean) => {
+    if (!group?._id) return;
+    const previous = leadersApprove;
+    setLeadersApprove(next); // optimistic
+    setIsSavingApproval(true);
+    try {
+      await setJoinApprovalMode({
+        groupId: group._id as Id<"groups">,
+        mode: next ? "leaders" : "admins",
+      });
+    } catch (error) {
+      setLeadersApprove(previous); // revert
+      Alert.alert(
+        "Couldn't update approvals",
+        formatError(error, "Failed to update who approves requests"),
+      );
+    } finally {
+      setIsSavingApproval(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------
+  // Handlers reused verbatim from GroupDetailScreen.
+  // ---------------------------------------------------------------------
+  const handleMembersPress = () => {
+    if (!group?._id) return;
+    if (isLeader || isAdmin) {
+      router.push(`/leader-tools/${group._id}/members`);
+      return;
+    }
+    router.push(`/inbox/${group._id}/general/members` as any);
+  };
+
+  const handleLeaveGroup = () => {
+    Alert.alert(
+      "Leave Group",
+      `Are you sure you want to leave ${
+        group?.title || group?.name || "this group"
+      }? You will need to re-join if you want to participate again.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Leave Group",
+          style: "destructive",
+          onPress: () => {
+            if (user?.id) {
+              leaveGroupMutation.mutate({
+                groupId: groupIdentifier,
+                userId: String(user.id),
+              });
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const handleJoinGroup = async () => {
+    if (!user?.id) {
+      Alert.alert("Error", "Please log in to join a group.");
+      return;
+    }
+    if (!group?._id && !group?.id) {
+      Alert.alert("Error", "Group information is missing. Please try again.");
+      return;
+    }
+    if (isPendingLimitLoading) return;
+    if (isAtPendingLimit) {
+      setShowPendingLimitModal(true);
+      return;
+    }
+    try {
+      await joinGroupMutation.mutateAsync();
+      setShowJoinSuccessModal(true);
+    } catch (error) {
+      console.error("Join group error:", error);
+    }
+  };
+
+  const handleWithdrawRequest = () => {
+    Alert.alert(
+      "Withdraw Request",
+      "Are you sure you want to withdraw your join request?",
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Withdraw", style: "destructive", onPress: () => withdrawMutation.mutate() },
+      ],
+    );
+  };
+
+  const handleArchiveGroup = () => {
+    Alert.alert(
+      "Archive Group",
+      `Are you sure you want to archive "${
+        group?.title || group?.name || "this group"
+      }"? This will hide the group from all members. This action can be undone by a community admin.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Archive",
+          style: "destructive",
+          onPress: async () => {
+            await archiveGroupMutation.mutate();
+          },
+        },
+      ],
+    );
+  };
+
+  const handleShareGroup = async () => {
+    if (!group?.shortId) {
+      Alert.alert("Cannot Share", "This group doesn't have a shareable link yet.");
+      return;
+    }
+    const groupUrl = DOMAIN_CONFIG.groupShareUrl(group.shortId);
+    const groupName = group.name || group.title || "Group";
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        { options: ["Cancel", "Copy Link", "Share"], cancelButtonIndex: 0 },
+        async (buttonIndex) => {
+          if (buttonIndex === 1) {
+            await Clipboard.setStringAsync(groupUrl);
+            Alert.alert("Link Copied", "Group link has been copied to clipboard.");
+          } else if (buttonIndex === 2) {
+            await Share.share({ message: `${groupName}\n${groupUrl}`, url: groupUrl });
+          }
+        },
+      );
+    } else {
+      await Share.share({ message: `${groupName}\n${groupUrl}` });
+    }
+  };
+
+  if (isLoading) {
+    return <GroupDetailSkeleton />;
+  }
+
+  if (error || !group) {
+    return (
+      <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <Text style={[styles.errorText, { color: colors.error }]}>Group not found</Text>
+        <TouchableOpacity
+          style={[styles.button, { backgroundColor: colors.link }]}
+          onPress={() => {
+            if (router.canGoBack()) {
+              router.back();
+            } else {
+              router.replace("/groups");
+            }
+          }}
+        >
+          <Text style={[styles.buttonText, { color: colors.textInverse }]}>Go Back</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // Non-members land on the existing, unmodified non-member page (share
+  // preview, join/request CTA, admin read-only peeking) — W13 is the info
+  // page for members; this keeps the route working for everyone else who
+  // can reach it (e.g. from a share link or Explore).
+  if (!isMember) {
+    return (
+      <>
+        <GroupNonMemberView
+          group={group}
+          onJoinPress={handleJoinGroup}
+          onWithdrawPress={handleWithdrawRequest}
+          isJoining={joinGroupMutation.isPending || isPendingLimitLoading}
+          isWithdrawing={withdrawMutation.isPending}
+        />
+        <PendingRequestLimitModal
+          visible={showPendingLimitModal}
+          onDismiss={() => setShowPendingLimitModal(false)}
+          onViewRequests={() => {
+            setShowPendingLimitModal(false);
+            router.push("/(tabs)/profile");
+          }}
+        />
+        <Modal
+          visible={showJoinSuccessModal}
+          transparent
+          animationType="fade"
+          onRequestClose={() => {
+            setShowJoinSuccessModal(false);
+            if (router.canGoBack()) router.back();
+          }}
+        >
+          <View style={[styles.modalOverlay, { backgroundColor: colors.overlay }]}>
+            <View style={[styles.modalContent, { backgroundColor: colors.modalBackground }]}>
+              <View style={styles.modalHeader}>
+                <Ionicons name="checkmark-circle" size={48} color={colors.success} />
+                <Text style={[styles.modalTitle, { color: colors.text }]}>Request Submitted!</Text>
+              </View>
+              <Text style={[styles.modalMessage, { color: colors.textSecondary }]}>
+                Your request to join this group has been sent to the group leaders for approval.
+              </Text>
+              <TouchableOpacity
+                style={[styles.modalButton, { backgroundColor: colors.link }]}
+                onPress={() => {
+                  setShowJoinSuccessModal(false);
+                  if (router.canGoBack()) router.back();
+                }}
+                activeOpacity={0.8}
+              >
+                <Text style={[styles.modalButtonText, { color: colors.textInverse }]}>OK</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </Modal>
+      </>
+    );
+  }
+
+  const cadence = formatCadence(group);
+  const address =
+    group.full_address ||
+    (group.address_line1 || group.city || group.state || group.zip_code
+      ? [
+          group.address_line1,
+          group.address_line2,
+          [group.city, group.state].filter(Boolean).join(", "),
+          group.zip_code,
+        ]
+          .filter(Boolean)
+          .join(", ")
+      : null) ||
+    group.location ||
+    null;
+
+  const handleAddressPress = async () => {
+    if (!address) return;
+    const encoded = encodeURIComponent(address);
+    const url =
+      Platform.OS === "ios"
+        ? `maps://maps.apple.com/?q=${encoded}`
+        : `https://www.google.com/maps/search/?api=1&query=${encoded}`;
+    try {
+      const canOpen = await Linking.canOpenURL(url);
+      if (canOpen) {
+        await Linking.openURL(url);
+      } else {
+        await Linking.openURL(`https://www.google.com/maps/search/?api=1&query=${encoded}`);
+      }
+    } catch (err) {
+      console.error("Error opening maps:", err);
+    }
+  };
+
+  const meetingTypeLabel =
+    group.default_meeting_type === 2
+      ? "Online"
+      : group.default_meeting_type === 1
+        ? "In-person"
+        : null;
+  const meetingLink = group.default_meeting_link || null;
+  const externalChatLink = (group as any).externalChatLink as string | undefined;
+  const externalChatInfo = externalChatLink ? getExternalChatInfo(externalChatLink) : null;
+
+  const showDetailsCard = !!cadence || !!address || !!meetingTypeLabel || !!externalChatLink;
+  const heroMetaParts = [
+    group.members_count
+      ? `${group.members_count} member${group.members_count === 1 ? "" : "s"}`
+      : null,
+    group.group_type_name || null,
+  ].filter(Boolean) as string[];
+
+  return (
+    <>
+      <ScrollView
+        style={[styles.scrollView, { backgroundColor: colors.background }]}
+        contentContainerStyle={{ paddingBottom: 24 }}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={isRefetching} onRefresh={handleRefresh} tintColor={colors.link} />
+        }
+      >
+        {/* 1. HERO — photo/name/cadence/description/edit-pencil all come
+            from the unmodified GroupHeader. We only add the member-count +
+            group-type meta line it doesn't already render. */}
+        <GroupHeader group={group} canEdit={canEditGroup} />
+        {heroMetaParts.length > 0 && (
+          <Text style={[styles.heroMeta, { color: colors.textSecondary }]}>
+            {heroMetaParts.join(" · ")}
+          </Text>
+        )}
+
+        {/* 2. ICON ACTION ROW — Share + Invite. Invite reuses the same
+            share flow for v1 (no separate invite-kit yet). */}
+        {!!group.shortId && (
+          <View style={styles.iconActionRow}>
+            <IconAction icon="share-outline" label="Share" onPress={handleShareGroup} />
+            <IconAction icon="person-add-outline" label="Invite" onPress={handleShareGroup} />
+          </View>
+        )}
+
+        {/* 3. MUTE GROUP — reuses the exact per-group notification
+            query/mutation NotificationPreferencesSection uses. */}
+        <View style={sectionStyles.section}>
+          <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
+            <View style={styles.muteRow}>
+              <Ionicons name="notifications-off-outline" size={20} color={colors.icon} />
+              <Text style={[styles.muteLabel, { color: colors.text }]}>Mute group</Text>
+              <Switch
+                value={isMuted}
+                onValueChange={handleToggleMuted}
+                disabled={isSavingMute}
+                trackColor={{ false: colors.border, true: primaryColor }}
+                thumbColor={colors.textInverse}
+              />
+            </View>
+          </View>
+        </View>
+
+        {/* 4. MEMBERS — same tap gates GroupDetailScreen applies
+            (announcement-group + non-member guard). */}
+        {((group.members && group.members.length > 0) ||
+          (group.leaders && group.leaders.length > 0) ||
+          (group.members_count && group.members_count > 0)) && (
+          <View style={sectionStyles.section}>
+            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>
+              MEMBERS{group.members_count ? ` · ${group.members_count}` : ""}
+            </Text>
+            {(() => {
+              const isAnnouncementRoster =
+                !!group.is_announcement_group && !(isLeader || isAdmin);
+              const hasGroupMembership = !!group.user_role;
+              const tapEnabled = !isAnnouncementRoster && hasGroupMembership;
+              const Container: React.ComponentType<any> = tapEnabled ? TouchableOpacity : View;
+              return (
+                <Container
+                  {...(tapEnabled ? { activeOpacity: 0.7, onPress: handleMembersPress } : {})}
+                  style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}
+                >
+                  <MembersRow
+                    members={group.members}
+                    leaders={group.leaders}
+                    totalCount={group.members_count ?? undefined}
+                  />
+                  {tapEnabled && (
+                    <View style={[sectionStyles.viewAllRow, { borderTopColor: colors.border }]}>
+                      <Text style={[sectionStyles.viewAllText, { color: colors.text }]}>
+                        View all members
+                      </Text>
+                      <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+                    </View>
+                  )}
+                </Container>
+              );
+            })()}
+            {showRequestsBadge && (
+              <TouchableOpacity
+                onPress={() => router.push(`/groups/${group._id}/requests` as any)}
+                activeOpacity={0.7}
+                style={[styles.requestsBadgeRow, { backgroundColor: colors.warning + "1A" }]}
+              >
+                <Ionicons name="person-add-outline" size={16} color={colors.warning} />
+                <Text style={[styles.requestsBadgeText, { color: colors.warning }]}>
+                  {pendingRequestCount} {pendingRequestCount === 1 ? "request" : "requests"} to join
+                </Text>
+                <Ionicons name="chevron-forward" size={16} color={colors.warning} />
+              </TouchableOpacity>
+            )}
+          </View>
+        )}
+
+        {/* 5. CHANNELS — rendered exactly as-is; not modified. */}
+        {group._id && <ChannelsSection groupId={group._id} userRole={group.user_role} />}
+
+        {/* 6. LEADER TOOLS — leader/admin only, reusing today's routes. */}
+        {(isLeader || isAdmin) && group._id && (
+          <View style={sectionStyles.section}>
+            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>
+              LEADER TOOLS
+            </Text>
+            <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
+              <LeaderToolRow
+                icon="pulse-outline"
+                label="People"
+                onPress={() => router.push(`/(user)/leader-tools/${group._id}/followup` as any)}
+                topBorder={false}
+              />
+              <LeaderToolRow
+                icon="checkmark-done-outline"
+                label="Attendance"
+                onPress={() => router.push(`/(user)/leader-tools/${group._id}/attendance` as any)}
+              />
+              <LeaderToolRow
+                icon="list-outline"
+                label="Tasks"
+                onPress={() => router.push(`/(user)/leader-tools/${group._id}/tasks` as any)}
+              />
+              <LeaderToolRow
+                icon="calendar-outline"
+                label="Rostering"
+                onPress={() => router.push(`/rostering/${group._id}` as any)}
+              />
+              <LeaderToolRow
+                icon="document-text-outline"
+                label="Run sheet"
+                onPress={() => router.push(`/(user)/leader-tools/${group._id}/run-sheet` as any)}
+              />
+              <LeaderToolRow
+                icon="folder-outline"
+                label="Resources"
+                onPress={() => router.push(`/(user)/leader-tools/${group._id}/resources` as any)}
+              />
+              <LeaderToolRow
+                icon="options-outline"
+                label="Toolbar settings"
+                onPress={() => router.push(`/(user)/leader-tools/${group._id}/toolbar-settings` as any)}
+              />
+            </View>
+          </View>
+        )}
+
+        {/* 7. BOTS — rendered exactly as-is (leader-gated internally). */}
+        {group._id && <GroupBotsSection groupId={group._id} isLeader={isLeader} />}
+
+        {/* 8. DETAILS — meeting day/time, meeting type/link, address,
+            external chat link. */}
+        {showDetailsCard && (
+          <View style={sectionStyles.section}>
+            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>DETAILS</Text>
+            <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
+              {!!cadence && (
+                <View style={sectionStyles.detailRow}>
+                  <Ionicons name="calendar-outline" size={20} color={colors.icon} />
+                  <Text style={[sectionStyles.detailText, { color: colors.text }]}>{cadence}</Text>
+                </View>
+              )}
+              {!!meetingTypeLabel && (
+                <TouchableOpacity
+                  onPress={meetingLink ? () => Linking.openURL(meetingLink) : undefined}
+                  disabled={!meetingLink}
+                  activeOpacity={0.7}
+                  style={[
+                    sectionStyles.detailRow,
+                    !!cadence && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
+                  ]}
+                >
+                  <Ionicons
+                    name={meetingTypeLabel === "Online" ? "videocam-outline" : "body-outline"}
+                    size={20}
+                    color={colors.icon}
+                  />
+                  <Text style={[sectionStyles.detailText, { color: colors.text }]} numberOfLines={1}>
+                    {meetingTypeLabel}{meetingLink ? ` · ${meetingLink}` : ""}
+                  </Text>
+                  {!!meetingLink && (
+                    <Ionicons name="open-outline" size={18} color={colors.textTertiary} />
+                  )}
+                </TouchableOpacity>
+              )}
+              {!!address && (
+                <TouchableOpacity
+                  onPress={handleAddressPress}
+                  activeOpacity={0.7}
+                  style={[
+                    sectionStyles.detailRow,
+                    (!!cadence || !!meetingTypeLabel) && {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                  ]}
+                >
+                  <Ionicons name="location-outline" size={20} color={colors.icon} />
+                  <Text style={[sectionStyles.detailText, { color: colors.text }]} numberOfLines={2}>
+                    {address}
+                  </Text>
+                  <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+                </TouchableOpacity>
+              )}
+              {!!externalChatLink && externalChatInfo && (
+                <TouchableOpacity
+                  onPress={() => openExternalChatLink(externalChatLink)}
+                  activeOpacity={0.7}
+                  style={[
+                    sectionStyles.detailRow,
+                    (!!cadence || !!meetingTypeLabel || !!address) && {
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.border,
+                    },
+                  ]}
+                >
+                  <Ionicons
+                    name={externalChatInfo.iconName as any}
+                    size={20}
+                    color={externalChatInfo.color}
+                  />
+                  <Text style={[sectionStyles.detailText, { color: colors.text }]} numberOfLines={1}>
+                    Also chats on {externalChatInfo.name}
+                  </Text>
+                  <Ionicons name="open-outline" size={18} color={colors.textTertiary} />
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        )}
+
+        {/* 9. SETTINGS — community-admin-only rows with an ADMIN tag,
+            reusing EditGroupScreen's exact mutations. */}
+        {isAdmin && (
+          <View style={sectionStyles.section}>
+            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>SETTINGS</Text>
+            <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
+              <View style={styles.settingsRow}>
+                <View style={styles.settingsRowTextWrap}>
+                  <View style={styles.settingsRowTitleLine}>
+                    <Text style={[styles.settingsRowLabel, { color: colors.text }]}>
+                      Hidden from discovery
+                    </Text>
+                    <AdminTag />
+                  </View>
+                  <Text style={[styles.settingsRowDescription, { color: colors.textSecondary }]}>
+                    Won't appear on the map, near-me page, or group browse.
+                  </Text>
+                </View>
+                <Switch
+                  value={hiddenFromDiscovery}
+                  onValueChange={handleToggleHiddenFromDiscovery}
+                  disabled={isSavingHidden}
+                  trackColor={{ false: colors.border, true: primaryColor }}
+                  thumbColor={colors.textInverse}
+                />
+              </View>
+              <View
+                style={[
+                  styles.settingsRow,
+                  { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
+                ]}
+              >
+                <View style={styles.settingsRowTextWrap}>
+                  <View style={styles.settingsRowTitleLine}>
+                    <Text style={[styles.settingsRowLabel, { color: colors.text }]}>
+                      Join approval: leaders
+                    </Text>
+                    <AdminTag />
+                  </View>
+                  <Text style={[styles.settingsRowDescription, { color: colors.textSecondary }]}>
+                    When off, community admins approve join requests instead.
+                  </Text>
+                </View>
+                <Switch
+                  value={leadersApprove}
+                  onValueChange={handleToggleLeadersApprove}
+                  disabled={isSavingApproval}
+                  trackColor={{ false: colors.border, true: primaryColor }}
+                  thumbColor={colors.textInverse}
+                />
+              </View>
+            </View>
+          </View>
+        )}
+
+        {/* 10. BOTTOM RED ROWS — Leave (hidden for announcement groups),
+            Archive (admin only, with ADMIN tag). */}
+        <View style={sectionStyles.section}>
+          <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
+            {!group.is_announcement_group && (
+              <TouchableOpacity
+                activeOpacity={0.7}
+                onPress={handleLeaveGroup}
+                style={styles.dangerRow}
+              >
+                <Ionicons name="exit-outline" size={20} color={colors.destructive} />
+                <Text style={[styles.dangerLabel, { color: colors.destructive }]}>Leave Group</Text>
+              </TouchableOpacity>
+            )}
+            {canArchiveGroup && (
+              <TouchableOpacity
+                activeOpacity={0.7}
+                onPress={handleArchiveGroup}
+                style={[
+                  styles.dangerRow,
+                  !group.is_announcement_group && {
+                    borderTopWidth: StyleSheet.hairlineWidth,
+                    borderTopColor: colors.border,
+                  },
+                ]}
+              >
+                <Ionicons name="archive-outline" size={20} color={colors.destructive} />
+                <Text style={[styles.dangerLabel, { color: colors.destructive }]}>Archive Group</Text>
+                <View style={{ flex: 1 }} />
+                <AdminTag />
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      </ScrollView>
+    </>
+  );
+}
+
+function IconAction({
+  icon,
+  label,
+  onPress,
+}: {
+  icon: React.ComponentProps<typeof Ionicons>["name"];
+  label: string;
+  onPress: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <TouchableOpacity style={styles.iconAction} onPress={onPress} activeOpacity={0.7}>
+      <View style={[styles.iconActionCircle, { backgroundColor: colors.surfaceSecondary }]}>
+        <Ionicons name={icon} size={22} color={colors.text} />
+      </View>
+      <Text style={[styles.iconActionLabel, { color: colors.text }]}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+function LeaderToolRow({
+  icon,
+  label,
+  onPress,
+  topBorder = true,
+}: {
+  icon: React.ComponentProps<typeof Ionicons>["name"];
+  label: string;
+  onPress: () => void;
+  topBorder?: boolean;
+}) {
+  const { colors } = useTheme();
+  return (
+    <TouchableOpacity
+      activeOpacity={0.7}
+      onPress={onPress}
+      style={[
+        styles.leaderToolRow,
+        topBorder && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
+      ]}
+    >
+      <Ionicons name={icon} size={20} color={colors.icon} />
+      <Text style={[styles.leaderToolLabel, { color: colors.text }]}>{label}</Text>
+      <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+    </TouchableOpacity>
+  );
+}
+
+/** Small monospace-ish "ADMIN" tag flagging community-admin-only rows. */
+function AdminTag() {
+  const { colors } = useTheme();
+  return (
+    <View style={[styles.adminTag, { backgroundColor: colors.textTertiary + "26", borderColor: colors.border }]}>
+      <Text style={[styles.adminTagText, { color: colors.textSecondary }]}>ADMIN</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 20,
+  },
+  errorText: {
+    fontSize: 16,
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  button: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  heroMeta: {
+    marginTop: -16,
+    marginBottom: 8,
+    fontSize: 13,
+    fontWeight: "500",
+    textAlign: "center",
+  },
+  iconActionRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 32,
+    paddingVertical: 12,
+  },
+  iconAction: {
+    alignItems: "center",
+    gap: 6,
+  },
+  iconActionCircle: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconActionLabel: {
+    fontSize: 12,
+    fontWeight: "500",
+  },
+  muteRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
+  },
+  muteLabel: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  requestsBadgeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginTop: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+  },
+  requestsBadgeText: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  leaderToolRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
+  },
+  leaderToolLabel: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  settingsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  settingsRowTextWrap: {
+    flex: 1,
+  },
+  settingsRowTitleLine: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  settingsRowLabel: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  settingsRowDescription: {
+    fontSize: 13,
+    marginTop: 4,
+    lineHeight: 18,
+  },
+  adminTag: {
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  adminTagText: {
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
+  },
+  dangerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
+  },
+  dangerLabel: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  modalOverlay: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 20,
+  },
+  modalContent: {
+    borderRadius: 16,
+    padding: 24,
+    width: "100%",
+    maxWidth: 340,
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  modalHeader: {
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: "600",
+    marginTop: 12,
+  },
+  modalMessage: {
+    fontSize: 16,
+    textAlign: "center",
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  modalButton: {
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    minWidth: 120,
+  },
+  modalButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/features/groups/components/__tests__/GroupInfoScreen.test.tsx
+++ b/apps/mobile/features/groups/components/__tests__/GroupInfoScreen.test.tsx
@@ -1,0 +1,282 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { GroupInfoScreen } from "../GroupInfoScreen";
+import { useGroupDetails, useLeaveGroup, useJoinGroup, useArchiveGroup } from "../../hooks";
+import { useAuth } from "@providers/AuthProvider";
+import { useUserData } from "@features/profile/hooks/useUserData";
+import { isGroupMember } from "../../utils";
+
+// Mirrors the mocking pattern established in GroupDetailScreen.test.tsx —
+// this screen reuses the same hooks/components, so the same doubles apply.
+jest.mock("@services/api/convex", () => ({
+  useQuery: jest.fn(),
+  useMutation: jest.fn(() => jest.fn()),
+  useAuthenticatedQuery: jest.fn(() => undefined),
+  useAuthenticatedMutation: jest.fn(() => jest.fn()),
+  api: {
+    functions: {
+      groups: {
+        index: {
+          getById: "api.functions.groups.index.getById",
+          getLeaders: "api.functions.groups.index.getLeaders",
+          setHiddenFromDiscovery: "api.functions.groups.index.setHiddenFromDiscovery",
+          setJoinApprovalMode: "api.functions.groups.index.setJoinApprovalMode",
+        },
+      },
+      groupMembers: {
+        list: "api.functions.groupMembers.list",
+        getMemberPreview: "api.functions.groupMembers.getMemberPreview",
+        getLeaderPreview: "api.functions.groupMembers.getLeaderPreview",
+        countGroupJoinRequests: "api.functions.groupMembers.countGroupJoinRequests",
+      },
+      notifications: {
+        preferences: {
+          getGroupNotifications: "api.functions.notifications.preferences.getGroupNotifications",
+          setGroupNotifications: "api.functions.notifications.preferences.setGroupNotifications",
+        },
+      },
+    },
+  },
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ group_id: "1" }),
+  useRouter: () => ({
+    push: jest.fn(),
+    back: jest.fn(),
+    replace: jest.fn(),
+    canGoBack: jest.fn(() => true),
+  }),
+}));
+
+jest.mock("../../hooks", () => ({
+  useGroupDetails: jest.fn(),
+  useLeaveGroup: jest.fn(),
+  useJoinGroup: jest.fn(),
+  useArchiveGroup: jest.fn(),
+}));
+
+jest.mock("../../hooks/useWithdrawJoinRequest", () => ({
+  useWithdrawJoinRequest: () => ({ mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false }),
+}));
+
+jest.mock("../../hooks/useMyPendingJoinRequests", () => ({
+  useMyPendingJoinRequests: () => ({
+    requests: [],
+    count: 0,
+    isAtLimit: false,
+    isLoading: false,
+  }),
+  PENDING_JOIN_REQUEST_LIMIT: 2,
+}));
+
+jest.mock("../PendingRequestLimitModal", () => ({
+  PendingRequestLimitModal: () => null,
+}));
+
+jest.mock("@providers/AuthProvider", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@features/profile/hooks/useUserData", () => ({
+  useUserData: jest.fn(),
+}));
+
+jest.mock("../../utils", () => ({
+  isGroupMember: jest.fn(),
+  formatCadence: jest.fn(() => "Sundays at 11:00am"),
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: "Ionicons",
+}));
+
+jest.mock("@components/ui", () => {
+  const { View } = require("react-native");
+  return {
+    Skeleton: (props: any) => <View testID="skeleton" {...props} />,
+    SkeletonAvatar: (props: any) => <View testID="skeleton-avatar" {...props} />,
+    SkeletonText: (props: any) => <View testID="skeleton-text" {...props} />,
+  };
+});
+
+jest.mock("../GroupHeader", () => {
+  const { View, Text } = require("react-native");
+  return {
+    GroupHeader: ({ group }: any) => (
+      <View testID="group-header">
+        <Text testID="group-header-title">{group?.title || group?.name}</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock("../GroupNonMemberView", () => {
+  const { View, Text } = require("react-native");
+  return {
+    GroupNonMemberView: () => (
+      <View testID="non-member-view">
+        <Text>Non-Member View</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock("../MembersRow", () => {
+  const { View, Text } = require("react-native");
+  return {
+    MembersRow: ({ members, leaders }: any) => (
+      <View testID="members-row">
+        <Text>Members: {members?.length || 0}, Leaders: {leaders?.length || 0}</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock("../ChannelsSection", () => {
+  const { View } = require("react-native");
+  return { ChannelsSection: () => <View testID="channels-section" /> };
+});
+
+jest.mock("../GroupBotsSection", () => {
+  const { View } = require("react-native");
+  return { GroupBotsSection: () => <View testID="bots-section" /> };
+});
+
+const mockGroup = {
+  _id: "1",
+  id: 1,
+  title: "Test Group",
+  name: "Test Group",
+  description: "Test description",
+  shortId: "abc123",
+  members_count: 2,
+  group_type_name: "Small Group",
+  members: [
+    { id: 1, first_name: "John", last_name: "Doe" },
+    { id: 2, first_name: "Jane", last_name: "Smith" },
+  ],
+  leaders: [],
+  highlights: [],
+};
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: any) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("GroupInfoScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useLeaveGroup as jest.Mock).mockReturnValue({ mutate: jest.fn(), isPending: false });
+    (useJoinGroup as jest.Mock).mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn().mockResolvedValue({}),
+      isPending: false,
+    });
+    (useArchiveGroup as jest.Mock).mockReturnValue({ mutate: jest.fn(), isPending: false });
+  });
+
+  it("renders loading state", () => {
+    (useGroupDetails as jest.Mock).mockReturnValue({ data: undefined, isLoading: true, error: null });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1 } });
+    (useUserData as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    (isGroupMember as jest.Mock).mockReturnValue(false);
+
+    render(<GroupInfoScreen />, { wrapper: createWrapper() });
+
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("renders error state", () => {
+    (useGroupDetails as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Not found"),
+    });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1 } });
+    (useUserData as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    (isGroupMember as jest.Mock).mockReturnValue(false);
+
+    render(<GroupInfoScreen />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Group not found")).toBeTruthy();
+  });
+
+  it("renders the existing non-member view (unmodified) for non-members", () => {
+    (useGroupDetails as jest.Mock).mockReturnValue({ data: mockGroup, isLoading: false, error: null });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 999 } });
+    (useUserData as jest.Mock).mockReturnValue({ data: { group_memberships: [] }, isLoading: false });
+    (isGroupMember as jest.Mock).mockReturnValue(false);
+
+    render(<GroupInfoScreen />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId("non-member-view")).toBeTruthy();
+  });
+
+  it("renders the W13 group-info layout for members", () => {
+    (useGroupDetails as jest.Mock).mockReturnValue({ data: mockGroup, isLoading: false, error: null });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1 } });
+    (useUserData as jest.Mock).mockReturnValue({ data: { group_memberships: [] }, isLoading: false });
+    (isGroupMember as jest.Mock).mockReturnValue(true);
+
+    render(<GroupInfoScreen />, { wrapper: createWrapper() });
+
+    expect(screen.queryByTestId("non-member-view")).toBeNull();
+    expect(screen.getByTestId("group-header-title")).toBeTruthy();
+    expect(screen.getByText("Mute group")).toBeTruthy();
+    expect(screen.getByTestId("members-row")).toBeTruthy();
+    expect(screen.getByTestId("channels-section")).toBeTruthy();
+    expect(screen.getByTestId("bots-section")).toBeTruthy();
+    expect(screen.getByText("Leave Group")).toBeTruthy();
+  });
+
+  it("hides Leave Group for the announcement group", () => {
+    (useGroupDetails as jest.Mock).mockReturnValue({
+      data: { ...mockGroup, is_announcement_group: true },
+      isLoading: false,
+      error: null,
+    });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1 } });
+    (useUserData as jest.Mock).mockReturnValue({ data: { group_memberships: [] }, isLoading: false });
+    (isGroupMember as jest.Mock).mockReturnValue(true);
+
+    render(<GroupInfoScreen />, { wrapper: createWrapper() });
+
+    expect(screen.queryByText("Leave Group")).toBeNull();
+  });
+
+  it("shows Leader Tools and admin Settings rows for a community admin", () => {
+    (useGroupDetails as jest.Mock).mockReturnValue({ data: mockGroup, isLoading: false, error: null });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, is_admin: true } });
+    (useUserData as jest.Mock).mockReturnValue({ data: { group_memberships: [] }, isLoading: false });
+    (isGroupMember as jest.Mock).mockReturnValue(true);
+
+    render(<GroupInfoScreen />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("LEADER TOOLS")).toBeTruthy();
+    expect(screen.getByText("People")).toBeTruthy();
+    expect(screen.getByText("Rostering")).toBeTruthy();
+    expect(screen.getByText("SETTINGS")).toBeTruthy();
+    expect(screen.getAllByText("ADMIN").length).toBeGreaterThan(0);
+    expect(screen.getByText("Archive Group")).toBeTruthy();
+  });
+
+  it("hides Leader Tools and Settings for a plain member", () => {
+    (useGroupDetails as jest.Mock).mockReturnValue({ data: mockGroup, isLoading: false, error: null });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, is_admin: false } });
+    (useUserData as jest.Mock).mockReturnValue({ data: { group_memberships: [] }, isLoading: false });
+    (isGroupMember as jest.Mock).mockReturnValue(true);
+
+    render(<GroupInfoScreen />, { wrapper: createWrapper() });
+
+    expect(screen.queryByText("LEADER TOOLS")).toBeNull();
+    expect(screen.queryByText("SETTINGS")).toBeNull();
+    expect(screen.queryByText("Archive Group")).toBeNull();
+  });
+});

--- a/apps/mobile/features/invite/components/InviteKitScreen.tsx
+++ b/apps/mobile/features/invite/components/InviteKitScreen.tsx
@@ -35,7 +35,7 @@ import * as Clipboard from 'expo-clipboard';
 import { DOMAIN_CONFIG } from '@togather/shared';
 import { useAuth } from '@providers/AuthProvider';
 import { useTheme } from '@hooks/useTheme';
-import { Card } from '@components/ui/Card';
+import { Card } from '@components/ui';
 import { QrCode } from '@components/ui/QrCode';
 import { useAuthenticatedQuery, api } from '@services/api/convex';
 import type { Id } from '@services/api/convex';

--- a/apps/mobile/features/invite/components/InviteKitScreen.tsx
+++ b/apps/mobile/features/invite/components/InviteKitScreen.tsx
@@ -57,8 +57,10 @@ export function InviteKitScreen() {
     community?.subdomain ? DOMAIN_CONFIG.communityUrl(community.subdomain) : null;
   const communityName = community?.name || 'Our church';
 
+  // Copy per the brief's Rule 3: the handoff message says the community-scope
+  // pitch explicitly ("your church gets its own app").
   const whatsappMessage = communityUrl
-    ? `Hi everyone! \u{1F44B} ${communityName} is moving to Togather — same groups, plus events & RSVPs. Join here: ${communityUrl}. Sign in with your phone number and you're in.`
+    ? `Hi everyone! \u{1F44B} ${communityName} is moving to Togather — our church gets its own app: same groups, plus events & RSVPs, with none of the other-group noise. Join here: ${communityUrl}. Sign in with your phone number and you're in.`
     : null;
 
   const myGroups = useAuthenticatedQuery(
@@ -75,8 +77,12 @@ export function InviteKitScreen() {
   }, [myGroups]);
 
   const handleCopy = async (text: string, label: string) => {
-    await Clipboard.setStringAsync(text);
-    Alert.alert('Copied', `${label} copied to clipboard.`);
+    try {
+      await Clipboard.setStringAsync(text);
+      Alert.alert('Copied', `${label} copied to clipboard.`);
+    } catch {
+      Alert.alert('Copy failed', 'Please try again.');
+    }
   };
 
   const handleShare = async (message: string, url?: string) => {

--- a/apps/mobile/features/invite/components/InviteKitScreen.tsx
+++ b/apps/mobile/features/invite/components/InviteKitScreen.tsx
@@ -1,0 +1,346 @@
+/**
+ * InviteKitScreen — "Invite your church"
+ *
+ * Member/admin-facing Invite Kit, adapted from the migration-wizard invite
+ * kit concept (docs/plans/church-migration-ui-redesign/README.md §6, W11
+ * step 4) into a standalone screen any member can reach from their profile
+ * menu, rather than an admin-only wizard step. Gated behind the
+ * whatsapp-shell flag end-to-end (see ProfileMenu.tsx).
+ *
+ * Three sections:
+ *  - Community: QR code + copy/share for the community's public URL
+ *    (`DOMAIN_CONFIG.communityUrl`, the same subdomain entry point the app
+ *    already routes through at sign-in — see `useCommunitySubdomain`).
+ *  - Send in WhatsApp: a prewritten handoff message with copy/share, so an
+ *    admin can paste it straight into their existing WhatsApp group.
+ *  - Group links: short links for groups the caller leads, using the same
+ *    `DOMAIN_CONFIG.groupShareUrl` helper as `GroupOptionsModal`'s
+ *    "Share Group" action.
+ */
+import React, { useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+  Share,
+  ActivityIndicator,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Clipboard from 'expo-clipboard';
+import { DOMAIN_CONFIG } from '@togather/shared';
+import { useAuth } from '@providers/AuthProvider';
+import { useTheme } from '@hooks/useTheme';
+import { Card } from '@components/ui/Card';
+import { QrCode } from '@components/ui/QrCode';
+import { useAuthenticatedQuery, api } from '@services/api/convex';
+import type { Id } from '@services/api/convex';
+
+interface LeaderGroup {
+  id: string;
+  name: string;
+  shortId?: string;
+}
+
+export function InviteKitScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { community } = useAuth();
+  const communityId = community?.id as Id<'communities'> | undefined;
+
+  const communityUrl =
+    community?.subdomain ? DOMAIN_CONFIG.communityUrl(community.subdomain) : null;
+  const communityName = community?.name || 'Our church';
+
+  const whatsappMessage = communityUrl
+    ? `Hi everyone! \u{1F44B} ${communityName} is moving to Togather — same groups, plus events & RSVPs. Join here: ${communityUrl}. Sign in with your phone number and you're in.`
+    : null;
+
+  const myGroups = useAuthenticatedQuery(
+    api.functions.groups.queries.listForUser,
+    communityId ? { communityId } : 'skip'
+  );
+  const isLoadingGroups = myGroups === undefined;
+
+  const leaderGroups: LeaderGroup[] = useMemo(() => {
+    if (!myGroups) return [];
+    return myGroups
+      .filter((g: any) => g.userRole === 'leader' && !!g.shortId)
+      .map((g: any) => ({ id: String(g._id), name: g.name, shortId: g.shortId }));
+  }, [myGroups]);
+
+  const handleCopy = async (text: string, label: string) => {
+    await Clipboard.setStringAsync(text);
+    Alert.alert('Copied', `${label} copied to clipboard.`);
+  };
+
+  const handleShare = async (message: string, url?: string) => {
+    try {
+      await Share.share(url ? { message, url } : { message });
+    } catch {
+      // User cancelled the share sheet — nothing to do.
+    }
+  };
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.backgroundSecondary },
+      ]}
+    >
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          style={styles.backButton}
+        >
+          <Ionicons name="chevron-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Invite your church</Text>
+        <View style={styles.backButton} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+          COMMUNITY
+        </Text>
+        <Card style={styles.card}>
+          {communityUrl ? (
+            <>
+              <View style={styles.qrWrap}>
+                <QrCode value={communityUrl} size={180} />
+              </View>
+              <Text style={[styles.urlText, { color: colors.textSecondary }]} numberOfLines={1}>
+                {communityUrl}
+              </Text>
+              <View style={styles.buttonRow}>
+                <TouchableOpacity
+                  style={[styles.secondaryButton, { borderColor: colors.border }]}
+                  onPress={() => handleCopy(communityUrl, 'Link')}
+                >
+                  <Ionicons name="copy-outline" size={18} color={colors.text} />
+                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
+                    Copy link
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.secondaryButton, { borderColor: colors.border }]}
+                  onPress={() =>
+                    handleShare(`${communityName}\n${communityUrl}`, communityUrl)
+                  }
+                >
+                  <Ionicons name="share-outline" size={18} color={colors.text} />
+                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
+                    Share
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </>
+          ) : (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              This community doesn't have a public link set up yet.
+            </Text>
+          )}
+        </Card>
+
+        <Text
+          style={[styles.sectionLabel, styles.sectionLabelSpaced, { color: colors.textSecondary }]}
+        >
+          SEND IN WHATSAPP
+        </Text>
+        <Card style={styles.card}>
+          {whatsappMessage ? (
+            <>
+              <Text style={[styles.messageText, { color: colors.text }]}>
+                {whatsappMessage}
+              </Text>
+              <View style={styles.buttonRow}>
+                <TouchableOpacity
+                  style={[styles.secondaryButton, { borderColor: colors.border }]}
+                  onPress={() => handleCopy(whatsappMessage, 'Message')}
+                >
+                  <Ionicons name="copy-outline" size={18} color={colors.text} />
+                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
+                    Copy message
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.secondaryButton, { borderColor: colors.border }]}
+                  onPress={() => handleShare(whatsappMessage)}
+                >
+                  <Ionicons name="share-outline" size={18} color={colors.text} />
+                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
+                    Share
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </>
+          ) : (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              This community doesn't have a public link set up yet.
+            </Text>
+          )}
+        </Card>
+
+        <Text
+          style={[styles.sectionLabel, styles.sectionLabelSpaced, { color: colors.textSecondary }]}
+        >
+          GROUP LINKS
+        </Text>
+        <Card style={styles.card}>
+          {isLoadingGroups ? (
+            <View style={styles.loadingRow}>
+              <ActivityIndicator color={colors.textSecondary} />
+            </View>
+          ) : leaderGroups.length === 0 ? (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              You don't lead any groups with a shareable link yet.
+            </Text>
+          ) : (
+            leaderGroups.map((group, index) => {
+              const groupUrl = DOMAIN_CONFIG.groupShareUrl(group.shortId!);
+              return (
+                <View
+                  key={group.id}
+                  style={[
+                    styles.groupRow,
+                    index < leaderGroups.length - 1 && {
+                      borderBottomWidth: StyleSheet.hairlineWidth,
+                      borderBottomColor: colors.border,
+                    },
+                  ]}
+                >
+                  <View style={styles.groupTextContainer}>
+                    <Text style={[styles.groupName, { color: colors.text }]} numberOfLines={1}>
+                      {group.name}
+                    </Text>
+                    <Text
+                      style={[styles.groupUrl, { color: colors.textSecondary }]}
+                      numberOfLines={1}
+                    >
+                      {groupUrl}
+                    </Text>
+                  </View>
+                  <TouchableOpacity
+                    style={styles.copyIconButton}
+                    onPress={() => handleCopy(groupUrl, `${group.name} link`)}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  >
+                    <Ionicons name="copy-outline" size={20} color={colors.icon} />
+                  </TouchableOpacity>
+                </View>
+              );
+            })
+          )}
+        </Card>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 40,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  sectionLabelSpaced: {
+    marginTop: 28,
+  },
+  card: {
+    padding: 20,
+  },
+  qrWrap: {
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  urlText: {
+    fontSize: 13,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  messageText: {
+    fontSize: 15,
+    lineHeight: 21,
+    marginBottom: 16,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  secondaryButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  secondaryButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  emptyText: {
+    fontSize: 14,
+    textAlign: 'center',
+    paddingVertical: 8,
+  },
+  loadingRow: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  groupRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  groupTextContainer: {
+    flex: 1,
+    marginRight: 12,
+  },
+  groupName: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  groupUrl: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  copyIconButton: {
+    padding: 4,
+  },
+});

--- a/apps/mobile/features/profile/components/ProfileMenu.tsx
+++ b/apps/mobile/features/profile/components/ProfileMenu.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '@hooks/useTheme';
 import { useAuthenticatedQuery, api } from '@services/api/convex';
 import type { Id } from '@services/api/convex';
 import { useDevAccess } from '@features/contribute/hooks/useDevAccess';
+import { useWhatsappShell } from '@hooks/useWhatsappShell';
 
 export function ProfileMenu() {
   const router = useRouter();
@@ -29,6 +30,10 @@ export function ProfileMenu() {
   // Contributor dev dashboard (ADR-029) — hidden unless the dev-assistant
   // maintainer check admits this user.
   const { hasAccess: hasDevAccess } = useDevAccess();
+  // Invite Kit (W11 invite-kit concept, adapted as a member/admin screen) —
+  // gated behind the whatsapp-shell flag so this row (and the route it
+  // opens) is a no-op for everyone until the flag is on.
+  const whatsappShell = useWhatsappShell();
 
   const handleSwitchCommunity = async () => {
     try {
@@ -97,6 +102,20 @@ export function ProfileMenu() {
             <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
           )}
         </TouchableOpacity>
+
+        {whatsappShell ? (
+          <TouchableOpacity
+            style={[styles.menuItem, { borderBottomColor: colors.border }]}
+            onPress={() => router.push('/(user)/invite')}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
+              <Ionicons name="person-add-outline" size={20} color={colors.text} />
+            </View>
+            <Text style={[styles.menuText, { color: colors.text }]}>Invite your church</Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
+          </TouchableOpacity>
+        ) : null}
 
         <TouchableOpacity
           style={[styles.menuItem, { borderBottomColor: colors.border }]}

--- a/apps/mobile/features/profile/components/__tests__/ProfileMenu.test.tsx
+++ b/apps/mobile/features/profile/components/__tests__/ProfileMenu.test.tsx
@@ -9,6 +9,12 @@ jest.mock("expo-router", () => ({
   useRouter: jest.fn(),
 }));
 
+// Flag off = the behavior this suite asserts; the real hook would reach
+// PostHog + a Convex query that the partial api mock below doesn't provide.
+jest.mock("@hooks/useWhatsappShell", () => ({
+  useWhatsappShell: () => false,
+}));
+
 jest.mock("@providers/AuthProvider", () => ({
   useAuth: jest.fn(),
 }));

--- a/apps/mobile/hooks/useWhatsappShell.ts
+++ b/apps/mobile/hooks/useWhatsappShell.ts
@@ -30,17 +30,28 @@ const POSTHOG_FLAG_KEY = "whatsapp-shell";
 const FORCE_ON_FLAG_KEY = "whatsapp-shell-on";
 const KILL_SWITCH_FLAG_KEY = "whatsapp-shell-kill";
 
-export function useWhatsappShell(): boolean {
+/**
+ * Loading-aware variant for route guards: screens that must redirect when
+ * the shell is off should wait for `loaded` before deciding, or a flag-on
+ * user gets bounced during the initial flag fetch.
+ */
+export function useWhatsappShellState(): { enabled: boolean; loaded: boolean } {
   const posthogEnabled = useFeatureFlag(POSTHOG_FLAG_KEY);
   const { enabled: forceOnEnabled, loaded: forceOnLoaded } =
     useConvexFeatureFlag(FORCE_ON_FLAG_KEY);
   const { enabled: killSwitchEnabled, loaded: killSwitchLoaded } =
     useConvexFeatureFlag(KILL_SWITCH_FLAG_KEY);
 
-  // Convex flag state isn't confirmed yet — stay on the current shell
-  // rather than risk showing the new one before we know it's not been
-  // force-disabled (or flashing it off for force-on users).
-  if (!killSwitchLoaded || !forceOnLoaded) return false;
+  const loaded = killSwitchLoaded && forceOnLoaded;
+  return {
+    loaded,
+    // Convex flag state isn't confirmed yet — stay on the current shell
+    // rather than risk showing the new one before we know it's not been
+    // force-disabled (or flashing it off for force-on users).
+    enabled: loaded && (posthogEnabled || forceOnEnabled) && !killSwitchEnabled,
+  };
+}
 
-  return (posthogEnabled || forceOnEnabled) && !killSwitchEnabled;
+export function useWhatsappShell(): boolean {
+  return useWhatsappShellState().enabled;
 }

--- a/apps/mobile/hooks/useWhatsappShell.ts
+++ b/apps/mobile/hooks/useWhatsappShell.ts
@@ -6,33 +6,41 @@
  * docs/plans/church-migration-ui-redesign/README.md §9.5 ("everything
  * behind one flag").
  *
- * Composes two flag sources:
+ * Composes three flag sources:
  *   - PostHog flag `"whatsapp-shell"` (`useFeatureFlag`) — the rollout
  *     lever, targeted per community/cohort so pilot churches can run the
  *     new shell while everyone else keeps today's app.
- *   - Convex `featureFlags` kill-switch `"whatsapp-shell-kill"`
- *     (`useConvexFeatureFlag`) — a staff-managed global override that, when
- *     on, forces the shell off everywhere regardless of PostHog.
+ *   - Convex `featureFlags` force-on `"whatsapp-shell-on"`
+ *     (`useConvexFeatureFlag`) — a staff-managed global enable for
+ *     environments where PostHog isn't set up (e.g. staging). System-wide:
+ *     it cannot target individual communities; use PostHog for that.
+ *   - Convex `featureFlags` kill-switch `"whatsapp-shell-kill"` — a
+ *     staff-managed global override that, when on, forces the shell off
+ *     everywhere regardless of the other two sources.
  *
- * Enabled only when PostHog says on AND the kill-switch is confirmed off.
- * Defaults to `false` while either source is still loading (or errored) —
- * flag-off is the safe default, never flag-on.
+ * Enabled when (PostHog says on OR the Convex force-on is on) AND the
+ * kill-switch is confirmed off. Defaults to `false` while the Convex flags
+ * are still loading (or errored) — flag-off is the safe default, never
+ * flag-on.
  */
 import { useFeatureFlag } from "./useFeatureFlag";
 import { useConvexFeatureFlag } from "./useConvexFeatureFlag";
 
 const POSTHOG_FLAG_KEY = "whatsapp-shell";
+const FORCE_ON_FLAG_KEY = "whatsapp-shell-on";
 const KILL_SWITCH_FLAG_KEY = "whatsapp-shell-kill";
 
 export function useWhatsappShell(): boolean {
   const posthogEnabled = useFeatureFlag(POSTHOG_FLAG_KEY);
+  const { enabled: forceOnEnabled, loaded: forceOnLoaded } =
+    useConvexFeatureFlag(FORCE_ON_FLAG_KEY);
   const { enabled: killSwitchEnabled, loaded: killSwitchLoaded } =
     useConvexFeatureFlag(KILL_SWITCH_FLAG_KEY);
 
-  // Kill-switch state isn't confirmed yet — stay on the current shell
+  // Convex flag state isn't confirmed yet — stay on the current shell
   // rather than risk showing the new one before we know it's not been
-  // force-disabled.
-  if (!killSwitchLoaded) return false;
+  // force-disabled (or flashing it off for force-on users).
+  if (!killSwitchLoaded || !forceOnLoaded) return false;
 
-  return posthogEnabled && !killSwitchEnabled;
+  return (posthogEnabled || forceOnEnabled) && !killSwitchEnabled;
 }

--- a/apps/mobile/utils/__tests__/qrcodegen.test.ts
+++ b/apps/mobile/utils/__tests__/qrcodegen.test.ts
@@ -83,3 +83,22 @@ describe('qrModules', () => {
     expect(() => qrModules(tooLong)).toThrow(/too long/i);
   });
 });
+
+describe('golden vector', () => {
+  // Full-matrix regression check: this exact output was verified scannable
+  // (independent zbar decode round-trip during PR #637 review). A change in
+  // ECC, interleaving, masking, or format-info placement — which the
+  // structural tests above cannot see — changes this hash.
+  test('known input reproduces the verified matrix', () => {
+    const mods = qrModules('https://livinggrace.togather.nyc');
+    expect(mods.length).toBe(29); // version 3
+
+    const s = mods.map((r) => r.map((b) => (b ? '1' : '0')).join('')).join('|');
+    let h = 0x811c9dc5;
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i);
+      h = Math.imul(h, 0x01000193) >>> 0;
+    }
+    expect(h.toString(16)).toBe('a03d811b');
+  });
+});

--- a/apps/mobile/utils/__tests__/qrcodegen.test.ts
+++ b/apps/mobile/utils/__tests__/qrcodegen.test.ts
@@ -1,0 +1,85 @@
+import { qrModules } from '../qrcodegen';
+
+describe('qrModules', () => {
+  test('returns a square, odd-sized matrix', () => {
+    const modules = qrModules('https://togather.nyc/c/demo');
+    const size = modules.length;
+    expect(size).toBeGreaterThan(0);
+    expect(size % 2).toBe(1);
+    for (const row of modules) {
+      expect(row.length).toBe(size);
+    }
+  });
+
+  test('places a 7x7 finder pattern at the top-left corner', () => {
+    const modules = qrModules('https://togather.nyc/g/abc123');
+
+    // Standard QR finder pattern: solid 7x7 dark border, one-module light
+    // ring inside it, solid 3x3 dark core.
+    for (let y = 0; y < 7; y++) {
+      for (let x = 0; x < 7; x++) {
+        const isBorder = x === 0 || x === 6 || y === 0 || y === 6;
+        const isCore = x >= 2 && x <= 4 && y >= 2 && y <= 4;
+        const expected = isBorder || isCore;
+        expect(modules[y][x]).toBe(expected);
+      }
+    }
+  });
+
+  test('places finder patterns at all three non-bottom-right corners', () => {
+    const modules = qrModules('https://togather.nyc/g/abc123');
+    const size = modules.length;
+
+    const isFinderShape = (getModule: (dx: number, dy: number) => boolean) => {
+      for (let y = 0; y < 7; y++) {
+        for (let x = 0; x < 7; x++) {
+          const isBorder = x === 0 || x === 6 || y === 0 || y === 6;
+          const isCore = x >= 2 && x <= 4 && y >= 2 && y <= 4;
+          if (getModule(x, y) !== (isBorder || isCore)) return false;
+        }
+      }
+      return true;
+    };
+
+    // Top-right finder pattern starts at column (size - 7).
+    expect(isFinderShape((dx, dy) => modules[dy][size - 7 + dx])).toBe(true);
+    // Bottom-left finder pattern starts at row (size - 7).
+    expect(isFinderShape((dx, dy) => modules[size - 7 + dy][dx])).toBe(true);
+  });
+
+  test('timing patterns on row 6 and column 6 alternate dark/light', () => {
+    const modules = qrModules('https://togather.nyc/c/demo');
+    const size = modules.length;
+
+    // The timing pattern runs between the two finder patterns (columns/rows
+    // 8 .. size-9) and must strictly alternate, starting dark at an even
+    // offset from the pattern's own start.
+    for (let x = 8; x <= size - 9; x++) {
+      expect(modules[6][x]).toBe(x % 2 === 0);
+    }
+    for (let y = 8; y <= size - 9; y++) {
+      expect(modules[y][6]).toBe(y % 2 === 0);
+    }
+  });
+
+  test('different inputs produce different matrices', () => {
+    const a = qrModules('https://togather.nyc/c/fount');
+    const b = qrModules('https://togather.nyc/c/riverside');
+
+    // Compare flattened matrices; they should differ somewhere (and,
+    // generally, in overall shape/size too since content length differs).
+    const flatten = (m: boolean[][]) => m.map((row) => row.join('')).join('|');
+    expect(flatten(a)).not.toBe(flatten(b));
+  });
+
+  test('same input produces a deterministic matrix', () => {
+    const a = qrModules('https://togather.nyc/c/fount');
+    const b = qrModules('https://togather.nyc/c/fount');
+    expect(a).toEqual(b);
+  });
+
+  test('throws a clear error for text exceeding version-10 ECC-M capacity', () => {
+    const tooLong = 'x'.repeat(500);
+    expect(() => qrModules(tooLong)).toThrow(/too long/i);
+  });
+});

--- a/apps/mobile/utils/qrcodegen.ts
+++ b/apps/mobile/utils/qrcodegen.ts
@@ -1,0 +1,614 @@
+/**
+ * QR Code generator — condensed TypeScript port for Togather's Invite Kit.
+ *
+ * Ported from "QR Code generator library" by Project Nayuki
+ * (https://www.nayuki.io/page/qr-code-generation-library), original
+ * TypeScript source: https://github.com/nayuki/QR-Code-generator
+ *
+ * Copyright (c) Project Nayuki. (MIT License)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ *
+ * This file trims the original library down to exactly what the Invite Kit
+ * needs, so it can ship with zero dependencies (no `react-native-svg`, no
+ * `qrcode` npm package):
+ *   - Byte mode only (raw UTF-8 bytes; no numeric/alphanumeric/kanji modes).
+ *   - Error correction level M only (good balance of scan reliability and
+ *     data capacity for the short invite URLs this renders).
+ *   - Automatic version selection from 1 to 10 (up to ~213 bytes of byte-mode
+ *     data at ECC M — comfortably more than any URL this app generates).
+ * The encoding pipeline (data codeword layout, Reed-Solomon error
+ * correction, function pattern placement, and mask-penalty scoring) mirrors
+ * the original library's algorithm so the output is spec-correct, scannable
+ * QR Code data.
+ */
+
+const MIN_VERSION = 1;
+const MAX_VERSION = 10;
+
+// Error correction codewords per block, and number of error-correction
+// blocks, for ECC level M, indexed by version (index 0 is unused/invalid).
+// Values come straight from the QR Code model 2 standard's ECC table.
+const ECC_CODEWORDS_PER_BLOCK_M = [-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26];
+const NUM_ERROR_CORRECTION_BLOCKS_M = [-1, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5];
+
+// Fixed format-info mask and ECC-level indicator bits for level M, per the
+// QR spec's format information encoding table.
+const FORMAT_INFO_MASK = 0x5412;
+const FORMAT_ECC_BITS_M = 0b00;
+
+const PENALTY_N1 = 3;
+const PENALTY_N2 = 3;
+const PENALTY_N3 = 40;
+const PENALTY_N4 = 10;
+
+/**
+ * Encodes `text` as a QR Code (byte mode, ECC level M) and returns its
+ * module matrix as `modules[row][col]`, `true` meaning a dark module.
+ * Automatically picks the smallest QR version (1-10) that fits the text.
+ */
+export function qrModules(text: string): boolean[][] {
+  const bytes = utf8Encode(text);
+  const version = selectVersion(bytes.length);
+  const dataCodewords = buildDataCodewords(bytes, version);
+  const allCodewords = addEccAndInterleave(dataCodewords, version);
+
+  const size = version * 4 + 17;
+  const modules: boolean[][] = makeGrid(size);
+  const isFunction: boolean[][] = makeGrid(size);
+
+  drawFunctionPatterns(modules, isFunction, size, version);
+  drawCodewords(modules, isFunction, size, allCodewords);
+
+  // Try all 8 mask patterns and keep whichever minimizes the standard
+  // penalty score (fewest scanner-confusing patterns).
+  let bestMask = 0;
+  let bestPenalty = Infinity;
+  for (let mask = 0; mask < 8; mask++) {
+    applyMask(modules, isFunction, size, mask);
+    drawFormatBits(modules, isFunction, size, mask);
+    const penalty = computePenalty(modules, size);
+    if (penalty < bestPenalty) {
+      bestPenalty = penalty;
+      bestMask = mask;
+    }
+    applyMask(modules, isFunction, size, mask); // XOR again == undo
+  }
+  applyMask(modules, isFunction, size, bestMask);
+  drawFormatBits(modules, isFunction, size, bestMask);
+
+  return modules;
+}
+
+function makeGrid(size: number): boolean[][] {
+  return Array.from({ length: size }, () => new Array<boolean>(size).fill(false));
+}
+
+// ============================================================
+// UTF-8 encoding (no Buffer/TextEncoder dependency)
+// ============================================================
+
+function utf8Encode(str: string): number[] {
+  const bytes: number[] = [];
+  for (let i = 0; i < str.length; i++) {
+    const codePoint = str.codePointAt(i);
+    if (codePoint === undefined) continue;
+    if (codePoint > 0xffff) i++; // consumed a surrogate pair
+
+    if (codePoint < 0x80) {
+      bytes.push(codePoint);
+    } else if (codePoint < 0x800) {
+      bytes.push(0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f));
+    } else if (codePoint < 0x10000) {
+      bytes.push(
+        0xe0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f)
+      );
+    } else {
+      bytes.push(
+        0xf0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3f),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f)
+      );
+    }
+  }
+  return bytes;
+}
+
+// ============================================================
+// Capacity / version selection
+// ============================================================
+
+function getNumRawDataModules(version: number): number {
+  let result = (16 * version + 128) * version + 64;
+  if (version >= 2) {
+    const numAlign = Math.floor(version / 7) + 2;
+    result -= (25 * numAlign - 10) * numAlign - 55;
+    if (version >= 7) result -= 36;
+  }
+  return result;
+}
+
+function getTotalCodewords(version: number): number {
+  return Math.floor(getNumRawDataModules(version) / 8);
+}
+
+function getNumDataCodewords(version: number): number {
+  return (
+    getTotalCodewords(version) -
+    ECC_CODEWORDS_PER_BLOCK_M[version] * NUM_ERROR_CORRECTION_BLOCKS_M[version]
+  );
+}
+
+function charCountBitsForVersion(version: number): number {
+  // Byte-mode character-count indicator width per the QR spec.
+  return version <= 9 ? 8 : 16;
+}
+
+function selectVersion(byteLength: number): number {
+  for (let version = MIN_VERSION; version <= MAX_VERSION; version++) {
+    const capacityBits = getNumDataCodewords(version) * 8;
+    const requiredBits = 4 + charCountBitsForVersion(version) + byteLength * 8;
+    if (requiredBits <= capacityBits) return version;
+  }
+  const maxBytes =
+    Math.floor(
+      (getNumDataCodewords(MAX_VERSION) * 8 - 4 - charCountBitsForVersion(MAX_VERSION)) / 8
+    );
+  throw new Error(
+    `qrModules: text is too long to encode at ECC level M within version ${MAX_VERSION} ` +
+      `(max ~${maxBytes} bytes, got ${byteLength} bytes).`
+  );
+}
+
+// ============================================================
+// Data codeword construction (mode + count + data + terminator + padding)
+// ============================================================
+
+function buildDataCodewords(bytes: number[], version: number): number[] {
+  const bits: number[] = [];
+  const pushBits = (val: number, len: number) => {
+    for (let i = len - 1; i >= 0; i--) bits.push((val >>> i) & 1);
+  };
+
+  pushBits(0b0100, 4); // byte mode indicator
+  pushBits(bytes.length, charCountBitsForVersion(version));
+  for (const b of bytes) pushBits(b, 8);
+
+  const capacityBits = getNumDataCodewords(version) * 8;
+
+  // Terminator (up to 4 zero bits, only as many as fit).
+  const terminatorLen = Math.max(0, Math.min(4, capacityBits - bits.length));
+  pushBits(0, terminatorLen);
+
+  // Pad to a byte boundary.
+  while (bits.length % 8 !== 0) bits.push(0);
+
+  // Pad codewords (alternating 0xEC, 0x11) to fill remaining capacity.
+  const padBytes = [0xec, 0x11];
+  let p = 0;
+  while (bits.length < capacityBits) {
+    pushBits(padBytes[p % 2], 8);
+    p++;
+  }
+
+  const codewords: number[] = [];
+  for (let i = 0; i < bits.length; i += 8) {
+    let byte = 0;
+    for (let j = 0; j < 8; j++) byte = (byte << 1) | bits[i + j];
+    codewords.push(byte);
+  }
+  return codewords;
+}
+
+// ============================================================
+// Reed-Solomon error correction (GF(256), primitive polynomial 0x11D)
+// ============================================================
+
+function reedSolomonMultiply(x: number, y: number): number {
+  let z = 0;
+  for (let i = 7; i >= 0; i--) {
+    z = (z << 1) ^ ((z >>> 7) * 0x11d);
+    z ^= ((y >>> i) & 1) * x;
+  }
+  return z & 0xff;
+}
+
+function reedSolomonComputeDivisor(degree: number): number[] {
+  const result = new Array<number>(degree).fill(0);
+  result[degree - 1] = 1; // start with the monomial x^0
+
+  let root = 1;
+  for (let i = 0; i < degree; i++) {
+    for (let j = 0; j < result.length; j++) {
+      result[j] = reedSolomonMultiply(result[j], root);
+      if (j + 1 < result.length) result[j] ^= result[j + 1];
+    }
+    root = reedSolomonMultiply(root, 0x02);
+  }
+  return result;
+}
+
+function reedSolomonComputeRemainder(data: number[], divisor: number[]): number[] {
+  let result = divisor.map(() => 0);
+  for (const b of data) {
+    const factor = b ^ (result.shift() as number);
+    result.push(0);
+    divisor.forEach((coef, i) => {
+      result[i] ^= reedSolomonMultiply(coef, factor);
+    });
+  }
+  return result;
+}
+
+/**
+ * Splits data codewords into the version's ECC blocks, computes each
+ * block's Reed-Solomon remainder, and interleaves data+ECC codewords in
+ * the order the QR spec requires them to be read off the matrix.
+ */
+function addEccAndInterleave(dataCodewords: number[], version: number): number[] {
+  const numBlocks = NUM_ERROR_CORRECTION_BLOCKS_M[version];
+  const blockEccLen = ECC_CODEWORDS_PER_BLOCK_M[version];
+  const rawCodewords = getTotalCodewords(version);
+  const numShortBlocks = numBlocks - (rawCodewords % numBlocks);
+  const shortBlockLen = Math.floor(rawCodewords / numBlocks);
+
+  const rsDiv = reedSolomonComputeDivisor(blockEccLen);
+  const blocks: number[][] = [];
+  let k = 0;
+  for (let i = 0; i < numBlocks; i++) {
+    const len = shortBlockLen - blockEccLen + (i < numShortBlocks ? 0 : 1);
+    const dat = dataCodewords.slice(k, k + len);
+    k += dat.length;
+    const ecc = reedSolomonComputeRemainder(dat, rsDiv);
+    if (i < numShortBlocks) dat.push(0); // pad short blocks to align interleaving
+    blocks.push(dat.concat(ecc));
+  }
+
+  const result: number[] = [];
+  for (let i = 0; i < blocks[0].length; i++) {
+    blocks.forEach((block, j) => {
+      // Skip the padding codeword inserted into short blocks above.
+      if (i !== shortBlockLen - blockEccLen || j >= numShortBlocks) {
+        result.push(block[i]);
+      }
+    });
+  }
+  return result;
+}
+
+// ============================================================
+// Matrix drawing: function patterns, codeword placement, masking
+// ============================================================
+
+function setFunctionModule(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  x: number,
+  y: number,
+  dark: boolean
+) {
+  modules[y][x] = dark;
+  isFunction[y][x] = true;
+}
+
+function getBit(x: number, i: number): boolean {
+  return ((x >>> i) & 1) !== 0;
+}
+
+function drawFinderPattern(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  size: number,
+  cx: number,
+  cy: number
+) {
+  for (let dy = -4; dy <= 4; dy++) {
+    for (let dx = -4; dx <= 4; dx++) {
+      const dist = Math.max(Math.abs(dx), Math.abs(dy));
+      const x = cx + dx;
+      const y = cy + dy;
+      if (x >= 0 && x < size && y >= 0 && y < size) {
+        setFunctionModule(modules, isFunction, x, y, dist !== 2 && dist !== 4);
+      }
+    }
+  }
+}
+
+function drawAlignmentPattern(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  cx: number,
+  cy: number
+) {
+  for (let dy = -2; dy <= 2; dy++) {
+    for (let dx = -2; dx <= 2; dx++) {
+      setFunctionModule(
+        modules,
+        isFunction,
+        cx + dx,
+        cy + dy,
+        Math.max(Math.abs(dx), Math.abs(dy)) !== 1
+      );
+    }
+  }
+}
+
+function getAlignmentPatternPositions(version: number, size: number): number[] {
+  if (version === 1) return [];
+  const numAlign = Math.floor(version / 7) + 2;
+  const step =
+    version === 32 ? 26 : Math.ceil((version * 4 + 4) / (numAlign * 2 - 2)) * 2;
+  const result = [6];
+  for (let pos = size - 7; result.length < numAlign; pos -= step) {
+    result.splice(1, 0, pos);
+  }
+  return result;
+}
+
+function drawFormatBits(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  size: number,
+  mask: number
+) {
+  const data = (FORMAT_ECC_BITS_M << 3) | mask;
+  let rem = data;
+  for (let i = 0; i < 10; i++) rem = (rem << 1) ^ ((rem >>> 9) * 0x537);
+  const bits = ((data << 10) | rem) ^ FORMAT_INFO_MASK;
+
+  for (let i = 0; i <= 5; i++) setFunctionModule(modules, isFunction, 8, i, getBit(bits, i));
+  setFunctionModule(modules, isFunction, 8, 7, getBit(bits, 6));
+  setFunctionModule(modules, isFunction, 8, 8, getBit(bits, 7));
+  setFunctionModule(modules, isFunction, 7, 8, getBit(bits, 8));
+  for (let i = 9; i < 15; i++) setFunctionModule(modules, isFunction, 14 - i, 8, getBit(bits, i));
+
+  for (let i = 0; i < 8; i++) {
+    setFunctionModule(modules, isFunction, size - 1 - i, 8, getBit(bits, i));
+  }
+  for (let i = 8; i < 15; i++) {
+    setFunctionModule(modules, isFunction, 8, size - 15 + i, getBit(bits, i));
+  }
+  setFunctionModule(modules, isFunction, 8, size - 8, true); // always-dark module
+}
+
+function drawVersionInfo(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  size: number,
+  version: number
+) {
+  if (version < 7) return;
+  let rem = version;
+  for (let i = 0; i < 12; i++) rem = (rem << 1) ^ ((rem >>> 11) * 0x1f25);
+  const bits = (version << 12) | rem;
+  for (let i = 0; i < 18; i++) {
+    const bit = getBit(bits, i);
+    const a = size - 11 + (i % 3);
+    const b = Math.floor(i / 3);
+    setFunctionModule(modules, isFunction, a, b, bit);
+    setFunctionModule(modules, isFunction, b, a, bit);
+  }
+}
+
+function drawFunctionPatterns(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  size: number,
+  version: number
+) {
+  // Timing patterns (row/col 6, alternating dark/light starting dark).
+  for (let i = 0; i < size; i++) {
+    setFunctionModule(modules, isFunction, 6, i, i % 2 === 0);
+    setFunctionModule(modules, isFunction, i, 6, i % 2 === 0);
+  }
+
+  // Finder patterns in the three non-bottom-right corners.
+  drawFinderPattern(modules, isFunction, size, 3, 3);
+  drawFinderPattern(modules, isFunction, size, size - 4, 3);
+  drawFinderPattern(modules, isFunction, size, 3, size - 4);
+
+  // Alignment patterns (skip the three finder corners).
+  const alignPos = getAlignmentPatternPositions(version, size);
+  const n = alignPos.length;
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      if ((i === 0 && j === 0) || (i === 0 && j === n - 1) || (i === n - 1 && j === 0)) {
+        continue;
+      }
+      drawAlignmentPattern(modules, isFunction, alignPos[i], alignPos[j]);
+    }
+  }
+
+  // Reserve format-info area (dummy mask 0; overwritten after mask selection)
+  // and draw version info (fixed regardless of mask, versions 7+ only).
+  drawFormatBits(modules, isFunction, size, 0);
+  drawVersionInfo(modules, isFunction, size, version);
+}
+
+function drawCodewords(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  size: number,
+  data: number[]
+) {
+  let i = 0;
+  for (let right = size - 1; right >= 1; right -= 2) {
+    if (right === 6) right = 5; // skip the vertical timing column
+    for (let vert = 0; vert < size; vert++) {
+      for (let j = 0; j < 2; j++) {
+        const x = right - j;
+        const upward = ((right + 1) & 2) === 0;
+        const y = upward ? size - 1 - vert : vert;
+        if (!isFunction[y][x] && i < data.length * 8) {
+          modules[y][x] = getBit(data[i >>> 3], 7 - (i & 7));
+          i++;
+        }
+      }
+    }
+  }
+}
+
+function getMaskBit(mask: number, x: number, y: number): boolean {
+  switch (mask) {
+    case 0:
+      return (x + y) % 2 === 0;
+    case 1:
+      return y % 2 === 0;
+    case 2:
+      return x % 3 === 0;
+    case 3:
+      return (x + y) % 3 === 0;
+    case 4:
+      return (Math.floor(y / 2) + Math.floor(x / 3)) % 2 === 0;
+    case 5:
+      return ((x * y) % 2) + ((x * y) % 3) === 0;
+    case 6:
+      return (((x * y) % 2) + ((x * y) % 3)) % 2 === 0;
+    case 7:
+      return (((x + y) % 2) + ((x * y) % 3)) % 2 === 0;
+    default:
+      throw new Error(`qrModules: invalid mask ${mask}`);
+  }
+}
+
+function applyMask(
+  modules: boolean[][],
+  isFunction: boolean[][],
+  size: number,
+  mask: number
+) {
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      if (!isFunction[y][x] && getMaskBit(mask, x, y)) {
+        modules[y][x] = !modules[y][x];
+      }
+    }
+  }
+}
+
+// ============================================================
+// Mask penalty scoring (the 4 standard QR penalty rules)
+// ============================================================
+
+function finderPenaltyCountPatterns(runHistory: number[]): number {
+  const n = runHistory[1];
+  const core =
+    n > 0 &&
+    runHistory[2] === n &&
+    runHistory[3] === n * 3 &&
+    runHistory[4] === n &&
+    runHistory[5] === n;
+  let count = 0;
+  if (core && runHistory[0] >= n * 4 && runHistory[6] >= n) count++;
+  if (core && runHistory[6] >= n * 4 && runHistory[0] >= n) count++;
+  return count;
+}
+
+function finderPenaltyAddHistory(currentRunLength: number, runHistory: number[], size: number) {
+  let len = currentRunLength;
+  if (runHistory[0] === 0) len += size; // initial run includes the light border
+  runHistory.pop();
+  runHistory.unshift(len);
+}
+
+function finderPenaltyTerminateAndCount(
+  currentRunColor: boolean,
+  currentRunLength: number,
+  runHistory: number[],
+  size: number
+): number {
+  let len = currentRunLength;
+  if (currentRunColor) {
+    finderPenaltyAddHistory(len, runHistory, size);
+    len = 0;
+  }
+  len += size; // final run includes the light border
+  finderPenaltyAddHistory(len, runHistory, size);
+  return finderPenaltyCountPatterns(runHistory);
+}
+
+function computePenalty(modules: boolean[][], size: number): number {
+  let result = 0;
+
+  // Rule 1 & 3: same-color runs and finder-like patterns, per row.
+  for (let y = 0; y < size; y++) {
+    let runColor = false;
+    let runX = 0;
+    const runHistory = [0, 0, 0, 0, 0, 0, 0];
+    for (let x = 0; x < size; x++) {
+      if (modules[y][x] === runColor) {
+        runX++;
+        if (runX === 5) result += PENALTY_N1;
+        else if (runX > 5) result++;
+      } else {
+        finderPenaltyAddHistory(runX, runHistory, size);
+        if (!runColor) result += finderPenaltyCountPatterns(runHistory) * PENALTY_N3;
+        runColor = modules[y][x];
+        runX = 1;
+      }
+    }
+    result += finderPenaltyTerminateAndCount(runColor, runX, runHistory, size) * PENALTY_N3;
+  }
+
+  // Rule 1 & 3: same-color runs and finder-like patterns, per column.
+  for (let x = 0; x < size; x++) {
+    let runColor = false;
+    let runY = 0;
+    const runHistory = [0, 0, 0, 0, 0, 0, 0];
+    for (let y = 0; y < size; y++) {
+      if (modules[y][x] === runColor) {
+        runY++;
+        if (runY === 5) result += PENALTY_N1;
+        else if (runY > 5) result++;
+      } else {
+        finderPenaltyAddHistory(runY, runHistory, size);
+        if (!runColor) result += finderPenaltyCountPatterns(runHistory) * PENALTY_N3;
+        runColor = modules[y][x];
+        runY = 1;
+      }
+    }
+    result += finderPenaltyTerminateAndCount(runColor, runY, runHistory, size) * PENALTY_N3;
+  }
+
+  // Rule 2: 2x2 blocks of the same color.
+  for (let y = 0; y < size - 1; y++) {
+    for (let x = 0; x < size - 1; x++) {
+      const color = modules[y][x];
+      if (
+        color === modules[y][x + 1] &&
+        color === modules[y + 1][x] &&
+        color === modules[y + 1][x + 1]
+      ) {
+        result += PENALTY_N2;
+      }
+    }
+  }
+
+  // Rule 4: balance of dark vs. light modules.
+  let dark = 0;
+  for (const row of modules) {
+    for (const cell of row) if (cell) dark++;
+  }
+  const total = size * size;
+  const k = Math.ceil(Math.abs(dark * 20 - total * 10) / total) - 1;
+  result += k * PENALTY_N4;
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Second slice of the church-migration redesign (follows #636). **Everything remains behind `whatsapp-shell` — default off; flag-off audited as behavior-identical.**

### Invite kit (W11 concepts, in-app)
- "Invite your church" screen (`/(user)/invite`, flag-gated ProfileMenu entry): community URL as a **QR code**, copy/share, prewritten WhatsApp handoff message, per-group short links for groups the caller leads
- QR generation is **dependency-free** per native-dep safety rules: MIT-attributed TS port of Project Nayuki's QR generator (byte mode, ECC M, v1–10, Reed-Solomon, all 8 masks scored) + a `QrCode` component rendering run-length-encoded Views (no SVG lib). Encoder verified via an independent decode round-trip incl. UTF-8 at version boundaries; jest covers structural invariants
- Communities without a subdomain get a graceful "no public link yet" fallback

### Chats-list hygiene (Rules 1–2 rendering)
- Flag-on header reads **"Chats"**; multi-channel clusters cap at main + 2 sub-rows (unread-first, then recency); muted channels never occupy sub-rows and are excluded from the group unread badge (quiet dot when only muted channels have unread); **"N more channels"** row links to the channel directory
- `getInboxChannels` additively exposes the caller's per-channel `isMuted` (built from the already-fetched memberships — no new query), with test coverage

### Group info page (W13)
- One WhatsApp-shaped page replacing three scattered settings surfaces when the flag is on — **pure composition**: GroupHeader hero, share/invite row, per-group notification toggle promoted as "Mute group", Members row + requests badge, unmodified `ChannelsSection`/`GroupBotsSection`, Leader-tools card (existing routes), Details card, `ADMIN`-tagged `hiddenFromDiscovery`/`joinApprovalMode` rows (existing mutations), red Leave/Archive
- Group route branches on the flag; flag off renders the untouched `GroupDetailScreen`. Screen tests follow the `GroupDetailScreen` test pattern

### Flag-leak audit (pre-PR)
All entries gated (`ProfileMenu` row, group-route branch, all chats changes); new routes/components unreachable when off; the only backend change is the additive `isMuted` field.

### Notes for reviewers
- Known follow-up (flagged by the implementing agent): in desktop sidebar mode the strict main+2 cap could hide the currently-open channel's row from the cluster; acceptable for pilot, revisit if it bites
- QR encoder was verified outside the project's test runner (no node_modules in the authoring env) — CI is the arbiter for the jest suite
- "(in progress)" checkpoint commits exist mid-history; squash-merge recommended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe

---
_Generated by [Claude Code](https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe)_