### PR TITLE
Document Phase-2 withdrawal safeguards as named ADR-032 requirements

### DIFF
--- a/apps/convex/functions/finance/ARCHITECTURE.md
+++ b/apps/convex/functions/finance/ARCHITECTURE.md
@@ -110,6 +110,14 @@ Four finance test files in `apps/convex/__tests__/`:
 
 ## Known Seams & TODOs
 
+- **Community withdrawals + solvency warnings are Phase-2 requirements** —
+  see ADR-032 "Phase 2 requirements": withdrawals draw from the General
+  fund's Account only, capped at settled (not ledger) balance; explicit
+  group-fund sweeps require double confirmation + notification to the fund's
+  finance admins; payout-destination drift (church re-pointing Stripe payouts
+  away from the managed Increase account via the Express Dashboard) must be
+  detected and surfaced.
+
 - **Allocation matches GROSS donation amounts against a NET payout.** A Stripe
   payout is net of processing fees, while `planAllocations` sums gross
   donation totals — so a payout will under-cover its own donations by roughly

--- a/apps/convex/functions/finance/ARCHITECTURE.md
+++ b/apps/convex/functions/finance/ARCHITECTURE.md
@@ -114,7 +114,7 @@ Four finance test files in `apps/convex/__tests__/`:
   see ADR-032 "Phase 2 requirements": withdrawals draw from the General
   fund's Account only, capped at settled (not ledger) balance; explicit
   group-fund sweeps require double confirmation + notification to the fund's
-  finance admins; payout-destination drift (church re-pointing Stripe payouts
+  finance admins and managers; payout-destination drift (church re-pointing Stripe payouts
   away from the managed Increase account via the Express Dashboard) must be
   detected and surfaced.
 

--- a/docs/architecture/decisions/ADR-032-group-giving.md
+++ b/docs/architecture/decisions/ADR-032-group-giving.md
@@ -280,9 +280,11 @@ already flagged in `functions/finance/ARCHITECTURE.md`:
    Account (holds money still attributed to groups pre-allocation) or from
    group Accounts. Fully audit-logged.
 2. **Solvency warning on withdrawal.** The withdrawal UX must distinguish
-   the General fund's *ledger* balance from its *settled bank* balance
-   (donations in the Stripe→Increase pipeline inflate the former) and cap
-   the withdrawable amount at settled funds, explaining the difference.
+   the General fund's *ledger* balance from what the bank will actually
+   honor (donations in the Stripe→Increase pipeline inflate the former;
+   holds and unsettled outbound ACH inflate the settled balance) and cap
+   the withdrawable amount at **min(non-negative ledger balance, Increase
+   `availableBalanceCents`)**, explaining the difference.
 3. **Explicit, loud group sweeps.** Taking money a group fund holds requires
    an explicit per-fund transfer with: a double confirmation stating the
    fund's leaders/managers currently see that balance and will watch it
@@ -294,9 +296,12 @@ already flagged in `functions/finance/ARCHITECTURE.md`:
    transparent rather than silent.
 4. **Payout-destination drift monitoring.** If a church changes its Stripe
    payout bank away from the managed Increase receiving Account (possible
-   via the Express Dashboard), detect it (`account.updated` external-account
-   changes), alert ops, and surface an in-app "group banking disconnected"
-   state — Phase 1 attribution keeps working; cards/allocation do not.
+   via the Express Dashboard), detect it by subscribing to the dedicated
+   Connect events `account.external_account.created` / `.updated` /
+   `.deleted` (`account.updated` alone does not observe every external-
+   account change), alert ops, and surface an in-app "group banking
+   disconnected" state — Phase 1 attribution keeps working;
+   cards/allocation do not.
 5. **Offboarding runbook.** A church leaving Togather gets its full balance
    ACH'd to its verified bank and its Increase accounts closed — tooling +
    terms-of-service clause, not a support ticket.

--- a/docs/architecture/decisions/ADR-032-group-giving.md
+++ b/docs/architecture/decisions/ADR-032-group-giving.md
@@ -269,6 +269,41 @@ semantics are all explicitly out of scope until the core loop is proven.
   side (Stripe) and the banking side (Increase) each remain independently
   swappable.
 
+## Phase 2 requirements (named, so they don't get lost)
+
+Committed product requirements for the Increase-live phase, beyond the seams
+already flagged in `functions/finance/ARCHITECTURE.md`:
+
+1. **Community withdrawal (self-serve).** A community admin can ACH money
+   from the **General fund's Increase Account only** to the church's own
+   verified external bank account. Withdrawals never draw from the receiving
+   Account (holds money still attributed to groups pre-allocation) or from
+   group Accounts. Fully audit-logged.
+2. **Solvency warning on withdrawal.** The withdrawal UX must distinguish
+   the General fund's *ledger* balance from its *settled bank* balance
+   (donations in the Stripe→Increase pipeline inflate the former) and cap
+   the withdrawable amount at settled funds, explaining the difference.
+3. **Explicit, loud group sweeps.** Taking money a group fund holds requires
+   an explicit per-fund transfer with: a double confirmation stating the
+   fund's leaders/managers currently see that balance and will watch it
+   drop ("you have the legal right — it's the church's money — but this is
+   visible"), a typed-amount confirmation, an immutable audit event, and a
+   push/in-app notification to that fund's finance admins and managers.
+   Group segregation is bank-enforced (a card or withdrawal cannot touch
+   another account); this requirement makes the *authorized* override
+   transparent rather than silent.
+4. **Payout-destination drift monitoring.** If a church changes its Stripe
+   payout bank away from the managed Increase receiving Account (possible
+   via the Express Dashboard), detect it (`account.updated` external-account
+   changes), alert ops, and surface an in-app "group banking disconnected"
+   state — Phase 1 attribution keeps working; cards/allocation do not.
+5. **Offboarding runbook.** A church leaving Togather gets its full balance
+   ACH'd to its verified bank and its Increase accounts closed — tooling +
+   terms-of-service clause, not a support ticket.
+6. **Net-amount allocation.** Allocation matching must switch from gross
+   donation totals to Stripe balance-transaction per-charge NET amounts
+   (already documented as a hard go-live prerequisite in ARCHITECTURE.md).
+
 ## Open questions
 
 - Increase program structure: confirm during underwriting that


### PR DESCRIPTION
## What

Docs-only. Captures the community-withdrawal safeguard design as six named "Phase 2 requirements" in ADR-032 (plus a Known Seams pointer in `functions/finance/ARCHITECTURE.md`) so Phase 2 can't ship without them:

1. Self-serve community withdrawal — General fund's Increase Account only, never the receiving or group Accounts, fully audited.
2. Solvency warning — withdrawable amount capped at *settled* bank balance, with the ledger-vs-settled difference (donations still in the Stripe→Increase pipeline) explained in the UX.
3. Loud explicit group sweeps — taking a group fund's money requires double confirmation ("this fund's leaders see this balance and will watch it drop"), typed amount, immutable audit event, and notification to that fund's finance admins/managers.
4. Payout-destination drift monitoring (church re-points Stripe payouts away from the managed Increase account via the Express Dashboard).
5. Offboarding runbook (full-balance ACH-out + account closure as tooling and ToS clause).
6. Net-amount allocation prerequisite (already in ARCHITECTURE.md, cross-referenced).

Context: bank-side segregation already makes silent raids structurally impossible (accounts per group); these requirements make the *authorized* overrides transparent instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq)_