### PR TITLE
Hotfix: listGroupChannels returns-validator missing isMuted (chat-open crash)

### DIFF
--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -4307,6 +4307,38 @@ describe("joinDiscoverableChannel", () => {
   });
 });
 
+describe("listGroupChannels isMuted", () => {
+  // Regression: prod's returns-validator rejected the row once isMuted was
+  // added to the mapping but not the validator (convex-test doesn't enforce
+  // returns validators, so only a field-presence assertion can pin this).
+  test("reports the caller's muted state per row", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId, accessToken } = await seedTestData(t);
+    const { accessToken: leaderToken } = await createLeaderUser(t, communityId, groupId);
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.channels.createCustomChannel,
+      { token: leaderToken, groupId, name: "Mutable" }
+    );
+    await t.mutation(api.functions.messaging.channels.joinDiscoverableChannel, {
+      token: accessToken,
+      channelId,
+    });
+    await t.mutation(api.functions.messaging.channels.setChannelMuted, {
+      token: accessToken,
+      channelId,
+      muted: true,
+    });
+
+    const channels = await t.query(api.functions.messaging.channels.listGroupChannels, {
+      token: accessToken,
+      groupId,
+    });
+    const muted = channels.find((c: any) => c._id === channelId);
+    expect(muted?.isMuted).toBe(true);
+  });
+});
+
 describe("setChannelMuted", () => {
   test("member can mute and unmute a channel they belong to", async () => {
     const t = convexTest(schema, modules);

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -1238,6 +1238,8 @@ export const listGroupChannels = query({
     isArchived: v.boolean(),
     isMember: v.boolean(),
     role: v.optional(v.string()),
+    /** Caller's chatChannelMembers.isMuted — whatsapp-shell mute state. */
+    isMuted: v.optional(v.boolean()),
     unreadCount: v.number(),
     isPinned: v.boolean(),
     lastMessageAt: v.optional(v.number()),


### PR DESCRIPTION
## Summary

Fixes the crash reported from a device pass on 1.0.23: opening a chat threw `ReturnsValidationError: Object contains extra field 'isMuted'` from `listGroupChannels`.

**Root cause:** #636 added `isMuted` to the query's row mapping but not to its explicit `returns:` validator. The production Convex runtime enforces returns validators; **convex-test does not**, so the existing tests that call this query stayed green.

**Fix:** add `isMuted: v.optional(v.boolean())` to the validator, plus a field-presence regression test (mute → assert `isMuted: true` in the rows — the only test shape that can pin this class of bug under convex-test).

**Audit of the other queries extended in #636/#637:** `getChannelBySlug` and `getInboxChannels` declare no `returns:` validators (safe); `listJoinableChannels`/`joinDiscoverableChannel` were authored with their payloads and validators together (match).

Affects all users regardless of the `whatsapp-shell` flag (the query is shared), so this should merge ASAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe

---
_Generated by [Claude Code](https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe)_