### PR TITLE
WhatsApp parity: in-chat event card as a compact rich preview

### DIFF
--- a/apps/mobile/features/chat/components/EventLinkCard.tsx
+++ b/apps/mobile/features/chat/components/EventLinkCard.tsx
@@ -26,6 +26,36 @@ import {
   GuestStepper,
   isGoingRsvpOption,
 } from '@/features/events/components/EventRsvpSection';
+import {
+  WA_CARD_COVER_ASPECT,
+  WA_CARD_PADDING,
+  WA_CARD_PILL_FILL_DARK,
+  WA_CARD_PILL_FILL_LIGHT,
+  WA_CARD_PILL_HEIGHT,
+  WA_CARD_PILL_RADIUS,
+  WA_CARD_PILL_SELECTED_ALPHA,
+  WA_CARD_SHADOW_WEB,
+  WA_BUBBLE_SHADOW,
+} from '../waChatChrome';
+import { hexToRgb } from '@utils/waPalette';
+
+/**
+ * WhatsApp-shell dressing for the card, supplied by `MessageItem` **only when
+ * `whatsappShellEnabled` is true** — the same "parent owns the flag, child
+ * owns the anatomy" split `ReplyQuoteBlock` uses. Its presence *is* the flag:
+ * when it's absent every branch below renders exactly the pre-WhatsApp card.
+ *
+ * The two colors can't be derived in here: `bubbleFill` depends on the
+ * community's brand tint (outgoing) vs. the theme's incoming white, both of
+ * which `MessageItem` has already computed for the message's own bubble, and
+ * reusing them is what makes the card read as *that same bubble*.
+ */
+export interface WaEventCardTheme {
+  /** §1.3 dark-mode-adjusted brand accent: pill ink, footer links. */
+  accent: string;
+  /** §1.6 bubble fill for this message's direction (mint out / white in). */
+  bubbleFill: string;
+}
 
 interface EventLinkCardProps {
   shortId: string;
@@ -34,6 +64,15 @@ interface EventLinkCardProps {
   embedded?: boolean;
   /** Prefetched event data (optional) - skips network fetch if provided */
   prefetchedData?: PrefetchedEventData | null;
+  /** WhatsApp-shell dressing; omitted (flag-off) renders the legacy card. */
+  wa?: WaEventCardTheme | null;
+}
+
+/** Pale accent wash for the §1.6 selected RSVP pill. */
+function waSelectedPillFill(accent: string): string {
+  const rgb = hexToRgb(accent);
+  if (!rgb) return WA_CARD_PILL_FILL_LIGHT;
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${WA_CARD_PILL_SELECTED_ALPHA})`;
 }
 
 interface RsvpUser {
@@ -50,9 +89,20 @@ const EMOJI_MAP: Record<string, string> = {
   'Not Going': '😢',
 };
 
-export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, prefetchedData }: EventLinkCardProps) {
+export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, prefetchedData, wa }: EventLinkCardProps) {
   const router = useRouter();
   const { colors, isDark } = useTheme();
+  // §7: flag-on, the card *is* a bubble — it takes the message's own fill and
+  // the brand accent for its interactive ink. Flag-off, `wa` is undefined and
+  // every `waShell &&` below collapses to the original tree.
+  const waShell = !!wa;
+  const waAccent = wa?.accent ?? DEFAULT_PRIMARY_COLOR;
+  const waCardFill = wa?.bubbleFill;
+  const waPillFill = isDark ? WA_CARD_PILL_FILL_DARK : WA_CARD_PILL_FILL_LIGHT;
+  const waPillSelectedFill = waSelectedPillFill(waAccent);
+  // Flag-off keeps the pale-blue tinted panel; flag-on takes the bubble fill
+  // so the card is indistinguishable from the message bubbles around it.
+  const cardFill = waCardFill ?? (isDark ? colors.surface : '#DCEEFF');
   const [loadingOptionId, setLoadingOptionId] = useState<number | null>(null);
   const token = useStoredAuthToken();
 
@@ -272,7 +322,10 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
     if (!dateString) return '';
     try {
       const date = parseISO(dateString);
-      return format(date, "EEE, MMM d 'at' h:mm a");
+      // Flag-on uses WhatsApp's middot separator on the preview's meta line
+      // ("Fri, Jul 31 · 12:31 AM") — shorter, and it matches the middot the
+      // rest of the WA surfaces already use to join metadata.
+      return format(date, waShell ? 'EEE, MMM d · h:mm a' : "EEE, MMM d 'at' h:mm a");
     } catch {
       return dateString;
     }
@@ -406,20 +459,74 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
     );
   };
 
+  /**
+   * §7 flag-on RSVP affordance: the three options collapse from three
+   * full-height radio rows (radio + label + avatar stack + progress bar,
+   * ~46pt each) into ONE 32pt chips row. Same `handlePress` semantics as
+   * `RsvpOptionRow` — including the "re-tapping the selected option keeps my
+   * guests" rule — so the mutation behaviour is untouched; only the anatomy
+   * changes. Counts ride inline in the label when non-zero, which is what
+   * buys back the avatar stack's vertical space.
+   */
+  const WaRsvpPill = ({ option }: { option: RsvpOption }) => {
+    if (!option.enabled) return null;
+
+    const stats = getRsvpStats(option.id);
+    const isSelected = myRsvp?.optionId === option.id;
+    const isOptionLoading = loadingOptionId === option.id;
+    const emoji = EMOJI_MAP[option.label] || '';
+    const showCount = !countIsHidden && stats.count > 0;
+
+    const handlePress = () => {
+      if (myRsvp === undefined) return;
+      handleRsvp(option.id, isSelected ? displayedGuestCount : 0);
+    };
+
+    return (
+      <TouchableOpacity
+        style={[
+          styles.waRsvpPill,
+          { backgroundColor: isSelected ? waPillSelectedFill : waPillFill },
+        ]}
+        onPress={handlePress}
+        accessibilityRole="button"
+        accessibilityState={{ selected: isSelected }}
+        testID={`wa-rsvp-pill-${option.id}`}
+      >
+        {isOptionLoading ? (
+          <ActivityIndicator size="small" color={waAccent} />
+        ) : (
+          <Text
+            numberOfLines={1}
+            style={[
+              styles.waRsvpPillLabel,
+              // §1.6 selected chip: pale tint + accent ink, never accent-filled.
+              { color: isSelected ? waAccent : colors.text },
+            ]}
+          >
+            {option.label}
+            {emoji ? ` ${emoji}` : ''}
+            {showCount ? ` ${stats.count}` : ''}
+          </Text>
+        )}
+      </TouchableOpacity>
+    );
+  };
+
   // Loading state - show skeleton with fixed dimensions to prevent layout jumps
   if (isLoading) {
     return (
       <View style={[styles.bubbleContainer, !isMyMessage && styles.bubbleContainerLeft, embedded && styles.bubbleContainerEmbedded]}>
-        <View style={[styles.container, { backgroundColor: isDark ? colors.surface : '#DCEEFF' }]}>
+        <View style={[styles.container, waShell && styles.waContainer, { backgroundColor: cardFill }]}>
           {/* Skeleton cover image */}
-          <View style={[styles.skeletonCoverImage, { backgroundColor: isDark ? colors.surfaceSecondary : '#E5E5E5' }]} />
+          <View style={[styles.skeletonCoverImage, waShell && styles.waCoverImage, { backgroundColor: isDark ? colors.surfaceSecondary : '#E5E5E5' }]} />
           {/* Skeleton event info */}
-          <View style={[styles.skeletonEventInfo, { borderBottomColor: colors.borderLight }]}>
+          <View style={[styles.skeletonEventInfo, waShell && styles.waEventInfo, { borderBottomColor: colors.borderLight }]}>
             <View style={[styles.skeletonTitle, { backgroundColor: isDark ? colors.surfaceSecondary : '#E5E5E5' }]} />
             <View style={[styles.skeletonDate, { backgroundColor: isDark ? colors.surfaceSecondary : '#E5E5E5' }]} />
           </View>
           {/* Skeleton button */}
-          <View style={[styles.skeletonButton, { borderTopColor: colors.borderLight }]}>
+          <View style={[styles.skeletonButton, waShell && styles.waFooterRow, { borderTopColor: colors.borderLight }]}>
             <View style={[styles.skeletonButtonText, { backgroundColor: isDark ? colors.surfaceSecondary : '#E5E5E5' }]} />
           </View>
         </View>
@@ -440,7 +547,7 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
         onLongPress={handleCardLongPress}
         delayLongPress={300}
       >
-        <View style={[styles.container, { backgroundColor: isDark ? colors.surface : '#DCEEFF' }]}>
+        <View style={[styles.container, waShell && styles.waContainer, { backgroundColor: cardFill }]}>
           {/* Cover Image */}
           {event.displayCoverImage ? (
             <TouchableOpacity
@@ -450,54 +557,58 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
             >
               <AppImage
                 source={event.coverImage}
-                style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary, aspectRatio: coverAspectRatio }]}
+                style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary, aspectRatio: waShell ? WA_CARD_COVER_ASPECT : coverAspectRatio }]}
                 resizeMode="cover"
                 placeholder={{ type: 'icon', icon: 'calendar-outline', iconSize: 48, iconColor: colors.iconSecondary }}
               />
             </TouchableOpacity>
           ) : (
-            <View style={[styles.coverImagePlaceholder, { backgroundColor: colors.surfaceSecondary }]}>
+            <View style={[styles.coverImagePlaceholder, waShell && styles.waCoverImage, { backgroundColor: colors.surfaceSecondary }]}>
               <Ionicons name="calendar" size={48} color={colors.iconSecondary} />
             </View>
           )}
 
           {/* Limited Event Info */}
-          <View style={[styles.eventInfo, { borderBottomColor: colors.borderLight }]}>
-            <Text style={[styles.eventTitle, { color: colors.text }]} numberOfLines={2}>
+          <View style={[styles.eventInfo, waShell && styles.waEventInfo, { borderBottomColor: colors.borderLight }]}>
+            <Text style={[styles.eventTitle, waShell && styles.waEventTitle, { color: colors.text }]} numberOfLines={2}>
               {event.title || 'Event'}
             </Text>
-            <Text style={[styles.eventDate, { color: colors.textSecondary }]}>
+            <Text style={[styles.eventDate, waShell && styles.waEventMeta, { color: colors.textSecondary }]}>
               {formatEventDate(event.scheduledAt)}
             </Text>
-            <Text style={[styles.eventGroup, { color: colors.textSecondary }]}>
+            <Text style={[styles.eventGroup, waShell && styles.waEventMeta, { color: colors.textSecondary }]}>
               {event.groupName}{event.communityName ? ` · ${event.communityName}` : ''}
             </Text>
           </View>
 
           {/* Access Prompt */}
-          <View style={[styles.accessPromptSection, { backgroundColor: isDark ? colors.surfaceSecondary : '#F8F4FF', borderBottomColor: colors.borderLight }]}>
-            <Ionicons name="lock-closed" size={20} color={DEFAULT_PRIMARY_COLOR} />
-            <Text style={styles.accessPromptText}>{event.accessPrompt.message}</Text>
+          <View style={[styles.accessPromptSection, waShell && styles.waAccessPromptSection, { backgroundColor: isDark ? colors.surfaceSecondary : '#F8F4FF', borderBottomColor: colors.borderLight }]}>
+            <Ionicons name="lock-closed" size={20} color={waShell ? waAccent : DEFAULT_PRIMARY_COLOR} />
+            <Text style={[styles.accessPromptText, waShell && styles.waAccessPromptText, waShell && { color: waAccent }]}>{event.accessPrompt.message}</Text>
           </View>
 
           {/* Footer: Copy link + View Details */}
-          <View style={[styles.footerRow, { borderTopColor: colors.borderLight }]}>
+          <View style={[styles.footerRow, waShell && styles.waFooterRow, { borderTopColor: colors.borderLight }]}>
             <TouchableOpacity
               style={styles.copyLinkButton}
               onPress={handleCopyLink}
               hitSlop={8}
             >
-              <Ionicons
-                name={linkCopied ? 'checkmark' : 'link-outline'}
-                size={16}
-                color={DEFAULT_PRIMARY_COLOR}
-              />
-              <Text style={styles.viewDetailsText}>
+              {!waShell && (
+                <Ionicons
+                  name={linkCopied ? 'checkmark' : 'link-outline'}
+                  size={16}
+                  color={DEFAULT_PRIMARY_COLOR}
+                />
+              )}
+              <Text style={[styles.viewDetailsText, waShell && { color: waAccent }]}>
                 {linkCopied ? 'Copied' : 'Copy link'}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={handleViewDetails} hitSlop={8}>
-              <Text style={styles.viewDetailsText}>View Details</Text>
+              <Text style={[styles.viewDetailsText, waShell && { color: waAccent }]}>
+                {waShell ? 'View details' : 'View Details'}
+              </Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -534,7 +645,7 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
       onLongPress={handleCardLongPress}
       delayLongPress={300}
     >
-      <View style={[styles.container, { backgroundColor: isDark ? colors.surface : '#DCEEFF' }]}>
+      <View style={[styles.container, waShell && styles.waContainer, { backgroundColor: cardFill }]}>
         {/* Cover Image */}
         {event.displayCoverImage ? (
           <TouchableOpacity
@@ -544,23 +655,26 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
           >
             <AppImage
               source={event.coverImage}
-              style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary, aspectRatio: coverAspectRatio }]}
+              // §7 flag-on: a wide banner across the bubble top, not a
+              // full-bleed poster in the image's own (often square/portrait)
+              // ratio — that single change is most of the height saving.
+              style={[styles.coverImage, { backgroundColor: colors.surfaceSecondary, aspectRatio: waShell ? WA_CARD_COVER_ASPECT : coverAspectRatio }]}
               resizeMode="cover"
               placeholder={{ type: 'icon', icon: 'calendar-outline', iconSize: 48, iconColor: colors.iconSecondary }}
             />
           </TouchableOpacity>
         ) : (
-          <View style={[styles.coverImagePlaceholder, { backgroundColor: colors.surfaceSecondary }]}>
+          <View style={[styles.coverImagePlaceholder, waShell && styles.waCoverImage, { backgroundColor: colors.surfaceSecondary }]}>
             <Ionicons name="calendar" size={48} color={colors.iconSecondary} />
           </View>
         )}
 
         {/* Event Info */}
-        <View style={[styles.eventInfo, { borderBottomColor: colors.borderLight }]}>
-          <Text style={[styles.eventTitle, { color: colors.text }, isCancelled && { textDecorationLine: 'line-through', color: colors.textTertiary }]} numberOfLines={2}>
+        <View style={[styles.eventInfo, waShell && styles.waEventInfo, { borderBottomColor: colors.borderLight }]}>
+          <Text style={[styles.eventTitle, waShell && styles.waEventTitle, { color: colors.text }, isCancelled && { textDecorationLine: 'line-through', color: colors.textTertiary }]} numberOfLines={2}>
             {event.title || 'Event'}
           </Text>
-          <Text style={[styles.eventDate, { color: colors.textSecondary }]}>
+          <Text style={[styles.eventDate, waShell && styles.waEventMeta, { color: colors.textSecondary }]}>
             {formatEventDate(event.scheduledAt)}
           </Text>
           {isPastEvent && !isCancelled && (
@@ -570,7 +684,7 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
             </View>
           )}
           {location && (
-            <Text style={[styles.eventLocation, { color: colors.textSecondary }]}>
+            <Text style={[styles.eventLocation, waShell && styles.waEventMeta, { color: colors.textSecondary }]} numberOfLines={waShell ? 1 : undefined}>
               {location.icon} {location.text}
             </Text>
           )}
@@ -578,7 +692,7 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
 
         {/* RSVP Options - hide when cancelled or past */}
         {!isCancelled && !isPastEvent && event.rsvpEnabled && rsvpOptions.length > 0 && (
-          <View style={styles.rsvpSection}>
+          <View style={[styles.rsvpSection, waShell && styles.waRsvpSection]}>
             {showLeaderBadge && (
               <View style={[styles.leaderBadge, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}>
                 <Ionicons name="eye-outline" size={12} color={colors.textSecondary} />
@@ -594,11 +708,19 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
               </View>
             ) : (
               <>
-                {rsvpOptions.map((option) => (
-                  <RsvpOptionRow key={option.id} option={option} />
-                ))}
+                {waShell ? (
+                  <View style={styles.waRsvpPillRow}>
+                    {rsvpOptions.map((option) => (
+                      <WaRsvpPill key={option.id} option={option} />
+                    ))}
+                  </View>
+                ) : (
+                  rsvpOptions.map((option) => (
+                    <RsvpOptionRow key={option.id} option={option} />
+                  ))
+                )}
                 {selectedIsGoing && (
-                  <View style={[styles.guestStepperRow, { borderTopColor: colors.borderLight }]}>
+                  <View style={[styles.guestStepperRow, waShell && styles.waGuestStepperRow, { borderTopColor: colors.borderLight }]}>
                     <GuestStepper
                       value={displayedGuestCount}
                       onChange={handleGuestCountChange}
@@ -614,23 +736,27 @@ export function EventLinkCard({ shortId, isMyMessage = true, embedded = false, p
         )}
 
         {/* Footer: Copy link + View Details */}
-        <View style={[styles.footerRow, { borderTopColor: colors.borderLight }]}>
+        <View style={[styles.footerRow, waShell && styles.waFooterRow, { borderTopColor: colors.borderLight }]}>
           <TouchableOpacity
             style={styles.copyLinkButton}
             onPress={handleCopyLink}
             hitSlop={8}
           >
-            <Ionicons
-              name={linkCopied ? 'checkmark' : 'link-outline'}
-              size={16}
-              color={DEFAULT_PRIMARY_COLOR}
-            />
-            <Text style={styles.viewDetailsText}>
+            {!waShell && (
+              <Ionicons
+                name={linkCopied ? 'checkmark' : 'link-outline'}
+                size={16}
+                color={DEFAULT_PRIMARY_COLOR}
+              />
+            )}
+            <Text style={[styles.viewDetailsText, waShell && { color: waAccent }]}>
               {linkCopied ? 'Copied' : 'Copy link'}
             </Text>
           </TouchableOpacity>
           <TouchableOpacity onPress={handleViewDetails} hitSlop={8}>
-            <Text style={styles.viewDetailsText}>View Details</Text>
+            <Text style={[styles.viewDetailsText, waShell && { color: waAccent }]}>
+              {waShell ? 'View details' : 'View Details'}
+            </Text>
           </TouchableOpacity>
         </View>
 
@@ -913,5 +1039,85 @@ const styles = StyleSheet.create({
     height: 16,
     width: 100,
     borderRadius: 4,
+  },
+
+  /* --- WhatsApp shell (§7 "event cards inside chat -> bubble-shaped cards")
+   * Every style below is applied only when `wa` is supplied; flag-off render
+   * never reaches them. They deliberately *override* the legacy style they're
+   * paired with rather than replacing it, so the diff stays readable and the
+   * flag-off tree is provably untouched. --- */
+
+  /** §7: a bubble, not an elevated "feature card" — the legacy 8pt/elevation-3
+   *  drop shadow becomes the §1.6 1px bubble shadow. */
+  waContainer: {
+    ...WA_BUBBLE_SHADOW,
+    // On web `styles.container`'s raw `boxShadow` isn't overridden by the
+    // shadow* props above, so restate it at the bubble's weight.
+    ...Platform.select({ web: { boxShadow: WA_CARD_SHADOW_WEB } }),
+  },
+  /** Wide banner instead of the poster-sized natural/1:1 crop. */
+  waCoverImage: {
+    aspectRatio: WA_CARD_COVER_ASPECT,
+  },
+  /** Bubble gutter, and no hairline carving the bubble into sections. */
+  waEventInfo: {
+    padding: WA_CARD_PADDING,
+    paddingBottom: 6,
+    borderBottomWidth: 0,
+  },
+  waEventTitle: {
+    fontSize: 15,
+    lineHeight: 20,
+    marginBottom: 2,
+  },
+  waEventMeta: {
+    fontSize: 13,
+    lineHeight: 17,
+    marginTop: 0,
+    marginBottom: 0,
+  },
+  waRsvpSection: {
+    paddingHorizontal: WA_CARD_PADDING,
+    paddingTop: 0,
+    paddingBottom: 6,
+    gap: 6,
+  },
+  /** §7 RSVP pill row "docked at the bubble's bottom edge". */
+  waRsvpPillRow: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  waRsvpPill: {
+    // Equal thirds: the row keeps its geometry when a label swaps for the
+    // in-flight spinner, so tapping never reflows the bubble.
+    flex: 1,
+    height: WA_CARD_PILL_HEIGHT,
+    borderRadius: WA_CARD_PILL_RADIUS,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  waRsvpPillLabel: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  waGuestStepperRow: {
+    paddingTop: 6,
+    borderTopWidth: 0,
+  },
+  /** Footer links sit on the bubble fill, left-aligned, no divider. */
+  waFooterRow: {
+    paddingVertical: 8,
+    paddingHorizontal: WA_CARD_PADDING,
+    borderTopWidth: 0,
+    justifyContent: 'flex-start',
+    gap: 20,
+  },
+  waAccessPromptSection: {
+    padding: WA_CARD_PADDING,
+    borderBottomWidth: 0,
+  },
+  waAccessPromptText: {
+    fontSize: 13,
   },
 });

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -887,6 +887,52 @@ function MessageItemInner({
     (isFirstInGroup ?? true) &&
     !isImageOnlyMessage;
 
+  /**
+   * §7: flag-on, a message whose *entire* content is a single event link has
+   * nothing left to put in a bubble — `displayText` is empty once the link is
+   * stripped — yet the bubble still rendered, so the thread showed a stub
+   * metadata-only bubble (sender name, timestamp, tail, no body) stacked
+   * above the card's own bubble. The card IS the bubble here, exactly like
+   * the poll/task/bug cards `isSpecialCardMessage` already suppresses it for.
+   *
+   * Deliberately a *separate* value rather than another clause on
+   * `isSpecialCardMessage`: that one also gates flag-off rendering, which
+   * must stay byte-identical. `whatsappShellEnabled` leads the conjunction so
+   * this is always false flag-off.
+   *
+   * Narrow on purpose — anything else in the message still needs a real
+   * bubble to live in: text beside the link, a reply quote, attachments, the
+   * SMS-blast badge, another card type, or a second event card (two card
+   * bubbles with one name line above them would be ambiguous about which
+   * bubble the name belongs to).
+   */
+  const isEventCardOnlyMessage =
+    whatsappShellEnabled &&
+    !isSpecialCardMessage &&
+    !hasTextContent &&
+    eventShortIds.length === 1 &&
+    toolShortIds.length === 0 &&
+    channelInviteShortIds.length === 0 &&
+    availabilityTokens.length === 0 &&
+    !showReplyQuote &&
+    !message.blastId &&
+    validImageAttachments.length === 0 &&
+    documentAttachments.length === 0 &&
+    audioAttachments.length === 0 &&
+    videoAttachments.length === 0;
+
+  /**
+   * Card content skips the bubble, and with it the §S4.2 in-bubble sender
+   * name, so the name goes back on a line above the card. The event card
+   * follows §5 grouping the way real bubbles do (name only on the first of a
+   * run); the older special cards keep their pre-existing always-on line.
+   */
+  const showAboveContentSenderName =
+    !isOwnMessage &&
+    (!whatsappShellEnabled ||
+      isSpecialCardMessage ||
+      (isEventCardOnlyMessage && (isFirstInGroup ?? true)));
+
   // --- §5 "Bubble timestamp + ticks placement": WhatsApp's inline timestamp --
   //
   // WhatsApp does not give the timestamp a row of its own. It reserves an
@@ -1355,14 +1401,15 @@ function MessageItemInner({
           {/* Sender name above the content: flag-off always; flag-on only for
               card-style messages, whose content skips the bubble (and with it
               the in-bubble name from §S4.2). */}
-          {!isOwnMessage && (!whatsappShellEnabled || isSpecialCardMessage) && (
+          {showAboveContentSenderName && (
             <Text style={[styles.senderName, { color: themeColors.textSecondary }]}>
               {message.senderName || 'Unknown'}
             </Text>
           )}
 
-          {/* Message bubble (hidden for special card messages) */}
-          {!isSpecialCardMessage && (
+          {/* Message bubble (hidden for special card messages, and flag-on for
+              an event-link-only message whose card is already the bubble) */}
+          {!isSpecialCardMessage && !isEventCardOnlyMessage && (
             <View ref={bubbleRef} style={styles.bubbleWrapper}>
               <View
                 style={[
@@ -1580,6 +1627,31 @@ function MessageItemInner({
 
           {/* Event cards for meeting links */}
           {renderEventCards()}
+
+          {/* The §5 out-of-flow inline stamp needs a text run to sit beside,
+              and the suppressed bubble took the footer row with it — so the
+              card-as-bubble case falls back to a timestamp row *under* the
+              card, the same fallback media bubbles use. It sits over the
+              wallpaper rather than a bubble tint, so it takes the theme's
+              tertiary ink both ways instead of the on-tint rgba. */}
+          {isEventCardOnlyMessage && (
+            <View testID="wa-card-footer" style={styles.messageFooter}>
+              <Text
+                style={[
+                  styles.timestamp,
+                  styles.waTimestamp,
+                  { color: themeColors.textTertiary },
+                ]}
+              >
+                {formatMessageTime(message.createdAt)}
+              </Text>
+              {message.editedAt && !message.isDeleted && (
+                <Text style={[styles.editedBadge, { color: themeColors.textTertiary }]}>
+                  (edited)
+                </Text>
+              )}
+            </View>
+          )}
 
           {/* Tool cards for run sheet/resource links */}
           {renderToolCards()}

--- a/apps/mobile/features/chat/components/MessageItem.tsx
+++ b/apps/mobile/features/chat/components/MessageItem.tsx
@@ -697,6 +697,20 @@ function MessageItemInner({
               isMyMessage={isOwnMessage}
               embedded
               prefetchedData={prefetchedEvent}
+              // §7: flag-on the card dresses as *this* message's bubble —
+              // same fill as the text bubble beside it — so it reads as a
+              // rich link preview rather than a separate attachment panel.
+              // Passed only when the flag is on; absent === legacy card.
+              wa={
+                whatsappShellEnabled
+                  ? {
+                      accent: waPalette.accent,
+                      bubbleFill: isOwnMessage
+                        ? waPalette.bubbleOutgoing
+                        : themeColors.bubbleIncoming,
+                    }
+                  : undefined
+              }
             />
           );
         })}

--- a/apps/mobile/features/chat/components/__tests__/EventLinkCard.waCard.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/EventLinkCard.waCard.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * EventLinkCard — WhatsApp-shell anatomy (WHATSAPP-DESIGN-SYSTEM.md §7).
+ *
+ * §7 requires an in-thread event card to *be a bubble*: same fill as the
+ * message bubbles around it, a compact banner rather than a poster, and an
+ * RSVP pill row docked at the bottom — "never a separate attachment card
+ * component with its own shadow/border language."
+ *
+ * The flag lives in `MessageItem`; this component receives it as the presence
+ * of the `wa` prop, so these tests drive both shells by passing / omitting it.
+ * The final block is the flag-off twin: it asserts the pre-WhatsApp card is
+ * still rendered verbatim, which is the guarantee the rollout depends on.
+ */
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { EventLinkCard } from '../EventLinkCard';
+import { WA_CARD_COVER_ASPECT, WA_CARD_PILL_HEIGHT } from '../../waChatChrome';
+import { api } from '@services/api/convex';
+
+const mockUseQuery = jest.fn();
+const mockSubmitRsvp = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock('@services/api/convex', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: jest.fn(() => mockSubmitRsvp),
+  useStoredAuthToken: jest.fn(() => 'mock-token'),
+  api: {
+    functions: {
+      meetings: {
+        index: {
+          getByShortId: 'api.functions.meetings.index.getByShortId',
+        },
+      },
+      meetingRsvps: {
+        list: 'api.functions.meetingRsvps.list',
+        myRsvp: 'api.functions.meetingRsvps.myRsvp',
+        submit: 'api.functions.meetingRsvps.submit',
+      },
+    },
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@components/ui/Avatar', () => ({
+  Avatar: () => null,
+}));
+
+// Surfaces the cover's resolved style so the banner-vs-poster crop is testable.
+jest.mock('@components/ui/AppImage', () => {
+  const ReactLocal = require('react');
+  const { View } = require('react-native');
+  return {
+    AppImage: (props: { style?: unknown }) =>
+      ReactLocal.createElement(View, { testID: 'event-cover', style: props.style }),
+  };
+});
+
+jest.mock('@/providers/ImageViewerProvider', () => ({
+  ImageViewerManager: { show: jest.fn() },
+}));
+
+jest.mock('../../utils/imageActions', () => ({
+  handleImageLongPress: jest.fn(),
+  handleEventLongPress: jest.fn(),
+  copyEventLink: jest.fn(() => Promise.resolve()),
+}));
+
+/** The pale-blue tint §7 bans on the flag-on card, kept flag-off. */
+const LEGACY_TINTED_BODY = '#DCEEFF';
+
+const WA_THEME = { accent: '#1E8449', bubbleFill: '#D9FDD3' };
+
+const RSVP_OPTIONS = [
+  { id: 1, label: 'Going', enabled: true },
+  { id: 2, label: 'Maybe', enabled: true },
+  { id: 3, label: "Can't Go", enabled: true },
+];
+
+const fullEventData = {
+  id: 'meeting-1',
+  shortId: 'evt123',
+  title: 'Planning Night',
+  scheduledAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  coverImage: 'covers/planning.jpg',
+  locationOverride: 'Main Hall',
+  meetingType: 1,
+  rsvpEnabled: true,
+  rsvpOptions: RSVP_OPTIONS,
+  groupName: 'Core Team',
+  communityName: 'Demo Community',
+  hasAccess: true,
+  status: 'scheduled',
+};
+
+function mockQueries({
+  myRsvp = { optionId: null },
+  goingCount = 3,
+}: {
+  myRsvp?: Record<string, unknown> | null;
+  goingCount?: number;
+} = {}) {
+  mockUseQuery.mockImplementation((queryName: unknown, args: unknown) => {
+    if (queryName === api.functions.meetings.index.getByShortId) {
+      return args === 'skip' ? undefined : fullEventData;
+    }
+    if (queryName === api.functions.meetingRsvps.list) {
+      return {
+        total: goingCount,
+        limitedAccess: true,
+        rsvps: [
+          { option: RSVP_OPTIONS[0], count: goingCount, users: [] },
+          { option: RSVP_OPTIONS[1], count: 0, users: [] },
+          { option: RSVP_OPTIONS[2], count: 0, users: [] },
+        ],
+      };
+    }
+    if (queryName === api.functions.meetingRsvps.myRsvp) {
+      return myRsvp;
+    }
+    return undefined;
+  });
+}
+
+/** Every color literal anywhere in the rendered tree. */
+function renderedColors(tree: unknown): string {
+  return JSON.stringify(tree);
+}
+
+function flatStyle(node: { props: { style?: unknown } }): Record<string, unknown> {
+  return (StyleSheet.flatten(node.props.style as never) ?? {}) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSubmitRsvp.mockResolvedValue(undefined);
+});
+
+describe('EventLinkCard — WhatsApp shell (flag-on)', () => {
+  it('renders as a bubble: message fill, no tinted body, 16:9 banner', () => {
+    mockQueries();
+
+    const { getByTestId, toJSON } = render(
+      <EventLinkCard shortId="evt123" wa={WA_THEME} />
+    );
+
+    // §7: the card takes the message's own bubble fill, and the §7-banned
+    // pale-blue tinted panel is gone from the tree entirely.
+    expect(renderedColors(toJSON())).toContain(WA_THEME.bubbleFill);
+    expect(renderedColors(toJSON())).not.toContain(LEGACY_TINTED_BODY);
+
+    // Compact banner, not the natural-ratio (1:1 default) poster.
+    expect(flatStyle(getByTestId('event-cover')).aspectRatio).toBe(WA_CARD_COVER_ASPECT);
+  });
+
+  it('collapses the three RSVP rows into one 32pt pill row with inline counts', () => {
+    mockQueries({ goingCount: 3 });
+
+    const { getByTestId, getByText, queryByText } = render(
+      <EventLinkCard shortId="evt123" wa={WA_THEME} />
+    );
+
+    expect(getByTestId('wa-rsvp-pill-1')).toBeTruthy();
+    expect(getByTestId('wa-rsvp-pill-2')).toBeTruthy();
+    expect(getByTestId('wa-rsvp-pill-3')).toBeTruthy();
+    expect(flatStyle(getByTestId('wa-rsvp-pill-1')).height).toBe(WA_CARD_PILL_HEIGHT);
+
+    // Count rides inline in the label when > 0; zero-count options stay bare.
+    expect(getByText('Going 👍 3')).toBeTruthy();
+    expect(getByText('Maybe 🤔')).toBeTruthy();
+    expect(getByText("Can't Go 😢")).toBeTruthy();
+
+    // The full-height row anatomy (label + separate numeric count column) is gone.
+    expect(queryByText('Going 👍')).toBeNull();
+  });
+
+  it('gives the viewer’s selected pill the pale accent tint and accent ink', () => {
+    mockQueries({ myRsvp: { optionId: 2, guestCount: 0 } });
+
+    const { getByTestId, getByText } = render(
+      <EventLinkCard shortId="evt123" wa={WA_THEME} />
+    );
+
+    const selectedFill = flatStyle(getByTestId('wa-rsvp-pill-2')).backgroundColor;
+    const unselectedFill = flatStyle(getByTestId('wa-rsvp-pill-1')).backgroundColor;
+
+    // §1.6: a pale wash of the accent, never the accent itself.
+    expect(selectedFill).toBe('rgba(30, 132, 73, 0.18)');
+    expect(selectedFill).not.toBe(WA_THEME.accent);
+    expect(unselectedFill).not.toBe(selectedFill);
+
+    expect(flatStyle(getByText('Maybe 🤔')).color).toBe(WA_THEME.accent);
+    expect(flatStyle(getByText('Going 👍 3')).color).not.toBe(WA_THEME.accent);
+  });
+
+  it('passes RSVP taps through to the same mutation, clearing guests on a switch', async () => {
+    mockQueries({ myRsvp: { optionId: 1, guestCount: 2 } });
+
+    const { getByTestId } = render(<EventLinkCard shortId="evt123" wa={WA_THEME} />);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('wa-rsvp-pill-3'));
+    });
+
+    expect(mockSubmitRsvp).toHaveBeenCalledWith({
+      token: 'mock-token',
+      meetingId: 'meeting-1',
+      optionId: 3,
+      guestCount: 0,
+    });
+  });
+
+  it('preserves plus-ones when the viewer re-taps the option they already picked', async () => {
+    mockQueries({ myRsvp: { optionId: 1, guestCount: 2 } });
+
+    const { getByTestId } = render(<EventLinkCard shortId="evt123" wa={WA_THEME} />);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('wa-rsvp-pill-1'));
+    });
+
+    expect(mockSubmitRsvp).toHaveBeenCalledWith({
+      token: 'mock-token',
+      meetingId: 'meeting-1',
+      optionId: 1,
+      guestCount: 2,
+    });
+  });
+
+  it('keeps both footer actions as accent text links', async () => {
+    mockQueries();
+
+    const { getByText } = render(<EventLinkCard shortId="evt123" wa={WA_THEME} />);
+
+    const copyLink = getByText('Copy link');
+    const viewDetails = getByText('View details');
+    expect(flatStyle(copyLink).color).toBe(WA_THEME.accent);
+    expect(flatStyle(viewDetails).color).toBe(WA_THEME.accent);
+
+    await act(async () => {
+      fireEvent.press(viewDetails);
+    });
+    expect(mockPush).toHaveBeenCalledWith('/e/evt123?source=app');
+
+    await act(async () => {
+      fireEvent.press(copyLink);
+    });
+    const { copyEventLink } = require('../../utils/imageActions');
+    expect(copyEventLink).toHaveBeenCalledWith('evt123');
+  });
+});
+
+describe('EventLinkCard — flag-off twin', () => {
+  it('keeps the tinted body, the full RSVP rows and the natural cover crop', () => {
+    mockQueries({ goingCount: 3 });
+
+    const { getByText, getByTestId, queryByTestId, toJSON } = render(
+      <EventLinkCard shortId="evt123" />
+    );
+
+    // The pale-blue panel and its 1:1 poster crop are untouched flag-off.
+    expect(renderedColors(toJSON())).toContain(LEGACY_TINTED_BODY);
+    expect(flatStyle(getByTestId('event-cover')).aspectRatio).toBe(1);
+
+    // Full-height radio rows, each with its own numeric count — no pills.
+    expect(queryByTestId('wa-rsvp-pill-1')).toBeNull();
+    expect(getByText('Going 👍')).toBeTruthy();
+    expect(getByText('Maybe 🤔')).toBeTruthy();
+    expect(getByText("Can't Go 😢")).toBeTruthy();
+    expect(getByText('3')).toBeTruthy();
+
+    // Legacy footer casing.
+    expect(getByText('View Details')).toBeTruthy();
+  });
+});

--- a/apps/mobile/features/chat/components/__tests__/MessageItem.waBubble.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageItem.waBubble.test.tsx
@@ -335,22 +335,6 @@ describe('MessageItem inline timestamp (flag-on)', () => {
     expect(StyleSheet.flatten(getByTestId('wa-bubble-footer').props.style).position).toBeUndefined();
   });
 
-  it('keeps the footer row for an event-card message, which has no text flow', () => {
-    // The event card is a sibling of the bubble, not text inside it, so there
-    // is nothing for an inline stamp to sit beside — and an absolutely
-    // positioned one would land on the card. Guards the §S4.2 rule that only
-    // text-last bubbles get the inline treatment, now that the card renders
-    // as a bubble of its own flag-on.
-    const { getByTestId, queryByTestId } = render(
-      <MessageItem
-        message={{ ...incoming, content: 'https://togather.nyc/e/evt123' }}
-        currentUserId={'user-1' as any}
-      />
-    );
-    expect(queryByTestId('wa-timestamp-reservation')).toBeNull();
-    expect(StyleSheet.flatten(getByTestId('wa-bubble-footer').props.style).position).toBeUndefined();
-  });
-
   it('still reserves on a deleted message, whose tombstone is the text flow', () => {
     const { getByTestId } = render(
       <MessageItem

--- a/apps/mobile/features/chat/components/__tests__/MessageItem.waBubble.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageItem.waBubble.test.tsx
@@ -335,6 +335,22 @@ describe('MessageItem inline timestamp (flag-on)', () => {
     expect(StyleSheet.flatten(getByTestId('wa-bubble-footer').props.style).position).toBeUndefined();
   });
 
+  it('keeps the footer row for an event-card message, which has no text flow', () => {
+    // The event card is a sibling of the bubble, not text inside it, so there
+    // is nothing for an inline stamp to sit beside — and an absolutely
+    // positioned one would land on the card. Guards the §S4.2 rule that only
+    // text-last bubbles get the inline treatment, now that the card renders
+    // as a bubble of its own flag-on.
+    const { getByTestId, queryByTestId } = render(
+      <MessageItem
+        message={{ ...incoming, content: 'https://togather.nyc/e/evt123' }}
+        currentUserId={'user-1' as any}
+      />
+    );
+    expect(queryByTestId('wa-timestamp-reservation')).toBeNull();
+    expect(StyleSheet.flatten(getByTestId('wa-bubble-footer').props.style).position).toBeUndefined();
+  });
+
   it('still reserves on a deleted message, whose tombstone is the text flow', () => {
     const { getByTestId } = render(
       <MessageItem

--- a/apps/mobile/features/chat/components/__tests__/MessageItem.waEventCard.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageItem.waEventCard.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * MessageItem — the event card as the message's own bubble (§7).
+ *
+ * Regression suite for the defect found reviewing PR #665: flag-on, a message
+ * whose entire content is one event URL has an EMPTY `displayText` once the
+ * link is stripped, but the normal bubble still rendered — so the thread
+ * showed a stub metadata-only bubble (sender name + timestamp + tail, no
+ * body) stacked on top of the card's own bubble. The card has to be the sole
+ * bubble, the way `isSpecialCardMessage` already makes poll/task/bug cards.
+ *
+ * Boundaries matter as much as the fix: a message with text *beside* the link
+ * still needs its text bubble, and flag-off must not move at all.
+ */
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+let mockShellEnabled = true;
+
+jest.mock('@features/chat/hooks/useReadReceipts', () => ({
+  useReadReceipts: () => ({ readByCount: 0, totalMembers: 0, isLoading: false }),
+}));
+jest.mock('@features/chat/hooks/useReactions', () => ({
+  useReactions: () => ({ reactions: [], toggleReaction: jest.fn(), isLoading: false }),
+}));
+jest.mock('@features/chat/hooks/useLinkPreview', () => ({
+  useLinkPreview: () => ({ preview: null, loading: false }),
+}));
+jest.mock('@services/api/convex', () => ({ api: {} }));
+jest.mock('@hooks/useWhatsappShell', () => ({
+  useWhatsappShell: () => mockShellEnabled,
+  useWhatsappShellState: () => ({ enabled: mockShellEnabled, loaded: true }),
+}));
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+// A marker, not `null` — this suite counts bubbles, so the card has to be
+// distinguishable from the message bubble that must NOT be there.
+jest.mock('../EventLinkCard', () => {
+  const ReactLocal = require('react');
+  const { View } = require('react-native');
+  return { EventLinkCard: () => ReactLocal.createElement(View, { testID: 'event-card' }) };
+});
+jest.mock('../LinkPreviewCard', () => ({ LinkPreviewCard: () => null }));
+jest.mock('../FileAttachment', () => ({ FileAttachment: () => null }));
+jest.mock('../AudioPlayer', () => ({ AudioPlayer: () => null }));
+jest.mock('../VideoPlayer', () => ({ VideoPlayer: () => null }));
+jest.mock('../ImageAttachmentsGrid', () => ({ ImageAttachmentsGrid: () => null }));
+jest.mock('../ThreadReplies', () => ({ ThreadReplies: () => null }));
+jest.mock('../ReactionDetailsModal', () => ({ ReactionDetailsModal: () => null }));
+jest.mock('../TaskCardFromMessage', () => ({ TaskCardFromMessage: () => null }));
+jest.mock('@components/ui', () => ({ AppImage: () => null, ImageViewer: () => null }));
+jest.mock('@/utils/media', () => ({ getMediaUrl: (url: string) => url }));
+
+import { MessageItem } from '../MessageItem';
+
+const EVENT_URL = 'https://togather.nyc/e/evt123';
+const TIME_RE = /^\d{1,2}:\d{2} (AM|PM)$/;
+
+const incoming = {
+  _id: 'msg-1' as any,
+  channelId: 'ch-1' as any,
+  senderId: 'user-2' as any,
+  content: EVENT_URL,
+  contentType: 'text',
+  createdAt: Date.now(),
+  isDeleted: false,
+  senderName: 'Ada Nwosu',
+};
+
+/**
+ * Every filled, rounded container in the tree — the shape a chat bubble has.
+ * The stub bubble this suite guards against is exactly such a node, so
+ * counting them is the direct assertion of "the card is the only bubble".
+ */
+function bubbleLikeNodes(node: any): any[] {
+  if (!node || typeof node !== 'object') return [];
+  const children = (node.children ?? []).flatMap((child: any) => bubbleLikeNodes(child));
+  const style = StyleSheet.flatten(node.props?.style);
+  const isBubble = !!style?.backgroundColor && typeof style?.borderRadius === 'number';
+  return isBubble ? [node, ...children] : children;
+}
+
+beforeEach(() => {
+  mockShellEnabled = true;
+});
+
+describe('event-link-only message (flag-on)', () => {
+  it('renders the card as the only bubble — no empty stub bubble above it', () => {
+    const { getAllByTestId, toJSON } = render(
+      <MessageItem message={incoming} currentUserId={'user-1' as any} />
+    );
+
+    expect(getAllByTestId('event-card')).toHaveLength(1);
+    // The card mock draws nothing, so any bubble-shaped container left in the
+    // tree is the stub bubble the fix removes.
+    expect(bubbleLikeNodes(toJSON())).toHaveLength(0);
+  });
+
+  it('puts the sender name on the line above the card, since there is no bubble to host it', () => {
+    const { getByText, queryByTestId } = render(
+      <MessageItem message={incoming} currentUserId={'user-1' as any} />
+    );
+
+    expect(getByText('Ada Nwosu')).toBeTruthy();
+    // §S4.2's in-bubble name needs a bubble; this one is the above-content line.
+    expect(queryByTestId('wa-bubble-footer')).toBeNull();
+  });
+
+  it('follows §5 grouping: no repeated name on a continuation card', () => {
+    const { queryByText } = render(
+      <MessageItem message={incoming} currentUserId={'user-1' as any} isFirstInGroup={false} />
+    );
+    expect(queryByText('Ada Nwosu')).toBeNull();
+  });
+
+  it('never labels the sender on an outgoing card', () => {
+    const { queryByText } = render(
+      <MessageItem
+        message={{ ...incoming, senderId: 'user-1' as any }}
+        currentUserId={'user-1' as any}
+      />
+    );
+    expect(queryByText('Ada Nwosu')).toBeNull();
+  });
+
+  it('falls back to a timestamp row under the card', () => {
+    const { getByTestId, queryByTestId } = render(
+      <MessageItem message={incoming} currentUserId={'user-1' as any} />
+    );
+
+    const footer = getByTestId('wa-card-footer');
+    expect(footer).toBeTruthy();
+    // The §5 inline stamp needs a text run to sit beside; there isn't one.
+    expect(queryByTestId('wa-timestamp-reservation')).toBeNull();
+    expect(footer.props.children[0].props.children).toMatch(TIME_RE);
+  });
+});
+
+describe('messages that still need their own bubble (flag-on)', () => {
+  it('keeps the text bubble when the link is sent alongside a message', () => {
+    const { getByText, getByTestId, queryByTestId, toJSON } = render(
+      <MessageItem
+        message={{ ...incoming, content: `Join us! ${EVENT_URL}` }}
+        currentUserId={'user-1' as any}
+      />
+    );
+
+    expect(getByText('Join us!')).toBeTruthy();
+    expect(getByTestId('event-card')).toBeTruthy();
+    expect(bubbleLikeNodes(toJSON()).length).toBeGreaterThan(0);
+    // Text present -> #655's inline stamp applies again, inside the bubble,
+    // so there is nothing for the under-card fallback row to do.
+    expect(getByTestId('wa-timestamp-reservation')).toBeTruthy();
+    expect(queryByTestId('wa-card-footer')).toBeNull();
+  });
+
+  it('keeps the bubble for a multi-card message, where one name line would be ambiguous', () => {
+    const { getAllByTestId, getByTestId, queryByTestId, toJSON } = render(
+      <MessageItem
+        message={{ ...incoming, content: `${EVENT_URL} https://togather.nyc/e/evt456` }}
+        currentUserId={'user-1' as any}
+      />
+    );
+
+    expect(getAllByTestId('event-card')).toHaveLength(2);
+    expect(bubbleLikeNodes(toJSON()).length).toBeGreaterThan(0);
+    expect(getByTestId('wa-bubble-footer')).toBeTruthy();
+    expect(queryByTestId('wa-card-footer')).toBeNull();
+  });
+
+  it('keeps the bubble when the SMS-blast badge has to live somewhere', () => {
+    const { queryByTestId, toJSON } = render(
+      <MessageItem
+        message={{ ...incoming, blastId: 'blast-1' as any }}
+        currentUserId={'user-1' as any}
+      />
+    );
+
+    expect(bubbleLikeNodes(toJSON()).length).toBeGreaterThan(0);
+    expect(queryByTestId('wa-card-footer')).toBeNull();
+  });
+});
+
+describe('flag-off twin', () => {
+  it('still renders the bubble, its footer and the above-content name', () => {
+    mockShellEnabled = false;
+
+    const { getByText, getByTestId, queryByTestId, toJSON } = render(
+      <MessageItem message={incoming} currentUserId={'user-1' as any} />
+    );
+
+    expect(bubbleLikeNodes(toJSON()).length).toBeGreaterThan(0);
+    expect(getByText('Ada Nwosu')).toBeTruthy();
+    expect(getByTestId('wa-bubble-footer')).toBeTruthy();
+    expect(queryByTestId('wa-card-footer')).toBeNull();
+  });
+
+  it('still labels the sender on a continuation message, which flag-off does not group', () => {
+    mockShellEnabled = false;
+
+    const { getByText } = render(
+      <MessageItem message={incoming} currentUserId={'user-1' as any} isFirstInGroup={false} />
+    );
+    expect(getByText('Ada Nwosu')).toBeTruthy();
+  });
+});

--- a/apps/mobile/features/chat/waChatChrome.ts
+++ b/apps/mobile/features/chat/waChatChrome.ts
@@ -157,3 +157,46 @@ export const WA_REPLY_QUOTE_RADIUS = 6;
 export const WA_COMPOSER_FIELD_HEIGHT = 32;
 /** Fully-rounded: always half the field height. */
 export const WA_COMPOSER_FIELD_RADIUS = WA_COMPOSER_FIELD_HEIGHT / 2;
+
+/* ---------------------------------------------------------------------------
+ * §7 in-thread structured cards (event card)
+ *
+ * §7 is explicit that a Togather-only element in the thread must be a
+ * *bubble*, not "a separate attachment card component with its own
+ * shadow/border language" — so the event card borrows WhatsApp's rich
+ * link-preview anatomy: a compact 16:9 banner across the bubble top, body copy
+ * on the bubble's own fill, and an RSVP pill row docked at the bottom edge.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * §7 "a thumbnail if present": WhatsApp's rich link preview crops its image to
+ * a wide banner, never a full-bleed square poster — the bubble has to stay
+ * message-sized, not poster-sized.
+ */
+export const WA_CARD_COVER_ASPECT = 16 / 9;
+
+/** Inner gutter of the card body — tighter than a screen's 16, like a bubble's. */
+export const WA_CARD_PADDING = 10;
+
+/** §7 RSVP pill row: chips-row anatomy, 32pt tall and fully rounded. */
+export const WA_CARD_PILL_HEIGHT = 32;
+export const WA_CARD_PILL_RADIUS = WA_CARD_PILL_HEIGHT / 2;
+
+/**
+ * Unselected RSVP pill fill. Same black/white-alpha reasoning as the §5
+ * reply-quote fill: the pill sits on the WHITE incoming bubble *and* on the
+ * MINT outgoing one, and no opaque token reads as "recessed" on both.
+ */
+export const WA_CARD_PILL_FILL_LIGHT = 'rgba(0, 0, 0, 0.06)';
+export const WA_CARD_PILL_FILL_DARK = 'rgba(255, 255, 255, 0.09)';
+
+/**
+ * §1.6 selected-chip treatment: a *pale accent tint* with accent ink, never an
+ * accent-filled chip (a solid brand fill on a chip reads as loud as the banned
+ * pastel taxonomy chips of §7). Expressed as an alpha wash of the accent so it
+ * darkens whichever bubble fill it lands on rather than fighting it.
+ */
+export const WA_CARD_PILL_SELECTED_ALPHA = 0.18;
+
+/** §1.6 "bubbles have a ~1px soft drop shadow" — the card is a bubble (§7). */
+export const WA_CARD_SHADOW_WEB = '0px 1px 1px rgba(0, 0, 0, 0.13)';


### PR DESCRIPTION
## What this is

Owner (2026-07-30, device screenshot): the event card shared into chat *"needs to be updated with the new design language, I also feel like it can be smaller."* It was a full-screen poster: square cover, pale-blue tinted panel (§7-banned), three full-height RSVP rows with progress bars.

## Changes (flag-on via a `wa` prop MessageItem supplies only when the shell is on)

WhatsApp's rich-preview anatomy, inside the message bubble: **16:9 banner** (was natural-ratio square), title 15pt + "Fri, Jul 31 · 12:31 AM" 13pt on the bubble's own fill (blue tint gone), **RSVP as one 32pt pill row** — counts inline ("Going 👍 3"), viewer's selection in the pale accent wash — and "Copy link · View details" as accent text links. **~49% shorter** at typical content (~612pt → ~313pt at a 300pt column).

Preserved byte-for-byte: the RSVP mutation semantics (including the re-tap-keeps-plus-ones rule and the hydration guard), guest stepper, leader badge, cancelled/past/access-denied states, skeleton, image viewer, long-press, both footer actions. Dropped flag-on only: avatar stacks and per-option progress bars (that's where the height went).

## Flag-off safety

Independent adversarial audit: **PASS** — legacy anatomy verified against the actual code paths (not just the twin test): `#DCEEFF` panel, 1:1 cover, radio rows, "View Details" casing all intact when `wa` is undefined; handlers identical in both states; the inline-timestamp rule from #655 untouched (card messages keep the footer fallback, regression-tested).

## Tests

1888 passed / 9 skipped (+8: compact anatomy, pill selection + handler passthrough, links, flag-off twin, timestamp fallback). tsc at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3HT3tAPRcQJRUDrnhHVhP