### PR TITLE
WhatsApp Plus wave 2: chats-list consistency, day pills, group/channel info, hero + quick actions

### DIFF
--- a/apps/mobile/app/inbox/[groupId]/channels.tsx
+++ b/apps/mobile/app/inbox/[groupId]/channels.tsx
@@ -13,7 +13,13 @@
  * on whatsapp-shell) and the inbox's "N more channels" collapse row. The
  * route also guards itself (defense in depth): deep links or stale
  * navigation state bypass flag-gated entry points, so the wrapper below
- * redirects when the shell is off.
+ * redirects when the shell is off. Because this screen only ever mounts
+ * flag-on, it's styled unconditionally to
+ * `docs/plans/church-migration-ui-redesign/WHATSAPP-DESIGN-SYSTEM.md` §3.1
+ * (full-bleed rows — this is a discovery list, not a settings surface) /
+ * §8 ("Directory" checklist) using the `components/wa/*` kit: `WaRow` +
+ * `WaSeparator` rows on `bg.plain`, `WaSectionLabel` section headers, and
+ * Join/Request rendered as small accent text-buttons trailing each row.
  */
 import React, { useCallback, useEffect, useState } from "react";
 import {
@@ -22,6 +28,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Pressable,
   ActivityIndicator,
   Alert,
 } from "react-native";
@@ -41,6 +48,7 @@ import { useTheme } from "@hooks/useTheme";
 import { errorMessage } from "@/utils/error-handling";
 import { useGroupChannels } from "@features/groups/hooks/useGroupChannels";
 import { useWhatsappShellState } from "@hooks/useWhatsappShell";
+import { WaRow, WaSeparator, WaSectionLabel, WA_ROW_LEADING_PADDING } from "@components/wa";
 
 type JoinableChannel = {
   channelId: Id<"chatChannels">;
@@ -175,11 +183,11 @@ function ChannelDirectoryScreen() {
   }, [router, groupId]);
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.surfaceSecondary }]}>
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
       {/* Header */}
-      <View style={[styles.header, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
-        <TouchableOpacity onPress={handleBack} style={styles.backButton}>
-          <Ionicons name="arrow-back" size={24} color={colors.text} />
+      <View style={[styles.header, { backgroundColor: colors.navBarBackground, borderBottomColor: colors.separator }]}>
+        <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={12}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text }]}>Channels</Text>
         <View style={styles.headerRight} />
@@ -187,91 +195,55 @@ function ChannelDirectoryScreen() {
 
       <ScrollView
         style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 32 }]}
         showsVerticalScrollIndicator={false}
       >
-        {/* Your channels */}
-        <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
-          YOUR CHANNELS
-        </Text>
+        {/* Your channels — full-bleed §3.1 rows (§8 Directory checklist:
+            "even though content is discovery, not chat"). */}
+        <View style={styles.sectionLabelWrapper}>
+          <WaSectionLabel>Your channels</WaSectionLabel>
+        </View>
         {channels === undefined ? (
-          <View style={[styles.card, { backgroundColor: colors.surface }]}>
-            <View style={styles.loadingRow}>
-              <ActivityIndicator size="small" color={primaryColor} />
-            </View>
+          <View style={styles.loadingRow}>
+            <ActivityIndicator size="small" color={primaryColor} />
           </View>
         ) : yourChannels.length === 0 ? (
-          <View style={[styles.card, { backgroundColor: colors.surface }]}>
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              You're not in any channels in this group yet.
-            </Text>
-          </View>
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            You're not in any channels in this group yet.
+          </Text>
         ) : (
-          <View style={[styles.card, { backgroundColor: colors.surface }]}>
-            {yourChannels.map((channel: any, idx: number) => {
-              const isMuted = channel.isMuted === true;
-              return (
-                <TouchableOpacity
-                  key={channel._id}
-                  activeOpacity={0.7}
+          <View>
+            {yourChannels.map((channel: any, idx: number) => (
+              <React.Fragment key={channel._id}>
+                {idx > 0 && <WaSeparator />}
+                <WaRow
+                  title={channel.name}
+                  subtitle={`${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""}`}
+                  showMutedDot={channel.isMuted === true}
+                  showChevron
+                  height={60}
                   onPress={() => handleOpenYourChannel(channel.slug)}
-                  style={[
-                    styles.row,
-                    idx > 0 && {
-                      borderTopWidth: StyleSheet.hairlineWidth,
-                      borderTopColor: colors.border,
-                    },
-                  ]}
-                >
-                  <View style={styles.rowInfo}>
-                    <View style={styles.rowNameLine}>
-                      <Text
-                        style={[styles.rowName, { color: colors.text }]}
-                        numberOfLines={1}
-                      >
-                        {channel.name}
-                      </Text>
-                      {isMuted && (
-                        <Ionicons
-                          name="notifications-off-outline"
-                          size={14}
-                          color={colors.textTertiary}
-                          style={styles.mutedIcon}
-                        />
-                      )}
-                    </View>
-                    <Text
-                      style={[styles.rowSubtitle, { color: colors.textSecondary }]}
-                      numberOfLines={1}
-                    >
-                      {channel.memberCount} member{channel.memberCount !== 1 ? "s" : ""}
-                    </Text>
-                  </View>
-                  <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
-                </TouchableOpacity>
-              );
-            })}
+                />
+              </React.Fragment>
+            ))}
           </View>
         )}
 
-        {/* Channels you can join */}
-        <Text style={[styles.sectionHeader, styles.sectionHeaderSpaced, { color: colors.textSecondary }]}>
-          CHANNELS YOU CAN JOIN
-        </Text>
+        {/* Channels you can join — Join/Request render as small accent
+            text-buttons trailing the row (§8: not a chip). */}
+        <View style={[styles.sectionLabelWrapper, styles.sectionHeaderSpaced]}>
+          <WaSectionLabel>Channels you can join</WaSectionLabel>
+        </View>
         {joinable === undefined ? (
-          <View style={[styles.card, { backgroundColor: colors.surface }]}>
-            <View style={styles.loadingRow}>
-              <ActivityIndicator size="small" color={primaryColor} />
-            </View>
+          <View style={styles.loadingRow}>
+            <ActivityIndicator size="small" color={primaryColor} />
           </View>
         ) : joinable.length === 0 ? (
-          <View style={[styles.card, { backgroundColor: colors.surface }]}>
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              No channels open to join right now.
-            </Text>
-          </View>
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            No channels open to join right now.
+          </Text>
         ) : (
-          <View style={[styles.card, { backgroundColor: colors.surface }]}>
+          <View>
             {joinable.map((channel, idx) => {
               const id = channel.channelId as string;
               const status = localStatus[id];
@@ -289,55 +261,34 @@ function ChannelDirectoryScreen() {
                     : "Join";
               const disabled = isBusy || isJoined || alreadyRequested;
               return (
-                <View
-                  key={channel.channelId}
-                  style={[
-                    styles.row,
-                    idx > 0 && {
-                      borderTopWidth: StyleSheet.hairlineWidth,
-                      borderTopColor: colors.border,
-                    },
-                  ]}
-                >
-                  <View style={styles.rowInfo}>
-                    <Text style={[styles.rowName, { color: colors.text }]} numberOfLines={1}>
-                      {channel.name}
-                    </Text>
-                    <Text
-                      style={[styles.rowSubtitle, { color: colors.textSecondary }]}
-                      numberOfLines={1}
-                    >
-                      {channel.memberCount} member{channel.memberCount !== 1 ? "s" : ""}
-                      {isRequestMode ? " · Approval required" : ""}
-                    </Text>
-                  </View>
-                  <TouchableOpacity
-                    onPress={() => handleJoinOrRequest(channel)}
-                    disabled={disabled}
-                    style={[
-                      styles.joinButton,
-                      {
-                        backgroundColor: disabled
-                          ? colors.surfaceSecondary
-                          : primaryColor + "15",
-                        borderColor: disabled ? colors.border : primaryColor,
-                      },
-                    ]}
-                  >
-                    {isBusy ? (
-                      <ActivityIndicator size="small" color={primaryColor} />
-                    ) : (
-                      <Text
-                        style={[
-                          styles.joinButtonText,
-                          { color: disabled ? colors.textTertiary : primaryColor },
-                        ]}
-                      >
-                        {label}
-                      </Text>
-                    )}
-                  </TouchableOpacity>
-                </View>
+                <React.Fragment key={channel.channelId}>
+                  {idx > 0 && <WaSeparator />}
+                  <WaRow
+                    title={channel.name}
+                    subtitle={`${channel.memberCount} member${channel.memberCount !== 1 ? "s" : ""}${isRequestMode ? " · Approval required" : ""}`}
+                    height={60}
+                    rightAccessory={
+                      isBusy ? (
+                        <ActivityIndicator size="small" color={primaryColor} />
+                      ) : (
+                        <Pressable
+                          onPress={() => handleJoinOrRequest(channel)}
+                          disabled={disabled}
+                          hitSlop={8}
+                        >
+                          <Text
+                            style={[
+                              styles.joinButtonText,
+                              { color: disabled ? colors.textTertiary : primaryColor },
+                            ]}
+                          >
+                            {label}
+                          </Text>
+                        </Pressable>
+                      )
+                    }
+                  />
+                </React.Fragment>
               );
             })}
           </View>
@@ -346,7 +297,7 @@ function ChannelDirectoryScreen() {
         {/* Leader-only footer link to the existing create-channel screen. */}
         {isLeader && (
           <TouchableOpacity
-            style={[styles.createCard, { backgroundColor: colors.surface }]}
+            style={styles.createRow}
             onPress={handleCreateChannel}
             activeOpacity={0.7}
           >
@@ -389,83 +340,43 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
   },
+  // No horizontal padding here — WaRow/WaSectionLabel bring their own §3.1
+  // edge padding (16pt), so an outer padded container would double it.
   scrollContent: {
-    padding: 16,
+    paddingTop: 12,
     paddingBottom: 32,
   },
-  sectionHeader: {
-    fontSize: 11,
-    fontWeight: "600",
-    letterSpacing: 0.6,
+  sectionLabelWrapper: {
     marginBottom: 8,
-    paddingHorizontal: 8,
   },
   sectionHeaderSpaced: {
     marginTop: 24,
   },
-  card: {
-    borderRadius: 12,
-    overflow: "hidden",
-  },
   loadingRow: {
     paddingVertical: 24,
+    paddingHorizontal: WA_ROW_LEADING_PADDING,
     alignItems: "center",
   },
   emptyText: {
     fontSize: 14,
-    paddingHorizontal: 16,
+    paddingHorizontal: WA_ROW_LEADING_PADDING,
     paddingVertical: 20,
     textAlign: "center",
   },
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    minHeight: 56,
-    gap: 12,
-  },
-  rowInfo: {
-    flex: 1,
-    minWidth: 0,
-  },
-  rowNameLine: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  rowName: {
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  mutedIcon: {
-    marginLeft: 6,
-  },
-  rowSubtitle: {
-    marginTop: 2,
-    fontSize: 13,
-  },
-  joinButton: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 8,
-    borderWidth: 1,
-    minWidth: 76,
-    alignItems: "center",
-    justifyContent: "center",
-  },
+  // §3.2 "Plain text action" convention (§1.3) — small accent text, no
+  // border/fill, per this screen's explicit restyle instruction.
   joinButtonText: {
-    fontSize: 13,
+    fontSize: 14,
     fontWeight: "600",
   },
-  createCard: {
+  createRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
-    marginTop: 16,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    borderRadius: 12,
     justifyContent: "center",
+    gap: 8,
+    marginTop: 16,
+    paddingHorizontal: WA_ROW_LEADING_PADDING,
+    paddingVertical: 14,
   },
   createLabel: {
     fontSize: 15,

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -21,6 +21,21 @@
  *   - CHANNEL ACTIONS (Share invite link, Leave channel)
  *   - LEADER CONTROLS (Active state, Rename, Discoverable [flag-gated,
  *     custom only], Share with groups, Archive)
+ *
+ * This screen serves BOTH the whatsapp-shell flag-off and flag-on paths (see
+ * `app/inbox/[groupId]/[channelSlug]/info.tsx`), so restyle work extends the
+ * existing `whatsappShell` gating rather than replacing it. Per
+ * `docs/plans/church-migration-ui-redesign/WHATSAPP-DESIGN-SYSTEM.md` §3.2/§8
+ * ("Channel info" checklist), when `whatsappShell` is on: the hero, Open
+ * chat + Mute row, Members (+ Add people), Channel actions, and Leader
+ * controls each regroup into `WaInsetGroup`/`WaCell` anatomy on
+ * `bg.grouped`. Per-type branching (main/leaders/reach_out/custom/pco/
+ * cross_team/announcements) is unchanged — only the visual shell around it
+ * is. Sections not named in the restyle task (pending shared-channel
+ * invite, Requests, cross-team members, PCO "Not in channel") are
+ * deliberately left in their pre-existing bespoke card styling in both
+ * flag states — see the restyle report for the reasoning. Flag-off is
+ * byte-identical to before this pass.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -76,6 +91,13 @@ import {
 } from "@/utils/channel-members";
 import { errorMessage } from "@/utils/error-handling";
 import { confirmAnnouncementsShareAccept } from "@features/groups/hooks/useRespondToChannelInvite";
+import {
+  WaInsetGroup,
+  WaCell,
+  WaRow,
+  WA_GROUP_SPACING,
+  WA_AVATAR_PROFILE,
+} from "@components/wa";
 
 type Props = {
   groupId: string;
@@ -915,11 +937,23 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
       | UnsyncedPerson[]
       | undefined) ?? [];
 
+  // Members (+ Add people) share these gates across both the whatsapp-shell
+  // WaInsetGroup rendering and the flag-off original cards below.
+  const showMemberRows = !isCrossTeam && memberRows.length > 0;
+  const showViewAll = showMemberRows && totalMemberCount > memberRows.length;
+  const showAddPeople = isLeader && !isMain;
+  // §3.2 "hairlines align with the label's leading edge" — leading padding
+  // (16) + this section's 40pt avatar + avatar-to-text gap (12).
+  const waMemberRowSeparatorInset = 16 + 40 + 12;
+
   return (
     <View
       style={[
         styles.container,
-        { paddingTop: insets.top, backgroundColor: colors.surface },
+        {
+          paddingTop: insets.top,
+          backgroundColor: whatsappShell ? colors.backgroundGrouped : colors.surface,
+        },
       ]}
     >
       <Header onBack={handleBack} colors={colors} />
@@ -938,9 +972,19 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           />
         )}
 
-        {/* Hero */}
+        {/* Hero — §3.2/§8: same anatomy (icon, #name + rename pencil,
+            member count, shared pill) either way; whatsapp-shell on scales
+            the icon circle to the kit's WA_AVATAR_PROFILE (108pt) and the
+            member-count subtitle to §2's 15pt-regular hero-subtitle scale,
+            with the shared pill recolored onto `bg.card`/`separator`
+            tokens instead of the flag-off `surfaceSecondary`/`border`. */}
         <View style={styles.heroSection}>
-          <View style={[styles.heroIconCircle, { backgroundColor: iconCfg.bg }]}>
+          <View
+            style={[
+              whatsappShell ? styles.heroIconCircleWa : styles.heroIconCircle,
+              { backgroundColor: iconCfg.bg },
+            ]}
+          >
             <Ionicons name={iconCfg.icon} size={48} color={iconCfg.color} />
           </View>
           {isRenameable && isLeader ? (
@@ -973,14 +1017,21 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
               {isCustom || isPco ? `#${channelDisplayName}` : channelDisplayName}
             </Text>
           )}
-          <Text style={[styles.heroSubtitle, { color: colors.textSecondary }]}>
+          <Text
+            style={[
+              whatsappShell ? styles.heroSubtitleWa : styles.heroSubtitle,
+              { color: colors.textSecondary },
+            ]}
+          >
             {totalMemberCount} {totalMemberCount === 1 ? "member" : "members"}
           </Text>
           {sharedGroupCount > 0 && (
             <View
               style={[
                 styles.sharedPill,
-                { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+                whatsappShell
+                  ? { backgroundColor: colors.surfaceGrouped, borderColor: colors.separator }
+                  : { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
               ]}
             >
               <Ionicons name="link" size={12} color={colors.textSecondary} />
@@ -1051,7 +1102,30 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
 
         {!isPendingShareInvite && (
         <>
-        {/* Open chat */}
+        {/* Open chat + Mute channel (W18) — §3.2 regroups both into one
+            WaInsetGroup when whatsapp-shell is on (Mute channel is
+            member-only: a leader viewing a channel they haven't joined has
+            no membership row to mute). Flag-off renders the original
+            bespoke cards unchanged. */}
+        {whatsappShell ? (
+          <View style={styles.waSection}>
+            <WaInsetGroup>
+              <WaCell icon="chatbubbles-outline" title="Open chat" onPress={handleOpenChat} />
+              {isMemberOfChannel && (
+                <WaCell
+                  icon={isChannelMuted ? "notifications-off-outline" : "notifications-outline"}
+                  title="Mute channel"
+                  variant="toggle"
+                  toggleValue={isChannelMuted}
+                  onToggleChange={handleToggleMuted}
+                  disabled={muteToggling}
+                  accent={primaryColor}
+                />
+              )}
+            </WaInsetGroup>
+          </View>
+        ) : (
+          <>
         <Pressable
           onPress={handleOpenChat}
           style={({ pressed }) => [
@@ -1069,36 +1143,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           </Text>
           <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
         </Pressable>
-
-        {/* Mute channel — W18. Member-only (a leader viewing a channel they
-            haven't joined has no membership row to mute). Flag-gated so the
-            screen is unchanged when whatsapp-shell is off. */}
-        {whatsappShell && isMemberOfChannel && (
-          <View
-            style={[
-              styles.actionCard,
-              { backgroundColor: colors.surfaceSecondary },
-            ]}
-          >
-            <View style={[styles.actionIcon, { backgroundColor: colors.textTertiary + "15" }]}>
-              <Ionicons
-                name={isChannelMuted ? "notifications-off-outline" : "notifications-outline"}
-                size={18}
-                color={colors.icon}
-              />
-            </View>
-            <Text style={[styles.actionLabel, { color: colors.text }]}>
-              Mute channel
-            </Text>
-            <Switch
-              value={isChannelMuted}
-              onValueChange={handleToggleMuted}
-              disabled={muteToggling}
-              trackColor={{ false: colors.border, true: primaryColor }}
-              thumbColor={colors.textInverse}
-              style={{ marginLeft: "auto" }}
-            />
-          </View>
+          </>
         )}
 
         {/* Pending join requests — leader-only, custom channels with
@@ -1216,8 +1261,53 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           />
         )}
 
-        {/* Members */}
-        {!isCrossTeam && memberRows.length > 0 && (
+        {/* Members (+ Add people, §3.2/§8) — whatsapp-shell on folds both
+            into one WaInsetGroup of WaRow member rows + trailing WaCells
+            ("View all"/"Add people"); flag-off keeps the original card.
+            The flag-off "Add people" standalone card further below is
+            gated `!whatsappShell` so it doesn't double-render here. */}
+        {whatsappShell && (showMemberRows || showAddPeople) && (
+          <View style={styles.waSection}>
+            <WaInsetGroup
+              header={showMemberRows ? "Members" : undefined}
+              separatorInset={waMemberRowSeparatorInset}
+            >
+              {showMemberRows &&
+                memberRows.map((m: any) => {
+                  const displayName = m.displayName || "Member";
+                  const isOwner = !!ownerId && m.userId === ownerId;
+                  const isSelf = m.userId === user?.id;
+                  return (
+                    <WaRow
+                      key={m.id}
+                      avatar={{ imageUrl: m.profilePhoto, label: displayName, size: 40 }}
+                      title={`${displayName}${isSelf ? " (you)" : ""}`}
+                      subtitle={isOwner ? "Owner" : undefined}
+                      showChevron
+                      onPress={() => router.push(`/profile/${m.userId}` as any)}
+                    />
+                  );
+                })}
+              {showViewAll && (
+                <WaCell
+                  variant="navigational"
+                  title={`View all ${totalMemberCount} members`}
+                  onPress={handleManageMembers}
+                />
+              )}
+              {showAddPeople && (
+                <WaCell
+                  icon="person-add-outline"
+                  title="Add people"
+                  onPress={isCrossTeam ? () => setAddPermanentVisible(true) : handleManageMembers}
+                />
+              )}
+            </WaInsetGroup>
+          </View>
+        )}
+
+        {/* Members — flag-off original card. */}
+        {!whatsappShell && showMemberRows && (
           <>
             <SectionHeader colors={colors} label="Members" />
             <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
@@ -1268,7 +1358,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                 );
               })}
             </View>
-            {totalMemberCount > memberRows.length && (
+            {showViewAll && (
               <Pressable
                 onPress={handleManageMembers}
                 style={({ pressed }) => [
@@ -1441,8 +1531,10 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
             people picker to pin a PERMANENT member (its roster is otherwise
             auto-synced, so there's no manage-members sub-route). Other channel
             types route to the existing manage-members screen. General's
-            membership is the group itself, so there's nothing to add here. */}
-        {isLeader && !isMain && (
+            membership is the group itself, so there's nothing to add here.
+            Flag-off only — whatsapp-shell on folds this into the Members
+            WaInsetGroup above (`showAddPeople`) instead. */}
+        {!whatsappShell && showAddPeople && (
           <Pressable
             onPress={
               isCrossTeam
@@ -1466,8 +1558,31 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
         )}
 
         {/* CHANNEL ACTIONS — General has no invite link and can't be left
-            (its membership is the group itself), so hide the whole section. */}
-        {!isMain && (
+            (its membership is the group itself), so hide the whole section.
+            §1.4/§3.3: Leave/Remove are red WaCell destructive rows (no
+            icon, no chevron) when whatsapp-shell is on. */}
+        {!isMain && whatsappShell && (
+          <View style={styles.waSection}>
+            <WaInsetGroup header="Channel actions" separatorInset={0}>
+              {isLeader && isCustom && (
+                <WaCell icon="share-outline" title="Share invite link" onPress={handleShareInvite} />
+              )}
+              <WaCell variant="destructive" title="Leave channel" onPress={() => setLeaveVisible(true)} />
+              {/* Remove shared channel — leader-only opt-out for a group that
+                  participates in this channel as a secondary (non-owning)
+                  group. Removes the whole group from the share, distinct from
+                  an individual leave. The owning group keeps the channel. */}
+              {isLeader && isSecondaryShare && (
+                <WaCell
+                  variant="destructive"
+                  title="Remove shared channel"
+                  onPress={() => setRemoveShareVisible(true)}
+                />
+              )}
+            </WaInsetGroup>
+          </View>
+        )}
+        {!isMain && !whatsappShell && (
           <>
             <SectionHeader colors={colors} label="Channel actions" />
             <View style={[styles.sectionGroup, { backgroundColor: colors.surfaceSecondary }]}>
@@ -1532,8 +1647,131 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
           </>
         )}
 
-        {/* LEADER CONTROLS */}
-        {isLeader && (
+        {/* LEADER CONTROLS — §3.2/§8: one WaInsetGroup of WaCells when
+            whatsapp-shell is on. Every row keeps its exact per-type gating
+            logic (isCustom/isPco/isCrossTeam/isReachOut/…) — only the
+            visual shell changes. The Reach Out / Leaders helper text moves
+            into the group's `footer` slot (§3.2 "section footers sit below
+            their card"). */}
+        {isLeader && whatsappShell && (
+          <View style={styles.waSection}>
+            <WaInsetGroup
+              header="Leader controls"
+              footer={
+                isReachOut
+                  ? "Reach Out requires the Leaders channel to be active."
+                  : isLeadersChannel
+                    ? "Leaders channel is private to group leaders and admins."
+                    : undefined
+              }
+            >
+              {/* Active state — common to main/leaders/reach_out/custom/pco.
+                  For General this is the only leader control: it's how a
+                  leader disables and (from the disabled row) re-enables it. */}
+              <WaCell icon="toggle-outline" title="Active state" onPress={handleActiveState} />
+
+              {/* Join mode — custom channels only. Routes to an explicit
+                  picker (Open / Approval required) so leaders don't have to
+                  dive into Share with groups → swap-icon to change it. */}
+              {isCustom && (
+                <WaCell
+                  icon="key-outline"
+                  title="Join mode"
+                  value={(inviteInfo?.joinMode ?? "open") === "open" ? "Open" : "Approval required"}
+                  onPress={handleJoinMode}
+                />
+              )}
+
+              {/* Discoverable — W17/W18. Custom channels only; undefined/true
+                  means listed in the group's "Channels you can join" directory,
+                  false hides it (invite-link / leader-add still work either
+                  way). */}
+              {isCustom && (
+                <WaCell
+                  icon="compass-outline"
+                  title="Discoverable"
+                  description='Listed in "Channels you can join"'
+                  variant="toggle"
+                  toggleValue={isChannelDiscoverable}
+                  onToggleChange={handleToggleDiscoverable}
+                  disabled={discoverableToggling}
+                  accent={primaryColor}
+                />
+              )}
+
+              {/* PCO Sync Settings — open the existing AutoChannelSettings
+                  modal. Only meaningful for PCO synced channels. */}
+              {isPco && (
+                <WaCell
+                  icon="sync-outline"
+                  title="PCO sync settings"
+                  onPress={() => setPcoSettingsVisible(true)}
+                />
+              )}
+
+              {/* Edit synced roles — cross-team channels. Reopens the
+                  selector picker prefilled from the current config and
+                  saves via updateCrossTeamChannel. */}
+              {isCrossTeam && (
+                <WaCell
+                  icon="git-merge-outline"
+                  title="Edit synced roles"
+                  onPress={() => setCrossTeamEditVisible(true)}
+                />
+              )}
+
+              {/* No "set up as serving team" here — ADR-024/ADR-025 removed
+                  the channel→team conversion path. Teams are created only in
+                  the Rostering hub via `createServingTeam`, and a team's
+                  roster is managed there, not from its chat channel. */}
+
+              {/* Composer hint — guidance text shown as the message-box
+                  placeholder (e.g. "put experience updates here"). Editing is
+                  authorized by `updateChannel` against the owning group, so we
+                  hide it for secondary-share viewers (a linked group's leader
+                  would otherwise open the modal only to hit "Not authorized").
+                  The owning group's leaders manage the shared hint. */}
+              {!isSecondaryShare && (
+                <WaCell
+                  icon="bulb-outline"
+                  title="Composer hint"
+                  value={channel?.hint || undefined}
+                  onPress={() => {
+                    setHintValue(channel?.hint ?? "");
+                    setHintError(null);
+                    setHintVisible(true);
+                  }}
+                />
+              )}
+
+              {/* Rename — custom, serving-team, and cross-team channels
+                  (backend gates the rest, and mirrors serving-team → team). */}
+              {isRenameable && (
+                <WaCell icon="create-outline" title="Rename" onPress={openRename} />
+              )}
+
+              {/* Share with groups — custom + pco_services + announcements.
+                  Announcements can only be shared by the OWNING group's
+                  leaders (a secondary group receives the share; it has
+                  nothing to share out). */}
+              {(isCustom || isPco || (isAnnouncements && !isSecondaryShare)) && (
+                <WaCell icon="people-outline" title="Share with groups" onPress={handleManageMembers} />
+              )}
+
+              {/* Archive — custom only (Leaders/Reach Out are toggled via
+                  Active state; archive is a stronger op). */}
+              {isCustom && (
+                <WaCell
+                  variant="destructive"
+                  title="Archive channel"
+                  onPress={() => setArchiveVisible(true)}
+                />
+              )}
+            </WaInsetGroup>
+          </View>
+        )}
+
+        {isLeader && !whatsappShell && (
           <>
             <SectionHeader colors={colors} label="Leader controls" />
             <View
@@ -1596,46 +1834,6 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                     color={colors.textTertiary}
                   />
                 </Pressable>
-              )}
-
-              {/* Discoverable — W17/W18. Custom channels only; undefined/true
-                  means listed in the group's "Channels you can join" directory,
-                  false hides it (invite-link / leader-add still work either
-                  way). Flag-gated so today's Leader Controls are unchanged
-                  when whatsapp-shell is off. */}
-              {whatsappShell && isCustom && (
-                <View
-                  style={[
-                    styles.actionRowFlat,
-                    {
-                      borderTopWidth: StyleSheet.hairlineWidth,
-                      borderTopColor: colors.border,
-                    },
-                  ]}
-                >
-                  <Ionicons name="compass-outline" size={20} color={colors.icon} />
-                  <View style={styles.discoverableText}>
-                    <Text style={[styles.actionLabel, { color: colors.text }]}>
-                      Discoverable
-                    </Text>
-                    <Text
-                      style={[
-                        styles.discoverableSubtitle,
-                        { color: colors.textSecondary },
-                      ]}
-                    >
-                      Listed in "Channels you can join"
-                    </Text>
-                  </View>
-                  <Switch
-                    value={isChannelDiscoverable}
-                    onValueChange={handleToggleDiscoverable}
-                    disabled={discoverableToggling}
-                    trackColor={{ false: colors.border, true: primaryColor }}
-                    thumbColor={colors.textInverse}
-                    style={{ marginLeft: "auto" }}
-                  />
-                </View>
               )}
 
               {/* PCO Sync Settings — open the existing AutoChannelSettings

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -2700,6 +2700,14 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
+  // whatsapp-shell hero — sized to the kit's WA_AVATAR_PROFILE (§6).
+  heroIconCircleWa: {
+    width: WA_AVATAR_PROFILE,
+    height: WA_AVATAR_PROFILE,
+    borderRadius: WA_AVATAR_PROFILE / 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   heroName: {
     marginTop: 16,
     fontSize: 22,
@@ -2718,6 +2726,15 @@ const styles = StyleSheet.create({
   heroSubtitle: {
     marginTop: 4,
     fontSize: 13,
+  },
+  // §2 "Community/group member count, hero subtitle": 15pt Regular.
+  heroSubtitleWa: {
+    marginTop: 4,
+    fontSize: 15,
+    fontWeight: "400",
+  },
+  waSection: {
+    marginTop: WA_GROUP_SPACING,
   },
   sharedPill: {
     flexDirection: "row",

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   View,
   Text,
+  TextInput,
   StyleSheet,
   ActivityIndicator,
   ScrollView,
@@ -67,6 +68,144 @@ const MIN_SEARCH_LENGTH = 2;
 const NAV_ROW_HEIGHT = 44;
 const SEARCH_BLOCK_HEIGHT = 64;
 const COLLAPSE_DISTANCE = NAV_ROW_HEIGHT + SEARCH_BLOCK_HEIGHT;
+
+// --- WhatsApp-shell row anatomy (flag-gated) --------------------------------
+// Brings the remaining row kinds this screen renders directly (DM, event,
+// Notifications, Message Requests) into the same flat WaRow anatomy
+// GroupedInboxItem.tsx already applies to group/channel/resource rows — same
+// 50pt avatar, same right column, same separator inset — so the blended Chats
+// list reads as one row language instead of two interleaved ones (see
+// docs/plans/church-migration-ui-redesign/WA-GAP-MATRIX.md, Chats-list rows).
+// Duplicated locally (not imported from `components/wa/WaRow`, which uses a
+// 56pt avatar) because GroupedInboxItem's WA_MAIN_AVATAR_SIZE=50 is the
+// metric already shipped and visible in this list; matching it here — rather
+// than the generic kit's 56pt — is what actually fixes the size mismatch the
+// gap matrix calls out. Only rendered when `whatsappShellEnabled`; every
+// flag-off row below is unchanged.
+const WA_ROW_AVATAR_SIZE = 50;
+const WA_ROW_SEPARATOR_INSET = 16 + WA_ROW_AVATAR_SIZE + 12; // 78, matches GroupedInboxItem
+
+/** Format a timestamp the same way GroupedInboxItem's row anatomy does, so
+ * every row in the blended list (group, DM, event, notifications, requests)
+ * shows recency in the same shape ("now", "2h", "Yesterday", "Jan 15"). */
+function formatRelativeTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const minutes = Math.floor(diff / (1000 * 60));
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  if (minutes < 1) return "now";
+  if (minutes < 60) return `${minutes}m`;
+  if (hours < 24) return `${hours}h`;
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days}d`;
+
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  const month = months[date.getMonth()];
+  const day = date.getDate();
+
+  if (date.getFullYear() !== now.getFullYear()) {
+    return `${month} ${day}, ${date.getFullYear()}`;
+  }
+
+  return `${month} ${day}`;
+}
+
+/**
+ * Right column shared by every WaRow-anatomy row in this file: timestamp
+ * (accent when unread) stacked above the unread badge. Mirrors
+ * GroupedInboxItem's `WaRightColumn` (no `isLoading`/`showMutedDot` here —
+ * none of this file's rows show a loading spinner or a muted dot).
+ */
+function WaRowRightColumn({
+  timestamp,
+  hasUnread,
+  unreadCount,
+  primaryColor,
+  colors,
+}: {
+  timestamp?: string;
+  hasUnread: boolean;
+  unreadCount?: number;
+  primaryColor: string;
+  colors: { textTertiary: string };
+}) {
+  return (
+    <View style={styles.waRightColumn}>
+      {timestamp ? (
+        <Text
+          style={[styles.waTimestamp, { color: hasUnread ? primaryColor : colors.textTertiary }]}
+          numberOfLines={1}
+        >
+          {timestamp}
+        </Text>
+      ) : null}
+      {hasUnread && unreadCount ? (
+        <View style={[styles.waBadge, { backgroundColor: primaryColor }]}>
+          <Text style={styles.waBadgeText}>{unreadCount > 99 ? "99+" : unreadCount}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+/**
+ * WhatsApp-shell search pill (flag-gated) — WHATSAPP-DESIGN-SYSTEM.md §4:
+ * 36-38pt tall, fully rounded, `bg.grouped`-ish fill, magnifying-glass icon +
+ * placeholder. Built locally rather than reusing the shared `SearchBar` (its
+ * own stylesheet bakes in a bordered-box shape that isn't reachable via
+ * props, and this pass is scoped to this file only) — same debounced
+ * search-as-you-type behavior as `SearchBar`.
+ */
+function WaChatSearchPill({
+  onSearch,
+  onClear,
+  colors,
+}: {
+  onSearch: (text: string) => void;
+  onClear: () => void;
+  colors: { backgroundGrouped: string; textTertiary: string; text: string };
+}) {
+  const [value, setValue] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleChangeText = (text: string) => {
+    setValue(text);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => onSearch(text), 300);
+  };
+
+  const handleClear = () => {
+    setValue("");
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    onClear();
+  };
+
+  return (
+    <View style={[styles.waSearchPill, { backgroundColor: colors.backgroundGrouped }]}>
+      <Ionicons name="search" size={15} color={colors.textTertiary} style={styles.waSearchIcon} />
+      <TextInput
+        style={[styles.waSearchInput, { color: colors.text }]}
+        placeholder="Search"
+        placeholderTextColor={colors.textTertiary}
+        value={value}
+        onChangeText={handleChangeText}
+        returnKeyType="search"
+        onSubmitEditing={() => onSearch(value)}
+      />
+      {value.length > 0 && (
+        <Pressable onPress={handleClear} hitSlop={8} accessibilityRole="button" accessibilityLabel="Clear search">
+          <Ionicons name="close-circle" size={16} color={colors.textTertiary} />
+        </Pressable>
+      )}
+    </View>
+  );
+}
 
 // Type for a channel as returned by getInboxChannels
 type InboxChannel = {
@@ -466,6 +605,50 @@ export function ChatInboxScreen({
         );
       }
       if (item.kind === "requests-link") {
+        // Not a serving-mode row (only pushed in the non-serving branch of
+        // listItemsWithDm below), so it gets the flat WA treatment same as
+        // every other top-level row: glyph circle avatar, title + subtitle,
+        // chevron (it navigates to a list, same as GroupedInboxItem's
+        // "N more channels" row — no unread badge, since the subtitle already
+        // states the pending count).
+        if (whatsappShellEnabled) {
+          return (
+            <Pressable
+              onPress={() => router.push("/inbox/requests" as any)}
+              style={({ pressed }) => [
+                styles.waRow,
+                pressed && { backgroundColor: colors.surfaceSecondary },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`${item.count} message request${item.count === 1 ? "" : "s"}`}
+            >
+              <View
+                style={[
+                  styles.waIconCircle,
+                  {
+                    width: WA_ROW_AVATAR_SIZE,
+                    height: WA_ROW_AVATAR_SIZE,
+                    borderRadius: WA_ROW_AVATAR_SIZE / 2,
+                    backgroundColor: primaryColor + "14",
+                  },
+                ]}
+              >
+                <Ionicons name="mail-unread-outline" size={22} color={primaryColor} />
+              </View>
+              <View style={styles.waContent}>
+                <Text style={[styles.waTitle, { color: colors.text }]} numberOfLines={1}>
+                  Message Requests
+                </Text>
+                <Text style={[styles.waPreview, { color: colors.textSecondary }]} numberOfLines={1}>
+                  {item.count} pending
+                </Text>
+              </View>
+              <View style={styles.waChevronColumn}>
+                <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
+              </View>
+            </Pressable>
+          );
+        }
         return (
           <Pressable
             onPress={() => router.push("/inbox/requests" as any)}
@@ -519,10 +702,14 @@ export function ChatInboxScreen({
             row={item.item}
             primaryColor={primaryColor}
             colors={colors}
+            whatsappShellEnabled={whatsappShellEnabled}
           />
         );
       }
       if (item.kind === "ghost") {
+        // Serving-mode only (see the `inServingMode` branch of
+        // listItemsWithDm below) — left untouched entirely per this pass's
+        // brief, same as the rest of serving mode.
         return <GhostChannelCard channel={item.item} />;
       }
       if (item.kind === "event") {
@@ -532,6 +719,7 @@ export function ChatInboxScreen({
             isActive={Boolean(
               sidebarMode && activeChannelSlug === item.item.channel.slug,
             )}
+            whatsappShellEnabled={whatsappShellEnabled}
           />
         );
       }
@@ -637,7 +825,15 @@ export function ChatInboxScreen({
           style={[styles.largeTitleWrap, largeTitleStyle]}
           pointerEvents="none"
         >
-          <Text style={[styles.headerTitle, { color: colors.text }]}>{collapsingHeaderTitle}</Text>
+          <Text
+            style={[
+              styles.headerTitle,
+              whatsappShellEnabled && styles.headerTitleWa,
+              { color: colors.text },
+            ]}
+          >
+            {collapsingHeaderTitle}
+          </Text>
         </Animated.View>
         <Animated.Text
           style={[styles.smallTitle, { color: colors.text }, smallTitleStyle]}
@@ -647,33 +843,58 @@ export function ChatInboxScreen({
           {collapsingHeaderTitle}
         </Animated.Text>
         {showCommunityEntry && (
+          // §4: the "⋯" header-circle slot is the community switcher per the
+          // Togather adaptation noted in components/wa/WaScreenHeader's JSDoc —
+          // styled as the same 40pt neutral-gray circle as the other header
+          // buttons. Only ever rendered when the flag is on (showCommunityEntry).
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Open community page"
             onPress={() => router.push("/community" as any)}
-            style={styles.headerActionButton}
+            style={[
+              styles.headerActionButton,
+              styles.headerActionButtonWa,
+              { marginRight: 8, backgroundColor: colors.backgroundGrouped },
+            ]}
             hitSlop={12}
           >
-            <Avatar name={community?.name} imageUrl={community?.logo} size={28} />
+            <Avatar name={community?.name} imageUrl={community?.logo} size={32} />
           </Pressable>
         )}
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Start a new chat"
           onPress={() => router.push("/inbox/new" as any)}
-          style={styles.headerActionButton}
+          style={[
+            styles.headerActionButton,
+            // §4: the compose "+" is the one filled-accent circle among the
+            // header buttons — everything else stays neutral gray/white.
+            whatsappShellEnabled && [styles.headerActionButtonWa, { backgroundColor: primaryColor }],
+          ]}
           hitSlop={12}
         >
-          <Ionicons name="create-outline" size={24} color={colors.text} />
+          <Ionicons
+            name="create-outline"
+            size={whatsappShellEnabled ? 18 : 24}
+            color={whatsappShellEnabled ? "#FFFFFF" : colors.text}
+          />
         </Pressable>
       </View>
 
       <Animated.View style={[styles.searchWrap, searchStyle]}>
-        <SearchBar
-          placeholder="Search messages"
-          onSearch={setSearchTerm}
-          onClear={() => setSearchTerm("")}
-        />
+        {whatsappShellEnabled ? (
+          <WaChatSearchPill
+            onSearch={setSearchTerm}
+            onClear={() => setSearchTerm("")}
+            colors={colors}
+          />
+        ) : (
+          <SearchBar
+            placeholder="Search messages"
+            onSearch={setSearchTerm}
+            onClear={() => setSearchTerm("")}
+          />
+        )}
       </Animated.View>
 
       <Animated.View
@@ -689,19 +910,30 @@ export function ChatInboxScreen({
   // "no community" empty state since the picker has nothing to search.
   const renderHeader = (showCompose: boolean) => (
     <View style={[styles.header, { paddingTop: headerPaddingTop }]}>
-      <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+      <Text
+        style={[
+          styles.headerTitle,
+          whatsappShellEnabled && styles.headerTitleWa,
+          { color: colors.text },
+        ]}
+      >
+        {whatsappShellEnabled ? "Chats" : "Inbox"}
+      </Text>
       {showCompose && (
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Start a new chat"
           onPress={() => router.push("/inbox/new" as any)}
-          style={styles.headerActionButton}
+          style={[
+            styles.headerActionButton,
+            whatsappShellEnabled && [styles.headerActionButtonWa, { backgroundColor: primaryColor }],
+          ]}
           hitSlop={12}
         >
           <Ionicons
             name="create-outline"
-            size={24}
-            color={colors.text}
+            size={whatsappShellEnabled ? 18 : 24}
+            color={whatsappShellEnabled ? "#FFFFFF" : colors.text}
           />
         </Pressable>
       )}
@@ -1082,18 +1314,28 @@ export function ChatInboxScreen({
           {renderHeader(true)}
           <EnableNotificationsBanner />
           <ScrollView contentContainerStyle={styles.centeredScrollContent}>
-            <Ionicons
-              name="chatbubbles-outline"
-              size={48}
-              color={colors.iconSecondary}
-              style={{ marginBottom: 16 }}
-            />
             {/* Serving mode always pins the Team card, so the inbox is never
                 empty there — this branch only renders outside serving mode. */}
-            <Text style={[styles.emptyTitle, { color: colors.text }]}>No Groups Yet</Text>
-            <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
-              Join a group to start chatting
-            </Text>
+            {whatsappShellEnabled ? (
+              // §6 Empty states, as narrowed by this pass's brief: simple
+              // centered secondary text, no illustration/icon.
+              <Text style={[styles.waEmptyText, { color: colors.textSecondary }]}>
+                No chats yet
+              </Text>
+            ) : (
+              <>
+                <Ionicons
+                  name="chatbubbles-outline"
+                  size={48}
+                  color={colors.iconSecondary}
+                  style={{ marginBottom: 16 }}
+                />
+                <Text style={[styles.emptyTitle, { color: colors.text }]}>No Groups Yet</Text>
+                <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+                  Join a group to start chatting
+                </Text>
+              </>
+            )}
           </ScrollView>
         </View>
       </Wrapper>
@@ -1186,6 +1428,9 @@ function EventsSection({ rows, activeChannelSlug }: EventsSectionProps) {
 interface EventInboxRowItemProps {
   row: EventInboxRow;
   isActive: boolean;
+  /** WA-GAP-MATRIX #2c: flat WaRow anatomy, no accent bar/pill/CTA. Flag off
+   * renders the existing bespoke card below, byte-identical to before. */
+  whatsappShellEnabled?: boolean;
 }
 
 /**
@@ -1377,7 +1622,7 @@ function DirectionsButton({
   );
 }
 
-function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
+function EventInboxRowItem({ row, isActive, whatsappShellEnabled }: EventInboxRowItemProps) {
   const router = useRouter();
   const { user } = useAuth();
   const { colors, isDark } = useTheme();
@@ -1463,6 +1708,95 @@ function EventInboxRowItem({ row, isActive }: EventInboxRowItemProps) {
   // on web. Instead, layout lives on the inner View and we flip the bg via
   // state + onPressIn/Out.
   const [isPressed, setIsPressed] = useState(false);
+
+  // WA-GAP-MATRIX #2c: "the most un-WhatsApp row shape in the list" — same
+  // flat WaRow anatomy as every other row, no accent bar, no urgency pill, no
+  // inline Directions CTA. The right column's timestamp carries what's left
+  // of the urgency signal (last-message time, falling back to "Live now" or
+  // the event's scheduled time when there's no message yet); location /
+  // Directions remain reachable by opening the event itself. Reuses the same
+  // `isPressed` press-state workaround as the flag-off row below (RN Web
+  // drops layout styles passed via Pressable's function-form `style`).
+  if (whatsappShellEnabled) {
+    const timestamp = channel.lastMessageAt
+      ? formatRelativeTime(channel.lastMessageAt)
+      : isLive
+        ? "Live now"
+        : eventWhen?.when;
+    return (
+      <Pressable
+        onPress={handlePress}
+        onPressIn={() => setIsPressed(true)}
+        onPressOut={() => setIsPressed(false)}
+        accessibilityRole="button"
+        accessibilityLabel={`${group.name} — ${channel.name}${
+          eventWhen ? `, ${eventWhen.when}` : ""
+        }${hasUnread ? `, ${channel.unreadCount} unread` : ""}`}
+      >
+        <View
+          style={[
+            styles.waRow,
+            {
+              backgroundColor: isPressed || isActive ? colors.surfaceSecondary : colors.surface,
+            },
+          ]}
+        >
+          {channel.meetingCoverImage ? (
+            <AppImage
+              source={channel.meetingCoverImage}
+              style={[styles.waAvatarMain, isPast && styles.eventAvatarMuted]}
+              optimizedWidth={150}
+              placeholder={{
+                type: "initials",
+                name: channel.name,
+                backgroundColor: isDark ? "#333" : "#E5E5E5",
+              }}
+            />
+          ) : (
+            <View
+              style={[
+                styles.waIconCircle,
+                {
+                  width: WA_ROW_AVATAR_SIZE,
+                  height: WA_ROW_AVATAR_SIZE,
+                  borderRadius: WA_ROW_AVATAR_SIZE / 2,
+                  backgroundColor: colors.surfaceSecondary,
+                },
+                isPast && styles.eventAvatarMuted,
+              ]}
+            >
+              <Ionicons name="calendar" size={22} color={colors.textSecondary} />
+            </View>
+          )}
+          <View style={styles.waContent}>
+            <Text
+              style={[styles.waTitle, { color: isPast ? colors.textSecondary : colors.text }]}
+              numberOfLines={1}
+            >
+              {group.name}: {channel.name}
+            </Text>
+            <Text
+              style={[
+                styles.waPreview,
+                { color: isPast ? colors.textTertiary : colors.textSecondary },
+                hasUnread && !isPast && { fontWeight: "600", color: colors.text },
+              ]}
+              numberOfLines={1}
+            >
+              {messagePreview}
+            </Text>
+          </View>
+          <WaRowRightColumn
+            timestamp={timestamp}
+            hasUnread={hasUnread && !isPast}
+            unreadCount={channel.unreadCount}
+            primaryColor={primaryColor}
+            colors={colors}
+          />
+        </View>
+      </Pressable>
+    );
+  }
 
   return (
     <Pressable
@@ -1645,12 +1979,21 @@ interface DirectMessageRowProps {
   colors: {
     text: string;
     textSecondary: string;
+    textTertiary: string;
     surface: string;
+    surfaceSecondary: string;
   };
+  /**
+   * WA-GAP-MATRIX #2a/#2b: flat WaRow anatomy — 50pt avatar (was 56pt,
+   * mismatched against GroupedInboxItem's rows) and a timestamp (previously
+   * dead-code-only, never rendered). Flag off renders byte-identical to
+   * before.
+   */
+  whatsappShellEnabled?: boolean;
 }
 
 
-function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) {
+function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: DirectMessageRowProps) {
   const router = useRouter();
 
   // Display name: for 1:1, the other member; for group_dm, the channel name
@@ -1691,6 +2034,60 @@ function DirectMessageRow({ row, primaryColor, colors }: DirectMessageRowProps) 
       },
     });
   };
+
+  if (whatsappShellEnabled) {
+    const hasUnread = row.unreadCount > 0;
+    const timestamp = row.lastMessageAt ? formatRelativeTime(row.lastMessageAt) : undefined;
+    return (
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [styles.waRow, pressed && { backgroundColor: colors.surfaceSecondary }]}
+      >
+        <View style={styles.waAvatarSlot}>
+          {useStackedAvatars ? (
+            <StackedMemberAvatars
+              members={row.otherMembers.map((m) => ({
+                name: m.displayName,
+                imageUrl: m.profilePhoto,
+              }))}
+              surfaceColor={colors.surface}
+              size={WA_ROW_AVATAR_SIZE}
+            />
+          ) : (
+            <Avatar
+              name={primaryAvatar?.displayName ?? headerName}
+              imageUrl={primaryAvatar?.profilePhoto ?? undefined}
+              size={WA_ROW_AVATAR_SIZE}
+              notificationsDisabled={primaryAvatar?.notificationsDisabled ?? false}
+              notificationsBadgeRingColor={colors.surface}
+            />
+          )}
+        </View>
+        <View style={styles.waContent}>
+          <Text style={[styles.waTitle, { color: colors.text }]} numberOfLines={1}>
+            {headerName}
+          </Text>
+          <Text
+            style={[
+              styles.waPreview,
+              { color: colors.textSecondary },
+              hasUnread && { fontWeight: "600", color: colors.text },
+            ]}
+            numberOfLines={1}
+          >
+            {previewWithSender}
+          </Text>
+        </View>
+        <WaRowRightColumn
+          timestamp={timestamp}
+          hasUnread={hasUnread}
+          unreadCount={row.unreadCount}
+          primaryColor={primaryColor}
+          colors={colors}
+        />
+      </Pressable>
+    );
+  }
 
   return (
     <Pressable onPress={onPress} style={styles.dmRow}>
@@ -1748,7 +2145,9 @@ interface NotificationsInboxRowProps {
   colors: {
     text: string;
     textSecondary: string;
+    textTertiary: string;
     surface: string;
+    surfaceSecondary: string;
   };
   onPress: () => void;
   /**
@@ -1771,6 +2170,56 @@ function NotificationsInboxRow({
   onPress,
   whatsappShellEnabled,
 }: NotificationsInboxRowProps) {
+  if (whatsappShellEnabled) {
+    const hasUnread = row.unreadCount > 0;
+    return (
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [styles.waRow, pressed && { backgroundColor: colors.surfaceSecondary }]}
+        accessibilityRole="button"
+        accessibilityLabel={`Notifications${
+          row.unreadCount > 0 ? `, ${row.unreadCount} unread` : ""
+        }`}
+      >
+        <View
+          style={[
+            styles.waIconCircle,
+            {
+              width: WA_ROW_AVATAR_SIZE,
+              height: WA_ROW_AVATAR_SIZE,
+              borderRadius: WA_ROW_AVATAR_SIZE / 2,
+              backgroundColor: primaryColor + "14",
+            },
+          ]}
+        >
+          <Ionicons name="notifications" size={22} color={primaryColor} />
+        </View>
+        <View style={styles.waContent}>
+          <Text style={[styles.waTitle, { color: colors.text }]} numberOfLines={1}>
+            Notifications
+          </Text>
+          <Text
+            style={[
+              styles.waPreview,
+              { color: colors.textSecondary },
+              hasUnread && { fontWeight: "600", color: colors.text },
+            ]}
+            numberOfLines={1}
+          >
+            {row.previewTitle}
+          </Text>
+        </View>
+        <WaRowRightColumn
+          timestamp={formatRelativeTime(row.sortTime)}
+          hasUnread={hasUnread}
+          unreadCount={row.unreadCount}
+          primaryColor={primaryColor}
+          colors={colors}
+        />
+      </Pressable>
+    );
+  }
+
   return (
     <Pressable
       onPress={onPress}
@@ -1781,18 +2230,9 @@ function NotificationsInboxRow({
       }`}
     >
       <View
-        style={[
-          styles.notificationsIcon,
-          whatsappShellEnabled
-            ? { width: 50, height: 50, borderRadius: 25, backgroundColor: primaryColor + "14" }
-            : { backgroundColor: primaryColor },
-        ]}
+        style={[styles.notificationsIcon, { backgroundColor: primaryColor }]}
       >
-        <Ionicons
-          name="notifications"
-          size={whatsappShellEnabled ? 24 : 26}
-          color={whatsappShellEnabled ? primaryColor : "#ffffff"}
-        />
+        <Ionicons name="notifications" size={26} color="#ffffff" />
       </View>
       <View style={styles.dmRowContent}>
         <View style={styles.dmRowTopLine}>
@@ -2098,12 +2538,125 @@ const styles = StyleSheet.create({
   listContainer: {
     paddingVertical: 8,
   },
-  // WhatsApp-shell hairline row divider (flag-gated). Inset to roughly the
-  // text column so it starts past the avatar, matching GroupedInboxItem's
-  // internal separators.
+  // WhatsApp-shell hairline row divider (flag-gated). Inset to the text
+  // column so it starts past the avatar, matching GroupedInboxItem's
+  // internal separators — applies uniformly between every top-level row this
+  // FlatList renders (group clusters, DMs, events, notifications, requests).
   waListSeparator: {
     height: StyleSheet.hairlineWidth,
-    marginLeft: 78,
+    marginLeft: WA_ROW_SEPARATOR_INSET,
+  },
+
+  // --- WhatsApp-shell shared row anatomy (flag-gated) -----------------------
+  // Same shape/metrics as GroupedInboxItem.tsx's local `wa*` styles (not
+  // imported — those aren't exported, and this pass is scoped to this file),
+  // reused here by DM, event, notifications, and message-request rows so the
+  // whole blended Chats list reads as one row language.
+  waRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  waAvatarMain: {
+    width: WA_ROW_AVATAR_SIZE,
+    height: WA_ROW_AVATAR_SIZE,
+    borderRadius: WA_ROW_AVATAR_SIZE / 2,
+    marginRight: 12,
+  },
+  // Wraps avatar-slot nodes that manage their own sizing (Avatar,
+  // StackedMemberAvatars) so they still get the row's standard gap.
+  waAvatarSlot: {
+    marginRight: 12,
+  },
+  waIconCircle: {
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: 12,
+  },
+  waContent: {
+    flex: 1,
+    minWidth: 0,
+    justifyContent: "center",
+  },
+  waTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  waPreview: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  // Right column: timestamp stacked above the badge, top-aligned like
+  // WhatsApp (not vertically centered against the two-line content block).
+  waRightColumn: {
+    alignItems: "flex-end",
+    justifyContent: "flex-start",
+    marginLeft: 8,
+    alignSelf: "stretch",
+    paddingTop: 1,
+  },
+  waTimestamp: {
+    fontSize: 12,
+  },
+  waBadge: {
+    minWidth: 20,
+    height: 20,
+    borderRadius: 10,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 6,
+    marginTop: 4,
+  },
+  waBadgeText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  // Trailing chevron column for navigational (non-chat) flat rows, e.g.
+  // Message Requests — vertically centered against the row rather than
+  // top-aligned like the timestamp/badge column above.
+  waChevronColumn: {
+    width: 60,
+    alignItems: "flex-end",
+    justifyContent: "center",
+    marginLeft: 8,
+  },
+  // §4 large title (34pt) — layered on top of the shared `headerTitle` style
+  // only when the flag is on, so the flag-off "Inbox" title is untouched.
+  headerTitleWa: {
+    fontSize: 34,
+  },
+  // §4 circular header buttons (40pt, neutral-gray fill) — the compose "+"
+  // additionally gets a filled-accent background via an inline style where
+  // it's used; the community-avatar entry sits on the same gray fill.
+  headerActionButtonWa: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+  // §4 search pill: fully rounded, `bg.grouped`-ish fill, 37pt tall.
+  waSearchPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    height: 37,
+    borderRadius: 37 / 2,
+    marginTop: 12,
+    paddingHorizontal: 12,
+  },
+  waSearchIcon: {
+    marginRight: 8,
+  },
+  waSearchInput: {
+    flex: 1,
+    fontSize: 17,
+    padding: 0,
+  },
+  // §6 empty state, simplified per this pass's brief: centered secondary
+  // text only, no illustration/icon.
+  waEmptyText: {
+    fontSize: 15,
+    textAlign: "center",
   },
 
   // Events section

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -174,6 +174,14 @@ function WaChatSearchPill({
   const [value, setValue] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Clear the pending debounce on unmount so a late onSearch can't fire
+  // after the user navigates away mid-typing.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
   const handleChangeText = (text: string) => {
     setValue(text);
     if (debounceRef.current) clearTimeout(debounceRef.current);

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -31,11 +31,13 @@ import type { Id } from '@services/api/convex';
 import { useMessages } from '../hooks/useMessages';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { useTheme } from '@hooks/useTheme';
+import { useWhatsappShell } from '@hooks/useWhatsappShell';
 import { MessageItem } from './MessageItem';
 import { GhostThreadPointer } from './GhostThreadPointer';
 import { buildThreadAwareTimeline } from '../utils/threadTimeline';
 import { ReactionsProvider } from '../context/ReactionsContext';
 import { useChatPrefetch } from '../context/ChatPrefetchContext';
+import { WaDayPill } from '@components/wa/WaDayPill';
 
 // Message type from Convex (matches schema.ts chatMessages table)
 interface Message {
@@ -189,6 +191,10 @@ export function MessageList({
 }: MessageListProps) {
   const { primaryColor } = useCommunityTheme();
   const { colors: themeColors } = useTheme();
+  // WHATSAPP-DESIGN-SYSTEM.md §5 "Day pills" — flag-gated swap of the date
+  // separator to the WaDayPill capsule; flag-off keeps today's line+label
+  // separator byte-identical.
+  const whatsappShellEnabled = useWhatsappShell();
   const router = useRouter();
   const listRef = useRef<FlatList<ListItem>>(null);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
@@ -443,6 +449,18 @@ export function MessageList({
   const renderItem = useCallback(
     ({ item }: { item: ListItem }) => {
       if (item.type === 'dateSeparator') {
+        // §5 "Day pills: centered, floating capsule ... `bg.card`-ish
+        // translucent fill". Flag-off keeps the original line+label
+        // separator; stickiness/positioning is out of scope here (§5 notes
+        // it's the chat-room screen's responsibility, and it's unchanged by
+        // this pass regardless).
+        if (whatsappShellEnabled) {
+          return (
+            <View style={styles.waDateSeparatorContainer}>
+              <WaDayPill label={item.date} />
+            </View>
+          );
+        }
         return (
           <View style={styles.dateSeparatorContainer}>
             <View style={[styles.dateSeparatorLine, { backgroundColor: themeColors.border }]} />
@@ -524,7 +542,7 @@ export function MessageList({
         />
       );
     },
-    [currentUserId, groupId, channelName, prefetchState, onMessageReply, onMessageReact, onMessageDelete, onMessageLongPress, onMessageDoubleTap, onRetryMessage, onAvatarPress, effectiveHighlightId, handleGhostOpenThread, handleGhostScrollToOriginal]
+    [currentUserId, groupId, channelName, prefetchState, onMessageReply, onMessageReact, onMessageDelete, onMessageLongPress, onMessageDoubleTap, onRetryMessage, onAvatarPress, effectiveHighlightId, handleGhostOpenThread, handleGhostScrollToOriginal, whatsappShellEnabled, themeColors]
   );
 
   // Key extractor
@@ -703,6 +721,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginHorizontal: 12,
     textTransform: 'uppercase',
+  },
+  // §5 day pill: centered, floating capsule — no divider lines (wallpaper
+  // shows through around it).
+  waDateSeparatorContainer: {
+    alignItems: 'center',
+    marginVertical: 16,
   },
   scrollToBottomButton: {
     position: 'absolute',

--- a/apps/mobile/features/community/components/CommunityPageScreen.tsx
+++ b/apps/mobile/features/community/components/CommunityPageScreen.tsx
@@ -404,9 +404,9 @@ export function CommunityPageScreen() {
             straight to the announcement channel, the same destination the
             Announcements row further down opens. */}
         {announcementGroup && announcementChannel ? (
-          {/* Deliberate deviation from §3.2's bg.grouped track: this screen
-              itself sits on backgroundGrouped, which would make the track
-              invisible — separator gives it the visible recessed fill. */}
+          // Deliberate deviation from §3.2's bg.grouped track: this screen
+          // itself sits on backgroundGrouped, which would make the track
+          // invisible — separator gives it the visible recessed fill.
           <View style={[styles.segmentedTrack, { backgroundColor: colors.separator }]}>
             <View style={[styles.segmentedPill, { backgroundColor: colors.surfaceGrouped }]}>
               <Text style={[styles.segmentedLabel, styles.segmentedLabelSelected, { color: colors.text }]}>

--- a/apps/mobile/features/community/components/CommunityPageScreen.tsx
+++ b/apps/mobile/features/community/components/CommunityPageScreen.tsx
@@ -4,20 +4,34 @@
  * The WhatsApp "community info" analog (docs/plans/church-migration-ui-redesign
  * /README.md, "W2 — Community page"). A pushed screen — not a tab — opened
  * from the Chats list header when the whatsapp-shell flag is on. Read-only v1:
- * branded identity header, Announcements entry, Groups you're in, Groups you
- * can join (+ "Find your group"), This week's events, and role-gated
- * Prayer/Admin cells.
+ * centered hero (branded identity + "Community · N groups"), quick-action
+ * row, Community/Announcements segmented control, Announcements entry,
+ * Groups you're in, Groups you can join (+ "Find your group"), This week's
+ * events, and role-gated Prayer/Admin cells.
  *
- * Styled to WHATSAPP-DESIGN-SYSTEM.md §1/§3/§4/§8 ("Community page" checklist)
- * fidelity using the `components/wa/*` foundation kit — see that doc for the
- * anatomy each section below implements.
+ * Styled to WHATSAPP-DESIGN-SYSTEM.md §1/§3/§4/§6/§8 ("Community page"
+ * checklist) fidelity using the `components/wa/*` foundation kit — see that
+ * doc for the anatomy each section below implements.
+ *
+ * Quick-action row (§3.2/§6/§8) maps to real destinations only — this
+ * screen has no "Add Members"/"Add Groups" mutation to launch a sheet for,
+ * so only Invite (`/(user)/invite`) and Search (`/(tabs)/search`) render,
+ * per the design-system contract's "skip actions with no destination" rule.
+ *
+ * The Community/Announcements segmented control (§3.2, "Tab-style segmented
+ * control") is the simplest faithful reading of the spec: "Community" is
+ * always the active/rendered state (this screen's own sections, below);
+ * tapping "Announcements" navigates straight to the announcement channel —
+ * the same destination the Announcements row further down opens — rather
+ * than building a second in-screen feed.
  *
  * Route: /(user)/community
  *
  * Backend (all pre-existing, no new Convex functions added):
  * - messaging.channels.getInboxChannels — resolves the Announcements group's
  *   main channel, same lookup ChatInboxScreen/GroupedInboxItem use. Also
- *   supplies the preview/timestamp/unread data for the Announcements row.
+ *   supplies the preview/timestamp/unread data for the Announcements row and
+ *   gates whether the segmented control renders (no channel = no control).
  * - groups.queries.listForUser — "Groups you're in".
  * - groupSearch.searchGroupsWithMembership — "Groups you can join" (community
  *   explore defaults applied, same as GroupsScreen). This endpoint doesn't
@@ -58,14 +72,18 @@ import {
   WA_GROUP_SPACING,
   WA_AVATAR_LG,
   WA_AVATAR_SQUIRCLE_RADIUS,
+  WA_AVATAR_PROFILE,
+  WA_QUICK_ACTION_CIRCLE,
+  WA_SEGMENTED_HEIGHT,
 } from "@components/wa";
 
 const MAX_SUGGESTED_GROUPS = 3;
 const MAX_THIS_WEEK_EVENTS = 8;
 
-/** Hero identity avatar — bigger than the §3.1 list avatar (56pt) but built
- * from the same squircle-radius ratio so it scales proportionally per §6. */
-const HERO_AVATAR_SIZE = 80;
+/** Hero identity avatar — the profile-hero scale (§6) built from the same
+ * squircle-radius ratio as the §3.1 list avatar (56pt → 18pt radius) so it
+ * scales proportionally rather than using an arbitrary size. */
+const HERO_AVATAR_SIZE = WA_AVATAR_PROFILE;
 const HERO_AVATAR_RADIUS = HERO_AVATAR_SIZE * (WA_AVATAR_SQUIRCLE_RADIUS / WA_AVATAR_LG);
 
 /** Row-rail timestamp, matching §2's "12:52 PM" (today) / "Sunday" (this
@@ -101,6 +119,38 @@ function WaIconAvatar({
     >
       <Ionicons name={icon} size={22} color={tint} />
     </View>
+  );
+}
+
+/** §3.2/§6/§8 quick-action row button — accent-tinted circular icon
+ * (`WA_QUICK_ACTION_CIRCLE`), no fill, with a 13pt label below, no card
+ * container (floats directly on `bg.grouped`). */
+function WaQuickAction({
+  icon,
+  label,
+  accent,
+  onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  accent: string;
+  onPress: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <Pressable onPress={onPress} style={styles.quickAction} hitSlop={8}>
+      <View
+        style={[
+          styles.quickActionCircle,
+          { width: WA_QUICK_ACTION_CIRCLE, height: WA_QUICK_ACTION_CIRCLE },
+        ]}
+      >
+        <Ionicons name={icon} size={22} color={accent} />
+      </View>
+      <Text style={[styles.quickActionLabel, { color: colors.text }]} numberOfLines={1}>
+        {label}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -303,8 +353,9 @@ export function CommunityPageScreen() {
         contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Community identity — squircle avatar (§6, the one squircle in the
-            system), name, "Community · N groups" hero subtitle (§2). */}
+        {/* Community identity — centered squircle hero avatar (§6, the one
+            squircle in the system, profile-hero scale per §8), name,
+            "Community · N groups" hero subtitle (§2). */}
         <View style={styles.identityRow}>
           <AppImage
             source={community?.logo}
@@ -320,15 +371,57 @@ export function CommunityPageScreen() {
               backgroundColor: primaryColor,
             }}
           />
-          <View style={styles.identityText}>
-            <Text style={[styles.identityName, { color: colors.text }]} numberOfLines={2}>
-              {community?.name || "Your Community"}
-            </Text>
-            <Text style={[styles.identitySubtitle, { color: colors.textSecondary }]}>
-              {identitySubtitle}
-            </Text>
-          </View>
+          <Text style={[styles.identityName, { color: colors.text }]} numberOfLines={2}>
+            {community?.name || "Your Community"}
+          </Text>
+          <Text style={[styles.identitySubtitle, { color: colors.textSecondary }]}>
+            {identitySubtitle}
+          </Text>
         </View>
+
+        {/* Quick-action row (§3.2/§6/§8) — accent-icon-only circular
+            buttons, no fill. Mapped to real destinations only: this
+            screen has no "Add Members"/"Add Groups" mutation to launch, so
+            only Invite/Search render (see report). */}
+        <View style={styles.quickActionRow}>
+          <WaQuickAction
+            icon="person-add-outline"
+            label="Invite"
+            accent={primaryColor}
+            onPress={() => router.push("/(user)/invite" as any)}
+          />
+          <WaQuickAction
+            icon="search-outline"
+            label="Search"
+            accent={primaryColor}
+            onPress={() => router.push("/(tabs)/search" as any)}
+          />
+        </View>
+
+        {/* Community/Announcements segmented control (§3.2/§8) —
+            "Community" shows this screen's existing sections below (no
+            second feed built, per contract); "Announcements" navigates
+            straight to the announcement channel, the same destination the
+            Announcements row further down opens. */}
+        {announcementGroup && announcementChannel ? (
+          <View style={[styles.segmentedTrack, { backgroundColor: colors.separator }]}>
+            <View style={[styles.segmentedPill, { backgroundColor: colors.surfaceGrouped }]}>
+              <Text style={[styles.segmentedLabel, styles.segmentedLabelSelected, { color: colors.text }]}>
+                Community
+              </Text>
+            </View>
+            <Pressable
+              onPress={openAnnouncements}
+              style={styles.segmentedPill}
+              accessibilityRole="button"
+              accessibilityLabel="Open Announcements"
+            >
+              <Text style={[styles.segmentedLabel, { color: colors.textSecondary }]}>
+                Announcements
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
 
         {/* Announcements — WaRow inside an inset group (§3.2), megaphone
             icon-bubble avatar, latest preview line, timestamp + unread badge. */}
@@ -459,24 +552,60 @@ const styles = StyleSheet.create({
     padding: 4,
   },
   identityRow: {
-    flexDirection: "row",
     alignItems: "center",
     paddingHorizontal: WA_GROUP_MARGIN,
     paddingTop: 12,
-    paddingBottom: 24,
-    gap: 16,
-  },
-  identityText: {
-    flex: 1,
-    minWidth: 0,
+    paddingBottom: 20,
   },
   identityName: {
     fontSize: 22,
     fontWeight: "700",
+    marginTop: 12,
+    textAlign: "center",
   },
   identitySubtitle: {
     fontSize: 15,
     marginTop: 2,
+    textAlign: "center",
+  },
+  quickActionRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 40,
+    paddingBottom: 20,
+  },
+  quickAction: {
+    alignItems: "center",
+    width: 72,
+  },
+  quickActionCircle: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  quickActionLabel: {
+    fontSize: 13,
+    marginTop: 4,
+  },
+  segmentedTrack: {
+    flexDirection: "row",
+    marginHorizontal: WA_GROUP_MARGIN,
+    marginBottom: WA_GROUP_SPACING,
+    height: WA_SEGMENTED_HEIGHT,
+    borderRadius: WA_SEGMENTED_HEIGHT / 2,
+    padding: 2,
+  },
+  segmentedPill: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: (WA_SEGMENTED_HEIGHT - 4) / 2,
+  },
+  segmentedLabel: {
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  segmentedLabelSelected: {
+    fontWeight: "600",
   },
   section: {
     marginTop: WA_GROUP_SPACING,

--- a/apps/mobile/features/community/components/CommunityPageScreen.tsx
+++ b/apps/mobile/features/community/components/CommunityPageScreen.tsx
@@ -404,6 +404,9 @@ export function CommunityPageScreen() {
             straight to the announcement channel, the same destination the
             Announcements row further down opens. */}
         {announcementGroup && announcementChannel ? (
+          {/* Deliberate deviation from §3.2's bg.grouped track: this screen
+              itself sits on backgroundGrouped, which would make the track
+              invisible — separator gives it the visible recessed fill. */}
           <View style={[styles.segmentedTrack, { backgroundColor: colors.separator }]}>
             <View style={[styles.segmentedPill, { backgroundColor: colors.surfaceGrouped }]}>
               <Text style={[styles.segmentedLabel, styles.segmentedLabelSelected, { color: colors.text }]}>

--- a/apps/mobile/features/groups/components/GroupInfoScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupInfoScreen.tsx
@@ -572,8 +572,10 @@ export function GroupInfoScreen() {
           </WaInsetGroup>
         </View>
 
-        {/* 4. MEMBERS — same tap gates GroupDetailScreen applies
-            (announcement-group + non-member guard). */}
+        {/* 4. MEMBERS — WaInsetGroup: the MembersRow avatar-stack preview
+            plus a "View all members" WaCell (§3.2 navigational row). Same
+            tap gates GroupDetailScreen applies (announcement-group +
+            non-member guard). */}
         {((group.members && group.members.length > 0) ||
           (group.leaders && group.leaders.length > 0) ||
           (group.members_count && group.members_count > 0) ||
@@ -581,37 +583,38 @@ export function GroupInfoScreen() {
           // signals are empty — GroupDetailScreen shows its Requests tile
           // independently of the members card.
           showRequestsBadge) && (
-          <View style={sectionStyles.section}>
-            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>
-              MEMBERS{group.members_count ? ` · ${group.members_count}` : ""}
-            </Text>
-            {(() => {
-              const isAnnouncementRoster =
-                !!group.is_announcement_group && !(isLeader || isAdmin);
-              const hasGroupMembership = !!group.user_role;
-              const tapEnabled = !isAnnouncementRoster && hasGroupMembership;
-              const Container: React.ComponentType<any> = tapEnabled ? TouchableOpacity : View;
-              return (
-                <Container
-                  {...(tapEnabled ? { activeOpacity: 0.7, onPress: handleMembersPress } : {})}
-                  style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}
-                >
-                  <MembersRow
-                    members={group.members}
-                    leaders={group.leaders}
-                    totalCount={group.members_count ?? undefined}
-                  />
-                  {tapEnabled && (
-                    <View style={[sectionStyles.viewAllRow, { borderTopColor: colors.border }]}>
-                      <Text style={[sectionStyles.viewAllText, { color: colors.text }]}>
-                        View all members
-                      </Text>
-                      <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
-                    </View>
-                  )}
-                </Container>
-              );
-            })()}
+          <View style={styles.waSection}>
+            <WaInsetGroup
+              header={`Members${group.members_count ? ` · ${group.members_count}` : ""}`}
+              separatorInset={0}
+            >
+              {(() => {
+                const isAnnouncementRoster =
+                  !!group.is_announcement_group && !(isLeader || isAdmin);
+                const hasGroupMembership = !!group.user_role;
+                const tapEnabled = !isAnnouncementRoster && hasGroupMembership;
+                const rows: React.ReactNode[] = [
+                  <View key="members-preview">
+                    <MembersRow
+                      members={group.members}
+                      leaders={group.leaders}
+                      totalCount={group.members_count ?? undefined}
+                    />
+                  </View>,
+                ];
+                if (tapEnabled) {
+                  rows.push(
+                    <WaCell
+                      key="view-all-members"
+                      variant="navigational"
+                      title="View all members"
+                      onPress={handleMembersPress}
+                    />,
+                  );
+                }
+                return rows;
+              })()}
+            </WaInsetGroup>
             {showRequestsBadge && (
               <TouchableOpacity
                 onPress={() => router.push(`/groups/${group._id}/requests` as any)}
@@ -628,278 +631,180 @@ export function GroupInfoScreen() {
           </View>
         )}
 
-        {/* 5. CHANNELS — rendered exactly as-is; not modified. */}
+        {/* 5. CHANNELS — rendered exactly as-is; not modified (out of
+            scope for this restyle pass — see file-header deferral note). */}
         {group._id && <ChannelsSection groupId={group._id} userRole={group.user_role} />}
 
-        {/* 6. LEADER TOOLS — leader/admin only, reusing today's routes. */}
+        {/* 6. LEADER TOOLS — leader/admin only, WaInsetGroup of navigational
+            WaCells (plain monochrome glyphs per §3.2), reusing today's
+            routes. */}
         {(isLeader || isAdmin) && group._id && (
-          <View style={sectionStyles.section}>
-            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>
-              LEADER TOOLS
-            </Text>
-            <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
-              <LeaderToolRow
+          <View style={styles.waSection}>
+            <WaInsetGroup header="Leader tools">
+              <WaCell
                 icon="pulse-outline"
-                label="People"
+                title="People"
                 onPress={() => router.push(`/(user)/leader-tools/${group._id}/followup` as any)}
-                topBorder={false}
               />
-              <LeaderToolRow
+              <WaCell
                 icon="checkmark-done-outline"
-                label="Attendance"
+                title="Attendance"
                 onPress={() => router.push(`/(user)/leader-tools/${group._id}/attendance` as any)}
               />
-              <LeaderToolRow
+              <WaCell
                 icon="list-outline"
-                label="Tasks"
+                title="Tasks"
                 onPress={() => router.push(`/(user)/leader-tools/${group._id}/tasks` as any)}
               />
-              <LeaderToolRow
+              <WaCell
                 icon="calendar-outline"
-                label="Rostering"
+                title="Rostering"
                 onPress={() => router.push(`/rostering/${group._id}` as any)}
               />
-              <LeaderToolRow
+              <WaCell
                 icon="document-text-outline"
-                label="Run sheet"
+                title="Run sheet"
                 onPress={() => router.push(`/(user)/leader-tools/${group._id}/run-sheet` as any)}
               />
-              <LeaderToolRow
+              <WaCell
                 icon="folder-outline"
-                label="Resources"
+                title="Resources"
                 onPress={() => router.push(`/(user)/leader-tools/${group._id}/resources` as any)}
               />
-              <LeaderToolRow
+              <WaCell
                 icon="options-outline"
-                label="Toolbar settings"
+                title="Toolbar settings"
                 onPress={() => router.push(`/(user)/leader-tools/${group._id}/toolbar-settings` as any)}
               />
-            </View>
+            </WaInsetGroup>
           </View>
         )}
 
-        {/* 7. BOTS — rendered exactly as-is (leader-gated internally). */}
+        {/* 7. BOTS — rendered exactly as-is (leader-gated internally, out
+            of scope for this restyle pass). */}
         {group._id && <GroupBotsSection groupId={group._id} isLeader={isLeader} />}
 
-        {/* 8. DETAILS — meeting day/time, meeting type/link, address,
-            external chat link. */}
+        {/* 8. DETAILS — WaInsetGroup of WaCells: meeting day/time, meeting
+            type/link, address, external chat link. Cadence has no onPress
+            (pure text), so its WaCell renders inert (still shows a chevron
+            — a known WaCell-anatomy limitation for "Navigational" rows;
+            see restyle report). `WaCell.title` is single-line, so a long
+            address now truncates instead of wrapping to 2 lines — also
+            noted in the restyle report. */}
         {showDetailsCard && (
-          <View style={sectionStyles.section}>
-            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>DETAILS</Text>
-            <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
-              {!!cadence && (
-                <View style={sectionStyles.detailRow}>
-                  <Ionicons name="calendar-outline" size={20} color={colors.icon} />
-                  <Text style={[sectionStyles.detailText, { color: colors.text }]}>{cadence}</Text>
-                </View>
-              )}
+          <View style={styles.waSection}>
+            <WaInsetGroup header="Details">
+              {!!cadence && <WaCell icon="calendar-outline" title={cadence} />}
               {!!meetingTypeLabel && (
-                <TouchableOpacity
+                <WaCell
+                  icon={meetingTypeLabel === "Online" ? "videocam-outline" : "body-outline"}
+                  title={meetingTypeLabel}
+                  description={meetingLink ?? undefined}
                   onPress={meetingLink ? () => Linking.openURL(meetingLink) : undefined}
-                  disabled={!meetingLink}
-                  activeOpacity={0.7}
-                  style={[
-                    sectionStyles.detailRow,
-                    !!cadence && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
-                  ]}
-                >
-                  <Ionicons
-                    name={meetingTypeLabel === "Online" ? "videocam-outline" : "body-outline"}
-                    size={20}
-                    color={colors.icon}
-                  />
-                  <Text style={[sectionStyles.detailText, { color: colors.text }]} numberOfLines={1}>
-                    {meetingTypeLabel}{meetingLink ? ` · ${meetingLink}` : ""}
-                  </Text>
-                  {!!meetingLink && (
-                    <Ionicons name="open-outline" size={18} color={colors.textTertiary} />
-                  )}
-                </TouchableOpacity>
+                />
               )}
               {!!address && (
-                <TouchableOpacity
+                <WaCell
+                  icon="location-outline"
+                  title={address}
                   onPress={handleAddressPress}
-                  activeOpacity={0.7}
-                  style={[
-                    sectionStyles.detailRow,
-                    (!!cadence || !!meetingTypeLabel) && {
-                      borderTopWidth: StyleSheet.hairlineWidth,
-                      borderTopColor: colors.border,
-                    },
-                  ]}
-                >
-                  <Ionicons name="location-outline" size={20} color={colors.icon} />
-                  <Text style={[sectionStyles.detailText, { color: colors.text }]} numberOfLines={2}>
-                    {address}
-                  </Text>
-                  <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
-                </TouchableOpacity>
+                />
               )}
               {!!externalChatLink && externalChatInfo && (
-                <TouchableOpacity
+                <WaCell
+                  icon={externalChatInfo.iconName as any}
+                  iconColor={externalChatInfo.color}
+                  title={`Also chats on ${externalChatInfo.name}`}
                   onPress={() => openExternalChatLink(externalChatLink)}
-                  activeOpacity={0.7}
-                  style={[
-                    sectionStyles.detailRow,
-                    (!!cadence || !!meetingTypeLabel || !!address) && {
-                      borderTopWidth: StyleSheet.hairlineWidth,
-                      borderTopColor: colors.border,
-                    },
-                  ]}
-                >
-                  <Ionicons
-                    name={externalChatInfo.iconName as any}
-                    size={20}
-                    color={externalChatInfo.color}
-                  />
-                  <Text style={[sectionStyles.detailText, { color: colors.text }]} numberOfLines={1}>
-                    Also chats on {externalChatInfo.name}
-                  </Text>
-                  <Ionicons name="open-outline" size={18} color={colors.textTertiary} />
-                </TouchableOpacity>
+                />
               )}
-            </View>
+            </WaInsetGroup>
           </View>
         )}
 
         {/* 9. SETTINGS — community-admin-only rows with an ADMIN tag,
-            reusing EditGroupScreen's exact mutations. */}
+            reusing EditGroupScreen's exact mutations. WaCell has no slot
+            for an inline badge next to the title, so these two rows stay a
+            bespoke toggle row (built to the same WA_CELL_* metrics as
+            WaCell) inside a WaInsetGroup card — see restyle report. */}
         {isAdmin && (
-          <View style={sectionStyles.section}>
-            <Text style={[sectionStyles.sectionHeader, { color: colors.textSecondary }]}>SETTINGS</Text>
-            <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
-              <View style={styles.settingsRow}>
-                <View style={styles.settingsRowTextWrap}>
-                  <View style={styles.settingsRowTitleLine}>
-                    <Text style={[styles.settingsRowLabel, { color: colors.text }]}>
-                      Hidden from discovery
-                    </Text>
-                    <AdminTag />
-                  </View>
-                  <Text style={[styles.settingsRowDescription, { color: colors.textSecondary }]}>
-                    Won't appear on the map, near-me page, or group browse.
-                  </Text>
-                </View>
-                <Switch
-                  value={hiddenFromDiscovery}
-                  onValueChange={handleToggleHiddenFromDiscovery}
-                  disabled={isSavingHidden}
-                  trackColor={{ false: colors.border, true: primaryColor }}
-                  thumbColor={colors.textInverse}
-                />
-              </View>
-              <View
-                style={[
-                  styles.settingsRow,
-                  { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
-                ]}
-              >
-                <View style={styles.settingsRowTextWrap}>
-                  <View style={styles.settingsRowTitleLine}>
-                    <Text style={[styles.settingsRowLabel, { color: colors.text }]}>
-                      Join approval: leaders
-                    </Text>
-                    <AdminTag />
-                  </View>
-                  <Text style={[styles.settingsRowDescription, { color: colors.textSecondary }]}>
-                    When off, community admins approve join requests instead.
-                  </Text>
-                </View>
-                <Switch
-                  value={leadersApprove}
-                  onValueChange={handleToggleLeadersApprove}
-                  disabled={isSavingApproval}
-                  trackColor={{ false: colors.border, true: primaryColor }}
-                  thumbColor={colors.textInverse}
-                />
-              </View>
-            </View>
+          <View style={styles.waSection}>
+            <WaInsetGroup header="Settings" separatorInset={0}>
+              <SettingsToggleRow
+                label="Hidden from discovery"
+                description="Won't appear on the map, near-me page, or group browse."
+                value={hiddenFromDiscovery}
+                onValueChange={handleToggleHiddenFromDiscovery}
+                disabled={isSavingHidden}
+                accent={primaryColor}
+              />
+              <SettingsToggleRow
+                label="Join approval: leaders"
+                description="When off, community admins approve join requests instead."
+                value={leadersApprove}
+                onValueChange={handleToggleLeadersApprove}
+                disabled={isSavingApproval}
+                accent={primaryColor}
+              />
+            </WaInsetGroup>
           </View>
         )}
 
-        {/* 10. BOTTOM RED ROWS — Leave (hidden for announcement groups),
-            Archive (admin only, with ADMIN tag). */}
-        <View style={sectionStyles.section}>
-          <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
+        {/* 10. BOTTOM RED ROWS (§1.4/§3.3/§8) — Leave (hidden for
+            announcement groups) as a plain WaCell destructive row (no
+            icon, no chevron); Archive (admin only) stays a bespoke
+            destructive row so it can carry the trailing ADMIN tag WaCell
+            has no slot for. */}
+        <View style={styles.waSection}>
+          <WaInsetGroup separatorInset={0}>
             {!group.is_announcement_group && (
-              <TouchableOpacity
-                activeOpacity={0.7}
-                onPress={handleLeaveGroup}
-                style={styles.dangerRow}
-              >
-                <Ionicons name="exit-outline" size={20} color={colors.destructive} />
-                <Text style={[styles.dangerLabel, { color: colors.destructive }]}>Leave Group</Text>
-              </TouchableOpacity>
+              <WaCell variant="destructive" title="Leave Group" onPress={handleLeaveGroup} />
             )}
             {canArchiveGroup && (
               <TouchableOpacity
                 activeOpacity={0.7}
                 onPress={handleArchiveGroup}
-                style={[
-                  styles.dangerRow,
-                  !group.is_announcement_group && {
-                    borderTopWidth: StyleSheet.hairlineWidth,
-                    borderTopColor: colors.border,
-                  },
-                ]}
+                style={styles.dangerRow}
               >
-                <Ionicons name="archive-outline" size={20} color={colors.destructive} />
                 <Text style={[styles.dangerLabel, { color: colors.destructive }]}>Archive Group</Text>
                 <View style={{ flex: 1 }} />
                 <AdminTag />
               </TouchableOpacity>
             )}
-          </View>
+          </WaInsetGroup>
         </View>
       </ScrollView>
     </>
   );
 }
 
+/**
+ * IconAction — the §3.2 "quick-action row" button (Add Members/Add Groups/
+ * Search on the reference Community-info screenshot): a card-colored pill,
+ * accent-tinted glyph, 13pt label. Accent-colored per §8's Group-info
+ * checklist ("icon action row … accent icons") — distinct from the
+ * monochrome rule that governs cell icons *inside* an inset-grouped card.
+ */
 function IconAction({
   icon,
   label,
   onPress,
+  accent,
 }: {
   icon: React.ComponentProps<typeof Ionicons>["name"];
   label: string;
   onPress: () => void;
-}) {
-  const { colors } = useTheme();
-  return (
-    <TouchableOpacity style={styles.iconAction} onPress={onPress} activeOpacity={0.7}>
-      <View style={[styles.iconActionCircle, { backgroundColor: colors.surfaceSecondary }]}>
-        <Ionicons name={icon} size={22} color={colors.text} />
-      </View>
-      <Text style={[styles.iconActionLabel, { color: colors.text }]}>{label}</Text>
-    </TouchableOpacity>
-  );
-}
-
-function LeaderToolRow({
-  icon,
-  label,
-  onPress,
-  topBorder = true,
-}: {
-  icon: React.ComponentProps<typeof Ionicons>["name"];
-  label: string;
-  onPress: () => void;
-  topBorder?: boolean;
+  accent: string;
 }) {
   const { colors } = useTheme();
   return (
     <TouchableOpacity
-      activeOpacity={0.7}
+      style={[styles.iconAction, { backgroundColor: colors.surfaceGrouped }]}
       onPress={onPress}
-      style={[
-        styles.leaderToolRow,
-        topBorder && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
-      ]}
+      activeOpacity={0.7}
     >
-      <Ionicons name={icon} size={20} color={colors.icon} />
-      <Text style={[styles.leaderToolLabel, { color: colors.text }]}>{label}</Text>
-      <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+      <Ionicons name={icon} size={22} color={accent} />
+      <Text style={[styles.iconActionLabel, { color: colors.text }]}>{label}</Text>
     </TouchableOpacity>
   );
 }
@@ -908,8 +813,53 @@ function LeaderToolRow({
 function AdminTag() {
   const { colors } = useTheme();
   return (
-    <View style={[styles.adminTag, { backgroundColor: colors.textTertiary + "26", borderColor: colors.border }]}>
+    <View style={[styles.adminTag, { backgroundColor: colors.textTertiary + "26", borderColor: colors.separator }]}>
       <Text style={[styles.adminTagText, { color: colors.textSecondary }]}>ADMIN</Text>
+    </View>
+  );
+}
+
+/**
+ * SettingsToggleRow — an ADMIN-tagged toggle row for the SETTINGS group
+ * (§9). `WaCell`'s `title` is a plain string with no slot for an inline
+ * badge next to it, so this is a bespoke row built to the same
+ * `WA_CELL_*` metrics as `WaCell` (padding, min height, type scale) rather
+ * than a literal `<WaCell>` — see the restyle report for why.
+ */
+function SettingsToggleRow({
+  label,
+  description,
+  value,
+  onValueChange,
+  disabled,
+  accent,
+}: {
+  label: string;
+  description: string;
+  value: boolean;
+  onValueChange: (next: boolean) => void;
+  disabled?: boolean;
+  accent: string;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.settingsRow}>
+      <View style={styles.settingsRowTextWrap}>
+        <View style={styles.settingsRowTitleLine}>
+          <Text style={[styles.settingsRowLabel, { color: colors.text }]}>{label}</Text>
+          <AdminTag />
+        </View>
+        <Text style={[styles.settingsRowDescription, { color: colors.textTertiary }]}>
+          {description}
+        </Text>
+      </View>
+      <Switch
+        value={value}
+        onValueChange={onValueChange}
+        disabled={disabled}
+        trackColor={{ false: colors.textTertiary, true: accent }}
+        thumbColor="#FFFFFF"
+      />
     </View>
   );
 }
@@ -938,45 +888,34 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
   },
+  // §2 "Community/group member count, hero subtitle": 15pt Regular, text.secondary.
   heroMeta: {
     marginTop: -16,
     marginBottom: 8,
-    fontSize: 13,
-    fontWeight: "500",
+    fontSize: 15,
+    fontWeight: "400",
     textAlign: "center",
+  },
+  waSection: {
+    marginTop: WA_GROUP_SPACING,
   },
   iconActionRow: {
     flexDirection: "row",
     justifyContent: "center",
-    gap: 32,
+    gap: 12,
+    paddingHorizontal: WA_GROUP_MARGIN,
     paddingVertical: 12,
   },
   iconAction: {
-    alignItems: "center",
-    gap: 6,
-  },
-  iconActionCircle: {
-    width: 52,
-    height: 52,
-    borderRadius: 26,
+    flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    gap: 6,
+    paddingVertical: 14,
+    borderRadius: 14,
   },
   iconActionLabel: {
-    fontSize: 12,
-    fontWeight: "500",
-  },
-  muteRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    minHeight: 48,
-  },
-  muteLabel: {
-    flex: 1,
-    fontSize: 16,
+    fontSize: 13,
     fontWeight: "500",
   },
   requestsBadgeRow: {
@@ -984,6 +923,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
     marginTop: 8,
+    marginHorizontal: WA_GROUP_MARGIN,
     paddingHorizontal: 12,
     paddingVertical: 10,
     borderRadius: 10,
@@ -992,19 +932,6 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 13,
     fontWeight: "600",
-  },
-  leaderToolRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    minHeight: 48,
-  },
-  leaderToolLabel: {
-    flex: 1,
-    fontSize: 16,
-    fontWeight: "500",
   },
   settingsRow: {
     flexDirection: "row",

--- a/apps/mobile/features/groups/components/GroupInfoScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupInfoScreen.tsx
@@ -12,18 +12,28 @@
  *
  * Rendered only behind the `whatsapp-shell` flag (see
  * `app/groups/[group_id]/index.tsx`); `GroupDetailScreen` is untouched and
- * keeps rendering when the flag is off.
+ * keeps rendering when the flag is off. Because this screen only ever
+ * mounts flag-on, it's styled unconditionally to
+ * `docs/plans/church-migration-ui-redesign/WHATSAPP-DESIGN-SYSTEM.md` §3b
+ * (inset-grouped) / §8 ("Group info" checklist) using the `components/wa/*`
+ * kit — `bg.grouped` canvas, `WaInsetGroup`/`WaCell` for every card, plain
+ * monochrome cell icons, red destructive cells with no icon/chevron.
  *
  * Deferred from the full W13 spec (out of scope for this composition pass):
  *   - Hero photo tap-to-viewer, cadence, description, and the edit pencil
- *     all come for free from the existing `GroupHeader` component.
+ *     all come for free from the existing `GroupHeader` component (already
+ *     a centered circular-avatar hero — out of this pass's touched-file
+ *     list, so left as-is).
  *   - "Search" in the icon action row (README's icon list) — the task's
  *     explicit v1 scope is Share + Invite only.
  *   - Events section (README lists it between Channels and Leader tools) —
  *     not in this task's explicit numbered scope; left for a follow-up pass.
  *   - Pinned-channel reorder mode and per-channel mute — `ChannelsSection`
- *     is rendered unmodified, so it ships whatever that component already
- *     supports today.
+ *     is rendered unmodified (explicitly out of scope for this restyle
+ *     pass), so it ships whatever that component already supports/looks
+ *     like today — including its own `colors.background`/bordered-card
+ *     styling, which now sits on this screen's `bg.grouped` canvas as a
+ *     known, deferred visual seam (see file-level restyle note below).
  *   - `isOnBreak` / `isPublic` settings rows — FEATURE-MAP §3 flags these as
  *     "schema-only, no UI today" backlog items, not part of this page yet.
  */
@@ -72,13 +82,18 @@ import { MembersRow } from "./MembersRow";
 import { GroupNonMemberView } from "./GroupNonMemberView";
 import { ChannelsSection } from "./ChannelsSection";
 import { GroupBotsSection } from "./GroupBotsSection";
-import { sectionStyles } from "./sectionStyles";
 import { isGroupMember, formatCadence } from "../utils";
 import { formatError } from "@/utils/error-handling";
 import {
   getExternalChatInfo,
   openExternalChatLink,
 } from "@features/chat/utils/externalChat";
+import {
+  WaInsetGroup,
+  WaCell,
+  WA_GROUP_SPACING,
+  WA_GROUP_MARGIN,
+} from "@components/wa";
 
 export function GroupInfoScreen() {
   // Router param name/shape matches the route file
@@ -511,16 +526,17 @@ export function GroupInfoScreen() {
   return (
     <>
       <ScrollView
-        style={[styles.scrollView, { backgroundColor: colors.background }]}
+        style={[styles.scrollView, { backgroundColor: colors.backgroundGrouped }]}
         contentContainerStyle={{ paddingBottom: 24 }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl refreshing={isRefetching} onRefresh={handleRefresh} tintColor={colors.link} />
         }
       >
-        {/* 1. HERO — photo/name/cadence/description/edit-pencil all come
-            from the unmodified GroupHeader. We only add the member-count +
-            group-type meta line it doesn't already render. */}
+        {/* 1. HERO — centered photo/name come from the unmodified
+            GroupHeader (already a §6-style centered circular hero — out of
+            this pass's touched-file list). We only add the §2 "member
+            count, hero subtitle" meta line it doesn't already render. */}
         <GroupHeader group={group} canEdit={canEditGroup} />
         {heroMetaParts.length > 0 && (
           <Text style={[styles.heroMeta, { color: colors.textSecondary }]}>
@@ -528,31 +544,32 @@ export function GroupInfoScreen() {
           </Text>
         )}
 
-        {/* 2. ICON ACTION ROW — Share + Invite. Invite reuses the same
-            share flow for v1 (no separate invite-kit yet). */}
+        {/* 2. ICON ACTION ROW (§3.2/§8) — Share + Invite. Accent-tinted
+            glyphs on a card-colored pill, no card container around the
+            row itself. Invite reuses the same share flow for v1 (no
+            separate invite-kit yet — see file-header deferral note). */}
         {!!group.shortId && (
           <View style={styles.iconActionRow}>
-            <IconAction icon="share-outline" label="Share" onPress={handleShareGroup} />
-            <IconAction icon="person-add-outline" label="Invite" onPress={handleShareGroup} />
+            <IconAction icon="share-outline" label="Share" onPress={handleShareGroup} accent={primaryColor} />
+            <IconAction icon="person-add-outline" label="Invite" onPress={handleShareGroup} accent={primaryColor} />
           </View>
         )}
 
-        {/* 3. MUTE GROUP — reuses the exact per-group notification
-            query/mutation NotificationPreferencesSection uses. */}
-        <View style={sectionStyles.section}>
-          <View style={[sectionStyles.card, { backgroundColor: colors.surfaceSecondary }]}>
-            <View style={styles.muteRow}>
-              <Ionicons name="notifications-off-outline" size={20} color={colors.icon} />
-              <Text style={[styles.muteLabel, { color: colors.text }]}>Mute group</Text>
-              <Switch
-                value={isMuted}
-                onValueChange={handleToggleMuted}
-                disabled={isSavingMute}
-                trackColor={{ false: colors.border, true: primaryColor }}
-                thumbColor={colors.textInverse}
-              />
-            </View>
-          </View>
+        {/* 3. MUTE GROUP — WaCell toggle (§3.2/§6: native Switch, accent-on
+            track). Reuses the exact per-group notification query/mutation
+            NotificationPreferencesSection uses. */}
+        <View style={styles.waSection}>
+          <WaInsetGroup>
+            <WaCell
+              icon="notifications-off-outline"
+              title="Mute group"
+              variant="toggle"
+              toggleValue={isMuted}
+              onToggleChange={handleToggleMuted}
+              disabled={isSavingMute}
+              accent={primaryColor}
+            />
+          </WaInsetGroup>
         </View>
 
         {/* 4. MEMBERS — same tap gates GroupDetailScreen applies

--- a/apps/mobile/features/profile/components/YouScreen.tsx
+++ b/apps/mobile/features/profile/components/YouScreen.tsx
@@ -9,8 +9,12 @@
  *
  * WHATSAPP-DESIGN-SYSTEM.md §3.2 (inset-grouped lists) + §4 (nav chrome) +
  * §8 You-tab checklist: `backgroundGrouped` canvas, `WaScreenHeader` large
- * title, stacked `WaInsetGroup`/`WaCell` cards, plain monochrome icons —
- * never a colored icon-chip background.
+ * title, a profile-hero tall cell (`YouProfileCell` — ~56pt avatar + name +
+ * community subtitle + chevron, matching the reference Settings screenshot's
+ * avatar/name/status treatment; a local variant since `WaCell`'s icon column
+ * is fixed at 28pt, too narrow for this avatar size), stacked
+ * `WaInsetGroup`/`WaCell` cards below it, plain monochrome icons — never a
+ * colored icon-chip background.
  *
  * Every route and permission gate below is copied verbatim from
  * `ProfileMenu.tsx` / `ProfileScreen.tsx` / `(tabs)/_layout.tsx` (Admin tab
@@ -18,7 +22,8 @@
  * mapping in each row's inline comment.
  */
 import React from "react";
-import { View, ScrollView, StyleSheet } from "react-native";
+import { View, Text, Pressable, ScrollView, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import Constants from "expo-constants";
@@ -34,7 +39,63 @@ import {
   WaCell,
   WaScreenHeader,
   WA_GROUP_SPACING,
+  WA_CELL_PADDING,
+  WA_ROW_AVATAR_GAP,
+  WA_AVATAR_LG,
+  WA_CHEVRON_SIZE,
 } from "@components/wa";
+
+/**
+ * WaCell's icon column is a fixed 28pt (`WA_CELL_ICON_COLUMN`) — too narrow
+ * for the ~56–60pt "tall cell" profile avatar the You-tab reference
+ * screenshot shows (avatar + name + status), so this is a minimal local row
+ * variant rather than a misuse of `WaCell`'s `iconNode` slot. It stays
+ * consistent with the kit: `WA_AVATAR_LG` (the same 56pt avatar size §3.1
+ * list rows use), `WA_CELL_PADDING`/`WA_ROW_AVATAR_GAP`/`WA_CHEVRON_SIZE`
+ * for spacing, and it's meant to sit as the sole child of a `WaInsetGroup`
+ * so it still gets the card fill/corner-radius/press-highlight for free.
+ */
+const YOU_PROFILE_AVATAR_SIZE = WA_AVATAR_LG;
+const YOU_PROFILE_CELL_MIN_HEIGHT = 84;
+
+function YouProfileCell({
+  name,
+  imageUrl,
+  subtitle,
+  onPress,
+  disabled,
+}: {
+  name: string;
+  imageUrl?: string | null;
+  subtitle?: string;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
+  const { colors, isDark } = useTheme();
+  const pressHighlight = isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.04)";
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [pressed && { backgroundColor: pressHighlight }]}
+    >
+      <View style={[styles.profileRow, { minHeight: YOU_PROFILE_CELL_MIN_HEIGHT }]}>
+        <Avatar name={name} imageUrl={imageUrl} size={YOU_PROFILE_AVATAR_SIZE} />
+        <View style={styles.profileTextColumn}>
+          <Text style={[styles.profileName, { color: colors.text }]} numberOfLines={1}>
+            {name || "Your profile"}
+          </Text>
+          {subtitle ? (
+            <Text style={[styles.profileSubtitle, { color: colors.textSecondary }]} numberOfLines={1}>
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+        <Ionicons name="chevron-forward" size={WA_CHEVRON_SIZE} color={colors.textTertiary} />
+      </View>
+    </Pressable>
+  );
+}
 
 export function YouScreen() {
   const insets = useSafeAreaInsets();
@@ -109,14 +170,17 @@ export function YouScreen() {
         contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 24 }]}
         showsVerticalScrollIndicator={false}
       >
-        {/* Profile card — avatar + name + community name, navigates to View Profile
-            (ProfileMenu's "View Profile" row / route). Editing is the header's pencil action. */}
+        {/* Profile hero cell — WhatsApp Settings' avatar+name+status tall
+            cell (§8 You-tab checklist): ~56pt avatar, name + community
+            subtitle, chevron. Navigates to View Profile (ProfileMenu's
+            "View Profile" row / route); editing is the header's pencil
+            action. */}
         <View style={styles.group}>
           <WaInsetGroup>
-            <WaCell
-              iconNode={<Avatar name={fullName} imageUrl={user?.profile_photo} size={36} />}
-              title={fullName || "Your profile"}
-              description={community?.name}
+            <YouProfileCell
+              name={fullName}
+              imageUrl={user?.profile_photo}
+              subtitle={community?.name}
               onPress={() => {
                 if (userId) router.push(`/(user)/profile/${userId}`);
               }}
@@ -271,5 +335,24 @@ const styles = StyleSheet.create({
   },
   group: {
     marginBottom: WA_GROUP_SPACING,
+  },
+  profileRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: WA_CELL_PADDING,
+  },
+  profileTextColumn: {
+    flex: 1,
+    minWidth: 0,
+    marginLeft: WA_ROW_AVATAR_GAP,
+    marginRight: 8,
+  },
+  profileName: {
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  profileSubtitle: {
+    fontSize: 15,
+    marginTop: 2,
   },
 });


### PR DESCRIPTION
## Summary

Second wave of the WhatsApp Plus visual-parity campaign (follows #640). All flag-gated; flag-off verified per surface.

### Chats list — one visual language
DM rows (gain timestamps for the first time), Notifications, event rows (accent bars/urgency pills/inline CTAs dropped per the gap matrix), and message-requests all join the flat WhatsApp anatomy; 34pt large title, 40pt circular header buttons, spec-metric search pill, uniform 50pt avatars, simplified empty state. Serving mode untouched.

### Chat room
Date separators as the centered WaDayPill capsule. Findings recorded: no inline reply-quote exists to restyle (Togather replies are thread-based — product difference, not a styling gap); message grouping needs a joint MessageList+MessageItem pass (queued wave 3).

### Group info / channel info / channel directory
Inset-grouped anatomy throughout (backgroundGrouped canvas, WaInsetGroup/WaCell, destructive cells, ADMIN-tagged bespoke rows where the kit lacks a badge slot); directory as full-bleed WaRows with accent Join/Request text-buttons. ChannelInfoScreen's flag-off branches verified byte-identical; per-type logic untouched. Documented deferred seams: embedded ChannelsSection/GroupBotsSection and pending-invite/requests/PCO panels.

### Community page + You tab spec gaps (from wave-1 review)
Community: centered WA_AVATAR_PROFILE squircle hero, accent quick-action circles (Invite, Search — only real destinations), Community/Announcements segmented control (Announcements segment navigates to the existing channel). You: proper tall profile cell (56pt avatar + name + community subtitle) replacing the squeezed WaCell row.

### Notes for reviewers
- wip checkpoint commits mid-history (stop-hook policy); squash-merge recommended
- No installs; CI is the arbiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe

---
_Generated by [Claude Code](https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe)_