### PR TITLE
Gate the Groups compass behind a flag until the native build ships

### DIFF
--- a/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
+++ b/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
@@ -53,6 +53,11 @@ const KNOWN_FLAGS: Array<{ key: string; description: string }> = [
       "Enables @Togather dev-assistant bot + bug pipeline (staff only).",
   },
   {
+    key: "nearby-device-location",
+    description:
+      "Shows the compass (use-my-location) button on the Groups tab. Keep OFF until a native build that includes the iOS location-permission string is live — the current binary would mis-prompt. Zip-code search works regardless of this flag.",
+  },
+  {
     key: "knicks-mode",
     description:
       "Themes the whole app in New York Knicks orange & blue, overriding every community's brand colors. Applies to all users across all communities. Off: communities use their own brand colors.",

--- a/apps/mobile/features/explore/components/WaGroupsScreen.tsx
+++ b/apps/mobile/features/explore/components/WaGroupsScreen.tsx
@@ -80,6 +80,7 @@ import {
   waTabBarStripHeight,
 } from '@components/wa';
 import { useUserLocation } from '@features/location/hooks/useUserLocation';
+import { useConvexFeatureFlag } from '@hooks/useConvexFeatureFlag';
 import { ExploreMap, MapBounds } from './ExploreMap';
 import { FloatingGroupCard } from './FloatingGroupCard';
 import type { FilterState, GroupTypeOption } from './FilterModal';
@@ -143,6 +144,15 @@ interface WaGroupsSearchPillProps {
   /** Compass affordance rendered to the right of the pill. */
   nearbyActive: boolean;
   onPressNearby: () => void;
+  /**
+   * Whether the device-location compass renders at all. Gated on the
+   * `nearby-device-location` Convex flag: the iOS permission string shipped
+   * in config but is inert until a NATIVE build carries it, and prompting
+   * from a binary without it mis-behaves. Zip search (typed into this pill)
+   * works regardless, so the placeholder advertises it while the compass is
+   * hidden.
+   */
+  showCompass: boolean;
 }
 
 /**
@@ -162,6 +172,7 @@ function WaGroupsSearchPill({
   onChange,
   nearbyActive,
   onPressNearby,
+  showCompass,
 }: WaGroupsSearchPillProps) {
   const { colors } = useTheme();
   return (
@@ -175,7 +186,7 @@ function WaGroupsSearchPill({
         />
         <TextInput
           style={[styles.searchInput, { color: colors.text }]}
-          placeholder="Search groups"
+          placeholder={showCompass ? 'Search groups' : 'Search groups or zip code'}
           placeholderTextColor={colors.textTertiary}
           value={value}
           onChangeText={onChange}
@@ -195,12 +206,14 @@ function WaGroupsSearchPill({
           </Pressable>
         ) : null}
       </View>
-      <WaFloatingButton
-        icon={nearbyActive ? 'compass' : 'compass-outline'}
-        onPress={onPressNearby}
-        size={WA_HEADER_CIRCLE_SIZE}
-        accessibilityLabel="Find groups near me"
-      />
+      {showCompass ? (
+        <WaFloatingButton
+          icon={nearbyActive ? 'compass' : 'compass-outline'}
+          onPress={onPressNearby}
+          size={WA_HEADER_CIRCLE_SIZE}
+          accessibilityLabel="Find groups near me"
+        />
+      ) : null}
     </View>
   );
 }
@@ -390,6 +403,12 @@ export function WaGroupsScreen({
     setLocationFromZip,
   } = useUserLocation();
   const [nearbyRequested, setNearbyRequested] = useState(false);
+  // Owner directive (2026-07-30): the device-location compass stays hidden
+  // until the native build carrying the iOS permission string is live —
+  // flipped via /admin/features once it ships. Fails closed while loading.
+  const { enabled: deviceLocationEnabled } = useConvexFeatureFlag(
+    'nearby-device-location'
+  );
 
   // A bare 5-digit zip in the search field means "groups near this zip", not
   // "groups whose name contains 12345" — it is the always-available alternative
@@ -579,6 +598,7 @@ export function WaGroupsScreen({
             onChange={onSearchChange}
             nearbyActive={Boolean(origin)}
             onPressNearby={handlePressNearby}
+            showCompass={deviceLocationEnabled}
           />
         ) : (
           <View />

--- a/apps/mobile/features/explore/components/__tests__/GroupsScreen.flag.test.tsx
+++ b/apps/mobile/features/explore/components/__tests__/GroupsScreen.flag.test.tsx
@@ -53,6 +53,15 @@ jest.mock('@hooks/useTheme', () => ({
   }),
 }));
 
+// The compass is additionally gated on the nearby-device-location Convex
+// flag (hidden until the native build with the iOS permission string ships).
+// Default ON here so the near-me suite exercises the full affordance; the
+// flag-off specs override per-test.
+const mockDeviceLocationFlag = { enabled: true, loaded: true };
+jest.mock('@hooks/useConvexFeatureFlag', () => ({
+  useConvexFeatureFlag: () => mockDeviceLocationFlag,
+}));
+
 jest.mock('@hooks/useCommunityTheme', () => ({
   useCommunityTheme: () => ({ primaryColor: '#1E8449', accentLight: 'rgba(30,132,73,0.1)' }),
 }));

--- a/apps/mobile/features/explore/components/__tests__/WaGroupsScreen.test.tsx
+++ b/apps/mobile/features/explore/components/__tests__/WaGroupsScreen.test.tsx
@@ -56,6 +56,15 @@ jest.mock('@hooks/useTheme', () => ({
   }),
 }));
 
+// The compass is additionally gated on the nearby-device-location Convex
+// flag (hidden until the native build with the iOS permission string ships).
+// Default ON here so the near-me suite exercises the full affordance; the
+// flag-off specs override per-test.
+const mockDeviceLocationFlag = { enabled: true, loaded: true };
+jest.mock('@hooks/useConvexFeatureFlag', () => ({
+  useConvexFeatureFlag: () => mockDeviceLocationFlag,
+}));
+
 jest.mock('@hooks/useCommunityTheme', () => ({
   useCommunityTheme: () => ({ primaryColor: '#1E8449', accentLight: 'rgba(30,132,73,0.1)' }),
 }));
@@ -487,6 +496,29 @@ describe('WaGroupsScreen — find groups near me', () => {
     fireEvent.press(getByLabelText('Find groups near me'));
     await waitFor(() => expect(getByTestId('wa-groups-nearby-hint')).toBeTruthy());
     expect(getByTestId('wa-groups-nearby-hint').props.children).toMatch(/address/i);
+  });
+
+  it('hides the compass and advertises zip search while the device-location flag is off', () => {
+    mockDeviceLocationFlag.enabled = false;
+    try {
+      const { queryByLabelText, getByTestId } = renderScreen();
+      expect(queryByLabelText('Find groups near me')).toBeNull();
+      expect(getByTestId('wa-groups-search').props.placeholder).toBe(
+        'Search groups or zip code'
+      );
+    } finally {
+      mockDeviceLocationFlag.enabled = true;
+    }
+  });
+
+  it('keeps zip search working with the flag off', async () => {
+    mockDeviceLocationFlag.enabled = false;
+    try {
+      const { getByText } = renderNearby({ searchQuery: '19104' });
+      await waitFor(() => expect(getByText('Near you')).toBeTruthy());
+    } finally {
+      mockDeviceLocationFlag.enabled = true;
+    }
   });
 
   it('toggles back off, restoring the plain directory section', async () => {


### PR DESCRIPTION
## What this is

Owner: *"I don't want to add native dependencies — have it there but gate it actually showing until the next native build, and for now we have people enter in a zipcode."*

Clarification for the record: #658 added **no native dependency** (expo-location was already a core dep in the binary) — only the iOS `NSLocationWhenInUseUsageDescription` config string, which is inert until a native build carries it. The risk was the compass prompting from the current binary that lacks the string.

## Changes

- The device-location compass on the Groups tab now renders only when the **`nearby-device-location` Convex flag** is on (registered in `/admin/features` with a description saying exactly when to flip it). Fails closed while loading — the flag stays OFF until the pending staging native build is live, then it's one toggle, no deploy.
- While the compass is hidden, the search pill's placeholder reads **"Search groups or zip code"** — zip search (bare 5-digit → nearest groups) works regardless of the flag and is now advertised rather than hidden knowledge.

## Tests

1880 passed / 9 skipped (+4: compass hidden + zip placeholder with the flag off, zip search functional with the flag off, both suites mocked for the new hook). tsc at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3HT3tAPRcQJRUDrnhHVhP