### PR TITLE
Time-aware attendance entry point on the event page

### DIFF
--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -604,8 +604,14 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   // One manager-only attendance slot whose label + destination follow the
   // event's lifecycle: "Check in" (live) before the grace window closes,
   // "Take attendance" (batch editor) after. Both write the same record.
+  // Suppressed for cancelled events — there is no attendance to take for an
+  // event that didn't happen, and the check-in/attendance mutations don't
+  // themselves reject cancelled meetings.
   const attendanceEntry =
-    eventData.id && eventData.groupId && eventData.scheduledAt
+    eventData.status !== 'cancelled' &&
+    eventData.id &&
+    eventData.groupId &&
+    eventData.scheduledAt
       ? resolveAttendanceEntry({
           isRsvpClosed,
           groupId: eventData.groupId,

--- a/apps/mobile/app/e/[shortId]/EventPageClient.tsx
+++ b/apps/mobile/app/e/[shortId]/EventPageClient.tsx
@@ -90,6 +90,7 @@ import * as Clipboard from "expo-clipboard";
 import { EventBlastSheet } from "@/features/leader-tools/components/EventBlastSheet";
 import { InviteGroupMembersSheet } from "@/features/leader-tools/components/InviteGroupMembersSheet";
 import { EventInvitesLog } from "@/features/leader-tools/components/EventInvitesLog";
+import { resolveAttendanceEntry } from "@/features/leader-tools/utils/checkIn";
 import { EventActivity } from "./EventActivity";
 
 /**
@@ -599,6 +600,20 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
   const isRsvpClosed = eventDate
     ? eventDate.getTime() < Date.now() - PAST_EVENT_BUFFER_MS
     : false;
+
+  // One manager-only attendance slot whose label + destination follow the
+  // event's lifecycle: "Check in" (live) before the grace window closes,
+  // "Take attendance" (batch editor) after. Both write the same record.
+  const attendanceEntry =
+    eventData.id && eventData.groupId && eventData.scheduledAt
+      ? resolveAttendanceEntry({
+          isRsvpClosed,
+          groupId: eventData.groupId,
+          meetingId: eventData.id as string,
+          scheduledAt: eventData.scheduledAt,
+        })
+      : null;
+
   const maxGuestsPerRsvp =
     ((eventData as any)?.maxGuestsPerRsvp as number | undefined) ??
     DEFAULT_MAX_GUESTS_PER_RSVP;
@@ -1030,21 +1045,21 @@ export default function EventPageClient({ initialEventData }: EventPageClientPro
               />
             )}
 
-          {/* Leader: jump into the attendance recorder for past events */}
-          {isLeader && isPastEvent && eventData.id && eventData.groupId && eventData.scheduledAt && (
+          {/* Manager: time-aware attendance entry point. Before the grace
+              window closes it's live "Check in" against the Going list;
+              afterward it becomes "Take attendance" and opens the post-event
+              attendance editor. Gated by canEdit (leader / host / community
+              admin) to match the check-in screen's own server gate. */}
+          {canEdit && attendanceEntry && (
             <TouchableOpacity
               style={[styles.messageAttendeesButton, { backgroundColor: colors.surfaceSecondary }]}
               onPress={() => {
-                const encodedDate = encodeURIComponent(eventData.scheduledAt!);
-                const meetingIdParam = encodeURIComponent(eventData.id as string);
-                router.push(
-                  `/(user)/leader-tools/${eventData.groupId}/attendance/edit?eventDate=${encodedDate}&meetingId=${meetingIdParam}`
-                );
+                router.push(attendanceEntry.href);
               }}
             >
               <Ionicons name="checkmark-done-outline" size={20} color={DEFAULT_PRIMARY_COLOR} />
               <Text style={[styles.messageAttendeesText, { color: DEFAULT_PRIMARY_COLOR }]}>
-                Record Attendance
+                {attendanceEntry.label}
               </Text>
             </TouchableOpacity>
           )}

--- a/apps/mobile/features/leader-tools/utils/__tests__/checkIn.test.ts
+++ b/apps/mobile/features/leader-tools/utils/__tests__/checkIn.test.ts
@@ -2,6 +2,7 @@ import {
   computeCheckInSummary,
   indexAttendanceByUser,
   isCheckedIn,
+  resolveAttendanceEntry,
   ATTENDANCE_PRESENT,
   ATTENDANCE_ABSENT,
   type GoingUser,
@@ -89,5 +90,35 @@ describe("computeCheckInSummary — live count", () => {
     expect(summary.checkedIn).toBe(3);
     expect(summary.total).toBe(3);
     expect(summary.fraction).toBe(1);
+  });
+});
+
+describe("resolveAttendanceEntry", () => {
+  const base = {
+    groupId: "g1",
+    meetingId: "m1",
+    scheduledAt: "2026-07-31T00:31:00.000Z",
+  };
+
+  it("is live check-in before the grace window closes", () => {
+    const entry = resolveAttendanceEntry({ ...base, isRsvpClosed: false });
+    expect(entry.label).toBe("Check in");
+    // Routes to the check-in screen with the id-<meetingId>|<date> encoding
+    // the screen parses.
+    expect(entry.href).toBe(
+      `/(user)/leader-tools/g1/events/id-m1|${encodeURIComponent(
+        base.scheduledAt
+      )}/checkin`
+    );
+  });
+
+  it("becomes the attendance editor after the grace window closes", () => {
+    const entry = resolveAttendanceEntry({ ...base, isRsvpClosed: true });
+    expect(entry.label).toBe("Take attendance");
+    expect(entry.href).toBe(
+      `/(user)/leader-tools/g1/attendance/edit?eventDate=${encodeURIComponent(
+        base.scheduledAt
+      )}&meetingId=${encodeURIComponent(base.meetingId)}`
+    );
   });
 });

--- a/apps/mobile/features/leader-tools/utils/checkIn.ts
+++ b/apps/mobile/features/leader-tools/utils/checkIn.ts
@@ -9,6 +9,48 @@
 export const ATTENDANCE_PRESENT = 1;
 export const ATTENDANCE_ABSENT = 0;
 
+/**
+ * The event-page attendance entry point is one slot whose label and destination
+ * depend on where we are in the event's lifecycle. Check-in and attendance
+ * write the SAME record (`meetingAttendances.status === 1`); the only real
+ * difference is timing — tapping people in as they arrive vs. reconciling the
+ * roster afterward — so a single slot serves both.
+ *
+ * `isRsvpClosed` (now > scheduledAt + PAST_EVENT_BUFFER_MS) is the app's
+ * existing "this event is over" signal; before it we show live check-in, after
+ * it the post-event attendance editor.
+ */
+export interface AttendanceEntry {
+  label: "Check in" | "Take attendance";
+  /** Expo-router path for `router.push`. */
+  href: string;
+}
+
+export function resolveAttendanceEntry(params: {
+  isRsvpClosed: boolean;
+  groupId: string;
+  meetingId: string;
+  /** ISO scheduledAt string, as carried on the event page. */
+  scheduledAt: string;
+}): AttendanceEntry {
+  const encodedDate = encodeURIComponent(params.scheduledAt);
+  if (!params.isRsvpClosed) {
+    // Live check-in. Route matches the `id-<meetingId>|<date>` encoding the
+    // check-in screen parses (see EventDetails.handleEdit / checkin.tsx).
+    return {
+      label: "Check in",
+      href: `/(user)/leader-tools/${params.groupId}/events/id-${params.meetingId}|${encodedDate}/checkin`,
+    };
+  }
+  // Post-event: the batch attendance editor (unchanged from the prior CTA).
+  return {
+    label: "Take attendance",
+    href: `/(user)/leader-tools/${params.groupId}/attendance/edit?eventDate=${encodedDate}&meetingId=${encodeURIComponent(
+      params.meetingId
+    )}`,
+  };
+}
+
 /** A person who RSVPed "Going" (subset of the RSVP roster user shape). */
 export interface GoingUser {
   id: string;

--- a/apps/web/src/pages/guides/Events.tsx
+++ b/apps/web/src/pages/guides/Events.tsx
@@ -123,10 +123,12 @@ export function Events() {
           </Step>
           <Step n={6}>
             <strong>Check-in at the door.</strong> On the day, open the event
-            from leader tools and tap <Term>Check in</Term> to run down the
-            <Term>Going</Term> list, tapping each person as they arrive. Added
-            names count as <Term>Present</Term> in your attendance numbers, and
-            walk-ins without an account can be added by name. See{" "}
+            and tap <Term>Check in</Term> to run down the <Term>Going</Term>{" "}
+            list, tapping each person as they arrive. Added names count as{" "}
+            <Term>Present</Term> in your attendance numbers, and walk-ins
+            without an account can be added by name. Once the event has wrapped,
+            that same button becomes <Term>Take attendance</Term> and opens the
+            full attendance editor for after-the-fact corrections. See{" "}
             <em>Check in: take attendance at the door</em> below.
           </Step>
         </Steps>
@@ -174,11 +176,13 @@ export function Events() {
         <P>
           When it's time to gather, you don't want to hunt through a
           group-by-group attendance grid — you want the door list for{" "}
-          <em>this</em> event. Open the event from{" "}
-          <Term>Leader tools → [group] → Events → [event]</Term> and tap{" "}
-          <Term>Check in</Term>. You'll see everyone who RSVP'd{" "}
+          <em>this</em> event. Open the event and tap <Term>Check in</Term>{" "}
+          (the button sits with the other manager actions and only shows for
+          people who can manage the event). You'll see everyone who RSVP'd{" "}
           <Term>Going</Term>, each with a tap-to-check circle and a live{" "}
-          <Term>N / M checked in</Term> count at the top.
+          <Term>N / M checked in</Term> count at the top. After the event has
+          passed, the same button reads <Term>Take attendance</Term> and opens
+          the full attendance editor instead.
         </P>
 
         <Steps>


### PR DESCRIPTION
## What & why

Follow-up to the Event Check-in feature (#654). Two problems it addresses:

1. **The check-in entry point was buried** in the leader-tools event sheet, not on the event page a host actually opens.
2. **"Check in" and "take attendance" are the same data** — both write `meetingAttendances.status === 1` via `markAttendance`; there is no separate `checkedInAt`. The only real difference is *timing*: tapping people in as they arrive vs. reconciling the roster afterward.

So this puts **one manager-only slot on the main event page** (`EventPageClient`) whose label and destination follow the event's lifecycle, instead of two competing entry points.

## Behavior

The slot reuses the page's existing `isRsvpClosed` flag (`now > scheduledAt + PAST_EVENT_BUFFER_MS`, the app's existing "event is over" signal — no new date math):

| Phase | Condition | Label | Opens |
| --- | --- | --- | --- |
| Live | `!isRsvpClosed` (before + 3h grace) | **Check in** | the live check-in screen (Going roster, tap-to-check) |
| Post-event | `isRsvpClosed` | **Take attendance** | the existing batch attendance editor |

Both destinations write the identical attendance record, so landing on the "wrong" one near the boundary loses no data.

**Gate:** widened from the old `isLeader && isPastEvent` to the page's existing `canEdit = isLeader || isHost || isEventCommunityAdmin`, matching the check-in screen's own server gate (`canManageAttendance` → `canEditMeeting`). This also means hosts and community admins now see it, and it's reachable *before* the event, not only after. The server remains authoritative regardless.

## Why the 3h buffer is the switch (not a manual "end event")

`PAST_EVENT_BUFFER_MS` already defines "this event is still happening" (it's the RSVP grace window). Reusing it keeps the label "Check in" for the whole time an organizer is realistically on-site, then flips to "Take attendance" once the event is clearly over. A manual close would need a new field + mutation + an organizer who remembers to tap it. A "correct it three days later" visit lands on "Take attendance" → the batch editor, which is exactly right.

## Changes

- `apps/mobile/app/e/[shortId]/EventPageClient.tsx` — replace the `isLeader && isPastEvent` "Record Attendance" CTA with the `canEdit`-gated, time-aware slot.
- `apps/mobile/features/leader-tools/utils/checkIn.ts` — new pure helper `resolveAttendanceEntry()` (label + route decision).
- `apps/mobile/features/leader-tools/utils/__tests__/checkIn.test.ts` — 2 new tests covering both phases (label + exact route, including the `id-<meetingId>|<date>` encoding the check-in screen parses).
- `apps/web/src/pages/guides/Events.tsx` — updated onboarding guide (reach Check in from the event page; post-event "Take attendance" label).

## Verification

- `npx jest features/leader-tools/utils/__tests__/checkIn.test.ts` → **9/9 pass** (2 new).
- `tsc --noEmit` clean for both changed files (pre-existing unrelated `@togather/shared` build-order and mock-typing errors elsewhere are untouched by this change).
- No device screenshot: this runs on a headless runner with no iOS simulator. The change is a label/route swap on an existing button using existing styles; the behavior is covered by the pure-helper tests above.

## Notes / out of scope

- The leader-tools `EventDetails` check-in row (from #654) is intentionally **left in place** — it's a different surface, not a duplicate on this page.
- A separate follow-up (**PR B**) will fix a pre-existing data-integrity gap: a "Going" non-member checked in on a public event is Present in the read-only report but absent/un-toggleable in the attendance editor (`useFilteredMembers` only falls back to the attendance list when group members is empty). Tracked separately because it touches a shared hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPbFhDEc72BH8QfvbdGs23

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPbFhDEc72BH8QfvbdGs23)_