### PR TITLE
Copy: community-agnostic language on generic surfaces

### DIFF
--- a/apps/convex/__tests__/demo-community.test.ts
+++ b/apps/convex/__tests__/demo-community.test.ts
@@ -300,7 +300,7 @@ describe("createDemoCommunity", () => {
 
     await expect(
       t.mutation(api.functions.demo.createDemoCommunity, { token, name: "   " }),
-    ).rejects.toThrow("Church name is required");
+    ).rejects.toThrow("Community name is required");
 
     await expect(
       t.mutation(api.functions.demo.createDemoCommunity, {

--- a/apps/convex/functions/demo.ts
+++ b/apps/convex/functions/demo.ts
@@ -342,7 +342,7 @@ const GETTING_STARTED_MISSIONS = [
     key: "update_giving",
     title: "Make giving yours",
     instruction:
-      "Make giving yours — open the announcements group → ⓘ Info → Toolbar Settings, and point 'Partner with us' at your church's giving page.",
+      "Make giving yours — open the announcements group → ⓘ Info → Toolbar Settings, and point 'Partner with us' at your community's giving page.",
   },
   {
     key: "birthday_bot",
@@ -1139,7 +1139,7 @@ export const createDemoCommunity = mutation({
     const userId = await requireAuth(ctx, args.token);
 
     const name = args.name.trim();
-    if (!name) throw new Error("Church name is required");
+    if (!name) throw new Error("Community name is required");
     if (args.primaryColor && !isValidHex(args.primaryColor)) {
       throw new Error("Primary color must be a hex color like #3B82F6");
     }

--- a/apps/mobile/app/index+api.ts
+++ b/apps/mobile/app/index+api.ts
@@ -20,12 +20,12 @@ function generateLandingPageHtml(): string {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Togather - Connect Your Community</title>
-  <meta name="description" content="Togather brings your groups, messaging, and events together in one place. The all-in-one platform for churches and communities.">
+  <meta name="description" content="Togather brings your groups, messaging, and events together in one place. The all-in-one platform for communities.">
   <meta name="theme-color" content="#D4A574">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Togather - Connect Your Community">
-  <meta property="og:description" content="Togather brings your groups, messaging, and events together in one place. The all-in-one platform for churches and communities.">
+  <meta property="og:description" content="Togather brings your groups, messaging, and events together in one place. The all-in-one platform for communities.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="${landingUrl}">
   <meta property="og:image" content="${landingUrl}/og-image.png">
@@ -369,7 +369,7 @@ ul, ol { list-style: none; }
                 <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
                 <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
               </svg>
-              <span>Built for churches</span>
+              <span>Built for communities</span>
             </div>
           </div>
         </div>
@@ -567,7 +567,7 @@ ul, ol { list-style: none; }
             <div class="step-number">2</div>
             <div class="step-content">
               <h3>Join your community</h3>
-              <p>Search for your church or organization and connect with your people.</p>
+              <p>Search for your community or organization and connect with your people.</p>
             </div>
           </div>
 
@@ -608,7 +608,7 @@ ul, ol { list-style: none; }
             <p class="perspective-desc">
               See at a glance who's showing up and who's been absent. Track attendance
               patterns, send timely follow-ups, and make data-driven decisions about
-              your ministry. No more spreadsheets or guesswork.
+              your community. No more spreadsheets or guesswork.
             </p>
             <ul class="perspective-list">
               <li>Attendance tracking with visual trends</li>

--- a/apps/mobile/features/invite/components/InviteKitScreen.tsx
+++ b/apps/mobile/features/invite/components/InviteKitScreen.tsx
@@ -1,5 +1,5 @@
 /**
- * InviteKitScreen — "Invite your church"
+ * InviteKitScreen — "Invite your community"
  *
  * Member/admin-facing Invite Kit, adapted from the migration-wizard invite
  * kit concept (docs/plans/church-migration-ui-redesign/README.md §6, W11
@@ -83,12 +83,12 @@ export function InviteKitScreen() {
 
   const communityUrl =
     community?.subdomain ? DOMAIN_CONFIG.communityUrl(community.subdomain) : null;
-  const communityName = community?.name || 'Our church';
+  const communityName = community?.name || 'Our community';
 
   // Copy per the brief's Rule 3: the handoff message says the community-scope
-  // pitch explicitly ("your church gets its own app").
+  // pitch explicitly ("your community gets its own app").
   const whatsappMessage = communityUrl
-    ? `Hi everyone! \u{1F44B} ${communityName} is moving to Togather — our church gets its own app: same groups, plus events & RSVPs, with none of the other-group noise. Join here: ${communityUrl}. Sign in with your phone number and you're in.`
+    ? `Hi everyone! \u{1F44B} ${communityName} is moving to Togather — our community gets its own app: same groups, plus events & RSVPs, with none of the other-group noise. Join here: ${communityUrl}. Sign in with your phone number and you're in.`
     : null;
 
   const myGroups = useAuthenticatedQuery(
@@ -136,7 +136,7 @@ export function InviteKitScreen() {
         >
           <Ionicons name="chevron-back" size={24} color={colors.text} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text }]}>Invite your church</Text>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Invite your community</Text>
         <View style={styles.backButton} />
       </View>
 

--- a/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
+++ b/apps/mobile/features/onboarding/components/DemoCommunityScreen.tsx
@@ -47,7 +47,7 @@ const MAX_NAMED_ITEMS = 12;
 
 const TOTAL_STEPS = 4;
 const STEP_TITLES = [
-  "About your church",
+  "About your community",
   "Campuses & teams",
   "Service times",
   "Branding",
@@ -321,11 +321,11 @@ export function DemoCommunityScreen() {
             <Ionicons name="sparkles" size={32} color={colors.link} />
           </View>
           <Text style={[styles.cardTitle, { color: colors.text }]}>
-            Try Togather with your church
+            Try Togather with your community
           </Text>
           <Text style={[styles.cardMessage, { color: colors.textSecondary }]}>
             Sign in first, then we'll set up a demo community that looks and
-            feels like your church — no payment or commitment required.
+            feels like your community — no payment or commitment required.
           </Text>
           <Pressable
             onPress={() => router.push("/(auth)/landing")}
@@ -356,7 +356,7 @@ export function DemoCommunityScreen() {
             conversations, and events. You're the admin — rename it, re-brand
             it, and click around. Everything works. When you're ready, tap
             "Go live" on the demo banner to add payment ($1/month per active
-            member) and open it to your congregation.
+            member) and open it to your community.
           </Text>
           <View
             style={[
@@ -619,7 +619,7 @@ export function DemoCommunityScreen() {
 }
 
 // ---------------------------------------------------------------------------
-// Step 1 — About your church
+// Step 1 — About your community
 // ---------------------------------------------------------------------------
 
 function StepAboutChurch({
@@ -643,7 +643,7 @@ function StepAboutChurch({
     <>
       <View style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.borderLight }]}>
         <View style={styles.fieldGroup}>
-          <Text style={[styles.label, { color: colors.textSecondary }]}>Church name</Text>
+          <Text style={[styles.label, { color: colors.textSecondary }]}>Community name</Text>
           <TextInput
             style={[styles.input, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
             value={name}
@@ -655,7 +655,7 @@ function StepAboutChurch({
 
         <View style={styles.fieldRow}>
           <View style={[styles.fieldGroup, styles.fieldHalf]}>
-            <Text style={[styles.label, { color: colors.textSecondary }]}>Church size</Text>
+            <Text style={[styles.label, { color: colors.textSecondary }]}>Community size</Text>
             <TextInput
               style={[styles.input, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
               value={totalSize}

--- a/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
+++ b/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
@@ -153,7 +153,7 @@ export function GoLiveScreen() {
               </Text>
               <Text style={[styles.message, { color: colors.textSecondary }]}>
                 Demo mode is off and the seeded demo members have been removed.
-                Time to invite your congregation.
+                Time to invite your community.
               </Text>
             </View>
           ) : (
@@ -192,7 +192,7 @@ export function GoLiveScreen() {
                 Going live keeps everything you've set up — your name, branding,
                 groups, and the teammates you've invited — and removes the {" "}
                 seeded demo members and their conversations, so you start clean
-                with your real congregation.
+                with your real community.
               </Text>
 
               {/* Pricing headline */}
@@ -228,7 +228,7 @@ export function GoLiveScreen() {
                 )}
                 {billing?.billableActiveUsers === 1 && (
                   <Text style={[styles.hint, { color: colors.textTertiary }]}>
-                    Go live for just $1 today, then invite your congregation —
+                    Go live for just $1 today, then invite your community —
                     your bill grows only as they start using it.
                   </Text>
                 )}
@@ -242,8 +242,8 @@ export function GoLiveScreen() {
                   Estimate your bill
                 </Text>
                 <Text style={[styles.cardBody, { color: colors.textSecondary }]}>
-                  We've generally seen around a third of a congregation active
-                  in a given month — though it depends on how often your church
+                  We've generally seen around a third of a community active
+                  in a given month — though it depends on how often your community
                   uses the app. Pick your size to estimate:
                 </Text>
                 <View style={styles.chipRow}>
@@ -283,7 +283,7 @@ export function GoLiveScreen() {
                 </View>
                 <Text style={[styles.hint, { color: colors.textTertiary }]}>
                   A realistic estimate — your actual number depends on how your
-                  church uses the app.
+                  community uses the app.
                 </Text>
               </View>
 

--- a/apps/mobile/features/onboarding/components/ProposalScreen.tsx
+++ b/apps/mobile/features/onboarding/components/ProposalScreen.tsx
@@ -210,7 +210,7 @@ export function ProposalScreen() {
             ]}
             value={communityName}
             onChangeText={setCommunityName}
-            placeholder="e.g. Grace Church NYC"
+            placeholder="e.g. Riverside Community NYC"
             placeholderTextColor={colors.inputPlaceholder}
             autoCapitalize="words"
           />

--- a/apps/mobile/features/profile/components/ProfileMenu.tsx
+++ b/apps/mobile/features/profile/components/ProfileMenu.tsx
@@ -112,7 +112,7 @@ export function ProfileMenu() {
             <View style={[styles.menuIconContainer, { backgroundColor: colors.surfaceSecondary }]}>
               <Ionicons name="person-add-outline" size={20} color={colors.text} />
             </View>
-            <Text style={[styles.menuText, { color: colors.text }]}>Invite your church</Text>
+            <Text style={[styles.menuText, { color: colors.text }]}>Invite your community</Text>
             <Ionicons name="chevron-forward" size={18} color={colors.iconSecondary} />
           </TouchableOpacity>
         ) : null}

--- a/apps/mobile/features/profile/components/YouScreen.tsx
+++ b/apps/mobile/features/profile/components/YouScreen.tsx
@@ -196,7 +196,7 @@ export function YouScreen() {
           disabled={!userId}
         />
 
-        {/* Switch community (ProfileMenu.handleSwitchCommunity) · Invite your church
+        {/* Switch community (ProfileMenu.handleSwitchCommunity) · Invite your community
             (ProfileMenu's whatsappShell-gated row — unconditional here since this whole
             screen only renders when the flag is on). "Use Togather on the web" omitted:
             no existing URL/help route to land it on — see report. */}
@@ -211,7 +211,7 @@ export function YouScreen() {
             />
             <WaCell
               icon="person-add-outline"
-              title="Invite your church"
+              title="Invite your community"
               onPress={() => router.push("/(user)/invite")}
             />
           </WaInsetGroup>

--- a/apps/mobile/features/profile/components/__tests__/YouScreen.test.tsx
+++ b/apps/mobile/features/profile/components/__tests__/YouScreen.test.tsx
@@ -83,7 +83,7 @@ describe("YouScreen", () => {
     const { getByText } = render(<YouScreen />);
     for (const label of [
       "Switch community",
-      "Invite your church",
+      "Invite your community",
       "My events",
       "My schedule",
       "Notifications",

--- a/apps/mobile/features/scheduling/components/MusicianRehearsalScreen.tsx
+++ b/apps/mobile/features/scheduling/components/MusicianRehearsalScreen.tsx
@@ -154,7 +154,7 @@ export function MusicianRehearsalScreen() {
 
           {songs.length === 0 ? (
             <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              No songs on this run sheet yet. Check back once the worship leader
+              No songs on this run sheet yet. Check back once the team leader
               has added them.
             </Text>
           ) : (

--- a/apps/mobile/features/scheduling/components/TeamCreateScreen.tsx
+++ b/apps/mobile/features/scheduling/components/TeamCreateScreen.tsx
@@ -151,7 +151,7 @@ export function TeamCreateScreen() {
         <TextInput
           value={name}
           onChangeText={setName}
-          placeholder="e.g. Worship, Hospitality, Communion Prep"
+          placeholder="e.g. Music, Hospitality, Setup Crew"
           placeholderTextColor={colors.inputPlaceholder}
           maxLength={50}
           autoFocus

--- a/apps/mobile/features/songs/components/SongLibraryScreen.tsx
+++ b/apps/mobile/features/songs/components/SongLibraryScreen.tsx
@@ -230,7 +230,7 @@ export function SongLibraryScreen() {
             <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
               {search.trim()
                 ? "No songs match your search."
-                : "No songs yet. Add your worship songs here so run sheets can link to them."}
+                : "No songs yet. Add your songs here so run sheets can link to them."}
             </Text>
           ) : (
             <View style={styles.list}>


### PR DESCRIPTION
## What this is

Owner directive: *"Togather is community agnostic — language like 'Invite your church' should read more generic. We may have church-specific features but other things should be generic."*

Copy-only sweep (34 lines changed across 13 files, zero logic/layout changes). Every hit was classified:

- **Generalized** (generic surfaces): "Invite your church" → "Invite your community" (You screen, ProfileMenu, InviteKitScreen incl. the WhatsApp handoff message), landing/marketing copy ("Built for churches" → communities, "your ministry" → "your community"), onboarding wizard (GoLive/DemoCommunity "congregation"→"community", "Church name/size" → "Community name/size"), proposal placeholder, demo-flow error string + test, song library ("worship songs" → "songs"), team-create placeholder, rehearsal "worship leader" → "team leader".
- **Kept — church-specific features**: the admin "Church Features" section (it literally configures the church-specific opt-ins), all prayer-feature copy (gated on `churchFeatures.prayerEnabled`), PCO/Slack service-bot config (inherently church software + a real customer's config).
- **Kept — internal identifiers**: `churchFeatures` schema/fields, route/component names, PCO API types, test fixtures.

Follow-ups noted, not done here: apps/web onboarding guides still say "church" in places; demo-seed default team names ("Worship Team" etc.) are seeded scenario *content*, a product decision beyond copy.

## Tests

Mobile jest 1561 green (assertion for the old string updated); convex demo-community suite 39/39; tsc baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3HT3tAPRcQJRUDrnhHVhP