### PR TITLE
WhatsApp Plus wave 3: message grouping, section seams, events + compose, invite kit, dark parity

### DIFF
--- a/apps/mobile/app/inbox/new.tsx
+++ b/apps/mobile/app/inbox/new.tsx
@@ -274,6 +274,42 @@ function StartChatScreen() {
   const renderItem = ({ item }: { item: SearchResult }) => {
     const isSelected = selected.has(item.userId);
     const subtitle = item.sharedCommunityNames.slice(0, 2).join(" • ");
+
+    // WhatsApp-shell (flag-gated): flat full-bleed WaRow anatomy (§3.1 "New-
+    // chat contact list" shares the same row geometry as the Chats list —
+    // 56pt circular avatar, hairline separators via WA_SEPARATOR_INSET below)
+    // with the existing selection checkmark as the row's rightAccessory
+    // instead of a trailing chevron. Flag off renders the original bordered
+    // row unchanged.
+    if (whatsappShellEnabled) {
+      return (
+        <WaRow
+          avatar={{ imageUrl: item.profilePhoto, label: item.displayName, shape: "circle" }}
+          title={item.displayName}
+          subtitle={subtitle.length > 0 ? subtitle : undefined}
+          accent={primaryColor}
+          onPress={() => toggleSelect(item)}
+          disabled={isSubmitting}
+          style={isSubmitting ? styles.rowDimmed : undefined}
+          rightAccessory={
+            <View
+              style={[
+                styles.checkmark,
+                {
+                  borderColor: isSelected ? primaryColor : colors.separator,
+                  backgroundColor: isSelected ? primaryColor : "transparent",
+                },
+              ]}
+            >
+              {isSelected ? (
+                <Ionicons name="checkmark" size={16} color="#ffffff" />
+              ) : null}
+            </View>
+          }
+        />
+      );
+    }
+
     return (
       <TouchableOpacity
         style={[
@@ -386,20 +422,36 @@ function StartChatScreen() {
         style={[
           styles.header,
           {
-            paddingTop: insets.top + 16,
-            borderBottomColor: colors.border,
+            paddingTop: insets.top + (whatsappShellEnabled ? 8 : 16),
+            paddingBottom: whatsappShellEnabled ? 10 : 12,
+            borderBottomColor: whatsappShellEnabled ? colors.separator : colors.border,
           },
         ]}
       >
-        <TouchableOpacity
-          onPress={handleClose}
-          style={styles.headerSide}
-          hitSlop={12}
-          accessibilityLabel="Close"
-          accessibilityRole="button"
-        >
-          <Ionicons name="close" size={26} color={colors.text} />
-        </TouchableOpacity>
+        {whatsappShellEnabled ? (
+          // §4: dismiss actions render neutral `text.primary`, never accent
+          // (the back-chevron/Cancel-button rule) — "New chat" sheet's own
+          // dismiss reads as "Cancel" here rather than the generic "×" icon.
+          <TouchableOpacity
+            onPress={handleClose}
+            style={[styles.headerSide, styles.headerCancelHit]}
+            hitSlop={12}
+            accessibilityLabel="Cancel"
+            accessibilityRole="button"
+          >
+            <Text style={[styles.headerCancelText, { color: colors.text }]}>Cancel</Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            onPress={handleClose}
+            style={styles.headerSide}
+            hitSlop={12}
+            accessibilityLabel="Close"
+            accessibilityRole="button"
+          >
+            <Ionicons name="close" size={26} color={colors.text} />
+          </TouchableOpacity>
+        )}
         <Text style={[styles.headerTitle, { color: colors.text }]}>
           {headerTitle}
         </Text>
@@ -415,84 +467,147 @@ function StartChatScreen() {
           contentContainerStyle={styles.chipsContent}
           keyboardShouldPersistTaps="handled"
         >
-          {Array.from(selected.values()).map((row) => (
-            <View
-              key={row.userId}
-              style={[
-                styles.chip,
-                { backgroundColor: accentLight },
-              ]}
-            >
-              <Avatar
-                name={row.displayName}
-                imageUrl={row.profilePhoto}
-                size={24}
-              />
-              <Text
-                style={[styles.chipText, { color: chipTextColor }]}
-                numberOfLines={1}
+          {Array.from(selected.values()).map((row) =>
+            whatsappShellEnabled ? (
+              // §7 "never colored category chips": the filled pill below
+              // becomes a plain avatar token — a small × overlay on the
+              // avatar itself, first name below it, no background fill.
+              <View key={row.userId} style={styles.waToken}>
+                <View style={styles.waTokenAvatarWrap}>
+                  <Avatar
+                    name={row.displayName}
+                    imageUrl={row.profilePhoto}
+                    size={48}
+                  />
+                  <TouchableOpacity
+                    onPress={() => removeSelected(row.userId)}
+                    accessibilityLabel={`Remove ${row.displayName}`}
+                    accessibilityRole="button"
+                    hitSlop={8}
+                    style={[styles.waTokenRemove, { backgroundColor: colors.textTertiary }]}
+                  >
+                    <Ionicons name="close" size={12} color="#ffffff" />
+                  </TouchableOpacity>
+                </View>
+                <Text
+                  style={[styles.waTokenName, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  {row.displayName.split(" ")[0]}
+                </Text>
+              </View>
+            ) : (
+              <View
+                key={row.userId}
+                style={[
+                  styles.chip,
+                  { backgroundColor: accentLight },
+                ]}
               >
-                {row.displayName.split(" ")[0]}
-              </Text>
-              <TouchableOpacity
-                onPress={() => removeSelected(row.userId)}
-                accessibilityLabel={`Remove ${row.displayName}`}
-                accessibilityRole="button"
-                hitSlop={12}
-                style={styles.chipRemoveHit}
-              >
-                <Ionicons
-                  name="close-circle"
-                  size={18}
-                  color={colors.textSecondary}
+                <Avatar
+                  name={row.displayName}
+                  imageUrl={row.profilePhoto}
+                  size={24}
                 />
-              </TouchableOpacity>
-            </View>
-          ))}
+                <Text
+                  style={[styles.chipText, { color: chipTextColor }]}
+                  numberOfLines={1}
+                >
+                  {row.displayName.split(" ")[0]}
+                </Text>
+                <TouchableOpacity
+                  onPress={() => removeSelected(row.userId)}
+                  accessibilityLabel={`Remove ${row.displayName}`}
+                  accessibilityRole="button"
+                  hitSlop={12}
+                  style={styles.chipRemoveHit}
+                >
+                  <Ionicons
+                    name="close-circle"
+                    size={18}
+                    color={colors.textSecondary}
+                  />
+                </TouchableOpacity>
+              </View>
+            )
+          )}
         </ScrollView>
       ) : null}
 
       {/* Optional chat name (only when 2+ selected) */}
       {isGroupMode ? (
         <View style={styles.searchContainer}>
-          <TextInput
-            value={chatName}
-            onChangeText={setChatName}
-            placeholder="Chat name (optional)"
-            placeholderTextColor={colors.textSecondary}
-            maxLength={100}
-            style={[
-              styles.searchInput,
-              {
-                color: colors.text,
-                backgroundColor: colors.surfaceSecondary,
-                borderColor: colors.border,
-              },
-            ]}
-          />
+          {whatsappShellEnabled ? (
+            <View style={[styles.waPill, { backgroundColor: colors.backgroundGrouped }]}>
+              <TextInput
+                value={chatName}
+                onChangeText={setChatName}
+                placeholder="Chat name (optional)"
+                placeholderTextColor={colors.textTertiary}
+                maxLength={100}
+                style={[styles.waPillInput, { color: colors.text }]}
+              />
+            </View>
+          ) : (
+            <TextInput
+              value={chatName}
+              onChangeText={setChatName}
+              placeholder="Chat name (optional)"
+              placeholderTextColor={colors.textSecondary}
+              maxLength={100}
+              style={[
+                styles.searchInput,
+                {
+                  color: colors.text,
+                  backgroundColor: colors.surfaceSecondary,
+                  borderColor: colors.border,
+                },
+              ]}
+            />
+          )}
         </View>
       ) : null}
 
       {/* Search input */}
       <View style={styles.searchContainer}>
-        <TextInput
-          value={query}
-          onChangeText={setQuery}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          placeholder="Search by name…"
-          placeholderTextColor={colors.textSecondary}
-          autoCorrect={false}
-          autoCapitalize="none"
-          style={[
-            styles.searchInput,
-            {
-              color: colors.text,
-              backgroundColor: colors.surfaceSecondary,
-              borderColor: isFocused ? primaryColor : colors.border,
-            },
-          ]}
-        />
+        {whatsappShellEnabled ? (
+          // §4 search pill: fully rounded, `bg.grouped` fill, magnifying-
+          // glass icon inset, `text.tertiary` placeholder — no focus border
+          // (WhatsApp's own search pill has none).
+          <View style={[styles.waPill, { backgroundColor: colors.backgroundGrouped }]}>
+            <Ionicons name="search" size={15} color={colors.textTertiary} style={styles.waPillIcon} />
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              placeholder="Search by name…"
+              placeholderTextColor={colors.textTertiary}
+              autoCorrect={false}
+              autoCapitalize="none"
+              style={[styles.waPillInput, { color: colors.text }]}
+            />
+          </View>
+        ) : (
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder="Search by name…"
+            placeholderTextColor={colors.textSecondary}
+            autoCorrect={false}
+            autoCapitalize="none"
+            style={[
+              styles.searchInput,
+              {
+                color: colors.text,
+                backgroundColor: colors.surfaceSecondary,
+                borderColor: isFocused ? primaryColor : colors.border,
+              },
+            ]}
+          />
+        )}
         {errorMessage ? (
           <Text style={[styles.errorText, { color: colors.error }]}>
             {errorMessage}
@@ -513,6 +628,11 @@ function StartChatScreen() {
             ? styles.emptyListContent
             : undefined
         }
+        // §3.1 hairline separators, inset to the text column — WaRow rows
+        // carry no border of their own (unlike the flag-off bordered row).
+        ItemSeparatorComponent={
+          whatsappShellEnabled ? () => <WaSeparator inset={WA_SEPARATOR_INSET} /> : undefined
+        }
       />
 
       {/* CTA */}
@@ -520,11 +640,14 @@ function StartChatScreen() {
         <View
           style={[
             styles.ctaBar,
+            // §7 "never cards-with-shadows" — the flag-on bar keeps its
+            // hairline top border only, no drop shadow/elevation.
+            !whatsappShellEnabled && styles.ctaBarShadow,
             {
               backgroundColor: colors.surface,
-              borderTopColor: colors.border,
+              borderTopColor: whatsappShellEnabled ? colors.separator : colors.border,
               paddingBottom: insets.bottom + 12,
-              shadowColor: colors.shadow,
+              ...(whatsappShellEnabled ? {} : { shadowColor: colors.shadow }),
             },
           ]}
         >
@@ -578,6 +701,16 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: "600",
   },
+  headerCancelHit: {
+    width: "auto",
+    minWidth: 44,
+    paddingHorizontal: 4,
+    alignItems: "flex-start",
+  },
+  headerCancelText: {
+    fontSize: 17,
+    fontWeight: "400",
+  },
   chipsRow: {
     flexGrow: 0,
   },
@@ -607,6 +740,32 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
+  // WhatsApp-shell selected-recipient token (flag-gated) — §7 "never colored
+  // category chips": an avatar + small × overlay instead of a filled pill.
+  waToken: {
+    alignItems: "center",
+    width: 56,
+  },
+  waTokenAvatarWrap: {
+    width: 48,
+    height: 48,
+    position: "relative",
+  },
+  waTokenRemove: {
+    position: "absolute",
+    top: -2,
+    right: -2,
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  waTokenName: {
+    marginTop: 4,
+    fontSize: 12,
+    fontWeight: "400",
+  },
   searchContainer: {
     paddingHorizontal: 16,
     paddingVertical: 8,
@@ -618,6 +777,23 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     fontSize: 16,
     minHeight: 44,
+  },
+  // §4 search pill — fully rounded, `bg.grouped` fill, no border. Reused for
+  // the optional "Chat name" field too (same input family, icon omitted).
+  waPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    height: 37,
+    borderRadius: 18.5,
+    paddingHorizontal: 12,
+  },
+  waPillIcon: {
+    marginRight: 8,
+  },
+  waPillInput: {
+    flex: 1,
+    fontSize: 17,
+    paddingVertical: 0,
   },
   errorText: {
     marginTop: 8,
@@ -680,8 +856,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
     borderTopWidth: StyleSheet.hairlineWidth,
-    // Subtle separation from list content. iOS/web pick up the shadow,
-    // Android falls back to elevation.
+  },
+  // Subtle separation from list content. iOS/web pick up the shadow,
+  // Android falls back to elevation. Flag-off only — §7 "never
+  // cards-with-shadows" drops this on the flag-on path (hairline border only).
+  ctaBarShadow: {
     ...Platform.select({
       ios: {
         shadowOffset: { width: 0, height: -2 },

--- a/apps/mobile/app/inbox/new.tsx
+++ b/apps/mobile/app/inbox/new.tsx
@@ -35,6 +35,8 @@ import { Avatar } from "@components/ui/Avatar";
 import { useAuth } from "@providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
+import { useWhatsappShell } from "@hooks/useWhatsappShell";
+import { WaRow, WaSeparator, WA_SEPARATOR_INSET } from "@components/wa";
 import { useQuery, useMutation, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import {
@@ -77,6 +79,7 @@ function StartChatScreen() {
   const { token, community, user } = useAuth();
   const { primaryColor, accentLight } = useCommunityTheme();
   const { colors, isDark } = useTheme();
+  const whatsappShellEnabled = useWhatsappShell();
   const communityId = community?.id as Id<"communities"> | undefined;
 
   const [query, setQuery] = useState("");

--- a/apps/mobile/components/wa/WaCell.tsx
+++ b/apps/mobile/components/wa/WaCell.tsx
@@ -15,6 +15,12 @@
  *   centered, own row) instead of the default inline-grouped rendering
  *   (17pt, left-aligned) — §1.4 documents both.
  *
+ * `trailingAccessory` (navigational variant only) is an escape hatch that
+ * replaces the default value+chevron block with an arbitrary node — e.g. a
+ * tappable copy-icon button (Invite kit's per-group links, §8: "per-group
+ * links as WaCells with copy accessories"). Purely additive: omitting it
+ * keeps the standard value/chevron rendering exactly as before.
+ *
  * Presentational only: reads `useTheme()` for neutral grays/destructive red;
  * brand accent is an explicit prop, never read from community theme here.
  */
@@ -48,6 +54,8 @@ export interface WaCellProps {
   description?: string;
   /** Right-aligned value before the chevron, e.g. "5.4 MB", "Off", "On" (`navigational` only). */
   value?: string;
+  /** Replaces the default value+chevron block entirely (`navigational` only) — e.g. a copy-icon button. */
+  trailingAccessory?: React.ReactNode;
   variant?: WaCellVariant;
   /** `toggle` only. */
   toggleValue?: boolean;
@@ -68,6 +76,7 @@ export function WaCell({
   title,
   description,
   value,
+  trailingAccessory,
   variant = 'navigational',
   toggleValue,
   onToggleChange,
@@ -134,6 +143,8 @@ export function WaCell({
             thumbColor="#FFFFFF"
             disabled={disabled}
           />
+        ) : trailingAccessory ? (
+          trailingAccessory
         ) : (
           <>
             {value ? (

--- a/apps/mobile/components/wa/WaRow.tsx
+++ b/apps/mobile/components/wa/WaRow.tsx
@@ -220,7 +220,11 @@ export function WaRow({
       </View>
 
       {rightAccessory ? (
-        <View style={styles.rightColumn}>{rightAccessory}</View>
+        // Unlike the fixed-width timestamp/badge column below, the accessory
+        // slot sizes to its content — accessories (Join pills, button pairs)
+        // are wider than WA_RIGHT_COLUMN_WIDTH and would overflow the title
+        // otherwise; the text column's flex/minWidth absorbs the difference.
+        <View style={styles.rightAccessorySlot}>{rightAccessory}</View>
       ) : (
         <View style={styles.rightColumn}>
           {timestamp ? (
@@ -317,6 +321,12 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignSelf: 'stretch',
     paddingTop: 2,
+    marginLeft: 8,
+  },
+  rightAccessorySlot: {
+    flexShrink: 0,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
     marginLeft: 8,
   },
   rightColumnBottom: {

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -77,6 +77,7 @@ import {
 import { useAuth } from "@providers/AuthProvider";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { waAccentPalette } from "@utils/waPalette";
 import { useWhatsappShell } from "@hooks/useWhatsappShell";
 import {
   useQuery,
@@ -166,8 +167,14 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { token, user } = useAuth();
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
   const { primaryColor } = useCommunityTheme();
+  // §1.2 dark-mode accent shift — never reuse the light-mode brand hex
+  // verbatim in dark mode. Only feeds whatsappShell-gated JSX below (see the
+  // per-usage comments); flag-off branches keep raw `primaryColor` unchanged
+  // (see MessageItem/MessageInput/ConvexChatRoomScreen/InviteKitScreen for
+  // the same split pattern in other dual-flag files).
+  const waAccent = useMemo(() => waAccentPalette(primaryColor, isDark).accent, [primaryColor, isDark]);
 
   const channel = useQuery(
     api.functions.messaging.channels.getChannelBySlug,
@@ -1068,7 +1075,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                 title={pendingResponding === "accept" ? "Accepting…" : "Accept"}
                 onPress={handleAcceptInvite}
                 disabled={pendingResponding !== null}
-                accent={primaryColor}
+                accent={waAccent}
               />
               <WaCell
                 variant="destructive"
@@ -1153,7 +1160,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                   toggleValue={isChannelMuted}
                   onToggleChange={handleToggleMuted}
                   disabled={muteToggling}
-                  accent={primaryColor}
+                  accent={waAccent}
                 />
               )}
             </WaInsetGroup>
@@ -1232,8 +1239,8 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                             styles.requestActionBtn,
                             {
                               backgroundColor: pressed
-                                ? primaryColor + "CC"
-                                : primaryColor,
+                                ? waAccent + "CC"
+                                : waAccent,
                               opacity: inFlight ? 0.6 : 1,
                             },
                           ]}
@@ -1356,6 +1363,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
             membership={crossTeamMembership}
             colors={colors}
             primaryColor={primaryColor}
+            waAccent={waAccent}
             canManage={isLeader}
             whatsappShell={whatsappShell}
             onAdd={() => setAddPermanentVisible(true)}
@@ -1563,8 +1571,8 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                               styles.unmatchedActionBtn,
                               {
                                 backgroundColor: pressed
-                                  ? primaryColor + "CC"
-                                  : primaryColor,
+                                  ? waAccent + "CC"
+                                  : waAccent,
                                 opacity: inFlight ? 0.6 : 1,
                               },
                             ]}
@@ -1936,7 +1944,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
                   toggleValue={isChannelDiscoverable}
                   onToggleChange={handleToggleDiscoverable}
                   disabled={discoverableToggling}
-                  accent={primaryColor}
+                  accent={waAccent}
                 />
               )}
 
@@ -2707,6 +2715,7 @@ function CrossTeamMembersSections({
   membership,
   colors,
   primaryColor,
+  waAccent,
   canManage,
   whatsappShell,
   onAdd,
@@ -2716,6 +2725,7 @@ function CrossTeamMembersSections({
   membership: CrossTeamChannelMembership | undefined;
   colors: ReturnType<typeof useTheme>["colors"];
   primaryColor: string;
+  waAccent: string;
   canManage: boolean;
   whatsappShell: boolean;
   onAdd: () => void;
@@ -2759,8 +2769,8 @@ function CrossTeamMembersSections({
                   style={styles.waPermanentAddButton}
                   hitSlop={8}
                 >
-                  <Ionicons name="add" size={18} color={primaryColor} />
-                  <Text style={[styles.waPermanentAddLabel, { color: primaryColor }]}>
+                  <Ionicons name="add" size={18} color={waAccent} />
+                  <Text style={[styles.waPermanentAddLabel, { color: waAccent }]}>
                     Add
                   </Text>
                 </TouchableOpacity>

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -1044,8 +1044,41 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
 
         {/* Pending shared-channel invitation — this group was invited to the
             channel but hasn't accepted. Show a focused accept/decline prompt
-            and hide the normal management surfaces until the leader responds. */}
-        {isPendingShareInvite && (
+            and hide the normal management surfaces until the leader responds.
+            whatsapp-shell on: §1.3/§1.4 inset-grouped anatomy — the
+            description moves into the card's `footer` slot and Accept/
+            Decline become an accent `action` row and a red `destructive`
+            row (§3.2 row variants). Both variants are plain text only (no
+            accessory slot for a spinner), so the in-flight state swaps the
+            row's own label instead of overlaying an `ActivityIndicator`. */}
+        {isPendingShareInvite && whatsappShell && (
+          <View style={styles.waSection}>
+            <WaInsetGroup
+              header="Shared channel invitation"
+              footer={
+                primaryGroupName
+                  ? `${primaryGroupName} invited your group to join this channel.`
+                  : "Your group has been invited to join this channel."
+              }
+              separatorInset={0}
+            >
+              <WaCell
+                variant="action"
+                title={pendingResponding === "accept" ? "Accepting…" : "Accept"}
+                onPress={handleAcceptInvite}
+                disabled={pendingResponding !== null}
+                accent={primaryColor}
+              />
+              <WaCell
+                variant="destructive"
+                title={pendingResponding === "decline" ? "Declining…" : "Decline"}
+                onPress={handleDeclineInvite}
+                disabled={pendingResponding !== null}
+              />
+            </WaInsetGroup>
+          </View>
+        )}
+        {isPendingShareInvite && !whatsappShell && (
           <View
             style={[
               styles.sectionGroup,
@@ -1148,8 +1181,80 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
 
         {/* Pending join requests — leader-only, custom channels with
             approval-required mode. Shown above Members so leaders see
-            pending work first. */}
-        {isLeader && (pendingRequests?.length ?? 0) > 0 && (
+            pending work first. whatsapp-shell on: §3.2 inset-grouped —
+            each request is a `WaRow` (avatar/title/subtitle) whose
+            `rightAccessory` escape hatch holds the same Decline/Approve
+            pill-button pair as flag-off (WaRow has no built-in two-button
+            accessory, and the buttons' own handlers/in-flight state are
+            unchanged). */}
+        {isLeader && (pendingRequests?.length ?? 0) > 0 && whatsappShell && (
+          <View style={styles.waSection}>
+            <WaInsetGroup
+              header={`Requests · ${pendingRequests!.length}`}
+              separatorInset={16 + 40 + 12}
+            >
+              {pendingRequests!.map((req: any) => {
+                const inFlight = requestInFlight === (req._id as string);
+                const requesterName = req.displayName || "Someone";
+                return (
+                  <WaRow
+                    key={req._id}
+                    avatar={{ imageUrl: req.profilePhoto, label: requesterName, size: 40 }}
+                    title={requesterName}
+                    subtitle="Wants to join"
+                    height={64}
+                    rightAccessory={
+                      <View style={styles.requestActions}>
+                        <Pressable
+                          onPress={() => handleDeclineRequest(req._id)}
+                          disabled={inFlight}
+                          style={({ pressed }) => [
+                            styles.requestActionBtn,
+                            {
+                              backgroundColor: pressed
+                                ? colors.selectedBackground
+                                : colors.surface,
+                              opacity: inFlight ? 0.5 : 1,
+                            },
+                          ]}
+                        >
+                          <Text
+                            style={[styles.requestActionLabel, { color: colors.destructive }]}
+                          >
+                            Decline
+                          </Text>
+                        </Pressable>
+                        <Pressable
+                          onPress={() => handleApproveRequest(req._id)}
+                          disabled={inFlight}
+                          style={({ pressed }) => [
+                            styles.requestActionBtn,
+                            {
+                              backgroundColor: pressed
+                                ? primaryColor + "CC"
+                                : primaryColor,
+                              opacity: inFlight ? 0.6 : 1,
+                            },
+                          ]}
+                        >
+                          {inFlight ? (
+                            <ActivityIndicator size="small" color="#fff" />
+                          ) : (
+                            <Text style={[styles.requestActionLabel, { color: "#fff" }]}>
+                              Approve
+                            </Text>
+                          )}
+                        </Pressable>
+                      </View>
+                    }
+                  />
+                );
+              })}
+            </WaInsetGroup>
+          </View>
+        )}
+
+        {isLeader && (pendingRequests?.length ?? 0) > 0 && !whatsappShell && (
           <>
             <SectionHeader
               colors={colors}
@@ -1251,6 +1356,7 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
             colors={colors}
             primaryColor={primaryColor}
             canManage={isLeader}
+            whatsappShell={whatsappShell}
             onAdd={() => setAddPermanentVisible(true)}
             onRemove={(userId, name) =>
               setPendingRemovePermanent({ userId, name })
@@ -1379,8 +1485,142 @@ export function ChannelInfoScreen({ groupId, channelSlug, channelId }: Props) {
             and quick actions. Mirrors the unmatched panel in PCO sync
             settings (image 5 in the original spec). Only renders when the
             backend returns unmatched data — leader access is enforced server
-            side via `getAutoChannelConfigByChannel`. */}
-        {isPco && isLeader && unmatchedPeople.length > 0 && (
+            side via `getAutoChannelConfigByChannel`. whatsapp-shell on:
+            §3.2 inset-grouped shell (header/footer, `bg.card` rows,
+            hairline separators) — the helper box becomes the card's
+            `footer` text; each row's internal content (warning glyph, name,
+            team/role/contact lines, reason, action buttons) has no
+            single-slot kit equivalent (WaCell/WaRow are one title + one
+            subtitle), so it stays the same bespoke layout as flag-off,
+            just placed inside the `WaInsetGroup` shell instead of a
+            hand-styled card. */}
+        {isPco && isLeader && unmatchedPeople.length > 0 && whatsappShell && (
+          <View style={styles.waSection}>
+            <WaInsetGroup
+              header={`Not in channel · ${unmatchedPeople.length}`}
+              footer="PCO matches Togather users by phone number. Make sure each person's phone in PCO matches their Togather account."
+              separatorInset={0}
+            >
+              {unmatchedPeople.map((person) => {
+                const inFlight = unmatchedActionInFlight === person.pcoPersonId;
+                const canAddToGroup = person.reason === "not_in_group";
+                const canSmsInvite = !!person.pcoPhone;
+                return (
+                  <View key={person.pcoPersonId} style={styles.unmatchedRow}>
+                    <View style={styles.unmatchedHeaderRow}>
+                      <View style={styles.unmatchedAvatarWarn}>
+                        <Ionicons name="warning" size={20} color="#B25000" />
+                      </View>
+                      <View style={styles.unmatchedTextWrap}>
+                        <Text
+                          style={[styles.memberRowName, { color: colors.text }]}
+                          numberOfLines={1}
+                        >
+                          {person.pcoName}
+                        </Text>
+                        {(person.teamName || person.position) && (
+                          <Text
+                            style={[styles.unmatchedSubLabel, { color: colors.textSecondary }]}
+                            numberOfLines={1}
+                          >
+                            {[person.teamName, person.position]
+                              .filter(Boolean)
+                              .join(" · ")}
+                          </Text>
+                        )}
+                        {person.pcoPhone ? (
+                          <Text
+                            style={[styles.unmatchedContactLine, { color: colors.textSecondary }]}
+                            numberOfLines={1}
+                          >
+                            {`📱 ${person.pcoPhone}`}
+                          </Text>
+                        ) : null}
+                        {person.pcoEmail ? (
+                          <Text
+                            style={[styles.unmatchedContactLine, { color: colors.textSecondary }]}
+                            numberOfLines={1}
+                          >
+                            {`✉️ ${person.pcoEmail}`}
+                          </Text>
+                        ) : null}
+                        <Text
+                          style={[styles.unmatchedReasonText, { color: "#B25000" }]}
+                          numberOfLines={2}
+                        >
+                          {getDebugReasonText(person.reason, person)}
+                        </Text>
+                      </View>
+                    </View>
+                    {(canAddToGroup || canSmsInvite) && (
+                      <View style={styles.unmatchedActionsRow}>
+                        {canAddToGroup && (
+                          <Pressable
+                            onPress={() => handleAddUnmatchedToGroup(person)}
+                            disabled={inFlight}
+                            style={({ pressed }) => [
+                              styles.unmatchedActionBtn,
+                              {
+                                backgroundColor: pressed
+                                  ? primaryColor + "CC"
+                                  : primaryColor,
+                                opacity: inFlight ? 0.6 : 1,
+                              },
+                            ]}
+                          >
+                            {inFlight ? (
+                              <ActivityIndicator size="small" color="#fff" />
+                            ) : (
+                              <>
+                                <Ionicons name="person-add" size={14} color="#fff" />
+                                <Text style={styles.unmatchedActionLabelLight}>
+                                  Add to group
+                                </Text>
+                              </>
+                            )}
+                          </Pressable>
+                        )}
+                        {canSmsInvite && (
+                          <Pressable
+                            onPress={() => handleInviteUnmatchedBySMS(person)}
+                            disabled={inFlight}
+                            style={({ pressed }) => [
+                              styles.unmatchedActionBtn,
+                              {
+                                backgroundColor: pressed
+                                  ? colors.selectedBackground
+                                  : colors.surface,
+                                borderWidth: StyleSheet.hairlineWidth,
+                                borderColor: colors.border,
+                                opacity: inFlight ? 0.6 : 1,
+                              },
+                            ]}
+                          >
+                            <Ionicons
+                              name="chatbubble-ellipses-outline"
+                              size={14}
+                              color={colors.text}
+                            />
+                            <Text
+                              style={[
+                                styles.unmatchedActionLabel,
+                                { color: colors.text },
+                              ]}
+                            >
+                              Invite via SMS
+                            </Text>
+                          </Pressable>
+                        )}
+                      </View>
+                    )}
+                  </View>
+                );
+              })}
+            </WaInsetGroup>
+          </View>
+        )}
+
+        {isPco && isLeader && unmatchedPeople.length > 0 && !whatsappShell && (
           <>
             <SectionHeader
               colors={colors}

--- a/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChannelInfoScreen.tsx
@@ -96,6 +96,7 @@ import {
   WaCell,
   WaRow,
   WA_GROUP_SPACING,
+  WA_GROUP_MARGIN,
   WA_AVATAR_PROFILE,
 } from "@components/wa";
 
@@ -2692,12 +2693,22 @@ function SectionHeader({
  *   - "Permanent" — manually pinned members ("Added manually"), each with a
  *     remove action; a header [+ Add] opens the people picker.
  * A person who is both pinned AND role-matched appears in both sections.
+ *
+ * whatsapp-shell on: §3.2 inset-grouped — both sections become
+ * `WaInsetGroup`s of `WaRow`s (avatar/title/subtitle, trailing sync glyph
+ * or remove button via `rightAccessory`). `WaInsetGroup`'s `header` is a
+ * plain string with no trailing element slot, so the "PERMANENT" + [+ Add]
+ * header stays the same bespoke row as flag-off, restyled to the kit's
+ * §2 header type scale (13pt uppercase, `WA_GROUP_MARGIN` leading padding)
+ * instead of the flag-off `sectionHeader` style — matching the precedent in
+ * `GroupInfoScreen`'s `SettingsToggleRow` for slots the kit doesn't cover.
  */
 function CrossTeamMembersSections({
   membership,
   colors,
   primaryColor,
   canManage,
+  whatsappShell,
   onAdd,
   onRemove,
   onOpenProfile,
@@ -2706,12 +2717,89 @@ function CrossTeamMembersSections({
   colors: ReturnType<typeof useTheme>["colors"];
   primaryColor: string;
   canManage: boolean;
+  whatsappShell: boolean;
   onAdd: () => void;
   onRemove: (userId: Id<"users">, name: string) => void;
   onOpenProfile: (userId: Id<"users">) => void;
 }) {
   const syncedRoleMembers = membership?.syncedRoleMembers ?? [];
   const permanentMembers = membership?.permanentMembers ?? [];
+
+  if (whatsappShell) {
+    return (
+      <>
+        {syncedRoleMembers.length > 0 && (
+          <View style={styles.waSection}>
+            <WaInsetGroup header="Synced by role" separatorInset={16 + 40 + 12}>
+              {syncedRoleMembers.map((m) => (
+                <WaRow
+                  key={`${m.userId}:${m.roleId}`}
+                  avatar={{ imageUrl: m.avatarUrl, label: m.name, size: 40 }}
+                  title={m.name}
+                  subtitle={`${m.teamName} · ${m.roleName}`}
+                  onPress={() => onOpenProfile(m.userId)}
+                  rightAccessory={
+                    <Ionicons name="sync" size={16} color={colors.textTertiary} />
+                  }
+                />
+              ))}
+            </WaInsetGroup>
+          </View>
+        )}
+
+        {(permanentMembers.length > 0 || canManage) && (
+          <View style={styles.waSection}>
+            <View style={styles.waPermanentHeaderRow}>
+              <Text style={[styles.waPermanentHeaderLabel, { color: colors.textSecondary }]}>
+                PERMANENT
+              </Text>
+              {canManage && (
+                <TouchableOpacity
+                  onPress={onAdd}
+                  style={styles.waPermanentAddButton}
+                  hitSlop={8}
+                >
+                  <Ionicons name="add" size={18} color={primaryColor} />
+                  <Text style={[styles.waPermanentAddLabel, { color: primaryColor }]}>
+                    Add
+                  </Text>
+                </TouchableOpacity>
+              )}
+            </View>
+            {permanentMembers.length > 0 ? (
+              <WaInsetGroup separatorInset={16 + 40 + 12}>
+                {permanentMembers.map((m) => (
+                  <WaRow
+                    key={m.userId}
+                    avatar={{ imageUrl: m.avatarUrl, label: m.name, size: 40 }}
+                    title={m.name}
+                    subtitle="Added manually"
+                    onPress={() => onOpenProfile(m.userId)}
+                    rightAccessory={
+                      canManage ? (
+                        <TouchableOpacity
+                          onPress={() => onRemove(m.userId, m.name)}
+                          style={[styles.waRemoveButton, { backgroundColor: colors.surfaceGrouped }]}
+                          hitSlop={8}
+                        >
+                          <Ionicons name="remove" size={18} color={colors.textSecondary} />
+                        </TouchableOpacity>
+                      ) : undefined
+                    }
+                  />
+                ))}
+              </WaInsetGroup>
+            ) : (
+              <Text style={[styles.waPermanentEmptyText, { color: colors.textTertiary }]}>
+                No permanent members yet. Add people who should always be in this
+                channel.
+              </Text>
+            )}
+          </View>
+        )}
+      </>
+    );
+  }
 
   return (
     <>
@@ -2975,6 +3063,42 @@ const styles = StyleSheet.create({
   },
   waSection: {
     marginTop: WA_GROUP_SPACING,
+  },
+  // "PERMANENT" header + [+ Add] — WaInsetGroup's `header` has no trailing
+  // element slot, so this stays a bespoke row (§2 header type scale: 13pt
+  // uppercase, WA_GROUP_MARGIN leading padding) rather than a WaSectionLabel.
+  waPermanentHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: WA_GROUP_MARGIN,
+    marginBottom: 8,
+  },
+  waPermanentHeaderLabel: {
+    fontSize: 13,
+    fontWeight: "400",
+    letterSpacing: 0.5,
+  },
+  waPermanentAddButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 2,
+  },
+  waPermanentAddLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  waRemoveButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  waPermanentEmptyText: {
+    paddingHorizontal: WA_GROUP_MARGIN,
+    paddingTop: 4,
+    fontSize: 13,
   },
   sharedPill: {
     flexDirection: "row",

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -1134,11 +1134,14 @@ function MessageItemInner({
           // §5 consecutive-message grouping: tighten the vertical gap within a
           // run (~2pt) vs. between different senders/runs (~9pt). Overrides
           // the flag-off `marginVertical: 2` baseline in `styles.container`
-          // above — undefined props default to a standalone run (both first
-          // and last), landing on the wider run-boundary gap on both sides.
+          // above — undefined props default to a standalone run (first in
+          // group), landing on the wider run-boundary gap. RN does not
+          // collapse vertical margins, so the whole gap lives on marginTop
+          // (owned by the lower bubble) and marginBottom is zeroed —
+          // otherwise adjacent rows' margins would sum to 4pt/18pt.
           whatsappShellEnabled && {
             marginTop: (isFirstInGroup ?? true) ? WA_BUBBLE_RUN_GAP : WA_BUBBLE_GROUPED_GAP,
-            marginBottom: (isLastInGroup ?? true) ? WA_BUBBLE_RUN_GAP : WA_BUBBLE_GROUPED_GAP,
+            marginBottom: 0,
           },
           isOptimistic && (optimisticStatus === 'error' || optimisticStatus === 'queued') && { opacity: 0.7 },
           isHighlighted && styles.highlightedContainer,

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -61,6 +61,8 @@ import {
   WA_BUBBLE_MAX_WIDTH_PCT,
   WA_BUBBLE_PADDING_V,
   WA_BUBBLE_PADDING_H,
+  WA_BUBBLE_RUN_GAP,
+  WA_BUBBLE_GROUPED_GAP,
 } from '@components/wa/metrics';
 import type { ChannelPrefetchState } from '../context/ChatPrefetchContext';
 
@@ -184,6 +186,18 @@ interface MessageItemProps {
    * user jumps to this message from inbox search so it stands out on arrival.
    */
   isHighlighted?: boolean;
+  /**
+   * WHATSAPP-DESIGN-SYSTEM.md §5 consecutive-message grouping — whether this
+   * message starts/ends a same-sender run (computed by MessageList: sender
+   * change, or a date separator/ghost boundary on that side). Read ONLY when
+   * `whatsappShellEnabled`; flag-off rendering never looks at these props.
+   * Undefined (no grouping info supplied) is treated as a standalone run —
+   * both first and last — which reproduces the pre-grouping flag-on look
+   * (sender name always shown, tail corner always squared).
+   */
+  isFirstInGroup?: boolean;
+  /** Mirrors `isFirstInGroup`, but for whether a same-sender message follows. */
+  isLastInGroup?: boolean;
 }
 
 /**
@@ -244,6 +258,8 @@ function MessageItemInner({
   onRetry,
   onAvatarPress,
   isHighlighted,
+  isFirstInGroup,
+  isLastInGroup,
 }: MessageItemProps) {
   const router = useRouter();
   const { colors: themeColors, isDark } = useTheme();
@@ -1115,6 +1131,15 @@ function MessageItemInner({
         style={[
           styles.container,
           isOwnMessage ? styles.ownMessageContainer : styles.otherMessageContainer,
+          // §5 consecutive-message grouping: tighten the vertical gap within a
+          // run (~2pt) vs. between different senders/runs (~9pt). Overrides
+          // the flag-off `marginVertical: 2` baseline in `styles.container`
+          // above — undefined props default to a standalone run (both first
+          // and last), landing on the wider run-boundary gap on both sides.
+          whatsappShellEnabled && {
+            marginTop: (isFirstInGroup ?? true) ? WA_BUBBLE_RUN_GAP : WA_BUBBLE_GROUPED_GAP,
+            marginBottom: (isLastInGroup ?? true) ? WA_BUBBLE_RUN_GAP : WA_BUBBLE_GROUPED_GAP,
+          },
           isOptimistic && (optimisticStatus === 'error' || optimisticStatus === 'queued') && { opacity: 0.7 },
           isHighlighted && styles.highlightedContainer,
           { backgroundColor: highlightBackground },
@@ -1169,8 +1194,11 @@ function MessageItemInner({
           {/* Sender name (only for others' messages). WhatsApp shell: 14pt
               semibold in a deterministic per-sender neutral color instead of
               the flag-off 11pt textSecondary line (§5, §1.3 — never the
-              brand accent). */}
-          {!isOwnMessage && (
+              brand accent). §5 grouping: shown only on the first bubble of a
+              run — `!whatsappShellEnabled ||` short-circuits so flag-off
+              never reads `isFirstInGroup`, and undefined defaults to shown
+              (standalone run), matching pre-grouping flag-on rendering. */}
+          {!isOwnMessage && (!whatsappShellEnabled || (isFirstInGroup ?? true)) && (
             <Text
               style={[
                 styles.senderName,
@@ -1197,13 +1225,16 @@ function MessageItemInner({
                   styles.messageBubble,
                   isOwnMessage ? styles.ownMessageBubble : styles.otherMessageBubble,
                   // §5 bubble geometry: 18pt radius, 4pt "tail corner" nearest
-                  // the sender's origin. No adjacent-message grouping props
-                  // exist on this message (MessageList doesn't pass run
-                  // position), so every bubble renders as if it were the
-                  // first-of-run — uniform per-message radii, not per-run.
+                  // the sender's origin, squared only on the first bubble of a
+                  // run — continuation bubbles get the full 18pt there (no
+                  // tail). Undefined `isFirstInGroup` defaults to true
+                  // (standalone run), reproducing the previous uniform
+                  // tail-corner rendering before MessageList wired grouping.
                   whatsappShellEnabled && styles.waMessageBubble,
                   whatsappShellEnabled &&
-                    (isOwnMessage ? styles.waOwnMessageBubble : styles.waOtherMessageBubble),
+                    (isOwnMessage
+                      ? ((isFirstInGroup ?? true) ? styles.waOwnMessageBubble : styles.waOwnMessageBubbleContinuation)
+                      : ((isFirstInGroup ?? true) ? styles.waOtherMessageBubble : styles.waOtherMessageBubbleContinuation)),
                   isImageOnlyMessage
                     ? styles.imageOnlyBubble
                     : {
@@ -1624,6 +1655,14 @@ const styles = StyleSheet.create({
   },
   waOtherMessageBubble: {
     borderBottomLeftRadius: WA_BUBBLE_TAIL_CORNER_RADIUS,
+  },
+  // §5 grouping: continuation bubbles (not first in their run) drop the tail
+  // and get the full radius on that corner instead of the squared one above.
+  waOwnMessageBubbleContinuation: {
+    borderBottomRightRadius: WA_BUBBLE_RADIUS,
+  },
+  waOtherMessageBubbleContinuation: {
+    borderBottomLeftRadius: WA_BUBBLE_RADIUS,
   },
   waBubbleTextContent: {
     paddingHorizontal: WA_BUBBLE_PADDING_H,

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -314,9 +314,13 @@ export function MessageList({
 
       // First in its run if the previous message is from a different sender
       // (or there's no previous message — sender-change/boundary rule).
+      // A missing senderId (bot/system message, schema marks it optional)
+      // always starts its own run: two different bots would otherwise
+      // compare undefined === undefined and merge into one run.
       // isLastInGroup is filled in by the backward pass below, once the
       // full timeline (including any optimistic messages) is known.
-      const isFirstInGroup = !previousMsg || msg.senderId !== previousMsg.senderId;
+      const isFirstInGroup =
+        !previousMsg || !msg.senderId || msg.senderId !== previousMsg.senderId;
       items.push({ type: 'message', data: msg, isFirstInGroup, isLastInGroup: false });
       previousMsg = msg;
     });
@@ -384,7 +388,10 @@ export function MessageList({
         nextMsg = undefined;
         continue;
       }
-      item.isLastInGroup = !nextMsg || item.data.senderId !== nextMsg.senderId;
+      // Mirror the forward pass's undefined-senderId rule: a bot/system
+      // message is always the last of its own run.
+      item.isLastInGroup =
+        !nextMsg || !item.data.senderId || item.data.senderId !== nextMsg.senderId;
       nextMsg = item.data;
     }
 

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -152,7 +152,20 @@ function formatDateSeparator(timestamp: number): string {
 
 // List item type (message, date separator, or floating "ghost" thread pointer)
 type ListItem =
-  | { type: 'message'; data: Message; showSenderInfo: boolean; isOptimistic?: boolean; optimisticStatus?: string }
+  | {
+      type: 'message';
+      data: Message;
+      // WHATSAPP-DESIGN-SYSTEM.md §5 consecutive-message grouping: whether
+      // this message starts/ends a same-sender run (sender changes, or a
+      // date separator/ghost sits on that side — "keep it simple" per the
+      // spec, no time-gap heuristic). Computed below and threaded down to
+      // MessageItem so flag-on rendering can collapse repeated sender names
+      // and tighten bubble geometry within a run.
+      isFirstInGroup: boolean;
+      isLastInGroup: boolean;
+      isOptimistic?: boolean;
+      optimisticStatus?: string;
+    }
   | { type: 'dateSeparator'; date: string }
   | {
       type: 'ghost';
@@ -276,6 +289,9 @@ export function MessageList({
       if (dateKey !== previousDateKey) {
         items.push({ type: 'dateSeparator', date: formatDateSeparator(ts) });
         previousDateKey = dateKey;
+        // A date separator visually breaks the sender-grouping run too —
+        // §5's grouping boundary is "sender changes OR separator boundary".
+        previousMsg = undefined;
       }
 
       if (entry.kind === 'ghost') {
@@ -296,9 +312,12 @@ export function MessageList({
         return;
       }
 
-      // Show sender info if previous message is from a different sender.
-      const showSenderInfo = !previousMsg || msg.senderId !== previousMsg.senderId;
-      items.push({ type: 'message', data: msg, showSenderInfo });
+      // First in its run if the previous message is from a different sender
+      // (or there's no previous message — sender-change/boundary rule).
+      // isLastInGroup is filled in by the backward pass below, once the
+      // full timeline (including any optimistic messages) is known.
+      const isFirstInGroup = !previousMsg || msg.senderId !== previousMsg.senderId;
+      items.push({ type: 'message', data: msg, isFirstInGroup, isLastInGroup: false });
       previousMsg = msg;
     });
 
@@ -334,16 +353,35 @@ export function MessageList({
 
       pendingOptimistic.forEach((optMsg, index) => {
         const prevMsg = index === 0 ? lastServerMsg : pendingOptimistic[index - 1];
-        const showSenderInfo = !prevMsg || optMsg.senderId !== prevMsg.senderId;
+        const isFirstInGroup = !prevMsg || optMsg.senderId !== prevMsg.senderId;
 
         items.push({
           type: 'message',
           data: optMsg as any,
-          showSenderInfo,
+          isFirstInGroup,
+          isLastInGroup: false,
           isOptimistic: true,
           optimisticStatus: optMsg._status,
         });
       });
+    }
+
+    // Fill in isLastInGroup with a backward pass mirroring the forward
+    // isFirstInGroup pass above: a message is last in its run when no
+    // message from the same sender immediately follows it in time, or a
+    // non-message boundary (date separator/ghost) follows. Runs over the
+    // full chronological `items` array — real timeline messages and any
+    // optimistic messages just appended above — so the server/optimistic
+    // seam is handled by the same single pass.
+    let nextMsg: Message | undefined;
+    for (let i = items.length - 1; i >= 0; i--) {
+      const item = items[i];
+      if (item.type !== 'message') {
+        nextMsg = undefined;
+        continue;
+      }
+      item.isLastInGroup = !nextMsg || item.data.senderId !== nextMsg.senderId;
+      nextMsg = item.data;
     }
 
     // Reverse for inverted list (newest first)
@@ -534,6 +572,8 @@ export function MessageList({
               onMessageDoubleTap(message, event);
             }
           }}
+          isFirstInGroup={item.isFirstInGroup}
+          isLastInGroup={item.isLastInGroup}
           isOptimistic={item.isOptimistic}
           optimisticStatus={item.optimisticStatus as any}
           onRetry={item.isOptimistic && onRetryMessage ? () => onRetryMessage(String(message._id)) : undefined}

--- a/apps/mobile/features/chat/components/MessageList.tsx
+++ b/apps/mobile/features/chat/components/MessageList.tsx
@@ -324,7 +324,11 @@ export function MessageList({
     // Append optimistic messages at the end (newest, after all server messages)
     // Skip optimistic messages that already have a matching real message (dedup)
     if (optimisticMessages && optimisticMessages.length > 0) {
-      const lastServerMsg = messages.length > 0 ? messages[messages.length - 1] : undefined;
+      // Predecessor for grouping is the forward pass's final `previousMsg`,
+      // not raw `messages[length-1]`: the constructed timeline may end with a
+      // ghost or date separator (both reset `previousMsg` to undefined), and
+      // an optimistic message must not merge into a run across that boundary.
+      const lastTimelineMsg = previousMsg;
 
       // For deduplication, check recent server messages (last 5 is plenty).
       // Track which server messages have already been matched so that
@@ -352,7 +356,7 @@ export function MessageList({
       });
 
       pendingOptimistic.forEach((optMsg, index) => {
-        const prevMsg = index === 0 ? lastServerMsg : pendingOptimistic[index - 1];
+        const prevMsg = index === 0 ? lastTimelineMsg : pendingOptimistic[index - 1];
         const isFirstInGroup = !prevMsg || optMsg.senderId !== prevMsg.senderId;
 
         items.push({

--- a/apps/mobile/features/community/components/CommunityPageScreen.tsx
+++ b/apps/mobile/features/community/components/CommunityPageScreen.tsx
@@ -57,6 +57,7 @@ import { formatTimeWithTimezone } from "@togather/shared";
 import { useAuth } from "@providers/AuthProvider";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { waAccentPalette } from "@utils/waPalette";
 import { useAuthenticatedQuery, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { AppImage } from "@components/ui/AppImage";
@@ -218,9 +219,13 @@ function GroupsSection({
 export function CommunityPageScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
   const { primaryColor, accentLight } = useCommunityTheme();
   const { user, community } = useAuth();
+  // §1.2 dark-mode accent shift — never reuse the light-mode brand hex
+  // verbatim in dark mode (see MessageItem/MessageInput/ConvexChatRoomScreen/
+  // InviteKitScreen for the same pattern).
+  const waAccent = useMemo(() => waAccentPalette(primaryColor, isDark).accent, [primaryColor, isDark]);
 
   const communityId = community?.id as Id<"communities"> | undefined;
   const isAdmin = user?.is_admin === true;
@@ -368,7 +373,7 @@ export function CommunityPageScreen() {
             placeholder={{
               type: "initials",
               name: community?.name || "Community",
-              backgroundColor: primaryColor,
+              backgroundColor: waAccent,
             }}
           />
           <Text style={[styles.identityName, { color: colors.text }]} numberOfLines={2}>
@@ -387,13 +392,13 @@ export function CommunityPageScreen() {
           <WaQuickAction
             icon="person-add-outline"
             label="Invite"
-            accent={primaryColor}
+            accent={waAccent}
             onPress={() => router.push("/(user)/invite" as any)}
           />
           <WaQuickAction
             icon="search-outline"
             label="Search"
-            accent={primaryColor}
+            accent={waAccent}
             onPress={() => router.push("/(tabs)/search" as any)}
           />
         </View>
@@ -432,7 +437,7 @@ export function CommunityPageScreen() {
           <View style={styles.section}>
             <WaInsetGroup>
               <WaRow
-                avatar={<WaIconAvatar icon="megaphone" tint={primaryColor} background={accentLight} />}
+                avatar={<WaIconAvatar icon="megaphone" tint={waAccent} background={accentLight} />}
                 title="Announcements"
                 isUnread={(announcementChannel.unreadCount ?? 0) > 0}
                 subtitle={announcementPreview}
@@ -444,7 +449,7 @@ export function CommunityPageScreen() {
                 unreadCount={announcementChannel.unreadCount}
                 showMutedDot={announcementChannel.isMuted && !announcementChannel.unreadCount}
                 showChevron
-                accent={primaryColor}
+                accent={waAccent}
                 onPress={openAnnouncements}
               />
             </WaInsetGroup>
@@ -458,7 +463,7 @@ export function CommunityPageScreen() {
             isLoading={myGroups === undefined}
             emptyMessage="You haven't joined any groups yet."
             groups={yourGroupItems}
-            accent={primaryColor}
+            accent={waAccent}
             onPressGroup={goToGroup}
           />
         </View>
@@ -475,14 +480,14 @@ export function CommunityPageScreen() {
             isLoading={suggestedGroupsLoading}
             emptyMessage="No groups to join right now."
             groups={suggestedGroupItems}
-            accent={primaryColor}
+            accent={waAccent}
             onPressGroup={goToGroup}
           />
           <Pressable
             onPress={() => router.push("/(tabs)/search" as any)}
             style={({ pressed }) => [
               styles.addGroupPill,
-              { backgroundColor: primaryColor, opacity: pressed ? 0.85 : 1 },
+              { backgroundColor: waAccent, opacity: pressed ? 0.85 : 1 },
             ]}
           >
             <Ionicons name="add" size={20} color="#FFFFFF" />
@@ -502,7 +507,7 @@ export function CommunityPageScreen() {
                 return (
                   <WaRow
                     key={event.id}
-                    avatar={<WaIconAvatar icon="calendar" tint={primaryColor} background={accentLight} />}
+                    avatar={<WaIconAvatar icon="calendar" tint={waAccent} background={accentLight} />}
                     title={event.title || "Untitled Event"}
                     subtitle={`${dateLabel} · ${timeLabel}`}
                     showChevron

--- a/apps/mobile/features/events/components/EventsScreen.tsx
+++ b/apps/mobile/features/events/components/EventsScreen.tsx
@@ -30,10 +30,22 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { format, toZonedTime } from 'date-fns-tz';
 import { useAuth } from '@providers/AuthProvider';
 import { useTheme } from '@hooks/useTheme';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { useWhatsappShell } from '@hooks/useWhatsappShell';
 import { AppImage } from '@components/ui';
+import {
+  WaRow,
+  WaSectionLabel,
+  WaScreenHeader,
+  WaSeparator,
+  WA_SEPARATOR_INSET,
+  WA_AVATAR_LG,
+  WA_GROUP_SPACING,
+} from '@components/wa';
+import { formatTimeWithTimezone } from '@togather/shared';
 import { useEventsByTimeWindow } from '../hooks/useEventsByTimeWindow';
 import { useLaterEvents } from '../hooks/useLaterEvents';
 import { useMyRsvpedEvents } from '../hooks/useCommunityEvents';
@@ -160,6 +172,121 @@ function HorizontalTileRow({ title, cards, colors }: HorizontalTileRowProps) {
   );
 }
 
+// --- WhatsApp-shell event rows (flag-gated) ---------------------------------
+// WHATSAPP-DESIGN-SYSTEM.md §7 "Event cards inside chat" governs bubble-shaped
+// events *inside a chat thread*; the Events tab itself is a full-bleed list
+// surface, so its rows follow the plain §3.1 WaRow anatomy instead (cover
+// thumbnail or calendar-glyph circle, title, one-line subtitle, trailing
+// chevron) — same treatment for individual and community-wide (CWE) cards,
+// so "horizontal card strips become rows" per this pass's brief. Flag off
+// renders the existing FeaturedEventTile/EventCardRow/EventRowCommunityWide
+// components below, untouched.
+
+/** Raw event/CWE card shape as returned by the Events tab queries — same
+ * union `Section`/`HorizontalTileRow` above already destructure ad hoc. */
+type EventTabCard = any;
+
+interface WaEventRowProps {
+  card: EventTabCard;
+  colors: ReturnType<typeof useTheme>['colors'];
+  accent: string;
+  userTimezone: string;
+  onCommunityWideTap: (parentId: Id<'communityWideEvents'>) => void;
+}
+
+function WaEventRow({ card, colors, accent, userTimezone, onCommunityWideTap }: WaEventRowProps) {
+  const router = useRouter();
+  const isCommunityWide = card.kind === 'community_wide';
+
+  const zonedDate = toZonedTime(new Date(card.scheduledAt), userTimezone);
+  const weekday = format(zonedDate, 'EEE', { timeZone: userTimezone });
+  const time = formatTimeWithTimezone(card.scheduledAt, userTimezone);
+  const title = card.title || 'Untitled Event';
+
+  // No per-card RSVP status is returned by the Events tab queries (see
+  // listForEventsTab/listLaterEvents) — only a chevron is shown in the right
+  // column (§8 "RSVP state as a small accent text label or chevron"), rather
+  // than inventing an RSVP label the backend doesn't give us.
+  const location = isCommunityWide
+    ? card.groupCount === 1
+      ? '1 location'
+      : `${card.groupCount} locations`
+    : card.locationOverride || card.group.name;
+  const subtitle = `${weekday} ${time} · ${location}`;
+
+  const coverImage: string | null | undefined = isCommunityWide
+    ? card.coverImage
+    : card.coverImage || card.group?.image;
+
+  const handlePress = () => {
+    if (isCommunityWide) {
+      onCommunityWideTap(card.parentId as Id<'communityWideEvents'>);
+    } else if (card.shortId) {
+      router.push(`/e/${card.shortId}?source=app`);
+    }
+  };
+
+  return (
+    <WaRow
+      avatar={
+        coverImage
+          ? { imageUrl: coverImage, label: title, shape: 'circle' }
+          : (
+              <View style={[styles.waCalendarGlyph, { backgroundColor: accent + '14' }]}>
+                <Ionicons name="calendar-outline" size={22} color={accent} />
+              </View>
+            )
+      }
+      title={title}
+      subtitle={subtitle}
+      showChevron
+      accent={accent}
+      onPress={handlePress}
+    />
+  );
+}
+
+interface WaEventSectionProps {
+  title: string;
+  cards: EventTabCard[];
+  colors: ReturnType<typeof useTheme>['colors'];
+  accent: string;
+  userTimezone: string;
+  onCommunityWideTap: (parentId: Id<'communityWideEvents'>) => void;
+}
+
+function WaEventSection({
+  title,
+  cards,
+  colors,
+  accent,
+  userTimezone,
+  onCommunityWideTap,
+}: WaEventSectionProps) {
+  if (!cards || cards.length === 0) return null;
+  return (
+    <View style={styles.waSection}>
+      <WaSectionLabel>{title}</WaSectionLabel>
+      <View>
+        {cards.map((card, index) => (
+          <React.Fragment
+            key={card.kind === 'community_wide' ? `cw-${String(card.parentId)}` : String(card.id)}
+          >
+            <WaEventRow
+              card={card}
+              colors={colors}
+              accent={accent}
+              userTimezone={userTimezone}
+              onCommunityWideTap={onCommunityWideTap}
+            />
+            {index < cards.length - 1 ? <WaSeparator inset={WA_SEPARATOR_INSET} /> : null}
+          </React.Fragment>
+        ))}
+      </View>
+    </View>
+  );
+}
+
 interface GreetingProps {
   firstName: string | null;
   colors: ReturnType<typeof useTheme>['colors'];
@@ -192,6 +319,8 @@ export function EventsScreen() {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const hasCommunityContext = !!community?.id;
+  const whatsappShellEnabled = useWhatsappShell();
+  const userTimezone = user?.timezone || 'America/New_York';
 
   const [expandedParentId, setExpandedParentId] =
     useState<Id<'communityWideEvents'> | null>(null);
@@ -303,14 +432,22 @@ export function EventsScreen() {
   // Floating controls — no static header. The List/Map toggle floats
   // over the top-left; the Create Event CTA floats over the bottom
   // center (above the tab bar). Content scrolls beneath them.
+  //
+  // Flag-on: the List/Map toggle moves into the WaScreenHeader's circular
+  // trailing buttons (§4 "header buttons above the large title"), so it's
+  // skipped here — the Create Event button stays floating either way (its
+  // handler/position are untouched per this pass's brief), just with its
+  // shadow killed on the flag-on path (§7 "never cards-with-shadows").
   const renderFloatingControls = () => (
     <>
-      <View
-        style={[styles.floatingToggle, { top: insets.top + 12 }]}
-        pointerEvents="box-none"
-      >
-        {renderViewToggle()}
-      </View>
+      {!whatsappShellEnabled && (
+        <View
+          style={[styles.floatingToggle, { top: insets.top + 12 }]}
+          pointerEvents="box-none"
+        >
+          {renderViewToggle()}
+        </View>
+      )}
       <View
         style={[
           styles.floatingCreateContainer,
@@ -318,7 +455,11 @@ export function EventsScreen() {
         ]}
       >
         <TouchableOpacity
-          style={[styles.floatingCreateButton, { backgroundColor: primaryColor }]}
+          style={[
+            styles.floatingCreateButton,
+            whatsappShellEnabled && styles.floatingCreateButtonWa,
+            { backgroundColor: primaryColor },
+          ]}
           onPress={handleCreateEvent}
           activeOpacity={0.85}
         >
@@ -333,6 +474,10 @@ export function EventsScreen() {
   // scroll content only clears the status bar, and the toggle visually
   // overlaps the empty area next to the first section header.
   const contentTopPadding = insets.top + 8;
+  // Flag-on: a real (non-floating) WaScreenHeader now occupies that top
+  // space, so the scroll content only needs a small gap below it — reusing
+  // `contentTopPadding` here would double the header's own top inset.
+  const mainContentTopPadding = whatsappShellEnabled ? 8 : contentTopPadding;
 
   // Infinite scroll: trigger loadMore when the user gets within a page of
   // the bottom. Runs on every scroll event; the pagination hook guards
@@ -450,6 +595,32 @@ export function EventsScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.backgroundSecondary }]}>
+      {whatsappShellEnabled && (
+        // §4 large-title header. The existing List/Map toggle becomes the
+        // circular trailing buttons — the active one filled-accent, the
+        // other neutral, matching the "one filled-accent circle" pattern the
+        // kit already uses for the compose `+` elsewhere. The map view itself
+        // is untouched below; only this entry point is restyled.
+        <WaScreenHeader
+          title="Events"
+          trailingButtons={[
+            {
+              icon: viewMode === 'list' ? 'list' : 'list-outline',
+              onPress: () => setViewMode('list'),
+              accent: viewMode === 'list',
+              accessibilityLabel: 'List view',
+            },
+            {
+              icon: viewMode === 'map' ? 'map' : 'map-outline',
+              onPress: () => setViewMode('map'),
+              accent: viewMode === 'map',
+              accessibilityLabel: 'Map view',
+            },
+          ]}
+          accent={primaryColor}
+          style={{ paddingTop: insets.top, backgroundColor: colors.backgroundSecondary }}
+        />
+      )}
       {viewMode === 'map' ? (
         <EventsMapView enabled={viewMode === 'map'} />
       ) : (
@@ -463,7 +634,7 @@ export function EventsScreen() {
               style={styles.scrollView}
               contentContainerStyle={[
                 styles.scrollContent,
-                { paddingTop: contentTopPadding },
+                { paddingTop: mainContentTopPadding },
               ]}
               onScroll={handleScroll}
               scrollEventThrottle={200}
@@ -489,25 +660,64 @@ export function EventsScreen() {
             primaryColor={primaryColor}
             onMakePlans={handleCreateEvent}
           />
-          <HorizontalTileRow title="My Events" cards={myEvents} colors={colors} />
-          <Section
-            title="Next Up"
-            cards={nextUp}
-            onCommunityWideTap={handleCommunityWideTap}
-            colors={colors}
-          />
-          <Section
-            title="This Week"
-            cards={thisWeek}
-            onCommunityWideTap={handleCommunityWideTap}
-            colors={colors}
-          />
-          <Section
-            title="Later"
-            cards={laterCards}
-            onCommunityWideTap={handleCommunityWideTap}
-            colors={colors}
-          />
+          {whatsappShellEnabled ? (
+            <>
+              <WaEventSection
+                title="My Events"
+                cards={myEvents}
+                colors={colors}
+                accent={primaryColor}
+                userTimezone={userTimezone}
+                onCommunityWideTap={handleCommunityWideTap}
+              />
+              <WaEventSection
+                title="Next Up"
+                cards={nextUp}
+                colors={colors}
+                accent={primaryColor}
+                userTimezone={userTimezone}
+                onCommunityWideTap={handleCommunityWideTap}
+              />
+              <WaEventSection
+                title="This Week"
+                cards={thisWeek}
+                colors={colors}
+                accent={primaryColor}
+                userTimezone={userTimezone}
+                onCommunityWideTap={handleCommunityWideTap}
+              />
+              <WaEventSection
+                title="Later"
+                cards={laterCards}
+                colors={colors}
+                accent={primaryColor}
+                userTimezone={userTimezone}
+                onCommunityWideTap={handleCommunityWideTap}
+              />
+            </>
+          ) : (
+            <>
+              <HorizontalTileRow title="My Events" cards={myEvents} colors={colors} />
+              <Section
+                title="Next Up"
+                cards={nextUp}
+                onCommunityWideTap={handleCommunityWideTap}
+                colors={colors}
+              />
+              <Section
+                title="This Week"
+                cards={thisWeek}
+                onCommunityWideTap={handleCommunityWideTap}
+                colors={colors}
+              />
+              <Section
+                title="Later"
+                cards={laterCards}
+                onCommunityWideTap={handleCommunityWideTap}
+                colors={colors}
+              />
+            </>
+          )}
           {laterStatus === 'LoadingMore' && (
             <View style={styles.loadMoreIndicator}>
               <ActivityIndicator size="small" color={colors.textSecondary} />
@@ -637,9 +847,31 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '600',
   },
+  // §7: "never cards-with-shadows" — kills the shadow/elevation above on the
+  // flag-on path only; position/handler/label are untouched.
+  floatingCreateButtonWa: {
+    ...Platform.select({
+      web: { boxShadow: 'none' },
+      default: { shadowOpacity: 0, elevation: 0 },
+    }),
+  },
   section: {
     marginTop: 28, // breathing room between section groups (Next Up → This week → Later)
     marginBottom: 8,
+  },
+  // WhatsApp-shell sections (flag-gated) — WaSectionLabel supplies its own
+  // header-to-row gap (§3.2's WA_SECTION_HEADER_GAP), so this only adds the
+  // generous inter-section rhythm (§3.2 "visibly more generous than the
+  // header-to-card gap").
+  waSection: {
+    marginTop: WA_GROUP_SPACING,
+  },
+  waCalendarGlyph: {
+    width: WA_AVATAR_LG,
+    height: WA_AVATAR_LG,
+    borderRadius: WA_AVATAR_LG / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   sectionTitle: {
     fontSize: 19,

--- a/apps/mobile/features/groups/components/ChannelsSection.tsx
+++ b/apps/mobile/features/groups/components/ChannelsSection.tsx
@@ -44,6 +44,12 @@ import { useWhatsappShell } from "@hooks/useWhatsappShell";
 import { errorMessage } from "@/utils/error-handling";
 import { useGroupChannels } from "../hooks/useGroupChannels";
 import { ChannelJoinRequestsBanner } from "./ChannelJoinRequestsBanner";
+import {
+  WaInsetGroup,
+  WaRow,
+  WaCell,
+  WA_GROUP_SPACING,
+} from "@components/wa";
 
 interface ChannelsSectionProps {
   groupId: string;
@@ -200,6 +206,17 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
   }, [router, groupId]);
 
   if (channels === undefined) {
+    if (whatsappShell) {
+      return (
+        <View style={styles.waContainer}>
+          <WaInsetGroup header="Channels">
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="small" color={primaryColor} />
+            </View>
+          </WaInsetGroup>
+        </View>
+      );
+    }
     return (
       <View style={[styles.container, { backgroundColor: colors.background }]}>
         <Text style={[styles.header, { color: colors.textSecondary }]}>CHANNELS</Text>
@@ -447,6 +464,128 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
   const activeRows = rows.filter((r) => !r.archived);
   const archivedRows = rows.filter((r) => r.archived);
 
+  // --- whatsapp-shell (flag-on) rendering ---------------------------------
+  // WHATSAPP-DESIGN-SYSTEM.md §3.2/§8: channel rows become `WaRow`s (glyph
+  // circle avatar, name, subtitle, badge/chevron) inside a `WaInsetGroup`.
+  // Same `rows`/`activeRows`/`archivedRows`/`pendingInvites` data as the
+  // flag-off render below — only the visual shell differs. Every
+  // handler/onPress is passed through unchanged.
+  if (whatsappShell) {
+    const renderWaRow = (row: Row) => {
+      const dimmed = !row.enabled;
+      const tappable = !!row.onPress;
+      return (
+        <WaRow
+          key={row.key}
+          avatar={
+            <View style={[styles.waGlyphCircle, { backgroundColor: row.iconBg }]}>
+              <Ionicons name={row.icon} size={20} color={row.iconColor} />
+            </View>
+          }
+          title={row.name}
+          // Pin state has no dedicated slot in WaRow's fixed anatomy
+          // (§3.1 has no "pinned" affordance beyond the muted bell-slash);
+          // fold it into the subtitle rather than dropping the signal.
+          subtitle={row.pinned ? `📌 ${row.subtitle}` : row.subtitle}
+          unreadCount={row.enabled ? row.unreadCount : undefined}
+          showChevron={tappable}
+          onPress={row.onPress}
+          disabled={!tappable}
+          accent={primaryColor}
+          height={60}
+          style={dimmed ? styles.waDimmedRow : undefined}
+        />
+      );
+    };
+
+    return (
+      <View style={styles.waContainer}>
+        {activeRows.length > 0 && (
+          <WaInsetGroup header="Channels">
+            {activeRows.map((row) => renderWaRow(row))}
+          </WaInsetGroup>
+        )}
+
+        {/* "See all channels" — W17 channel directory. §1.3: plain
+            accent-colored action row, no icon, no chevron. */}
+        <View style={styles.waActionSection}>
+          <WaInsetGroup separatorInset={0}>
+            <WaCell
+              variant="action"
+              title="See all channels"
+              onPress={() => router.push(`/inbox/${groupId}/channels` as any)}
+              accent={primaryColor}
+            />
+          </WaInsetGroup>
+        </View>
+
+        {/* Archived/disabled channels — a single disclosure `WaCell` that
+            reveals a second `WaInsetGroup` of the same `WaRow` anatomy.
+            WaCell's chevron is fixed (always chevron-forward, no up/down
+            disclosure state); the count in `value` communicates state
+            instead. */}
+        {archivedRows.length > 0 && (
+          <View style={styles.waActionSection}>
+            <WaInsetGroup separatorInset={0}>
+              <WaCell
+                icon="archive-outline"
+                title="Archived"
+                value={`${archivedRows.length} channel${archivedRows.length !== 1 ? "s" : ""}`}
+                onPress={() => setArchivedExpanded((v) => !v)}
+              />
+            </WaInsetGroup>
+            {archivedExpanded && (
+              <View style={styles.waNestedGroup}>
+                <WaInsetGroup separatorInset={16 + 40 + 12}>
+                  {archivedRows.map((row) => renderWaRow(row))}
+                </WaInsetGroup>
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* Create Channel — leaders only, same accent action-row treatment
+            as "See all channels". */}
+        {isLeader && (
+          <View style={styles.waActionSection}>
+            <WaInsetGroup separatorInset={0}>
+              <WaCell
+                variant="action"
+                title="Create Channel"
+                onPress={handleCreateChannel}
+                accent={primaryColor}
+              />
+            </WaInsetGroup>
+          </View>
+        )}
+
+        {/* Shared channel requests — pending invites from other groups.
+            Each row navigates to the channel's info screen (accept/decline
+            happens there), same as flag-off. */}
+        {isLeader && pendingInvites && pendingInvites.length > 0 && (
+          <View style={styles.waActionSection}>
+            <WaInsetGroup header="Shared channel requests">
+              {pendingInvites.map((invite) => (
+                <WaCell
+                  key={invite.channelId}
+                  icon="link"
+                  iconColor="#8B5CF6"
+                  title={`#${invite.channelName}`}
+                  description={`From ${invite.primaryGroupName} · invited by ${invite.invitedByName}`}
+                  onPress={() =>
+                    navigateToChannelInfo(invite.channelSlug, invite.channelId)
+                  }
+                />
+              ))}
+            </WaInsetGroup>
+          </View>
+        )}
+
+        {isLeader && <ChannelJoinRequestsBanner groupId={groupId} />}
+      </View>
+    );
+  }
+
   const renderRow = (row: Row, idx: number) => {
     const isFirst = idx === 0;
     const dimmed = !row.enabled;
@@ -525,24 +664,9 @@ export function ChannelsSection({ groupId, userRole, onChannelPress }: ChannelsS
         </View>
       )}
 
-      {/* See all channels — W17 channel directory (Your channels + Channels
-          you can join). Flag-gated: whatsapp-shell off means this row (and
-          the route it links to) simply doesn't render/exist for the user. */}
-      {whatsappShell && (
-        <TouchableOpacity
-          style={[styles.seeAllRow, { backgroundColor: colors.surfaceSecondary }]}
-          onPress={() => router.push(`/inbox/${groupId}/channels` as any)}
-          activeOpacity={0.7}
-        >
-          <View style={[styles.iconContainer, { backgroundColor: colors.textTertiary + "15" }]}>
-            <Ionicons name="grid-outline" size={20} color={colors.textSecondary} />
-          </View>
-          <Text style={[styles.rowName, { color: colors.text }]}>
-            See all channels
-          </Text>
-          <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
-        </TouchableOpacity>
-      )}
+      {/* "See all channels" (W17 channel directory) only ever rendered when
+          whatsapp-shell is on, and that path now returns early above (its
+          own WaCell-styled row) — this flag-off branch never mounts. */}
 
       {/* Archived/disabled channels fold into one collapsible group so they
           don't clutter the active list. Leaders only — members never receive
@@ -668,6 +792,26 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 8,
   },
+  // --- whatsapp-shell (flag-on) -------------------------------------------
+  waContainer: {
+    marginTop: WA_GROUP_SPACING,
+  },
+  waActionSection: {
+    marginTop: WA_GROUP_SPACING,
+  },
+  waNestedGroup: {
+    marginTop: 8,
+  },
+  waGlyphCircle: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  waDimmedRow: {
+    opacity: 0.55,
+  },
   header: {
     fontSize: 11,
     fontWeight: "600",
@@ -738,16 +882,6 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: "700",
     color: "#fff",
-  },
-  seeAllRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    marginTop: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    borderRadius: 12,
-    minHeight: 48,
   },
   createCard: {
     flexDirection: "row",

--- a/apps/mobile/features/groups/components/GroupBotsSection.tsx
+++ b/apps/mobile/features/groups/components/GroupBotsSection.tsx
@@ -7,6 +7,16 @@
  * config modals BotsScreen does so behavior is identical.
  *
  * Hidden for non-leaders. Hidden if the bots query returns no entries.
+ *
+ * whatsapp-shell (flag-on): restyled to
+ * `docs/plans/church-migration-ui-redesign/WHATSAPP-DESIGN-SYSTEM.md` §3.2 —
+ * a `WaInsetGroup` of `WaCell`s (`variant="toggle"`), the bot's emoji as the
+ * `iconNode`, and (for bots with config UI) the row's own `onPress` opening
+ * Configure — replacing the flag-off card's separate "Configure" link
+ * (`WaCell` has one description slot, no secondary tap target inside a row;
+ * see the flag-on branch below). This component is also rendered unmodified
+ * inside `GroupDetailScreen` (flag off), so every render is gated on
+ * `useWhatsappShell()`; flag-off is byte-identical to before this pass.
  */
 import React, { useState } from "react";
 import {
@@ -25,9 +35,11 @@ import {
 import type { Id } from "@services/api/convex";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { useWhatsappShell } from "@hooks/useWhatsappShell";
 import { BotConfigModal } from "@features/leader-tools/components/BotConfigModal";
 import { TaskReminderConfigModal } from "@features/leader-tools/components/TaskReminderConfigModal";
 import { CommunicationBotConfigModal } from "@features/leader-tools/components/CommunicationBotConfigModal";
+import { WaInsetGroup, WaCell, WA_GROUP_SPACING } from "@components/wa";
 
 interface Props {
   groupId: string;
@@ -48,6 +60,7 @@ type Bot = {
 export function GroupBotsSection({ groupId, isLeader }: Props) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
+  const whatsappShell = useWhatsappShell();
 
   const [selectedBot, setSelectedBot] = useState<Bot | null>(null);
   const [configModalVisible, setConfigModalVisible] = useState(false);
@@ -123,6 +136,62 @@ export function GroupBotsSection({ groupId, isLeader }: Props) {
       config,
     });
   };
+
+  if (whatsappShell) {
+    return (
+      <View style={styles.waSection}>
+        <WaInsetGroup header="Bots">
+          {bots.map((bot) => {
+            const hasConfigure = !!(bot.hasConfig || bot.customConfigUI);
+            return (
+              <WaCell
+                key={bot.id}
+                iconNode={<Text style={styles.waBotGlyph}>{bot.icon}</Text>}
+                title={bot.name}
+                description={bot.description}
+                variant="toggle"
+                toggleValue={bot.enabled}
+                onToggleChange={(value) => handleToggle(bot, value)}
+                accent={primaryColor}
+                // Configure via row press — WaCell has one description slot
+                // and no secondary tap target inside a toggle row, so the
+                // flag-off card's separate "Configure" link becomes "tap the
+                // row" here; the trailing Switch keeps its own touch target.
+                onPress={hasConfigure ? () => handleOpenConfig(bot) : undefined}
+              />
+            );
+          })}
+        </WaInsetGroup>
+
+        {selectedBot &&
+          selectedBot.id !== "task-reminder" &&
+          selectedBot.id !== "communication" && (
+            <BotConfigModal
+              visible={configModalVisible}
+              onClose={handleCloseConfig}
+              groupId={groupId}
+              botId={selectedBot.id}
+              botName={selectedBot.name}
+              botIcon={selectedBot.icon}
+            />
+          )}
+
+        <TaskReminderConfigModal
+          visible={taskReminderModalVisible}
+          onClose={handleCloseConfig}
+          groupId={groupId}
+        />
+
+        <CommunicationBotConfigModal
+          visible={communicationBotModalVisible}
+          onClose={handleCloseConfig}
+          groupId={groupId as Id<"groups">}
+          initialConfig={communicationBotConfig?.config as any}
+          onSave={handleSaveCommunicationBotConfig}
+        />
+      </View>
+    );
+  }
 
   return (
     <View style={styles.section}>
@@ -210,6 +279,14 @@ export function GroupBotsSection({ groupId, isLeader }: Props) {
 }
 
 const styles = StyleSheet.create({
+  // --- whatsapp-shell (flag-on) -------------------------------------------
+  waSection: {
+    marginTop: WA_GROUP_SPACING,
+  },
+  waBotGlyph: {
+    fontSize: 20,
+    lineHeight: 24,
+  },
   section: {
     marginTop: 24,
     paddingHorizontal: 16,

--- a/apps/mobile/features/groups/components/GroupInfoScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupInfoScreen.tsx
@@ -65,6 +65,7 @@ import type { Id } from "@services/api/convex";
 import { DOMAIN_CONFIG } from "@togather/shared";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { waAccentPalette } from "@utils/waPalette";
 import { useAuth } from "@providers/AuthProvider";
 import { useUserData } from "@features/profile/hooks/useUserData";
 import {
@@ -102,8 +103,12 @@ export function GroupInfoScreen() {
   const group_id = params.group_id;
   const router = useRouter();
   const { user } = useAuth();
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
   const { primaryColor } = useCommunityTheme();
+  // §1.2 dark-mode accent shift — never reuse the light-mode brand hex
+  // verbatim in dark mode (see MessageItem/MessageInput/ConvexChatRoomScreen/
+  // InviteKitScreen for the same pattern).
+  const waAccent = useMemo(() => waAccentPalette(primaryColor, isDark).accent, [primaryColor, isDark]);
 
   const [showJoinSuccessModal, setShowJoinSuccessModal] = useState(false);
   const [showPendingLimitModal, setShowPendingLimitModal] = useState(false);
@@ -550,8 +555,8 @@ export function GroupInfoScreen() {
             separate invite-kit yet — see file-header deferral note). */}
         {!!group.shortId && (
           <View style={styles.iconActionRow}>
-            <IconAction icon="share-outline" label="Share" onPress={handleShareGroup} accent={primaryColor} />
-            <IconAction icon="person-add-outline" label="Invite" onPress={handleShareGroup} accent={primaryColor} />
+            <IconAction icon="share-outline" label="Share" onPress={handleShareGroup} accent={waAccent} />
+            <IconAction icon="person-add-outline" label="Invite" onPress={handleShareGroup} accent={waAccent} />
           </View>
         )}
 
@@ -567,7 +572,7 @@ export function GroupInfoScreen() {
               toggleValue={isMuted}
               onToggleChange={handleToggleMuted}
               disabled={isSavingMute}
-              accent={primaryColor}
+              accent={waAccent}
             />
           </WaInsetGroup>
         </View>
@@ -736,7 +741,7 @@ export function GroupInfoScreen() {
                 value={hiddenFromDiscovery}
                 onValueChange={handleToggleHiddenFromDiscovery}
                 disabled={isSavingHidden}
-                accent={primaryColor}
+                accent={waAccent}
               />
               <SettingsToggleRow
                 label="Join approval: leaders"
@@ -744,7 +749,7 @@ export function GroupInfoScreen() {
                 value={leadersApprove}
                 onValueChange={handleToggleLeadersApprove}
                 disabled={isSavingApproval}
-                accent={primaryColor}
+                accent={waAccent}
               />
             </WaInsetGroup>
           </View>

--- a/apps/mobile/features/invite/components/InviteKitScreen.tsx
+++ b/apps/mobile/features/invite/components/InviteKitScreen.tsx
@@ -5,17 +5,26 @@
  * kit concept (docs/plans/church-migration-ui-redesign/README.md §6, W11
  * step 4) into a standalone screen any member can reach from their profile
  * menu, rather than an admin-only wizard step. Gated behind the
- * whatsapp-shell flag end-to-end (see ProfileMenu.tsx).
+ * whatsapp-shell flag end-to-end (see ProfileMenu.tsx and
+ * `app/(user)/invite.tsx`'s defense-in-depth redirect) — because this screen
+ * only ever mounts flag-on, it's styled unconditionally to
+ * `docs/plans/church-migration-ui-redesign/WHATSAPP-DESIGN-SYSTEM.md` §3.2
+ * (inset-grouped) / §8's "Invite kit" checklist row using the
+ * `components/wa/*` kit: `bg.grouped` canvas, `WaInsetGroup`/`WaCell` cards,
+ * accent-colored action rows (§1.3 "action-sheet-style green text rows").
  *
- * Three sections:
- *  - Community: QR code + copy/share for the community's public URL
- *    (`DOMAIN_CONFIG.communityUrl`, the same subdomain entry point the app
- *    already routes through at sign-in — see `useCommunitySubdomain`).
- *  - Send in WhatsApp: a prewritten handoff message with copy/share, so an
- *    admin can paste it straight into their existing WhatsApp group.
- *  - Group links: short links for groups the caller leads, using the same
- *    `DOMAIN_CONFIG.groupShareUrl` helper as `GroupOptionsModal`'s
- *    "Share Group" action.
+ * Three sections, each its own `WaInsetGroup` card:
+ *  - Community: a QR code (on a pure-white tile — QR scanners need strong
+ *    light/dark contrast, so this is one of two spots in the app that
+ *    intentionally never themes to `bg.card`, see `QrCode.tsx`'s own
+ *    comment) + the public URL, with copy/share as accent action cells.
+ *  - Send in WhatsApp: the prewritten handoff message rendered as a
+ *    footer-style quoted block (§2 footer typography + §5 reply-quote-bar
+ *    visual language: left accent border, recessed tint), with copy/share
+ *    as accent action cells.
+ *  - Group links: short links for groups the caller leads, as `WaCell`s
+ *    with a trailing copy-icon accessory (`DOMAIN_CONFIG.groupShareUrl`,
+ *    same helper `GroupOptionsModal`'s "Share Group" action uses).
  */
 import React, { useMemo } from 'react';
 import {
@@ -24,6 +33,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Pressable,
   Alert,
   Share,
   ActivityIndicator,
@@ -35,8 +45,16 @@ import * as Clipboard from 'expo-clipboard';
 import { DOMAIN_CONFIG } from '@togather/shared';
 import { useAuth } from '@providers/AuthProvider';
 import { useTheme } from '@hooks/useTheme';
-import { Card } from '@components/ui';
+import { useCommunityTheme } from '@hooks/useCommunityTheme';
 import { QrCode } from '@components/ui/QrCode';
+import { waAccentPalette } from '@utils/waPalette';
+import {
+  WaInsetGroup,
+  WaCell,
+  WA_GROUP_SPACING,
+  WA_CELL_PADDING,
+  WA_REPLY_QUOTE_BORDER_WIDTH,
+} from '@components/wa';
 import { useAuthenticatedQuery, api } from '@services/api/convex';
 import type { Id } from '@services/api/convex';
 
@@ -49,9 +67,19 @@ interface LeaderGroup {
 export function InviteKitScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
+  const { primaryColor } = useCommunityTheme();
   const { community } = useAuth();
   const communityId = community?.id as Id<'communities'> | undefined;
+
+  // §1.2 dark-mode accent shift — never reuse the light-mode brand hex
+  // verbatim in dark mode (this screen's own accent-dependent rendering, see
+  // restyle report's "accent consumption" finding for the *other* WA-shell
+  // surfaces that skip this step).
+  const accent = useMemo(
+    () => waAccentPalette(primaryColor, isDark).accent,
+    [primaryColor, isDark]
+  );
 
   const communityUrl =
     community?.subdomain ? DOMAIN_CONFIG.communityUrl(community.subdomain) : null;
@@ -97,10 +125,10 @@ export function InviteKitScreen() {
     <View
       style={[
         styles.container,
-        { paddingTop: insets.top, backgroundColor: colors.backgroundSecondary },
+        { paddingTop: insets.top, backgroundColor: colors.backgroundGrouped },
       ]}
     >
-      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+      <View style={[styles.header, { backgroundColor: colors.navBarBackground, borderBottomColor: colors.separator }]}>
         <TouchableOpacity
           onPress={() => router.back()}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
@@ -112,141 +140,141 @@ export function InviteKitScreen() {
         <View style={styles.backButton} />
       </View>
 
-      <ScrollView contentContainerStyle={styles.scrollContent}>
-        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
-          COMMUNITY
-        </Text>
-        <Card style={styles.card}>
-          {communityUrl ? (
-            <>
-              <View style={styles.qrWrap}>
-                <QrCode value={communityUrl} size={180} />
-              </View>
-              <Text style={[styles.urlText, { color: colors.textSecondary }]} numberOfLines={1}>
-                {communityUrl}
-              </Text>
-              <View style={styles.buttonRow}>
-                <TouchableOpacity
-                  style={[styles.secondaryButton, { borderColor: colors.border }]}
+      <ScrollView
+        style={{ backgroundColor: colors.backgroundGrouped }}
+        contentContainerStyle={styles.scrollContent}
+      >
+        <View style={styles.waSection}>
+          {/* separatorInset=0: none of this card's rows have a leading icon
+              column, so the default icon-aligned inset (§3.2's
+              WA_CELL_PADDING + WA_CELL_ICON_COLUMN) would misalign hairlines
+              against this card's flush-left text — same reasoning
+              GroupInfoScreen's icon-less cards use (see its "Settings"/
+              bottom-red-rows WaInsetGroups). */}
+          <WaInsetGroup header="Community" separatorInset={0}>
+            {communityUrl ? (
+              <>
+                {/* QR + URL caption are one visual unit — a single
+                    WaInsetGroup child so no hairline splits them; the
+                    separator (auto-inserted by WaInsetGroup) lands between
+                    this unit and "Copy link" instead. QR must stay on pure
+                    white regardless of theme/dark-mode — same contrast
+                    rationale as QrCode.tsx's own comment: a themed/dark tile
+                    could drop scanner contrast below what finder patterns
+                    need. */}
+                <View>
+                  <View style={styles.qrTile}>
+                    <QrCode value={communityUrl} size={180} />
+                  </View>
+                  <View style={styles.urlRow}>
+                    <Text style={[styles.urlText, { color: colors.textSecondary }]} numberOfLines={1}>
+                      {communityUrl}
+                    </Text>
+                  </View>
+                </View>
+                <WaCell
+                  variant="action"
+                  title="Copy link"
+                  accent={accent}
                   onPress={() => handleCopy(communityUrl, 'Link')}
-                >
-                  <Ionicons name="copy-outline" size={18} color={colors.text} />
-                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
-                    Copy link
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.secondaryButton, { borderColor: colors.border }]}
-                  onPress={() =>
-                    handleShare(`${communityName}\n${communityUrl}`, communityUrl)
-                  }
-                >
-                  <Ionicons name="share-outline" size={18} color={colors.text} />
-                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
-                    Share
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            </>
-          ) : (
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              This community doesn't have a public link set up yet.
-            </Text>
-          )}
-        </Card>
+                />
+                <WaCell
+                  variant="action"
+                  title="Share"
+                  accent={accent}
+                  onPress={() => handleShare(`${communityName}\n${communityUrl}`, communityUrl)}
+                />
+              </>
+            ) : (
+              <EmptyCellText>
+                This community doesn't have a public link set up yet.
+              </EmptyCellText>
+            )}
+          </WaInsetGroup>
+        </View>
 
-        <Text
-          style={[styles.sectionLabel, styles.sectionLabelSpaced, { color: colors.textSecondary }]}
-        >
-          SEND IN WHATSAPP
-        </Text>
-        <Card style={styles.card}>
-          {whatsappMessage ? (
-            <>
-              <Text style={[styles.messageText, { color: colors.text }]}>
-                {whatsappMessage}
-              </Text>
-              <View style={styles.buttonRow}>
-                <TouchableOpacity
-                  style={[styles.secondaryButton, { borderColor: colors.border }]}
-                  onPress={() => handleCopy(whatsappMessage, 'Message')}
-                >
-                  <Ionicons name="copy-outline" size={18} color={colors.text} />
-                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
-                    Copy message
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.secondaryButton, { borderColor: colors.border }]}
-                  onPress={() => handleShare(whatsappMessage)}
-                >
-                  <Ionicons name="share-outline" size={18} color={colors.text} />
-                  <Text style={[styles.secondaryButtonText, { color: colors.text }]}>
-                    Share
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            </>
-          ) : (
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              This community doesn't have a public link set up yet.
-            </Text>
-          )}
-        </Card>
-
-        <Text
-          style={[styles.sectionLabel, styles.sectionLabelSpaced, { color: colors.textSecondary }]}
-        >
-          GROUP LINKS
-        </Text>
-        <Card style={styles.card}>
-          {isLoadingGroups ? (
-            <View style={styles.loadingRow}>
-              <ActivityIndicator color={colors.textSecondary} />
-            </View>
-          ) : leaderGroups.length === 0 ? (
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              You don't lead any groups with a shareable link yet.
-            </Text>
-          ) : (
-            leaderGroups.map((group, index) => {
-              const groupUrl = DOMAIN_CONFIG.groupShareUrl(group.shortId!);
-              return (
+        <View style={styles.waSection}>
+          <WaInsetGroup header="Send in WhatsApp" separatorInset={0}>
+            {whatsappMessage ? (
+              <>
                 <View
-                  key={group.id}
                   style={[
-                    styles.groupRow,
-                    index < leaderGroups.length - 1 && {
-                      borderBottomWidth: StyleSheet.hairlineWidth,
-                      borderBottomColor: colors.border,
+                    styles.quoteBlock,
+                    {
+                      backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+                      borderLeftColor: accent,
                     },
                   ]}
                 >
-                  <View style={styles.groupTextContainer}>
-                    <Text style={[styles.groupName, { color: colors.text }]} numberOfLines={1}>
-                      {group.name}
-                    </Text>
-                    <Text
-                      style={[styles.groupUrl, { color: colors.textSecondary }]}
-                      numberOfLines={1}
-                    >
-                      {groupUrl}
-                    </Text>
-                  </View>
-                  <TouchableOpacity
-                    style={styles.copyIconButton}
-                    onPress={() => handleCopy(groupUrl, `${group.name} link`)}
-                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  >
-                    <Ionicons name="copy-outline" size={20} color={colors.icon} />
-                  </TouchableOpacity>
+                  <Text style={[styles.quoteText, { color: colors.textTertiary }]}>
+                    {whatsappMessage}
+                  </Text>
                 </View>
-              );
-            })
-          )}
-        </Card>
+                <WaCell
+                  variant="action"
+                  title="Copy message"
+                  accent={accent}
+                  onPress={() => handleCopy(whatsappMessage, 'Message')}
+                />
+                <WaCell
+                  variant="action"
+                  title="Share"
+                  accent={accent}
+                  onPress={() => handleShare(whatsappMessage)}
+                />
+              </>
+            ) : (
+              <EmptyCellText>
+                This community doesn't have a public link set up yet.
+              </EmptyCellText>
+            )}
+          </WaInsetGroup>
+        </View>
+
+        <View style={styles.waSection}>
+          <WaInsetGroup header="Group links" separatorInset={0}>
+            {isLoadingGroups ? (
+              <View style={styles.loadingRow}>
+                <ActivityIndicator color={colors.textSecondary} />
+              </View>
+            ) : leaderGroups.length === 0 ? (
+              <EmptyCellText>
+                You don't lead any groups with a shareable link yet.
+              </EmptyCellText>
+            ) : (
+              leaderGroups.map((group) => {
+                const groupUrl = DOMAIN_CONFIG.groupShareUrl(group.shortId!);
+                return (
+                  <WaCell
+                    key={group.id}
+                    title={group.name}
+                    description={groupUrl}
+                    trailingAccessory={
+                      <Pressable
+                        onPress={() => handleCopy(groupUrl, `${group.name} link`)}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Copy ${group.name} link`}
+                      >
+                        <Ionicons name="copy-outline" size={20} color={colors.icon} />
+                      </Pressable>
+                    }
+                  />
+                );
+              })
+            )}
+          </WaInsetGroup>
+        </View>
       </ScrollView>
     </View>
+  );
+}
+
+/** Plain centered helper text sized to sit inside a `WaInsetGroup` card as its only row (no cell chrome needed for a one-off empty state). */
+function EmptyCellText({ children }: { children: string }) {
+  const { colors } = useTheme();
+  return (
+    <Text style={[styles.emptyText, { color: colors.textSecondary }]}>{children}</Text>
   );
 }
 
@@ -272,81 +300,50 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   scrollContent: {
-    paddingHorizontal: 16,
     paddingBottom: 40,
   },
-  sectionLabel: {
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 0.5,
-    marginTop: 16,
-    marginBottom: 8,
+  waSection: {
+    marginTop: WA_GROUP_SPACING,
   },
-  sectionLabelSpaced: {
-    marginTop: 28,
-  },
-  card: {
-    padding: 20,
-  },
-  qrWrap: {
+  qrTile: {
     alignItems: 'center',
-    marginBottom: 12,
+    justifyContent: 'center',
+    paddingVertical: 20,
+    // Intentionally hardcoded, not `colors.surfaceGrouped` — the QR tile
+    // must render on pure white in both light and dark mode (see file
+    // header + `QrCode.tsx`'s own comment on scanner contrast).
+    backgroundColor: '#FFFFFF',
+  },
+  urlRow: {
+    paddingHorizontal: WA_CELL_PADDING,
+    paddingTop: 12,
+    paddingBottom: 4,
   },
   urlText: {
     fontSize: 13,
     textAlign: 'center',
-    marginBottom: 16,
   },
-  messageText: {
-    fontSize: 15,
-    lineHeight: 21,
-    marginBottom: 16,
+  quoteBlock: {
+    marginHorizontal: WA_CELL_PADDING,
+    marginTop: WA_CELL_PADDING,
+    marginBottom: 4,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderLeftWidth: WA_REPLY_QUOTE_BORDER_WIDTH,
+    borderRadius: 6,
   },
-  buttonRow: {
-    flexDirection: 'row',
-    gap: 10,
-  },
-  secondaryButton: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-    paddingVertical: 12,
-    borderRadius: 10,
-    borderWidth: StyleSheet.hairlineWidth,
-  },
-  secondaryButtonText: {
-    fontSize: 14,
-    fontWeight: '600',
+  quoteText: {
+    fontSize: 13,
+    lineHeight: 18,
   },
   emptyText: {
     fontSize: 14,
     textAlign: 'center',
-    paddingVertical: 8,
+    paddingVertical: 16,
+    paddingHorizontal: WA_CELL_PADDING,
   },
   loadingRow: {
     paddingVertical: 16,
     alignItems: 'center',
-  },
-  groupRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 12,
-  },
-  groupTextContainer: {
-    flex: 1,
-    marginRight: 12,
-  },
-  groupName: {
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  groupUrl: {
-    fontSize: 13,
-    marginTop: 2,
-  },
-  copyIconButton: {
-    padding: 4,
   },
 });

--- a/apps/mobile/features/profile/components/YouScreen.tsx
+++ b/apps/mobile/features/profile/components/YouScreen.tsx
@@ -21,7 +21,7 @@
  * gate) — no new permission logic is introduced here. See the gate-by-gate
  * mapping in each row's inline comment.
  */
-import React from "react";
+import React, { useMemo } from "react";
 import { View, Text, Pressable, ScrollView, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -30,6 +30,7 @@ import Constants from "expo-constants";
 import { useAuth } from "@providers/AuthProvider";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { waAccentPalette } from "@utils/waPalette";
 import { useAuthenticatedQuery, api } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { Avatar } from "@components/ui";
@@ -101,8 +102,12 @@ export function YouScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { user, community, logout } = useAuth();
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
   const { primaryColor } = useCommunityTheme();
+  // §1.2 dark-mode accent shift — never reuse the light-mode brand hex
+  // verbatim in dark mode (see MessageItem/MessageInput/ConvexChatRoomScreen/
+  // InviteKitScreen for the same pattern).
+  const waAccent = useMemo(() => waAccentPalette(primaryColor, isDark).accent, [primaryColor, isDark]);
 
   const userId = user?.id as Id<"users"> | undefined;
   const communityId = community?.id as Id<"communities"> | undefined;
@@ -162,7 +167,7 @@ export function YouScreen() {
             accessibilityLabel: "Edit profile",
           },
         ]}
-        accent={primaryColor}
+        accent={waAccent}
         style={{ paddingTop: insets.top }}
       />
 


### PR DESCRIPTION
## Summary

Final wave of the WhatsApp Plus visual-parity campaign (follows #640, #641). All flag-gated; flag-off verified per surface.

### Message grouping (MessageList + MessageItem joint pass)
Real adjacency (sender-change or date/thread boundary; backward pass covers optimistic messages): sender name only on first-of-run, 4pt tail corner only on first-of-run, 2pt within-run gaps. Flag-off never reads the new optional props. Also fixes the dead `showSenderInfo` computation's missed date-boundary reset.

### Embedded-section seams
ChannelsSection + GroupBotsSection gain flag-on kit branches (inset groups, toggle cells, action cells) sharing all data/handlers with untouched flag-off renders; dead unreachable code removed. ChannelInfoScreen's four deferred panels (pending share-invite, requests, cross-team members, PCO unmatched) join the flag-on branching with byte-identical flag-off siblings.

### Events tab + compose
EventsScreen: WaScreenHeader with circular list/map toggles, sections as flat WaRows, tile strips collapsed to rows, RSVP as chevron (tab queries carry no per-card RSVP state — documented, not fabricated). Compose: Cancel text button, search-pill fields, WaRow results, avatar-token recipients replacing colored chips.

### Invite kit + dark parity
InviteKitScreen to inset-grouped anatomy (QR stays on a deliberately unthemed pure-white tile for scanner contrast); WaCell gains an additive `trailingAccessory`. Dark-token sweep: zero spec contradictions in theme values; the §1.2 dark-accent shift is now applied on the four surfaces that had passed raw light-mode brand hex in dark mode (ChannelInfoScreen's flag-off branches keep raw primaryColor, each usage traced).

### Notes for reviewers
- wip checkpoint commits mid-history (stop-hook policy); squash-merge recommended
- No installs; CI is the arbiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe

---
_Generated by [Claude Code](https://claude.ai/code/session_0116yPAHYDWSnbZiLYEiMNwe)_