### PR TITLE
Pass GH_PACKAGES_TOKEN to the sync-secrets reusable workflow

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -12,6 +12,11 @@ name: Sync Secrets from 1Password
 #     `Togather` vault
 #   - GH_ADMIN_TOKEN: GitHub PAT with repo admin scope (secrets:write) — the
 #     default GITHUB_TOKEN cannot manage repository/environment secrets
+#   - GH_PACKAGES_TOKEN: PAT with read:packages on Supa-Media (same durable
+#     token EAS native builds use). MANUALLY SEEDED, like the two above —
+#     although the allowlist also syncs it, the sync itself needs it to
+#     install @supa-media/scripts, so it must never be left to the sync to
+#     bootstrap (and must be re-seeded by hand if it ever expires).
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -58,3 +58,8 @@ jobs:
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+      # Cross-org GitHub Packages read: the reusable workflow installs
+      # @supa-media/scripts, and this repo's own github.token cannot read
+      # Supa-Media's packages (npm 401). Same durable token EAS native
+      # builds use — see docs/secrets.md "GitHub Packages auth".
+      packages-token: ${{ secrets.GH_PACKAGES_TOKEN }}


### PR DESCRIPTION
## What

Both legs of the 1Password → GitHub secrets sync currently fail with `npm 401 Unauthorized` installing `@supa-media/scripts`: the reusable workflow (`Supa-Media/supa-framework sync-secrets.yml@v1`) falls back to this repo's own `github.token`, which cannot read Supa-Media's GitHub Packages cross-org. The reusable workflow exposes a `packages-token` secret input for exactly this case — pass the durable `GH_PACKAGES_TOKEN` repo secret already used for EAS native builds (`docs/secrets.md` "GitHub Packages auth for native builds").

One-line (plus comment) workflow change; unblocks syncing the new group-giving secrets (`INCREASE_API_KEY`, `STRIPE_CONNECT_WEBHOOK_SECRET`, `INCREASE_API_BASE_URL`) to GitHub → Convex.

## Testing

Failed runs 30520346452 / 30519955596 show the 401 with no `packages-token` passed; will re-dispatch `sync-secrets.yml -f environment=both` after merge to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq)_