### PR TITLE
Add api.togather.nyc DNS records for Convex HTTP Actions custom domain

### DIFF
--- a/docs/api/attendance-api.md
+++ b/docs/api/attendance-api.md
@@ -28,10 +28,13 @@ Authorization: Bearer tgk_xxxxxxxxxxxxxxxx
 ## Endpoint
 
 ```
-GET https://<your-deployment>.convex.site/api/v1/attendance
+GET https://api.togather.nyc/api/v1/attendance
 ```
 
-The exact base URL for a community is shown on the API Keys screen in the app.
+`https://api.togather.nyc` is the canonical base URL for the production API.
+The underlying deployment URL (`https://<deployment>.convex.site`) continues to
+work — existing integrations don't need to change. The base URL for a community
+is also shown on the API Keys screen in the app.
 
 ### Query parameters (all optional)
 
@@ -59,7 +62,7 @@ was exhausted (possible with selective `status`/`groupType` filters). Narrow the
 
 ```bash
 curl -H "Authorization: Bearer $TOGATHER_API_KEY" \
-  "https://<deployment>.convex.site/api/v1/attendance?groupType=dinner-parties&since=2026-01-01"
+  "https://api.togather.nyc/api/v1/attendance?groupType=dinner-parties&since=2026-01-01"
 ```
 
 ### Response
@@ -101,7 +104,7 @@ Field notes:
 ## Summary endpoint (rolled up)
 
 ```
-GET https://<deployment>.convex.site/api/v1/attendance/summary
+GET https://api.togather.nyc/api/v1/attendance/summary
 ```
 
 A lighter companion to `/api/v1/attendance`: returns one row per group **per

--- a/ee/infrastructure/cloudflare/dns.tf
+++ b/ee/infrastructure/cloudflare/dns.tf
@@ -102,6 +102,42 @@ resource "cloudflare_record" "wildcard" {
 }
 
 # -----------------------------------------------------------------------------
+# API Subdomain - Convex HTTP Actions (production: artful-echidna-883)
+# -----------------------------------------------------------------------------
+# Serves the routes in apps/convex/http.ts (public REST API /api/v1/*, webhooks,
+# link-preview metadata) from a branded URL. The default
+# artful-echidna-883.convex.site URL keeps working - this is purely additive.
+#
+# proxied MUST stay false (DNS only):
+#   1. Convex provisions and serves the TLS certificate itself; a proxied
+#      record breaks certificate issuance/verification.
+#   2. The link-preview Worker has a *.togather.nyc/* route
+#      (apps/link-preview/wrangler.toml). Proxying api.togather.nyc would send
+#      every API request through that Worker, which would misroute it as a
+#      community subdomain. DNS-only records bypass Workers entirely.
+# This explicit record takes precedence over the proxied wildcard (*) above.
+
+resource "cloudflare_record" "api" {
+  zone_id         = local.zone_id
+  name            = "api"
+  type            = "CNAME"
+  content         = "convex.domains"
+  proxied         = false
+  comment         = "Convex HTTP Actions custom domain (production) - must stay DNS-only"
+  allow_overwrite = true
+}
+
+# Convex domain-ownership verification for api.togather.nyc
+resource "cloudflare_record" "api_convex_verification" {
+  zone_id         = local.zone_id
+  name            = "_convex_domains.api"
+  type            = "TXT"
+  content         = "artful-echidna-883"
+  comment         = "Convex custom domain verification for api.togather.nyc"
+  allow_overwrite = true
+}
+
+# -----------------------------------------------------------------------------
 # Email Records (if using Resend or other email service)
 # -----------------------------------------------------------------------------
 # Uncomment and configure if you have email sending set up


### PR DESCRIPTION
## What

Adds the two DNS records (via the existing Terraform Cloudflare setup) needed to verify and serve the `api.togather.nyc` custom domain that was added in the Convex dashboard for the production deployment's **HTTP Actions** endpoint (`artful-echidna-883.convex.site`):

- `CNAME api.togather.nyc → convex.domains` — **DNS-only (`proxied = false`)**
- `TXT _convex_domains.api.togather.nyc → "artful-echidna-883"` — Convex domain-ownership verification

Also updates `docs/api/attendance-api.md` to advertise `https://api.togather.nyc` as the canonical public API base URL.

## Why DNS-only (grey cloud) is load-bearing

1. Convex provisions and serves the TLS certificate for the custom domain itself; a proxied record breaks issuance/verification.
2. The link-preview Worker has a `*.togather.nyc/*` route (`apps/link-preview/wrangler.toml`). If `api.togather.nyc` were proxied, that Worker would intercept every API request and misroute it as a community subdomain. DNS-only records bypass Workers entirely.

The explicit `api` record takes precedence over the existing proxied wildcard (`*`) record.

## Backwards compatibility

Purely additive: the default `artful-echidna-883.convex.site` URL keeps serving traffic, so existing webhook registrations (Stripe, Increase, Slack), the link-preview worker's `CONVEX_SITE_URL`, and all other references keep working unchanged.

## Deploy

Merging to main triggers `terraform apply` via the Terraform DNS workflow (production environment). Convex then verifies the domain in the background (dashboard says up to 30 minutes) and starts serving traffic on `https://api.togather.nyc`. Post-merge check: `curl https://api.togather.nyc/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tKoqWVYY7QcbtDi335kfb

---
_Generated by [Claude Code](https://claude.ai/code/session_013tKoqWVYY7QcbtDi335kfb)_